### PR TITLE
feat(#106): rubric quality events, score divergence & reliability insights

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -6,6 +6,9 @@ const {
 } = require("./relay-manifest");
 
 const ALLOWED_ITERATION_STATUSES = new Set(["pass", "fail", "not_run"]);
+const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
+const ALLOWED_RUBRIC_GRADES = new Set(["A", "B", "C", "D"]);
+const ALLOWED_TASK_SIZES = new Set(["S", "M", "L", "XL"]);
 
 function normalizeEventValue(value) {
   return value === undefined ? null : value;
@@ -74,6 +77,102 @@ function appendIterationScore(repoRoot, runId, { round, scores } = {}) {
       observed: score.observed,
       met: score.met,
       status: score.status,
+      ...(ALLOWED_SCORE_TIERS.has(score.tier) ? { tier: score.tier } : {}),
+    })),
+  };
+
+  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  return record;
+}
+
+function appendRubricQuality(repoRoot, runId, data = {}) {
+  if (!runId) {
+    throw new Error("run_id is required");
+  }
+  if (!ALLOWED_RUBRIC_GRADES.has(data.grade)) {
+    throw new Error("grade must be one of: A, B, C, D");
+  }
+  for (const field of ["prerequisites", "contract_factors", "quality_factors", "substantive_total"]) {
+    if (typeof data[field] !== "number" || Number.isNaN(data[field])) {
+      throw new Error(`${field} must be a number`);
+    }
+  }
+  for (const field of ["quality_ratio", "auto_coverage"]) {
+    if (typeof data[field] !== "number" || Number.isNaN(data[field])) {
+      throw new Error(`${field} must be a number`);
+    }
+  }
+  if (!Array.isArray(data.risk_signals)) {
+    throw new Error("risk_signals must be an array of strings");
+  }
+  data.risk_signals.forEach((signal, index) => {
+    if (typeof signal !== "string") {
+      throw new Error(`risk_signals[${index}] must be a string`);
+    }
+  });
+  if (!ALLOWED_TASK_SIZES.has(data.task_size)) {
+    throw new Error("task_size must be one of: S, M, L, XL");
+  }
+
+  ensureRunLayout(repoRoot, runId);
+  const record = {
+    ts: new Date().toISOString(),
+    event: "rubric_quality",
+    run_id: runId,
+    grade: data.grade,
+    prerequisites: data.prerequisites,
+    contract_factors: data.contract_factors,
+    quality_factors: data.quality_factors,
+    substantive_total: data.substantive_total,
+    quality_ratio: data.quality_ratio,
+    auto_coverage: data.auto_coverage,
+    risk_signals: [...data.risk_signals],
+    task_size: data.task_size,
+  };
+
+  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  return record;
+}
+
+function appendScoreDivergence(repoRoot, runId, { round, divergences } = {}) {
+  if (!runId) {
+    throw new Error("run_id is required");
+  }
+  if (!Array.isArray(divergences) || divergences.length === 0) {
+    throw new Error("divergences must be a non-empty array");
+  }
+
+  divergences.forEach((entry, index) => {
+    const location = `divergences[${index}]`;
+    if (typeof entry?.factor !== "string" || !entry.factor.trim()) {
+      throw new Error(`${location}.factor is required`);
+    }
+    if (typeof entry.executor !== "string") {
+      throw new Error(`${location}.executor must be a string`);
+    }
+    if (typeof entry.reviewer !== "string") {
+      throw new Error(`${location}.reviewer must be a string`);
+    }
+    if (typeof entry.delta !== "number" || Number.isNaN(entry.delta)) {
+      throw new Error(`${location}.delta must be a number`);
+    }
+    if (!ALLOWED_SCORE_TIERS.has(entry.tier)) {
+      throw new Error(`${location}.tier must be one of: contract, quality`);
+    }
+  });
+
+  ensureRunLayout(repoRoot, runId);
+  const record = {
+    ts: new Date().toISOString(),
+    event: "score_divergence",
+    run_id: runId,
+    round,
+    divergences: divergences.map((entry) => ({
+      factor: entry.factor,
+      executor: entry.executor,
+      reviewer: entry.reviewer,
+      delta: entry.delta,
+      tier: entry.tier,
     })),
   };
 
@@ -102,7 +201,9 @@ function readAllRunEvents(repoRoot) {
 
 module.exports = {
   appendIterationScore,
+  appendRubricQuality,
   appendRunEvent,
+  appendScoreDivergence,
   readAllRunEvents,
   readRunEvents,
 };

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -5,7 +5,12 @@ const os = require("os");
 const path = require("path");
 
 const { getEventsPath } = require("./relay-manifest");
-const { appendIterationScore, readRunEvents } = require("./relay-events");
+const {
+  appendIterationScore,
+  appendRubricQuality,
+  appendScoreDivergence,
+  readRunEvents,
+} = require("./relay-events");
 
 function createContext() {
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
@@ -22,6 +27,32 @@ function createScore(overrides = {}) {
     observed: "8/10",
     met: true,
     status: "pass",
+    ...overrides,
+  };
+}
+
+function createRubricQuality(overrides = {}) {
+  return {
+    grade: "A",
+    prerequisites: 2,
+    contract_factors: 2,
+    quality_factors: 1,
+    substantive_total: 3,
+    quality_ratio: 0.3333,
+    auto_coverage: 0.5,
+    risk_signals: ["high_factor_count"],
+    task_size: "M",
+    ...overrides,
+  };
+}
+
+function createDivergence(overrides = {}) {
+  return {
+    factor: "Coverage",
+    executor: "9/10",
+    reviewer: "6/10",
+    delta: 3,
+    tier: "contract",
     ...overrides,
   };
 }
@@ -120,4 +151,92 @@ test("appendIterationScore rejects invalid status values", () => {
     round: 1,
     scores: [createScore({ status: "partial" })],
   }), /scores\[0\]\.status must be one of: pass, fail, not_run/);
+});
+
+test("appendIterationScore persists a valid tier and omits invalid or missing tiers", () => {
+  const { repoRoot, runId } = createContext();
+  appendIterationScore(repoRoot, runId, {
+    round: 1,
+    scores: [
+      createScore({ factor: "Contract", tier: "contract" }),
+      createScore({ factor: "No tier", tier: undefined }),
+      createScore({ factor: "Invalid tier", tier: "unknown" }),
+    ],
+  });
+
+  const [event] = readRunEvents(repoRoot, runId);
+  assert.equal(event.scores[0].tier, "contract");
+  assert.ok(!("tier" in event.scores[1]));
+  assert.ok(!("tier" in event.scores[2]));
+});
+
+test("appendRubricQuality writes a rubric_quality record to events.jsonl", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendRubricQuality(repoRoot, runId, createRubricQuality());
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  const lines = fs.readFileSync(eventsPath, "utf-8").trim().split("\n");
+  assert.equal(lines.length, 1);
+
+  const parsed = JSON.parse(lines[0]);
+  assert.deepEqual(parsed, record);
+  assert.deepEqual(readRunEvents(repoRoot, runId), [record]);
+});
+
+test("appendRubricQuality rejects an invalid grade", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendRubricQuality(repoRoot, runId, createRubricQuality({ grade: "E" })), /grade must be one of: A, B, C, D/);
+});
+
+test("appendRubricQuality rejects non-array risk_signals", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendRubricQuality(repoRoot, runId, createRubricQuality({ risk_signals: "bad" })), /risk_signals must be an array of strings/);
+});
+
+test("appendRubricQuality rejects an invalid task_size", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendRubricQuality(repoRoot, runId, createRubricQuality({ task_size: "XXL" })), /task_size must be one of: S, M, L, XL/);
+});
+
+test("appendScoreDivergence writes a score_divergence record to events.jsonl", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendScoreDivergence(repoRoot, runId, {
+    round: 2,
+    divergences: [
+      createDivergence(),
+      createDivergence({ factor: "Docs", executor: "8", reviewer: "5", delta: 3, tier: "quality" }),
+    ],
+  });
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  const lines = fs.readFileSync(eventsPath, "utf-8").trim().split("\n");
+  assert.equal(lines.length, 1);
+
+  const parsed = JSON.parse(lines[0]);
+  assert.deepEqual(parsed, record);
+  assert.deepEqual(readRunEvents(repoRoot, runId), [record]);
+});
+
+test("appendScoreDivergence rejects an empty divergences array", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendScoreDivergence(repoRoot, runId, {
+    round: 1,
+    divergences: [],
+  }), /divergences must be a non-empty array/);
+});
+
+test("appendScoreDivergence rejects an invalid tier", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendScoreDivergence(repoRoot, runId, {
+    round: 1,
+    divergences: [createDivergence({ tier: "hygiene" })],
+  }), /divergences\[0\]\.tier must be one of: contract, quality/);
+});
+
+test("appendScoreDivergence rejects a missing factor", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(() => appendScoreDivergence(repoRoot, runId, {
+    round: 1,
+    divergences: [createDivergence({ factor: "   " })],
+  }), /divergences\[0\]\.factor is required/);
 });

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -52,6 +52,235 @@ function average(values) {
   return Number((total / values.length).toFixed(4));
 }
 
