### PR TITLE
feat(#95): per-factor score tracking in event journal

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -5,6 +5,8 @@ const {
   getRunsDir,
 } = require("./relay-manifest");
 
+const ALLOWED_ITERATION_STATUSES = new Set(["pass", "fail", "not_run"]);
+
 function normalizeEventValue(value) {
   return value === undefined ? null : value;
 }
@@ -33,6 +35,52 @@ function appendRunEvent(repoRoot, runId, eventData) {
   return record;
 }
 
+function appendIterationScore(repoRoot, runId, { round, scores } = {}) {
+  if (!runId) {
+    throw new Error("run_id is required");
+  }
+  if (!Array.isArray(scores) || scores.length === 0) {
+    throw new Error("scores must be a non-empty array");
+  }
+
+  for (const [index, score] of scores.entries()) {
+    const location = `scores[${index}]`;
+    if (typeof score?.factor !== "string" || !score.factor.trim()) {
+      throw new Error(`${location}.factor is required`);
+    }
+    if (typeof score.target !== "string") {
+      throw new Error(`${location}.target is required`);
+    }
+    if (typeof score.observed !== "string") {
+      throw new Error(`${location}.observed is required`);
+    }
+    if (typeof score.met !== "boolean") {
+      throw new Error(`${location}.met must be boolean`);
+    }
+    if (!ALLOWED_ITERATION_STATUSES.has(score.status)) {
+      throw new Error(`${location}.status must be one of: pass, fail, not_run`);
+    }
+  }
+
+  ensureRunLayout(repoRoot, runId);
+  const record = {
+    ts: new Date().toISOString(),
+    event: "iteration_score",
+    run_id: runId,
+    round,
+    scores: scores.map((score) => ({
+      factor: score.factor,
+      target: score.target,
+      observed: score.observed,
+      met: score.met,
+      status: score.status,
+    })),
+  };
+
+  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  return record;
+}
+
 function readRunEvents(repoRoot, runId) {
   const eventsPath = getEventsPath(repoRoot, runId);
   if (!fs.existsSync(eventsPath)) return [];
@@ -53,6 +101,7 @@ function readAllRunEvents(repoRoot) {
 }
 
 module.exports = {
+  appendIterationScore,
   appendRunEvent,
   readAllRunEvents,
   readRunEvents,

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -1,0 +1,123 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { getEventsPath } = require("./relay-manifest");
+const { appendIterationScore, readRunEvents } = require("./relay-events");
+
+function createContext() {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  return {
+    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-")),
+    runId: "issue-95-20260406000000000",
+  };
+}
+
+function createScore(overrides = {}) {
+  return {
+    factor: "Integration correctness",
+    target: ">= 8/10",
+    observed: "8/10",
+    met: true,
+    status: "pass",
+    ...overrides,
+  };
+}
+
+test("appendIterationScore writes an iteration_score record to events.jsonl", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendIterationScore(repoRoot, runId, {
+    round: 2,
+    scores: [
+      createScore(),
+      createScore({
+        factor: "Factor analysis correctness",
+        observed: "6/10",
+        met: false,
+        status: "fail",
+      }),
+    ],
+  });
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  const lines = fs.readFileSync(eventsPath, "utf-8").trim().split("\n");
+  assert.equal(lines.length, 1);
+
+  const parsed = JSON.parse(lines[0]);
+  assert.deepEqual(parsed, record);
+  assert.deepEqual(readRunEvents(repoRoot, runId), [record]);
+});
+
+test("appendIterationScore requires run_id", () => {
+  const { repoRoot } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, "", {
+    round: 1,
+    scores: [createScore()],
+  }), /run_id is required/);
+});
+
+test("appendIterationScore rejects an empty scores array", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [],
+  }), /scores must be a non-empty array/);
+});
+
+test("appendIterationScore rejects a non-array scores value", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: "bad",
+  }), /scores must be a non-empty array/);
+});
+
+test("appendIterationScore requires factor for each score", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [createScore({ factor: "   " })],
+  }), /scores\[0\]\.factor is required/);
+});
+
+test("appendIterationScore requires target for each score", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [createScore({ target: undefined })],
+  }), /scores\[0\]\.target is required/);
+});
+
+test("appendIterationScore requires observed for each score", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [createScore({ observed: undefined })],
+  }), /scores\[0\]\.observed is required/);
+});
+
+test("appendIterationScore requires met to be boolean", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [createScore({ met: "true" })],
+  }), /scores\[0\]\.met must be boolean/);
+});
+
+test("appendIterationScore requires status for each score", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [createScore({ status: undefined })],
+  }), /scores\[0\]\.status must be one of: pass, fail, not_run/);
+});
+
+test("appendIterationScore rejects invalid status values", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [createScore({ status: "partial" })],
+  }), /scores\[0\]\.status must be one of: pass, fail, not_run/);
+});

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -46,6 +46,94 @@ function median(values) {
   return sorted[middle];
 }
 
