### PR TITLE
feat(#128): add readiness assessment, preflight actions, and interaction events

### DIFF
--- a/skills/relay-intake/SKILL.md
+++ b/skills/relay-intake/SKILL.md
@@ -32,6 +32,14 @@ Persist all of the following under `~/.relay/requests/<repo-slug>/<request-id>/`
 - frozen Done Criteria: `done-criteria/<leaf-id>.md`
 - append-only events: `events.jsonl`
 
+The request artifact frontmatter may also carry:
+- `readiness.clarity`
+- `readiness.granularity`
+- `readiness.dependency`
+- `readiness.verifiability`
+- `readiness.risk`
+- `next_action`
+
 The normalized handoff must contain:
 - `request_id`
 - `leaf_id`
@@ -65,6 +73,22 @@ Persist it with:
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/persist-request.js --repo . --contract-file /tmp/relay-intake-contract.json --json
 ```
+
+Optional contract fields:
+- `readiness.clarity`: `high | medium | low`
+- `readiness.granularity`: `single_task | multi_task | unclear`
+- `readiness.dependency`: `none | internal | external`
+- `readiness.verifiability`: `high | medium | low`
+- `readiness.risk`: `low | medium | high`
+
+Preflight shaping stays append-only in `events.jsonl`. Use the portable intake event types:
+- `proposal_presented`
+- `question_asked`
+- `question_answered`
+- `proposal_accepted`
+- `proposal_edited`
+
+Track the immediate follow-up as `next_action` on the request artifact. Do not create a second state machine for intake.
 
 ## Downstream Handoff
 

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -277,6 +277,20 @@ function getRequestRecord(repoRoot, requestId) {
   return { requestPath, artifact: readRequestArtifact(requestPath) };
 }
 
+function isRelayReadyRequestArtifact(artifact) {
+  return artifact.data?.state === "relay_ready" || Boolean(artifact.data?.paths?.handoff);
+}
+
+function assertPreflightMutable(requestId, requestRecord) {
+  if (!isRelayReadyRequestArtifact(requestRecord.artifact)) {
+    return;
+  }
+
+  throw new Error(
+    `request_id '${requestId}' is already relay_ready; preflight intake interactions cannot mutate a frozen handoff`
+  );
+}
+
 function resolveRequestLeafId(artifact, leafId) {
   if (leafId) return leafId;
   if (artifact.data?.leaf_id) return artifact.data.leaf_id;
@@ -356,7 +370,7 @@ function assertRequestArtifactsAbsent(requestId, artifactPaths) {
 }
 
 function appendInteractionEvent(repoRoot, requestId, eventData, nextAction, bootstrapData = {}) {
-  const requestRecord = ensureRequestArtifact(repoRoot, requestId, bootstrapData, nextAction);
+  const requestRecord = ensurePreflightRequestArtifact(repoRoot, requestId, bootstrapData, nextAction);
   const leafId = resolveRequestLeafId(requestRecord.artifact, eventData.leaf_id);
   const record = appendRequestEvent(repoRoot, requestId, { ...eventData, leaf_id: leafId });
 
@@ -568,6 +582,19 @@ function bootstrapRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
 
 function ensureRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
   return bootstrapRequestArtifact(repoRoot, requestId, data, nextAction);
+}
+
+function ensurePreflightRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
+  const requestPath = getRequestPath(repoRoot, requestId);
+  if (!fs.existsSync(requestPath)) {
+    return bootstrapRequestArtifact(repoRoot, requestId, data, nextAction);
+  }
+
+  const requestRecord = getRequestRecord(repoRoot, requestId);
+  assertPreflightMutable(requestId, requestRecord);
+  const bootstrapData = normalizeRequestBootstrapData(data);
+  validateBootstrapData(repoRoot, requestId, requestRecord, bootstrapData);
+  return applyBootstrapDataPatch(repoRoot, requestId, requestRecord, bootstrapData);
 }
 
 function propose(repoRoot, requestId, data = {}) {

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -9,6 +9,24 @@ const {
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 
+const READINESS_LEVELS = {
+  clarity: new Set(["high", "medium", "low"]),
+  granularity: new Set(["single_task", "multi_task", "unclear"]),
+  dependency: new Set(["none", "internal", "external"]),
+  verifiability: new Set(["high", "medium", "low"]),
+  risk: new Set(["low", "medium", "high"]),
+};
+
+const DEFAULT_NEXT_ACTIONS = {
+  acceptProposal: "relay_plan",
+  answerQuestion: "review_answer",
+  clarify: "await_answer",
+  editProposal: "review_proposal_edits",
+  persist: "relay_plan",
+  propose: "await_proposal_response",
+  structure: "await_proposal_response",
+};
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -76,6 +94,60 @@ function normalizeStringArray(value, fieldName) {
   });
 }
 
+function normalizeOptionalStringArray(value, fieldName) {
+  if (value === undefined) return undefined;
+  return normalizeStringArray(value, fieldName);
+}
+
+function normalizeRequiredString(value, fieldName) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return value.trim();
+}
+
+function normalizeOptionalString(value, fieldName) {
+  if (value === undefined || value === null) return undefined;
+  return normalizeRequiredString(value, fieldName);
+}
+
+function normalizeOptionalBoolean(value, fieldName) {
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new Error(`${fieldName} must be a boolean`);
+  }
+  return value;
+}
+
+function normalizeEnum(value, values, fieldName) {
+  const normalized = normalizeRequiredString(value, fieldName);
+  if (!values.has(normalized)) {
+    throw new Error(`${fieldName} must be one of: ${[...values].join(", ")}`);
+  }
+  return normalized;
+}
+
+function normalizeReadiness(readiness) {
+  if (readiness === undefined) return undefined;
+  if (!readiness || typeof readiness !== "object" || Array.isArray(readiness)) {
+    throw new Error("readiness must be an object");
+  }
+
+  return Object.fromEntries(
+    Object.entries(READINESS_LEVELS).map(([field, values]) => [
+      field,
+      normalizeEnum(readiness[field], values, `readiness.${field}`),
+    ])
+  );
+}
+
+function normalizeNextAction(value, fallback) {
+  if (value === undefined || value === null || value === "") {
+    return fallback;
+  }
+  return normalizeRequiredString(value, "next_action");
+}
+
 function normalizeSingleLeafContract(contract) {
   if (!contract || typeof contract !== "object") {
     throw new Error("contract must be an object");
@@ -115,6 +187,7 @@ function normalizeSingleLeafContract(contract) {
       kind: contract.source.kind.trim(),
     },
     requestText: contract.request_text.trim(),
+    readiness: normalizeReadiness(contract.readiness),
     handoff: {
       leafId: handoff.leaf_id.trim(),
       title: handoff.title.trim(),
@@ -177,6 +250,42 @@ function buildHandoffBody(handoff) {
   ].join("\n");
 }
 
+function pickDefinedEntries(object) {
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
+}
+
+function getRequestRecord(repoRoot, requestId) {
+  const requestPath = getRequestPath(repoRoot, requestId);
+  if (!fs.existsSync(requestPath)) {
+    throw new Error(`request artifact not found: ${requestPath}`);
+  }
+  return { requestPath, artifact: readRequestArtifact(requestPath) };
+}
+
+function resolveRequestLeafId(artifact, leafId) {
+  if (leafId) return leafId;
+  if (artifact.data?.leaf_id) return artifact.data.leaf_id;
+
+  const handoffPath = artifact.data?.paths?.handoff;
+  if (!handoffPath || !fs.existsSync(handoffPath)) {
+    throw new Error("leaf_id is required");
+  }
+
+  return normalizeRequiredString(readRequestArtifact(handoffPath).data?.leaf_id, "leaf_id");
+}
+
+function updateRequestArtifact(repoRoot, requestId, patch, requestRecord = getRequestRecord(repoRoot, requestId)) {
+  writeManifest(requestRecord.requestPath, {
+    ...requestRecord.artifact.data,
+    ...patch,
+    timestamps: {
+      ...(requestRecord.artifact.data.timestamps || {}),
+      updated_at: nowIso(),
+    },
+  }, requestRecord.artifact.body);
+  return readRequestArtifact(requestRecord.requestPath);
+}
+
 function appendRequestEvent(repoRoot, requestId, eventData) {
   if (!requestId) {
     throw new Error("request_id is required to append a relay-intake event");
@@ -187,6 +296,7 @@ function appendRequestEvent(repoRoot, requestId, eventData) {
 
   const { eventsPath } = ensureRequestLayout(repoRoot, requestId);
   const record = {
+    ...pickDefinedEntries(eventData),
     ts: eventData.ts || nowIso(),
     event: eventData.event,
     actor: getActorName(repoRoot),
@@ -227,6 +337,122 @@ function assertRequestArtifactsAbsent(requestId, artifactPaths) {
   }
 }
 
+function appendInteractionEvent(repoRoot, requestId, eventData, nextAction) {
+  const requestRecord = getRequestRecord(repoRoot, requestId);
+  const leafId = resolveRequestLeafId(requestRecord.artifact, eventData.leaf_id);
+  const record = appendRequestEvent(repoRoot, requestId, { ...eventData, leaf_id: leafId });
+
+  if (nextAction !== undefined) {
+    updateRequestArtifact(repoRoot, requestId, { next_action: nextAction }, requestRecord);
+  }
+
+  return record;
+}
+
+function normalizeProposalFields(data = {}, fieldName = "proposal_summary") {
+  return pickDefinedEntries({
+    leaf_id: normalizeOptionalString(data.leaf_id, "leaf_id"),
+    proposal_summary: normalizeRequiredString(data[fieldName], fieldName),
+    proposal_text: normalizeOptionalString(data.proposal_text, "proposal_text"),
+    proposal_kind: normalizeOptionalString(data.proposal_kind, "proposal_kind"),
+    response_options: normalizeOptionalStringArray(data.response_options, "response_options"),
+    reason: normalizeOptionalString(data.reason, "reason"),
+  });
+}
+
+function normalizeQuestionFields(data = {}) {
+  return pickDefinedEntries({
+    leaf_id: normalizeOptionalString(data.leaf_id, "leaf_id"),
+    question_text: normalizeRequiredString(data.question_text, "question_text"),
+    response_options: normalizeOptionalStringArray(data.response_options, "response_options"),
+    reason: normalizeOptionalString(data.reason, "reason"),
+  });
+}
+
+function normalizeQuestionAnswerFields(data = {}) {
+  return pickDefinedEntries({
+    leaf_id: normalizeOptionalString(data.leaf_id, "leaf_id"),
+    question_text: normalizeRequiredString(data.question_text, "question_text"),
+    answer_text: normalizeRequiredString(data.answer_text, "answer_text"),
+    answer_choice: normalizeOptionalString(data.answer_choice, "answer_choice"),
+    reason: normalizeOptionalString(data.reason, "reason"),
+  });
+}
+
+function normalizeProposalAcceptanceFields(data = {}) {
+  return pickDefinedEntries({
+    leaf_id: normalizeOptionalString(data.leaf_id, "leaf_id"),
+    proposal_summary: normalizeRequiredString(data.proposal_summary, "proposal_summary"),
+    acceptance_note: normalizeOptionalString(data.acceptance_note, "acceptance_note"),
+    accepted_with_edits: normalizeOptionalBoolean(data.accepted_with_edits, "accepted_with_edits"),
+    reason: normalizeOptionalString(data.reason, "reason"),
+  });
+}
+
+function normalizeProposalEditFields(data = {}) {
+  return pickDefinedEntries({
+    leaf_id: normalizeOptionalString(data.leaf_id, "leaf_id"),
+    proposal_summary: normalizeRequiredString(data.proposal_summary, "proposal_summary"),
+    edit_summary: normalizeRequiredString(data.edit_summary, "edit_summary"),
+    proposal_text: normalizeOptionalString(data.proposal_text, "proposal_text"),
+    reason: normalizeOptionalString(data.reason, "reason"),
+  });
+}
+
+function propose(repoRoot, requestId, data = {}) {
+  const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.propose);
+  return appendInteractionEvent(repoRoot, requestId, {
+    event: "proposal_presented",
+    ...normalizeProposalFields(data),
+  }, nextAction);
+}
+
+function clarify(repoRoot, requestId, data = {}) {
+  const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.clarify);
+  return appendInteractionEvent(repoRoot, requestId, {
+    event: "question_asked",
+    ...normalizeQuestionFields(data),
+  }, nextAction);
+}
+
+function structure(repoRoot, requestId, data = {}) {
+  const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.structure);
+  const event = data.edits_existing_proposal ? "proposal_edited" : "proposal_presented";
+  const details = data.edits_existing_proposal
+    ? normalizeProposalEditFields(data)
+    : normalizeProposalFields(data);
+
+  return appendInteractionEvent(repoRoot, requestId, {
+    event,
+    structure_kind: normalizeOptionalString(data.structure_kind, "structure_kind") || "restructure",
+    ...details,
+  }, nextAction);
+}
+
+function answerQuestion(repoRoot, requestId, data = {}) {
+  const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.answerQuestion);
+  return appendInteractionEvent(repoRoot, requestId, {
+    event: "question_answered",
+    ...normalizeQuestionAnswerFields(data),
+  }, nextAction);
+}
+
+function acceptProposal(repoRoot, requestId, data = {}) {
+  const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.acceptProposal);
+  return appendInteractionEvent(repoRoot, requestId, {
+    event: "proposal_accepted",
+    ...normalizeProposalAcceptanceFields(data),
+  }, nextAction);
+}
+
+function editProposal(repoRoot, requestId, data = {}) {
+  const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.editProposal);
+  return appendInteractionEvent(repoRoot, requestId, {
+    event: "proposal_edited",
+    ...normalizeProposalEditFields(data),
+  }, nextAction);
+}
+
 function persistRequestContract(repoRoot, contract, options = {}) {
   const normalized = normalizeSingleLeafContract(contract);
   const requestId = options.requestId || createRequestId();
@@ -261,9 +487,12 @@ function persistRequestContract(repoRoot, contract, options = {}) {
   writeManifest(layout.requestPath, {
     request_id: requestId,
     state: "relay_ready",
+    leaf_id: normalized.handoff.leafId,
+    next_action: DEFAULT_NEXT_ACTIONS.persist,
     source: {
       kind: normalized.source.kind,
     },
+    ...(normalized.readiness ? { readiness: normalized.readiness } : {}),
     leaf_count: 1,
     paths: {
       raw_request: layout.rawRequestPath,
@@ -305,14 +534,20 @@ function persistRequestContract(repoRoot, contract, options = {}) {
     handoffPath,
     doneCriteriaPath,
     leafId: normalized.handoff.leafId,
+    nextAction: DEFAULT_NEXT_ACTIONS.persist,
+    readiness: normalized.readiness || null,
     title: normalized.handoff.title,
     sourceKind: normalized.source.kind,
   };
 }
 
 module.exports = {
+  acceptProposal,
+  answerQuestion,
   appendRequestEvent,
+  clarify,
   createRequestId,
+  editProposal,
   ensureRequestLayout,
   getRequestDir,
   getRequestEventsPath,
@@ -321,6 +556,8 @@ module.exports = {
   getRequestsDir,
   normalizeSingleLeafContract,
   persistRequestContract,
+  propose,
   readRequestArtifact,
   readRequestEvents,
+  structure,
 };

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -435,10 +435,6 @@ function normalizeRequestBootstrapData(data = {}) {
     throw new Error("source_kind and request_text are required together to bootstrap a request artifact");
   }
 
-  if (!hasBootstrapIdentity && readiness !== undefined) {
-    throw new Error("readiness requires source_kind and request_text when bootstrapping a request artifact");
-  }
-
   return { sourceKind, requestText, readiness };
 }
 
@@ -466,6 +462,24 @@ function validateBootstrapData(repoRoot, requestId, requestRecord, bootstrapData
       throw new Error(`request_id '${requestId}' already exists with a different raw request`);
     }
   }
+}
+
+function applyBootstrapDataPatch(repoRoot, requestId, requestRecord, bootstrapData) {
+  if (bootstrapData.readiness === undefined) {
+    return requestRecord;
+  }
+
+  const existingReadiness = requestRecord.artifact.data?.readiness;
+  if (JSON.stringify(existingReadiness) === JSON.stringify(bootstrapData.readiness)) {
+    return requestRecord;
+  }
+
+  return {
+    requestPath: requestRecord.requestPath,
+    artifact: updateRequestArtifact(repoRoot, requestId, {
+      readiness: bootstrapData.readiness,
+    }, requestRecord),
+  };
 }
 
 function buildRequestArtifactData({
@@ -509,13 +523,13 @@ function bootstrapRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
   }
 
   const layout = ensureRequestLayout(repoRoot, requestId);
+  const bootstrapData = normalizeRequestBootstrapData(data);
   if (fs.existsSync(layout.requestPath)) {
     const requestRecord = getRequestRecord(repoRoot, requestId);
-    validateBootstrapData(repoRoot, requestId, requestRecord, normalizeRequestBootstrapData(data));
-    return requestRecord;
+    validateBootstrapData(repoRoot, requestId, requestRecord, bootstrapData);
+    return applyBootstrapDataPatch(repoRoot, requestId, requestRecord, bootstrapData);
   }
 
-  const bootstrapData = normalizeRequestBootstrapData(data);
   if (!bootstrapData.sourceKind || !bootstrapData.requestText) {
     throw new Error(
       `request artifact not found: ${layout.requestPath}; source_kind and request_text are required to bootstrap it`

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -175,6 +175,16 @@ function normalizeSingleLeafContract(contract) {
     throw new Error("handoff is required");
   }
 
+  const contractReadiness = normalizeReadiness(contract.readiness);
+  const handoffReadiness = normalizeReadiness(handoff.readiness);
+  if (
+    contractReadiness &&
+    handoffReadiness &&
+    JSON.stringify(contractReadiness) !== JSON.stringify(handoffReadiness)
+  ) {
+    throw new Error("readiness must not conflict between contract.readiness and handoff.readiness");
+  }
+
   const requiredStrings = ["leaf_id", "title", "goal", "done_criteria_markdown"];
   for (const field of requiredStrings) {
     if (typeof handoff[field] !== "string" || !handoff[field].trim()) {
@@ -187,7 +197,7 @@ function normalizeSingleLeafContract(contract) {
       kind: contract.source.kind.trim(),
     },
     requestText: contract.request_text.trim(),
-    readiness: normalizeReadiness(contract.readiness),
+    readiness: contractReadiness || handoffReadiness,
     handoff: {
       leafId: handoff.leaf_id.trim(),
       title: handoff.title.trim(),
@@ -209,7 +219,12 @@ function formatBulletList(items) {
   return items.map((item) => `- ${item}`).join("\n");
 }
 
-function buildRequestBody({ sourceKind, requestText, leafId, handoffRelativePath, doneCriteriaRelativePath }) {
+function buildRequestBody({
+  sourceKind,
+  requestText,
+  relayReadyLeaves = [],
+  doneCriteriaSnapshots = [],
+}) {
   return [
     "# Relay Intake Request",
     "",
@@ -220,10 +235,10 @@ function buildRequestBody({ sourceKind, requestText, leafId, handoffRelativePath
     requestText,
     "",
     "## Relay-Ready Leaves",
-    `- ${leafId}: ${handoffRelativePath}`,
+    formatBulletList(relayReadyLeaves),
     "",
     "## Frozen Done Criteria",
-    `- ${leafId}: ${doneCriteriaRelativePath}`,
+    formatBulletList(doneCriteriaSnapshots),
     "",
   ].join("\n");
 }
@@ -267,7 +282,10 @@ function resolveRequestLeafId(artifact, leafId) {
   if (artifact.data?.leaf_id) return artifact.data.leaf_id;
 
   const handoffPath = artifact.data?.paths?.handoff;
-  if (!handoffPath || !fs.existsSync(handoffPath)) {
+  if (!handoffPath) {
+    return null;
+  }
+  if (!fs.existsSync(handoffPath)) {
     throw new Error("leaf_id is required");
   }
 
@@ -337,8 +355,8 @@ function assertRequestArtifactsAbsent(requestId, artifactPaths) {
   }
 }
 
-function appendInteractionEvent(repoRoot, requestId, eventData, nextAction) {
-  const requestRecord = getRequestRecord(repoRoot, requestId);
+function appendInteractionEvent(repoRoot, requestId, eventData, nextAction, bootstrapData = {}) {
+  const requestRecord = ensureRequestArtifact(repoRoot, requestId, bootstrapData, nextAction);
   const leafId = resolveRequestLeafId(requestRecord.artifact, eventData.leaf_id);
   const record = appendRequestEvent(repoRoot, requestId, { ...eventData, leaf_id: leafId });
 
@@ -399,12 +417,151 @@ function normalizeProposalEditFields(data = {}) {
   });
 }
 
+function normalizeRequestBootstrapData(data = {}) {
+  const source = data.source;
+  if (source !== undefined && (!source || typeof source !== "object" || Array.isArray(source))) {
+    throw new Error("source must be an object");
+  }
+
+  const sourceKind = normalizeOptionalString(
+    data.source_kind ?? source?.kind,
+    "source_kind"
+  );
+  const requestText = normalizeOptionalString(data.request_text, "request_text");
+  const readiness = normalizeReadiness(data.readiness);
+  const hasBootstrapIdentity = sourceKind !== undefined || requestText !== undefined;
+
+  if (hasBootstrapIdentity && (sourceKind === undefined || requestText === undefined)) {
+    throw new Error("source_kind and request_text are required together to bootstrap a request artifact");
+  }
+
+  if (!hasBootstrapIdentity && readiness !== undefined) {
+    throw new Error("readiness requires source_kind and request_text when bootstrapping a request artifact");
+  }
+
+  return { sourceKind, requestText, readiness };
+}
+
+function readRawRequestText(rawRequestPath) {
+  return fs.readFileSync(rawRequestPath, "utf-8").replace(/\r?\n$/, "");
+}
+
+function validateBootstrapData(repoRoot, requestId, requestRecord, bootstrapData) {
+  if (!bootstrapData.sourceKind && !bootstrapData.requestText && bootstrapData.readiness === undefined) {
+    return;
+  }
+
+  const existingSourceKind = requestRecord.artifact.data?.source?.kind;
+  if (bootstrapData.sourceKind && existingSourceKind && bootstrapData.sourceKind !== existingSourceKind) {
+    throw new Error(
+      `request_id '${requestId}' already exists with source.kind '${existingSourceKind}'`
+    );
+  }
+
+  const rawRequestPath = requestRecord.artifact.data?.paths?.raw_request
+    || path.join(getRequestDir(repoRoot, requestId), "raw-request.md");
+  if (bootstrapData.requestText && fs.existsSync(rawRequestPath)) {
+    const existingRequestText = readRawRequestText(rawRequestPath);
+    if (existingRequestText !== bootstrapData.requestText) {
+      throw new Error(`request_id '${requestId}' already exists with a different raw request`);
+    }
+  }
+}
+
+function buildRequestArtifactData({
+  requestId,
+  state,
+  leafId,
+  nextAction,
+  sourceKind,
+  readiness,
+  rawRequestPath,
+  handoffPath,
+  doneCriteriaPath,
+  createdAt,
+  updatedAt,
+}) {
+  return pickDefinedEntries({
+    request_id: requestId,
+    state,
+    leaf_id: leafId,
+    next_action: nextAction,
+    source: {
+      kind: sourceKind,
+    },
+    ...(readiness ? { readiness } : {}),
+    leaf_count: handoffPath ? 1 : 0,
+    paths: pickDefinedEntries({
+      raw_request: rawRequestPath,
+      handoff: handoffPath,
+      done_criteria: doneCriteriaPath,
+    }),
+    timestamps: {
+      created_at: createdAt,
+      updated_at: updatedAt,
+    },
+  });
+}
+
+function bootstrapRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
+  if (!requestId) {
+    throw new Error("request_id is required");
+  }
+
+  const layout = ensureRequestLayout(repoRoot, requestId);
+  if (fs.existsSync(layout.requestPath)) {
+    const requestRecord = getRequestRecord(repoRoot, requestId);
+    validateBootstrapData(repoRoot, requestId, requestRecord, normalizeRequestBootstrapData(data));
+    return requestRecord;
+  }
+
+  const bootstrapData = normalizeRequestBootstrapData(data);
+  if (!bootstrapData.sourceKind || !bootstrapData.requestText) {
+    throw new Error(
+      `request artifact not found: ${layout.requestPath}; source_kind and request_text are required to bootstrap it`
+    );
+  }
+
+  const createdAt = nowIso();
+  assertRequestArtifactsAbsent(requestId, [
+    ["request artifact", layout.requestPath],
+    ["request event log", layout.eventsPath],
+    ["raw request artifact", layout.rawRequestPath],
+  ]);
+
+  fs.writeFileSync(layout.rawRequestPath, `${bootstrapData.requestText}\n`, "utf-8");
+  writeManifest(layout.requestPath, buildRequestArtifactData({
+    requestId,
+    state: "intake",
+    nextAction,
+    sourceKind: bootstrapData.sourceKind,
+    readiness: bootstrapData.readiness,
+    rawRequestPath: layout.rawRequestPath,
+    createdAt,
+    updatedAt: createdAt,
+  }), buildRequestBody({
+    sourceKind: bootstrapData.sourceKind,
+    requestText: bootstrapData.requestText,
+  }));
+
+  appendRequestEvent(repoRoot, requestId, {
+    event: "request_persisted",
+    source_kind: bootstrapData.sourceKind,
+  });
+
+  return getRequestRecord(repoRoot, requestId);
+}
+
+function ensureRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
+  return bootstrapRequestArtifact(repoRoot, requestId, data, nextAction);
+}
+
 function propose(repoRoot, requestId, data = {}) {
   const nextAction = normalizeNextAction(data.next_action, DEFAULT_NEXT_ACTIONS.propose);
   return appendInteractionEvent(repoRoot, requestId, {
     event: "proposal_presented",
     ...normalizeProposalFields(data),
-  }, nextAction);
+  }, nextAction, data);
 }
 
 function clarify(repoRoot, requestId, data = {}) {
@@ -412,7 +569,7 @@ function clarify(repoRoot, requestId, data = {}) {
   return appendInteractionEvent(repoRoot, requestId, {
     event: "question_asked",
     ...normalizeQuestionFields(data),
-  }, nextAction);
+  }, nextAction, data);
 }
 
 function structure(repoRoot, requestId, data = {}) {
@@ -426,7 +583,7 @@ function structure(repoRoot, requestId, data = {}) {
     event,
     structure_kind: normalizeOptionalString(data.structure_kind, "structure_kind") || "restructure",
     ...details,
-  }, nextAction);
+  }, nextAction, data);
 }
 
 function answerQuestion(repoRoot, requestId, data = {}) {
@@ -434,7 +591,7 @@ function answerQuestion(repoRoot, requestId, data = {}) {
   return appendInteractionEvent(repoRoot, requestId, {
     event: "question_answered",
     ...normalizeQuestionAnswerFields(data),
-  }, nextAction);
+  }, nextAction, data);
 }
 
 function acceptProposal(repoRoot, requestId, data = {}) {
@@ -442,7 +599,7 @@ function acceptProposal(repoRoot, requestId, data = {}) {
   return appendInteractionEvent(repoRoot, requestId, {
     event: "proposal_accepted",
     ...normalizeProposalAcceptanceFields(data),
-  }, nextAction);
+  }, nextAction, data);
 }
 
 function editProposal(repoRoot, requestId, data = {}) {
@@ -450,30 +607,45 @@ function editProposal(repoRoot, requestId, data = {}) {
   return appendInteractionEvent(repoRoot, requestId, {
     event: "proposal_edited",
     ...normalizeProposalEditFields(data),
-  }, nextAction);
+  }, nextAction, data);
 }
 
 function persistRequestContract(repoRoot, contract, options = {}) {
   const normalized = normalizeSingleLeafContract(contract);
   const requestId = options.requestId || createRequestId();
-  const createdAt = nowIso();
-  const layout = ensureRequestLayout(repoRoot, requestId);
-  const requestArtifactDir = path.dirname(layout.requestPath);
+  const existingRequestPath = getRequestPath(repoRoot, requestId);
+  if (fs.existsSync(existingRequestPath)) {
+    const existingRequest = getRequestRecord(repoRoot, requestId);
+    if (existingRequest.artifact.data?.state === "relay_ready" || existingRequest.artifact.data?.paths?.handoff) {
+      throw new Error(
+        `request_id '${requestId}' already exists; refusing to overwrite existing request artifact: ${existingRequest.requestPath}`
+      );
+    }
+  }
+  const requestRecord = bootstrapRequestArtifact(repoRoot, requestId, {
+    source_kind: normalized.source.kind,
+    request_text: normalized.requestText,
+    readiness: normalized.readiness,
+  }, DEFAULT_NEXT_ACTIONS.persist);
+  const requestArtifactPath = requestRecord.requestPath;
+  const requestArtifactDir = path.dirname(requestArtifactPath);
   const handoffFileName = `${normalized.handoff.leafId}.md`;
-  const handoffPath = path.join(layout.relayReadyDir, handoffFileName);
-  const doneCriteriaPath = path.join(layout.doneCriteriaDir, handoffFileName);
+  const relayReadyDir = path.join(getRequestDir(repoRoot, requestId), "relay-ready");
+  const doneCriteriaDir = path.join(getRequestDir(repoRoot, requestId), "done-criteria");
+  const handoffPath = path.join(relayReadyDir, handoffFileName);
+  const doneCriteriaPath = path.join(doneCriteriaDir, handoffFileName);
   const handoffRelativePath = path.relative(requestArtifactDir, handoffPath);
   const doneCriteriaRelativePath = path.relative(requestArtifactDir, doneCriteriaPath);
+  const requestReadiness = normalized.readiness || requestRecord.artifact.data?.readiness;
+  const rawRequestPath = requestRecord.artifact.data?.paths?.raw_request;
+  const createdAt = requestRecord.artifact.data?.timestamps?.created_at || nowIso();
+  const updatedAt = nowIso();
 
   assertRequestArtifactsAbsent(requestId, [
-    ["request artifact", layout.requestPath],
-    ["request event log", layout.eventsPath],
-    ["raw request artifact", layout.rawRequestPath],
     ["relay-ready handoff", handoffPath],
     ["done criteria snapshot", doneCriteriaPath],
   ]);
 
-  fs.writeFileSync(layout.rawRequestPath, `${normalized.requestText}\n`, "utf-8");
   fs.writeFileSync(doneCriteriaPath, `${normalized.handoff.doneCriteriaMarkdown}\n`, "utf-8");
 
   writeManifest(handoffPath, {
@@ -484,40 +656,25 @@ function persistRequestContract(repoRoot, contract, options = {}) {
     done_criteria_path: doneCriteriaPath,
   }, buildHandoffBody(normalized.handoff));
 
-  writeManifest(layout.requestPath, {
-    request_id: requestId,
+  writeManifest(requestArtifactPath, buildRequestArtifactData({
+    requestId,
     state: "relay_ready",
-    leaf_id: normalized.handoff.leafId,
-    next_action: DEFAULT_NEXT_ACTIONS.persist,
-    source: {
-      kind: normalized.source.kind,
-    },
-    ...(normalized.readiness ? { readiness: normalized.readiness } : {}),
-    leaf_count: 1,
-    paths: {
-      raw_request: layout.rawRequestPath,
-      handoff: handoffPath,
-      done_criteria: doneCriteriaPath,
-    },
-    timestamps: {
-      created_at: createdAt,
-      updated_at: createdAt,
-    },
-  }, buildRequestBody({
+    leafId: normalized.handoff.leafId,
+    nextAction: DEFAULT_NEXT_ACTIONS.persist,
+    sourceKind: normalized.source.kind,
+    readiness: requestReadiness,
+    rawRequestPath,
+    handoffPath,
+    doneCriteriaPath,
+    createdAt,
+    updatedAt,
+  }), buildRequestBody({
     sourceKind: normalized.source.kind,
     requestText: normalized.requestText,
-    leafId: normalized.handoff.leafId,
-    handoffRelativePath,
-    doneCriteriaRelativePath,
+    relayReadyLeaves: [`${normalized.handoff.leafId}: ${handoffRelativePath}`],
+    doneCriteriaSnapshots: [`${normalized.handoff.leafId}: ${doneCriteriaRelativePath}`],
   }));
 
-  appendRequestEvent(repoRoot, requestId, {
-    event: "request_persisted",
-    source_kind: normalized.source.kind,
-    leaf_id: normalized.handoff.leafId,
-    handoff_path: handoffPath,
-    done_criteria_path: doneCriteriaPath,
-  });
   appendRequestEvent(repoRoot, requestId, {
     event: "relay_ready_handoff_persisted",
     source_kind: normalized.source.kind,
@@ -528,14 +685,14 @@ function persistRequestContract(repoRoot, contract, options = {}) {
 
   return {
     requestId,
-    requestPath: layout.requestPath,
-    requestDir: layout.requestDir,
-    rawRequestPath: layout.rawRequestPath,
+    requestPath: requestArtifactPath,
+    requestDir: getRequestDir(repoRoot, requestId),
+    rawRequestPath,
     handoffPath,
     doneCriteriaPath,
     leafId: normalized.handoff.leafId,
     nextAction: DEFAULT_NEXT_ACTIONS.persist,
-    readiness: normalized.readiness || null,
+    readiness: requestReadiness || null,
     title: normalized.handoff.title,
     sourceKind: normalized.source.kind,
   };

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -214,12 +214,19 @@ test("persistRequestContract rejects request_id collisions before overwriting fr
 test("preflight helpers bootstrap a non-ready request artifact before relay-ready persistence", () => {
   const { repoRoot } = setupRepo();
   const requestId = "req-20260409050505000";
-  const readiness = createReadiness({ dependency: "external" });
+  const initialReadiness = createReadiness({
+    clarity: "low",
+    granularity: "unclear",
+    dependency: "external",
+    verifiability: "low",
+    risk: "high",
+  });
+  const reassessedReadiness = createReadiness({ dependency: "internal" });
 
   const proposal = propose(repoRoot, requestId, {
     source_kind: "raw_text",
     request_text: createContract().request_text,
-    readiness,
+    readiness: initialReadiness,
     proposal_summary: "Keep the work as a single auth redirect leaf.",
     proposal_text: "A. Update the guard\nB. Add redirect tests\nC. Free text",
     response_options: ["A", "B", "C + free text"],
@@ -228,6 +235,7 @@ test("preflight helpers bootstrap a non-ready request artifact before relay-read
   assert.equal(proposal.leaf_id, null);
 
   const question = clarify(repoRoot, requestId, {
+    readiness: reassessedReadiness,
     question_text: "Should guest deep links still route to /login?",
     response_options: ["A. Yes", "B. No", "C. Other"],
   });
@@ -247,7 +255,7 @@ test("preflight helpers bootstrap a non-ready request artifact before relay-read
   assert.equal(requestArtifact.data.leaf_id, undefined);
   assert.equal(requestArtifact.data.next_action, "await_proposal_response");
   assert.equal(requestArtifact.data.paths.handoff, undefined);
-  assert.deepEqual(requestArtifact.data.readiness, readiness);
+  assert.deepEqual(requestArtifact.data.readiness, reassessedReadiness);
   assert.equal(
     fs.readFileSync(requestArtifact.data.paths.raw_request, "utf-8"),
     `${createContract().request_text}\n`
@@ -266,8 +274,8 @@ test("preflight helpers bootstrap a non-ready request artifact before relay-read
   assert.equal(promotedArtifact.data.leaf_id, "leaf-01");
   assert.equal(promotedArtifact.data.next_action, "relay_plan");
   assert.equal(promotedArtifact.data.paths.handoff, intake.handoffPath);
-  assert.deepEqual(promotedArtifact.data.readiness, readiness);
-  assert.deepEqual(intake.readiness, readiness);
+  assert.deepEqual(promotedArtifact.data.readiness, reassessedReadiness);
+  assert.deepEqual(intake.readiness, reassessedReadiness);
 
   const events = readRequestEvents(repoRoot, requestId);
   assert.deepEqual(
@@ -285,6 +293,7 @@ test("preflight helpers bootstrap a non-ready request artifact before relay-read
 test("preflight actions append typed events and update next_action without a second state machine", () => {
   const { repoRoot } = setupRepo();
   const intake = persistRequestContract(repoRoot, createContract());
+  const reassessedReadiness = createReadiness({ granularity: "multi_task" });
 
   const proposal = propose(repoRoot, intake.requestId, {
     proposal_summary: "Keep the work as a single auth redirect leaf.",
@@ -297,12 +306,14 @@ test("preflight actions append typed events and update next_action without a sec
   assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
 
   const question = clarify(repoRoot, intake.requestId, {
+    readiness: reassessedReadiness,
     question_text: "Should guest deep links still route to /login?",
     response_options: ["A. Yes", "B. No", "C. Other"],
   });
   assert.equal(question.event, "question_asked");
   assert.deepEqual(question.response_options, ["A. Yes", "B. No", "C. Other"]);
   assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_answer");
+  assert.deepEqual(readRequestArtifact(intake.requestPath).data.readiness, reassessedReadiness);
 
   const structured = structure(repoRoot, intake.requestId, {
     proposal_summary: "Restructure the handoff around one guard change plus tests.",

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -6,7 +6,17 @@ const os = require("os");
 const path = require("path");
 
 const { readManifest } = require("../../relay-dispatch/scripts/relay-manifest");
-const { readRequestEvents, persistRequestContract, readRequestArtifact } = require("./relay-request");
+const {
+  acceptProposal,
+  answerQuestion,
+  clarify,
+  editProposal,
+  propose,
+  readRequestEvents,
+  persistRequestContract,
+  readRequestArtifact,
+  structure,
+} = require("./relay-request");
 
 const PERSIST_SCRIPT = path.join(__dirname, "persist-request.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
@@ -39,6 +49,17 @@ function createContract(overrides = {}) {
       done_criteria_markdown: "# Done Criteria\n\n- Authenticated users stay off /login\n- Guests still reach /login\n",
       escalation_conditions: ["Auth state source is unclear"],
     },
+    ...overrides,
+  };
+}
+
+function createReadiness(overrides = {}) {
+  return {
+    clarity: "high",
+    granularity: "single_task",
+    dependency: "internal",
+    verifiability: "high",
+    risk: "medium",
     ...overrides,
   };
 }
@@ -76,6 +97,9 @@ test("persistRequestContract writes request artifact, relay-ready handoff, done 
   const requestArtifact = readRequestArtifact(result.requestPath);
   assert.equal(requestArtifact.data.request_id, result.requestId);
   assert.equal(requestArtifact.data.state, "relay_ready");
+  assert.equal(requestArtifact.data.leaf_id, "leaf-01");
+  assert.equal(requestArtifact.data.next_action, "relay_plan");
+  assert.equal(requestArtifact.data.readiness, undefined);
   assert.equal(requestArtifact.data.source.kind, "raw_text");
   assert.equal(requestArtifact.data.paths.handoff, result.handoffPath);
   assert.match(requestArtifact.body, /Relay Intake Request/);
@@ -98,6 +122,8 @@ test("persistRequestContract writes request artifact, relay-ready handoff, done 
   assert.equal(events[0].event, "request_persisted");
   assert.equal(events[1].event, "relay_ready_handoff_persisted");
   assert.equal(events[1].leaf_id, "leaf-01");
+  assert.equal(result.nextAction, "relay_plan");
+  assert.equal(result.readiness, null);
 });
 
 test("persist-request CLI persists the single-leaf request bundle", () => {
@@ -118,6 +144,17 @@ test("persist-request CLI persists the single-leaf request bundle", () => {
   assert.ok(fs.existsSync(result.requestPath));
   assert.ok(fs.existsSync(result.handoffPath));
   assert.ok(fs.existsSync(result.doneCriteriaPath));
+});
+
+test("persistRequestContract stores readiness dimensions in request frontmatter when provided", () => {
+  const { repoRoot } = setupRepo();
+  const readiness = createReadiness({ risk: "low" });
+
+  const result = persistRequestContract(repoRoot, createContract({ readiness }));
+  const requestArtifact = readRequestArtifact(result.requestPath);
+
+  assert.deepEqual(requestArtifact.data.readiness, readiness);
+  assert.deepEqual(result.readiness, readiness);
 });
 
 test("persistRequestContract rejects multi-leaf handoff input with an explicit #129 TODO", () => {
@@ -155,6 +192,95 @@ test("persistRequestContract rejects request_id collisions before overwriting fr
 
   assert.equal(fs.readFileSync(first.doneCriteriaPath, "utf-8"), originalDoneCriteria);
   assert.equal(readRequestEvents(repoRoot, requestId).length, 2);
+});
+
+test("preflight actions append typed events and update next_action without a second state machine", () => {
+  const { repoRoot } = setupRepo();
+  const intake = persistRequestContract(repoRoot, createContract());
+
+  const proposal = propose(repoRoot, intake.requestId, {
+    proposal_summary: "Keep the work as a single auth redirect leaf.",
+    proposal_text: "A. Update the guard\nB. Add redirect tests\nC. Free text",
+    response_options: ["A", "B", "C + free text"],
+  });
+  assert.equal(proposal.event, "proposal_presented");
+  assert.equal(proposal.request_id, intake.requestId);
+  assert.equal(proposal.leaf_id, intake.leafId);
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
+
+  const question = clarify(repoRoot, intake.requestId, {
+    question_text: "Should guest deep links still route to /login?",
+    response_options: ["A. Yes", "B. No", "C. Other"],
+  });
+  assert.equal(question.event, "question_asked");
+  assert.deepEqual(question.response_options, ["A. Yes", "B. No", "C. Other"]);
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_answer");
+
+  const structured = structure(repoRoot, intake.requestId, {
+    proposal_summary: "Restructure the handoff around one guard change plus tests.",
+    proposal_kind: "structure",
+    structure_kind: "decompose",
+  });
+  assert.equal(structured.event, "proposal_presented");
+  assert.equal(structured.structure_kind, "decompose");
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
+
+  const structuredEdit = structure(repoRoot, intake.requestId, {
+    proposal_summary: "Keep one leaf but tighten the handoff wording.",
+    edit_summary: "Fold the test wording into the main proposal summary.",
+    edits_existing_proposal: true,
+    structure_kind: "restructure",
+  });
+  assert.equal(structuredEdit.event, "proposal_edited");
+  assert.equal(structuredEdit.edit_summary, "Fold the test wording into the main proposal summary.");
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
+
+  const events = readRequestEvents(repoRoot, intake.requestId);
+  assert.deepEqual(
+    events.slice(-4).map((event) => event.event),
+    ["proposal_presented", "question_asked", "proposal_presented", "proposal_edited"]
+  );
+});
+
+test("interaction event helpers persist portable fields for answers, edits, and acceptance", () => {
+  const { repoRoot } = setupRepo();
+  const intake = persistRequestContract(repoRoot, createContract());
+
+  const answered = answerQuestion(repoRoot, intake.requestId, {
+    question_text: "Should guest deep links still route to /login?",
+    answer_text: "A. Yes, keep the guest login route as-is.",
+    answer_choice: "A",
+  });
+  assert.equal(answered.event, "question_answered");
+  assert.equal(answered.question_text, "Should guest deep links still route to /login?");
+  assert.equal(answered.answer_text, "A. Yes, keep the guest login route as-is.");
+  assert.equal(answered.answer_choice, "A");
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "review_answer");
+
+  const edited = editProposal(repoRoot, intake.requestId, {
+    proposal_summary: "Keep one relay leaf for the redirect loop fix.",
+    edit_summary: "Add the cookie-session assumption to the proposal text.",
+    proposal_text: "Scope the work to the redirect guard and add tests.",
+  });
+  assert.equal(edited.event, "proposal_edited");
+  assert.equal(edited.edit_summary, "Add the cookie-session assumption to the proposal text.");
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "review_proposal_edits");
+
+  const accepted = acceptProposal(repoRoot, intake.requestId, {
+    proposal_summary: "Keep one relay leaf for the redirect loop fix.",
+    acceptance_note: "Ship the single-leaf handoff.",
+    accepted_with_edits: true,
+  });
+  assert.equal(accepted.event, "proposal_accepted");
+  assert.equal(accepted.acceptance_note, "Ship the single-leaf handoff.");
+  assert.equal(accepted.accepted_with_edits, true);
+  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "relay_plan");
+
+  const events = readRequestEvents(repoRoot, intake.requestId);
+  assert.deepEqual(
+    events.slice(-3).map((event) => event.event),
+    ["question_answered", "proposal_edited", "proposal_accepted"]
+  );
 });
 
 test("raw request can flow through intake persistence, dispatch linkage, and review prepare-only", () => {

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -292,39 +292,41 @@ test("preflight helpers bootstrap a non-ready request artifact before relay-read
 
 test("preflight actions append typed events and update next_action without a second state machine", () => {
   const { repoRoot } = setupRepo();
-  const intake = persistRequestContract(repoRoot, createContract());
+  const requestId = "req-20260409060606000";
   const reassessedReadiness = createReadiness({ granularity: "multi_task" });
 
-  const proposal = propose(repoRoot, intake.requestId, {
+  const proposal = propose(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: createContract().request_text,
     proposal_summary: "Keep the work as a single auth redirect leaf.",
     proposal_text: "A. Update the guard\nB. Add redirect tests\nC. Free text",
     response_options: ["A", "B", "C + free text"],
   });
   assert.equal(proposal.event, "proposal_presented");
-  assert.equal(proposal.request_id, intake.requestId);
-  assert.equal(proposal.leaf_id, intake.leafId);
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
+  assert.equal(proposal.request_id, requestId);
+  assert.equal(proposal.leaf_id, null);
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "await_proposal_response");
 
-  const question = clarify(repoRoot, intake.requestId, {
+  const question = clarify(repoRoot, requestId, {
     readiness: reassessedReadiness,
     question_text: "Should guest deep links still route to /login?",
     response_options: ["A. Yes", "B. No", "C. Other"],
   });
   assert.equal(question.event, "question_asked");
   assert.deepEqual(question.response_options, ["A. Yes", "B. No", "C. Other"]);
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_answer");
-  assert.deepEqual(readRequestArtifact(intake.requestPath).data.readiness, reassessedReadiness);
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "await_answer");
+  assert.deepEqual(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.readiness, reassessedReadiness);
 
-  const structured = structure(repoRoot, intake.requestId, {
+  const structured = structure(repoRoot, requestId, {
     proposal_summary: "Restructure the handoff around one guard change plus tests.",
     proposal_kind: "structure",
     structure_kind: "decompose",
   });
   assert.equal(structured.event, "proposal_presented");
   assert.equal(structured.structure_kind, "decompose");
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "await_proposal_response");
 
-  const structuredEdit = structure(repoRoot, intake.requestId, {
+  const structuredEdit = structure(repoRoot, requestId, {
     proposal_summary: "Keep one leaf but tighten the handoff wording.",
     edit_summary: "Fold the test wording into the main proposal summary.",
     edits_existing_proposal: true,
@@ -332,20 +334,25 @@ test("preflight actions append typed events and update next_action without a sec
   });
   assert.equal(structuredEdit.event, "proposal_edited");
   assert.equal(structuredEdit.edit_summary, "Fold the test wording into the main proposal summary.");
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "await_proposal_response");
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "await_proposal_response");
 
-  const events = readRequestEvents(repoRoot, intake.requestId);
+  const events = readRequestEvents(repoRoot, requestId);
   assert.deepEqual(
-    events.slice(-4).map((event) => event.event),
-    ["proposal_presented", "question_asked", "proposal_presented", "proposal_edited"]
+    events.map((event) => event.event),
+    ["request_persisted", "proposal_presented", "question_asked", "proposal_presented", "proposal_edited"]
   );
 });
 
 test("interaction event helpers persist portable fields for answers, edits, and acceptance", () => {
   const { repoRoot } = setupRepo();
-  const intake = persistRequestContract(repoRoot, createContract());
+  const requestId = "req-20260409070707000";
+  propose(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: createContract().request_text,
+    proposal_summary: "Keep one relay leaf for the redirect loop fix.",
+  });
 
-  const answered = answerQuestion(repoRoot, intake.requestId, {
+  const answered = answerQuestion(repoRoot, requestId, {
     question_text: "Should guest deep links still route to /login?",
     answer_text: "A. Yes, keep the guest login route as-is.",
     answer_choice: "A",
@@ -354,18 +361,18 @@ test("interaction event helpers persist portable fields for answers, edits, and 
   assert.equal(answered.question_text, "Should guest deep links still route to /login?");
   assert.equal(answered.answer_text, "A. Yes, keep the guest login route as-is.");
   assert.equal(answered.answer_choice, "A");
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "review_answer");
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "review_answer");
 
-  const edited = editProposal(repoRoot, intake.requestId, {
+  const edited = editProposal(repoRoot, requestId, {
     proposal_summary: "Keep one relay leaf for the redirect loop fix.",
     edit_summary: "Add the cookie-session assumption to the proposal text.",
     proposal_text: "Scope the work to the redirect guard and add tests.",
   });
   assert.equal(edited.event, "proposal_edited");
   assert.equal(edited.edit_summary, "Add the cookie-session assumption to the proposal text.");
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "review_proposal_edits");
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "review_proposal_edits");
 
-  const accepted = acceptProposal(repoRoot, intake.requestId, {
+  const accepted = acceptProposal(repoRoot, requestId, {
     proposal_summary: "Keep one relay leaf for the redirect loop fix.",
     acceptance_note: "Ship the single-leaf handoff.",
     accepted_with_edits: true,
@@ -373,13 +380,46 @@ test("interaction event helpers persist portable fields for answers, edits, and 
   assert.equal(accepted.event, "proposal_accepted");
   assert.equal(accepted.acceptance_note, "Ship the single-leaf handoff.");
   assert.equal(accepted.accepted_with_edits, true);
-  assert.equal(readRequestArtifact(intake.requestPath).data.next_action, "relay_plan");
+  assert.equal(readRequestArtifact(getRequestPath(repoRoot, requestId)).data.next_action, "relay_plan");
 
-  const events = readRequestEvents(repoRoot, intake.requestId);
+  const events = readRequestEvents(repoRoot, requestId);
   assert.deepEqual(
     events.slice(-3).map((event) => event.event),
     ["question_answered", "proposal_edited", "proposal_accepted"]
   );
+});
+
+test("preflight helpers reject mutations after relay-ready persistence", () => {
+  const { repoRoot } = setupRepo();
+  const readiness = createReadiness({ risk: "low" });
+  const intake = persistRequestContract(repoRoot, createContract({ readiness }));
+  const initialArtifact = readRequestArtifact(intake.requestPath);
+  const initialEvents = readRequestEvents(repoRoot, intake.requestId);
+
+  assert.throws(
+    () => propose(repoRoot, intake.requestId, {
+      proposal_summary: "Try to reshape the frozen handoff.",
+    }),
+    /already relay_ready; preflight intake interactions cannot mutate a frozen handoff/
+  );
+  assert.throws(
+    () => clarify(repoRoot, intake.requestId, {
+      readiness: createReadiness({ risk: "high" }),
+      question_text: "Should this still be editable after the handoff exists?",
+    }),
+    /already relay_ready; preflight intake interactions cannot mutate a frozen handoff/
+  );
+  assert.throws(
+    () => structure(repoRoot, intake.requestId, {
+      proposal_summary: "Restructure the frozen request.",
+    }),
+    /already relay_ready; preflight intake interactions cannot mutate a frozen handoff/
+  );
+
+  const currentArtifact = readRequestArtifact(intake.requestPath);
+  assert.equal(currentArtifact.data.next_action, initialArtifact.data.next_action);
+  assert.deepEqual(currentArtifact.data.readiness, initialArtifact.data.readiness);
+  assert.deepEqual(readRequestEvents(repoRoot, intake.requestId), initialEvents);
 });
 
 test("raw request can flow through intake persistence, dispatch linkage, and review prepare-only", () => {

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -11,6 +11,7 @@ const {
   answerQuestion,
   clarify,
   editProposal,
+  getRequestPath,
   propose,
   readRequestEvents,
   persistRequestContract,
@@ -157,6 +158,22 @@ test("persistRequestContract stores readiness dimensions in request frontmatter 
   assert.deepEqual(result.readiness, readiness);
 });
 
+test("persistRequestContract stores readiness dimensions from handoff.readiness", () => {
+  const { repoRoot } = setupRepo();
+  const readiness = createReadiness({ clarity: "medium" });
+
+  const result = persistRequestContract(repoRoot, createContract({
+    handoff: {
+      ...createContract().handoff,
+      readiness,
+    },
+  }));
+  const requestArtifact = readRequestArtifact(result.requestPath);
+
+  assert.deepEqual(requestArtifact.data.readiness, readiness);
+  assert.deepEqual(result.readiness, readiness);
+});
+
 test("persistRequestContract rejects multi-leaf handoff input with an explicit #129 TODO", () => {
   const { repoRoot } = setupRepo();
   const contract = createContract({
@@ -192,6 +209,77 @@ test("persistRequestContract rejects request_id collisions before overwriting fr
 
   assert.equal(fs.readFileSync(first.doneCriteriaPath, "utf-8"), originalDoneCriteria);
   assert.equal(readRequestEvents(repoRoot, requestId).length, 2);
+});
+
+test("preflight helpers bootstrap a non-ready request artifact before relay-ready persistence", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409050505000";
+  const readiness = createReadiness({ dependency: "external" });
+
+  const proposal = propose(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: createContract().request_text,
+    readiness,
+    proposal_summary: "Keep the work as a single auth redirect leaf.",
+    proposal_text: "A. Update the guard\nB. Add redirect tests\nC. Free text",
+    response_options: ["A", "B", "C + free text"],
+  });
+  assert.equal(proposal.event, "proposal_presented");
+  assert.equal(proposal.leaf_id, null);
+
+  const question = clarify(repoRoot, requestId, {
+    question_text: "Should guest deep links still route to /login?",
+    response_options: ["A. Yes", "B. No", "C. Other"],
+  });
+  assert.equal(question.event, "question_asked");
+  assert.equal(question.leaf_id, null);
+
+  const structured = structure(repoRoot, requestId, {
+    proposal_summary: "Restructure the intake around one guard change plus tests.",
+    proposal_kind: "structure",
+    structure_kind: "decompose",
+  });
+  assert.equal(structured.event, "proposal_presented");
+  assert.equal(structured.leaf_id, null);
+
+  const requestArtifact = readRequestArtifact(getRequestPath(repoRoot, requestId));
+  assert.equal(requestArtifact.data.state, "intake");
+  assert.equal(requestArtifact.data.leaf_id, undefined);
+  assert.equal(requestArtifact.data.next_action, "await_proposal_response");
+  assert.equal(requestArtifact.data.paths.handoff, undefined);
+  assert.deepEqual(requestArtifact.data.readiness, readiness);
+  assert.equal(
+    fs.readFileSync(requestArtifact.data.paths.raw_request, "utf-8"),
+    `${createContract().request_text}\n`
+  );
+
+  const preflightEvents = readRequestEvents(repoRoot, requestId);
+  assert.deepEqual(
+    preflightEvents.map((event) => event.event),
+    ["request_persisted", "proposal_presented", "question_asked", "proposal_presented"]
+  );
+
+  const intake = persistRequestContract(repoRoot, createContract(), { requestId });
+  const promotedArtifact = readRequestArtifact(intake.requestPath);
+
+  assert.equal(promotedArtifact.data.state, "relay_ready");
+  assert.equal(promotedArtifact.data.leaf_id, "leaf-01");
+  assert.equal(promotedArtifact.data.next_action, "relay_plan");
+  assert.equal(promotedArtifact.data.paths.handoff, intake.handoffPath);
+  assert.deepEqual(promotedArtifact.data.readiness, readiness);
+  assert.deepEqual(intake.readiness, readiness);
+
+  const events = readRequestEvents(repoRoot, requestId);
+  assert.deepEqual(
+    events.map((event) => event.event),
+    [
+      "request_persisted",
+      "proposal_presented",
+      "question_asked",
+      "proposal_presented",
+      "relay_ready_handoff_persisted",
+    ]
+  );
 });
 
 test("preflight actions append typed events and update next_action without a second state machine", () => {


### PR DESCRIPTION
## Summary

Extends relay-intake request persistence (from PR #134) with:
- **Readiness assessment dimensions** (clarity, granularity, dependency, verifiability, risk) persisted in request artifact frontmatter
- **Preflight action helpers** (propose, clarify, structure) that append typed events
- **Portable interaction events** (proposal_presented, question_asked, question_answered, proposal_accepted, proposal_edited)
- **Next-action tracking** as lightweight fields in request artifact

## Test plan

- [ ] All existing tests pass: `node --test skills/relay-intake/scripts/*.test.js`
- [ ] Readiness dimensions round-trip through persistence
- [ ] Preflight actions append correct event types
- [ ] Backward compatibility: contracts without readiness still work
- [ ] Event model is portable (no host-specific dependencies)

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 요청 아티팩트 메타데이터 확장: 준비도 필드(readiness.clarity, granularity, dependency, verifiability, risk) 및 next_action 추가. preflight는 events.jsonl에 append-only임을 명시하고 휴대 가능한 인테이크 이벤트 유형(proposal_presented, question_asked, question_answered, proposal_accepted, proposal_edited) 규정.

* **새 기능**
  * 요청 상호작용 흐름 지원: propose/clarify/structure/answer/accept/edit 워크플로우와 next_action 기본값 및 부트스트랩/패치 동작 추가.
  * relay_ready 상태의 아티팩트 보호 및 readiness·next_action 지속 처리.

* **테스트**
  * 인테이크 워크플로우, 이벤트 페이로드, next_action 전환 및 relay_ready 이후 변경 금지 검증 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->