### PR TITLE
feat(#129): decompose larger requests into internal leaf-task plans

### DIFF
--- a/skills/relay-intake/SKILL.md
+++ b/skills/relay-intake/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relay-intake
 argument-hint: "[raw request or ambiguous task description]"
-description: Shape a raw request into a single relay-ready leaf contract with a frozen Done Criteria snapshot. Use before relay-plan when the task is ambiguous, oversized, or missing a stable review anchor.
+description: Shape a raw request into one-or-more relay-ready leaf contracts with frozen Done Criteria snapshots. Use before relay-plan when the task is ambiguous, oversized, or missing a stable review anchor.
 compatibility: Requires git and Node.js 18+.
 metadata:
   related-skills: "relay, relay-plan, relay-dispatch, relay-review"
@@ -23,13 +23,11 @@ Bypass intake only for a single relay-ready task with a trustworthy review ancho
 
 ## Output Contract
 
-This slice supports **single-leaf only**.
-
 Persist all of the following under `~/.relay/requests/<repo-slug>/<request-id>/`:
 - request artifact: `../<request-id>.md`
 - raw request: `raw-request.md`
-- relay-ready handoff: `relay-ready/<leaf-id>.md`
-- frozen Done Criteria: `done-criteria/<leaf-id>.md`
+- relay-ready handoffs: `relay-ready/<leaf-id>.md`
+- frozen Done Criteria snapshots: `done-criteria/<leaf-id>.md`
 - append-only events: `events.jsonl`
 
 The request artifact frontmatter may also carry:
@@ -39,34 +37,35 @@ The request artifact frontmatter may also carry:
 - `readiness.verifiability`
 - `readiness.risk`
 - `next_action`
+- `leaf_count`
+- `paths.handoff` + `paths.done_criteria` for single-leaf requests
+- `paths.handoffs` + `paths.done_criteria` for multi-leaf requests
+- `decomposition.leaf_order`
+- `decomposition.dependencies`
 
-The normalized handoff must contain:
+Each normalized handoff must contain:
 - `request_id`
 - `leaf_id`
 - `title`
 - `goal`
+- `order`
+- `depends_on`
 - `in_scope`
 - `out_of_scope`
 - `assumptions`
 - `done_criteria_path`
 - `escalation_conditions`
 
-If the request decomposes into multiple leaves, stop with:
-- `TODO(#129): multi-leaf relay-intake handoff is not implemented yet`
-
 ## Persistence Step
 
 Write a JSON contract file with:
 - `source.kind`
 - `request_text`
-- `handoff.leaf_id`
-- `handoff.title`
-- `handoff.goal`
-- `handoff.in_scope`
-- `handoff.out_of_scope`
-- `handoff.assumptions`
-- `handoff.done_criteria_markdown`
-- `handoff.escalation_conditions`
+- either `handoff` for single-leaf or `handoffs[]` for multi-leaf
+- per leaf: `leaf_id`, `title`, `goal`, `order`
+- optional per leaf: `depends_on`
+- per leaf: `in_scope`, `out_of_scope`, `assumptions`
+- per leaf: `done_criteria_markdown`, `escalation_conditions`
 
 Persist it with:
 
@@ -105,6 +104,7 @@ ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
   --done-criteria-file <done-criteria-path>
 ```
 
-3. let `relay-review` read the frozen snapshot from the run manifest anchor
+3. for multi-leaf requests, dispatch leaves in `decomposition.leaf_order`, respecting `depends_on`
+4. let `relay-review` read the frozen snapshot from the run manifest anchor
 
 Do not create a second lifecycle. Intake stops once the relay-ready contract is persisted.

--- a/skills/relay-intake/scripts/persist-request.js
+++ b/skills/relay-intake/scripts/persist-request.js
@@ -11,7 +11,7 @@ const KNOWN_FLAGS = ["--repo", "--contract-file", "--json", "--help", "-h"];
 if (!args.length || args.includes("--help") || args.includes("-h")) {
   console.log("Usage: persist-request.js --repo <path> --contract-file <path> [--json]");
   console.log("");
-  console.log("Persist a single-leaf relay-intake request artifact and handoff bundle.");
+  console.log("Persist a relay-intake request artifact and one-or-more leaf handoff bundles.");
   process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
 }
 
@@ -57,8 +57,18 @@ try {
     console.log(`Request:       ${result.requestId}`);
     console.log(`Artifact:      ${result.requestPath}`);
     console.log(`Raw request:   ${result.rawRequestPath}`);
-    console.log(`Relay-ready:   ${result.handoffPath}`);
-    console.log(`Done criteria: ${result.doneCriteriaPath}`);
+    if (result.leafCount === 1) {
+      console.log(`Relay-ready:   ${result.handoffPath}`);
+      console.log(`Done criteria: ${result.doneCriteriaPath}`);
+    } else {
+      console.log(`Leaf count:    ${result.leafCount}`);
+      for (const [index, leafId] of result.leafIds.entries()) {
+        console.log(`Relay-ready:   ${leafId} -> ${result.handoffPaths[index]}`);
+      }
+      for (const [index, leafId] of result.leafIds.entries()) {
+        console.log(`Done criteria: ${leafId} -> ${result.doneCriteriaPaths[index]}`);
+      }
+    }
   }
 } catch (error) {
   console.error(`Error: ${error.message}`);

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -119,6 +119,13 @@ function normalizeOptionalBoolean(value, fieldName) {
   return value;
 }
 
+function normalizePositiveInteger(value, fieldName) {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${fieldName} must be a positive integer`);
+  }
+  return value;
+}
+
 function normalizeEnum(value, values, fieldName) {
   const normalized = normalizeRequiredString(value, fieldName);
   if (!values.has(normalized)) {
@@ -148,7 +155,140 @@ function normalizeNextAction(value, fallback) {
   return normalizeRequiredString(value, "next_action");
 }
 
-function normalizeSingleLeafContract(contract) {
+function collectContractHandoffs(contract) {
+  if (Array.isArray(contract.handoffs)) {
+    if (!contract.handoffs.length) {
+      throw new Error("handoffs must include at least one leaf");
+    }
+    return contract.handoffs;
+  }
+  if (contract.handoff !== undefined) {
+    return [contract.handoff];
+  }
+  throw new Error("handoff is required");
+}
+
+function normalizeLeafHandoff(handoff, fieldName, defaultOrder) {
+  if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) {
+    throw new Error(`${fieldName} must be an object`);
+  }
+
+  const requiredStrings = ["leaf_id", "title", "goal", "done_criteria_markdown"];
+  for (const field of requiredStrings) {
+    if (typeof handoff[field] !== "string" || !handoff[field].trim()) {
+      throw new Error(`${fieldName}.${field} is required`);
+    }
+  }
+
+  const order = handoff.order === undefined
+    ? defaultOrder
+    : normalizePositiveInteger(handoff.order, `${fieldName}.order`);
+  if (order === undefined) {
+    throw new Error(`${fieldName}.order is required`);
+  }
+
+  return {
+    leafId: handoff.leaf_id.trim(),
+    title: handoff.title.trim(),
+    goal: handoff.goal.trim(),
+    order,
+    dependsOn: normalizeOptionalStringArray(handoff.depends_on, `${fieldName}.depends_on`) || [],
+    inScope: normalizeStringArray(handoff.in_scope || [], `${fieldName}.in_scope`),
+    outOfScope: normalizeStringArray(handoff.out_of_scope || [], `${fieldName}.out_of_scope`),
+    assumptions: normalizeStringArray(handoff.assumptions || [], `${fieldName}.assumptions`),
+    doneCriteriaMarkdown: handoff.done_criteria_markdown.trim(),
+    escalationConditions: normalizeStringArray(
+      handoff.escalation_conditions || [],
+      `${fieldName}.escalation_conditions`
+    ),
+    readiness: normalizeReadiness(handoff.readiness),
+  };
+}
+
+function sameValue(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function resolveContractReadiness(contractReadiness, handoffs) {
+  const leafReadiness = handoffs
+    .map((handoff) => handoff.readiness)
+    .filter(Boolean);
+  const [firstLeafReadiness] = leafReadiness;
+
+  for (const readiness of leafReadiness.slice(1)) {
+    if (!sameValue(readiness, firstLeafReadiness)) {
+      throw new Error("readiness must not conflict across handoffs");
+    }
+  }
+  if (contractReadiness && firstLeafReadiness && !sameValue(contractReadiness, firstLeafReadiness)) {
+    throw new Error("readiness must not conflict between contract.readiness and handoff.readiness");
+  }
+  return contractReadiness || firstLeafReadiness;
+}
+
+function assertUniqueLeafIds(handoffs) {
+  const seen = new Set();
+  for (const handoff of handoffs) {
+    if (seen.has(handoff.leafId)) {
+      throw new Error(`leaf_id '${handoff.leafId}' must be unique within a request`);
+    }
+    seen.add(handoff.leafId);
+  }
+}
+
+function assertUniqueLeafOrder(handoffs) {
+  const seen = new Map();
+  for (const handoff of handoffs) {
+    if (seen.has(handoff.order)) {
+      throw new Error(`order '${handoff.order}' must be unique within a request`);
+    }
+    seen.set(handoff.order, handoff.leafId);
+  }
+}
+
+function assertValidDependencies(handoffs) {
+  const orderByLeafId = new Map(handoffs.map((handoff) => [handoff.leafId, handoff.order]));
+  for (const handoff of handoffs) {
+    const seen = new Set();
+    for (const dependency of handoff.dependsOn) {
+      if (dependency === handoff.leafId) {
+        throw new Error(`leaf '${handoff.leafId}' cannot depend on itself`);
+      }
+      if (seen.has(dependency)) {
+        throw new Error(`leaf '${handoff.leafId}' must not repeat depends_on '${dependency}'`);
+      }
+      if (!orderByLeafId.has(dependency)) {
+        throw new Error(`leaf '${handoff.leafId}' depends_on unknown leaf '${dependency}'`);
+      }
+      if (orderByLeafId.get(dependency) >= handoff.order) {
+        throw new Error(`leaf '${handoff.leafId}' depends_on '${dependency}' but order does not respect that dependency`);
+      }
+      seen.add(dependency);
+    }
+  }
+}
+
+function sortHandoffsByOrder(handoffs) {
+  return [...handoffs].sort((left, right) => left.order - right.order);
+}
+
+function buildDecomposition(handoffs) {
+  return {
+    leaf_order: handoffs.map((handoff) => handoff.leafId),
+    dependencies: Object.fromEntries(
+      handoffs
+        .filter((handoff) => handoff.dependsOn.length)
+        .map((handoff) => [handoff.leafId, handoff.dependsOn])
+    ),
+  };
+}
+
+function stripLeafReadiness(handoff) {
+  const { readiness, ...rest } = handoff;
+  return rest;
+}
+
+function normalizeRequestContract(contract) {
   if (!contract || typeof contract !== "object") {
     throw new Error("contract must be an object");
   }
@@ -163,54 +303,42 @@ function normalizeSingleLeafContract(contract) {
     throw new Error("request_text is required");
   }
 
-  let handoff = contract.handoff;
-  if (Array.isArray(contract.handoffs)) {
-    if (contract.handoffs.length !== 1) {
-      throw new Error("TODO(#129): multi-leaf relay-intake handoff is not implemented yet");
-    }
-    [handoff] = contract.handoffs;
-  }
-
-  if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) {
-    throw new Error("handoff is required");
-  }
-
+  const rawHandoffs = collectContractHandoffs(contract);
   const contractReadiness = normalizeReadiness(contract.readiness);
-  const handoffReadiness = normalizeReadiness(handoff.readiness);
-  if (
-    contractReadiness &&
-    handoffReadiness &&
-    JSON.stringify(contractReadiness) !== JSON.stringify(handoffReadiness)
-  ) {
-    throw new Error("readiness must not conflict between contract.readiness and handoff.readiness");
-  }
+  const defaultOrder = rawHandoffs.length === 1 ? 1 : undefined;
+  const handoffs = rawHandoffs.map((handoff, index) => normalizeLeafHandoff(
+    handoff,
+    Array.isArray(contract.handoffs) ? `handoffs[${index}]` : "handoff",
+    defaultOrder
+  ));
+  const orderedHandoffs = sortHandoffsByOrder(handoffs);
 
-  const requiredStrings = ["leaf_id", "title", "goal", "done_criteria_markdown"];
-  for (const field of requiredStrings) {
-    if (typeof handoff[field] !== "string" || !handoff[field].trim()) {
-      throw new Error(`handoff.${field} is required`);
-    }
-  }
+  assertUniqueLeafIds(orderedHandoffs);
+  assertUniqueLeafOrder(orderedHandoffs);
+  assertValidDependencies(orderedHandoffs);
 
   return {
     source: {
       kind: contract.source.kind.trim(),
     },
     requestText: contract.request_text.trim(),
-    readiness: contractReadiness || handoffReadiness,
-    handoff: {
-      leafId: handoff.leaf_id.trim(),
-      title: handoff.title.trim(),
-      goal: handoff.goal.trim(),
-      inScope: normalizeStringArray(handoff.in_scope || [], "handoff.in_scope"),
-      outOfScope: normalizeStringArray(handoff.out_of_scope || [], "handoff.out_of_scope"),
-      assumptions: normalizeStringArray(handoff.assumptions || [], "handoff.assumptions"),
-      doneCriteriaMarkdown: handoff.done_criteria_markdown.trim(),
-      escalationConditions: normalizeStringArray(
-        handoff.escalation_conditions || [],
-        "handoff.escalation_conditions"
-      ),
-    },
+    readiness: resolveContractReadiness(contractReadiness, orderedHandoffs),
+    handoffs: orderedHandoffs.map(stripLeafReadiness),
+    leafCount: orderedHandoffs.length,
+    decomposition: buildDecomposition(orderedHandoffs),
+  };
+}
+
+function normalizeSingleLeafContract(contract) {
+  const normalized = normalizeRequestContract(contract);
+  if (normalized.leafCount !== 1) {
+    throw new Error(`contract must resolve to exactly one handoff; received ${normalized.leafCount}`);
+  }
+  return {
+    source: normalized.source,
+    requestText: normalized.requestText,
+    readiness: normalized.readiness,
+    handoff: normalized.handoffs[0],
   };
 }
 
@@ -265,6 +393,75 @@ function buildHandoffBody(handoff) {
   ].join("\n");
 }
 
+function shouldParseStructuredValue(value) {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  return trimmed.startsWith("[") || trimmed.startsWith("{");
+}
+
+function parseStructuredValue(value, fieldName) {
+  if (!shouldParseStructuredValue(value)) return value;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`invalid serialized ${fieldName}: ${error.message}`);
+  }
+}
+
+function serializeStructuredFields(data) {
+  const next = { ...data };
+  if (next.paths && typeof next.paths === "object" && !Array.isArray(next.paths)) {
+    next.paths = {
+      ...next.paths,
+      ...(Array.isArray(next.paths.handoffs)
+        ? { handoffs: JSON.stringify(next.paths.handoffs) }
+        : {}),
+      ...(Array.isArray(next.paths.done_criteria)
+        ? { done_criteria: JSON.stringify(next.paths.done_criteria) }
+        : {}),
+    };
+  }
+  if (next.decomposition && typeof next.decomposition === "object" && !Array.isArray(next.decomposition)) {
+    next.decomposition = {
+      ...next.decomposition,
+      ...(Array.isArray(next.decomposition.leaf_order)
+        ? { leaf_order: JSON.stringify(next.decomposition.leaf_order) }
+        : {}),
+      ...(next.decomposition.dependencies
+        ? { dependencies: JSON.stringify(next.decomposition.dependencies) }
+        : {}),
+    };
+  }
+  if (Array.isArray(next.depends_on)) {
+    next.depends_on = JSON.stringify(next.depends_on);
+  }
+  return next;
+}
+
+function hydrateStructuredFields(data) {
+  const next = { ...data };
+  if (next.paths && typeof next.paths === "object" && !Array.isArray(next.paths)) {
+    next.paths = {
+      ...next.paths,
+      handoffs: parseStructuredValue(next.paths.handoffs, "paths.handoffs"),
+      done_criteria: parseStructuredValue(next.paths.done_criteria, "paths.done_criteria"),
+    };
+  }
+  if (next.decomposition && typeof next.decomposition === "object" && !Array.isArray(next.decomposition)) {
+    next.decomposition = {
+      ...next.decomposition,
+      leaf_order: parseStructuredValue(next.decomposition.leaf_order, "decomposition.leaf_order"),
+      dependencies: parseStructuredValue(next.decomposition.dependencies, "decomposition.dependencies"),
+    };
+  }
+  next.depends_on = parseStructuredValue(next.depends_on, "depends_on");
+  return next;
+}
+
+function writeRequestManifest(manifestPath, data, body) {
+  writeManifest(manifestPath, serializeStructuredFields(data), body);
+}
+
 function pickDefinedEntries(object) {
   return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
 }