+function buildEmptyRubricInsights() {
+  return {
+    quality_grade_distribution: null,
+    avg_quality_ratio: null,
+    tier_effectiveness: null,
+    divergence_hotspots: null,
+    auto_vs_eval_correlation: null,
+  };
+}
+
+function normalizeAutoCoverageRatio(event) {
+  const autoCoverage = Number(event?.auto_coverage);
+  if (!Number.isFinite(autoCoverage)) return null;
+  if (autoCoverage >= 0 && autoCoverage <= 1) {
+    return autoCoverage;
+  }
+
+  const totalChecks = Number(event?.prerequisites || 0)
+    + Number(event?.contract_factors || 0)
+    + Number(event?.quality_factors || 0);
+  if (!Number.isFinite(totalChecks) || totalChecks <= 0) {
+    return null;
+  }
+  return Number((autoCoverage / totalChecks).toFixed(4));
+}
+
+function buildTierEffectiveness(events) {
+  const runFactors = new Map();
+
+  for (const event of events) {
+    if (event.event !== "iteration_score" || !event.run_id || !Array.isArray(event.scores)) continue;
+    const round = Number(event.round);
+    const roundNumber = Number.isFinite(round) ? round : null;
+
+    if (!runFactors.has(event.run_id)) {
+      runFactors.set(event.run_id, new Map());
+    }
+
+    const factorsForRun = runFactors.get(event.run_id);
+    for (const score of event.scores) {
+      const tier = typeof score?.tier === "string" ? score.tier : null;
+      const factor = typeof score?.factor === "string" ? score.factor.trim() : "";
+      if (!factor || (tier !== "contract" && tier !== "quality")) continue;
+
+      const key = `${tier}\u0000${factor}`;
+      if (!factorsForRun.has(key)) {
+        factorsForRun.set(key, {
+          tier,
+          met: false,
+          firstMetRound: null,
+        });
+      }
+
+      if (score.met === true) {
+        const current = factorsForRun.get(key);
+        current.met = true;
+        if (roundNumber !== null && (current.firstMetRound === null || roundNumber < current.firstMetRound)) {
+          current.firstMetRound = roundNumber;
+        }
+      }
+    }
+  }
+
+  const aggregate = {
+    contract: { appearances: 0, metRuns: 0, roundsToMet: [] },
+    quality: { appearances: 0, metRuns: 0, roundsToMet: [] },
+  };
+
+  for (const factorsForRun of runFactors.values()) {
+    for (const state of factorsForRun.values()) {
+      aggregate[state.tier].appearances += 1;
+      if (state.met) {
+        aggregate[state.tier].metRuns += 1;
+        if (state.firstMetRound !== null) {
+          aggregate[state.tier].roundsToMet.push(state.firstMetRound);
+        }
+      }
+    }
+  }
+
+  if (aggregate.contract.appearances === 0 && aggregate.quality.appearances === 0) {
+    return null;
+  }
+
+  return {
+    contract: {
+      avg_met_rate: ratio(aggregate.contract.metRuns, aggregate.contract.appearances),
+      avg_rounds_to_met: average(aggregate.contract.roundsToMet),
+    },
+    quality: {
+      avg_met_rate: ratio(aggregate.quality.metRuns, aggregate.quality.appearances),
+      avg_rounds_to_met: average(aggregate.quality.roundsToMet),
+    },
+  };
+}
+
+function buildDivergenceHotspots(events) {
+  const divergenceEvents = events.filter((event) => event.event === "score_divergence" && Array.isArray(event.divergences));
+  if (divergenceEvents.length === 0) return null;
+
+  const grouped = new Map();
+  for (const event of divergenceEvents) {
+    for (const entry of event.divergences) {
+      const factor = typeof entry?.factor === "string" ? entry.factor.trim() : "";
+      const delta = Number(entry?.delta);
+      if (!factor || !Number.isFinite(delta)) continue;
+
+      if (!grouped.has(factor)) {
+        grouped.set(factor, {
+          occurrences: 0,
+          deltas: [],
+        });
+      }
+      const current = grouped.get(factor);
+      current.occurrences += 1;
+      current.deltas.push(delta);
+    }
+  }
+
+  if (grouped.size === 0) return null;
+
+  return [...grouped.entries()]
+    .map(([factorPattern, summary]) => {
+      const avgDelta = average(summary.deltas);
+      let recommendation = "Review scoring examples for this factor.";
+      if (avgDelta !== null && avgDelta >= 0.5) {
+        recommendation = "Executor scores trend higher than review; tighten examples or add automation.";
+      } else if (avgDelta !== null && avgDelta <= -0.5) {
+        recommendation = "Reviewer scores trend higher than executor; check whether the factor is underspecified.";
+      }
+
+      return {
+        factor_pattern: factorPattern,
+        occurrences: summary.occurrences,
+        avg_delta: avgDelta,
+        recommendation,
+      };
+    })
+    .sort((left, right) => (
+      right.occurrences - left.occurrences
+      || Math.abs(right.avg_delta || 0) - Math.abs(left.avg_delta || 0)
+      || left.factor_pattern.localeCompare(right.factor_pattern)
+    ));
+}
+
+function buildAutoVsEvalCorrelation(rubricQualityEvents, manifests) {
+  const manifestsByRun = new Map(
+    manifests
+      .filter((manifest) => manifest?.data?.run_id)
+      .map((manifest) => [manifest.data.run_id, manifest.data])
+  );
+
+  const latestQualityByRun = new Map();
+  for (const event of rubricQualityEvents) {
+    if (event?.run_id) {
+      latestQualityByRun.set(event.run_id, event);
+    }
+  }
+
+  const buckets = {
+    high_auto_runs: [],
+    low_auto_runs: [],
+  };
+
+  for (const [runId, event] of latestQualityByRun.entries()) {
+    const manifest = manifestsByRun.get(runId);
+    if (!manifest) continue;
+
+    const coverageRatio = normalizeAutoCoverageRatio(event);
+    if (coverageRatio === null) continue;
+
+    const bucketName = coverageRatio >= 0.5 ? "high_auto_runs" : "low_auto_runs";
+    buckets[bucketName].push({
+      rounds: Number(manifest.review?.rounds),
+      success: [STATES.READY_TO_MERGE, STATES.MERGED].includes(manifest.state),
+    });
+  }
+
+  if (buckets.high_auto_runs.length === 0 && buckets.low_auto_runs.length === 0) {
+    return null;
+  }
+
+  function summarizeBucket(entries) {
+    const rounds = entries
+      .map((entry) => entry.rounds)
+      .filter((value) => Number.isFinite(value) && value >= 0);
+    return {
+      avg_rounds: average(rounds),
+      success_rate: ratio(entries.filter((entry) => entry.success).length, entries.length),
+    };
+  }
+
+  return {
+    high_auto_runs: summarizeBucket(buckets.high_auto_runs),
+    low_auto_runs: summarizeBucket(buckets.low_auto_runs),
+  };
+}
+
+function buildRubricInsights(events, manifests) {
+  const insights = buildEmptyRubricInsights();
+  const rubricQualityEvents = events.filter((event) => event.event === "rubric_quality");
+
+  if (rubricQualityEvents.length > 0) {
+    insights.quality_grade_distribution = { A: 0, B: 0, C: 0, D: 0 };
+    const qualityRatios = [];
+
+    for (const event of rubricQualityEvents) {
+      if (Object.hasOwn(insights.quality_grade_distribution, event.grade)) {
+        insights.quality_grade_distribution[event.grade] += 1;
+      }
+      if (typeof event.quality_ratio === "number" && !Number.isNaN(event.quality_ratio)) {
+        qualityRatios.push(event.quality_ratio);
+      }
+    }
+
+    insights.avg_quality_ratio = average(qualityRatios);
+  }
+
+  insights.tier_effectiveness = buildTierEffectiveness(events);
+  insights.divergence_hotspots = buildDivergenceHotspots(events);
+  insights.auto_vs_eval_correlation = buildAutoVsEvalCorrelation(rubricQualityEvents, manifests);
+
+  return insights;
+}
+
+function hasRubricInsights(insights) {
+  return Object.values(insights || {}).some((value) => value !== null);
+}
+
 function buildFactorAnalysis(events) {
   const factorsByRun = new Map();
 
@@ -198,6 +427,7 @@ function main() {
       stale_open_runs_72h: staleOpenRuns.length,
     },
     factor_analysis: buildFactorAnalysis(events),
+    rubric_insights: buildRubricInsights(events, manifests),
   };
 
   if (hasFlag("--json")) {
@@ -212,6 +442,16 @@ function main() {
   console.log(`  median_rounds_to_ready: ${report.metrics.median_rounds_to_ready ?? "n/a"}`);
   console.log(`  stale_open_runs_72h: ${report.metrics.stale_open_runs_72h}`);
   console.log(`  most_stuck_factor: ${report.factor_analysis.most_stuck_factor ?? "n/a"}`);
+  if (hasRubricInsights(report.rubric_insights)) {
+    const gradeDistribution = report.rubric_insights.quality_grade_distribution;
+    const gradeText = gradeDistribution
+      ? `A:${gradeDistribution.A} B:${gradeDistribution.B} C:${gradeDistribution.C} D:${gradeDistribution.D}`
+      : "n/a";
+    const topHotspot = report.rubric_insights.divergence_hotspots?.[0];
+    console.log(`  rubric_grades: ${gradeText}`);
+    console.log(`  avg_quality_ratio: ${report.rubric_insights.avg_quality_ratio ?? "n/a"}`);
+    console.log(`  top_divergence_hotspot: ${topHotspot ? `${topHotspot.factor_pattern} (${topHotspot.avg_delta})` : "n/a"}`);
+  }
 }
 
 try {

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -12,7 +12,12 @@ const {
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
-const { appendIterationScore, appendRunEvent } = require("./relay-events");
+const {
+  appendIterationScore,
+  appendRubricQuality,
+  appendRunEvent,
+  appendScoreDivergence,
+} = require("./relay-events");
 
 const SCRIPT = path.join(__dirname, "reliability-report.js");
 
@@ -230,5 +235,234 @@ test("reliability-report keeps factor analysis backwards compatible without iter
   assert.deepEqual(report.factor_analysis, {
     factors: {},
     most_stuck_factor: null,
+  });
+});
+
+test("reliability-report keeps rubric_insights null-safe when new events are absent", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-empty-insights-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-ready",
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.rubric_insights, {
+    quality_grade_distribution: null,
+    avg_quality_ratio: null,
+    tier_effectiveness: null,
+    divergence_hotspots: null,
+    auto_vs_eval_correlation: null,
+  });
+});
+
+test("reliability-report derives rubric grade distribution and average quality ratio", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-rubric-quality-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-a",
+    state: STATES.READY_TO_MERGE,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: "run-b",
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 3,
+    updatedAt: recentTs,
+  });
+
+  appendRubricQuality(repoRoot, "run-a", {
+    grade: "A",
+    prerequisites: 2,
+    contract_factors: 2,
+    quality_factors: 2,
+    substantive_total: 4,
+    quality_ratio: 0.5,
+    auto_coverage: 0.75,
+    risk_signals: [],
+    task_size: "M",
+  });
+  appendRubricQuality(repoRoot, "run-b", {
+    grade: "C",
+    prerequisites: 2,
+    contract_factors: 2,
+    quality_factors: 1,
+    substantive_total: 3,
+    quality_ratio: 0.3333,
+    auto_coverage: 0.25,
+    risk_signals: ["low_quality_ratio"],
+    task_size: "M",
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.rubric_insights.quality_grade_distribution, {
+    A: 1,
+    B: 0,
+    C: 1,
+    D: 0,
+  });
+  assert.equal(report.rubric_insights.avg_quality_ratio, 0.4166);
+  assert.deepEqual(report.rubric_insights.auto_vs_eval_correlation, {
+    high_auto_runs: {
+      avg_rounds: 2,
+      success_rate: 1,
+    },
+    low_auto_runs: {
+      avg_rounds: 3,
+      success_rate: 0,
+    },
+  });
+});
+
+test("reliability-report derives tier effectiveness from tiered iteration scores", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-tier-effectiveness-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-a",
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: "run-b",
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  appendIterationScore(repoRoot, "run-a", {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "5", met: false, status: "fail", tier: "contract" },
+      { factor: "Docs", target: ">= 8", observed: "8", met: true, status: "pass", tier: "quality" },
+    ],
+  });
+  appendIterationScore(repoRoot, "run-a", {
+    round: 2,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass", tier: "contract" },
+    ],
+  });
+  appendIterationScore(repoRoot, "run-b", {
+    round: 1,
+    scores: [
+      { factor: "Latency", target: "< 200ms", observed: "180ms", met: true, status: "pass", tier: "contract" },
+      { factor: "Architecture", target: ">= 8", observed: "6", met: false, status: "fail", tier: "quality" },
+    ],
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.rubric_insights.tier_effectiveness, {
+    contract: {
+      avg_met_rate: 1,
+      avg_rounds_to_met: 1.5,
+    },
+    quality: {
+      avg_met_rate: 0.5,
+      avg_rounds_to_met: 1,
+    },
+  });
+});
+
+test("reliability-report derives divergence hotspots from score_divergence events", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-divergence-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-a",
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+
+  appendScoreDivergence(repoRoot, "run-a", {
+    round: 1,
+    divergences: [
+      { factor: "Coverage", executor: "9", reviewer: "6", delta: 3, tier: "contract" },
+      { factor: "Coverage", executor: "8", reviewer: "6", delta: 2, tier: "contract" },
+      { factor: "Docs", executor: "5", reviewer: "7", delta: -2, tier: "quality" },
+    ],
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.rubric_insights.divergence_hotspots, [
+    {
+      factor_pattern: "Coverage",
+      occurrences: 2,
+      avg_delta: 2.5,
+      recommendation: "Executor scores trend higher than review; tighten examples or add automation.",
+    },
+    {
+      factor_pattern: "Docs",
+      occurrences: 1,
+      avg_delta: -2,
+      recommendation: "Reviewer scores trend higher than executor; check whether the factor is underspecified.",
+    },
+  ]);
+});
+
+test("reliability-report populates only available rubric insight subfields", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-partial-insights-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  writeRun(repoRoot, {
+    runId: "run-a",
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  appendRubricQuality(repoRoot, "run-a", {
+    grade: "B",
+    prerequisites: 1,
+    contract_factors: 1,
+    quality_factors: 1,
+    substantive_total: 2,
+    quality_ratio: 0.5,
+    auto_coverage: 1,
+    risk_signals: [],
+    task_size: "S",
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.rubric_insights.quality_grade_distribution, {
+    A: 0,
+    B: 1,
+    C: 0,
+    D: 0,
+  });
+  assert.equal(report.rubric_insights.avg_quality_ratio, 0.5);
+  assert.equal(report.rubric_insights.tier_effectiveness, null);
+  assert.equal(report.rubric_insights.divergence_hotspots, null);
+  assert.deepEqual(report.rubric_insights.auto_vs_eval_correlation, {
+    high_auto_runs: {
+      avg_rounds: 1,
+      success_rate: 1,
+    },
+    low_auto_runs: {
+      avg_rounds: null,
+      success_rate: null,
+    },
   });
 });

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -44,6 +44,7 @@ const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-re
 const {
   appendIterationScore,
   appendRunEvent,
+  appendScoreDivergence,
 } = require("../../relay-dispatch/scripts/relay-events");
 
 const REVIEWER_PROMPT_PATH = path.join(__dirname, "..", "references", "reviewer-prompt.md");
@@ -52,6 +53,7 @@ const REVIEW_ROUND_MARKER = "<!-- relay-review-round -->";
 const ALLOWED_VERDICTS = new Set(["pass", "changes_requested", "escalated"]);
 const ALLOWED_NEXT_ACTIONS = new Set(["ready_to_merge", "changes_requested", "escalated"]);
 const ALLOWED_STATUSES = new Set(["pass", "fail", "not_run"]);
+const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
@@ -299,6 +301,9 @@ function validateRubricScore(score, index) {
   if (!ALLOWED_STATUSES.has(score.status)) {
     throw new Error(`${location}.status must be one of: ${Array.from(ALLOWED_STATUSES).join(", ")}`);
   }
+  if (score.tier !== undefined && !ALLOWED_SCORE_TIERS.has(score.tier)) {
+    throw new Error(`${location}.tier must be one of: ${Array.from(ALLOWED_SCORE_TIERS).join(", ")}`);
+  }
 }
 
 const ALLOWED_DRIFT_STATUSES = new Set(
@@ -398,9 +403,19 @@ function formatIssueList(issues) {
   return issues.map((issue) => `- ${issue.file}:${issue.line} — ${issue.title}: ${issue.body}`).join("\n");
 }
 
-function buildCommentBody(verdict, round) {
+function appendCommentWarnings(commentBody, warnings = []) {
+  if (!Array.isArray(warnings) || warnings.length === 0) return commentBody;
+  return [
+    commentBody,
+    "",
+    "Score divergence warnings:",
+    ...warnings.map((warning) => `- ${warning}`),
+  ].join("\n");
+}
+
+function buildCommentBody(verdict, round, { warnings = [] } = {}) {
   if (verdict.verdict === "pass") {
-    return [
+    return appendCommentWarnings([
       REVIEW_MARKER,
       "## Relay Review",
       "Verdict: LGTM",
@@ -408,21 +423,21 @@ function buildCommentBody(verdict, round) {
       `Contract: ${verdict.contract_status.toUpperCase()}`,
       `Quality: ${verdict.quality_status.toUpperCase()}`,
       `Rounds: ${round}`,
-    ].join("\n");
+    ].join("\n"), warnings);
   }
 
   if (verdict.verdict === "changes_requested") {
-    return [
+    return appendCommentWarnings([
       REVIEW_ROUND_MARKER,
       `## Relay Review Round ${round}`,
       "Verdict: CHANGES_REQUESTED",
       `Summary: ${verdict.summary}`,
       "Issues:",
       formatIssueList(verdict.issues),
-    ].join("\n");
+    ].join("\n"), warnings);
   }
 
-  return [
+  return appendCommentWarnings([
     REVIEW_MARKER,
     "## Relay Review",
     "Verdict: ESCALATED",
@@ -430,7 +445,145 @@ function buildCommentBody(verdict, round) {
     `Rounds: ${round}`,
     "Issues:",
     formatIssueList(verdict.issues),
-  ].join("\n");
+  ].join("\n"), warnings);
+}
+
+function splitMarkdownTableRow(line) {
+  const trimmed = String(line || "").trim();
+  if (!trimmed.startsWith("|")) return null;
+  const content = trimmed.endsWith("|") ? trimmed.slice(1, -1) : trimmed.slice(1);
+  return content.split("|").map((cell) => cell.trim());
+}
+
+function isMarkdownTableDivider(line) {
+  const cells = splitMarkdownTableRow(line);
+  return Array.isArray(cells) && cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.replace(/\s+/g, "")));
+}
+
+function isMissingScoreCell(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return !normalized || normalized === "—" || normalized === "–" || normalized === "-" || normalized === "n/a" || normalized === "na";
+}
+
+function parseScoreLog(markdownText) {
+  if (typeof markdownText !== "string" || !markdownText.trim()) {
+    return [];
+  }
+
+  const lines = markdownText.replace(/\r\n/g, "\n").split("\n");
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const headerCells = splitMarkdownTableRow(lines[index]);
+    if (!headerCells || headerCells.length < 2 || !isMarkdownTableDivider(lines[index + 1])) {
+      continue;
+    }
+
+    const normalizedHeaders = headerCells.map((cell) => cell.toLowerCase());
+    const factorIndex = normalizedHeaders.indexOf("factor");
+    const statusIndex = normalizedHeaders.indexOf("status");
+    const finalIndex = normalizedHeaders.indexOf("final");
+    const iterIndexes = normalizedHeaders
+      .map((cell, cellIndex) => (/^iter\s+\d+$/i.test(cell) ? cellIndex : -1))
+      .filter((cellIndex) => cellIndex !== -1);
+    if (factorIndex === -1 || statusIndex === -1 || (finalIndex === -1 && iterIndexes.length === 0)) {
+      continue;
+    }
+
+    const parsedRows = [];
+    for (let rowIndex = index + 2; rowIndex < lines.length; rowIndex += 1) {
+      const rowCells = splitMarkdownTableRow(lines[rowIndex]);
+      if (!rowCells) break;
+
+      const factor = String(rowCells[factorIndex] || "").trim();
+      if (!factor) continue;
+
+      let score = finalIndex !== -1 ? String(rowCells[finalIndex] || "").trim() : "";
+      if (isMissingScoreCell(score)) {
+        const fallbackIndex = [...iterIndexes]
+          .reverse()
+          .find((candidateIndex) => !isMissingScoreCell(rowCells[candidateIndex]));
+        score = fallbackIndex === undefined ? "" : String(rowCells[fallbackIndex] || "").trim();
+      }
+      if (isMissingScoreCell(score)) {
+        continue;
+      }
+      parsedRows.push({ factor, score });
+    }
+
+    if (parsedRows.length > 0) {
+      return parsedRows;
+    }
+  }
+
+  return [];
+}
+
+function normalizeFactorKey(value) {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function parseNumericScore(value) {
+  const text = String(value || "").trim();
+  if (isMissingScoreCell(text)) return null;
+  const match = text.match(/^(-?\d+(?:\.\d+)?)(?:\s*\/\s*10(?:\.0+)?)?$/);
+  if (!match) return null;
+  return Number(match[1]);
+}
+
+function loadPrBody(repoPath, prNumber) {
+  if (!prNumber) return "";
+  try {
+    const raw = gh(repoPath, "pr", "view", String(prNumber), "--json", "body");
+    return String(JSON.parse(raw).body || "");
+  } catch {
+    return "";
+  }
+}
+
+function formatDelta(delta) {
+  return `${delta > 0 ? "+" : ""}${delta}`;
+}
+
+function buildScoreDivergenceAnalysis(markdownText, rubricScores) {
+  if (!Array.isArray(rubricScores) || rubricScores.length === 0) {
+    return { warnings: [], eventPayload: [] };
+  }
+
+  const scoreLog = parseScoreLog(markdownText);
+  if (scoreLog.length === 0) {
+    return { warnings: [], eventPayload: [] };
+  }
+
+  const executorScores = new Map(scoreLog.map((entry) => [normalizeFactorKey(entry.factor), entry.score]));
+  const numericMatches = [];
+  for (const score of rubricScores) {
+    const factorKey = normalizeFactorKey(score.factor);
+    const executor = executorScores.get(factorKey);
+    if (!executor) continue;
+
+    const executorNumeric = parseNumericScore(executor);
+    const reviewerNumeric = parseNumericScore(score.observed);
+    if (executorNumeric === null || reviewerNumeric === null) continue;
+
+    const delta = Number((executorNumeric - reviewerNumeric).toFixed(4));
+    numericMatches.push({
+      factor: score.factor,
+      executor,
+      reviewer: score.observed,
+      delta,
+      tier: ALLOWED_SCORE_TIERS.has(score.tier) ? score.tier : null,
+    });
+  }
+
+  if (numericMatches.length === 0) {
+    return { warnings: [], eventPayload: [] };
+  }
+
+  return {
+    warnings: numericMatches
+      .filter((entry) => Math.abs(entry.delta) >= 3)
+      .map((entry) => `${entry.factor}: executor ${entry.executor}, reviewer ${entry.reviewer} (${formatDelta(entry.delta)})`),
+    eventPayload: numericMatches.filter((entry) => entry.tier !== null),
+  };
 }
 
 function formatPriorVerdictSummary(verdicts) {
@@ -905,7 +1058,11 @@ function run() {
     writeText(redispatchPath, `${buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth)}\n`);
   }
 
-  const commentBody = buildCommentBody(verdict, round);
+  const { warnings: divergenceWarnings, eventPayload: divergencePayload } = buildScoreDivergenceAnalysis(
+    loadPrBody(repoPath, prNumber),
+    verdict.rubric_scores
+  );
+  const commentBody = buildCommentBody(verdict, round, { warnings: divergenceWarnings });
   if (!noComment) {
     postComment(repoPath, prNumber, commentBody);
     result.commentPosted = true;
@@ -937,7 +1094,14 @@ function run() {
         observed: score.observed,
         met: score.status === "pass",
         status: score.status,
+        ...(ALLOWED_SCORE_TIERS.has(score.tier) ? { tier: score.tier } : {}),
       })),
+    });
+  }
+  if (divergencePayload.length > 0) {
+    appendScoreDivergence(repoPath, data.run_id, {
+      round,
+      divergences: divergencePayload,
     });
   }
 
@@ -978,6 +1142,7 @@ module.exports = {
   formatIssueList,
   formatPriorVerdictSummary,
   formatScopeDrift,
+  parseScoreLog,
   parseReviewVerdict,
   resolveIssueNumber,
   validateReviewVerdict,

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -110,6 +110,39 @@ process.stdout.write(${JSON.stringify(JSON.stringify(verdict))});
   return filePath;
 }
 
+function runReviewRunnerModule(lines) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-module-"));
+  const helperPath = path.join(tmpDir, "helper.js");
+  fs.writeFileSync(helperPath, [
+    `process.argv = ["node", "helper.js", "--repo", "/dev/null", "--branch", "x", "--pr", "1"];`,
+    `const reviewRunner = require(${JSON.stringify(SCRIPT)});`,
+    ...lines,
+  ].join("\n"), "utf-8");
+  return execFileSync("node", [helperPath], { encoding: "utf-8" });
+}
+
+function writeFakeGhScript(repoRoot, { prBody, capturePath }) {
+  const filePath = path.join(repoRoot, "gh");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({ body: ${JSON.stringify(prBody)} }));
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "comment") {
+  const bodyIndex = args.indexOf("--body");
+  const body = bodyIndex !== -1 ? args[bodyIndex + 1] : "";
+  fs.writeFileSync(${JSON.stringify(capturePath)}, body, "utf-8");
+  process.exit(0);
+}
+process.stderr.write("Unsupported gh invocation: " + args.join(" "));
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
 test("prepare-only writes a prompt bundle without changing manifest state", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 
@@ -334,6 +367,101 @@ test("review-runner records rubric_scores as iteration_score events", () => {
     ],
   });
   assert.match(events.at(-1).ts, /\d{4}-\d{2}-\d{2}T/);