+function average(values) {
+  if (!values.length) return null;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return Number((total / values.length).toFixed(4));
+}
+
+function buildFactorAnalysis(events) {
+  const factorsByRun = new Map();
+
+  for (const event of events) {
+    if (event.event !== "iteration_score" || !event.run_id) continue;
+    if (!Array.isArray(event.scores) || event.scores.length === 0) continue;
+
+    const round = Number(event.round);
+    const roundNumber = Number.isFinite(round) ? round : null;
+    if (!factorsByRun.has(event.run_id)) {
+      factorsByRun.set(event.run_id, new Map());
+    }
+
+    const runFactors = factorsByRun.get(event.run_id);
+    for (const score of event.scores) {
+      const factor = typeof score?.factor === "string" ? score.factor.trim() : "";
+      if (!factor) continue;
+
+      if (!runFactors.has(factor)) {
+        runFactors.set(factor, {
+          met: false,
+          firstMetRound: null,
+        });
+      }
+
+      if (score.met === true) {
+        const current = runFactors.get(factor);
+        current.met = true;
+        if (roundNumber !== null && (current.firstMetRound === null || roundNumber < current.firstMetRound)) {
+          current.firstMetRound = roundNumber;
+        }
+      }
+    }
+  }
+
+  const aggregatedFactors = new Map();
+  for (const runFactors of factorsByRun.values()) {
+    for (const [factor, state] of runFactors.entries()) {
+      if (!aggregatedFactors.has(factor)) {
+        aggregatedFactors.set(factor, {
+          appearances: 0,
+          metRuns: 0,
+          roundsToMet: [],
+        });
+      }
+
+      const summary = aggregatedFactors.get(factor);
+      summary.appearances += 1;
+      if (state.met) {
+        summary.metRuns += 1;
+        if (state.firstMetRound !== null) {
+          summary.roundsToMet.push(state.firstMetRound);
+        }
+      }
+    }
+  }
+
+  const factors = {};
+  let mostStuckFactor = null;
+  let lowestMetRate = null;
+
+  for (const factor of [...aggregatedFactors.keys()].sort((a, b) => a.localeCompare(b))) {
+    const summary = aggregatedFactors.get(factor);
+    const metRate = ratio(summary.metRuns, summary.appearances);
+    factors[factor] = {
+      appearances: summary.appearances,
+      met_rate: metRate,
+      avg_rounds_to_met: average(summary.roundsToMet),
+    };
+
+    if (mostStuckFactor === null || metRate < lowestMetRate) {
+      mostStuckFactor = factor;
+      lowestMetRate = metRate;
+    }
+  }
+
+  return {
+    factors,
+    most_stuck_factor: mostStuckFactor,
+  };
+}
+
 function main() {
   const repoRoot = path.resolve(getArg("--repo", "."));
   const staleHours = parseHours(getArg("--stale-hours", "72"));
@@ -109,6 +197,7 @@ function main() {
       median_rounds_to_ready: median(readyRounds),
       stale_open_runs_72h: staleOpenRuns.length,
     },
+    factor_analysis: buildFactorAnalysis(events),
   };
 
   if (hasFlag("--json")) {
@@ -122,6 +211,7 @@ function main() {
   console.log(`  max_rounds_enforcement_rate: ${report.metrics.max_rounds_enforcement_rate ?? "n/a"}`);
   console.log(`  median_rounds_to_ready: ${report.metrics.median_rounds_to_ready ?? "n/a"}`);
   console.log(`  stale_open_runs_72h: ${report.metrics.stale_open_runs_72h}`);
+  console.log(`  most_stuck_factor: ${report.factor_analysis.most_stuck_factor ?? "n/a"}`);
 }
 
 try {

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -12,7 +12,7 @@ const {
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
-const { appendRunEvent } = require("./relay-events");
+const { appendIterationScore, appendRunEvent } = require("./relay-events");
 
 const SCRIPT = path.join(__dirname, "reliability-report.js");
 
@@ -118,4 +118,117 @@ test("reliability-report derives the core scorecard from manifests and events", 
   assert.equal(report.metrics.max_rounds_enforcement_rate, 1);
   assert.equal(report.metrics.median_rounds_to_ready, 3);
   assert.equal(report.metrics.stale_open_runs_72h, 1);
+});
+
+test("reliability-report aggregates factor analysis across runs and rounds", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-factors-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-a",
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 3,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: "run-b",
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: "run-c",
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  appendIterationScore(repoRoot, "run-a", {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "6", met: false, status: "fail" },
+      { factor: "Docs", target: ">= 8", observed: "not started", met: false, status: "not_run" },
+    ],
+  });
+  appendIterationScore(repoRoot, "run-a", {
+    round: 2,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass" },
+      { factor: "Docs", target: ">= 8", observed: "6", met: false, status: "fail" },
+    ],
+  });
+  appendIterationScore(repoRoot, "run-a", {
+    round: 3,
+    scores: [
+      { factor: "Docs", target: ">= 8", observed: "8", met: true, status: "pass" },
+    ],
+  });
+
+  appendIterationScore(repoRoot, "run-b", {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "5", met: false, status: "fail" },
+      { factor: "Docs", target: ">= 8", observed: "4", met: false, status: "fail" },
+      { factor: "Perf", target: ">= 8", observed: "8", met: true, status: "pass" },
+    ],
+  });
+  appendIterationScore(repoRoot, "run-b", {
+    round: 2,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "7", met: false, status: "fail" },
+    ],
+  });
+
+  appendIterationScore(repoRoot, "run-c", {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "9", met: true, status: "pass" },
+    ],
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.factor_analysis, {
+    factors: {
+      Coverage: {
+        appearances: 3,
+        met_rate: 0.6667,
+        avg_rounds_to_met: 1.5,
+      },
+      Docs: {
+        appearances: 2,
+        met_rate: 0.5,
+        avg_rounds_to_met: 3,
+      },
+      Perf: {
+        appearances: 1,
+        met_rate: 1,
+        avg_rounds_to_met: 1,
+      },
+    },
+    most_stuck_factor: "Docs",
+  });
+});
+
+test("reliability-report keeps factor analysis backwards compatible without iteration scores", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-empty-factors-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-ready",
+    state: STATES.READY_TO_MERGE,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.factor_analysis, {
+    factors: {},
+    most_stuck_factor: null,
+  });
 });

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -41,7 +41,10 @@ const {
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
-const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
+const {
+  appendIterationScore,
+  appendRunEvent,
+} = require("../../relay-dispatch/scripts/relay-events");
 
 const REVIEWER_PROMPT_PATH = path.join(__dirname, "..", "references", "reviewer-prompt.md");
 const REVIEW_MARKER = "<!-- relay-review -->";
@@ -925,6 +928,18 @@ function run() {
     round,
     reason: verdict.verdict,
   });
