### PR TITLE
Validate anchor.rubric_path: file exists + path containment (#148)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -64,11 +64,15 @@ const {
   createRunId,
   ensureRunLayout,
   formatAttemptsForPrompt,
+  getRubricAnchorStatus,
   getManifestPath,
   getRunDir,
+  hasRubricPath,
   inferIssueNumber,
+  isRubricGrandfathered,
   readPreviousAttempts,
   updateManifestState,
+  validateRubricPathContainment,
   writeManifest,
 } = require("./relay-manifest");
 const { resolveManifestRecord } = require("./relay-resolver");
@@ -286,14 +290,6 @@ function validateResumeRequestLinkage(manifest, { requestId, leafId, doneCriteri
   }
 }
 
-function hasAnchoredRubricPath(manifest) {
-  return typeof manifest?.anchor?.rubric_path === "string" && manifest.anchor.rubric_path.trim() !== "";
-}
-
-function isRubricGrandfathered(manifest) {
-  return manifest?.anchor?.rubric_grandfathered === true;
-}
-
 function markRubricGrandfathered(manifest) {
   return {
     ...manifest,
@@ -310,19 +306,45 @@ function clearRubricGrandfathering(anchor = {}) {
   return nextAnchor;
 }
 
-function enforceRubricPersistence(manifest) {
+function failRubricPersistence(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function getPersistedRubricPath(runDir, rubricPath = "rubric.yaml") {
+  const containment = validateRubricPathContainment(rubricPath, runDir);
+  if (!containment.valid) {
+    failRubricPersistence(containment.reason);
+  }
+  return containment;
+}
+
+function enforceRubricPersistence(manifest, runDir) {
   // Grandfathering is an explicit per-run migration marker, not a timestamp-derived cutoff.
-  if (RUBRIC_GRANDFATHERED && hasAnchoredRubricPath(manifest)) {
-    console.error("Error: --rubric-grandfathered is only valid when the run does not already have anchor.rubric_path");
-    process.exit(1);
+  if (RUBRIC_GRANDFATHERED && hasRubricPath(manifest)) {
+    failRubricPersistence("--rubric-grandfathered is only valid when the run does not already have anchor.rubric_path");
   }
 
-  if (!RUBRIC_FILE && !hasAnchoredRubricPath(manifest) && !isRubricGrandfathered(manifest) && !RUBRIC_GRANDFATHERED) {
-    console.error(
-      "Error: --rubric-file is required. Generate the rubric with relay-plan and pass --rubric-file <path> to dispatch.js. " +
+  if (RUBRIC_FILE) {
+    getPersistedRubricPath(runDir);
+    return;
+  }
+
+  if (!hasRubricPath(manifest) && !isRubricGrandfathered(manifest) && !RUBRIC_GRANDFATHERED) {
+    failRubricPersistence(
+      "--rubric-file is required. Generate the rubric with relay-plan and pass --rubric-file <path> to dispatch.js. " +
       "Only explicit legacy-run migration may bypass this with --rubric-grandfathered."
     );
-    process.exit(1);
+  }
+
+  if (hasRubricPath(manifest) && !isRubricGrandfathered(manifest)) {
+    const rubricAnchor = getRubricAnchorStatus(manifest, { runDir });
+    if (!rubricAnchor.satisfied) {
+      failRubricPersistence(
+        `${rubricAnchor.error} Re-dispatch with --rubric-file to repair the run's rubric anchor, ` +
+        "or explicitly grandfather a pre-change run."
+      );
+    }
   }
 }
 
@@ -505,7 +527,8 @@ async function main() {
     }
   }
 
-  enforceRubricPersistence(manifest);
+  const manifestRunDir = getRunDir(repoRoot, runId);
+  enforceRubricPersistence(manifest, manifestRunDir);
 
   if (RESUME_MODE && RUBRIC_GRANDFATHERED) {
     manifest = markRubricGrandfathered(manifest);
@@ -703,15 +726,20 @@ async function main() {
   if (RUBRIC_FILE) {
     const rubricSrc = path.resolve(RUBRIC_FILE);
     const runDir = getRunDir(repoRoot, runId);
-    const rubricDest = path.join(runDir, "rubric.yaml");
+    const persistedRubric = getPersistedRubricPath(runDir, "rubric.yaml");
+    const rubricDest = persistedRubric.resolvedPath;
     fs.copyFileSync(rubricSrc, rubricDest);
     manifest = {
       ...manifest,
       anchor: {
         ...clearRubricGrandfathering(manifest.anchor || {}),
-        rubric_path: "rubric.yaml",
+        rubric_path: persistedRubric.rubricPath,
       },
     };
+    const rubricAnchor = getRubricAnchorStatus(manifest, { runDir });
+    if (!rubricAnchor.satisfied) {
+      failRubricPersistence(rubricAnchor.error);
+    }
     writeManifest(manifestPath, manifest);
   }
 
@@ -967,11 +995,12 @@ async function main() {
     }
   }
 
+  const rubricAnchor = getRubricAnchorStatus(manifest, { runDir });
   const result = {
     runId,
     runDir,
     manifestPath,
-    rubricPath: manifest.anchor?.rubric_path ? path.join(runDir, manifest.anchor.rubric_path) : null,
+    rubricPath: rubricAnchor.resolvedPath || null,
     rubricGrandfathered: manifest.anchor?.rubric_grandfathered === true,
     requestId: manifest.source?.request_id || null,
     leafId: manifest.source?.leaf_id || null,

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -112,6 +112,25 @@ function runDispatch(repoRoot, args, env) {
   });
 }
 
+function tamperResumableRunRubricPath(repoRoot, env, rubricPath) {
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-rubric-anchor",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+
+  const record = readManifest(first.manifestPath);
+  const updated = {
+    ...updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    anchor: {
+      ...(record.data.anchor || {}),
+      rubric_path: rubricPath,
+    },
+  };
+  writeManifest(first.manifestPath, updated, record.body);
+  return first;
+}
+
 test("dispatch reuses the same run and worktree on resume", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
@@ -685,6 +704,44 @@ test("dispatch fails when rubric file does not exist", () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /rubric file not found/);
+});
+
+test("dispatch resume rejects anchor.rubric_path values with parent traversal", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = tamperResumableRunRubricPath(repoRoot, env, "../escape.yaml");
+  const result = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume with invalid rubric anchor",
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /\.\./);
+  assert.match(result.stderr, /inside the run directory/i);
+});
+
+test("dispatch resume rejects absolute anchor.rubric_path values", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = tamperResumableRunRubricPath(repoRoot, env, "/tmp/escape.yaml");
+  const result = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume with invalid rubric anchor",
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /absolute paths are not allowed/i);
+  assert.match(result.stderr, /\/tmp\/escape\.yaml/);
 });
 
 test("dispatch fails when done criteria file does not exist", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -298,17 +298,197 @@ function isRubricGrandfathered(data) {
   return data?.anchor?.rubric_grandfathered === true;
 }
 
-function getRubricAnchorStatus(data) {
+function resolveRubricRunDir(data, options = {}) {
+  if (options.runDir) {
+    return path.resolve(options.runDir);
+  }
+
+  const repoRoot = options.repoRoot || data?.paths?.repo_root || null;
+  const runId = options.runId || data?.run_id || null;
+  if (!repoRoot || !runId) {
+    return null;
+  }
+  return getRunDir(repoRoot, runId);
+}
+
+function validateRubricPathContainment(rubricPath, runDir) {
+  const normalizedPath = typeof rubricPath === "string" ? rubricPath.trim() : "";
+  const resolvedRunDir = typeof runDir === "string" && runDir.trim() !== ""
+    ? path.resolve(runDir)
+    : null;
+  const segments = normalizedPath.split(/[\\/]+/).filter(Boolean);
+  const containsParentTraversal = segments.includes("..");
+  const absolute = normalizedPath ? path.isAbsolute(normalizedPath) : false;
+  const resolvedPath = normalizedPath && resolvedRunDir
+    ? path.resolve(resolvedRunDir, normalizedPath)
+    : null;
+  const insideRunDir = Boolean(
+    resolvedRunDir &&
+    resolvedPath &&
+    resolvedPath !== resolvedRunDir &&
+    resolvedPath.startsWith(`${resolvedRunDir}${path.sep}`)
+  );
+
+  if (!normalizedPath) {
+    return {
+      valid: false,
+      status: "missing_path",
+      rubricPath: null,
+      runDir: resolvedRunDir,
+      resolvedPath: null,
+      reason: "anchor.rubric_path is not set.",
+    };
+  }
+
+  if (!resolvedRunDir) {
+    return {
+      valid: false,
+      status: "run_dir_unavailable",
+      rubricPath: normalizedPath,
+      runDir: null,
+      resolvedPath: null,
+      reason: `Unable to resolve the run directory for anchor.rubric_path=${JSON.stringify(normalizedPath)}.`,
+    };
+  }
+
+  if (absolute) {
+    return {
+      valid: false,
+      status: "outside_run_dir",
+      rubricPath: normalizedPath,
+      runDir: resolvedRunDir,
+      resolvedPath,
+      reason: `anchor.rubric_path must resolve inside the run directory; absolute paths are not allowed (got ${JSON.stringify(normalizedPath)}).`,
+    };
+  }
+
+  if (containsParentTraversal) {
+    return {
+      valid: false,
+      status: "outside_run_dir",
+      rubricPath: normalizedPath,
+      runDir: resolvedRunDir,
+      resolvedPath,
+      reason: `anchor.rubric_path must resolve inside the run directory and may not contain '..' segments (got ${JSON.stringify(normalizedPath)}).`,
+    };
+  }
+
+  if (!insideRunDir) {
+    return {
+      valid: false,
+      status: "outside_run_dir",
+      rubricPath: normalizedPath,
+      runDir: resolvedRunDir,
+      resolvedPath,
+      reason: `anchor.rubric_path must resolve inside the run directory ${JSON.stringify(resolvedRunDir)} (got ${JSON.stringify(normalizedPath)} -> ${JSON.stringify(resolvedPath)}).`,
+    };
+  }
+
+  return {
+    valid: true,
+    status: "contained",
+    rubricPath: normalizedPath,
+    runDir: resolvedRunDir,
+    resolvedPath,
+    reason: null,
+  };
+}
+
+function getRubricAnchorStatus(data, options = {}) {
   const rubricPath = hasRubricPath(data) ? data.anchor.rubric_path.trim() : null;
   const grandfathered = isRubricGrandfathered(data);
-  return {
+  const runDir = resolveRubricRunDir(data, options);
+  const baseStatus = {
+    status: "missing_path",
     rubricPath,
+    runDir,
+    resolvedPath: null,
     grandfathered,
-    satisfied: Boolean(rubricPath) || grandfathered,
-    note: grandfathered
-      ? "Grandfathered pre-rubric run: merge/review gates are allowing missing anchor.rubric_path because anchor.rubric_grandfathered=true."
-      : null,
+    satisfied: false,
+    exists: false,
+    empty: false,
+    content: null,
+    note: null,
+    error: null,
   };
+
+  // Grandfathering is an explicit legacy-run override. If both fields are present,
+  // keep the run on the grandfathered path rather than reinterpreting it mid-flight.
+  if (grandfathered) {
+    return {
+      ...baseStatus,
+      status: "grandfathered",
+      satisfied: true,
+      note: "Grandfathered pre-rubric run: merge/review gates are allowing missing anchor.rubric_path because anchor.rubric_grandfathered=true.",
+    };
+  }
+
+  if (!rubricPath) {
+    return {
+      ...baseStatus,
+      error: "anchor.rubric_path is required before review/merge unless anchor.rubric_grandfathered=true.",
+    };
+  }
+
+  const containment = validateRubricPathContainment(rubricPath, runDir);
+  if (!containment.valid) {
+    return {
+      ...baseStatus,
+      ...containment,
+      status: containment.status,
+      error: containment.reason,
+    };
+  }
+
+  try {
+    const stat = fs.statSync(containment.resolvedPath);
+    if (!stat.isFile()) {
+      return {
+        ...baseStatus,
+        ...containment,
+        status: "not_file",
+        error: `anchor.rubric_path must point to a file inside the run directory (got ${JSON.stringify(containment.resolvedPath)}).`,
+      };
+    }
+
+    const content = fs.readFileSync(containment.resolvedPath, "utf-8");
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      return {
+        ...baseStatus,
+        ...containment,
+        status: "empty",
+        exists: true,
+        empty: true,
+        error: `rubric file is empty: ${containment.resolvedPath}`,
+      };
+    }
+
+    return {
+      ...baseStatus,
+      ...containment,
+      status: "satisfied",
+      satisfied: true,
+      exists: true,
+      content: options.includeContent ? trimmedContent : null,
+    };
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return {
+        ...baseStatus,
+        ...containment,
+        status: "missing",
+        error: `rubric file is missing from the run directory: ${containment.resolvedPath}`,
+      };
+    }
+
+    return {
+      ...baseStatus,
+      ...containment,
+      status: "unreadable",
+      error: `Unable to read rubric file ${containment.resolvedPath}: ${summarizeError(error)}`,
+    };
+  }
 }
 
 function validateTransitionInvariants(data, fromState, toState) {
@@ -316,7 +496,7 @@ function validateTransitionInvariants(data, fromState, toState) {
     const rubricAnchor = getRubricAnchorStatus(data);
     if (!rubricAnchor.satisfied) {
       throw new Error(
-        "Cannot transition dispatched -> review_pending without anchor.rubric_path. " +
+        `Cannot transition dispatched -> review_pending because ${rubricAnchor.error} ` +
         "Generate the rubric with relay-plan and dispatch with --rubric-file, " +
         "or explicitly grandfather a pre-change run with anchor.rubric_grandfathered: true."
       );
@@ -726,6 +906,7 @@ module.exports = {
   summarizeError,
   updateManifestCleanup,
   updateManifestState,
+  validateRubricPathContainment,
   validateTransition,
   validateTransitionInvariants,
   writeManifest,

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -15,6 +15,7 @@ const {
   createRunId,
   ensureRunLayout,
   formatAttemptsForPrompt,
+  getRubricAnchorStatus,
   getRepoSlug,
   inferIssueNumber,
   readManifest,
@@ -28,6 +29,14 @@ function initGitRepo(repoRoot, actor = "Relay Test") {
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
   execFileSync("git", ["config", "user.name", actor], { cwd: repoRoot, stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function writeRunRubric(repoRoot, runId, rubricPath = "rubric.yaml", content = "rubric:\n  factors:\n    - name: manifest\n") {
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  const fullPath = path.join(runDir, rubricPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, "utf-8");
+  return { runDir, fullPath };
 }
 
 function withGitIdentityDisabled(testFn) {
@@ -255,10 +264,17 @@ test("updateManifestState rejects dispatched -> review_pending when anchor.rubri
 });
 
 test("updateManifestState allows dispatched -> review_pending when anchor.rubric_path is present", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-rubric-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Maintainer");
+  const runId = "issue-42-20260412000001000";
+  writeRunRubric(repoRoot, runId);
   const manifest = {
+    run_id: runId,
     state: STATES.DISPATCHED,
     next_action: "await_dispatch_result",
     anchor: { rubric_path: "rubric.yaml" },
+    paths: { repo_root: repoRoot },
     timestamps: { created_at: "2026-04-12T00:00:00Z", updated_at: "2026-04-12T00:00:00Z" },
   };
 
@@ -268,14 +284,58 @@ test("updateManifestState allows dispatched -> review_pending when anchor.rubric
 
 test("updateManifestState allows dispatched -> review_pending when rubric is grandfathered", () => {
   const manifest = {
+    run_id: "issue-42-20260412000002000",
     state: STATES.DISPATCHED,
     next_action: "await_dispatch_result",
     anchor: { rubric_grandfathered: true },
+    paths: { repo_root: "/tmp/relay-grandfathered" },
     timestamps: { created_at: "2026-04-12T00:00:00Z", updated_at: "2026-04-12T00:00:00Z" },
   };
 
   const updated = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
   assert.equal(updated.state, STATES.REVIEW_PENDING);
+});
+
+test("getRubricAnchorStatus distinguishes satisfied, empty, outside_run_dir, and grandfathered", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-anchor-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Maintainer");
+
+  const runId = "issue-42-20260412000003000";
+  writeRunRubric(repoRoot, runId);
+  const satisfied = getRubricAnchorStatus({
+    run_id: runId,
+    anchor: { rubric_path: "rubric.yaml" },
+    paths: { repo_root: repoRoot },
+  });
+  assert.equal(satisfied.status, "satisfied");
+  assert.equal(satisfied.satisfied, true);
+
+  const emptyRunId = "issue-42-20260412000004000";
+  writeRunRubric(repoRoot, emptyRunId, "rubric.yaml", "   \n");
+  const empty = getRubricAnchorStatus({
+    run_id: emptyRunId,
+    anchor: { rubric_path: "rubric.yaml" },
+    paths: { repo_root: repoRoot },
+  });
+  assert.equal(empty.status, "empty");
+  assert.equal(empty.satisfied, false);
+
+  const escaped = getRubricAnchorStatus({
+    run_id: runId,
+    anchor: { rubric_path: "../escape.yaml" },
+    paths: { repo_root: repoRoot },
+  });
+  assert.equal(escaped.status, "outside_run_dir");
+  assert.equal(escaped.satisfied, false);
+
+  const grandfathered = getRubricAnchorStatus({
+    run_id: runId,
+    anchor: { rubric_path: "rubric.yaml", rubric_grandfathered: true },
+    paths: { repo_root: repoRoot },
+  });
+  assert.equal(grandfathered.status, "grandfathered");
+  assert.equal(grandfathered.satisfied, true);
 });
 
 test("updateManifestCleanup records cleanup metadata without changing state", () => {

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -25,6 +25,7 @@
 const { execFileSync } = require("child_process");
 const path = require("path");
 const {
+  getRunDir,
   STATES,
   updateManifestState,
   writeManifest,
@@ -283,6 +284,7 @@ function main() {
         commits: preMerge.commits,
         manifestData: data,
         expectedReviewerLogin: data.review?.reviewer_login || null,
+        runDir: getRunDir(data.paths?.repo_root || repoPath, data.run_id),
       });
       if (!reviewGate.readyToMerge) {
         if (!dryRun) {

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -26,6 +26,7 @@
 
 const { execFileSync } = require("child_process");
 const { buildSkipComment, evaluateReviewGate } = require("./review-gate");
+const { getRunDir } = require("../../relay-dispatch/scripts/relay-manifest");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 
 // ---------------------------------------------------------------------------
@@ -108,6 +109,18 @@ function output(result) {
     } else if (result.status === "missing_rubric_path") {
       console.log(`✗ PR #${PR_NUM}: run is missing anchor.rubric_path — merge blocked`);
       console.log("  Re-dispatch from relay-plan with --rubric-file, or explicitly grandfather a pre-change run.");
+    } else if (result.status === "missing_rubric_file") {
+      console.log(`✗ PR #${PR_NUM}: anchored rubric file is missing from the run directory — merge blocked`);
+      if (result.reason) console.log(`  ${result.reason}`);
+    } else if (result.status === "empty_rubric_file") {
+      console.log(`✗ PR #${PR_NUM}: anchored rubric file is empty — merge blocked`);
+      if (result.reason) console.log(`  ${result.reason}`);
+    } else if (result.status === "invalid_rubric_path") {
+      console.log(`✗ PR #${PR_NUM}: anchor.rubric_path escapes the run directory — merge blocked`);
+      if (result.reason) console.log(`  ${result.reason}`);
+    } else if (result.status === "invalid_rubric_file") {
+      console.log(`✗ PR #${PR_NUM}: anchor.rubric_path does not point to a readable rubric file — merge blocked`);
+      if (result.reason) console.log(`  ${result.reason}`);
     } else if (result.status === "manifest_resolution_failed") {
       console.log(`✗ PR #${PR_NUM}: unable to resolve relay manifest — merge blocked`);
       if (result.reason) console.log(`  ${result.reason}`);
@@ -149,6 +162,7 @@ function main() {
   let comments;
   let commits;
   let manifestData = null;
+  let runDir = null;
   if (DRY_RUN) {
     // Dry-run: read JSON object/array from stdin, or plain text as single comment
     const stdin = require("fs").readFileSync(0, "utf-8").trim();
@@ -158,6 +172,7 @@ function main() {
       comments = parsed.comments || parsed;
       commits = Array.isArray(parsed.commits) ? parsed.commits : [];
       manifestData = parsed.manifest || null;
+      runDir = typeof parsed.runDir === "string" ? parsed.runDir : null;
     } catch {
       // Plain text: treat entire stdin as one comment body
       comments = [{ body: stdin, createdAt: null }];
@@ -181,6 +196,7 @@ function main() {
       process.exit(1);
     }
     manifestData = manifestRecord.data;
+    runDir = getRunDir(manifestData.paths?.repo_root || process.cwd(), manifestData.run_id);
   }
 
   const expectedReviewerLogin = manifestData?.review?.reviewer_login || null;
@@ -193,6 +209,7 @@ function main() {
     commits,
     manifestData,
     expectedReviewerLogin,
+    runDir,
   });
   if (result.note) {
     console.error(`Note: ${result.note}`);

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -8,16 +8,44 @@ const {
   createManifestSkeleton,
   createRunId,
   getManifestPath,
+  getRunDir,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 
 const SCRIPT = path.join(__dirname, "gate-check.js");
 
+function looksLikeContainedRubricPath(rubricPath) {
+  return typeof rubricPath === "string"
+    && rubricPath.trim() !== ""
+    && !path.isAbsolute(rubricPath)
+    && !rubricPath.split(/[\\/]+/).includes("..");
+}
+
+function ensureDryRunRubricFixture(payload) {
+  if (!payload?.manifest?.anchor?.rubric_path || payload.runDir) {
+    return payload;
+  }
+
+  const rubricPath = payload.manifest.anchor.rubric_path;
+  if (!looksLikeContainedRubricPath(rubricPath)) {
+    return payload;
+  }
+
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-run-"));
+  const fullPath = path.join(runDir, rubricPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, "rubric:\n  factors:\n    - name: gate check\n", "utf-8");
+  return { ...payload, runDir };
+}
+
 function runGateCheckDryRun(payload) {
+  const preparedPayload = Array.isArray(payload)
+    ? payload
+    : ensureDryRunRubricFixture(payload);
   const input = JSON.stringify(
-    Array.isArray(payload)
-      ? payload.map((body) => ({ body }))
-      : payload
+    Array.isArray(preparedPayload)
+      ? preparedPayload.map((body) => ({ body }))
+      : preparedPayload
   );
   const result = spawnSync("node", [
     SCRIPT,
@@ -51,7 +79,7 @@ process.exit(1);
   fs.chmodSync(ghPath, 0o755);
 }
 
-function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git = {} } = {}) {
+function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git = {}, rubricContent } = {}) {
   process.env.RELAY_HOME = relayHome;
   const runId = createRunId({
     issueNumber: 40,
@@ -87,15 +115,21 @@ function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git 
     },
   };
   writeManifest(manifestPath, manifest);
-  return { manifestPath, runId };
+  const runDir = getRunDir(repoRoot, runId);
+  if (looksLikeContainedRubricPath(anchor.rubric_path) && rubricContent !== false) {
+    const fullPath = path.join(runDir, anchor.rubric_path);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, rubricContent || "rubric:\n  factors:\n    - name: live gate check\n", "utf-8");
+  }
+  return { manifestPath, runId, runDir };
 }
 
-function runGateCheckLive({ manifest, prViewPayload }) {
+function runGateCheckLive({ manifest, prViewPayload, rubricContent }) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-check-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
   const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-bin-")));
   writeFakeGh(binDir);
-  writeLiveManifest(repoRoot, relayHome, manifest);
+  writeLiveManifest(repoRoot, relayHome, { ...manifest, rubricContent });
 
   const result = spawnSync("node", [
     SCRIPT,
@@ -416,6 +450,89 @@ test("gate-check resolves the manifest in PR mode and rejects missing anchor.rub
   assert.equal(result.status, 1);
   assert.equal(result.json.status, "missing_rubric_path");
   assert.equal(result.json.readyToMerge, false);
+});
+
+test("gate-check blocks merge when the anchored rubric file is missing at merge time", () => {
+  const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-check-missing-file-")));
+  const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-bin-")));
+  writeFakeGh(binDir);
+  const { runDir } = writeLiveManifest(repoRoot, relayHome, {
+    anchor: {
+      rubric_path: "rubric.yaml",
+    },
+    review: {
+      reviewer_login: "trusted-reviewer",
+      last_reviewed_sha: "abc123",
+    },
+  });
+  fs.unlinkSync(path.join(runDir, "rubric.yaml"));
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "40",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      PATH: `${binDir}:${process.env.PATH}`,
+      FAKE_GH_PR_VIEW_JSON: JSON.stringify({
+        headRefName: "issue-40",
+        comments: [
+          {
+            body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+            author: { login: "trusted-reviewer" },
+            createdAt: "2026-04-03T08:00:00Z",
+          },
+        ],
+        commits: [
+          { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
+        ],
+      }),
+    },
+  });
+
+  const json = JSON.parse(result.stdout);
+  assert.equal(result.status, 1);
+  assert.equal(json.status, "missing_rubric_file");
+  assert.equal(json.rubricStatus, "missing");
+  assert.match(json.reason, /missing from the run directory/);
+});
+
+test("gate-check blocks merge when the anchored rubric file is empty", () => {
+  const result = runGateCheckLive({
+    manifest: {
+      anchor: {
+        rubric_path: "rubric.yaml",
+      },
+      review: {
+        reviewer_login: "trusted-reviewer",
+        last_reviewed_sha: "abc123",
+      },
+    },
+    rubricContent: "   \n",
+    prViewPayload: {
+      headRefName: "issue-40",
+      comments: [
+        {
+          body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+          author: { login: "trusted-reviewer" },
+          createdAt: "2026-04-03T08:00:00Z",
+        },
+      ],
+      commits: [
+        { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "empty_rubric_file");
+  assert.equal(result.json.rubricStatus, "empty");
+  assert.match(result.json.reason, /empty/);
 });
 
 test("gate-check fails closed when PR manifest resolution fails", () => {

--- a/skills/relay-merge/scripts/review-gate.js
+++ b/skills/relay-merge/scripts/review-gate.js
@@ -49,26 +49,76 @@ function extractLatestCommit(commits) {
 }
 
 function withRubricNote(result, rubricAnchor) {
-  if (!rubricAnchor?.note) return result;
-  return {
+  if (!rubricAnchor) return result;
+  const next = {
     ...result,
-    note: rubricAnchor.note,
-    rubricGrandfathered: true,
+    rubricStatus: rubricAnchor.status,
   };
+  if (rubricAnchor.rubricPath) {
+    next.rubricPath = rubricAnchor.rubricPath;
+  }
+  if (rubricAnchor.resolvedPath) {
+    next.rubricResolvedPath = rubricAnchor.resolvedPath;
+  }
+  if (rubricAnchor.note) {
+    next.note = rubricAnchor.note;
+  }
+  if (rubricAnchor.status === "grandfathered") {
+    next.rubricGrandfathered = true;
+  }
+  return next;
 }
 
-function evaluateReviewGate({ prNumber, comments, commits, manifestData, expectedReviewerLogin }) {
+function buildRubricGateFailure(prNumber, rubricAnchor) {
+  switch (rubricAnchor?.status) {
+    case "missing_path":
+      return withRubricNote({
+        status: "missing_rubric_path",
+        pr: prNumber,
+        readyToMerge: false,
+        reason: "anchor.rubric_path is required before merge unless anchor.rubric_grandfathered=true",
+      }, rubricAnchor);
+    case "missing":
+      return withRubricNote({
+        status: "missing_rubric_file",
+        pr: prNumber,
+        readyToMerge: false,
+        reason: rubricAnchor.error,
+      }, rubricAnchor);
+    case "empty":
+      return withRubricNote({
+        status: "empty_rubric_file",
+        pr: prNumber,
+        readyToMerge: false,
+        reason: rubricAnchor.error,
+      }, rubricAnchor);
+    case "outside_run_dir":
+    case "run_dir_unavailable":
+      return withRubricNote({
+        status: "invalid_rubric_path",
+        pr: prNumber,
+        readyToMerge: false,
+        reason: rubricAnchor.error,
+      }, rubricAnchor);
+    default:
+      return withRubricNote({
+        status: "invalid_rubric_file",
+        pr: prNumber,
+        readyToMerge: false,
+        reason: rubricAnchor?.error || "anchor.rubric_path did not resolve to a readable rubric file",
+      }, rubricAnchor);
+  }
+}
+
+function evaluateReviewGate({ prNumber, comments, commits, manifestData, expectedReviewerLogin, runDir }) {
   const commentRecords = normalizeCommentRecords(comments);
   const { latestCommit, latestCommitAt } = extractLatestCommit(commits);
-  const rubricAnchor = getRubricAnchorStatus(manifestData);
+  const rubricAnchor = manifestData
+    ? getRubricAnchorStatus(manifestData, runDir ? { runDir } : undefined)
+    : null;
 
   if (manifestData && !rubricAnchor.satisfied) {
-    return {
-      status: "missing_rubric_path",
-      pr: prNumber,
-      readyToMerge: false,
-      reason: "anchor.rubric_path is required before merge unless anchor.rubric_grandfathered=true",
-    };
+    return buildRubricGateFailure(prNumber, rubricAnchor);
   }
 
   let lastReviewComment = null;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -35,6 +35,7 @@ const { REVIEW_VERDICT_JSON_SCHEMA } = require("./review-schema");
 const {
   STATES,
   ensureRunLayout,
+  getRubricAnchorStatus,
   getRunDir,
   readManifest,
   updateManifestState,
@@ -263,18 +264,91 @@ function formatPriorRoundContext(runDir, round) {
   return ["## Prior Round Context", "", "Verify whether prior issues were resolved.", "", ...lines].join("\n");
 }
 
+function formatRubricWarning(label, rubricAnchor) {
+  const details = [];
+  if (rubricAnchor.rubricPath) {
+    details.push(`anchor.rubric_path=${JSON.stringify(rubricAnchor.rubricPath)}`);
+  }
+  if (rubricAnchor.resolvedPath) {
+    details.push(`resolved_path=${JSON.stringify(rubricAnchor.resolvedPath)}`);
+  }
+  return [
+    `WARNING: [${label}] ${rubricAnchor.error}`,
+    details.length ? `Context: ${details.join(", ")}` : null,
+    "Flag this invariant failure in the review output instead of silently evaluating without the rubric.",
+  ].filter(Boolean).join("\n");
+}
+
 function loadRubricFromRunDir(runDir, manifestData) {
-  const rubricPath = manifestData?.anchor?.rubric_path;
-  if (!rubricPath || !runDir) return null;
-  const fullPath = path.join(runDir, rubricPath);
-  try {
-    return fs.readFileSync(fullPath, "utf-8").trim();
-  } catch {
-    return null;
+  const rubricAnchor = getRubricAnchorStatus(manifestData, { runDir, includeContent: true });
+  switch (rubricAnchor.status) {
+    case "satisfied":
+      return {
+        state: "loaded",
+        status: rubricAnchor.status,
+        content: rubricAnchor.content,
+        warning: null,
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
+    case "grandfathered":
+      return {
+        state: "grandfathered",
+        status: rubricAnchor.status,
+        content: null,
+        warning: null,
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
+    case "missing_path":
+      return {
+        state: "not_set",
+        status: rubricAnchor.status,
+        content: null,
+        warning: null,
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
+    case "missing":
+      return {
+        state: "missing",
+        status: rubricAnchor.status,
+        content: null,
+        warning: formatRubricWarning("rubric missing", rubricAnchor),
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
+    case "outside_run_dir":
+      return {
+        state: "outside_run_dir",
+        status: rubricAnchor.status,
+        content: null,
+        warning: formatRubricWarning("rubric path outside run dir", rubricAnchor),
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
+    case "empty":
+      return {
+        state: "empty",
+        status: rubricAnchor.status,
+        content: null,
+        warning: formatRubricWarning("rubric empty", rubricAnchor),
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
+    default:
+      return {
+        state: "invalid",
+        status: rubricAnchor.status,
+        content: null,
+        warning: formatRubricWarning("rubric invalid", rubricAnchor),
+        rubricPath: rubricAnchor.rubricPath,
+        resolvedPath: rubricAnchor.resolvedPath,
+      };
   }
 }
 
-function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricContent }) {
+function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricLoad }) {
   const template = readText(REVIEWER_PROMPT_PATH)
     .replace("source=\"done-criteria\"", `source="${doneCriteriaSource || "done-criteria"}"`)
     .replace("[PASTE DONE CRITERIA HERE]", doneCriteria)
@@ -290,7 +364,13 @@ function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneC
     template,
   ];
 
-  if (rubricContent) {
+  if (rubricLoad.warning) {
+    sections.push(
+      "",
+      "## Scoring Rubric",
+      rubricLoad.warning,
+    );
+  } else if (rubricLoad.content) {
     sections.push(
       "",
       "## Scoring Rubric",
@@ -298,7 +378,7 @@ function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneC
       "For each factor, populate a `rubric_scores` entry with `factor`, `target`, `observed`, `status`, `tier`, and `notes`.",
       "Do NOT leave `rubric_scores` empty when a rubric is provided.",
       "",
-      rubricContent,
+      rubricLoad.content,
     );
   }
 
@@ -319,7 +399,7 @@ function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneC
     '- If `verdict` is `pass`, set both `contract_status` and `quality_status` to `pass`.',
     '- If `verdict` is `changes_requested`, include actionable issues with `file` and `line`, and set `next_action` to `changes_requested`.',
     '- If `verdict` is `escalated`, include the blocking issues or reason that automation should stop, and set `next_action` to `escalated`.',
-    rubricContent
+    rubricLoad.content
       ? '- `rubric_scores` is REQUIRED — score every factor from the rubric. Each entry must include `factor`, `target`, `observed`, `status`, `tier`, and `notes`.'
       : '- If no Score Log is available, set `rubric_scores` to `[]`.',
     '- When `rubric_scores` is not empty, each entry must include `factor`, `target`, `observed`, `status`, `tier`, and `notes`.',
@@ -1014,8 +1094,8 @@ function run() {
     data
   );
   const diffText = loadDiff(repoPath, prNumber, diffFile);
-  const rubricContent = loadRubricFromRunDir(runDir, data);
-  const promptText = buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricContent });
+  const rubricLoad = loadRubricFromRunDir(runDir, data);
+  const promptText = buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricLoad });
 
   const doneCriteriaPath = path.join(runDir, `review-round-${round}-done-criteria.md`);
   const diffPath = path.join(runDir, `review-round-${round}-diff.patch`);
@@ -1052,7 +1132,9 @@ function run() {
     reviewer: reviewerName,
     reviewerScript,
     reviewFile: reviewFile || null,
-    rubricLoaded: !!rubricContent,
+    rubricLoaded: rubricLoad.state,
+    rubricStatus: rubricLoad.status,
+    rubricWarning: rubricLoad.warning || null,
     rawResponsePath: null,
     verdictPath: null,
     redispatchPath: null,
@@ -1126,7 +1208,7 @@ function run() {
   }
 
   let verdict = parseReviewVerdict(reviewText);
-  if (rubricContent && (!Array.isArray(verdict.rubric_scores) || verdict.rubric_scores.length === 0)) {
+  if (rubricLoad.state === "loaded" && (!Array.isArray(verdict.rubric_scores) || verdict.rubric_scores.length === 0)) {
     throw new Error(
       "Review verdict has empty rubric_scores but a rubric was provided. " +
       "The reviewer must score every rubric factor."

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1306,9 +1306,11 @@ test("review-runner loads rubric from run dir and includes rubric factor names a
     "    - name: API pagination",
     "      target: \">= 8/10\"",
   ].join("\n"), "utf-8");
+  const nextAnchor = { ...(data.anchor || {}), rubric_path: "rubric.yaml" };
+  delete nextAnchor.rubric_grandfathered;
   const updated = {
     ...data,
-    anchor: { ...data.anchor, rubric_path: "rubric.yaml" },
+    anchor: nextAnchor,
   };
   writeManifest(manifestPath, updated, body);
 
@@ -1324,12 +1326,73 @@ test("review-runner loads rubric from run dir and includes rubric factor names a
   ], { encoding: "utf-8" });
 
   const result = JSON.parse(stdout);
-  assert.equal(result.rubricLoaded, true);
+  assert.equal(result.rubricLoaded, "loaded");
   const promptText = fs.readFileSync(result.promptPath, "utf-8");
   assert.match(promptText, /## Scoring Rubric/);
   assert.match(promptText, /API pagination/);
   assert.match(promptText, />= 8\/10/);
   assert.match(promptText, /rubric_scores.*REQUIRED/i);
+});
+
+test("review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  const { data, body } = readManifest(manifestPath);
+  const nextAnchor = { ...(data.anchor || {}), rubric_path: "rubric.yaml" };
+  delete nextAnchor.rubric_grandfathered;
+  writeManifest(manifestPath, {
+    ...data,
+    anchor: nextAnchor,
+  }, body);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.rubricLoaded, "missing");
+  assert.match(result.rubricWarning, /\[rubric missing\]/i);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /## Scoring Rubric/);
+  assert.match(promptText, /WARNING: \[rubric missing\]/i);
+  assert.match(promptText, /Flag this invariant failure/i);
+});
+
+test("review-runner distinguishes rubric paths that resolve outside the run dir", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  const { data, body } = readManifest(manifestPath);
+  const nextAnchor = { ...(data.anchor || {}), rubric_path: "../escape.yaml" };
+  delete nextAnchor.rubric_grandfathered;
+  writeManifest(manifestPath, {
+    ...data,
+    anchor: nextAnchor,
+  }, body);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.rubricLoaded, "outside_run_dir");
+  assert.match(result.rubricWarning, /\[rubric path outside run dir\]/i);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /WARNING: \[rubric path outside run dir\]/i);
+  assert.match(promptText, /\.\./);
 });
 
 test("review-runner rejects empty rubric_scores when rubric is present", () => {
@@ -1339,9 +1402,11 @@ test("review-runner rejects empty rubric_scores when rubric is present", () => {
   const { data, body } = readManifest(manifestPath);
   const runDir = ensureRunLayout(repoRoot, runId).runDir;
   fs.writeFileSync(path.join(runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: test\n", "utf-8");
+  const nextAnchor = { ...(data.anchor || {}), rubric_path: "rubric.yaml" };
+  delete nextAnchor.rubric_grandfathered;
   const updated = {
     ...data,
-    anchor: { ...data.anchor, rubric_path: "rubric.yaml" },
+    anchor: nextAnchor,
   };
   writeManifest(manifestPath, updated, body);
 
@@ -1398,5 +1463,5 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
 
   const result = JSON.parse(stdout);
   assert.equal(result.state, STATES.READY_TO_MERGE);
-  assert.equal(result.rubricLoaded, false);
+  assert.equal(result.rubricLoaded, "grandfathered");
 });


### PR DESCRIPTION
## Summary
- Made `anchor.rubric_path` a file-backed invariant: `getRubricAnchorStatus()` now resolves the run dir, rejects out-of-tree paths, and requires a readable non-empty rubric file unless the run is explicitly grandfathered.
- Enforced the shared containment rule at dispatch, review, and merge time so malicious `..` / absolute paths, deleted rubric files, and empty rubric files produce distinct operator-facing failures instead of silent fallbacks.
- Added regression coverage for the merge-time missing-file case, dispatch-time path escapes, review-time warning rendering, grandfathered collision behavior, and empty/outside-run-dir status branches. Verified this run's own manifest still resolves to `status=satisfied`.

## Score Log

| Factor | Target | Baseline | Iter 1 | Final | Status |
|--------|--------|----------|--------|-------|--------|
| getRubricAnchorStatus validates file existence + returns structured status | >= 8/10 | 2/10 | 9/10 | 9/10 | locked |
| Path containment enforced at both write (dispatch) and read (review-runner) | >= 8/10 | 2/10 | 9/10 | 9/10 | locked |
| loadRubricFromRunDir surfaces missing rubric as visible warning, not silent null | >= 8/10 | 1/10 | 9/10 | 9/10 | locked |
| 4 regression tests present — each bypass vector is exercised | >= 8/10 | 2/10 | 9/10 | 9/10 | locked |
| Grandfathered runs preserved — legacy bypass behavior unchanged | >= 8/10 | 6/10 | 9/10 | 9/10 | locked |
| Attack surface enumeration — remaining bypass vectors documented | >= 8/10 | 1/10 | 8/10 | 8/10 | locked |
| Structured status enables consumer divergence — not a boolean-rename refactor | >= 8/10 | 2/10 | 9/10 | 9/10 | locked |

## Anti-Theater Check
- `skills/relay-merge/scripts/gate-check.test.js`: if I remove the new file-backed gate and delete `rubric.yaml`, `gate-check blocks merge when the anchored rubric file is missing at merge time` fails because the old code returns `lgtm`.
- `skills/relay-dispatch/scripts/dispatch.test.js`: if I remove the new containment validation, both `dispatch resume rejects anchor.rubric_path values with parent traversal` and `dispatch resume rejects absolute anchor.rubric_path values` fail because resume proceeds on a non-empty string anchor.
- `skills/relay-review/scripts/review-runner.test.js`: if I restore `catch { return null }`, `review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing` fails because the prompt no longer contains the warning and `rubricLoaded` collapses back to the rubric-less case.
- `skills/relay-review/scripts/review-runner.test.js`: if I skip the shared containment helper on read, `review-runner distinguishes rubric paths that resolve outside the run dir` fails because the prompt loses the `[rubric path outside run dir]` warning.

## Attack Surface / Remaining Bypass Vectors
- Symlink escape from `rubric.yaml` to an out-of-tree target: deferred. This patch uses `path.resolve`, not `fs.realpath`, so symlink traversal is still possible. No existing issue; a follow-up should be filed.
- Non-empty but semantically invalid rubric content: deferred. This patch blocks empty/whitespace-only files, but malformed YAML or text that is structurally useless still reaches reviewers and downstream consumers. No existing issue; a follow-up should be filed before #139 assumes schema-valid content.
- Mid-review / mid-merge race after the first read: deferred. Review prompt generation and merge gating each read once; a later delete or truncate is outside this patch’s scope. No existing issue; a follow-up should be filed.
- `anchor.rubric_path` pointing at a directory or unreadable filesystem node: partially covered in code via `invalid_rubric_file`, but not expanded into its own dedicated regression test here. No existing issue; a follow-up should be filed if we want tighter fixture coverage.
- Skip-path bypasses in `gate-check --skip` / `finalize-run --skip-review`: deferred to #150.
- Manifest hand-edit that flips `anchor.rubric_grandfathered` on an active run: deferred to #151.
- Repo-root / repo-slug inconsistency between base repo and worktree paths: deferred to #152.
- Windows-specific separator / normalization edge cases: partially mitigated because containment rejects `..` segments across both `/` and `\\`, but there is no Windows CI coverage in this PR. No existing issue; a follow-up should be filed.

## Test Plan
- `node --test skills/relay-dispatch/scripts/dispatch.test.js`
  Expected: the new subtests `dispatch resume rejects anchor.rubric_path values with parent traversal` and `dispatch resume rejects absolute anchor.rubric_path values` both pass.
- `node --test skills/relay-review/scripts/review-runner.test.js`
  Expected: the new subtests `review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing` and `review-runner distinguishes rubric paths that resolve outside the run dir` both pass and preserve grandfathered behavior.
- `node --test skills/relay-merge/scripts/gate-check.test.js`
  Expected: the new subtests `gate-check blocks merge when the anchored rubric file is missing at merge time` and `gate-check blocks merge when the anchored rubric file is empty` both pass with non-`lgtm` statuses that differ from `missing_rubric_path`.
- `node --check skills/relay-dispatch/scripts/relay-manifest.js && node --check skills/relay-dispatch/scripts/dispatch.js && node --check skills/relay-review/scripts/review-runner.js && node --check skills/relay-merge/scripts/review-gate.js`
  Expected: exit 0.
- `node --test skills/relay-dispatch/scripts/*.test.js skills/relay-review/scripts/*.test.js skills/relay-merge/scripts/*.test.js skills/relay-intake/scripts/*.test.js`
  Expected: exit 0. Current result: pass (`185` tests, `0` failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 루브릭 파일 경로 검증 강화: 부모 디렉토리 접근 및 절대 경로 방지

* **버그 수정**
  * 루브릭 파일 존재 여부 및 내용 검증 개선
  * 병합 프로세스 중 루브릭 파일 검증 강화
  * 오류 메시지 및 실패 처리 로직 개선

* **테스트**
  * 루브릭 경로 검증 시나리오에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->