### PR TITLE
Validate run_id before resolving relay run paths (#156)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -106,10 +106,97 @@ function inferIssueNumber(branch) {
   return match ? Number(match[1]) : null;
 }
 
+const RUN_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*-\d{17}$/;
+const RUN_ID_PATTERN_DESCRIPTION = "/^[a-z0-9]+(?:-[a-z0-9]+)*-\\d{17}$/";
+
+function validateRunId(runId) {
+  const normalizedRunId = typeof runId === "string" ? runId.trim() : "";
+  const runIdSegments = normalizedRunId.split(/[\\/]+/).filter(Boolean);
+  const buildResult = ({ valid, status, reason }) => ({
+    valid,
+    status,
+    runId: normalizedRunId || null,
+    reason,
+  });
+
+  if (!normalizedRunId) {
+    return buildResult({
+      valid: false,
+      status: "missing_run_id",
+      reason: `run_id must be set to a single path segment matching ${RUN_ID_PATTERN_DESCRIPTION} (got ${JSON.stringify(runId)}).`,
+    });
+  }
+
+  if (normalizedRunId === "." || normalizedRunId === "..") {
+    return buildResult({
+      valid: false,
+      status: "invalid_run_id",
+      reason: `run_id must be a single path segment matching ${RUN_ID_PATTERN_DESCRIPTION} and may not be '.' or '..' (got ${JSON.stringify(normalizedRunId)}).`,
+    });
+  }
+
+  if (runIdSegments.includes("..")) {
+    return buildResult({
+      valid: false,
+      status: "invalid_run_id",
+      reason: `run_id must be a single path segment matching ${RUN_ID_PATTERN_DESCRIPTION} and may not contain '..' segments (got ${JSON.stringify(normalizedRunId)}).`,
+    });
+  }
+
+  if (normalizedRunId.includes("/")) {
+    return buildResult({
+      valid: false,
+      status: "invalid_run_id",
+      reason: `run_id must be a single path segment matching ${RUN_ID_PATTERN_DESCRIPTION} and may not contain '/' (got ${JSON.stringify(normalizedRunId)}).`,
+    });
+  }
+
+  if (normalizedRunId.includes("\\")) {
+    return buildResult({
+      valid: false,
+      status: "invalid_run_id",
+      reason: `run_id must be a single path segment matching ${RUN_ID_PATTERN_DESCRIPTION} and may not contain '\\\\' (got ${JSON.stringify(normalizedRunId)}).`,
+    });
+  }
+
+  if (
+    path.basename(normalizedRunId) !== normalizedRunId
+    || path.win32.basename(normalizedRunId) !== normalizedRunId
+  ) {
+    return buildResult({
+      valid: false,
+      status: "invalid_run_id",
+      reason: `run_id must resolve to a single path segment matching ${RUN_ID_PATTERN_DESCRIPTION} (got ${JSON.stringify(normalizedRunId)}).`,
+    });
+  }
+
+  if (!RUN_ID_PATTERN.test(normalizedRunId)) {
+    return buildResult({
+      valid: false,
+      status: "invalid_run_id",
+      reason: `run_id must match the shape emitted by createRunId (${RUN_ID_PATTERN_DESCRIPTION}) and remain a single path segment (got ${JSON.stringify(normalizedRunId)}).`,
+    });
+  }
+
+  return buildResult({
+    valid: true,
+    status: "valid",
+    reason: null,
+  });
+}
+
+function requireValidRunId(runId) {
+  const validation = validateRunId(runId);
+  if (!validation.valid) {
+    throw new Error(validation.reason);
+  }
+  return validation.runId;
+}
+
 function createRunId({ issueNumber, branch, timestamp = new Date() } = {}) {
   const prefix = issueNumber ? `issue-${issueNumber}` : slugify(branch || "run");
   const iso = timestamp.toISOString().replace(/[-:TZ.]/g, "").slice(0, 17);
-  return `${prefix}-${iso}`;
+  return requireValidRunId(`${prefix}-${iso}`);
 }
 
 function getRunsDir(repoRoot) {
@@ -117,11 +204,11 @@ function getRunsDir(repoRoot) {
 }
 
 function getRunDir(repoRoot, runId) {
-  return path.join(getRunsDir(repoRoot), runId);
+  return path.join(getRunsDir(repoRoot), requireValidRunId(runId));
 }
 
 function getManifestPath(repoRoot, runId) {
-  return path.join(getRunsDir(repoRoot), `${runId}.md`);
+  return path.join(getRunsDir(repoRoot), `${requireValidRunId(runId)}.md`);
 }
 
 function getEventsPath(repoRoot, runId) {
@@ -308,7 +395,7 @@ function resolveRubricRunDir(data, options = {}) {
   if (!repoRoot || !runId) {
     return null;
   }
-  return getRunDir(repoRoot, runId);
+  return path.resolve(getRunDir(repoRoot, runId));
 }
 
 function validateRubricPathContainment(rubricPath, runDir) {
@@ -563,10 +650,11 @@ function createManifestSkeleton({
   doneCriteriaSource = null,
 }) {
   const createdAt = nowIso();
+  const normalizedRunId = requireValidRunId(runId);
 
   const manifest = {
     relay_version: RELAY_VERSION,
-    run_id: runId,
+    run_id: normalizedRunId,
     state: STATES.DRAFT,
     next_action: "start_dispatch",
     actor: {
@@ -907,6 +995,7 @@ module.exports = {
   updateManifestCleanup,
   updateManifestState,
   validateRubricPathContainment,
+  validateRunId,
   validateTransition,
   validateTransitionInvariants,
   writeManifest,

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -391,11 +391,17 @@ function resolveRubricRunDir(data, options = {}) {
   }
 
   const repoRoot = options.repoRoot || data?.paths?.repo_root || null;
-  const runId = options.runId || data?.run_id || null;
-  if (!repoRoot || !runId) {
+  const runId = Object.prototype.hasOwnProperty.call(options, "runId")
+    ? options.runId
+    : data?.run_id;
+  const validation = validateRunId(runId);
+  if (!validation.valid) {
+    throw new Error(validation.reason);
+  }
+  if (!repoRoot) {
     return null;
   }
-  return path.resolve(getRunDir(repoRoot, runId));
+  return path.resolve(getRunDir(repoRoot, validation.runId));
 }
 
 function validateRubricPathContainment(rubricPath, runDir) {

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -339,6 +339,7 @@ test("updateManifestState allows valid transitions and rejects invalid ones", ()
 
 test("updateManifestState rejects dispatched -> review_pending when anchor.rubric_path is missing", () => {
   const manifest = {
+    run_id: "issue-42-20260412000000000",
     state: STATES.DISPATCHED,
     next_action: "await_dispatch_result",
     anchor: {},
@@ -396,6 +397,60 @@ test("getRubricAnchorStatus rejects invalid run_id even for grandfathered runs",
     }),
     /may not contain '\.\.' segments/
   );
+});
+
+test("getRubricAnchorStatus rejects missing and empty run_id before rubric or grandfathered handling", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-missing-runid-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  const cases = [
+    {
+      label: "missing run_id with rubric_path",
+      manifest: {
+        anchor: { rubric_path: "rubric.yaml" },
+        paths: { repo_root: repoRoot },
+      },
+      pattern: /got undefined/,
+    },
+    {
+      label: "empty run_id with rubric_path",
+      manifest: {
+        run_id: "",
+        anchor: { rubric_path: "rubric.yaml" },
+        paths: { repo_root: repoRoot },
+      },
+      pattern: /got ""/,
+    },
+    {
+      label: "missing run_id with grandfathered anchor",
+      manifest: {
+        anchor: { rubric_grandfathered: true },
+        paths: { repo_root: repoRoot },
+      },
+      pattern: /got undefined/,
+    },
+    {
+      label: "empty run_id with grandfathered anchor",
+      manifest: {
+        run_id: "",
+        anchor: { rubric_grandfathered: true },
+        paths: { repo_root: repoRoot },
+      },
+      pattern: /got ""/,
+    },
+  ];
+
+  for (const entry of cases) {
+    assert.throws(
+      () => getRubricAnchorStatus(entry.manifest),
+      (error) => {
+        assert.match(error.message, /run_id must be set to a single path segment/);
+        assert.match(error.message, entry.pattern);
+        return true;
+      },
+      entry.label
+    );
+  }
 });
 
 test("getRubricAnchorStatus distinguishes satisfied, empty, outside_run_dir, and grandfathered", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -15,13 +15,16 @@ const {
   createRunId,
   ensureRunLayout,
   formatAttemptsForPrompt,
+  getManifestPath,
   getRubricAnchorStatus,
   getRepoSlug,
+  getRunDir,
   inferIssueNumber,
   readManifest,
   readPreviousAttempts,
   updateManifestCleanup,
   updateManifestState,
+  validateRunId,
   writeManifest,
 } = require("./relay-manifest");
 
@@ -79,11 +82,96 @@ test("createRunId is branch-stable and filesystem-safe", () => {
   assert.equal(runId, "feature-auth-flow-20260402123456000");
 });
 
+test("validateRunId accepts sampled historical relay run_ids", () => {
+  const historicalRunIds = [
+    "issue-114-20260408100846873",
+    "issue-132-20260410150841243",
+    "issue-138-20260412044608184",
+    "issue-148-20260412072649097",
+    "issue-156-20260412101412608",
+  ];
+
+  for (const runId of historicalRunIds) {
+    const result = validateRunId(runId);
+    assert.equal(result.valid, true, `${runId} should be accepted`);
+    assert.equal(result.status, "valid");
+    assert.equal(result.runId, runId);
+    assert.equal(result.reason, null);
+  }
+});
+
+test("validateRunId rejects unsafe and non-conforming values", () => {
+  const cases = [
+    {
+      runId: null,
+      status: "missing_run_id",
+      pattern: /run_id must be set to a single path segment/,
+    },
+    {
+      runId: "",
+      status: "missing_run_id",
+      pattern: /got ""/,
+    },
+    {
+      runId: ".",
+      status: "invalid_run_id",
+      pattern: /may not be '\.' or '\.\.'/,
+    },
+    {
+      runId: "..",
+      status: "invalid_run_id",
+      pattern: /may not be '\.' or '\.\.'/,
+    },
+    {
+      runId: "../victim-run",
+      status: "invalid_run_id",
+      pattern: /may not contain '\.\.' segments/,
+    },
+    {
+      runId: "issue-42/20260412000000000",
+      status: "invalid_run_id",
+      pattern: /may not contain '\/'/,
+    },
+    {
+      runId: "issue-42\\20260412000000000",
+      status: "invalid_run_id",
+      pattern: /may not contain '\\\\'/,
+    },
+    {
+      runId: "Issue-42-20260412000000000",
+      status: "invalid_run_id",
+      pattern: /shape emitted by createRunId/,
+    },
+  ];
+
+  for (const entry of cases) {
+    const result = validateRunId(entry.runId);
+    assert.equal(result.valid, false, `${JSON.stringify(entry.runId)} should be rejected`);
+    assert.equal(result.status, entry.status);
+    assert.match(result.reason, entry.pattern);
+    assert.match(result.reason, new RegExp(String.raw`${JSON.stringify(entry.runId).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  }
+});
+
+test("getRunDir and getManifestPath reject invalid run_id before path derivation", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-runid-paths-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  assert.throws(
+    () => getRunDir(repoRoot, "../victim-run"),
+    /run_id must be a single path segment/
+  );
+  assert.throws(
+    () => getManifestPath(repoRoot, "issue-42\\20260412000000000"),
+    /run_id must be a single path segment/
+  );
+});
+
 test("manifest round-trips through frontmatter helpers", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   initGitRepo(repoRoot, "Relay Maintainer");
-  const runId = "issue-42-20260402103000";
+  const runId = "issue-42-20260402103000000";
   const worktreePath = path.join(repoRoot, "wt");
   const { manifestPath } = ensureRunLayout(repoRoot, runId);
   const manifest = createManifestSkeleton({
@@ -115,7 +203,7 @@ test("manifest round-trips through frontmatter helpers", () => {
 test("manifest round-trips multiline scalar values", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-multiline-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
-  const runId = "issue-42-20260402103001";
+  const runId = "issue-42-20260402103001000";
   const worktreePath = path.join(repoRoot, "wt");
   const { manifestPath } = ensureRunLayout(repoRoot, runId);
   const manifest = createManifestSkeleton({
@@ -145,7 +233,7 @@ test("createManifestSkeleton falls back to unknown actor when git user.name is u
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-actor-missing-"));
     const manifest = createManifestSkeleton({
       repoRoot,
-      runId: "issue-42-20260402103002",
+      runId: "issue-42-20260402103002000",
       branch: "issue-42",
       baseBranch: "main",
       issueNumber: 42,
@@ -166,7 +254,7 @@ test("createManifestSkeleton stores optional intake linkage without changing sta
 
   const manifest = createManifestSkeleton({
     repoRoot,
-    runId: "issue-42-20260402103003",
+    runId: "issue-42-20260402103003000",
     branch: "issue-42",
     baseBranch: "main",
     issueNumber: 42,
@@ -190,7 +278,7 @@ test("createManifestSkeleton stores optional intake linkage without changing sta
 test("readManifest migrates v1 roles.worker to roles.executor", () => {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-migrate-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
-  const runId = "migrate-v1-20260402103000";
+  const runId = "migrate-v1-20260402103000000";
   const wtPath = path.join(tmpRoot, "wt");
   const { manifestPath } = ensureRunLayout(tmpRoot, runId);
   const manifest = createManifestSkeleton({
@@ -294,6 +382,20 @@ test("updateManifestState allows dispatched -> review_pending when rubric is gra
 
   const updated = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
   assert.equal(updated.state, STATES.REVIEW_PENDING);
+});
+
+test("getRubricAnchorStatus rejects invalid run_id even for grandfathered runs", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-grandfather-runid-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  assert.throws(
+    () => getRubricAnchorStatus({
+      run_id: "../victim-run",
+      anchor: { rubric_grandfathered: true },
+      paths: { repo_root: repoRoot },
+    }),
+    /may not contain '\.\.' segments/
+  );
 });
 
 test("getRubricAnchorStatus distinguishes satisfied, empty, outside_run_dir, and grandfathered", () => {

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { listManifestRecords, readManifest } = require("./relay-manifest");
+const { listManifestRecords, readManifest, validateRunId } = require("./relay-manifest");
 
 function formatSelector({ runId, manifestPath, branch, prNumber }) {
   if (manifestPath) return `manifest '${manifestPath}'`;
@@ -22,14 +22,36 @@ function hasStoredPrNumber(record) {
   return record?.data?.git?.pr_number !== undefined && record?.data?.git?.pr_number !== null;
 }
 
+function validateRequestedRunId(runId) {
+  const validation = validateRunId(runId);
+  if (!validation.valid) {
+    throw new Error(validation.reason);
+  }
+  return validation.runId;
+}
+
+function validateManifestRecordRunId(record) {
+  const validation = validateRunId(record?.data?.run_id);
+  if (!validation.valid) {
+    throw new Error(
+      `Relay manifest ${JSON.stringify(record?.manifestPath || "unknown")} has invalid run_id: ${validation.reason}`
+    );
+  }
+  return record;
+}
+
 function findManifestByRunId(repoRoot, runId) {
+  const normalizedRunId = validateRequestedRunId(runId);
   const matches = listManifestRecords(repoRoot)
-    .filter(({ data, manifestPath }) => data?.run_id === runId || path.basename(manifestPath, ".md") === runId);
+    .filter(({ data, manifestPath }) => (
+      data?.run_id === normalizedRunId
+      || path.basename(manifestPath, ".md") === normalizedRunId
+    ));
 
   if (matches.length > 1) {
-    throw new Error(`Ambiguous relay manifest for run_id '${runId}'`);
+    throw new Error(`Ambiguous relay manifest for run_id '${normalizedRunId}'`);
   }
-  return matches[0] || null;
+  return matches[0] ? validateManifestRecordRunId(matches[0]) : null;
 }
 
 function ensureUniqueRecord(matches, selector) {
@@ -54,7 +76,7 @@ function resolveManifestRecord({
 }) {
   if (manifestPath) {
     const resolved = path.resolve(manifestPath);
-    return { manifestPath: resolved, ...readManifest(resolved) };
+    return validateManifestRecordRunId({ manifestPath: resolved, ...readManifest(resolved) });
   }
 
   if (runId) {
@@ -85,7 +107,7 @@ function resolveManifestRecord({
     matches = filterByPr(allRecords, prNumber);
   }
 
-  return ensureUniqueRecord(matches, { branch, prNumber });
+  return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch, prNumber }));
 }
 
 module.exports = {

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -1,0 +1,92 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("./relay-manifest");
+const { findManifestByRunId, resolveManifestRecord } = require("./relay-resolver");
+
+function writeReviewPendingManifest(repoRoot, {
+  runId,
+  storedRunId = runId,
+  branch = "issue-42",
+  issueNumber = 42,
+  updatedAt = "2026-04-03T00:00:00.000Z",
+} = {}) {
+  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber,
+    worktreePath: path.join(repoRoot, "wt", branch),
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "claude",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_grandfathered = true;
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest.run_id = storedRunId;
+  manifest.timestamps.updated_at = updatedAt;
+  manifest.timestamps.created_at = updatedAt;
+  writeManifest(manifestPath, manifest);
+  return manifestPath;
+}
+
+test("findManifestByRunId rejects invalid run_id selectors before scanning manifests", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-find-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  assert.throws(
+    () => findManifestByRunId(repoRoot, "../victim-run"),
+    /may not contain '\.\.' segments/
+  );
+  assert.throws(
+    () => findManifestByRunId(repoRoot, "issue-42\\20260412000000000"),
+    /may not contain '\\\\'/
+  );
+});
+
+test("resolveManifestRecord rejects non-conforming run_id selectors", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-shape-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  writeReviewPendingManifest(repoRoot, {
+    runId: createRunId({
+      branch: "issue-42",
+      timestamp: new Date("2026-04-03T00:00:00.000Z"),
+    }),
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, runId: "Issue-42-20260412000000000" }),
+    /shape emitted by createRunId/
+  );
+});
+
+test("resolveManifestRecord rejects manifests whose stored run_id is invalid", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-invalid-manifest-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  writeReviewPendingManifest(repoRoot, {
+    runId: createRunId({
+      branch: "issue-42",
+      timestamp: new Date("2026-04-03T00:05:00.000Z"),
+    }),
+    storedRunId: "../victim-run",
+    updatedAt: "2026-04-03T00:05:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "issue-42" }),
+    /has invalid run_id: run_id must be a single path segment/
+  );
+});

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -8,6 +8,7 @@ const path = require("path");
 const {
   STATES,
   createManifestSkeleton,
+  createRunId,
   ensureRunLayout,
   updateManifestState,
   writeManifest,
@@ -66,26 +67,29 @@ test("reliability-report derives the core scorecard from manifests and events", 
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(); // 1 hour ago
   const staleTs = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(); // 10 days ago
+  const runReady = createRunId({ branch: "run-ready", timestamp: new Date("2026-04-12T00:00:00.000Z") });
+  const runMerged = createRunId({ branch: "run-merged", timestamp: new Date("2026-04-12T00:00:01.000Z") });
+  const runStaleOpen = createRunId({ branch: "run-stale-open", timestamp: new Date("2026-04-12T00:00:02.000Z") });
   writeRun(repoRoot, {
-    runId: "run-ready",
+    runId: runReady,
     state: STATES.READY_TO_MERGE,
     rounds: 2,
     updatedAt: recentTs,
   });
   writeRun(repoRoot, {
-    runId: "run-merged",
+    runId: runMerged,
     state: STATES.MERGED,
     rounds: 4,
     updatedAt: recentTs,
   });
   writeRun(repoRoot, {
-    runId: "run-stale-open",
+    runId: runStaleOpen,
     state: STATES.REVIEW_PENDING,
     rounds: 1,
     updatedAt: staleTs,
   });
 
-  appendRunEvent(repoRoot, "run-ready", {
+  appendRunEvent(repoRoot, runReady, {
     event: "dispatch_start",
     state_from: STATES.CHANGES_REQUESTED,
     state_to: STATES.DISPATCHED,
@@ -93,7 +97,7 @@ test("reliability-report derives the core scorecard from manifests and events", 
     round: 2,
     reason: "same_run_resume",
   });
-  appendRunEvent(repoRoot, "run-ready", {
+  appendRunEvent(repoRoot, runReady, {
     event: "dispatch_result",
     state_from: STATES.DISPATCHED,
     state_to: STATES.REVIEW_PENDING,
@@ -101,7 +105,7 @@ test("reliability-report derives the core scorecard from manifests and events", 
     round: 2,
     reason: "same_run_resume:completed",
   });
-  appendRunEvent(repoRoot, "run-ready", {
+  appendRunEvent(repoRoot, runReady, {
     event: "review_apply",
     state_from: STATES.REVIEW_PENDING,
     state_to: STATES.READY_TO_MERGE,
@@ -109,7 +113,7 @@ test("reliability-report derives the core scorecard from manifests and events", 
     round: 2,
     reason: "pass",
   });
-  appendRunEvent(repoRoot, "run-merged", {
+  appendRunEvent(repoRoot, runMerged, {
     event: "merge_blocked",
     state_from: STATES.READY_TO_MERGE,
     state_to: STATES.READY_TO_MERGE,
@@ -117,7 +121,7 @@ test("reliability-report derives the core scorecard from manifests and events", 
     round: 4,
     reason: "stale",
   });
-  appendRunEvent(repoRoot, "run-merged", {
+  appendRunEvent(repoRoot, runMerged, {
     event: "merge_finalize",
     state_from: STATES.READY_TO_MERGE,
     state_to: STATES.MERGED,
@@ -141,48 +145,51 @@ test("reliability-report aggregates factor analysis across runs and rounds", () 
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-factors-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-a", timestamp: new Date("2026-04-12T01:00:00.000Z") });
+  const runB = createRunId({ branch: "run-b", timestamp: new Date("2026-04-12T01:00:01.000Z") });
+  const runC = createRunId({ branch: "run-c", timestamp: new Date("2026-04-12T01:00:02.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-a",
+    runId: runA,
     state: STATES.CHANGES_REQUESTED,
     rounds: 3,
     updatedAt: recentTs,
   });
   writeRun(repoRoot, {
-    runId: "run-b",
+    runId: runB,
     state: STATES.CHANGES_REQUESTED,
     rounds: 2,
     updatedAt: recentTs,
   });
   writeRun(repoRoot, {
-    runId: "run-c",
+    runId: runC,
     state: STATES.READY_TO_MERGE,
     rounds: 1,
     updatedAt: recentTs,
   });
 
-  appendIterationScore(repoRoot, "run-a", {
+  appendIterationScore(repoRoot, runA, {
     round: 1,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "6", met: false, status: "fail" },
       { factor: "Docs", target: ">= 8", observed: "not started", met: false, status: "not_run" },
     ],
   });
-  appendIterationScore(repoRoot, "run-a", {
+  appendIterationScore(repoRoot, runA, {
     round: 2,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass" },
       { factor: "Docs", target: ">= 8", observed: "6", met: false, status: "fail" },
     ],
   });
-  appendIterationScore(repoRoot, "run-a", {
+  appendIterationScore(repoRoot, runA, {
     round: 3,
     scores: [
       { factor: "Docs", target: ">= 8", observed: "8", met: true, status: "pass" },
     ],
   });
 
-  appendIterationScore(repoRoot, "run-b", {
+  appendIterationScore(repoRoot, runB, {
     round: 1,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "5", met: false, status: "fail" },
@@ -190,14 +197,14 @@ test("reliability-report aggregates factor analysis across runs and rounds", () 
       { factor: "Perf", target: ">= 8", observed: "8", met: true, status: "pass" },
     ],
   });
-  appendIterationScore(repoRoot, "run-b", {
+  appendIterationScore(repoRoot, runB, {
     round: 2,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "7", met: false, status: "fail" },
     ],
   });
 
-  appendIterationScore(repoRoot, "run-c", {
+  appendIterationScore(repoRoot, runC, {
     round: 1,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "9", met: true, status: "pass" },
@@ -233,9 +240,10 @@ test("reliability-report keeps factor analysis backwards compatible without iter
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-empty-factors-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runReady = createRunId({ branch: "run-ready", timestamp: new Date("2026-04-12T02:00:00.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-ready",
+    runId: runReady,
     state: STATES.READY_TO_MERGE,
     rounds: 2,
     updatedAt: recentTs,
@@ -254,9 +262,10 @@ test("reliability-report keeps rubric_insights null-safe when new events are abs
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-empty-insights-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runReady = createRunId({ branch: "run-ready", timestamp: new Date("2026-04-12T02:10:00.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-ready",
+    runId: runReady,
     state: STATES.READY_TO_MERGE,
     rounds: 1,
     updatedAt: recentTs,
@@ -278,21 +287,23 @@ test("reliability-report derives rubric grade distribution and average quality r
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-rubric-quality-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-a", timestamp: new Date("2026-04-12T03:00:00.000Z") });
+  const runB = createRunId({ branch: "run-b", timestamp: new Date("2026-04-12T03:00:01.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-a",
+    runId: runA,
     state: STATES.READY_TO_MERGE,
     rounds: 2,
     updatedAt: recentTs,
   });
   writeRun(repoRoot, {
-    runId: "run-b",
+    runId: runB,
     state: STATES.CHANGES_REQUESTED,
     rounds: 3,
     updatedAt: recentTs,
   });
 
-  appendRubricQuality(repoRoot, "run-a", {
+  appendRubricQuality(repoRoot, runA, {
     grade: "A",
     prerequisites: 2,
     contract_factors: 2,
@@ -303,7 +314,7 @@ test("reliability-report derives rubric grade distribution and average quality r
     risk_signals: [],
     task_size: "M",
   });
-  appendRubricQuality(repoRoot, "run-b", {
+  appendRubricQuality(repoRoot, runB, {
     grade: "C",
     prerequisites: 2,
     contract_factors: 2,
@@ -341,34 +352,36 @@ test("reliability-report derives tier effectiveness from tiered iteration scores
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-tier-effectiveness-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-a", timestamp: new Date("2026-04-12T04:00:00.000Z") });
+  const runB = createRunId({ branch: "run-b", timestamp: new Date("2026-04-12T04:00:01.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-a",
+    runId: runA,
     state: STATES.CHANGES_REQUESTED,
     rounds: 2,
     updatedAt: recentTs,
   });
   writeRun(repoRoot, {
-    runId: "run-b",
+    runId: runB,
     state: STATES.READY_TO_MERGE,
     rounds: 1,
     updatedAt: recentTs,
   });
 
-  appendIterationScore(repoRoot, "run-a", {
+  appendIterationScore(repoRoot, runA, {
     round: 1,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "5", met: false, status: "fail", tier: "contract" },
       { factor: "Docs", target: ">= 8", observed: "8", met: true, status: "pass", tier: "quality" },
     ],
   });
-  appendIterationScore(repoRoot, "run-a", {
+  appendIterationScore(repoRoot, runA, {
     round: 2,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass", tier: "contract" },
     ],
   });
-  appendIterationScore(repoRoot, "run-b", {
+  appendIterationScore(repoRoot, runB, {
     round: 1,
     scores: [
       { factor: "Latency", target: "< 200ms", observed: "180ms", met: true, status: "pass", tier: "contract" },
@@ -395,15 +408,16 @@ test("reliability-report derives divergence hotspots from score_divergence event
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-divergence-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-a", timestamp: new Date("2026-04-12T05:00:00.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-a",
+    runId: runA,
     state: STATES.CHANGES_REQUESTED,
     rounds: 2,
     updatedAt: recentTs,
   });
 
-  appendScoreDivergence(repoRoot, "run-a", {
+  appendScoreDivergence(repoRoot, runA, {
     round: 1,
     divergences: [
       { factor: "Coverage", executor: "9", reviewer: "6", delta: 3, tier: "contract" },
@@ -435,15 +449,16 @@ test("reliability-report populates only available rubric insight subfields", () 
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-partial-insights-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-a", timestamp: new Date("2026-04-12T05:10:00.000Z") });
 
   writeRun(repoRoot, {
-    runId: "run-a",
+    runId: runA,
     state: STATES.READY_TO_MERGE,
     rounds: 1,
     updatedAt: recentTs,
   });
 
-  appendRubricQuality(repoRoot, "run-a", {
+  appendRubricQuality(repoRoot, runA, {
     grade: "B",
     prerequisites: 1,
     contract_factors: 1,
@@ -484,15 +499,17 @@ test("reliability-report adds run-level grouping when --by-actor is set", () => 
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   initGitRepo(repoRoot, "Alice");
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runAlice = createRunId({ branch: "run-alice", timestamp: new Date("2026-04-12T06:00:00.000Z") });
+  const runBob = createRunId({ branch: "run-bob", timestamp: new Date("2026-04-12T06:00:01.000Z") });
 
   setGitActor(repoRoot, "Alice");
   writeRun(repoRoot, {
-    runId: "run-alice",
+    runId: runAlice,
     state: STATES.READY_TO_MERGE,
     rounds: 2,
     updatedAt: recentTs,
   });
-  appendIterationScore(repoRoot, "run-alice", {
+  appendIterationScore(repoRoot, runAlice, {
     round: 1,
     scores: [
       { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass" },
@@ -501,12 +518,12 @@ test("reliability-report adds run-level grouping when --by-actor is set", () => 
 
   setGitActor(repoRoot, "Bob");
   writeRun(repoRoot, {
-    runId: "run-bob",
+    runId: runBob,
     state: STATES.CHANGES_REQUESTED,
     rounds: 3,
     updatedAt: recentTs,
   });
-  appendIterationScore(repoRoot, "run-bob", {
+  appendIterationScore(repoRoot, runBob, {
     round: 1,
     scores: [
       { factor: "Docs", target: ">= 8", observed: "5", met: false, status: "fail" },

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -221,6 +221,49 @@ test("finalize-run merges and cleans a ready run", () => {
   assert.match(ghLog, /issue close 42 --comment Resolved in PR #123/);
 });
 
+test("finalize-run rejects invalid manifest run_id before merge finalization", () => {
+  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
+  const logPath = path.join(repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      {
+        oid: headSha,
+        committedDate: "2026-04-03T08:00:00Z",
+      },
+    ],
+  });
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    run_id: "../victim-finalize-run",
+  }, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  }), (error) => {
+    assert.match(String(error.stderr), /run_id must be a single path segment/);
+    return true;
+  });
+
+  assert.equal(fs.existsSync(worktreePath), true);
+  assert.equal(branchExists(repoRoot, branch), true);
+});
+
 test("finalize-run resumes cleanup when the PR is already merged", () => {
   const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
   const logPath = path.join(repoRoot, "gh.log");

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -196,7 +196,17 @@ function main() {
       process.exit(1);
     }
     manifestData = manifestRecord.data;
-    runDir = getRunDir(manifestData.paths?.repo_root || process.cwd(), manifestData.run_id);
+    try {
+      runDir = getRunDir(manifestData.paths?.repo_root || process.cwd(), manifestData.run_id);
+    } catch (error) {
+      output({
+        status: "manifest_resolution_failed",
+        pr: PR_NUM,
+        readyToMerge: false,
+        reason: error.message,
+      });
+      process.exit(1);
+    }
   }
 
   const expectedReviewerLogin = manifestData?.review?.reviewer_login || null;

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -79,7 +79,7 @@ process.exit(1);
   fs.chmodSync(ghPath, 0o755);
 }
 
-function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git = {}, rubricContent } = {}) {
+function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git = {}, rubricContent, storedRunId } = {}) {
   process.env.RELAY_HOME = relayHome;
   const runId = createRunId({
     issueNumber: 40,
@@ -114,6 +114,9 @@ function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git 
       ...review,
     },
   };
+  if (typeof storedRunId === "string") {
+    manifest.run_id = storedRunId;
+  }
   writeManifest(manifestPath, manifest);
   const runDir = getRunDir(repoRoot, runId);
   if (looksLikeContainedRubricPath(anchor.rubric_path) && rubricContent !== false) {
@@ -151,6 +154,7 @@ function runGateCheckLive({ manifest, prViewPayload, rubricContent }) {
     stdout: result.stdout,
     stderr: result.stderr,
     json: result.stdout ? JSON.parse(result.stdout) : null,
+    relayHome,
   };
 }
 
@@ -314,6 +318,27 @@ test("gate-check passes review from authorized author when reviewer_login is set
   assert.equal(result.status, 0);
   assert.equal(result.json.status, "lgtm");
   assert.equal(result.json.readyToMerge, true);
+});
+
+test("gate-check rejects manifests whose stored run_id is invalid", () => {
+  const result = runGateCheckLive({
+    manifest: {
+      anchor: {
+        rubric_grandfathered: true,
+      },
+      storedRunId: "../victim-gate-run",
+    },
+    prViewPayload: {
+      comments: [],
+      commits: [],
+      headRefName: "issue-40",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "manifest_resolution_failed");
+  assert.match(result.json.reason, /run_id must be a single path segment/);
+  assert.equal(fs.existsSync(path.join(result.relayHome, "runs", "victim-gate-run")), false);
 });
 
 test("gate-check skips unauthorized and uses authorized review when both exist", () => {

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -437,6 +437,7 @@ test("gate-check rejects merge when manifest is missing anchor.rubric_path", () 
       { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
     ],
     manifest: {
+      run_id: "issue-40-20260412010000000",
       anchor: {},
       review: {
         last_reviewed_sha: "abc123",
@@ -604,6 +605,7 @@ test("gate-check allows grandfathered runs and surfaces the note", () => {
       { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
     ],
     manifest: {
+      run_id: "issue-40-20260412010000000",
       anchor: {
         rubric_grandfathered: true,
       },

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -1059,8 +1059,9 @@ function run() {
 
   const round = Number(data.review?.rounds || 0) + 1;
   const maxRounds = Number(data.review?.max_rounds || 20);
-  const runDir = getRunDir(repoPath, data.run_id);
-  ensureRunLayout(repoPath, data.run_id);
+  const runRepoPath = path.resolve(data.paths?.repo_root || repoPath);
+  const runDir = getRunDir(runRepoPath, data.run_id);
+  ensureRunLayout(runRepoPath, data.run_id);
   let reviewedHeadSha = null;
   try {
     reviewedHeadSha = git(reviewRepoPath, "rev-parse", "HEAD").trim();

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -1076,7 +1076,7 @@ function run() {
       "max_rounds_exceeded"
     );
     writeManifest(manifestPath, escalatedManifest, body);
-    appendRunEvent(repoPath, data.run_id, {
+    appendRunEvent(runRepoPath, data.run_id, {
       event: "review_apply",
       state_from: data.state,
       state_to: STATES.ESCALATED,
@@ -1192,7 +1192,7 @@ function run() {
         "policy_violation"
       );
       writeManifest(manifestPath, escalatedManifest, body);
-      appendRunEvent(repoPath, data.run_id, {
+      appendRunEvent(runRepoPath, data.run_id, {
         event: "review_apply",
         state_from: data.state,
         state_to: STATES.ESCALATED,
@@ -1261,7 +1261,7 @@ function run() {
     }
   }
   writeManifest(manifestPath, updatedManifest, body);
-  appendRunEvent(repoPath, data.run_id, {
+  appendRunEvent(runRepoPath, data.run_id, {
     event: "review_apply",
     state_from: data.state,
     state_to: updatedManifest.state,
@@ -1270,7 +1270,7 @@ function run() {
     reason: verdict.verdict,
   });
   if (Array.isArray(verdict.rubric_scores) && verdict.rubric_scores.length > 0) {
-    appendIterationScore(repoPath, data.run_id, {
+    appendIterationScore(runRepoPath, data.run_id, {
       round,
       scores: verdict.rubric_scores.map((score) => ({
         factor: score.factor,
@@ -1283,7 +1283,7 @@ function run() {
     });
   }
   if (divergencePayload.length > 0) {
-    appendScoreDivergence(repoPath, data.run_id, {
+    appendScoreDivergence(runRepoPath, data.run_id, {
       round,
       divergences: divergencePayload,
     });

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -565,6 +565,83 @@ test("review-runner records score divergence and appends warning text to the PR 
   assert.doesNotMatch(commentBody, /Docs & Notes\?: executor 8, reviewer 7/);
 });
 
+test("review-runner keeps event journals on the manifest repo slug when --repo is a symlinked alias", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const repoAliasPath = `${repoRoot}-alias`;
+  fs.symlinkSync(repoRoot, repoAliasPath, "dir");
+  writeFakeGhScript(repoRoot, {
+    capturePath: path.join(repoRoot, "unused-comment.txt"),
+    prBody: [
+      "## Score Log",
+      "",
+      "| Factor | Target | Baseline | Iter 1 | Final | Status |",
+      "|--------|--------|----------|--------|-------|--------|",
+      "| Coverage | >= 8 | — | 9 | 9 | locked |",
+    ].join("\n"),
+  });
+  const reviewFile = writeVerdict(repoRoot, "changes-with-alias-divergence.json", {
+    verdict: "changes_requested",
+    summary: "Coverage still misses the bar.",
+    contract_status: "fail",
+    quality_status: "pass",
+    next_action: "changes_requested",
+    issues: [
+      {
+        title: "Missing smoke file",
+        body: "The PR does not add the required smoke.txt output.",
+        file: "src/index.js",
+        line: 12,
+        category: "contract",
+        severity: "high",
+      },
+    ],
+    rubric_scores: [
+      {
+        factor: "Coverage",
+        target: ">= 8",
+        observed: "6",
+        status: "fail",
+        notes: "Still below bar.",
+        tier: "contract",
+      },
+    ],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoAliasPath,
+    "--manifest", manifestPath,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${repoRoot}:${process.env.PATH}`,
+    },
+  });
+
+  const result = JSON.parse(stdout);
+  const canonicalRunDir = path.join(getRunsDir(repoRoot), runId);
+  const aliasEventsPath = path.join(getRunsDir(repoAliasPath), runId, "events.jsonl");
+  const events = readRunEvents(repoRoot, runId);
+
+  assert.ok(result.verdictPath.startsWith(canonicalRunDir));
+  assert.deepEqual(events.map((event) => event.event), [
+    "review_apply",
+    "iteration_score",
+    "score_divergence",
+  ]);
+  assert.equal(events.at(-1).divergences[0].factor, "Coverage");
+  assert.equal(fs.existsSync(aliasEventsPath), false);
+  assert.deepEqual(readRunEvents(repoAliasPath, runId), []);
+});
+
 test("reviewer-script invocation can drive a round without --review-file", () => {
   const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
   const reviewerScript = writeReviewerScript(repoRoot, "reviewer-pass.js", {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -9,6 +9,7 @@ const {
   STATES,
   createManifestSkeleton,
   ensureRunLayout,
+  getRunsDir,
   updateManifestState,
   writeManifest,
   readManifest,
@@ -309,6 +310,32 @@ test("pass verdict rejects quality_status=not_run", () => {
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);
   assert.equal(manifest.review.latest_verdict, "pending");
+});
+
+test("review-runner rejects invalid manifest run_id before creating a sibling run directory", () => {
+  const { repoRoot, manifestPath, diffPath } = setupRepo();
+  const record = readManifest(manifestPath);
+  const victimRunDir = path.resolve(getRunsDir(repoRoot), "../victim-review-run");
+
+  writeManifest(manifestPath, {
+    ...record.data,
+    run_id: "../victim-review-run",
+  }, record.body);
+
+  assert.equal(fs.existsSync(victimRunDir), false);
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--manifest", manifestPath,
+    "--pr", "123",
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
+    assert.match(String(error.stderr), /run_id must be a single path segment/);
+    return true;
+  });
+  assert.equal(fs.existsSync(victimRunDir), false);
 });
 
 test("changes_requested verdict creates a re-dispatch artifact", () => {


### PR DESCRIPTION
## Summary
Closes the `run_id` trust-root bypass surfaced in the post-merge re-review of #155. `rubric_path` containment was validating against `runDir`, but `runDir` itself could still be steered with a forged manifest `run_id` like `../victim-run`. This PR pins that trust root by introducing `validateRunId(runId)` and routing every filesystem-path consumer through it before any run directory or manifest path is derived.

## What Changed
- added `validateRunId()` in `relay-manifest.js` with single-segment, no `..`, no `/`, no `\\`, basename-stable, `createRunId`-shape validation
- enforced it at the shared chokepoints: `createRunId`, `createManifestSkeleton`, `getRunDir`, `getManifestPath`, `resolveRubricRunDir`
- made `relay-resolver` reject invalid `--run-id` selectors and manifests whose stored `data.run_id` is malformed
- made live `gate-check` fail closed with `manifest_resolution_failed` when manifest `run_id` is invalid
- added per-boundary regression coverage in `relay-manifest.test.js`, new `relay-resolver.test.js`, `review-runner.test.js`, `gate-check.test.js`, plus `finalize-run.test.js`
- updated `reliability-report` fixtures to use real relay-shaped run IDs now that the path layer is strict

## Root Cause
#148 added `rubric_path` containment, but the containment base was still attacker-controlled because `data.run_id` was never validated before `getRunDir()` or sibling manifest-path helpers used it. A crafted manifest could redirect `review-runner`, `gate-check`, `finalize-run`, and resolver-driven flows to a sibling run directory where rubric containment would then appear valid.

## Validation
- `node --check skills/relay-dispatch/scripts/relay-manifest.js`
- `node --check skills/relay-dispatch/scripts/relay-resolver.js`
- `node --check skills/relay-review/scripts/review-runner.js`
- `node --check skills/relay-merge/scripts/gate-check.js`
- `node --check skills/relay-merge/scripts/finalize-run.js`
- `node --test skills/relay-dispatch/scripts/*.test.js skills/relay-review/scripts/*.test.js skills/relay-merge/scripts/*.test.js skills/relay-intake/scripts/*.test.js skills/relay-plan/scripts/*.test.js`

## run_id consumers audited
- `skills/relay-dispatch/scripts/relay-manifest.js:createRunId` — fixed here. Self-check ensures newly emitted IDs match the enforced positive shape.
- `skills/relay-dispatch/scripts/relay-manifest.js:getRunDir` — fixed here. Primary run-directory trust root now rejects forged IDs before path derivation.
- `skills/relay-dispatch/scripts/relay-manifest.js:getManifestPath` — fixed here. Sibling manifest-path trust root now shares the same validator.
- `skills/relay-dispatch/scripts/relay-manifest.js:resolveRubricRunDir` — fixed here. Inherits validated `getRunDir` before rubric containment or grandfathering logic.
- `skills/relay-dispatch/scripts/relay-manifest.js:createManifestSkeleton` — fixed here. Prevents new manifests from persisting malformed `run_id`.
- `skills/relay-dispatch/scripts/relay-resolver.js:findManifestByRunId` — fixed here. Rejects malformed external selectors and malformed stored `data.run_id`.
- `skills/relay-dispatch/scripts/relay-resolver.js:resolveManifestRecord` — fixed here. Branch/PR/manifest-path resolution now rejects records whose stored `run_id` is invalid before returning them.
- `skills/relay-dispatch/scripts/dispatch.js` (`RUN_ID`, `manifest.run_id`, `getManifestPath`, `getRunDir`, `ensureRunLayout`) — fixed here via shared chokepoints. New dispatches and resumes reject malformed IDs before run-dir or manifest-path use.
- `skills/relay-dispatch/scripts/close-run.js` (`--run-id` -> `resolveManifestRecord`) — fixed here via resolver validation. External selector can no longer target a forged manifest.
- `skills/relay-dispatch/scripts/update-manifest-state.js` (`--run-id` -> `resolveManifestRecord`) — fixed here via resolver validation.
- `skills/relay-dispatch/scripts/relay-events.js` (`ensureRunLayout`, `getEventsPath`, `readRunEvents`) — fixed here via validated run-dir derivation. This covers the events-journal path surface.
- `skills/relay-dispatch/scripts/reliability-report.js` (`readAllRunEvents`, `manifest.data.run_id`, `event.run_id`) — not a direct trust boundary. It consumes already-validated run-dir names and stored manifest/event IDs; fixtures were updated to real run-id shape.
- `skills/relay-dispatch/scripts/cleanup-worktrees.js` (`data.run_id || basename(manifestPath)`) — not a direct filesystem trust boundary in this script. It only reports/forwards the value; downstream `close-run` / `appendRunEvent` now validate before any path use.
- `skills/relay-review/scripts/review-runner.js:1063` — fixed here. `getRunDir`/`ensureRunLayout` now reject forged manifest `data.run_id` before any sibling run directory can be created.
- `skills/relay-merge/scripts/gate-check.js:200` — fixed here. Live PR gate now fails closed with `manifest_resolution_failed` when manifest `run_id` is invalid.
- `skills/relay-merge/scripts/finalize-run.js:287` — fixed here. Final merge gate inherits the validated run-dir trust root before review/rubric evaluation.
- Windows-separator handling (`\\`) — fixed here. `validateRunId` rejects backslashes explicitly and double-checks `path.win32.basename(...)`.
- Symlink traversal — not a `run_id` trust boundary; unchanged here. #156 pins the directory identity, while symlink canonicalization remains a rubric/file-path concern rather than a `run_id` consumer.
- Resolver stale-branch / PR-number strictness — deferred to #149. This PR validates stored/selected `run_id` but does not alter selector disambiguation policy.
- Review-runner fail-closed on non-loaded rubric state — deferred to #157. This PR only closes the forged `run_id` trust root under the existing review-gate semantics.

## Score Log
| Factor | Target | Final | Notes |
| --- | --- | --- | --- |
| `validateRunId(runId)` helper exists and rejects every unsafe shape | ≥ 8/10 | 10/10 | Shared validator rejects empty, non-string, `.`, `..`, `../...`, `/`, `\\`, basename mismatches, and non-`createRunId` shapes; historical sample IDs pass. |
| Every runDir-deriving consumer validates `run_id` before use | ≥ 8/10 | 9/10 | `getRunDir`/`getManifestPath` are the shared chokepoints, resolver rejects invalid stored selectors, and live gate-check/review/finalize paths now fail closed. |
| Regression tests exercise rejection at each consumer independently | ≥ 8/10 | 9/10 | Added manifest, resolver, review-runner, gate-check, and finalize-run regressions; suite covers `..`, `/`, `\\`, empty, and non-conforming shapes. |
| PR body enumerates every audited `run_id` consumer + decision | ≥ 8/10 | 9/10 | Audit lists the concrete surfaces across dispatch, resolver, review, merge, events, reliability-report, cleanup-worktrees, Windows separators, and symlink notes. |
| Rejections are actionable and symmetric with `validateRubricPathContainment` | ≥ 8/10 | 8/10 | Errors name the offending value and the violated invariant; gate-check surfaces malformed manifest IDs as `manifest_resolution_failed`. |
| Existing legitimate manifests keep working without manual migration | ≥ 8/10 | 9/10 | Historical samples including #138 and #148 validate successfully; grandfathered rubric bypass still works when `run_id` itself is valid. |

## Scope Boundary
- Deliberately not touched here: #157 (review-runner fail-closed on non-loaded rubric state), #149 (resolver strictness / stale-branch fallback), #150, #151, #152, #153, #158.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실행 식별자 검증을 추가하여 안전한 경로 세그먼트 준수 강제
  * 매니페스트 처리, 리졸버 기능, 병합 작업 중 식별자 검증 적용
  * 잘못된 매니페스트 상태가 처리되기 전에 거부되도록 개선

* **테스트**
  * 여러 워크플로우에 걸쳐 식별자 검증 테스트 커버리지 확대
  * 유효하지 않은 실행 식별자 거부 동작 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->