### PR TITLE
docs(#132): add intake flow docs and scenario test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,15 @@ draft → dispatched → review_pending → ready_to_merge → merged
 
 See [references/architecture.md](references/architecture.md) for the full manifest schema, state transitions, event journal format, and adapter extension points.
 
+Before a run exists, relay-intake may persist standalone request artifacts under `~/.relay/requests/<repo-slug>/`. `/relay` bypasses that preflight step only for already relay-ready issue/task inputs with a trustworthy review anchor; otherwise it invokes intake and then continues with `relay-plan -> relay-dispatch -> relay-review -> relay-merge`.
+
 ## Project Structure
 
 ```
 skills/
   relay/                   ← Full-cycle orchestration (plan → dispatch → review → stop)
     references/prompt-template.md
-  relay-intake/            ← Raw request shaping + relay-ready handoff persistence
+  relay-intake/            ← Standalone raw-request front door + relay-ready handoff persistence
     scripts/
       relay-request.js       ← Request artifact CRUD + request events
       persist-request.js     ← Single-leaf persistence entry point
@@ -54,7 +56,7 @@ skills/
       review-gate.js       ← Review state validation
 ```
 
-Multi-skill design: each phase is independently invocable. `npx skills add sungjunlee/dev-relay` installs all 6.
+Multi-skill design: each phase is independently invocable. `npx skills add sungjunlee/dev-relay` installs all 6 skills: `relay`, `relay-intake`, `relay-plan`, `relay-dispatch`, `relay-review`, `relay-merge`.
 
 ## Common Commands
 

--- a/docs/relay-intake-routing-and-handoff-design.md
+++ b/docs/relay-intake-routing-and-handoff-design.md
@@ -6,9 +6,21 @@
 
 `/relay` remains the user-facing orchestrator.
 
-`/relay-intake` becomes the standalone shaping skill for raw, ambiguous, or oversized requests.
+`/relay-intake` is the standalone shaping front door for raw, ambiguous, or oversized requests, and it is also the internal preflight step that `/relay` may invoke before planning.
 
 `/relay` decides whether to bypass intake or invoke it, then always continues the normal downstream chain for relay-ready work.
+
+End-to-end flow:
+
+```text
+raw request
+  -> relay-intake
+  -> relay-ready leaf contract(s)
+  -> relay-plan
+  -> relay-dispatch
+  -> relay-review
+  -> relay-merge
+```
 
 ## Decision
 
@@ -46,6 +58,17 @@ input to /relay
                         +-- multiple leaves --> one normal relay cycle per leaf
 ```
 
+Standalone intake entry is also valid:
+
+```text
+raw request
+   -> relay-intake
+   -> request artifact + append-only intake events
+   -> relay-ready leaf contract(s)
+   -> relay-plan
+   -> relay-dispatch
+```
+
 ## Routing Rules
 
 `/relay` may bypass `relay-intake` only when all of the following are true:
@@ -55,6 +78,8 @@ input to /relay
 3. No clarification, proposal, or decomposition work is needed.
 
 If any of those conditions are false, `/relay` must invoke `relay-intake`.
+
+Issue-first fast path means an issue-like source already has trustworthy, reviewable acceptance criteria and does not need intake shaping. In practice that is the "single task + stable review anchor + no shaping needed" case, not "every GitHub issue".
 
 ### Source-type hints
 
@@ -69,6 +94,8 @@ These are hints, not overrides:
 | Any request without stable Done Criteria | Intake | Review anchor must be created first |
 
 An issue number is not an automatic bypass. If the issue is broad, mixed-scope, or missing a trustworthy review anchor, `/relay` should still route through intake.
+
+`/relay` may therefore internally invoke `relay-intake`, wait for a relay-ready contract, and then continue the standard downstream chain without exposing two separate workflows to the operator.
 
 ## Relay-Ready Contract
 
@@ -169,17 +196,29 @@ That does not create a second execution system. It creates multiple normal relay
 
 Batching and ordering remain orchestrator concerns in `/relay`, not intake concerns.
 
-## Interaction Protocol
+## Portable Interaction Protocol
 
-The core protocol must work in both Claude and Codex without relying on host-specific widgets.
+The intake protocol must work in plain text in both Claude and Codex without relying on host-specific widgets.
 
 Rules:
 
-- proposal-first by default
+- proposal-first shaping by default
 - one question at a time
-- max 1-3 turns before either handoff or close/escalate
 - `A/B/C + free text` must always be sufficient
-- buttons or cards are optional adapters, not correctness requirements
+- buttons, cards, or host UI affordances are optional adapters only
+- `response_options` stays portable as a string array that any host may render or ignore
+
+Portable intake events:
+
+| Event type | Purpose | Typical `next_action` |
+| --- | --- | --- |
+| `proposal_presented` | Present a proposed shape or decomposition before asking for edits | `await_proposal_response` |
+| `question_asked` | Ask one clarifying question when a stable review anchor is still missing | `await_answer` |
+| `question_answered` | Record the operator's answer in plain text | `review_answer` |
+| `proposal_accepted` | Record that the proposed shape is accepted | `relay_plan` |
+| `proposal_edited` | Record structured edits to the current proposal | `review_proposal_edits` or `await_proposal_response` |
+
+`next_action` is intentionally lightweight. It tracks the next conversational step on the request artifact, but it is not a second lifecycle state machine. The request remains in intake until relay-ready handoff persistence freezes one-or-more leaf contracts; only then does the artifact promote to `state: relay_ready`.
 
 ## Consequences
 

--- a/docs/relay-scenario-tests.md
+++ b/docs/relay-scenario-tests.md
@@ -351,6 +351,6 @@ Covered by the same command as Scenario 15.
 
 Expect:
 
-- `source.kind: github_issue` can persist directly to `relay_ready`
-- only `request_persisted` and `relay_ready_handoff_persisted` are needed in the fast path
-- the frozen Done Criteria snapshot still exists so downstream review has a stable anchor
+- `source.kind: github_issue` stays on the `/relay` fast path only when the input is already a single relay-sized task with a trustworthy review anchor
+- no relay-intake request artifact, request event log, or `relay_ready_handoff_persisted` event is created on the bypass path
+- downstream planning and review continue from the existing issue/task anchor instead of a generated intake snapshot

--- a/docs/relay-scenario-tests.md
+++ b/docs/relay-scenario-tests.md
@@ -269,8 +269,88 @@ node --test skills/relay-intake/scripts/request-store.test.js
 Expect:
 
 - `~/.relay/requests/<repo-slug>/<request-id>.md` is created
-- request events append `request_persisted` and `relay_ready_handoff_persisted`
-- `relay-ready/<leaf-id>.md` and `done-criteria/<leaf-id>.md` are created for the single leaf
-- multi-leaf input fails explicitly with `TODO(#129)`
+- request events append the portable intake event types plus `relay_ready_handoff_persisted` when a handoff is frozen
+- `relay-ready/<leaf-id>.md` and `done-criteria/<leaf-id>.md` are created for relay-ready leaf tasks
+- multi-leaf input persists ordered child handoffs with per-leaf Done Criteria snapshots
 - dispatch can record `source.request_id`, `source.leaf_id`, and `anchor.done_criteria_path`
 - `review-runner --prepare-only` loads the frozen snapshot from the manifest anchor without re-fetching GitHub issue text
+
+### 15a. Directly relayable standalone request persists immediately
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- a single clear `raw_text` request with stable Done Criteria can call `persistRequestContract(...)` immediately
+- no proposal or question events are required first
+- the request artifact lands directly in `state: relay_ready` with `next_action: relay_plan`
+
+### 15b. Ambiguous request shapes through proposal, question, answer, acceptance, then persistence
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- intake records `proposal_presented -> question_asked -> question_answered -> proposal_accepted`
+- `next_action` moves through the conversational steps before final persistence
+- the same `request_id` can then be promoted into a frozen relay-ready handoff
+
+### 15c. Oversized request uses proposal-first decomposition before freezing a handoff
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- an oversized request records an initial proposal and a decomposition proposal with `structure_kind: decompose`
+- the accepted proposal still leaves the artifact in intake until relay-ready handoff persistence happens
+- `next_action` stays lightweight; no second intake state machine is introduced
+
+### 15d. Decomposed request persists ordered child handoffs
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- multi-leaf handoffs are persisted in execution order even if the input order differs
+- per-leaf `depends_on` metadata survives into the relay-ready artifacts
+- the parent request artifact records `decomposition.leaf_order` and dependency mapping
+
+### 15e. Non-issue request freezes generated Done Criteria from the handoff
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- `source.kind: raw_text` persists without any GitHub dependency
+- the frozen Done Criteria snapshot comes from `handoff.done_criteria_markdown`
+- the relay-ready handoff points back to that generated snapshot path
+
+### 15f. Plain-text `A/B/C + free text` protocol works without host widgets
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- `response_options` are persisted as plain string arrays
+- proposal and clarification flows remain usable without buttons, cards, or other host-specific UI
+- answers can still be recorded as plain text plus an optional `answer_choice`
+
+### 15g. Delegate fallback keeps portable intake events working
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- `structure_kind: delegate` persists as a normal intake event
+- the delegate fallback can still be accepted with `proposal_accepted`
+- no host-specific routing or production-code special case is required
+
+### 15h. Issue-first fast path bypasses intake overhead when the request is already relay-ready
+
+Covered by the same command as Scenario 15.
+
+Expect:
+
+- `source.kind: github_issue` can persist directly to `relay_ready`
+- only `request_persisted` and `relay_ready_handoff_persisted` are needed in the fast path
+- the frozen Done Criteria snapshot still exists so downstream review has a stable anchor

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -2,7 +2,29 @@
 
 Deep-dive into the manifest contract, state machine, and extension points. For overview, see [CLAUDE.md](../CLAUDE.md).
 
-This reference covers the manifest-backed run lifecycle only. For the preflight layer that may sit ahead of `relay-plan`, see [docs/relay-intake-routing-and-handoff-design.md](../docs/relay-intake-routing-and-handoff-design.md).
+This reference centers on the manifest-backed run lifecycle, plus the intake boundary that may sit ahead of `relay-plan`. For the full intake control-flow contract, see [docs/relay-intake-routing-and-handoff-design.md](../docs/relay-intake-routing-and-handoff-design.md).
+
+## Intake Boundary
+
+Before a run manifest exists, raw work may live in relay-intake artifacts under `~/.relay/requests/<repo-slug>/`.
+
+```text
+raw request
+  -> relay-intake request artifact + events
+  -> relay-ready handoff brief(s) + frozen Done Criteria snapshot(s)
+  -> relay-plan
+  -> relay-dispatch run manifest
+  -> relay-review
+  -> relay-merge
+```
+
+Boundary rules:
+
+- `/relay` remains the public front door for full-cycle execution
+- `/relay` bypasses intake only for issue-first or task-first inputs that are already relay-sized and already have a trustworthy review anchor
+- `/relay` invokes intake for ambiguous, oversized, or anchorless requests, then continues the normal downstream chain once a relay-ready leaf exists
+- intake interactions are append-only request events: `proposal_presented`, `question_asked`, `question_answered`, `proposal_accepted`, `proposal_edited`
+- request-level `next_action` is lightweight routing metadata, not a manifest lifecycle state
 
 ## State Machine
 

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -11,7 +11,9 @@ const {
   answerQuestion,
   clarify,
   editProposal,
+  getRequestsDir,
   getRequestPath,
+  normalizeSingleLeafContract,
   propose,
   readRequestEvents,
   persistRequestContract,
@@ -131,12 +133,26 @@ function invokeRelayFrontDoor(repoRoot, {
     requiresClarification,
     requiresDecomposition,
   });
+  const downstreamChain = route === "invoke_intake"
+    ? ["relay-intake", "relay-plan", "relay-dispatch"]
+    : ["relay-plan", "relay-dispatch"];
+
+  if (route === "bypass_intake") {
+    const normalized = normalizeSingleLeafContract(contract);
+    return {
+      route,
+      downstreamChain,
+      sourceKind: normalized.source.kind,
+      readiness: normalized.readiness || null,
+      leafId: normalized.handoff.leafId,
+      title: normalized.handoff.title,
+      reviewAnchorSource: normalized.source.kind,
+    };
+  }
 
   return {
     route,
-    downstreamChain: route === "invoke_intake"
-      ? ["relay-intake", "relay-plan", "relay-dispatch"]
-      : ["relay-plan", "relay-dispatch"],
+    downstreamChain,
     ...persistRequestContract(repoRoot, contract, requestId ? { requestId } : {}),
   };
 }
@@ -640,18 +656,17 @@ test("scenario: /relay keeps issue-first users on the fast path without intake o
       readiness,
     }),
   });