@@ -278,7 +475,12 @@ function getRequestRecord(repoRoot, requestId) {
 }
 
 function isRelayReadyRequestArtifact(artifact) {
-  return artifact.data?.state === "relay_ready" || Boolean(artifact.data?.paths?.handoff);
+  return (
+    artifact.data?.state === "relay_ready" ||
+    Boolean(artifact.data?.paths?.handoff) ||
+    Array.isArray(artifact.data?.paths?.handoffs) ||
+    artifact.data?.leaf_count > 0
+  );
 }
 
 function assertPreflightMutable(requestId, requestRecord) {
@@ -295,19 +497,21 @@ function resolveRequestLeafId(artifact, leafId) {
   if (leafId) return leafId;
   if (artifact.data?.leaf_id) return artifact.data.leaf_id;
 
-  const handoffPath = artifact.data?.paths?.handoff;
-  if (!handoffPath) {
+  const handoffPaths = artifact.data?.paths?.handoff
+    ? [artifact.data.paths.handoff]
+    : artifact.data?.paths?.handoffs;
+  if (!Array.isArray(handoffPaths) || !handoffPaths.length) {
     return null;
   }
-  if (!fs.existsSync(handoffPath)) {
+  if (handoffPaths.length !== 1 || !fs.existsSync(handoffPaths[0])) {
     throw new Error("leaf_id is required");
   }
 
-  return normalizeRequiredString(readRequestArtifact(handoffPath).data?.leaf_id, "leaf_id");
+  return normalizeRequiredString(readRequestArtifact(handoffPaths[0]).data?.leaf_id, "leaf_id");
 }
 
 function updateRequestArtifact(repoRoot, requestId, patch, requestRecord = getRequestRecord(repoRoot, requestId)) {
-  writeManifest(requestRecord.requestPath, {
+  writeRequestManifest(requestRecord.requestPath, {
     ...requestRecord.artifact.data,
     ...patch,
     timestamps: {
@@ -356,7 +560,11 @@ function readRequestEvents(repoRoot, requestId) {
 
 function readRequestArtifact(requestPath) {
   const text = fs.readFileSync(requestPath, "utf-8");
-  return parseFrontmatter(text);
+  const artifact = parseFrontmatter(text);
+  return {
+    ...artifact,
+    data: hydrateStructuredFields(artifact.data),
+  };
 }
 
 function assertRequestArtifactsAbsent(requestId, artifactPaths) {
@@ -500,15 +708,26 @@ function buildRequestArtifactData({
   requestId,
   state,
   leafId,
+  leafArtifacts = [],
   nextAction,
   sourceKind,
   readiness,
   rawRequestPath,
-  handoffPath,
-  doneCriteriaPath,
   createdAt,
   updatedAt,
 }) {
+  const isSingleLeaf = leafArtifacts.length === 1;
+  const decomposition = leafArtifacts.length > 1
+    ? {
+      leaf_order: leafArtifacts.map((leaf) => leaf.leafId),
+      dependencies: Object.fromEntries(
+        leafArtifacts
+          .filter((leaf) => leaf.dependsOn.length)
+          .map((leaf) => [leaf.leafId, leaf.dependsOn])
+      ),
+    }
+    : undefined;
+
   return pickDefinedEntries({
     request_id: requestId,
     state,
@@ -518,17 +737,76 @@ function buildRequestArtifactData({
       kind: sourceKind,
     },
     ...(readiness ? { readiness } : {}),
-    leaf_count: handoffPath ? 1 : 0,
+    leaf_count: leafArtifacts.length,
     paths: pickDefinedEntries({
       raw_request: rawRequestPath,
-      handoff: handoffPath,
-      done_criteria: doneCriteriaPath,
+      ...(isSingleLeaf
+        ? {
+          handoff: leafArtifacts[0].handoffPath,
+          done_criteria: leafArtifacts[0].doneCriteriaPath,
+        }
+        : {}),
+      ...(leafArtifacts.length > 1
+        ? {
+          handoffs: leafArtifacts.map((leaf) => leaf.handoffPath),
+          done_criteria: leafArtifacts.map((leaf) => leaf.doneCriteriaPath),
+        }
+        : {}),
     }),
+    decomposition,
     timestamps: {
       created_at: createdAt,
       updated_at: updatedAt,
     },
   });
+}
+
+function buildLeafArtifacts(layout, requestArtifactDir, handoffs) {
+  return handoffs.map((handoff) => {
+    const fileName = `${handoff.leafId}.md`;
+    const handoffPath = path.join(layout.relayReadyDir, fileName);
+    const doneCriteriaPath = path.join(layout.doneCriteriaDir, fileName);
+    return {
+      ...handoff,
+      handoffPath,
+      doneCriteriaPath,
+      handoffRelativePath: path.relative(requestArtifactDir, handoffPath),
+      doneCriteriaRelativePath: path.relative(requestArtifactDir, doneCriteriaPath),
+    };
+  });
+}
+
+function buildPersistResult({
+  requestId,
+  requestPath,
+  requestDir,
+  rawRequestPath,
+  leafArtifacts,
+  nextAction,
+  readiness,
+  sourceKind,
+}) {
+  const result = {
+    requestId,
+    requestPath,
+    requestDir,
+    rawRequestPath,
+    leafIds: leafArtifacts.map((leaf) => leaf.leafId),
+    handoffPaths: leafArtifacts.map((leaf) => leaf.handoffPath),
+    doneCriteriaPaths: leafArtifacts.map((leaf) => leaf.doneCriteriaPath),
+    leafCount: leafArtifacts.length,
+    nextAction,
+    readiness: readiness || null,
+    sourceKind,
+  };
+
+  if (leafArtifacts.length === 1) {
+    result.leafId = leafArtifacts[0].leafId;
+    result.handoffPath = leafArtifacts[0].handoffPath;
+    result.doneCriteriaPath = leafArtifacts[0].doneCriteriaPath;
+    result.title = leafArtifacts[0].title;
+  }
+  return result;
 }
 
 function bootstrapRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
@@ -558,13 +836,14 @@ function bootstrapRequestArtifact(repoRoot, requestId, data = {}, nextAction) {
   ]);
 
   fs.writeFileSync(layout.rawRequestPath, `${bootstrapData.requestText}\n`, "utf-8");
-  writeManifest(layout.requestPath, buildRequestArtifactData({
+  writeRequestManifest(layout.requestPath, buildRequestArtifactData({
     requestId,
     state: "intake",
     nextAction,
     sourceKind: bootstrapData.sourceKind,
     readiness: bootstrapData.readiness,
     rawRequestPath: layout.rawRequestPath,
+    leafArtifacts: [],
     createdAt,
     updatedAt: createdAt,
   }), buildRequestBody({
@@ -652,12 +931,11 @@ function editProposal(repoRoot, requestId, data = {}) {
 }
 
 function persistRequestContract(repoRoot, contract, options = {}) {
-  const normalized = normalizeSingleLeafContract(contract);
+  const normalized = normalizeRequestContract(contract);
   const requestId = options.requestId || createRequestId();
-  const existingRequestPath = getRequestPath(repoRoot, requestId);
-  if (fs.existsSync(existingRequestPath)) {
+  if (fs.existsSync(getRequestPath(repoRoot, requestId))) {
     const existingRequest = getRequestRecord(repoRoot, requestId);
-    if (existingRequest.artifact.data?.state === "relay_ready" || existingRequest.artifact.data?.paths?.handoff) {
+    if (isRelayReadyRequestArtifact(existingRequest.artifact)) {
       throw new Error(
         `request_id '${requestId}' already exists; refusing to overwrite existing request artifact: ${existingRequest.requestPath}`
       );
@@ -670,73 +948,75 @@ function persistRequestContract(repoRoot, contract, options = {}) {
   }, DEFAULT_NEXT_ACTIONS.persist);
   const requestArtifactPath = requestRecord.requestPath;
   const requestArtifactDir = path.dirname(requestArtifactPath);
-  const handoffFileName = `${normalized.handoff.leafId}.md`;
-  const relayReadyDir = path.join(getRequestDir(repoRoot, requestId), "relay-ready");
-  const doneCriteriaDir = path.join(getRequestDir(repoRoot, requestId), "done-criteria");
-  const handoffPath = path.join(relayReadyDir, handoffFileName);
-  const doneCriteriaPath = path.join(doneCriteriaDir, handoffFileName);
-  const handoffRelativePath = path.relative(requestArtifactDir, handoffPath);
-  const doneCriteriaRelativePath = path.relative(requestArtifactDir, doneCriteriaPath);
+  const layout = ensureRequestLayout(repoRoot, requestId);
+  const leafArtifacts = buildLeafArtifacts(layout, requestArtifactDir, normalized.handoffs);
   const requestReadiness = normalized.readiness || requestRecord.artifact.data?.readiness;
   const rawRequestPath = requestRecord.artifact.data?.paths?.raw_request;
   const createdAt = requestRecord.artifact.data?.timestamps?.created_at || nowIso();
   const updatedAt = nowIso();
 
-  assertRequestArtifactsAbsent(requestId, [
-    ["relay-ready handoff", handoffPath],
-    ["done criteria snapshot", doneCriteriaPath],
-  ]);
+  assertRequestArtifactsAbsent(requestId, leafArtifacts.flatMap((leaf) => [
+    ["relay-ready handoff", leaf.handoffPath],
+    ["done criteria snapshot", leaf.doneCriteriaPath],
+  ]));
 
-  fs.writeFileSync(doneCriteriaPath, `${normalized.handoff.doneCriteriaMarkdown}\n`, "utf-8");
+  for (const leaf of leafArtifacts) {
+    fs.writeFileSync(leaf.doneCriteriaPath, `${leaf.doneCriteriaMarkdown}\n`, "utf-8");
+    writeRequestManifest(leaf.handoffPath, {
+      request_id: requestId,
+      leaf_id: leaf.leafId,
+      title: leaf.title,
+      goal: leaf.goal,
+      order: leaf.order,
+      depends_on: leaf.dependsOn,
+      done_criteria_path: leaf.doneCriteriaPath,
+    }, buildHandoffBody(leaf));
+  }
 
-  writeManifest(handoffPath, {
-    request_id: requestId,
-    leaf_id: normalized.handoff.leafId,
-    title: normalized.handoff.title,
-    goal: normalized.handoff.goal,
-    done_criteria_path: doneCriteriaPath,
-  }, buildHandoffBody(normalized.handoff));
-
-  writeManifest(requestArtifactPath, buildRequestArtifactData({
+  writeRequestManifest(requestArtifactPath, buildRequestArtifactData({
     requestId,
     state: "relay_ready",
-    leafId: normalized.handoff.leafId,
+    leafId: leafArtifacts.length === 1 ? leafArtifacts[0].leafId : undefined,
+    leafArtifacts,
     nextAction: DEFAULT_NEXT_ACTIONS.persist,
     sourceKind: normalized.source.kind,
     readiness: requestReadiness,
     rawRequestPath,
-    handoffPath,
-    doneCriteriaPath,
     createdAt,
     updatedAt,
   }), buildRequestBody({
     sourceKind: normalized.source.kind,
     requestText: normalized.requestText,
-    relayReadyLeaves: [`${normalized.handoff.leafId}: ${handoffRelativePath}`],
-    doneCriteriaSnapshots: [`${normalized.handoff.leafId}: ${doneCriteriaRelativePath}`],
+    relayReadyLeaves: leafArtifacts.map(
+      (leaf) => `${leaf.leafId} [order ${leaf.order}] ${leaf.title}: ${leaf.handoffRelativePath}${
+        leaf.dependsOn.length ? ` (depends_on: ${leaf.dependsOn.join(", ")})` : ""
+      }`
+    ),
+    doneCriteriaSnapshots: leafArtifacts.map(
+      (leaf) => `${leaf.leafId}: ${leaf.doneCriteriaRelativePath}`
+    ),
   }));
 
-  appendRequestEvent(repoRoot, requestId, {
-    event: "relay_ready_handoff_persisted",
-    source_kind: normalized.source.kind,
-    leaf_id: normalized.handoff.leafId,
-    handoff_path: handoffPath,
-    done_criteria_path: doneCriteriaPath,
-  });
+  for (const leaf of leafArtifacts) {
+    appendRequestEvent(repoRoot, requestId, {
+      event: "relay_ready_handoff_persisted",
+      source_kind: normalized.source.kind,
+      leaf_id: leaf.leafId,
+      handoff_path: leaf.handoffPath,
+      done_criteria_path: leaf.doneCriteriaPath,
+    });
+  }
 
-  return {
+  return buildPersistResult({
     requestId,
     requestPath: requestArtifactPath,
     requestDir: getRequestDir(repoRoot, requestId),
     rawRequestPath,
-    handoffPath,
-    doneCriteriaPath,
-    leafId: normalized.handoff.leafId,
+    leafArtifacts,
     nextAction: DEFAULT_NEXT_ACTIONS.persist,
-    readiness: requestReadiness || null,
-    title: normalized.handoff.title,
+    readiness: requestReadiness,
     sourceKind: normalized.source.kind,
-  };
+  });
 }
 
 module.exports = {

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -54,6 +54,39 @@ function createContract(overrides = {}) {
   };
 }
 
+function createMultiLeafContract(overrides = {}) {
+  const baseHandoff = createContract().handoff;
+  return {
+    source: { kind: "raw_text" },
+    request_text: "Fix the login redirect loop and backfill auth redirect coverage.",
+    handoffs: [
+      {
+        ...baseHandoff,
+        leaf_id: "leaf-02",
+        title: "Backfill auth redirect coverage",
+        goal: "Add regression coverage for authenticated and guest redirects",
+        order: 2,
+        depends_on: ["leaf-01"],
+        in_scope: ["Add redirect regression coverage", "Cover guest and authenticated states"],
+        out_of_scope: ["Changing auth providers"],
+        assumptions: ["The existing auth test harness can simulate both states"],
+        done_criteria_markdown: "# Done Criteria\n\n- Redirect regressions are covered for guests and authenticated users\n",
+        escalation_conditions: ["The auth test harness cannot simulate both states"],
+      },
+      {
+        ...baseHandoff,
+        leaf_id: "leaf-01",
+        title: "Fix login redirect loop",
+        goal: "Stop authenticated users from bouncing back to /login",
+        order: 1,
+        depends_on: [],
+        done_criteria_markdown: "# Done Criteria\n\n- Authenticated users stay off /login\n- Guests still reach /login\n",
+      },
+    ],
+    ...overrides,
+  };
+}
+
 function createReadiness(overrides = {}) {
   return {
     clarity: "high",
@@ -94,6 +127,10 @@ test("persistRequestContract writes request artifact, relay-ready handoff, done 
   assert.ok(fs.existsSync(result.rawRequestPath));
   assert.ok(fs.existsSync(result.handoffPath));
   assert.ok(fs.existsSync(result.doneCriteriaPath));
+  assert.equal(result.leafCount, 1);
+  assert.deepEqual(result.leafIds, ["leaf-01"]);
+  assert.deepEqual(result.handoffPaths, [result.handoffPath]);
+  assert.deepEqual(result.doneCriteriaPaths, [result.doneCriteriaPath]);
 
   const requestArtifact = readRequestArtifact(result.requestPath);
   assert.equal(requestArtifact.data.request_id, result.requestId);
@@ -111,6 +148,8 @@ test("persistRequestContract writes request artifact, relay-ready handoff, done 
   const handoffArtifact = readRequestArtifact(result.handoffPath);
   assert.equal(handoffArtifact.data.request_id, result.requestId);
   assert.equal(handoffArtifact.data.leaf_id, "leaf-01");
+  assert.equal(handoffArtifact.data.order, 1);
+  assert.deepEqual(handoffArtifact.data.depends_on, []);
   assert.equal(handoffArtifact.data.done_criteria_path, result.doneCriteriaPath);
   assert.match(handoffArtifact.body, /In Scope/);
   assert.match(handoffArtifact.body, /Update the redirect guard/);
@@ -147,6 +186,27 @@ test("persist-request CLI persists the single-leaf request bundle", () => {
   assert.ok(fs.existsSync(result.doneCriteriaPath));
 });
 
+test("persist-request CLI returns multi-leaf paths in execution order", () => {
+  const { repoRoot } = setupRepo();
+  const contractPath = path.join(repoRoot, "multi-contract.json");
+  fs.writeFileSync(contractPath, `${JSON.stringify(createMultiLeafContract(), null, 2)}\n`, "utf-8");
+
+  const stdout = execFileSync("node", [
+    PERSIST_SCRIPT,
+    "--repo", repoRoot,
+    "--contract-file", contractPath,
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.leafCount, 2);
+  assert.deepEqual(result.leafIds, ["leaf-01", "leaf-02"]);
+  assert.equal(result.handoffPath, undefined);
+  assert.equal(result.doneCriteriaPath, undefined);
+  assert.equal(result.handoffPaths.length, 2);
+  assert.equal(result.doneCriteriaPaths.length, 2);
+});
+
 test("persistRequestContract stores readiness dimensions in request frontmatter when provided", () => {
   const { repoRoot } = setupRepo();
   const readiness = createReadiness({ risk: "low" });
@@ -174,19 +234,79 @@ test("persistRequestContract stores readiness dimensions from handoff.readiness"
   assert.deepEqual(result.readiness, readiness);
 });
 
-test("persistRequestContract rejects multi-leaf handoff input with an explicit #129 TODO", () => {
+test("persistRequestContract persists multi-leaf handoffs with ordering, dependencies, and per-leaf artifacts", () => {
   const { repoRoot } = setupRepo();
-  const contract = createContract({
-    handoff: undefined,
+  const result = persistRequestContract(repoRoot, createMultiLeafContract());
+
+  assert.equal(result.leafCount, 2);
+  assert.equal(result.leafId, undefined);
+  assert.equal(result.handoffPath, undefined);
+  assert.equal(result.doneCriteriaPath, undefined);
+  assert.deepEqual(result.leafIds, ["leaf-01", "leaf-02"]);
+  assert.equal(result.handoffPaths.length, 2);
+  assert.equal(result.doneCriteriaPaths.length, 2);
+  for (const artifactPath of [...result.handoffPaths, ...result.doneCriteriaPaths]) {
+    assert.ok(fs.existsSync(artifactPath));
+  }
+
+  const requestArtifact = readRequestArtifact(result.requestPath);
+  assert.equal(requestArtifact.data.request_id, result.requestId);
+  assert.equal(requestArtifact.data.state, "relay_ready");
+  assert.equal(requestArtifact.data.leaf_id, undefined);
+  assert.equal(requestArtifact.data.leaf_count, 2);
+  assert.deepEqual(requestArtifact.data.paths.handoffs, result.handoffPaths);
+  assert.deepEqual(requestArtifact.data.paths.done_criteria, result.doneCriteriaPaths);
+  assert.equal(requestArtifact.data.paths.handoff, undefined);
+  assert.deepEqual(requestArtifact.data.decomposition.leaf_order, ["leaf-01", "leaf-02"]);
+  assert.deepEqual(requestArtifact.data.decomposition.dependencies, {
+    "leaf-02": ["leaf-01"],
+  });
+  assert.match(requestArtifact.body, /leaf-01 \[order 1\] Fix login redirect loop/);
+  assert.match(requestArtifact.body, /leaf-02 \[order 2\] Backfill auth redirect coverage/);
+  assert.match(requestArtifact.body, /depends_on: leaf-01/);
+  assert.match(requestArtifact.body, new RegExp(`${result.requestId}/relay-ready/leaf-01\\.md`));
+  assert.match(requestArtifact.body, new RegExp(`${result.requestId}/relay-ready/leaf-02\\.md`));
+  assert.match(requestArtifact.body, new RegExp(`${result.requestId}/done-criteria/leaf-01\\.md`));
+  assert.match(requestArtifact.body, new RegExp(`${result.requestId}/done-criteria/leaf-02\\.md`));
+
+  const firstHandoff = readRequestArtifact(result.handoffPaths[0]);
+  assert.equal(firstHandoff.data.leaf_id, "leaf-01");
+  assert.equal(firstHandoff.data.order, 1);
+  assert.deepEqual(firstHandoff.data.depends_on, []);
+  assert.equal(firstHandoff.data.done_criteria_path, result.doneCriteriaPaths[0]);
+
+  const secondHandoff = readRequestArtifact(result.handoffPaths[1]);
+  assert.equal(secondHandoff.data.leaf_id, "leaf-02");
+  assert.equal(secondHandoff.data.order, 2);
+  assert.deepEqual(secondHandoff.data.depends_on, ["leaf-01"]);
+  assert.equal(secondHandoff.data.done_criteria_path, result.doneCriteriaPaths[1]);
+
+  const firstDoneCriteria = fs.readFileSync(result.doneCriteriaPaths[0], "utf-8");
+  const secondDoneCriteria = fs.readFileSync(result.doneCriteriaPaths[1], "utf-8");
+  assert.match(firstDoneCriteria, /Authenticated users stay off \/login/);
+  assert.match(secondDoneCriteria, /Redirect regressions are covered/);
+
+  const events = readRequestEvents(repoRoot, result.requestId);
+  assert.equal(events.length, 3);
+  assert.equal(events[0].event, "request_persisted");
+  assert.deepEqual(
+    events.slice(1).map((event) => event.leaf_id),
+    ["leaf-01", "leaf-02"]
+  );
+});
+
+test("persistRequestContract rejects duplicate leaf IDs within a multi-leaf request", () => {
+  const { repoRoot } = setupRepo();
+  const contract = createMultiLeafContract({
     handoffs: [
-      createContract().handoff,
-      { ...createContract().handoff, leaf_id: "leaf-02", title: "Second leaf" },
+      { ...createMultiLeafContract().handoffs[0], leaf_id: "leaf-01" },
+      createMultiLeafContract().handoffs[1],
     ],
   });
 
   assert.throws(
     () => persistRequestContract(repoRoot, contract),
-    /TODO\(#129\): multi-leaf relay-intake handoff is not implemented yet/
+    /leaf_id 'leaf-01' must be unique within a request/
   );
 });
 


### PR DESCRIPTION
## Summary

- Replaces `TODO(#129)` with working multi-leaf contract normalization and persistence
- Each leaf gets its own `relay-ready/<leaf-id>.md` handoff and `done-criteria/<leaf-id>.md` snapshot
- Decomposition metadata (order, depends_on) persisted per-leaf in handoff frontmatter
- Request artifact tracks `leaf_count`, all handoff/done-criteria paths, and decomposition structure
- Single-leaf backward compatibility fully preserved

## Test plan

- [ ] All existing tests pass: `node --test skills/relay-intake/scripts/*.test.js`
- [ ] Multi-leaf contracts persist all leaves correctly
- [ ] Ordering and dependency metadata round-trip through persistence
- [ ] Single-leaf contracts work identically to before
- [ ] Duplicate leaf_id rejection works

Closes #129