### PR TITLE
docs: document direct-read relay operator path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ npx skills add . -g -y
 ```
 </details>
 
+Working from a repo checkout without installing skills? See [docs/direct-read-relay-operator-note.md](docs/direct-read-relay-operator-note.md).
+
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/code) or [Codex](https://chatgpt.com/codex)

--- a/docs/direct-read-relay-operator-note.md
+++ b/docs/direct-read-relay-operator-note.md
@@ -1,0 +1,42 @@
+# Direct-Read Relay Operator Note
+
+Use this path when you want to operate relay from a local checkout of `dev-relay` without installing the skill package.
+
+## Source of Truth
+
+Start with `skills/relay/SKILL.md` in the checkout you are operating on. That file is the operator entry point for the full relay flow.
+
+When `skills/relay/SKILL.md` calls into a phase-specific workflow, keep reading the files from the same repo:
+
+- `skills/relay-dispatch/SKILL.md`
+- `skills/relay-review/SKILL.md`
+- `skills/relay-merge/SKILL.md`
+
+Do not rely on globally installed skills for this path. The repo-local `SKILL.md` files are the source of truth for the checkout in front of you.
+
+## Operator Flow
+
+1. Start Codex in the target repo with `-C <repo-path>`.
+2. Tell Codex to read `skills/relay/SKILL.md` from disk before it does any relay work.
+3. Let that file drive the workflow, opening the phase skill files above when the relay steps require them.
+4. Keep every relay command and follow-up step scoped to the same repo checkout.
+
+## Fresh-Session Example
+
+```bash
+codex exec -C /Users/sjlee/workspace/active/harness-stack/dev-relay --full-auto "
+Operate directly from the repo checkout. Do not rely on installed skills.
+
+Repo root: /Users/sjlee/workspace/active/harness-stack/dev-relay
+
+Read these files first:
+- /Users/sjlee/workspace/active/harness-stack/dev-relay/skills/relay/SKILL.md
+- /Users/sjlee/workspace/active/harness-stack/dev-relay/skills/relay-dispatch/SKILL.md
+- /Users/sjlee/workspace/active/harness-stack/dev-relay/skills/relay-review/SKILL.md
+- /Users/sjlee/workspace/active/harness-stack/dev-relay/skills/relay-merge/SKILL.md
+
+Use the repo-local skill files as the source of truth and run the relay operator flow against this repo.
+"
+```
+
+If you only need one phase, start from the matching repo-local skill file. For the full operator path, always start with `skills/relay/SKILL.md`.


### PR DESCRIPTION
## Summary
- add `docs/direct-read-relay-operator-note.md` for operators who want to use the repo-local relay skill files directly from disk without installing the skill package
- add a short README pointer to the new note
- keep scope limited to documentation

## Checks
- `test -f docs/direct-read-relay-operator-note.md` -> exit 0
- `rg -n "docs/direct-read-relay-operator-note.md" README.md` -> exit 0
- `rg -n "codex exec" docs/direct-read-relay-operator-note.md` -> exit 0

## Score Log

| Factor | Target | Iter 1 | Iter 2 | Final |
|---|---|---|---|---|
| Doc exists | exit 0 | exit 0 |  | exit 0 |
| README link exists | exit 0 | exit 0 |  | exit 0 |
| Fresh-session example exists | exit 0 | exit 0 |  | exit 0 |
| Zero-context operator clarity | >= 8/10 | 9/10 |  | 9/10 |
| Scope fidelity | >= 8/10 | 10/10 |  | 10/10 |
| Maintenance resilience | >= 7/10 | 8/10 |  | 8/10 |

Closes #48.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* README에 로컬 저장소 체크아웃 사용자를 위한 릴레이 운영자 설명서에 대한 참조 추가
* 로컬 `dev-relay` 환경에서 릴레이 운영자 흐름을 직접 실행하는 방법을 안내하는 새로운 설명서 파일 추가 (단계별 지침 및 구체적인 실행 예제 포함)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->