### PR TITLE
feat: add actor identity to manifest and event journal

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const {
   ensureRunLayout,
   getEventsPath,
+  getActorName,
   getRunsDir,
 } = require("./relay-manifest");
 
@@ -26,6 +27,7 @@ function appendRunEvent(repoRoot, runId, eventData) {
   const record = {
     ts: eventData.ts || new Date().toISOString(),
     event: eventData.event,
+    actor: getActorName(repoRoot),
     run_id: runId,
     state_from: normalizeEventValue(eventData.state_from),
     state_to: normalizeEventValue(eventData.state_to),
@@ -69,6 +71,7 @@ function appendIterationScore(repoRoot, runId, { round, scores } = {}) {
   const record = {
     ts: new Date().toISOString(),
     event: "iteration_score",
+    actor: getActorName(repoRoot),
     run_id: runId,
     round,
     scores: scores.map((score) => ({
@@ -118,6 +121,7 @@ function appendRubricQuality(repoRoot, runId, data = {}) {
   const record = {
     ts: new Date().toISOString(),
     event: "rubric_quality",
+    actor: getActorName(repoRoot),
     run_id: runId,
     grade: data.grade,
     prerequisites: data.prerequisites,
@@ -165,6 +169,7 @@ function appendScoreDivergence(repoRoot, runId, { round, divergences } = {}) {
   const record = {
     ts: new Date().toISOString(),
     event: "score_divergence",
+    actor: getActorName(repoRoot),
     run_id: runId,
     round,
     divergences: divergences.map((entry) => ({

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -8,15 +9,58 @@ const { getEventsPath } = require("./relay-manifest");
 const {
   appendIterationScore,
   appendRubricQuality,
+  appendRunEvent,
   appendScoreDivergence,
   readRunEvents,
 } = require("./relay-events");
 
-function createContext() {
+function initGitRepo(repoRoot, actor = "Relay Events Test") {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", actor], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function withGitIdentityDisabled(testFn) {
+  const previousEnv = {
+    HOME: process.env.HOME,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    GIT_CONFIG_NOSYSTEM: process.env.GIT_CONFIG_NOSYSTEM,
+  };
+  const isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-isolated-"));
+  const isolatedXdg = fs.mkdtempSync(path.join(os.tmpdir(), "relay-xdg-isolated-"));
+
+  process.env.HOME = isolatedHome;
+  process.env.XDG_CONFIG_HOME = isolatedXdg;
+  process.env.GIT_CONFIG_NOSYSTEM = "1";
+
+  try {
+    testFn();
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function createContext(actor = "Relay Events Test") {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-"));
+  initGitRepo(repoRoot, actor);
+  return {
+    repoRoot,
+    runId: "issue-95-20260406000000000",
+  };
+}
+
+function createContextWithoutActor() {
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   return {
-    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-")),
-    runId: "issue-95-20260406000000000",
+    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-missing-actor-")),
+    runId: "issue-95-20260406000000001",
   };
 }
 
@@ -77,8 +121,22 @@ test("appendIterationScore writes an iteration_score record to events.jsonl", ()
   assert.equal(lines.length, 1);
 
   const parsed = JSON.parse(lines[0]);
+  assert.equal(record.actor, "Relay Events Test");
   assert.deepEqual(parsed, record);
   assert.deepEqual(readRunEvents(repoRoot, runId), [record]);
+});
+
+test("appendRunEvent writes actor from git config user.name", () => {
+  const { repoRoot, runId } = createContext("Relay Operator");
+  const record = appendRunEvent(repoRoot, runId, {
+    event: "dispatch_start",
+    state_from: "draft",
+    state_to: "dispatched",
+  });
+
+  const [parsed] = readRunEvents(repoRoot, runId);
+  assert.equal(record.actor, "Relay Operator");
+  assert.equal(parsed.actor, "Relay Operator");
 });
 
 test("appendIterationScore requires run_id", () => {
@@ -179,6 +237,7 @@ test("appendRubricQuality writes a rubric_quality record to events.jsonl", () =>
   assert.equal(lines.length, 1);
 
   const parsed = JSON.parse(lines[0]);
+  assert.equal(record.actor, "Relay Events Test");
   assert.deepEqual(parsed, record);
   assert.deepEqual(readRunEvents(repoRoot, runId), [record]);
 });
@@ -213,8 +272,21 @@ test("appendScoreDivergence writes a score_divergence record to events.jsonl", (
   assert.equal(lines.length, 1);
 
   const parsed = JSON.parse(lines[0]);
+  assert.equal(record.actor, "Relay Events Test");
   assert.deepEqual(parsed, record);
   assert.deepEqual(readRunEvents(repoRoot, runId), [record]);
+});
+
+test("appendIterationScore falls back to unknown actor when git user.name is unavailable", () => {
+  withGitIdentityDisabled(() => {
+    const { repoRoot, runId } = createContextWithoutActor();
+    const record = appendIterationScore(repoRoot, runId, {
+      round: 1,
+      scores: [createScore()],
+    });
+
+    assert.equal(record.actor, "unknown");
+  });
 });
 
 test("appendScoreDivergence rejects an empty divergences array", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -65,6 +65,22 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+function getActorName(repoRoot) {
+  if (!repoRoot || typeof repoRoot !== "string") {
+    return "unknown";
+  }
+
+  try {
+    const actor = execFileSync("git", ["-C", repoRoot, "config", "user.name"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+    return actor || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 function createCleanupSkeleton() {
   return {
     status: CLEANUP_STATUSES.PENDING,
@@ -333,6 +349,9 @@ function createManifestSkeleton({
     run_id: runId,
     state: STATES.DRAFT,
     next_action: "start_dispatch",
+    actor: {
+      name: getActorName(repoRoot),
+    },
     issue: {
       number: issueNumber,
       source: issueNumber ? "github" : "unknown",
@@ -634,6 +653,7 @@ module.exports = {
   createRunId,
   ensureRunLayout,
   formatAttemptsForPrompt,
+  getActorName,
   getAttemptsPath,
   getEventsPath,
   getManifestPath,

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -24,6 +24,38 @@ const {
   writeManifest,
 } = require("./relay-manifest");
 
+function initGitRepo(repoRoot, actor = "Relay Test") {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", actor], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function withGitIdentityDisabled(testFn) {
+  const previousEnv = {
+    HOME: process.env.HOME,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    GIT_CONFIG_NOSYSTEM: process.env.GIT_CONFIG_NOSYSTEM,
+  };
+  const isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-isolated-"));
+  const isolatedXdg = fs.mkdtempSync(path.join(os.tmpdir(), "relay-xdg-isolated-"));
+
+  process.env.HOME = isolatedHome;
+  process.env.XDG_CONFIG_HOME = isolatedXdg;
+  process.env.GIT_CONFIG_NOSYSTEM = "1";
+
+  try {
+    testFn();
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 test("inferIssueNumber extracts issue numbers from issue branches", () => {
   assert.equal(inferIssueNumber("issue-42"), 42);
   assert.equal(inferIssueNumber("feature/issue-99-auth"), 99);
@@ -41,6 +73,7 @@ test("createRunId is branch-stable and filesystem-safe", () => {
 test("manifest round-trips through frontmatter helpers", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Maintainer");
   const runId = "issue-42-20260402103000";
   const worktreePath = path.join(repoRoot, "wt");
   const { manifestPath } = ensureRunLayout(repoRoot, runId);
@@ -61,6 +94,7 @@ test("manifest round-trips through frontmatter helpers", () => {
 
   assert.equal(parsed.data.run_id, runId);
   assert.equal(parsed.data.state, STATES.DRAFT);
+  assert.equal(parsed.data.actor.name, "Relay Maintainer");
   assert.equal(parsed.data.issue.number, 42);
   assert.equal(parsed.data.roles.reviewer, "claude");
   assert.equal(parsed.data.git.head_sha, null);
@@ -95,6 +129,25 @@ test("manifest round-trips multiline scalar values", () => {
     parsed.data.cleanup.error,
     "dirty worktree: M README.md\n?? docs/direct-read-relay-operator-note.md"
   );
+});
+
+test("createManifestSkeleton falls back to unknown actor when git user.name is unavailable", () => {
+  withGitIdentityDisabled(() => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-actor-missing-"));
+    const manifest = createManifestSkeleton({
+      repoRoot,
+      runId: "issue-42-20260402103002",
+      branch: "issue-42",
+      baseBranch: "main",
+      issueNumber: 42,
+      worktreePath: path.join(repoRoot, "wt"),
+      orchestrator: "codex",
+      executor: "codex",
+      reviewer: "claude",
+    });
+
+    assert.deepEqual(manifest.actor, { name: "unknown" });
+  });
 });
 
 test("readManifest migrates v1 roles.worker to roles.executor", () => {

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -5,10 +5,10 @@ const { STATES, listManifestRecords } = require("./relay-manifest");
 const { readAllRunEvents } = require("./relay-events");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--stale-hours", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--stale-hours", "--json", "--by-actor", "--help", "-h"];
 
 if (args.includes("--help") || args.includes("-h")) {
-  console.log("Usage: reliability-report.js [--repo <path>] [--stale-hours <hours>] [--json]");
+  console.log("Usage: reliability-report.js [--repo <path>] [--stale-hours <hours>] [--json] [--by-actor]");
   process.exit(0);
 }
 
@@ -50,6 +50,10 @@ function average(values) {
   if (!values.length) return null;
   const total = values.reduce((sum, value) => sum + value, 0);
   return Number((total / values.length).toFixed(4));
+}
+
+function normalizeActorName(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
 }
 
 function buildEmptyRubricInsights() {
@@ -363,13 +367,7 @@ function buildFactorAnalysis(events) {
   };
 }
 
-function main() {
-  const repoRoot = path.resolve(getArg("--repo", "."));
-  const staleHours = parseHours(getArg("--stale-hours", "72"));
-  const now = Date.now();
-  const manifests = listManifestRecords(repoRoot);
-  const events = readAllRunEvents(repoRoot);
-
+function buildReport({ repoRoot, staleHours, now, manifests, events }) {
   const resumeStarts = events.filter((event) => (
     event.event === "dispatch_start" && event.state_from === STATES.CHANGES_REQUESTED
   ));
@@ -409,7 +407,7 @@ function main() {
     return updatedAt <= now - staleHours * 60 * 60 * 1000;
   });
 
-  const report = {
+  return {
     repoRoot,
     staleHours,
     totals: {
@@ -429,6 +427,43 @@ function main() {
     factor_analysis: buildFactorAnalysis(events),
     rubric_insights: buildRubricInsights(events, manifests),
   };
+}
+
+function buildActorReports({ repoRoot, staleHours, now, manifests, events }) {
+  const actorNames = [...new Set(
+    manifests.map(({ data }) => normalizeActorName(data?.actor?.name))
+  )].sort((left, right) => left.localeCompare(right));
+
+  return Object.fromEntries(actorNames.map((actor) => {
+    const actorManifests = manifests.filter(({ data }) => normalizeActorName(data?.actor?.name) === actor);
+    const actorRunIds = new Set(
+      actorManifests
+        .map(({ data }) => data?.run_id)
+        .filter(Boolean)
+    );
+    // Group by manifest actor so run-level metrics stay coherent even when different people touch one run later.
+    const actorEvents = events.filter((event) => actorRunIds.has(event.run_id));
+    return [actor, buildReport({
+      repoRoot,
+      staleHours,
+      now,
+      manifests: actorManifests,
+      events: actorEvents,
+    })];
+  }));
+}
+
+function main() {
+  const repoRoot = path.resolve(getArg("--repo", "."));
+  const staleHours = parseHours(getArg("--stale-hours", "72"));
+  const now = Date.now();
+  const manifests = listManifestRecords(repoRoot);
+  const events = readAllRunEvents(repoRoot);
+  const report = buildReport({ repoRoot, staleHours, now, manifests, events });
+
+  if (hasFlag("--by-actor")) {
+    report.by_actor = buildActorReports({ repoRoot, staleHours, now, manifests, events });
+  }
 
   if (hasFlag("--json")) {
     console.log(JSON.stringify(report, null, 2));
@@ -451,6 +486,19 @@ function main() {
     console.log(`  rubric_grades: ${gradeText}`);
     console.log(`  avg_quality_ratio: ${report.rubric_insights.avg_quality_ratio ?? "n/a"}`);
     console.log(`  top_divergence_hotspot: ${topHotspot ? `${topHotspot.factor_pattern} (${topHotspot.avg_delta})` : "n/a"}`);
+  }
+  if (hasFlag("--by-actor")) {
+    const actorEntries = Object.entries(report.by_actor || {});
+    console.log("  by_actor:");
+    if (actorEntries.length === 0) {
+      console.log("    n/a");
+    }
+    for (const [actor, actorReport] of actorEntries) {
+      console.log(
+        `    ${actor}: manifests=${actorReport.totals.manifests} events=${actorReport.totals.events} ` +
+        `most_stuck_factor=${actorReport.factor_analysis.most_stuck_factor ?? "n/a"}`
+      );
+    }
   }
 }
 

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -21,6 +21,16 @@ const {
 
 const SCRIPT = path.join(__dirname, "reliability-report.js");
 
+function initGitRepo(repoRoot, actor = "Relay Test") {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", actor], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function setGitActor(repoRoot, actor) {
+  execFileSync("git", ["config", "user.name", actor], { cwd: repoRoot, stdio: "pipe" });
+}
+
 function writeRun(repoRoot, { runId, state, rounds, updatedAt }) {
   const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
   let manifest = createManifestSkeleton({
@@ -118,6 +128,7 @@ test("reliability-report derives the core scorecard from manifests and events", 
   const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
   const report = JSON.parse(stdout);
 
+  assert.equal("by_actor" in report, false);
   assert.equal(report.metrics.same_run_resume_success_rate, 1);
   assert.equal(report.metrics.fresh_review_merge_block_rate, 0.5);
   assert.equal(report.metrics.max_rounds_enforcement_rate, 1);
@@ -465,4 +476,52 @@ test("reliability-report populates only available rubric insight subfields", () 
       success_rate: null,
     },
   });
+});
+
+test("reliability-report adds run-level grouping when --by-actor is set", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-by-actor-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Alice");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  setGitActor(repoRoot, "Alice");
+  writeRun(repoRoot, {
+    runId: "run-alice",
+    state: STATES.READY_TO_MERGE,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+  appendIterationScore(repoRoot, "run-alice", {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass" },
+    ],
+  });
+
+  setGitActor(repoRoot, "Bob");
+  writeRun(repoRoot, {
+    runId: "run-bob",
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 3,
+    updatedAt: recentTs,
+  });
+  appendIterationScore(repoRoot, "run-bob", {
+    round: 1,
+    scores: [
+      { factor: "Docs", target: ">= 8", observed: "5", met: false, status: "fail" },
+    ],
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json", "--by-actor"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(Object.keys(report.by_actor), ["Alice", "Bob"]);
+  assert.equal(report.by_actor.Alice.totals.manifests, 1);
+  assert.equal(report.by_actor.Alice.totals.events, 1);
+  assert.equal(report.by_actor.Alice.metrics.median_rounds_to_ready, 2);
+  assert.equal(report.by_actor.Alice.factor_analysis.most_stuck_factor, "Coverage");
+  assert.equal(report.by_actor.Bob.totals.manifests, 1);
+  assert.equal(report.by_actor.Bob.totals.events, 1);
+  assert.equal(report.by_actor.Bob.metrics.median_rounds_to_ready, null);
+  assert.equal(report.by_actor.Bob.factor_analysis.most_stuck_factor, "Docs");
 });


### PR DESCRIPTION
## Summary
- Adds `actor.name` field to manifest skeleton (from `git config user.name`, fallback to "unknown")
- Adds `actor` string to all event journal `append*` functions
- Adds `--by-actor` flag to reliability-report for per-actor grouping
- Tests for all changes including graceful fallback

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `--by-actor` 플래그를 통해 신뢰성 보고서를 배우별로 그룹화하여 조회 가능
  * 모든 이벤트 기록에 Git 사용자 정보를 자동으로 포함하여 추적 개선
  * Git 설정에서 사용자명 자동 추출, 불가능 시 "unknown"으로 기본값 설정

* **테스트**
  * 배우 기반 보고서 생성 및 필터링 검증 테스트 추가
  * 이벤트 레코드 추적 기능에 대한 통합 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->