+  if (Array.isArray(verdict.rubric_scores) && verdict.rubric_scores.length > 0) {
+    appendIterationScore(repoPath, data.run_id, {
+      round,
+      scores: verdict.rubric_scores.map((score) => ({
+        factor: score.factor,
+        target: score.target,
+        observed: score.observed,
+        met: score.status === "pass",
+        status: score.status,
+      })),
+    });
+  }
 
   result.nextState = updatedManifest.state;
   result.state = updatedManifest.state;

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -13,6 +13,7 @@ const {
   writeManifest,
   readManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
 
 const SCRIPT = path.join(__dirname, "review-runner.js");
 
@@ -256,6 +257,83 @@ test("changes_requested verdict creates a re-dispatch artifact", () => {
   assert.equal(manifest.review.rounds, 1);
   assert.equal(manifest.review.latest_verdict, "changes_requested");
   assert.equal(manifest.review.repeated_issue_count, 1);
+});
+
+test("review-runner records rubric_scores as iteration_score events", () => {
+  const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewFile = writeVerdict(repoRoot, "changes-with-scores.json", {
+    verdict: "changes_requested",
+    summary: "Coverage and docs still need work.",
+    contract_status: "fail",
+    quality_status: "pass",
+    next_action: "changes_requested",
+    issues: [
+      {
+        title: "Missing smoke file",
+        body: "The PR does not add the required smoke.txt output.",
+        file: "src/index.js",
+        line: 12,
+        category: "contract",
+        severity: "high",
+      },
+    ],
+    rubric_scores: [
+      {
+        factor: "Coverage",
+        target: ">= 8",
+        observed: "6",
+        status: "fail",
+        notes: "Still below bar.",
+      },
+      {
+        factor: "Docs",
+        target: ">= 8",
+        observed: "8",
+        status: "pass",
+        notes: "Docs are complete.",
+      },
+    ],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const events = readRunEvents(repoRoot, runId);
+  assert.equal(events.at(-2).event, "review_apply");
+  assert.equal(events.at(-1).event, "iteration_score");
+  assert.deepEqual(events.at(-1), {
+    ts: events.at(-1).ts,
+    event: "iteration_score",
+    run_id: runId,
+    round: 1,
+    scores: [
+      {
+        factor: "Coverage",
+        target: ">= 8",
+        observed: "6",
+        met: false,
+        status: "fail",
+      },
+      {
+        factor: "Docs",
+        target: ">= 8",
+        observed: "8",
+        met: true,
+        status: "pass",
+      },
+    ],
+  });
+  assert.match(events.at(-1).ts, /\d{4}-\d{2}-\d{2}T/);
 });
 
 test("reviewer-script invocation can drive a round without --review-file", () => {


### PR DESCRIPTION
## Summary

- Add `appendIterationScore()` to relay-events.js with schema validation for per-factor iteration scores
- Integrate with review-runner.js to record `iteration_score` events after each review verdict
- Add `factor_analysis` block to reliability-report.js (met_rate, avg_rounds_to_met, most_stuck_factor)

## Changes

| File | Change |
|------|--------|
| `relay-events.js` | `appendIterationScore` + validation |
| `relay-events.test.js` (new) | Schema validation tests |
| `review-runner.js` | Call appendIterationScore after verdict |
| `review-runner.test.js` (new) | Integration tests |
| `reliability-report.js` | factor_analysis metrics |
| `reliability-report.test.js` | factor_analysis tests |

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 반복별 점수 기록 및 추적 기능 추가
- 요소별 신뢰성 분석으로 성능 병목 지점 파악 지원
- 검수 결과 점수가 보고서에 자동으로 통합

## 테스트
- 새로운 기능에 대한 포괄적인 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->