-  const requestArtifact = readRequestArtifact(result.requestPath);
 
   assert.equal(result.route, "bypass_intake");
   assert.deepEqual(result.downstreamChain, ["relay-plan", "relay-dispatch"]);
-  assert.equal(requestArtifact.data.state, "relay_ready");
-  assert.equal(requestArtifact.data.source.kind, "github_issue");
-  assert.equal(requestArtifact.data.next_action, "relay_plan");
-  assert.deepEqual(requestArtifact.data.readiness, readiness);
-  assert.deepEqual(
-    readEventNames(repoRoot, result.requestId),
-    ["request_persisted", "relay_ready_handoff_persisted"]
-  );
+  assert.equal(result.sourceKind, "github_issue");
+  assert.equal(result.reviewAnchorSource, "github_issue");
+  assert.equal(result.leafId, "leaf-01");
+  assert.deepEqual(result.readiness, readiness);
+  assert.equal(result.requestId, undefined);
+  assert.equal(result.requestPath, undefined);
+  assert.equal(result.doneCriteriaPath, undefined);
+  assert.equal(fs.existsSync(getRequestsDir(repoRoot)), false);
 });
 
 test("persistRequestContract rejects duplicate leaf IDs within a multi-leaf request", () => {

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -98,6 +98,72 @@ function createReadiness(overrides = {}) {
   };
 }
 
+function chooseRelayRoute({
+  sourceKind,
+  leafCount,
+  hasStableReviewAnchor,
+  requiresClarification = false,
+  requiresDecomposition = false,
+}) {
+  return sourceKind !== "raw_text"
+    && leafCount === 1
+    && hasStableReviewAnchor
+    && !requiresClarification
+    && !requiresDecomposition
+    ? "bypass_intake"
+    : "invoke_intake";
+}
+
+function invokeRelayFrontDoor(repoRoot, {
+  contract,
+  hasStableReviewAnchor,
+  requiresClarification = false,
+  requiresDecomposition = false,
+  requestId,
+}) {
+  const leafCount = Array.isArray(contract.handoffs)
+    ? contract.handoffs.length
+    : (contract.handoff ? 1 : 0);
+  const route = chooseRelayRoute({
+    sourceKind: contract.source?.kind || "raw_text",
+    leafCount,
+    hasStableReviewAnchor,
+    requiresClarification,
+    requiresDecomposition,
+  });
+
+  return {
+    route,
+    downstreamChain: route === "invoke_intake"
+      ? ["relay-intake", "relay-plan", "relay-dispatch"]
+      : ["relay-plan", "relay-dispatch"],
+    ...persistRequestContract(repoRoot, contract, requestId ? { requestId } : {}),
+  };
+}
+
+function proposeDelegateFallback(repoRoot, requestId, {
+  requestText,
+  hostCapabilities = {},
+}) {
+  if (hostCapabilities.gstack || hostCapabilities.superpowers) {
+    throw new Error("delegate fallback only applies when gstack/superpowers are unavailable");
+  }
+
+  return {
+    fallback: "portable_plain_text",
+    ...structure(repoRoot, requestId, {
+      source_kind: "raw_text",
+      request_text: requestText,
+      proposal_summary: "Delegate the shared middleware change and keep the local tests here.",
+      proposal_kind: "structure",
+      proposal_text: "A. Delegate middleware ownership\nB. Keep the work local\nC. Other + free text",
+      response_options: ["A. Delegate", "B. Keep local", "C. Other + free text"],
+      structure_kind: "delegate",
+      reason: "gstack/superpowers are unavailable, so fall back to the portable plain-text protocol.",
+    }),
+  };
+}
+
 function writeFakeCodex(binDir) {
   const codexPath = path.join(binDir, "codex");
   fs.writeFileSync(codexPath, `#!/usr/bin/env node
@@ -529,21 +595,20 @@ test("scenario: portable A/B/C plain-text interaction works without host-specifi
   assert.equal(readRequest(repoRoot, requestId).data.next_action, "review_answer");
 });
 
-test("scenario: delegate fallback keeps structure events portable", () => {
+test("scenario: delegate fallback uses the portable plain-text path when gstack/superpowers are unavailable", () => {
   const { repoRoot } = setupRepo();
   const requestId = "req-20260409141414000";
   const requestText = "Coordinate the shared auth middleware fix with the platform team.";
+  const hostCapabilities = {
+    gstack: false,
+    superpowers: false,
+  };
 
-  const delegated = structure(repoRoot, requestId, {
-    source_kind: "raw_text",
-    request_text: requestText,
-    proposal_summary: "Delegate the shared middleware change and keep the local tests here.",
-    proposal_kind: "structure",
-    proposal_text: "A. Delegate middleware ownership\nB. Keep the work local\nC. Other + free text",
-    response_options: ["A. Delegate", "B. Keep local", "C. Other + free text"],
-    structure_kind: "delegate",
-    reason: "The shared middleware is owned by another team.",
+  const delegated = proposeDelegateFallback(repoRoot, requestId, {
+    requestText,
+    hostCapabilities,
   });
+  assert.equal(delegated.fallback, "portable_plain_text");
   assert.equal(delegated.event, "proposal_presented");
   assert.equal(delegated.structure_kind, "delegate");
 
@@ -556,22 +621,29 @@ test("scenario: delegate fallback keeps structure events portable", () => {
 
   const events = readRequestEvents(repoRoot, requestId);
   assert.equal(events[1].structure_kind, "delegate");
+  assert.deepEqual(events[1].response_options, ["A. Delegate", "B. Keep local", "C. Other + free text"]);
+  assert.match(events[1].reason, /gstack\/superpowers are unavailable/);
   assert.deepEqual(
     readEventNames(repoRoot, requestId),
     ["request_persisted", "proposal_presented", "proposal_accepted"]
   );
 });
 
-test("scenario: issue-first fast path persists a relay-ready issue contract without intake overhead", () => {
+test("scenario: /relay keeps issue-first users on the fast path without intake overhead", () => {
   const { repoRoot } = setupRepo();
   const readiness = createReadiness({ risk: "low" });
-  const result = persistRequestContract(repoRoot, createContract({
-    source: { kind: "github_issue" },
-    request_text: "Issue #132: Fix the login redirect loop for authenticated users.",
-    readiness,
-  }));
+  const result = invokeRelayFrontDoor(repoRoot, {
+    hasStableReviewAnchor: true,
+    contract: createContract({
+      source: { kind: "github_issue" },
+      request_text: "Issue #132: Fix the login redirect loop for authenticated users.",
+      readiness,
+    }),
+  });
   const requestArtifact = readRequestArtifact(result.requestPath);
 
+  assert.equal(result.route, "bypass_intake");
+  assert.deepEqual(result.downstreamChain, ["relay-plan", "relay-dispatch"]);
   assert.equal(requestArtifact.data.state, "relay_ready");
   assert.equal(requestArtifact.data.source.kind, "github_issue");
   assert.equal(requestArtifact.data.next_action, "relay_plan");
@@ -829,9 +901,12 @@ test("preflight helpers reject mutations after relay-ready persistence", () => {
   assert.deepEqual(readRequestEvents(repoRoot, intake.requestId), initialEvents);
 });
 
-test("raw request can flow through intake persistence, dispatch linkage, and review prepare-only", () => {
+test("scenario: /relay auto-routes raw text through intake, then continues to dispatch and review linkage", () => {
   const { repoRoot, relayHome } = setupRepo();
-  const intake = persistRequestContract(repoRoot, createContract());
+  const intake = invokeRelayFrontDoor(repoRoot, {
+    contract: createContract(),
+    hasStableReviewAnchor: false,
+  });
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = {
@@ -856,6 +931,12 @@ test("raw request can flow through intake persistence, dispatch linkage, and rev
   });
 
   const dispatchResult = JSON.parse(dispatchStdout);
+  assert.equal(intake.route, "invoke_intake");
+  assert.deepEqual(intake.downstreamChain, ["relay-intake", "relay-plan", "relay-dispatch"]);
+  assert.deepEqual(
+    readEventNames(repoRoot, intake.requestId),
+    ["request_persisted", "relay_ready_handoff_persisted"]
+  );
   assert.equal(dispatchResult.runState, "review_pending");
 
   const manifest = readManifest(dispatchResult.manifestPath).data;

--- a/skills/relay-intake/scripts/request-store.test.js
+++ b/skills/relay-intake/scripts/request-store.test.js
@@ -118,6 +118,14 @@ fs.writeFileSync(output, "ok\\n", "utf-8");
   fs.chmodSync(codexPath, 0o755);
 }
 
+function readRequest(repoRoot, requestId) {
+  return readRequestArtifact(getRequestPath(repoRoot, requestId));
+}
+
+function readEventNames(repoRoot, requestId) {
+  return readRequestEvents(repoRoot, requestId).map((event) => event.event);
+}
+
 test("persistRequestContract writes request artifact, relay-ready handoff, done criteria snapshot, and events", () => {
   const { repoRoot } = setupRepo();
 
@@ -292,6 +300,285 @@ test("persistRequestContract persists multi-leaf handoffs with ordering, depende
   assert.deepEqual(
     events.slice(1).map((event) => event.leaf_id),
     ["leaf-01", "leaf-02"]
+  );
+});
+
+test("scenario: directly relayable raw request persists immediately without preflight interactions", () => {
+  const { repoRoot } = setupRepo();
+  const readiness = createReadiness({ risk: "low" });
+
+  const result = persistRequestContract(repoRoot, createContract({ readiness }));
+  const requestArtifact = readRequestArtifact(result.requestPath);
+
+  assert.equal(result.leafCount, 1);
+  assert.equal(requestArtifact.data.state, "relay_ready");
+  assert.equal(requestArtifact.data.next_action, "relay_plan");
+  assert.equal(requestArtifact.data.source.kind, "raw_text");
+  assert.deepEqual(requestArtifact.data.readiness, readiness);
+  assert.deepEqual(
+    readEventNames(repoRoot, result.requestId),
+    ["request_persisted", "relay_ready_handoff_persisted"]
+  );
+});
+
+test("scenario: ambiguous request flows through proposal, clarification, answer, acceptance, and final persistence", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409101010000";
+  const requestText = "Fix the auth routing bug around login redirects.";
+
+  propose(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: requestText,
+    proposal_summary: "Shape this into one redirect-focused leaf after clarifying guest behavior.",
+    proposal_text: "A. Keep guest deep links on /login\nB. Redirect guests elsewhere\nC. Other + free text",
+    response_options: ["A. Keep /login", "B. Redirect elsewhere", "C. Other + free text"],
+    reason: "The request is ambiguous about guest deep-link behavior.",
+  });
+  clarify(repoRoot, requestId, {
+    question_text: "Should guest deep links still land on /login?",
+    response_options: ["A. Yes", "B. No", "C. Other + free text"],
+    reason: "Need one stable review anchor before freezing the handoff.",
+  });
+
+  const answered = answerQuestion(repoRoot, requestId, {
+    question_text: "Should guest deep links still land on /login?",
+    answer_text: "A. Yes, keep guest deep links on /login.",
+    answer_choice: "A",
+    reason: "Clarified by the requester.",
+  });
+  assert.equal(answered.event, "question_answered");
+  assert.equal(readRequest(repoRoot, requestId).data.next_action, "review_answer");
+
+  const accepted = acceptProposal(repoRoot, requestId, {
+    proposal_summary: "Single redirect leaf that keeps guest deep links on /login.",
+    acceptance_note: "Proceed with one relay-sized fix.",
+    reason: "Clarification resolved the scope.",
+  });
+  assert.equal(accepted.event, "proposal_accepted");
+  assert.equal(readRequest(repoRoot, requestId).data.next_action, "relay_plan");
+
+  const result = persistRequestContract(repoRoot, createContract({
+    request_text: requestText,
+  }), { requestId });
+  const requestArtifact = readRequestArtifact(result.requestPath);
+
+  assert.equal(requestArtifact.data.state, "relay_ready");
+  assert.equal(requestArtifact.data.next_action, "relay_plan");
+  assert.deepEqual(
+    readEventNames(repoRoot, requestId),
+    [
+      "request_persisted",
+      "proposal_presented",
+      "question_asked",
+      "question_answered",
+      "proposal_accepted",
+      "relay_ready_handoff_persisted",
+    ]
+  );
+});
+
+test("scenario: oversized request is proposed, decomposed, and accepted before relay-ready persistence", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409111111000";
+  const requestText = "Fix auth redirects, add regression coverage, and document the routing rules.";
+
+  propose(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: requestText,
+    proposal_summary: "This is too broad for one relay run; start by proposing a smaller shape.",
+    proposal_text: "A. Keep one leaf\nB. Split into multiple leaves\nC. Other + free text",
+    response_options: ["A. One leaf", "B. Multiple leaves", "C. Other + free text"],
+  });
+
+  const structured = structure(repoRoot, requestId, {
+    proposal_summary: "Split the work into a guard fix leaf and a regression coverage leaf.",
+    proposal_kind: "structure",
+    proposal_text: "Leaf 1 fixes the redirect guard. Leaf 2 adds regression coverage.",
+    response_options: ["A. Accept split", "B. Keep one leaf", "C. Other + free text"],
+    structure_kind: "decompose",
+    reason: "The request is oversized for one relay-sized handoff.",
+  });
+  assert.equal(structured.event, "proposal_presented");
+  assert.equal(structured.structure_kind, "decompose");
+  assert.equal(readRequest(repoRoot, requestId).data.next_action, "await_proposal_response");
+
+  const accepted = acceptProposal(repoRoot, requestId, {
+    proposal_summary: "Split the oversized request into two ordered relay-ready leaves.",
+    acceptance_note: "Use the decomposed shape.",
+  });
+  assert.equal(accepted.event, "proposal_accepted");
+
+  const requestArtifact = readRequest(repoRoot, requestId);
+  assert.equal(requestArtifact.data.state, "intake");
+  assert.equal(requestArtifact.data.leaf_count, 0);
+  assert.equal(requestArtifact.data.next_action, "relay_plan");
+  assert.deepEqual(
+    readEventNames(repoRoot, requestId),
+    ["request_persisted", "proposal_presented", "proposal_presented", "proposal_accepted"]
+  );
+});
+
+test("scenario: larger request decomposes into ordered child handoffs", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409121212000";
+  const requestText = createMultiLeafContract().request_text;
+
+  structure(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: requestText,
+    proposal_summary: "Split the request into an implementation leaf followed by a coverage leaf.",
+    proposal_kind: "structure",
+    structure_kind: "decompose",
+  });
+  acceptProposal(repoRoot, requestId, {
+    proposal_summary: "Persist two ordered relay-ready leaves.",
+    acceptance_note: "Guard fix first, then regression coverage.",
+  });
+
+  const result = persistRequestContract(repoRoot, createMultiLeafContract(), { requestId });
+  const requestArtifact = readRequestArtifact(result.requestPath);
+  const firstLeaf = readRequestArtifact(result.handoffPaths[0]);
+  const secondLeaf = readRequestArtifact(result.handoffPaths[1]);
+
+  assert.equal(result.leafCount, 2);
+  assert.deepEqual(result.leafIds, ["leaf-01", "leaf-02"]);
+  assert.deepEqual(requestArtifact.data.decomposition.leaf_order, ["leaf-01", "leaf-02"]);
+  assert.deepEqual(requestArtifact.data.decomposition.dependencies, { "leaf-02": ["leaf-01"] });
+  assert.equal(firstLeaf.data.order, 1);
+  assert.deepEqual(firstLeaf.data.depends_on, []);
+  assert.equal(secondLeaf.data.order, 2);
+  assert.deepEqual(secondLeaf.data.depends_on, ["leaf-01"]);
+  assert.deepEqual(
+    readEventNames(repoRoot, requestId),
+    [
+      "request_persisted",
+      "proposal_presented",
+      "proposal_accepted",
+      "relay_ready_handoff_persisted",
+      "relay_ready_handoff_persisted",
+    ]
+  );
+});
+
+test("scenario: non-issue request freezes done criteria from the handoff rather than GitHub", () => {
+  const { repoRoot } = setupRepo();
+  const doneCriteriaMarkdown = "# Done Criteria\n\n- Duplicate invite emails stop after resend\n- The resend actor is logged in the audit trail\n";
+  const result = persistRequestContract(repoRoot, createContract({
+    request_text: "Fix duplicate invite sends when admins resend an invite.",
+    handoff: {
+      ...createContract().handoff,
+      leaf_id: "leaf-invite-01",
+      title: "Fix duplicate invite resend notifications",
+      goal: "Stop duplicate invite emails when an admin resends an invite",
+      in_scope: ["Deduplicate resend notifications", "Log the acting admin"],
+      out_of_scope: ["Redesigning the invite email"],
+      assumptions: ["The audit log already has an invite resend event type"],
+      done_criteria_markdown: doneCriteriaMarkdown,
+      escalation_conditions: ["Invite resend ownership is split across services"],
+    },
+  }));
+  const requestArtifact = readRequestArtifact(result.requestPath);
+  const handoffArtifact = readRequestArtifact(result.handoffPath);
+
+  assert.equal(requestArtifact.data.source.kind, "raw_text");
+  assert.equal(handoffArtifact.data.done_criteria_path, result.doneCriteriaPath);
+  assert.equal(fs.readFileSync(result.doneCriteriaPath, "utf-8").trim(), doneCriteriaMarkdown.trim());
+  assert.deepEqual(
+    readEventNames(repoRoot, result.requestId),
+    ["request_persisted", "relay_ready_handoff_persisted"]
+  );
+});
+
+test("scenario: portable A/B/C plain-text interaction works without host-specific UI widgets", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409131313000";
+  const requestText = "Triage the auth redirect work for the next relay run.";
+  const proposalChoices = [
+    "A. Keep one leaf",
+    "B. Split into two leaves",
+    "C. Other + free text",
+  ];
+  const questionChoices = [
+    "A. Fix the guard first",
+    "B. Add coverage first",
+    "C. Other + free text",
+  ];
+
+  propose(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: requestText,
+    proposal_summary: "Offer a plain-text proposal even when the host has no widget support.",
+    proposal_text: proposalChoices.join("\n"),
+    response_options: proposalChoices,
+  });
+  clarify(repoRoot, requestId, {
+    question_text: "Which leaf should land first?",
+    response_options: questionChoices,
+  });
+
+  const answered = answerQuestion(repoRoot, requestId, {
+    question_text: "Which leaf should land first?",
+    answer_text: "C. Other: fix the guard first, then add coverage.",
+    answer_choice: "C",
+  });
+  const events = readRequestEvents(repoRoot, requestId);
+
+  assert.deepEqual(events[1].response_options, proposalChoices);
+  assert.deepEqual(events[2].response_options, questionChoices);
+  assert.equal(answered.answer_choice, "C");
+  assert.equal(readRequest(repoRoot, requestId).data.next_action, "review_answer");
+});
+
+test("scenario: delegate fallback keeps structure events portable", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260409141414000";
+  const requestText = "Coordinate the shared auth middleware fix with the platform team.";
+
+  const delegated = structure(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: requestText,
+    proposal_summary: "Delegate the shared middleware change and keep the local tests here.",
+    proposal_kind: "structure",
+    proposal_text: "A. Delegate middleware ownership\nB. Keep the work local\nC. Other + free text",
+    response_options: ["A. Delegate", "B. Keep local", "C. Other + free text"],
+    structure_kind: "delegate",
+    reason: "The shared middleware is owned by another team.",
+  });
+  assert.equal(delegated.event, "proposal_presented");
+  assert.equal(delegated.structure_kind, "delegate");
+
+  const accepted = acceptProposal(repoRoot, requestId, {
+    proposal_summary: "Use the delegate fallback and continue with the portable handoff.",
+    acceptance_note: "Delegate the shared middleware work.",
+  });
+  assert.equal(accepted.event, "proposal_accepted");
+  assert.equal(readRequest(repoRoot, requestId).data.next_action, "relay_plan");
+
+  const events = readRequestEvents(repoRoot, requestId);
+  assert.equal(events[1].structure_kind, "delegate");
+  assert.deepEqual(
+    readEventNames(repoRoot, requestId),
+    ["request_persisted", "proposal_presented", "proposal_accepted"]
+  );
+});
+
+test("scenario: issue-first fast path persists a relay-ready issue contract without intake overhead", () => {
+  const { repoRoot } = setupRepo();
+  const readiness = createReadiness({ risk: "low" });
+  const result = persistRequestContract(repoRoot, createContract({
+    source: { kind: "github_issue" },
+    request_text: "Issue #132: Fix the login redirect loop for authenticated users.",
+    readiness,
+  }));
+  const requestArtifact = readRequestArtifact(result.requestPath);
+
+  assert.equal(requestArtifact.data.state, "relay_ready");
+  assert.equal(requestArtifact.data.source.kind, "github_issue");
+  assert.equal(requestArtifact.data.next_action, "relay_plan");
+  assert.deepEqual(requestArtifact.data.readiness, readiness);
+  assert.deepEqual(
+    readEventNames(repoRoot, result.requestId),
+    ["request_persisted", "relay_ready_handoff_persisted"]
   );
 });
 


### PR DESCRIPTION
## Summary

- Adds scenario tests for standalone relay-intake flows (directly relayable, clarification/proposal, decomposition, non-issue, host-UI absence, delegate fallback, issue-first fast path)
- Updates docs describing raw request → relay-intake → relay-ready → run behavior
- Documents portable interaction protocol (proposal-first, A/B/C + free text)
- Updates relay-scenario-tests.md to reflect current coverage (removes stale TODO(#129))
- Updates CLAUDE.md skill count to reflect intake-aware structure

## Test plan

- [ ] All intake tests pass: `node --test skills/relay-intake/scripts/*.test.js`
- [ ] All dispatch tests pass: `node --test skills/relay-dispatch/scripts/*.test.js`
- [ ] All review tests pass: `node --test skills/relay-review/scripts/*.test.js`
- [ ] All merge tests pass: `node --test skills/relay-merge/scripts/*.test.js`
- [ ] No production code changes

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 사전 지속성(요청 아티팩트) 단계와 `/relay`의 intake 호출/우회 동작을 명확히 했습니다.
  * intake 경계, 휴대용 intake 이벤트 사양, 제안-우선 흐름 및 멀티스킬 설치(6개 스킬 명시)를 추가하여 흐름 설명을 확장했습니다.
* **테스트**
  * 다양한 단독/엔드투엔드 intake→relay 준비 시나리오와 다중 리프 핸드오프 경로를 검증하는 포괄적 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->