### PR TITLE
test: prior-round context and dispatch timeout/artifact tests

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -182,6 +182,29 @@ test("dispatch with --executor claude creates worktree and collects result", () 
   assert.match(resultText, /ok/);
 });
 
+test("dispatch artifacts are persisted in the run directory", () => {
+  const repoRoot = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-artifact",
+    "--prompt", "artifact test task",
+    "--json",
+  ], env));
+  assert.equal(result.status, "completed");
+
+  const runDir = path.join(repoRoot, ".relay", "runs", result.runId);
+  assert.ok(fs.existsSync(path.join(runDir, "dispatch-prompt.md")));
+  const promptText = fs.readFileSync(path.join(runDir, "dispatch-prompt.md"), "utf-8");
+  assert.match(promptText, /artifact test task/);
+
+  assert.ok(fs.existsSync(path.join(runDir, "dispatch-result.txt")));
+  const resultText = fs.readFileSync(path.join(runDir, "dispatch-result.txt"), "utf-8");
+  assert.match(resultText, /ok/);
+});
+
 test("dispatch with --executor claude supports resume", () => {
   const repoRoot = setupRepo();
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-claude-bin-"));
@@ -212,4 +235,65 @@ test("dispatch with --executor claude supports resume", () => {
   assert.equal(second.worktree, first.worktree);
   assert.equal(second.executor, "claude");
   assert.equal(second.runState, STATES.REVIEW_PENDING);
+});
+
+test("timeout with commits produces completed-with-warning", () => {
+  const repoRoot = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  // Fake codex that commits a file then sleeps forever (killed by timeout)
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("codex-fake\\n"); process.exit(0); }
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+fs.writeFileSync(cwd + "/timeout-work.txt", "partial\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", "timeout-work.txt"], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "partial work"], { stdio: "pipe" });
+fs.writeFileSync(output, "partial result\\n", "utf-8");
+setTimeout(() => {}, 60000);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-timeout-work",
+    "--prompt", "slow task",
+    "--timeout", "1",
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed-with-warning");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.match(result.error, /timed out/);
+});
+
+test("timeout without commits produces failed", () => {
+  const repoRoot = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  // Fake codex that does nothing but sleep
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("codex-fake\\n"); process.exit(0); }
+setTimeout(() => {}, 60000);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  // dispatch exits non-zero on failure but still writes JSON to stdout
+  const proc = spawnSync("node", [SCRIPT, repoRoot,
+    "-b", "issue-timeout-empty",
+    "--prompt", "idle task",
+    "--timeout", "1",
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.match(result.error, /timed out/);
 });

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -511,3 +511,175 @@ test("repeated identical issues escalate on the third consecutive round", () => 
   assert.equal(manifest.review.latest_verdict, "escalated");
   assert.equal(manifest.review.repeated_issue_count, 0);
 });
