### PR TITLE
feat: rubric stress-test for L/XL tasks (#78)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -73,14 +73,13 @@ rubric:
 |--------|------|
 | **required** | Must meet target before PR. No cross-factor compensation — each evaluated independently. |
 | **best-effort** | Note in PR if below target |
-**`setup`**: Commands to run before automated checks (start server, seed DB). Omit if not needed.
-**`baseline`**: Capture before-state for delta metrics. Run checks BEFORE changes; improvement is keep, regression is discard.
-**`criteria`**: Multi-line, specific. Each bullet is a concrete thing to check, not "good error handling" but "timeouts on external calls, retry with backoff on idempotent ops only."
-**`scoring_guide`**: Three calibration anchors — `low` (failure), `mid` (partially met), `high` (target zone). Each level tells the executor what to fix next. Shared scale between executor and reviewer.
+**`setup`** / **`baseline`**: Run setup commands before checks; capture baseline for delta metrics (run BEFORE changes).
+**`criteria`**: Multi-line, specific bullets — not "good error handling" but "timeouts on external calls, retry with backoff."
+**`scoring_guide`**: Three anchors (low/mid/high) — each tells the executor what to fix next. Shared scale between executor and reviewer.
 
 ### Domain references (for expert perspective)
 
-After designing factors, consult the matching `references/rubric-*.md` for specialist thinking you may have missed. Design factors from the task's AC, informed by (not copied from) the reference.
+Consult `references/rubric-*.md` for specialist thinking. Design factors from AC, informed by (not copied from) references.
 
 | Task type | Reference | Key signal |
 |-----------|-----------|-----------|
@@ -94,15 +93,25 @@ After designing factors, consult the matching `references/rubric-*.md` for speci
 
 Before dispatch, verify:
 
-- [ ] ≥ 1 automated check exists (ground truth — evaluated-only rubrics have no anchor)
-- [ ] Automated check commands are immutable — executor must not modify them
-- [ ] Every evaluated factor has `scoring_guide` with low/mid/high anchors (prevents generous self-scoring)
+- [ ] ≥ 1 automated check exists (ground truth) + commands are immutable
+- [ ] Every evaluated factor has `scoring_guide` with low/mid/high anchors
 - [ ] Criteria are specific ("timeouts on external calls") not vague ("good error handling")
-- [ ] 3-5 factors total (more slows iteration without adding signal)
-- [ ] Targets are concrete ("≥ 8/10", "< 200ms") not relative ("good", "fast")
+- [ ] 3-5 factors total; targets are concrete ("≥ 8/10", "< 200ms") not relative
 - [ ] Automated checks measure outcomes ("API < 200ms") not proxies ("tests pass")
 
-Any check fails → revise before proceeding. See `references/rubric-design-guide.md` for fix patterns and optional calibration protocol.
+Any check fails → revise. See `references/rubric-design-guide.md` for fix patterns.
+
+### 3.5 Review the rubric (L/XL tasks)
+
+For 5+ AC items, stress-test the rubric before dispatch. **Max 1 round**, then proceed.
+
+| Size | AC count | Review |
+|------|----------|--------|
+| S/M | 1-4 | Skip |
+| L | 5-6 | Stress-test: subagent games rubric (gaming vectors, coverage gaps, disappear test) |
+| XL | 7+ or cross-domain | Stress-test + calibration simulation (parallel) |
+
+Skip: S/M tasks, re-dispatches with iteration history, all-automated rubrics. Full protocol + prompt templates: `references/rubric-stress-test.md`
 
 ### 4. Generate dispatch prompt
 
@@ -112,27 +121,18 @@ Take the base template (`relay/references/prompt-template.md`) and add these sec
 - **Scoring Rubric**: automated checks table + evaluated factors table
 - **Iteration Protocol** (autoloop-style measure-fix-keep):
   ```
-  BEFORE LOOP: If baseline is defined, run it now. Save output for delta comparison.
-  RULE: Do NOT modify automated check commands. They are immutable ground truth. Fix the code, not the check.
-
+  BEFORE LOOP: Run baseline if defined. RULE: Do NOT modify automated check commands.
   LOOP (max 5 iterations):
-    1. Run ALL automated checks, record each score (compare to baseline if delta target)
-    2. Self-evaluate ALL evaluated factors, record each score (1-10)
-    3. Append scores to the Score Log (keep ALL iterations, not just final)
-    4. All required factors meet target →
-       Final self-review: verify Done Criteria item-by-item, scan for stubs/TODOs, confirm tests pass; issues? fix → step 1 →
-       create PR with full Score Log
-    5. Else → identify lowest required factor → make ONE focused fix → commit → repeat
-    6. Stuck on same factor 3 consecutive iterations →
-       - best-effort: note in PR, continue to next factor
-       - required: stop iteration, create PR with Score Log showing failure, flag for human review
+    1. Run ALL automated checks + self-evaluate ALL evaluated factors, record scores
+    2. Append to Score Log (keep ALL iterations, not just final)
+    3. All required meet target → final self-review (Done Criteria, stubs/TODOs, tests) → PR
+    4. Else → lowest required factor → ONE focused fix → commit → repeat
+    5. Stuck 3 iterations → best-effort: note in PR | required: stop, flag for human
   ```
-- **Score Log**: table in PR description showing each iteration's scores (reviewer will re-score independently):
+- **Score Log**: iteration scores table in PR description (reviewer re-scores independently):
   ```
   | Factor | Target | Baseline | Iter 1 | Iter 2 | Final |
   |--------|--------|----------|--------|--------|-------|
-  | Response time | < 0.2s | 0.18s | 0.35s | 0.15s | 0.15s |
-  | Failure mode design | ≥ 8 | — | 5 | 8 | 8 |
   ```
 
 ### 5. Dispatch

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -1,0 +1,148 @@
+# Rubric Stress-Test for L/XL Tasks
+
+For complex tasks (5+ AC items), stress-test the rubric before dispatch. A subagent with fresh context attempts to "game" the rubric — finding minimal implementations that technically pass but a senior engineer would reject.
+
+## Task Size Classification
+
+| Size | Criteria | Rubric Review |
+|------|----------|---------------|
+| S/M | 1-4 AC items | None (current flow) |
+| L | 5-6 AC items | Stress-test (1 subagent) |
+| XL | 7+ AC items or cross-domain | Stress-test + Calibration simulation (parallel) |
+
+**Cross-domain**: task spans frontend + backend, infra + application, or multiple services.
+
+## Process: Validate → Review → Generate
+
+Insert this between "Validate the rubric" (step 3) and "Generate dispatch prompt" (step 4):
+
+```
+Step 3 (Validate) → Step 3.5 (Rubric Review) → Step 4 (Generate dispatch prompt)
+```
+
+## Stress-Test (L and XL)
+
+Launch a subagent with **fresh context** (no planning conversation). Hand it the rubric YAML + original AC as a structured artifact.
+
+### Prompt Template
+
+```
+You are reviewing a scoring rubric for quality before it goes to an executor.
+You have NOT seen the planning conversation — only the rubric and the AC.
+
+## Task AC
+{paste original acceptance criteria}
+
+## Rubric
+{paste rubric YAML}
+
+## Your Job
+
+For each rubric factor, answer these three questions:
+
+### 1. Gaming Vector
+Describe the MINIMAL implementation that PASSES this factor's target
+but a senior engineer would reject. Be concrete — name the shortcut,
+not "could be gamed."
+
+### 2. Coverage Gap
+What does this factor fail to catch that the AC implies should be checked?
+Look for AC items with no corresponding factor, or factor criteria that
+miss an AC dimension.
+
+### 3. Disappear Test
+If this specific AC item disappeared from the task, would this factor
+still be a worthwhile quality check? If yes → the factor may be generic
+filler rather than task-specific.
+
+## Output Format
+
+| Factor | Gaming Vector | Coverage Gap | Disappear Test |
+|--------|---------------|--------------|----------------|
+| {name} | {specific minimal implementation} | {what's missed} | {pass/fail + reason} |
+
+## Summary
+- Factors that need tightening: {list}
+- Missing factors for uncovered AC: {list}
+- Generic factors to reconsider: {list}
+```
+
+## Calibration Simulation (XL only)
+
+Run **parallel** with stress-test. A second subagent imagines three implementations and scores each against evaluated factors.
+
+### Prompt Template
+
+```
+You are calibrating a scoring rubric by testing whether it discriminates
+between good and bad implementations.
+
+## Rubric (evaluated factors only)
+{paste evaluated factors with scoring_guide}
+
+## Your Job
+
+Imagine 3 implementations of this task:
+
+A) TERRIBLE — technically runs, a senior engineer would reject it.
+   Describe in 2-3 sentences what makes it bad.
+
+B) ADEQUATE — meets the bar, nothing special.
+   Describe in 2-3 sentences what it does right.
+
+C) EXCELLENT — a senior engineer would praise this.
+   Describe in 2-3 sentences what makes it stand out.
+
+Now score each implementation against every evaluated factor using
+the scoring_guide anchors (low/mid/high → 1-3/4-6/7-10).
+
+## Output Format
+
+| Factor | Terrible (A) | Adequate (B) | Excellent (C) | Spread |
+|--------|-------------|--------------|---------------|--------|
+| {name} | {score} | {score} | {score} | {C - A} |
+
+## Flags
+- Any factor where Terrible scores > 3: RUBRIC TOO LENIENT
+  → Tighten criteria or lower the "low" anchor
+- Any factor where Excellent scores < 8: RUBRIC TOO STRICT
+  → Relax criteria or raise the "high" anchor
+- Any factor where Spread < 3: NO DISCRIMINATING POWER
+  → Factor cannot distinguish quality levels, rewrite or remove
+```
+
+## Orchestrator Rubric-Patch Protocol
+
+After receiving stress-test (and calibration) results:
+
+1. **Triage**: For each flagged issue, decide: patch rubric, add factor, or accept risk
+2. **Patch**: Apply changes to rubric YAML — tighten criteria, add missing factors, remove generic ones
+3. **Max 1 round**: Do NOT re-run stress-test after patching. Research shows diminishing returns on 2+ rounds (SupervisorAgent: 29.7% token waste in iterative debate). One round catches 80%+ of issues.
+4. **Proceed to dispatch**: Generate dispatch prompt with the patched rubric
+
+### Patch Actions
+
+| Finding | Action |
+|---------|--------|
+| Gaming vector found | Tighten criteria to close the loophole |
+| Coverage gap | Add factor or expand existing criteria |
+| Disappear test fails | Consider removing or merging with another factor |
+| Calibration: too lenient | Lower the "low" anchor, tighten criteria |
+| Calibration: too strict | Raise the "high" anchor, relax edge-case requirements |
+| Calibration: no spread | Rewrite factor with sharper criteria, or convert to automated |
+
+## When to Skip
+
+- **S/M tasks** (1-4 AC): Rubric is simple enough that stress-testing adds overhead without proportional value
+- **Re-dispatches with iteration history**: The rubric was already stress-tested on the first dispatch; re-dispatch focuses on addressing reviewer feedback, not rubric quality
+- **All-automated rubrics**: No evaluated factors to calibrate — stress-test adds nothing
+- **Time-critical hotfixes**: Skip to dispatch immediately; accept rubric risk
+
+## Token Budget
+
+| Size | Overhead | Mechanism |
+|------|----------|-----------|
+| L | ~2-3K tokens | 1 subagent (stress-test) |
+| XL | ~5-6K tokens | 2 subagents parallel (stress-test + calibration) |
+
+Compared to a failed dispatch + re-dispatch cycle (~50-100K tokens), the overhead is negligible for tasks where rubric quality is the primary risk.


### PR DESCRIPTION
## Summary
- Add structured rubric review phase (step 3.5) before dispatch for L/XL tasks (5+ AC items)
- Subagent with fresh context games the rubric — finds gaming vectors, coverage gaps, disappear test failures
- XL tasks (7+ AC) get parallel calibration simulation that tests rubric discriminating power
- Full protocol, prompt templates, and patch actions in `references/rubric-stress-test.md`
- SKILL.md stays at 150 lines by compacting validation checklist and iteration protocol

## Test plan
- [ ] Verify SKILL.md is ≤ 150 lines
- [ ] Verify step 3.5 appears between Validate (step 3) and Generate dispatch (step 4)
- [ ] Verify `references/rubric-stress-test.md` contains all 4 sections: stress-test, calibration, patch protocol, skip conditions
- [ ] Walk through an L-size task (5 AC) and confirm the stress-test flow makes sense
- [ ] Walk through an XL-size task (7+ AC) and confirm parallel stress-test + calibration flow

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* 루브릭 사양이 더욱 명확하고 간결하게 개선되었습니다.
* 대규모 작업(L/XL)을 위한 새로운 루브릭 검토 절차가 추가되었습니다.
* 반복 및 검증 프로세스가 간소화되었습니다.
* 루브릭 품질을 평가하기 위한 스트레스 테스트 절차가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->