### PR TITLE
Add relay-intake request persistence and immutable handoff linkage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ See [references/architecture.md](references/architecture.md) for the full manife
 skills/
   relay/                   ← Full-cycle orchestration (plan → dispatch → review → stop)
     references/prompt-template.md
+  relay-intake/            ← Raw request shaping + relay-ready handoff persistence
+    scripts/
+      relay-request.js       ← Request artifact CRUD + request events
+      persist-request.js     ← Single-leaf persistence entry point
   relay-plan/              ← AC → scoring rubric → dispatch prompt
     scripts/
       probe-executor-env.js  ← Executor environment probe (agent + project tools)
@@ -50,12 +54,13 @@ skills/
       review-gate.js       ← Review state validation
 ```
 
-Multi-skill design: each phase is independently invocable. `npx skills add sungjunlee/dev-relay` installs all 5.
+Multi-skill design: each phase is independently invocable. `npx skills add sungjunlee/dev-relay` installs all 6.
 
 ## Common Commands
 
 ```bash
 # Run tests (Node.js built-in test runner, no install needed)
+node --test skills/relay-intake/scripts/*.test.js
 node --test skills/relay-plan/scripts/*.test.js
 node --test skills/relay-dispatch/scripts/*.test.js
 node --test skills/relay-review/scripts/*.test.js

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Roles are bound at manifest creation time and serve as defaults. Any supported a
 npx skills add sungjunlee/dev-relay
 ```
 
-Installs all 5 skills as [Claude Code custom slash commands](https://docs.anthropic.com/en/docs/claude-code/skills). Add `-g -y` for global install without prompts:
+Installs all 6 skills as [Claude Code custom slash commands](https://docs.anthropic.com/en/docs/claude-code/skills). Add `-g -y` for global install without prompts:
 
 ```bash
 npx skills add sungjunlee/dev-relay -g -y
@@ -80,11 +80,14 @@ Working from a repo checkout without installing skills? See [docs/direct-read-re
 
 Reads issue #42, builds a scoring rubric if the task is complex, dispatches to the executor in a worktree, reviews the resulting PR, and stops at `ready_to_merge`. It runs all four phases (plan, dispatch, review, gate check) but does not auto-merge. Use `/relay-merge` to land it explicitly.
 
+For raw or ambiguous requests, `/relay` now routes through `/relay-intake` first, persists a request artifact under `~/.relay/requests/<repo-slug>/`, freezes Done Criteria for review, then resumes the normal `relay-plan -> relay-dispatch -> relay-review` chain.
+
 ### Step by step
 
 Use individual skills when you want control over each phase:
 
 ```bash
+/relay-intake "fix the auth redirect mess"   # Shape a raw request into one relay-ready leaf + frozen Done Criteria
 /relay-plan 42          # Convert issue AC into a scoring rubric
 /relay-dispatch         # Dispatch to executor (worktree -> implement -> PR)
 /relay-review fix/42    # Review PR in a fresh context
@@ -108,7 +111,7 @@ Use individual skills when you want control over each phase:
 
 ### Plan ... `/relay-plan`
 
-Converts acceptance criteria into a **scoring rubric** that guides both the executor and the reviewer:
+Converts acceptance criteria into a **scoring rubric** that guides both the executor and the reviewer. If `/relay-intake` already produced `relay-ready/<leaf-id>.md`, that handoff brief becomes the planning source of truth:
 
 | Rubric element | Example |
 |---------------|---------|
@@ -127,7 +130,7 @@ For L/XL tasks (5+ acceptance criteria), an optional stress-test catches gaming 
 
 ### Dispatch ... `/relay-dispatch`
 
-Creates an isolated git worktree, merges the base branch for freshness, writes a relay run manifest, runs the executor with the task prompt, and collects results.
+Creates an isolated git worktree, merges the base branch for freshness, writes a relay run manifest, runs the executor with the task prompt, and collects results. Intake-produced runs can also carry `source.request_id`, `source.leaf_id`, and `anchor.done_criteria_path` so review stays anchored to the frozen snapshot instead of drifting to PR prose.
 
 ```bash
 # Minimal
@@ -135,6 +138,9 @@ Creates an isolated git worktree, merges the base branch for freshness, writes a
 
 # With rubric and extended timeout
 /relay-dispatch --branch feat/search --prompt-file rubric.md --timeout 3600
+
+# Intake-linked dispatch
+/relay-dispatch --branch fix/login-loop --prompt-file ~/.relay/requests/<slug>/<request-id>/relay-ready/leaf-01.md --request-id <request-id> --leaf-id leaf-01 --done-criteria-file ~/.relay/requests/<slug>/<request-id>/done-criteria/leaf-01.md
 
 # Resume after review requested changes (reuses retained worktree)
 /relay-dispatch --run-id issue-42-20260403120000000 --prompt-file review-round-2-redispatch.md
@@ -213,6 +219,7 @@ For hotfixes, `finalize-run.js --skip-review "reason"` bypasses the review gate 
 | Command | Phase | Description |
 |---------|-------|-------------|
 | `/relay [issue]` | All | Full cycle through `ready_to_merge` |
+| `/relay-intake [request]` | Intake | Shape a raw request into a single relay-ready handoff + frozen Done Criteria |
 | `/relay-plan [issue]` | Plan | Build scoring rubric from acceptance criteria |
 | `/relay-dispatch` | Execute | Dispatch to executor via git worktree isolation |
 | `/relay-review [branch]` | Review | Independent PR review with convergence loop |
@@ -450,6 +457,7 @@ Issues and PRs welcome. Please open an issue first for non-trivial changes.
 ### Running tests
 
 ```bash
+node --test skills/relay-intake/scripts/*.test.js
 node --test skills/relay-plan/scripts/*.test.js
 node --test skills/relay-dispatch/scripts/*.test.js
 node --test skills/relay-review/scripts/*.test.js

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Creates an isolated git worktree, merges the base branch for freshness, writes a
 # With rubric and extended timeout
 /relay-dispatch --branch feat/search --prompt-file rubric.md --timeout 3600
 
-# Intake-linked dispatch
-/relay-dispatch --branch fix/login-loop --prompt-file ~/.relay/requests/<slug>/<request-id>/relay-ready/leaf-01.md --request-id <request-id> --leaf-id leaf-01 --done-criteria-file ~/.relay/requests/<slug>/<request-id>/done-criteria/leaf-01.md
+# Intake-linked dispatch after relay-plan produced the executor prompt
+/relay-dispatch --branch fix/login-loop --prompt-file /tmp/dispatch-login-loop.md --request-id <request-id> --leaf-id leaf-01 --done-criteria-file ~/.relay/requests/<slug>/<request-id>/done-criteria/leaf-01.md
 
 # Resume after review requested changes (reuses retained worktree)
 /relay-dispatch --run-id issue-42-20260403120000000 --prompt-file review-round-2-redispatch.md

--- a/docs/direct-read-relay-operator-note.md
+++ b/docs/direct-read-relay-operator-note.md
@@ -8,6 +8,7 @@ Start with `skills/relay/SKILL.md` in the checkout you are operating on. That fi
 
 When `skills/relay/SKILL.md` calls into a phase-specific workflow, keep reading the files from the same repo:
 
+- `skills/relay-intake/SKILL.md`
 - `skills/relay-dispatch/SKILL.md`
 - `skills/relay-review/SKILL.md`
 - `skills/relay-merge/SKILL.md`
@@ -31,6 +32,7 @@ Repo root: /path/to/dev-relay
 
 Read these files first:
 - /path/to/dev-relay/skills/relay/SKILL.md
+- /path/to/dev-relay/skills/relay-intake/SKILL.md
 - /path/to/dev-relay/skills/relay-dispatch/SKILL.md
 - /path/to/dev-relay/skills/relay-review/SKILL.md
 - /path/to/dev-relay/skills/relay-merge/SKILL.md

--- a/docs/relay-scenario-tests.md
+++ b/docs/relay-scenario-tests.md
@@ -4,7 +4,7 @@ Scenario matrix for the same-run lifecycle and reliability scorecard wave.
 
 ## Goal
 
-Exercise the implemented same-run lifecycle, fresh merge gate, append-only events, explicit close path, and derived reporting.
+Exercise the implemented same-run lifecycle, intake request persistence, fresh merge gate, append-only events, explicit close path, and derived reporting.
 
 ## Current Coverage
 
@@ -241,3 +241,20 @@ Covers:
 - a no-sprint live run in `dev-relay`
 - a sprint-enabled live run in the disposable GitHub fixture repo
 - exact operator prompts, run IDs, manifest paths, PR/review URLs, merge SHAs, and known gaps
+
+### 15. Raw request intake persists a relay-ready handoff and feeds downstream review anchors
+
+Command:
+
+```bash
+node --test skills/relay-intake/scripts/request-store.test.js
+```
+
+Expect:
+
+- `~/.relay/requests/<repo-slug>/<request-id>.md` is created
+- request events append `request_persisted` and `relay_ready_handoff_persisted`
+- `relay-ready/<leaf-id>.md` and `done-criteria/<leaf-id>.md` are created for the single leaf
+- multi-leaf input fails explicitly with `TODO(#129)`
+- dispatch can record `source.request_id`, `source.leaf_id`, and `anchor.done_criteria_path`
+- `review-runner --prepare-only` loads the frozen snapshot from the manifest anchor without re-fetching GitHub issue text

--- a/docs/relay-scenario-tests.md
+++ b/docs/relay-scenario-tests.md
@@ -116,6 +116,8 @@ Expect:
 - a run in `changes_requested` resumes on the same worktree and manifest
 - re-dispatch keeps the same `run_id`
 - missing retained worktrees fail loudly without creating a replacement run
+- intake-linked runs can resume only with the exact same `request_id`, `leaf_id`, and `done_criteria_path`
+- issue-first runs cannot gain relay-intake linkage retroactively during resume
 
 ### 7. Review runner validates structured verdicts and updates manifest state
 
@@ -155,6 +157,20 @@ Interpretation:
 - this is a repo-wide skill-format mismatch with the strict Codex validator
 - it is not a regression from the manifest foundation work
 - the actual YAML syntax issue in `relay-review/SKILL.md` is fixed
+
+### 8a. Intake request persistence rejects frozen-snapshot collisions
+
+Command:
+
+```bash
+node --test skills/relay-intake/scripts/request-store.test.js
+```
+
+Expect:
+
+- reusing the same `request_id` fails before any request artifact is overwritten
+- the original frozen Done Criteria snapshot stays unchanged
+- the request event log remains append-only with the original two persistence events only
 
 ### 9. Optional live adapter verification
 

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -4,7 +4,7 @@ argument-hint: "<repo-path> (-b <branch> | --run-id <id>) -p <prompt> [options]"
 description: Dispatch implementation tasks via worktree isolation. Use when delegating work to an executor, running background dispatches, or parallelizing independent tasks.
 compatibility: Requires executor CLI (e.g., codex), git, and Node.js 18+.
 metadata:
-  related-skills: "relay, relay-plan, relay-review, relay-merge"
+  related-skills: "relay, relay-intake, relay-plan, relay-review, relay-merge"
 ---
 
 # Relay Dispatch
@@ -43,6 +43,9 @@ For background and parallel dispatch, see "Background & Parallel" section below.
 | `--sandbox` | `workspace-write` (default) or `read-only` |
 | `--copy <files>` | Additional files to copy |
 | `--timeout` | Timeout in seconds (default: 1800) |
+| `--request-id` | Link the run back to a relay-intake request artifact |
+| `--leaf-id` | Link the run back to a relay-intake relay-ready leaf |
+| `--done-criteria-file` | Persist a frozen Done Criteria anchor path into the run manifest |
 | `--register` | Register session in executor's app (keeps worktree) |
 | `--no-cleanup` | Compatibility alias; worktree is retained by default |
 | `--dry-run` | Show plan without executing |
@@ -52,6 +55,8 @@ Creates worktree → writes a relay run manifest → runs executor → collects 
 Exits with non-zero code on failure.
 
 Each dispatch writes a manifest to `~/.relay/runs/<repo-slug>/<run-id>.md` and appends lifecycle evidence to `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. `run_id` is the canonical identity for re-dispatch, review, merge, close, and reporting.
+
+When dispatch resumes from relay-intake, it can also store `source.request_id`, `source.leaf_id`, and `anchor.done_criteria_path` so review stays pinned to the frozen snapshot.
 
 ### Timeout guidance
 

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -23,6 +23,9 @@
  *   --copy <file,...>      Additional files to copy
  *   --timeout <seconds>    Exec timeout (default: 1800)
  *   --rubric-file <path>   Copy rubric YAML to run dir (persists for review)
+ *   --request-id <id>      Link the run back to a relay-intake request
+ *   --leaf-id <id>         Link the run back to a relay-intake leaf handoff
+ *   --done-criteria-file   Persist a frozen Done Criteria anchor path
  *   --register             Register session in executor's app (keeps worktree)
  *   --no-cleanup           Compatibility alias; worktree is retained by default
  *   --dry-run              Show plan without executing
@@ -79,6 +82,7 @@ const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
   "--model", "-m", "--sandbox", "--copy", "--timeout", "--rubric-file",
+  "--request-id", "--leaf-id", "--done-criteria-file",
   "--register", "--no-cleanup", "--dry-run", "--json", "--help", "-h",
 ];
 
@@ -98,6 +102,9 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
   console.log("  --sandbox          workspace-write | read-only (default: workspace-write)");
   console.log("  --copy <files>     Additional files to copy (comma-separated)");
   console.log("  --timeout          Exec timeout in seconds (default: 1800)");
+  console.log("  --request-id       Link the run back to a relay-intake request");
+  console.log("  --leaf-id          Link the run back to a relay-intake leaf handoff");
+  console.log("  --done-criteria-file  Persist a frozen Done Criteria anchor path");
   console.log("  --register         Register session in executor's app (keeps worktree)");
   console.log("  --rubric-file      Copy rubric YAML to run dir (persists for review)");
   console.log("  --no-cleanup       Compatibility alias; worktree is retained by default");
@@ -141,6 +148,9 @@ const MODEL = getArg(["--model", "-m"], undefined);
 const SANDBOX = getArg("--sandbox", "workspace-write");
 const COPY_FILES = getArg("--copy", "").split(",").filter(Boolean);
 const RUBRIC_FILE = getArg("--rubric-file", undefined);
+const REQUEST_ID = getArg("--request-id", undefined);
+const LEAF_ID = getArg("--leaf-id", undefined);
+const DONE_CRITERIA_FILE = getArg("--done-criteria-file", undefined);
 const TIMEOUT = parseInt(getArg("--timeout", "1800"), 10);
 if (isNaN(TIMEOUT) || TIMEOUT <= 0) {
   console.error("Error: --timeout must be a positive integer");
@@ -175,6 +185,14 @@ if (RUBRIC_FILE) {
   const rubricPath = path.resolve(RUBRIC_FILE);
   if (!fs.existsSync(rubricPath)) {
     console.error(`Error: rubric file not found: ${rubricPath}`);
+    process.exit(1);
+  }
+}
+
+if (DONE_CRITERIA_FILE) {
+  const doneCriteriaPath = path.resolve(DONE_CRITERIA_FILE);
+  if (!fs.existsSync(doneCriteriaPath)) {
+    console.error(`Error: done criteria file not found: ${doneCriteriaPath}`);
     process.exit(1);
   }
 }
@@ -243,6 +261,34 @@ function terminateProcessTree(pid) {
   } catch {}
 }
 
+function applyRequestLinkage(manifest, { requestId, leafId, doneCriteriaPath }) {
+  let next = manifest;
+
+  if (requestId || leafId) {
+    next = {
+      ...next,
+      source: {
+        ...(next.source || {}),
+        ...(requestId ? { request_id: requestId } : {}),
+        ...(leafId ? { leaf_id: leafId } : {}),
+      },
+    };
+  }
+
+  if (doneCriteriaPath) {
+    next = {
+      ...next,
+      anchor: {
+        ...(next.anchor || {}),
+        done_criteria_path: doneCriteriaPath,
+        done_criteria_source: "request_snapshot",
+      },
+    };
+  }
+
+  return next;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -259,6 +305,7 @@ async function main() {
   const resultFile = path.join(os.tmpdir(), `dispatch-${EXECUTOR}-${wtId}.txt`);
   const stdoutLog = path.join(os.tmpdir(), `dispatch-${EXECUTOR}-${wtId}.log`);
   const stderrLog = path.join(os.tmpdir(), `dispatch-${EXECUTOR}-${wtId}.err`);
+  const resolvedDoneCriteriaPath = DONE_CRITERIA_FILE ? path.resolve(DONE_CRITERIA_FILE) : null;
   let branch = BRANCH;
   let runId = RUN_ID;
   let manifestPath = MANIFEST_INPUT ? path.resolve(MANIFEST_INPUT) : null;
@@ -363,6 +410,9 @@ async function main() {
       cleanupPolicy,
       worktreeinclude: includeFiles,
       rubricFile: RUBRIC_FILE || null,
+      requestId: REQUEST_ID || manifest?.source?.request_id || null,
+      leafId: LEAF_ID || manifest?.source?.leaf_id || null,
+      doneCriteriaFile: resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null,
       environment: RESUME_MODE ? (manifest?.environment || null) : "collected-at-dispatch",
     };
     if (JSON_OUT) {
@@ -385,6 +435,15 @@ async function main() {
       console.log(`  Timeout:  ${TIMEOUT}s`);
       if (RUBRIC_FILE) {
         console.log(`  Rubric:   ${RUBRIC_FILE}`);
+      }
+      if (REQUEST_ID || manifest?.source?.request_id) {
+        console.log(`  Request:  ${REQUEST_ID || manifest.source.request_id}`);
+      }
+      if (LEAF_ID || manifest?.source?.leaf_id) {
+        console.log(`  Leaf:     ${LEAF_ID || manifest.source.leaf_id}`);
+      }
+      if (resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path) {
+        console.log(`  Done AC:  ${resolvedDoneCriteriaPath || manifest.anchor.done_criteria_path}`);
       }
       if (includeFiles.length) {
         console.log(`  .worktreeinclude: ${includeFiles.join(", ")}`);
@@ -463,10 +522,21 @@ async function main() {
       reviewer: process.env.RELAY_REVIEWER || "unknown",
       cleanupPolicy,
       environment,
+      requestId: REQUEST_ID || null,
+      leafId: LEAF_ID || null,
+      doneCriteriaPath: resolvedDoneCriteriaPath,
+      doneCriteriaSource: resolvedDoneCriteriaPath ? "request_snapshot" : null,
     });
     ensureRunLayout(repoRoot, runId);
     writeManifest(manifestPath, manifest);
   }
+
+  manifest = applyRequestLinkage(manifest, {
+    requestId: REQUEST_ID,
+    leafId: LEAF_ID,
+    doneCriteriaPath: resolvedDoneCriteriaPath,
+  });
+  writeManifest(manifestPath, manifest);
 
   // --- Copy rubric file to run dir ---
   if (RUBRIC_FILE) {
@@ -741,6 +811,9 @@ async function main() {
     runDir,
     manifestPath,
     rubricPath: manifest.anchor?.rubric_path ? path.join(runDir, manifest.anchor.rubric_path) : null,
+    requestId: manifest.source?.request_id || null,
+    leafId: manifest.source?.leaf_id || null,
+    doneCriteriaPath: manifest.anchor?.done_criteria_path || null,
     runState: manifest.state,
     cleanupPolicy,
     status,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -261,32 +261,42 @@ function terminateProcessTree(pid) {
   } catch {}
 }
 
-function applyRequestLinkage(manifest, { requestId, leafId, doneCriteriaPath }) {
-  let next = manifest;
+function validateResumeRequestLinkage(manifest, { requestId, leafId, doneCriteriaPath }) {
+  const checks = [
+    {
+      field: "source.request_id",
+      existing: manifest?.source?.request_id || null,
+      incoming: requestId || null,
+    },
+    {
+      field: "source.leaf_id",
+      existing: manifest?.source?.leaf_id || null,
+      incoming: leafId || null,
+    },
+    {
+      field: "anchor.done_criteria_path",
+      existing: manifest?.anchor?.done_criteria_path || null,
+      incoming: doneCriteriaPath || null,
+      normalize: (value) => path.resolve(value),
+    },
+  ];
 
-  if (requestId || leafId) {
-    next = {
-      ...next,
-      source: {
-        ...(next.source || {}),
-        ...(requestId ? { request_id: requestId } : {}),
-        ...(leafId ? { leaf_id: leafId } : {}),
-      },
-    };
+  for (const check of checks) {
+    if (!check.incoming) continue;
+
+    if (!check.existing) {
+      throw new Error(
+        `same-run resume cannot add immutable ${check.field}; intake linkage must be bound when the run is created`
+      );
+    }
+
+    const normalize = check.normalize || ((value) => value);
+    if (normalize(check.existing) !== normalize(check.incoming)) {
+      throw new Error(
+        `same-run resume cannot change immutable ${check.field} (existing: ${check.existing}, incoming: ${check.incoming})`
+      );
+    }
   }
-
-  if (doneCriteriaPath) {
-    next = {
-      ...next,
-      anchor: {
-        ...(next.anchor || {}),
-        done_criteria_path: doneCriteriaPath,
-        done_criteria_source: "request_snapshot",
-      },
-    };
-  }
-
-  return next;
 }
 
 // ---------------------------------------------------------------------------
@@ -383,6 +393,19 @@ async function main() {
     } catch {}
     if (fs.existsSync(wtPath)) {
       console.error(`Error: worktree path already exists: ${wtPath}`);
+      process.exit(1);
+    }
+  }
+
+  if (RESUME_MODE) {
+    try {
+      validateResumeRequestLinkage(manifest, {
+        requestId: REQUEST_ID,
+        leafId: LEAF_ID,
+        doneCriteriaPath: resolvedDoneCriteriaPath,
+      });
+    } catch (error) {
+      console.error(`Error: ${error.message}`);
       process.exit(1);
     }
   }
@@ -530,13 +553,6 @@ async function main() {
     ensureRunLayout(repoRoot, runId);
     writeManifest(manifestPath, manifest);
   }
-
-  manifest = applyRequestLinkage(manifest, {
-    requestId: REQUEST_ID,
-    leafId: LEAF_ID,
-    doneCriteriaPath: resolvedDoneCriteriaPath,
-  });
-  writeManifest(manifestPath, manifest);
 
   // --- Copy rubric file to run dir ---
   if (RUBRIC_FILE) {

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -522,6 +522,132 @@ test("dispatch dry-run includes request linkage and frozen done criteria file in
   assert.equal(result.doneCriteriaFile, doneCriteriaFile);
 });
 
+test("dispatch resume rejects changes to immutable intake linkage", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const doneCriteriaFile = path.join(repoRoot, "done-criteria.md");
+  const alternateDoneCriteriaFile = path.join(repoRoot, "done-criteria-v2.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Original intake snapshot\n", "utf-8");
+  fs.writeFileSync(alternateDoneCriteriaFile, "# Done Criteria\n\n- Changed intake snapshot\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-intake-resume-guard",
+    "--prompt", "first pass",
+    "--request-id", "req-20260409030303000",
+    "--leaf-id", "leaf-01",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+  assert.equal(first.runState, STATES.REVIEW_PENDING);
+
+  const record = readManifest(first.manifestPath);
+  const updated = updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+  writeManifest(first.manifestPath, updated, record.body);
+
+  const result = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume pass",
+    "--request-id", "req-20260409030303000",
+    "--leaf-id", "leaf-01",
+    "--done-criteria-file", alternateDoneCriteriaFile,
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /cannot change immutable anchor\.done_criteria_path/);
+
+  const manifest = readManifest(first.manifestPath).data;
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.source.request_id, "req-20260409030303000");
+});
+
+test("dispatch resume keeps the original intake linkage when the same immutable values are supplied", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const doneCriteriaFile = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Preserve the intake snapshot\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-intake-resume-stable",
+    "--prompt", "first pass",
+    "--request-id", "req-20260409050505000",
+    "--leaf-id", "leaf-01",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+  assert.equal(first.runState, STATES.REVIEW_PENDING);
+
+  const record = readManifest(first.manifestPath);
+  const updated = updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+  writeManifest(first.manifestPath, updated, record.body);
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", first.runId,
+    "--prompt", "resume pass",
+    "--request-id", "req-20260409050505000",
+    "--leaf-id", "leaf-01",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+
+  assert.equal(second.mode, "resume");
+  assert.equal(second.runId, first.runId);
+  assert.equal(second.requestId, "req-20260409050505000");
+  assert.equal(second.leafId, "leaf-01");
+  assert.equal(second.doneCriteriaPath, doneCriteriaFile);
+
+  const manifest = readManifest(first.manifestPath).data;
+  assert.equal(manifest.source.request_id, "req-20260409050505000");
+  assert.equal(manifest.source.leaf_id, "leaf-01");
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+});
+
+test("dispatch resume rejects adding intake linkage to a run that started without it", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-intake-resume-addition",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+  assert.equal(first.runState, STATES.REVIEW_PENDING);
+
+  const record = readManifest(first.manifestPath);
+  const updated = updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+  writeManifest(first.manifestPath, updated, record.body);
+
+  const doneCriteriaFile = path.join(repoRoot, "done-criteria-late.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Late linkage must fail\n", "utf-8");
+
+  const result = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume pass",
+    "--request-id", "req-20260409060606000",
+    "--leaf-id", "leaf-01",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /cannot add immutable source\.request_id/);
+
+  const manifest = readManifest(first.manifestPath).data;
+  assert.equal(manifest.source, undefined);
+  assert.equal(manifest.anchor.done_criteria_path, undefined);
+});
+
 test("dispatch fails when rubric file does not exist", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -467,6 +467,61 @@ test("dispatch dry-run includes rubric file info", () => {
   fs.unlinkSync(rubricFile);
 });
 
+test("dispatch stores request linkage and frozen done criteria anchor in manifest", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const doneCriteriaFile = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Intake snapshot\n", "utf-8");
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-intake-linkage",
+    "--prompt", "linkage test",
+    "--request-id", "req-20260409010101000",
+    "--leaf-id", "leaf-01",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.requestId, "req-20260409010101000");
+  assert.equal(result.leafId, "leaf-01");
+  assert.equal(result.doneCriteriaPath, doneCriteriaFile);
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.source.request_id, "req-20260409010101000");
+  assert.equal(manifest.source.leaf_id, "leaf-01");
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_source, "request_snapshot");
+});
+
+test("dispatch dry-run includes request linkage and frozen done criteria file info", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const doneCriteriaFile = path.join(repoRoot, "done-criteria-dry.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Dry run snapshot\n", "utf-8");
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-intake-dry",
+    "--prompt", "dry linkage test",
+    "--request-id", "req-20260409020202000",
+    "--leaf-id", "leaf-99",
+    "--done-criteria-file", doneCriteriaFile,
+    "--dry-run", "--json",
+  ], env));
+
+  assert.equal(result.requestId, "req-20260409020202000");
+  assert.equal(result.leafId, "leaf-99");
+  assert.equal(result.doneCriteriaFile, doneCriteriaFile);
+});
+
 test("dispatch fails when rubric file does not exist", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
@@ -483,6 +538,24 @@ test("dispatch fails when rubric file does not exist", () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /rubric file not found/);
+});
+
+test("dispatch fails when done criteria file does not exist", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const result = spawnSync("node", [SCRIPT, repoRoot,
+    "-b", "issue-nodonecriteria",
+    "--prompt", "test",
+    "--done-criteria-file", "/tmp/nonexistent-done-criteria-file.md",
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /done criteria file not found/);
 });
 
 test("dispatch without --rubric-file leaves rubric_path unset", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -341,10 +341,14 @@ function createManifestSkeleton({
   cleanupPolicy = "on_close",
   reviewerWritePolicy = "forbid",
   environment = null,
+  requestId = null,
+  leafId = null,
+  doneCriteriaPath = null,
+  doneCriteriaSource = null,
 }) {
   const createdAt = nowIso();
 
-  return {
+  const manifest = {
     relay_version: RELAY_VERSION,
     run_id: runId,
     state: STATES.DRAFT,
@@ -377,8 +381,9 @@ function createManifestSkeleton({
       reviewer_write: reviewerWritePolicy,
     },
     anchor: {
-      done_criteria_source: issueNumber ? "issue" : "unknown",
+      done_criteria_source: doneCriteriaSource || (issueNumber ? "issue" : "unknown"),
       rubric_source: "manifest",
+      ...(doneCriteriaPath ? { done_criteria_path: doneCriteriaPath } : {}),
     },
     review: {
       rounds: 0,
@@ -399,6 +404,15 @@ function createManifestSkeleton({
       updated_at: createdAt,
     },
   };
+
+  if (requestId || leafId) {
+    manifest.source = {
+      ...(requestId ? { request_id: requestId } : {}),
+      ...(leafId ? { leaf_id: leafId } : {}),
+    };
+  }
+
+  return manifest;
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -150,6 +150,34 @@ test("createManifestSkeleton falls back to unknown actor when git user.name is u
   });
 });
 
+test("createManifestSkeleton stores optional intake linkage without changing state semantics", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-intake-linkage-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Maintainer");
+
+  const manifest = createManifestSkeleton({
+    repoRoot,
+    runId: "issue-42-20260402103003",
+    branch: "issue-42",
+    baseBranch: "main",
+    issueNumber: 42,
+    worktreePath: path.join(repoRoot, "wt"),
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "claude",
+    requestId: "req-20260409000000000",
+    leafId: "leaf-01",
+    doneCriteriaPath: "/tmp/frozen-done-criteria.md",
+    doneCriteriaSource: "request_snapshot",
+  });
+
+  assert.equal(manifest.state, STATES.DRAFT);
+  assert.equal(manifest.source.request_id, "req-20260409000000000");
+  assert.equal(manifest.source.leaf_id, "leaf-01");
+  assert.equal(manifest.anchor.done_criteria_path, "/tmp/frozen-done-criteria.md");
+  assert.equal(manifest.anchor.done_criteria_source, "request_snapshot");
+});
+
 test("readManifest migrates v1 roles.worker to roles.executor", () => {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-migrate-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));

--- a/skills/relay-intake/SKILL.md
+++ b/skills/relay-intake/SKILL.md
@@ -75,7 +75,7 @@ After persistence succeeds:
 ```bash
 ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
   -b <branch> \
-  --prompt-file <handoff-path> \
+  --prompt-file <dispatch-prompt-path> \
   --request-id <request-id> \
   --leaf-id <leaf-id> \
   --done-criteria-file <done-criteria-path>

--- a/skills/relay-intake/SKILL.md
+++ b/skills/relay-intake/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: relay-intake
+argument-hint: "[raw request or ambiguous task description]"
+description: Shape a raw request into a single relay-ready leaf contract with a frozen Done Criteria snapshot. Use before relay-plan when the task is ambiguous, oversized, or missing a stable review anchor.
+compatibility: Requires git and Node.js 18+.
+metadata:
+  related-skills: "relay, relay-plan, relay-dispatch, relay-review"
+---
+
+# Relay Intake
+
+Use this skill when `/relay` cannot safely bypass straight to planning.
+
+## When Intake Is Required
+
+Run intake when any of these are true:
+- the request is free-form or ambiguous
+- the task may contain multiple steps or multiple leaves
+- no stable Done Criteria anchor exists yet
+- the issue/task text is too broad to review safely as-is
+
+Bypass intake only for a single relay-ready task with a trustworthy review anchor already available.
+
+## Output Contract
+
+This slice supports **single-leaf only**.
+
+Persist all of the following under `~/.relay/requests/<repo-slug>/<request-id>/`:
+- request artifact: `../<request-id>.md`
+- raw request: `raw-request.md`
+- relay-ready handoff: `relay-ready/<leaf-id>.md`
+- frozen Done Criteria: `done-criteria/<leaf-id>.md`
+- append-only events: `events.jsonl`
+
+The normalized handoff must contain:
+- `request_id`
+- `leaf_id`
+- `title`
+- `goal`
+- `in_scope`
+- `out_of_scope`
+- `assumptions`
+- `done_criteria_path`
+- `escalation_conditions`
+
+If the request decomposes into multiple leaves, stop with:
+- `TODO(#129): multi-leaf relay-intake handoff is not implemented yet`
+
+## Persistence Step
+
+Write a JSON contract file with:
+- `source.kind`
+- `request_text`
+- `handoff.leaf_id`
+- `handoff.title`
+- `handoff.goal`
+- `handoff.in_scope`
+- `handoff.out_of_scope`
+- `handoff.assumptions`
+- `handoff.done_criteria_markdown`
+- `handoff.escalation_conditions`
+
+Persist it with:
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/persist-request.js --repo . --contract-file /tmp/relay-intake-contract.json --json
+```
+
+## Downstream Handoff
+
+After persistence succeeds:
+1. use `relay-ready/<leaf-id>.md` as the source-of-truth input for `relay-plan`
+2. dispatch with:
+
+```bash
+${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
+  -b <branch> \
+  --prompt-file <handoff-path> \
+  --request-id <request-id> \
+  --leaf-id <leaf-id> \
+  --done-criteria-file <done-criteria-path>
+```
+
+3. let `relay-review` read the frozen snapshot from the run manifest anchor
+
+Do not create a second lifecycle. Intake stops once the relay-ready contract is persisted.

--- a/skills/relay-intake/scripts/persist-request.js
+++ b/skills/relay-intake/scripts/persist-request.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const { persistRequestContract } = require("./relay-request");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--contract-file", "--json", "--help", "-h"];
+
+if (!args.length || args.includes("--help") || args.includes("-h")) {
+  console.log("Usage: persist-request.js --repo <path> --contract-file <path> [--json]");
+  console.log("");
+  console.log("Persist a single-leaf relay-intake request artifact and handoff bundle.");
+  process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
+}
+
+function getArg(flag) {
+  const index = args.indexOf(flag);
+  if (index === -1 || index + 1 >= args.length) return undefined;
+  const value = args[index + 1];
+  return KNOWN_FLAGS.includes(value) ? undefined : value;
+}
+
+function hasFlag(flag) {
+  return args.includes(flag);
+}
+
+const repoRoot = path.resolve(getArg("--repo") || ".");
+const contractFile = getArg("--contract-file");
+const jsonOut = hasFlag("--json");
+
+if (!contractFile) {
+  console.error("Error: --contract-file is required");
+  process.exit(1);
+}
+
+const resolvedContractFile = path.resolve(contractFile);
+if (!fs.existsSync(resolvedContractFile)) {
+  console.error(`Error: contract file not found: ${resolvedContractFile}`);
+  process.exit(1);
+}
+
+let contract;
+try {
+  contract = JSON.parse(fs.readFileSync(resolvedContractFile, "utf-8"));
+} catch (error) {
+  console.error(`Error: failed to parse contract JSON: ${error.message}`);
+  process.exit(1);
+}
+
+try {
+  const result = persistRequestContract(repoRoot, contract);
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Request:       ${result.requestId}`);
+    console.log(`Artifact:      ${result.requestPath}`);
+    console.log(`Raw request:   ${result.rawRequestPath}`);
+    console.log(`Relay-ready:   ${result.handoffPath}`);
+    console.log(`Done criteria: ${result.doneCriteriaPath}`);
+  }
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -1,0 +1,307 @@
+const fs = require("fs");
+const path = require("path");
+
+const {
+  getActorName,
+  getRelayHome,
+  getRepoSlug,
+  parseFrontmatter,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/relay-manifest");
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function createRequestId(timestamp = new Date()) {
+  const iso = timestamp.toISOString().replace(/[-:TZ.]/g, "").slice(0, 17);
+  return `req-${iso}`;
+}
+
+function getRequestsBase() {
+  return process.env.RELAY_REQUESTS_BASE || path.join(getRelayHome(), "requests");
+}
+
+function getRequestsDir(repoRoot) {
+  return path.join(getRequestsBase(), getRepoSlug(repoRoot));
+}
+
+function getRequestDir(repoRoot, requestId) {
+  return path.join(getRequestsDir(repoRoot), requestId);
+}
+
+function getRequestPath(repoRoot, requestId) {
+  return path.join(getRequestsDir(repoRoot), `${requestId}.md`);
+}
+
+function getRequestEventsPath(repoRoot, requestId) {
+  return path.join(getRequestDir(repoRoot, requestId), "events.jsonl");
+}
+
+function ensureRequestLayout(repoRoot, requestId) {
+  if (!requestId) {
+    throw new Error("request_id is required to create relay-intake layout");
+  }
+
+  const requestsDir = getRequestsDir(repoRoot);
+  const requestDir = getRequestDir(repoRoot, requestId);
+  const relayReadyDir = path.join(requestDir, "relay-ready");
+  const doneCriteriaDir = path.join(requestDir, "done-criteria");
+
+  fs.mkdirSync(requestsDir, { recursive: true });
+  fs.mkdirSync(requestDir, { recursive: true });
+  fs.mkdirSync(relayReadyDir, { recursive: true });
+  fs.mkdirSync(doneCriteriaDir, { recursive: true });
+
+  return {
+    requestsDir,
+    requestDir,
+    requestPath: getRequestPath(repoRoot, requestId),
+    eventsPath: getRequestEventsPath(repoRoot, requestId),
+    rawRequestPath: path.join(requestDir, "raw-request.md"),
+    relayReadyDir,
+    doneCriteriaDir,
+  };
+}
+
+function normalizeStringArray(value, fieldName) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldName} must be an array of strings`);
+  }
+  return value.map((entry, index) => {
+    if (typeof entry !== "string" || !entry.trim()) {
+      throw new Error(`${fieldName}[${index}] must be a non-empty string`);
+    }
+    return entry.trim();
+  });
+}
+
+function normalizeSingleLeafContract(contract) {
+  if (!contract || typeof contract !== "object") {
+    throw new Error("contract must be an object");
+  }
+
+  if (!contract.source || typeof contract.source !== "object") {
+    throw new Error("source is required");
+  }
+  if (typeof contract.source.kind !== "string" || !contract.source.kind.trim()) {
+    throw new Error("source.kind is required");
+  }
+  if (typeof contract.request_text !== "string" || !contract.request_text.trim()) {
+    throw new Error("request_text is required");
+  }
+
+  let handoff = contract.handoff;
+  if (Array.isArray(contract.handoffs)) {
+    if (contract.handoffs.length !== 1) {
+      throw new Error("TODO(#129): multi-leaf relay-intake handoff is not implemented yet");
+    }
+    [handoff] = contract.handoffs;
+  }
+
+  if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) {
+    throw new Error("handoff is required");
+  }
+
+  const requiredStrings = ["leaf_id", "title", "goal", "done_criteria_markdown"];
+  for (const field of requiredStrings) {
+    if (typeof handoff[field] !== "string" || !handoff[field].trim()) {
+      throw new Error(`handoff.${field} is required`);
+    }
+  }
+
+  return {
+    source: {
+      kind: contract.source.kind.trim(),
+    },
+    requestText: contract.request_text.trim(),
+    handoff: {
+      leafId: handoff.leaf_id.trim(),
+      title: handoff.title.trim(),
+      goal: handoff.goal.trim(),
+      inScope: normalizeStringArray(handoff.in_scope || [], "handoff.in_scope"),
+      outOfScope: normalizeStringArray(handoff.out_of_scope || [], "handoff.out_of_scope"),
+      assumptions: normalizeStringArray(handoff.assumptions || [], "handoff.assumptions"),
+      doneCriteriaMarkdown: handoff.done_criteria_markdown.trim(),
+      escalationConditions: normalizeStringArray(
+        handoff.escalation_conditions || [],
+        "handoff.escalation_conditions"
+      ),
+    },
+  };
+}
+
+function formatBulletList(items) {
+  if (!items.length) return "- None";
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function buildRequestBody({ sourceKind, requestText, leafId, handoffRelativePath, doneCriteriaRelativePath }) {
+  return [
+    "# Relay Intake Request",
+    "",
+    "## Source",
+    `Kind: ${sourceKind}`,
+    "",
+    "## Raw Request",
+    requestText,
+    "",
+    "## Relay-Ready Leaves",
+    `- ${leafId}: ${handoffRelativePath}`,
+    "",
+    "## Frozen Done Criteria",
+    `- ${leafId}: ${doneCriteriaRelativePath}`,
+    "",
+  ].join("\n");
+}
+
+function buildHandoffBody(handoff) {
+  return [
+    "# Relay-Ready Handoff",
+    "",
+    "## Goal",
+    handoff.goal,
+    "",
+    "## In Scope",
+    formatBulletList(handoff.inScope),
+    "",
+    "## Out of Scope",
+    formatBulletList(handoff.outOfScope),
+    "",
+    "## Assumptions",
+    formatBulletList(handoff.assumptions),
+    "",
+    "## Escalation Conditions",
+    formatBulletList(handoff.escalationConditions),
+    "",
+  ].join("\n");
+}
+
+function appendRequestEvent(repoRoot, requestId, eventData) {
+  if (!requestId) {
+    throw new Error("request_id is required to append a relay-intake event");
+  }
+  if (!String(eventData?.event || "").trim()) {
+    throw new Error("event is required to append a relay-intake event");
+  }
+
+  const { eventsPath } = ensureRequestLayout(repoRoot, requestId);
+  const record = {
+    ts: eventData.ts || nowIso(),
+    event: eventData.event,
+    actor: getActorName(repoRoot),
+    request_id: requestId,
+    leaf_id: eventData.leaf_id || null,
+    source_kind: eventData.source_kind || null,
+    handoff_path: eventData.handoff_path || null,
+    done_criteria_path: eventData.done_criteria_path || null,
+    reason: eventData.reason || null,
+  };
+
+  fs.appendFileSync(eventsPath, `${JSON.stringify(record)}\n`, "utf-8");
+  return record;
+}
+
+function readRequestEvents(repoRoot, requestId) {
+  const eventsPath = getRequestEventsPath(repoRoot, requestId);
+  if (!fs.existsSync(eventsPath)) return [];
+  return fs.readFileSync(eventsPath, "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function readRequestArtifact(requestPath) {
+  const text = fs.readFileSync(requestPath, "utf-8");
+  return parseFrontmatter(text);
+}
+
+function persistRequestContract(repoRoot, contract, options = {}) {
+  const normalized = normalizeSingleLeafContract(contract);
+  const requestId = options.requestId || createRequestId();
+  const createdAt = nowIso();
+  const layout = ensureRequestLayout(repoRoot, requestId);
+  const handoffFileName = `${normalized.handoff.leafId}.md`;
+  const handoffPath = path.join(layout.relayReadyDir, handoffFileName);
+  const doneCriteriaPath = path.join(layout.doneCriteriaDir, handoffFileName);
+  const handoffRelativePath = path.relative(layout.requestDir, handoffPath);
+  const doneCriteriaRelativePath = path.relative(layout.requestDir, doneCriteriaPath);
+
+  fs.writeFileSync(layout.rawRequestPath, `${normalized.requestText}\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${normalized.handoff.doneCriteriaMarkdown}\n`, "utf-8");
+
+  writeManifest(handoffPath, {
+    request_id: requestId,
+    leaf_id: normalized.handoff.leafId,
+    title: normalized.handoff.title,
+    goal: normalized.handoff.goal,
+    done_criteria_path: doneCriteriaPath,
+  }, buildHandoffBody(normalized.handoff));
+
+  writeManifest(layout.requestPath, {
+    request_id: requestId,
+    state: "relay_ready",
+    source: {
+      kind: normalized.source.kind,
+    },
+    leaf_count: 1,
+    paths: {
+      raw_request: layout.rawRequestPath,
+      handoff: handoffPath,
+      done_criteria: doneCriteriaPath,
+    },
+    timestamps: {
+      created_at: createdAt,
+      updated_at: createdAt,
+    },
+  }, buildRequestBody({
+    sourceKind: normalized.source.kind,
+    requestText: normalized.requestText,
+    leafId: normalized.handoff.leafId,
+    handoffRelativePath,
+    doneCriteriaRelativePath,
+  }));
+
+  appendRequestEvent(repoRoot, requestId, {
+    event: "request_persisted",
+    source_kind: normalized.source.kind,
+    leaf_id: normalized.handoff.leafId,
+    handoff_path: handoffPath,
+    done_criteria_path: doneCriteriaPath,
+  });
+  appendRequestEvent(repoRoot, requestId, {
+    event: "relay_ready_handoff_persisted",
+    source_kind: normalized.source.kind,
+    leaf_id: normalized.handoff.leafId,
+    handoff_path: handoffPath,
+    done_criteria_path: doneCriteriaPath,
+  });
+
+  return {
+    requestId,
+    requestPath: layout.requestPath,
+    requestDir: layout.requestDir,
+    rawRequestPath: layout.rawRequestPath,
+    handoffPath,
+    doneCriteriaPath,
+    leafId: normalized.handoff.leafId,
+    title: normalized.handoff.title,
+    sourceKind: normalized.source.kind,
+  };
+}
+
+module.exports = {
+  appendRequestEvent,
+  createRequestId,
+  ensureRequestLayout,
+  getRequestDir,
+  getRequestEventsPath,
+  getRequestPath,
+  getRequestsBase,
+  getRequestsDir,
+  normalizeSingleLeafContract,
+  persistRequestContract,
+  readRequestArtifact,
+  readRequestEvents,
+};

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -217,16 +217,35 @@ function readRequestArtifact(requestPath) {
   return parseFrontmatter(text);
 }
 
+function assertRequestArtifactsAbsent(requestId, artifactPaths) {
+  for (const [label, artifactPath] of artifactPaths) {
+    if (fs.existsSync(artifactPath)) {
+      throw new Error(
+        `request_id '${requestId}' already exists; refusing to overwrite existing ${label}: ${artifactPath}`
+      );
+    }
+  }
+}
+
 function persistRequestContract(repoRoot, contract, options = {}) {
   const normalized = normalizeSingleLeafContract(contract);
   const requestId = options.requestId || createRequestId();
   const createdAt = nowIso();
   const layout = ensureRequestLayout(repoRoot, requestId);
+  const requestArtifactDir = path.dirname(layout.requestPath);
   const handoffFileName = `${normalized.handoff.leafId}.md`;
   const handoffPath = path.join(layout.relayReadyDir, handoffFileName);
   const doneCriteriaPath = path.join(layout.doneCriteriaDir, handoffFileName);
-  const handoffRelativePath = path.relative(layout.requestDir, handoffPath);
-  const doneCriteriaRelativePath = path.relative(layout.requestDir, doneCriteriaPath);
+  const handoffRelativePath = path.relative(requestArtifactDir, handoffPath);
+  const doneCriteriaRelativePath = path.relative(requestArtifactDir, doneCriteriaPath);
+
+  assertRequestArtifactsAbsent(requestId, [
+    ["request artifact", layout.requestPath],
+    ["request event log", layout.eventsPath],
+    ["raw request artifact", layout.rawRequestPath],
+    ["relay-ready handoff", handoffPath],
+    ["done criteria snapshot", doneCriteriaPath],
+  ]);
 
   fs.writeFileSync(layout.rawRequestPath, `${normalized.requestText}\n`, "utf-8");
   fs.writeFileSync(doneCriteriaPath, `${normalized.handoff.doneCriteriaMarkdown}\n`, "utf-8");

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -1,0 +1,197 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { readManifest } = require("../../relay-dispatch/scripts/relay-manifest");
+const { readRequestEvents, persistRequestContract, readRequestArtifact } = require("./relay-request");
+
+const PERSIST_SCRIPT = path.join(__dirname, "persist-request.js");
+const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
+const REVIEW_RUNNER_SCRIPT = path.join(__dirname, "..", "..", "relay-review", "scripts", "review-runner.js");
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-intake-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Intake Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-intake@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  process.env.RELAY_HOME = relayHome;
+  return { repoRoot, relayHome };
+}
+
+function createContract(overrides = {}) {
+  return {
+    source: { kind: "raw_text" },
+    request_text: "Fix the login redirect loop for authenticated users.",
+    handoff: {
+      leaf_id: "leaf-01",
+      title: "Fix login redirect loop",
+      goal: "Stop authenticated users from bouncing back to /login",
+      in_scope: ["Update the redirect guard", "Cover both auth states"],
+      out_of_scope: ["Redesigning the login page"],
+      assumptions: ["Session state remains cookie-based"],
+      done_criteria_markdown: "# Done Criteria\n\n- Authenticated users stay off /login\n- Guests still reach /login\n",
+      escalation_conditions: ["Auth state source is unclear"],
+    },
+    ...overrides,
+  };
+}
+
+function writeFakeCodex(binDir) {
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+fs.writeFileSync(cwd + "/intake.txt", "ok\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", "intake.txt"], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake intake commit"], { stdio: "pipe" });
+fs.writeFileSync(output, "ok\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+}
+
+test("persistRequestContract writes request artifact, relay-ready handoff, done criteria snapshot, and events", () => {
+  const { repoRoot } = setupRepo();
+
+  const result = persistRequestContract(repoRoot, createContract());
+
+  assert.ok(fs.existsSync(result.requestPath));
+  assert.ok(fs.existsSync(result.rawRequestPath));
+  assert.ok(fs.existsSync(result.handoffPath));
+  assert.ok(fs.existsSync(result.doneCriteriaPath));
+
+  const requestArtifact = readRequestArtifact(result.requestPath);
+  assert.equal(requestArtifact.data.request_id, result.requestId);
+  assert.equal(requestArtifact.data.state, "relay_ready");
+  assert.equal(requestArtifact.data.source.kind, "raw_text");
+  assert.equal(requestArtifact.data.paths.handoff, result.handoffPath);
+  assert.match(requestArtifact.body, /Relay Intake Request/);
+  assert.match(requestArtifact.body, /leaf-01/);
+
+  const handoffArtifact = readRequestArtifact(result.handoffPath);
+  assert.equal(handoffArtifact.data.request_id, result.requestId);
+  assert.equal(handoffArtifact.data.leaf_id, "leaf-01");
+  assert.equal(handoffArtifact.data.done_criteria_path, result.doneCriteriaPath);
+  assert.match(handoffArtifact.body, /In Scope/);
+  assert.match(handoffArtifact.body, /Update the redirect guard/);
+
+  const doneCriteria = fs.readFileSync(result.doneCriteriaPath, "utf-8");
+  assert.match(doneCriteria, /Authenticated users stay off \/login/);
+
+  const events = readRequestEvents(repoRoot, result.requestId);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].event, "request_persisted");
+  assert.equal(events[1].event, "relay_ready_handoff_persisted");
+  assert.equal(events[1].leaf_id, "leaf-01");
+});
+
+test("persist-request CLI persists the single-leaf request bundle", () => {
+  const { repoRoot } = setupRepo();
+  const contractPath = path.join(repoRoot, "contract.json");
+  fs.writeFileSync(contractPath, `${JSON.stringify(createContract(), null, 2)}\n`, "utf-8");
+
+  const stdout = execFileSync("node", [
+    PERSIST_SCRIPT,
+    "--repo", repoRoot,
+    "--contract-file", contractPath,
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.ok(result.requestId);
+  assert.equal(result.leafId, "leaf-01");
+  assert.ok(fs.existsSync(result.requestPath));
+  assert.ok(fs.existsSync(result.handoffPath));
+  assert.ok(fs.existsSync(result.doneCriteriaPath));
+});
+
+test("persistRequestContract rejects multi-leaf handoff input with an explicit #129 TODO", () => {
+  const { repoRoot } = setupRepo();
+  const contract = createContract({
+    handoff: undefined,
+    handoffs: [
+      createContract().handoff,
+      { ...createContract().handoff, leaf_id: "leaf-02", title: "Second leaf" },
+    ],
+  });
+
+  assert.throws(
+    () => persistRequestContract(repoRoot, contract),
+    /TODO\(#129\): multi-leaf relay-intake handoff is not implemented yet/
+  );
+});
+
+test("raw request can flow through intake persistence, dispatch linkage, and review prepare-only", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  const intake = persistRequestContract(repoRoot, createContract());
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = {
+    ...process.env,
+    RELAY_HOME: relayHome,
+    PATH: `${binDir}:${process.env.PATH}`,
+  };
+
+  const dispatchStdout = execFileSync("node", [
+    DISPATCH_SCRIPT,
+    repoRoot,
+    "-b", "issue-127-raw-intake",
+    "--prompt-file", intake.handoffPath,
+    "--request-id", intake.requestId,
+    "--leaf-id", intake.leafId,
+    "--done-criteria-file", intake.doneCriteriaPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  const dispatchResult = JSON.parse(dispatchStdout);
+  assert.equal(dispatchResult.runState, "review_pending");
+
+  const manifest = readManifest(dispatchResult.manifestPath).data;
+  const dispatchPrompt = fs.readFileSync(path.join(dispatchResult.runDir, "dispatch-prompt.md"), "utf-8");
+  assert.equal(manifest.source.request_id, intake.requestId);
+  assert.equal(manifest.source.leaf_id, intake.leafId);
+  assert.equal(manifest.anchor.done_criteria_path, intake.doneCriteriaPath);
+  assert.equal(manifest.anchor.done_criteria_source, "request_snapshot");
+  assert.match(dispatchPrompt, /Fix login redirect loop/);
+
+  const diffPath = path.join(repoRoot, "pr.diff");
+  fs.writeFileSync(diffPath, "diff --git a/intake.txt b/intake.txt\n+ok\n", "utf-8");
+
+  const reviewStdout = execFileSync("node", [
+    REVIEW_RUNNER_SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", dispatchResult.runId,
+    "--pr", "123",
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  const reviewResult = JSON.parse(reviewStdout);
+  const preparedDoneCriteria = fs.readFileSync(reviewResult.doneCriteriaPath, "utf-8");
+  const promptText = fs.readFileSync(reviewResult.promptPath, "utf-8");
+
+  assert.match(preparedDoneCriteria, /Authenticated users stay off \/login/);
+  assert.match(promptText, /source="request_snapshot"/);
+});

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -80,6 +80,8 @@ test("persistRequestContract writes request artifact, relay-ready handoff, done 
   assert.equal(requestArtifact.data.paths.handoff, result.handoffPath);
   assert.match(requestArtifact.body, /Relay Intake Request/);
   assert.match(requestArtifact.body, /leaf-01/);
+  assert.match(requestArtifact.body, new RegExp(`${result.requestId}/relay-ready/leaf-01\\.md`));
+  assert.match(requestArtifact.body, new RegExp(`${result.requestId}/done-criteria/leaf-01\\.md`));
 
   const handoffArtifact = readRequestArtifact(result.handoffPath);
   assert.equal(handoffArtifact.data.request_id, result.requestId);
@@ -132,6 +134,27 @@ test("persistRequestContract rejects multi-leaf handoff input with an explicit #
     () => persistRequestContract(repoRoot, contract),
     /TODO\(#129\): multi-leaf relay-intake handoff is not implemented yet/
   );
+});
+
+test("persistRequestContract rejects request_id collisions before overwriting frozen artifacts", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409040404000";
+  const first = persistRequestContract(repoRoot, createContract(), { requestId });
+  const originalDoneCriteria = fs.readFileSync(first.doneCriteriaPath, "utf-8");
+
+  assert.throws(
+    () => persistRequestContract(repoRoot, createContract({
+      request_text: "A different raw request that must not replace the original.",
+      handoff: {
+        ...createContract().handoff,
+        done_criteria_markdown: "# Done Criteria\n\n- Replacement snapshot that must never land\n",
+      },
+    }), { requestId }),
+    /already exists; refusing to overwrite existing request artifact/
+  );
+
+  assert.equal(fs.readFileSync(first.doneCriteriaPath, "utf-8"), originalDoneCriteria);
+  assert.equal(readRequestEvents(repoRoot, requestId).length, 2);
 });
 
 test("raw request can flow through intake persistence, dispatch linkage, and review prepare-only", () => {

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -4,7 +4,7 @@ argument-hint: "[issue-number]"
 description: Convert task acceptance criteria into a scored rubric for autonomous iteration. Always used before relay-dispatch — rubric depth scales with task size.
 compatibility: Requires gh CLI. Task AC reading falls back to local files or user input.
 metadata:
-  related-skills: "relay, relay-dispatch, relay-review, dev-backlog"
+  related-skills: "relay, relay-intake, relay-dispatch, relay-review, dev-backlog"
 ---
 
 # Relay Plan
@@ -15,10 +15,13 @@ Build a scoring rubric from task Acceptance Criteria (AC), then generate a dispa
 
 ### 1. Read the task
 
-Read the issue AC (try in order, use first that succeeds):
+Read the normalized task source (try in order, use first that succeeds):
+- Relay-ready handoff brief from relay-intake: `~/.relay/requests/<repo-slug>/<request-id>/relay-ready/<leaf-id>.md`
 - Local task file: `backlog/tasks/{PREFIX}-{N} - {Title}.md`
 - GitHub: `gh issue view <N>`
 - User-provided description
+
+If relay-intake already produced a handoff brief, treat that file as the source of truth instead of re-reading the raw request.
 
 ### 2. Build the rubric
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -5,7 +5,7 @@ description: Independent PR review against Done Criteria in a fresh context, fre
 context: fork
 compatibility: "Requires gh CLI. Context isolation is enforced per-platform (see Context Isolation section)."
 metadata:
-  related-skills: "relay, relay-plan, relay-dispatch, relay-merge"
+  related-skills: "relay, relay-intake, relay-plan, relay-dispatch, relay-merge"
 ---
 
 # Relay Review
@@ -49,7 +49,7 @@ gh issue view $ISSUE_NUM  # Done Criteria / Acceptance Criteria source
 ```
 
 2. **Fix the anchor** — these do NOT change across rounds:
-   - Done Criteria from the issue (the contract)
+   - Done Criteria from `anchor.done_criteria_path` when present, otherwise from the issue (the contract)
    - Rubric factors + targets from the Score Log (if relay-plan was used)
    - Original scope boundary ("do not change" areas)
 

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -182,8 +182,21 @@ function resolveIssueNumber(repoPath, prNumber, branch, manifestData) {
   return issueMatch ? Number(issueMatch[1]) : null;
 }
 
-function loadDoneCriteria(repoPath, issueNumber, prNumber, doneCriteriaFile) {
+function loadDoneCriteria(repoPath, issueNumber, prNumber, doneCriteriaFile, manifestData) {
   if (doneCriteriaFile) return { text: readText(doneCriteriaFile).trim(), source: "file" };
+
+  const manifestDoneCriteriaPath = manifestData?.anchor?.done_criteria_path;
+  if (manifestDoneCriteriaPath) {
+    if (!fs.existsSync(manifestDoneCriteriaPath)) {
+      throw new Error(
+        `Manifest anchor.done_criteria_path points to a missing file: ${manifestDoneCriteriaPath}`
+      );
+    }
+    return {
+      text: readText(manifestDoneCriteriaPath).trim(),
+      source: manifestData?.anchor?.done_criteria_source || "request_snapshot",
+    };
+  }
 
   const errors = [];
 
@@ -221,7 +234,7 @@ function loadDoneCriteria(repoPath, issueNumber, prNumber, doneCriteriaFile) {
   const detail = errors.length ? ` Attempted: ${errors.join("; ")}` : "";
   throw new Error(
     `Cannot resolve Done Criteria: no issue, no PR description.${detail} ` +
-    "Provide --done-criteria-file for tasks without a GitHub issue."
+    "Provide --done-criteria-file or persist anchor.done_criteria_path for tasks without a GitHub issue."
   );
 }
 
@@ -880,7 +893,10 @@ function applyPolicyViolationToManifest(data, round, prNumber, reviewedHeadSha, 
 }
 
 function resolveReviewerName(data, reviewerArg) {
-  return reviewerArg || data.roles?.reviewer || process.env.RELAY_REVIEWER || "codex";
+  const manifestReviewer = data.roles?.reviewer;
+  if (reviewerArg) return reviewerArg;
+  if (manifestReviewer && manifestReviewer !== "unknown") return manifestReviewer;
+  return process.env.RELAY_REVIEWER || "codex";
 }
 
 function resolveReviewerScript(reviewerName, reviewerScriptArg) {
@@ -990,7 +1006,13 @@ function run() {
     throw new Error(`Review round cap exceeded: next round ${round} would exceed max_rounds=${maxRounds}`);
   }
 
-  const { text: doneCriteria, source: doneCriteriaSource } = loadDoneCriteria(repoPath, issueNumber, prNumber, doneCriteriaFile);
+  const { text: doneCriteria, source: doneCriteriaSource } = loadDoneCriteria(
+    repoPath,
+    issueNumber,
+    prNumber,
+    doneCriteriaFile,
+    data
+  );
   const diffText = loadDiff(repoPath, prNumber, diffFile);
   const rubricContent = loadRubricFromRunDir(runDir, data);
   const promptText = buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricContent });

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -169,6 +169,68 @@ test("prepare-only writes a prompt bundle without changing manifest state", () =
   assert.equal(readManifest(manifestPath).data.run_id, runId);
 });
 
+test("prepare-only loads frozen Done Criteria from manifest anchor before GitHub fallbacks", () => {
+  const { repoRoot, manifestPath, runId, diffPath } = setupRepo();
+  const anchoredDoneCriteriaPath = path.join(repoRoot, "frozen-done-criteria.md");
+  fs.writeFileSync(anchoredDoneCriteriaPath, "# Frozen Done Criteria\n\n- Use the persisted intake snapshot\n", "utf-8");
+
+  const record = readManifest(manifestPath);
+  const updated = {
+    ...record.data,
+    anchor: {
+      ...(record.data.anchor || {}),
+      done_criteria_path: anchoredDoneCriteriaPath,
+      done_criteria_source: "request_snapshot",
+    },
+  };
+  writeManifest(manifestPath, updated, record.body);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  const doneCriteriaText = fs.readFileSync(result.doneCriteriaPath, "utf-8");
+  assert.match(promptText, /source="request_snapshot"/);
+  assert.match(doneCriteriaText, /Use the persisted intake snapshot/);
+});
+
+test("missing manifest-anchored Done Criteria fails loudly without fallback", () => {
+  const { repoRoot, manifestPath, runId, diffPath } = setupRepo();
+  const missingDoneCriteriaPath = path.join(repoRoot, "missing-frozen-done-criteria.md");
+
+  const record = readManifest(manifestPath);
+  const updated = {
+    ...record.data,
+    anchor: {
+      ...(record.data.anchor || {}),
+      done_criteria_path: missingDoneCriteriaPath,
+      done_criteria_source: "request_snapshot",
+    },
+  };
+  writeManifest(manifestPath, updated, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
+    assert.match(String(error.stderr), /Manifest anchor\.done_criteria_path points to a missing file/);
+    return true;
+  });
+});
+
 test("pass verdict moves review_pending to ready_to_merge", () => {
   const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
   const reviewFile = writeVerdict(repoRoot, "pass.json", {

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -4,7 +4,7 @@ argument-hint: "[issue-number or task description]"
 description: Execute the full relay cycle — plan, dispatch, review, merge. Use when implementing a GitHub issue or task through autonomous executor dispatch. Integrates with dev-backlog sprint files.
 compatibility: Requires Claude Code or Codex, gh CLI, git, and Node.js 18+. Task AC reading falls back to local files or user input.
 metadata:
-  related-skills: "relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog"
+  related-skills: "relay-intake, relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog"
 ---
 
 # Dev Relay
@@ -31,7 +31,7 @@ Always run before every task — standalone or batch. Ensures current state, not
 
 No sprint file? Just do the `git fetch`. Takes <5 seconds; never skip this step.
 
-## Step 1: Read Context
+## Step 1: Route and Read Context
 
 Gather task details and sprint context:
 1. **Task AC** (try in order, use first that succeeds):
@@ -39,8 +39,24 @@ Gather task details and sprint context:
    - GitHub: `gh issue view <N>`
    - User-provided description (from argument or conversation)
 2. **Sprint context** (optional): If `backlog/sprints/` has an active sprint file, read Running Context and batch info. If no sprint file, proceed without — sprint tracking is skipped.
+3. **Fast path vs intake path**:
+   - Bypass intake only when the input is already one relay-ready task, has a stable review anchor, and needs no clarification or decomposition.
+   - Otherwise run `relay-intake` first, persist a request artifact, and use the generated `relay-ready/<leaf-id>.md` as the downstream source of truth.
 
 If no issue number, use a descriptive branch name (e.g., `feat/<slug>`) and skip issue-close in Step 6.
+
+### Intake path
+
+If intake is required, persist a single-leaf contract first:
+
+```bash
+${CLAUDE_SKILL_DIR}/../relay-intake/scripts/persist-request.js --repo . --contract-file /tmp/relay-intake-contract.json --json
+```
+
+Carry these artifacts forward:
+- handoff brief: `~/.relay/requests/<repo-slug>/<request-id>/relay-ready/<leaf-id>.md`
+- frozen Done Criteria: `~/.relay/requests/<repo-slug>/<request-id>/done-criteria/<leaf-id>.md`
+- linkage: `request_id`, `leaf_id`
 
 ## Step 1.5: Check for in-flight work
 
@@ -63,6 +79,7 @@ Rubric depth scales with task size (determined by orchestrator judgment on norma
 - **XL** (architecture change): 5-8 factors + stress-test + calibration
 
 Write the dispatch prompt to a temp file (e.g., `/tmp/dispatch-<N>.md`).
+If intake ran, the relay-ready handoff brief becomes the task source of truth for planning.
 Write the rubric YAML to a temp file (e.g., `/tmp/rubric-<N>.yaml`).
 
 ## Step 3: Dispatch (relay-dispatch)
@@ -70,6 +87,12 @@ Write the rubric YAML to a temp file (e.g., `/tmp/rubric-<N>.yaml`).
 ```bash
 ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
   -b issue-<N> --prompt-file /tmp/dispatch-<N>.md --rubric-file /tmp/rubric-<N>.yaml --timeout 3600
+```
+
+If intake ran, also pass:
+
+```bash
+  --request-id <request-id> --leaf-id <leaf-id> --done-criteria-file <done-criteria-path>
 ```
 
 While dispatch runs in the background, optionally monitor progress:
@@ -93,7 +116,7 @@ Get PR number:
 PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
 ```
 
-The manifest is written under `~/.relay/runs/<repo-slug>/`. This is the shared state surface for later review/merge lifecycle work.
+The manifest is written under `~/.relay/runs/<repo-slug>/`. This is the shared state surface for later review/merge lifecycle work. Intake linkage is recorded there, but the run lifecycle remains execution-only.
 
 Current scope: dispatch writes the manifest. Review and merge still follow their existing PR-comment and gate-check flow.
 


### PR DESCRIPTION
## Summary
- add the relay-intake skill and script-backed request persistence under `~/.relay/requests/...`
- thread intake linkage and frozen done criteria through dispatch and review without changing run state semantics
- harden resume/linkage immutability and request artifact path/collision handling with focused scenario coverage

## Testing
- node --test skills/relay-intake/scripts/*.test.js
- node --test skills/relay-dispatch/scripts/*.test.js
- node --test skills/relay-review/scripts/*.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 요청 수집 워크플로우 추가: 원본 요청을 표준화된 형식으로 저장하고 고정된 완료 기준으로 추적합니다.
  * 요청 링크 기능: 실행 중에 요청 ID, 리프 ID, 고정 완료 기준 경로를 저장하여 여러 단계에서 참조합니다.
  * 매니페스트 기반 앵커링: 검토 단계에서 고정된 스냅샷을 사용하여 일관성을 유지합니다.

* **문서**
  * 새로운 요청 수집 스킬 문서 추가
  * 라우팅 로직 및 워크플로우 단계 업데이트

* **테스트**
  * 요청 지속성 및 링크 검증을 위한 테스트 추가
  * 매니페스트 앵커 동작 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->