+
+test("formatPriorVerdictSummary produces correct round numbers and rubric summaries", () => {
+  // Module-level argv parsing prevents direct require(), so use a helper script
+  // that sets process.argv before requiring the module.
+  const verdicts = [
+    {
+      verdict: "changes_requested",
+      summary: "Missing tests",
+      issues: [{ title: "a", body: "b", file: "x.js", line: 1, category: "contract", severity: "high" }],
+      rubric_scores: [
+        { factor: "Coverage", target: ">= 8", observed: "5", status: "fail", notes: "low" },
+      ],
+    },
+    {
+      verdict: "changes_requested",
+      summary: "No auth guard",
+      issues: [
+        { title: "c", body: "d", file: "y.js", line: 2, category: "quality", severity: "medium" },
+        { title: "e", body: "f", file: "z.js", line: 3, category: "contract", severity: "high" },
+      ],
+      rubric_scores: [],
+    },
+  ];
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-unit-"));
+  const helperPath = path.join(tmpDir, "helper.js");
+  fs.writeFileSync(helperPath, [
+    `process.argv = ["node", "helper.js", "--repo", "/dev/null", "--branch", "x", "--pr", "1"];`,
+    `const { formatPriorVerdictSummary } = require(${JSON.stringify(SCRIPT)});`,
+    `const verdicts = ${JSON.stringify(verdicts)};`,
+    `const result = formatPriorVerdictSummary(verdicts);`,
+    `const empty = formatPriorVerdictSummary([]);`,
+    `process.stdout.write(JSON.stringify({ result, empty }));`,
+  ].join("\n"), "utf-8");
+  const out = JSON.parse(execFileSync("node", [helperPath], { encoding: "utf-8" }));
+
+  assert.match(out.result, /^Prior review rounds:/);
+  assert.match(out.result, /- Round 2: changes_requested — Missing tests \[1 issue\(s\), Coverage: 5 \(target >= 8, fail\)\]/);
+  assert.match(out.result, /- Round 1: changes_requested — No auth guard \[2 issue\(s\), no rubric scores\]/);
+  assert.equal(out.empty, "");
+});
+
+test("round 2 review prompt contains Prior Round Context section", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  // Run round 1: changes_requested
+  const reviewFile = writeVerdict(repoRoot, "r1-changes.json", {
+    verdict: "changes_requested",
+    summary: "Smoke file not created.",
+    contract_status: "fail",
+    quality_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Missing smoke file",
+      body: "smoke.txt not found",
+      file: "src/index.js",
+      line: 10,
+      category: "contract",
+      severity: "high",
+    }],
+    rubric_scores: [],
+  });
+
+  execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  // Transition back to review_pending for round 2
+  setReviewPending(manifestPath);
+
+  // Round 2: prepare-only to inspect the prompt
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.round, 2);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /## Prior Round Context/);
+  assert.match(promptText, /### Round 1: changes_requested/);
+  assert.match(promptText, /Smoke file not created\./);
+  assert.match(promptText, /Verify whether prior issues were resolved/);
+});
+
+test("round 2 redispatch artifact contains prior round summary", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  // Round 1: changes_requested
+  const r1File = writeVerdict(repoRoot, "r1.json", {
+    verdict: "changes_requested",
+    summary: "Missing smoke file.",
+    contract_status: "fail",
+    quality_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "No smoke.txt",
+      body: "Add it.",
+      file: "src/index.js",
+      line: 5,
+      category: "contract",
+      severity: "high",
+    }],
+    rubric_scores: [],
+  });
+
+  execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", r1File,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  setReviewPending(manifestPath);
+
+  // Round 2: changes_requested again → triggers redispatch with prior summary
+  const r2File = writeVerdict(repoRoot, "r2.json", {
+    verdict: "changes_requested",
+    summary: "Still missing.",
+    contract_status: "fail",
+    quality_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "No smoke.txt",
+      body: "Still not there.",
+      file: "src/index.js",
+      line: 5,
+      category: "contract",
+      severity: "high",
+    }],
+    rubric_scores: [],
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", r2File,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.CHANGES_REQUESTED);
+  assert.ok(result.redispatchPath);
+  const redispatchText = fs.readFileSync(result.redispatchPath, "utf-8");
+  assert.match(redispatchText, /This is round 3/);
+  assert.match(redispatchText, /Prior review rounds:/);
+  assert.match(redispatchText, /Round 1: changes_requested — Missing smoke file\./);
+});


### PR DESCRIPTION
## Summary
- Adds 3 tests for review-runner prior-round context (#71): `formatPriorVerdictSummary` unit test, round-2 prompt `## Prior Round Context` integration, round-2 redispatch `Prior review rounds:` integration
- Adds 3 tests for dispatch timeout/artifact (#72): timeout+commits → `completed-with-warning`, timeout+no-commits → `failed`, artifact persistence (`dispatch-prompt.md`, `dispatch-result.txt`)

Closes #71, closes #72

## Test plan
- [x] All 21 review-runner tests pass (11 existing + 3 new)
- [x] All 7 dispatch tests pass (4 existing + 3 new)
- [x] All 15 relay-merge tests pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 테스트 커버리지가 개선되었습니다. 아티팩트 저장소, 실행 타임아웃 및 이전 라운드 문맥 처리에 대한 새로운 테스트 케이스들이 추가되었습니다.

**참고:** 이 릴리스는 내부 테스트 개선사항만 포함하며 사용자 대면 기능의 변경사항은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->