+});
+
+test("review-runner records score divergence and appends warning text to the PR comment", () => {
+  const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const commentCapturePath = path.join(repoRoot, "captured-comment.txt");
+  writeFakeGhScript(repoRoot, {
+    capturePath: commentCapturePath,
+    prBody: [
+      "## Score Log",
+      "",
+      "| Factor | Target | Baseline | Iter 1 | Final | Status |",
+      "|--------|--------|----------|--------|-------|--------|",
+      "| Coverage | >= 8 | — | 9 | 9 | locked |",
+      "| Docs & Notes? | >= 8 | — | 8 | — | locked |",
+      "| Placeholder | >= 8 | — | n/a | — | — |",
+    ].join("\n"),
+  });
+  const reviewFile = writeVerdict(repoRoot, "changes-with-divergence.json", {
+    verdict: "changes_requested",
+    summary: "Scores disagree on implementation quality.",
+    contract_status: "fail",
+    quality_status: "fail",
+    next_action: "changes_requested",
+    issues: [
+      {
+        title: "Missing smoke file",
+        body: "The PR does not add the required smoke.txt output.",
+        file: "src/index.js",
+        line: 12,
+        category: "contract",
+        severity: "high",
+      },
+    ],
+    rubric_scores: [
+      {
+        factor: "Coverage",
+        target: ">= 8",
+        observed: "6",
+        status: "fail",
+        notes: "Still below bar.",
+        tier: "contract",
+      },
+      {
+        factor: "Docs & Notes?",
+        target: ">= 8",
+        observed: "7",
+        status: "fail",
+        notes: "Clarity still needs work.",
+        tier: "quality",
+      },
+    ],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${repoRoot}:${process.env.PATH}`,
+    },
+  });
+
+  const events = readRunEvents(repoRoot, runId);
+  assert.equal(events.at(-2).event, "iteration_score");
+  assert.equal(events.at(-1).event, "score_divergence");
+  assert.deepEqual(events.at(-1).divergences, [
+    {
+      factor: "Coverage",
+      executor: "9",
+      reviewer: "6",
+      delta: 3,
+      tier: "contract",
+    },
+    {
+      factor: "Docs & Notes?",
+      executor: "8",
+      reviewer: "7",
+      delta: 1,
+      tier: "quality",
+    },
+  ]);
+
+  const commentBody = fs.readFileSync(commentCapturePath, "utf-8");
+  assert.match(commentBody, /Score divergence warnings:/);
+  assert.match(commentBody, /Coverage: executor 9, reviewer 6 \(\+3\)/);
+  assert.doesNotMatch(commentBody, /Docs & Notes\?: executor 8, reviewer 7/);
 });
 
 test("reviewer-script invocation can drive a round without --review-file", () => {
@@ -767,6 +895,43 @@ test("formatPriorVerdictSummary produces correct round numbers and rubric summar
   assert.match(out.result, /- Round 2: changes_requested — Missing tests \[1 issue\(s\), Coverage: 5 \(target >= 8, fail\)\]/);
   assert.match(out.result, /- Round 1: changes_requested — No auth guard \[2 issue\(s\), no rubric scores\]/);
   assert.equal(out.empty, "");
+});
+
+test("parseScoreLog extracts final scores and falls back to the last populated iteration", () => {
+  const markdown = [
+    "# PR",
+    "",
+    "## Score Log",
+    "",
+    "| Factor | Target | Baseline | Iter 1 | Iter 2 | Final | Status |",
+    "|--------|--------|----------|--------|--------|-------|--------|",
+    "| Coverage | >= 8 | — | 6 | 9 | 9 | locked |",
+    "| Docs & Notes? | >= 8 | — | 6 | 7 | — | locked |",
+    "| Placeholder | >= 8 | — | n/a | — | — | — |",
+  ].join("\n");
+
+  const out = JSON.parse(runReviewRunnerModule([
+    `const result = reviewRunner.parseScoreLog(${JSON.stringify(markdown)});`,
+    `process.stdout.write(JSON.stringify(result));`,
+  ]));
+
+  assert.deepEqual(out, [
+    { factor: "Coverage", score: "9" },
+    { factor: "Docs & Notes?", score: "7" },
+  ]);
+});
+
+test("parseScoreLog returns [] for missing or malformed tables", () => {
+  const out = JSON.parse(runReviewRunnerModule([
+    `const missing = reviewRunner.parseScoreLog("No score log here");`,
+    `const malformed = reviewRunner.parseScoreLog("| Factor | Final |\\n| bad | row |");`,
+    `process.stdout.write(JSON.stringify({ missing, malformed }));`,
+  ]));
+
+  assert.deepEqual(out, {
+    missing: [],
+    malformed: [],
+  });
 });
 
 test("round 2 review prompt contains Prior Round Context section", () => {

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -58,6 +58,10 @@ const REVIEW_VERDICT_JSON_SCHEMA = {
           factor: { type: "string", minLength: 1 },
           target: { type: "string", minLength: 1 },
           observed: { type: "string", minLength: 1 },
+          tier: {
+            type: "string",
+            enum: ["contract", "quality"],
+          },
           status: {
             type: "string",
             enum: ["pass", "fail", "not_run"],


### PR DESCRIPTION
## Summary
- Add `appendRubricQuality` and `appendScoreDivergence` event functions to relay-events.js
- Add optional `tier` field to `iteration_score` events (backwards compatible)
- Add Score Log parser and divergence recording to review-runner.js
- Add `rubric_insights` block to reliability-report.js (grade distribution, tier effectiveness, divergence hotspots)
- Comprehensive test coverage for all new functions

Closes #106

## Score Log

| Factor | Target | Iter 1 | Final | Status |
|--------|--------|--------|-------|--------|
| rubric_quality event function | PASS | PASS | PASS | locked |
| score_divergence event function | PASS | PASS | PASS | locked |
| iteration_score tier field | PASS | PASS | PASS | locked |
| rubric_insights in report | PASS | PASS | PASS | locked |
| Score divergence implementation | >= 8/10 | 8 | 8 | locked |
| Backwards compat & test coverage | >= 8/10 | 8 | 8 | locked |

## Test plan
- [ ] `node --test skills/relay-dispatch/scripts/*.test.js` passes
- [ ] `node --test skills/relay-review/scripts/*.test.js` passes
- [ ] No `execSync` usage — all `execFileSync`
- [ ] Backwards compatible with existing events.jsonl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 루브릭 품질 및 점수 편차 추적 기능 추가
  * 신뢰성 리포트에 루브릭 인사이트 추가 (등급 분포, 점수 유효성, 편차 핫스팟)
  * PR 검토 시 점수 편차 경고 메시지 표시

* **개선 사항**
  * 루브릭 점수 검증 강화 (등급, 계층, 작업 규모 유효성 검사)
  * 점수 계층(contract/quality) 태그 지원

* **스키마 업데이트**
  * 루브릭 점수에 계층 필드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->