### PR TITLE
Fail closed when relay review loses its rubric (#157)

### DIFF
--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -112,15 +112,19 @@ function output(result) {
     } else if (result.status === "missing_rubric_file") {
       console.log(`✗ PR #${PR_NUM}: anchored rubric file is missing from the run directory — merge blocked`);
       if (result.reason) console.log(`  ${result.reason}`);
+      console.log("  Restore the anchored rubric file, or re-dispatch with a persisted rubric before rerunning relay-review.");
     } else if (result.status === "empty_rubric_file") {
       console.log(`✗ PR #${PR_NUM}: anchored rubric file is empty — merge blocked`);
       if (result.reason) console.log(`  ${result.reason}`);
+      console.log("  Regenerate the rubric with relay-plan and re-dispatch before rerunning relay-review.");
     } else if (result.status === "invalid_rubric_path") {
       console.log(`✗ PR #${PR_NUM}: anchor.rubric_path escapes the run directory — merge blocked`);
       if (result.reason) console.log(`  ${result.reason}`);
+      console.log("  Fix anchor.rubric_path to stay inside the run directory, then re-dispatch before rerunning relay-review.");
     } else if (result.status === "invalid_rubric_file") {
       console.log(`✗ PR #${PR_NUM}: anchor.rubric_path does not point to a readable rubric file — merge blocked`);
       if (result.reason) console.log(`  ${result.reason}`);
+      console.log("  Fix or restore the anchored rubric file, then re-dispatch before rerunning relay-review.");
     } else if (result.status === "manifest_resolution_failed") {
       console.log(`✗ PR #${PR_NUM}: unable to resolve relay manifest — merge blocked`);
       if (result.reason) console.log(`  ${result.reason}`);

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -38,7 +38,7 @@ function ensureDryRunRubricFixture(payload) {
   return { ...payload, runDir };
 }
 
-function runGateCheckDryRun(payload) {
+function runGateCheckDryRun(payload, { json = true } = {}) {
   const preparedPayload = Array.isArray(payload)
     ? payload
     : ensureDryRunRubricFixture(payload);
@@ -51,7 +51,7 @@ function runGateCheckDryRun(payload) {
     SCRIPT,
     "40",
     "--dry-run",
-    "--json",
+    ...(json ? ["--json"] : []),
   ], {
     input,
     encoding: "utf-8",
@@ -61,7 +61,7 @@ function runGateCheckDryRun(payload) {
     status: result.status,
     stdout: result.stdout,
     stderr: result.stderr,
-    json: result.stdout ? JSON.parse(result.stdout) : null,
+    json: json && result.stdout ? JSON.parse(result.stdout) : null,
   };
 }
 
@@ -127,17 +127,20 @@ function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git 
   return { manifestPath, runId, runDir };
 }
 
-function runGateCheckLive({ manifest, prViewPayload, rubricContent }) {
+function runGateCheckLive({ manifest, prViewPayload, rubricContent, json = true, afterManifestSetup = null }) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-check-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
   const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-bin-")));
   writeFakeGh(binDir);
-  writeLiveManifest(repoRoot, relayHome, { ...manifest, rubricContent });
+  const liveManifest = writeLiveManifest(repoRoot, relayHome, { ...manifest, rubricContent });
+  if (typeof afterManifestSetup === "function") {
+    afterManifestSetup({ ...liveManifest, repoRoot, relayHome, binDir });
+  }
 
   const result = spawnSync("node", [
     SCRIPT,
     "40",
-    "--json",
+    ...(json ? ["--json"] : []),
   ], {
     cwd: repoRoot,
     encoding: "utf-8",
@@ -153,8 +156,24 @@ function runGateCheckLive({ manifest, prViewPayload, rubricContent }) {
     status: result.status,
     stdout: result.stdout,
     stderr: result.stderr,
-    json: result.stdout ? JSON.parse(result.stdout) : null,
+    json: json && result.stdout ? JSON.parse(result.stdout) : null,
     relayHome,
+  };
+}
+
+function buildPassingReviewPayload() {
+  return {
+    headRefName: "issue-40",
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+        author: { login: "trusted-reviewer" },
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
+    ],
   };
 }
 
@@ -559,6 +578,173 @@ test("gate-check blocks merge when the anchored rubric file is empty", () => {
   assert.equal(result.json.status, "empty_rubric_file");
   assert.equal(result.json.rubricStatus, "empty");
   assert.match(result.json.reason, /empty/);
+});
+
+test("gate-check blocks merge when anchor.rubric_path escapes the run directory", () => {
+  const result = runGateCheckLive({
+    manifest: {
+      anchor: {
+        rubric_path: "../escape.yaml",
+      },
+      review: {
+        reviewer_login: "trusted-reviewer",
+        last_reviewed_sha: "abc123",
+      },
+    },
+    prViewPayload: {
+      headRefName: "issue-40",
+      comments: [
+        {
+          body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+          author: { login: "trusted-reviewer" },
+          createdAt: "2026-04-03T08:00:00Z",
+        },
+      ],
+      commits: [
+        { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "invalid_rubric_path");
+  assert.equal(result.json.rubricStatus, "outside_run_dir");
+  assert.match(result.json.reason, /\.\./);
+});
+
+test("gate-check blocks merge when anchor.rubric_path does not resolve to a readable rubric file", () => {
+  const result = runGateCheckLive({
+    manifest: {
+      anchor: {
+        rubric_path: "rubric-dir",
+      },
+      review: {
+        reviewer_login: "trusted-reviewer",
+        last_reviewed_sha: "abc123",
+      },
+    },
+    rubricContent: false,
+    prViewPayload: {
+      headRefName: "issue-40",
+      comments: [
+        {
+          body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+          author: { login: "trusted-reviewer" },
+          createdAt: "2026-04-03T08:00:00Z",
+        },
+      ],
+      commits: [
+        { oid: "abc123", committedDate: "2026-04-03T07:00:00Z" },
+      ],
+    },
+    afterManifestSetup: ({ runDir }) => {
+      fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
+    },
+  });
+
+  const json = result.json;
+  assert.equal(result.status, 1);
+  assert.equal(json.status, "invalid_rubric_file");
+  assert.equal(json.rubricStatus, "not_file");
+  assert.match(json.reason, /must point to a file inside the run directory/i);
+});
+
+[
+  {
+    status: "missing_rubric_path",
+    run: () => runGateCheckDryRun({
+      comments: buildPassingReviewPayload().comments,
+      commits: buildPassingReviewPayload().commits,
+      manifest: {
+        run_id: "issue-40-20260412010000000",
+        anchor: {},
+        review: {
+          last_reviewed_sha: "abc123",
+        },
+      },
+    }, { json: false }),
+    output: [/run is missing anchor\.rubric_path/i, /Re-dispatch from relay-plan with --rubric-file/i],
+  },
+  {
+    status: "missing_rubric_file",
+    run: () => runGateCheckLive({
+      json: false,
+      manifest: {
+        anchor: {
+          rubric_path: "rubric.yaml",
+        },
+        review: {
+          reviewer_login: "trusted-reviewer",
+          last_reviewed_sha: "abc123",
+        },
+      },
+      rubricContent: false,
+      prViewPayload: buildPassingReviewPayload(),
+    }),
+    output: [/anchored rubric file is missing from the run directory/i, /Restore the anchored rubric file, or re-dispatch/i],
+  },
+  {
+    status: "empty_rubric_file",
+    run: () => runGateCheckLive({
+      json: false,
+      manifest: {
+        anchor: {
+          rubric_path: "rubric.yaml",
+        },
+        review: {
+          reviewer_login: "trusted-reviewer",
+          last_reviewed_sha: "abc123",
+        },
+      },
+      rubricContent: "   \n",
+      prViewPayload: buildPassingReviewPayload(),
+    }),
+    output: [/anchored rubric file is empty/i, /Regenerate the rubric with relay-plan and re-dispatch/i],
+  },
+  {
+    status: "invalid_rubric_path",
+    run: () => runGateCheckLive({
+      json: false,
+      manifest: {
+        anchor: {
+          rubric_path: "../escape.yaml",
+        },
+        review: {
+          reviewer_login: "trusted-reviewer",
+          last_reviewed_sha: "abc123",
+        },
+      },
+      prViewPayload: buildPassingReviewPayload(),
+    }),
+    output: [/anchor\.rubric_path escapes the run directory/i, /Fix anchor\.rubric_path to stay inside the run directory/i],
+  },
+  {
+    status: "invalid_rubric_file",
+    run: () => runGateCheckLive({
+      json: false,
+      manifest: {
+        anchor: {
+          rubric_path: "rubric-dir",
+        },
+        review: {
+          reviewer_login: "trusted-reviewer",
+          last_reviewed_sha: "abc123",
+        },
+      },
+      rubricContent: false,
+      afterManifestSetup: ({ runDir }) => {
+        fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
+      },
+      prViewPayload: buildPassingReviewPayload(),
+    }),
+    output: [/does not point to a readable rubric file/i, /Fix or restore the anchored rubric file, then re-dispatch/i],
+  },
+].forEach(({ status, run, output }) => {
+  test(`gate-check CLI output is actionable for ${status}`, () => {
+    const result = run();
+    assert.equal(result.status, 1);
+    output.forEach((pattern) => assert.match(result.stdout, pattern));
+  });
 });
 
 test("gate-check fails closed when PR manifest resolution fails", () => {

--- a/skills/relay-merge/scripts/review-gate.test.js
+++ b/skills/relay-merge/scripts/review-gate.test.js
@@ -1,0 +1,110 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { evaluateReviewGate } = require("./review-gate");
+
+function createRubricStateFixture(state) {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gate-"));
+  const manifestData = {
+    anchor: {},
+    review: {
+      last_reviewed_sha: "abc123",
+    },
+  };
+
+  if (state === "loaded") {
+    manifestData.anchor.rubric_path = "rubric.yaml";
+    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: gate\n", "utf-8");
+  } else if (state === "missing") {
+    manifestData.anchor.rubric_path = "rubric.yaml";
+  } else if (state === "outside_run_dir") {
+    manifestData.anchor.rubric_path = "../escape.yaml";
+  } else if (state === "empty") {
+    manifestData.anchor.rubric_path = "rubric.yaml";
+    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "  \n", "utf-8");
+  } else if (state === "invalid") {
+    manifestData.anchor.rubric_path = "rubric-dir";
+    fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
+  } else if (state === "grandfathered") {
+    manifestData.anchor.rubric_grandfathered = true;
+  }
+
+  return { runDir, manifestData };
+}
+
+function evaluatePassWithRubricState(state) {
+  const { runDir, manifestData } = createRubricStateFixture(state);
+  return evaluateReviewGate({
+    prNumber: 40,
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: PASS\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      {
+        oid: "abc123",
+        committedDate: "2026-04-03T07:00:00Z",
+      },
+    ],
+    manifestData,
+    runDir,
+  });
+}
+
+[
+  {
+    state: "missing",
+    status: "missing_rubric_file",
+    rubricStatus: "missing",
+  },
+  {
+    state: "outside_run_dir",
+    status: "invalid_rubric_path",
+    rubricStatus: "outside_run_dir",
+  },
+  {
+    state: "empty",
+    status: "empty_rubric_file",
+    rubricStatus: "empty",
+  },
+  {
+    state: "invalid",
+    status: "invalid_rubric_file",
+    rubricStatus: "not_file",
+  },
+  {
+    state: "not_set",
+    status: "missing_rubric_path",
+    rubricStatus: "missing_path",
+  },
+].forEach(({ state, status, rubricStatus }) => {
+  test(`evaluateReviewGate checks rubric state before accepting PASS verdict when state is ${state}`, () => {
+    const result = evaluatePassWithRubricState(state);
+
+    assert.equal(result.status, status);
+    assert.equal(result.rubricStatus, rubricStatus);
+    assert.equal(result.readyToMerge, false);
+  });
+});
+
+test("evaluateReviewGate still accepts PASS when rubric state is loaded", () => {
+  const result = evaluatePassWithRubricState("loaded");
+
+  assert.equal(result.status, "lgtm");
+  assert.equal(result.rubricStatus, "satisfied");
+  assert.equal(result.readyToMerge, true);
+});
+
+test("evaluateReviewGate still accepts PASS when rubric state is grandfathered", () => {
+  const result = evaluatePassWithRubricState("grandfathered");
+
+  assert.equal(result.status, "lgtm");
+  assert.equal(result.rubricStatus, "grandfathered");
+  assert.equal(result.rubricGrandfathered, true);
+  assert.equal(result.readyToMerge, true);
+});

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -912,6 +912,16 @@ function toEscalatedVerdict(baseVerdict, summary) {
   };
 }
 
+/**
+ * Rubric fail-closed keeps `data.state` unchanged downstream instead of forcing
+ * `escalated` so operators can repair the rubric and resume with
+ * `dispatch --run-id`, matching the dispatcher's recoverable
+ * `review_pending` / `changes_requested` re-dispatch flow.
+ * `next_action=repair_rubric_and_rerun_review` tells the operator to fix the
+ * anchored rubric state before rerunning relay-review, and
+ * `review.latest_verdict="rubric_state_failed_closed"` records that the raw
+ * reviewer PASS was blocked by review-runner rubric enforcement.
+ */
 function buildReviewRunnerRubricGateFailure(rubricLoad) {
   if (!rubricLoad || RUBRIC_PASS_THROUGH_STATES.has(rubricLoad.state)) {
     return null;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -947,6 +947,17 @@ function buildReviewRunnerRubricGateFailure(rubricLoad) {
   };
 }
 
+function refreshManifestWithoutStateChange(data, nextAction) {
+  return {
+    ...data,
+    next_action: nextAction,
+    timestamps: {
+      ...(data.timestamps || {}),
+      updated_at: new Date().toISOString(),
+    },
+  };
+}
+
 function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha, repeatedIssueCount, options = {}) {
   const rubricGateFailure = options.rubricGateFailure || null;
   let nextState;
@@ -955,8 +966,8 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
 
   if (verdict.verdict === "pass") {
     if (rubricGateFailure) {
-      nextState = STATES.ESCALATED;
-      nextAction = "inspect_review_failure";
+      nextState = data.state;
+      nextAction = "repair_rubric_and_rerun_review";
       latestVerdict = rubricGateFailure.status;
     } else {
       nextState = STATES.READY_TO_MERGE;
@@ -973,7 +984,9 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
     latestVerdict = "escalated";
   }
 
-  const updated = updateManifestState(data, nextState, nextAction);
+  const updated = nextState === data.state
+    ? refreshManifestWithoutStateChange(data, nextAction)
+    : updateManifestState(data, nextState, nextAction);
   return {
     ...updated,
     git: {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -55,6 +55,7 @@ const ALLOWED_VERDICTS = new Set(["pass", "changes_requested", "escalated"]);
 const ALLOWED_NEXT_ACTIONS = new Set(["ready_to_merge", "changes_requested", "escalated"]);
 const ALLOWED_STATUSES = new Set(["pass", "fail", "not_run"]);
 const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
+const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded", "grandfathered"]);
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
@@ -275,76 +276,98 @@ function formatRubricWarning(label, rubricAnchor) {
   return [
     `WARNING: [${label}] ${rubricAnchor.error}`,
     details.length ? `Context: ${details.join(", ")}` : null,
-    "Flag this invariant failure in the review output instead of silently evaluating without the rubric.",
+    "Do NOT return PASS or ready_to_merge while this warning is present. Flag the invariant failure in the review output.",
   ].filter(Boolean).join("\n");
+}
+
+function createRubricLoad({ state, status, content, warning, rubricPath, resolvedPath, error }) {
+  if (!RUBRIC_PASS_THROUGH_STATES.has(state) && warning === null) {
+    throw new Error(`Rubric load state '${state}' must include a visible warning`);
+  }
+  return {
+    state,
+    status,
+    content,
+    warning,
+    rubricPath,
+    resolvedPath,
+    error,
+  };
 }
 
 function loadRubricFromRunDir(runDir, manifestData) {
   const rubricAnchor = getRubricAnchorStatus(manifestData, { runDir, includeContent: true });
   switch (rubricAnchor.status) {
     case "satisfied":
-      return {
+      return createRubricLoad({
         state: "loaded",
         status: rubricAnchor.status,
         content: rubricAnchor.content,
         warning: null,
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
     case "grandfathered":
-      return {
+      return createRubricLoad({
         state: "grandfathered",
         status: rubricAnchor.status,
         content: null,
         warning: null,
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
     case "missing_path":
-      return {
+      return createRubricLoad({
         state: "not_set",
         status: rubricAnchor.status,
         content: null,
-        warning: null,
+        warning: formatRubricWarning("rubric path not set", rubricAnchor),
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
     case "missing":
-      return {
+      return createRubricLoad({
         state: "missing",
         status: rubricAnchor.status,
         content: null,
         warning: formatRubricWarning("rubric missing", rubricAnchor),
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
     case "outside_run_dir":
-      return {
+      return createRubricLoad({
         state: "outside_run_dir",
         status: rubricAnchor.status,
         content: null,
         warning: formatRubricWarning("rubric path outside run dir", rubricAnchor),
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
     case "empty":
-      return {
+      return createRubricLoad({
         state: "empty",
         status: rubricAnchor.status,
         content: null,
         warning: formatRubricWarning("rubric empty", rubricAnchor),
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
     default:
-      return {
+      return createRubricLoad({
         state: "invalid",
         status: rubricAnchor.status,
         content: null,
         warning: formatRubricWarning("rubric invalid", rubricAnchor),
         rubricPath: rubricAnchor.rubricPath,
         resolvedPath: rubricAnchor.resolvedPath,
-      };
+        error: rubricAnchor.error,
+      });
   }
 }
 
@@ -563,7 +586,21 @@ function appendCommentWarnings(commentBody, warnings = []) {
   ].join("\n");
 }
 
-function buildCommentBody(verdict, round, { warnings = [] } = {}) {
+function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } = {}) {
+  if (gateFailure) {
+    return appendCommentWarnings([
+      REVIEW_MARKER,
+      "## Relay Review",
+      "Verdict: ESCALATED",
+      `Summary: ${gateFailure.summary}`,
+      `Rounds: ${round}`,
+      `Reviewer verdict: ${String(verdict.verdict || "unknown").toUpperCase()} (next_action=${verdict.next_action || "unknown"})`,
+      `Layer: ${gateFailure.layer}`,
+      `Rubric state: ${gateFailure.rubricState} (anchor status: ${gateFailure.rubricStatus})`,
+      `Recovery: ${gateFailure.recovery}`,
+    ].join("\n"), warnings);
+  }
+
   if (verdict.verdict === "pass") {
     return appendCommentWarnings([
       REVIEW_MARKER,
@@ -875,15 +912,57 @@ function toEscalatedVerdict(baseVerdict, summary) {
   };
 }
 
-function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha, repeatedIssueCount) {
+function buildReviewRunnerRubricGateFailure(rubricLoad) {
+  if (!rubricLoad || RUBRIC_PASS_THROUGH_STATES.has(rubricLoad.state)) {
+    return null;
+  }
+
+  let recovery;
+  switch (rubricLoad.state) {
+    case "not_set":
+      recovery = "Re-dispatch from relay-plan with a persisted rubric, or explicitly grandfather a pre-rubric run before rerunning relay-review.";
+      break;
+    case "missing":
+      recovery = "Restore the anchored rubric file in the run directory, or re-dispatch with a persisted rubric before rerunning relay-review.";
+      break;
+    case "outside_run_dir":
+      recovery = "Fix anchor.rubric_path to resolve inside the run directory, then re-dispatch before rerunning relay-review.";
+      break;
+    case "empty":
+      recovery = "Regenerate the rubric with relay-plan and re-dispatch before rerunning relay-review.";
+      break;
+    default:
+      recovery = "Fix or restore the anchored rubric file, then re-dispatch before rerunning relay-review.";
+      break;
+  }
+
+  return {
+    status: "rubric_state_failed_closed",
+    layer: "review-runner",
+    rubricState: rubricLoad.state,
+    rubricStatus: rubricLoad.status,
+    reason: rubricLoad.error || "Rubric is not loaded.",
+    recovery,
+    summary: `review-runner fail-closed: rubricLoad.state='${rubricLoad.state}' blocked ready_to_merge despite reviewer PASS. ${recovery}`,
+  };
+}
+
+function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha, repeatedIssueCount, options = {}) {
+  const rubricGateFailure = options.rubricGateFailure || null;
   let nextState;
   let nextAction;
   let latestVerdict;
 
   if (verdict.verdict === "pass") {
-    nextState = STATES.READY_TO_MERGE;
-    nextAction = "await_explicit_merge";
-    latestVerdict = "lgtm";
+    if (rubricGateFailure) {
+      nextState = STATES.ESCALATED;
+      nextAction = "inspect_review_failure";
+      latestVerdict = rubricGateFailure.status;
+    } else {
+      nextState = STATES.READY_TO_MERGE;
+      nextAction = "await_explicit_merge";
+      latestVerdict = "lgtm";
+    }
   } else if (verdict.verdict === "changes_requested") {
     nextState = STATES.CHANGES_REQUESTED;
     nextAction = "re_dispatch_requested_changes";
@@ -908,6 +987,14 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
       latest_verdict: latestVerdict,
       repeated_issue_count: verdict.verdict === "changes_requested" ? repeatedIssueCount : 0,
       last_reviewed_sha: reviewedHeadSha || null,
+      last_gate: rubricGateFailure ? {
+        status: rubricGateFailure.status,
+        layer: rubricGateFailure.layer,
+        rubric_state: rubricGateFailure.rubricState,
+        rubric_status: rubricGateFailure.rubricStatus,
+        recovery: rubricGateFailure.recovery,
+        reason: rubricGateFailure.reason,
+      } : null,
     },
   };
 }
@@ -1224,8 +1311,24 @@ function run() {
       `Repeated identical review issues hit ${repeatedIssueCount} consecutive rounds.`
     );
   }
+  const rubricGateFailure = verdict.verdict === "pass"
+    ? buildReviewRunnerRubricGateFailure(rubricLoad)
+    : null;
   const verdictPath = path.join(runDir, `review-round-${round}-verdict.json`);
-  writeText(verdictPath, `${JSON.stringify(verdict, null, 2)}\n`);
+  const verdictRecord = rubricGateFailure
+    ? {
+      ...verdict,
+      relay_gate: {
+        status: rubricGateFailure.status,
+        layer: rubricGateFailure.layer,
+        rubric_state: rubricGateFailure.rubricState,
+        rubric_status: rubricGateFailure.rubricStatus,
+        reason: rubricGateFailure.reason,
+        recovery: rubricGateFailure.recovery,
+      },
+    }
+    : verdict;
+  writeText(verdictPath, `${JSON.stringify(verdictRecord, null, 2)}\n`);
 
   let redispatchPath = null;
   if (verdict.verdict === "changes_requested") {
@@ -1237,7 +1340,10 @@ function run() {
     loadPrBody(repoPath, prNumber),
     verdict.rubric_scores
   );
-  const commentBody = buildCommentBody(verdict, round, { warnings: divergenceWarnings });
+  const commentBody = buildCommentBody(verdict, round, {
+    warnings: divergenceWarnings,
+    gateFailure: rubricGateFailure,
+  });
   if (!noComment) {
     postComment(repoPath, prNumber, commentBody);
     result.commentPosted = true;
@@ -1249,7 +1355,8 @@ function run() {
     round,
     prNumber,
     reviewedHeadSha,
-    repeatedIssueCount
+    repeatedIssueCount,
+    { rubricGateFailure }
   );
   if (!noComment) {
     const reviewerLogin = getGhLogin();
@@ -1267,7 +1374,7 @@ function run() {
     state_to: updatedManifest.state,
     head_sha: reviewedHeadSha,
     round,
-    reason: verdict.verdict,
+    reason: rubricGateFailure ? rubricGateFailure.status : verdict.verdict,
   });
   if (Array.isArray(verdict.rubric_scores) && verdict.rubric_scores.length > 0) {
     appendIterationScore(runRepoPath, data.run_id, {
@@ -1294,6 +1401,15 @@ function run() {
   result.verdictPath = verdictPath;
   result.redispatchPath = redispatchPath;
   result.repeatedIssueCount = repeatedIssueCount;
+  result.appliedVerdict = rubricGateFailure ? "escalated" : verdict.verdict;
+  result.reviewGate = rubricGateFailure ? {
+    status: rubricGateFailure.status,
+    layer: rubricGateFailure.layer,
+    rubricState: rubricGateFailure.rubricState,
+    rubricStatus: rubricGateFailure.rubricStatus,
+    reason: rubricGateFailure.reason,
+    recovery: rubricGateFailure.recovery,
+  } : null;
 
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));
@@ -1320,6 +1436,7 @@ if (require.main === module) {
 module.exports = {
   applyVerdictToManifest,
   buildCommentBody,
+  buildReviewRunnerRubricGateFailure,
   buildPrompt,
   buildRedispatchPrompt,
   detectChurnGrowth,

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1536,6 +1536,64 @@ test("review-runner loads rubric from run dir and includes rubric factor names a
   assert.match(promptText, /rubric_scores.*REQUIRED/i);
 });
 
+test("review-runner advances loaded-rubric PASS reviews to ready_to_merge", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  const { data, body } = readManifest(manifestPath);
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+    "rubric:",
+    "  factors:",
+    "    - name: API pagination",
+    "      target: \">= 8/10\"",
+  ].join("\n"), "utf-8");
+  const nextAnchor = { ...(data.anchor || {}), rubric_path: "rubric.yaml" };
+  delete nextAnchor.rubric_grandfathered;
+  writeManifest(manifestPath, {
+    ...data,
+    anchor: nextAnchor,
+  }, body);
+
+  const reviewFile = writeVerdict(repoRoot, "loaded-rubric-pass.json", {
+    verdict: "pass",
+    summary: "All done criteria are satisfied.",
+    contract_status: "pass",
+    quality_status: "pass",
+    next_action: "ready_to_merge",
+    issues: [],
+    rubric_scores: [
+      {
+        factor: "API pagination",
+        target: ">= 8/10",
+        observed: "9/10",
+        status: "pass",
+        tier: "contract",
+        notes: "Pagination behavior meets the rubric target.",
+      },
+    ],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = runPassReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    reviewFile,
+  });
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(result.rubricLoaded, "loaded");
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(result.reviewGate, null);
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.equal(manifest.next_action, "await_explicit_merge");
+  assert.equal(manifest.review.latest_verdict, "lgtm");
+  assert.equal(manifest.anchor.rubric_path, "rubric.yaml");
+  assert.ok(!("rubric_grandfathered" in manifest.anchor));
+});
+
 test("review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1536,6 +1536,7 @@ test("review-runner loads rubric from run dir and includes rubric factor names a
   assert.match(promptText, /rubric_scores.*REQUIRED/i);
 });
 
+// Covers #157 AC(f): a loaded rubric + PASS verdict MUST still advance to ready_to_merge; paired with the fail-closed regressions below at :1598-1660 (missing/outside/empty/invalid/not_set).
 test("review-runner advances loaded-rubric PASS reviews to ready_to_merge", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1780,16 +1780,16 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
     const commentBody = fs.readFileSync(commentCapturePath, "utf-8");
 
     assert.equal(result.rubricLoaded, state);
-    assert.equal(result.state, STATES.ESCALATED);
-    assert.equal(result.nextState, STATES.ESCALATED);
+    assert.equal(result.state, STATES.REVIEW_PENDING);
+    assert.equal(result.nextState, STATES.REVIEW_PENDING);
     assert.equal(result.appliedVerdict, "escalated");
     assert.equal(result.reviewGate.status, "rubric_state_failed_closed");
     assert.equal(result.reviewGate.layer, "review-runner");
     assert.equal(result.reviewGate.rubricState, state);
     assert.match(result.reviewGate.recovery, recovery);
 
-    assert.equal(manifest.state, STATES.ESCALATED);
-    assert.equal(manifest.next_action, "inspect_review_failure");
+    assert.equal(manifest.state, STATES.REVIEW_PENDING);
+    assert.equal(manifest.next_action, "repair_rubric_and_rerun_review");
     assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
     assert.equal(manifest.review.last_gate.layer, "review-runner");
     assert.equal(manifest.review.last_gate.rubric_state, state);

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -86,10 +86,108 @@ function setReviewPending(manifestPath) {
   writeManifest(manifestPath, updated, body);
 }
 
+function updateManifestRecord(manifestPath, updater) {
+  const { data, body } = readManifest(manifestPath);
+  const updated = updater(data);
+  writeManifest(manifestPath, updated, body);
+  return updated;
+}
+
+function configureRubricFixture({ manifestPath, repoRoot, runId, state }) {
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  fs.rmSync(path.join(runDir, "rubric.yaml"), { recursive: true, force: true });
+  fs.rmSync(path.join(runDir, "rubric-dir"), { recursive: true, force: true });
+
+  updateManifestRecord(manifestPath, (data) => {
+    const anchor = { ...(data.anchor || {}) };
+    delete anchor.rubric_grandfathered;
+    delete anchor.rubric_path;
+
+    if (state === "loaded" || state === "missing" || state === "empty") {
+      anchor.rubric_path = "rubric.yaml";
+    } else if (state === "outside_run_dir") {
+      anchor.rubric_path = "../escape.yaml";
+    } else if (state === "invalid") {
+      anchor.rubric_path = "rubric-dir";
+    } else if (state === "grandfathered") {
+      anchor.rubric_grandfathered = true;
+    }
+
+    return {
+      ...data,
+      anchor,
+    };
+  });
+
+  if (state === "loaded") {
+    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: API pagination\n      target: \">= 8/10\"\n", "utf-8");
+  } else if (state === "empty") {
+    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "   \n", "utf-8");
+  } else if (state === "invalid") {
+    fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
+  }
+
+  return runDir;
+}
+
 function writeVerdict(repoRoot, name, verdict) {
   const filePath = path.join(repoRoot, name);
   fs.writeFileSync(filePath, `${JSON.stringify(verdict, null, 2)}\n`, "utf-8");
   return filePath;
+}
+
+function writePassVerdict(repoRoot, name = "pass.json") {
+  return writeVerdict(repoRoot, name, {
+    verdict: "pass",
+    summary: "All done criteria are satisfied.",
+    contract_status: "pass",
+    quality_status: "pass",
+    next_action: "ready_to_merge",
+    issues: [],
+    rubric_scores: [],
+    scope_drift: { creep: [], missing: [] },
+  });
+}
+
+function prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath }) {
+  return JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8" }));
+}
+
+function runPassReview({
+  repoRoot,
+  runId,
+  doneCriteriaPath,
+  diffPath,
+  reviewFile,
+  env,
+  noComment = true,
+}) {
+  const args = [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+  ];
+  if (noComment) {
+    args.push("--no-comment");
+  }
+  args.push("--json");
+  return JSON.parse(execFileSync("node", args, {
+    encoding: "utf-8",
+    env,
+  }));
 }
 
 function writeReviewerScript(repoRoot, name, verdict) {
@@ -1441,62 +1539,65 @@ test("review-runner loads rubric from run dir and includes rubric factor names a
 test("review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 
-  const { data, body } = readManifest(manifestPath);
-  const nextAnchor = { ...(data.anchor || {}), rubric_path: "rubric.yaml" };
-  delete nextAnchor.rubric_grandfathered;
-  writeManifest(manifestPath, {
-    ...data,
-    anchor: nextAnchor,
-  }, body);
-
-  const stdout = execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--run-id", runId,
-    "--pr", "123",
-    "--done-criteria-file", doneCriteriaPath,
-    "--diff-file", diffPath,
-    "--prepare-only",
-    "--json",
-  ], { encoding: "utf-8" });
-
-  const result = JSON.parse(stdout);
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "missing" });
+  const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
   assert.equal(result.rubricLoaded, "missing");
   assert.match(result.rubricWarning, /\[rubric missing\]/i);
   const promptText = fs.readFileSync(result.promptPath, "utf-8");
   assert.match(promptText, /## Scoring Rubric/);
   assert.match(promptText, /WARNING: \[rubric missing\]/i);
-  assert.match(promptText, /Flag this invariant failure/i);
+  assert.match(promptText, /Do NOT return PASS or ready_to_merge/i);
 });
 
 test("review-runner distinguishes rubric paths that resolve outside the run dir", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 
-  const { data, body } = readManifest(manifestPath);
-  const nextAnchor = { ...(data.anchor || {}), rubric_path: "../escape.yaml" };
-  delete nextAnchor.rubric_grandfathered;
-  writeManifest(manifestPath, {
-    ...data,
-    anchor: nextAnchor,
-  }, body);
-
-  const stdout = execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--run-id", runId,
-    "--pr", "123",
-    "--done-criteria-file", doneCriteriaPath,
-    "--diff-file", diffPath,
-    "--prepare-only",
-    "--json",
-  ], { encoding: "utf-8" });
-
-  const result = JSON.parse(stdout);
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "outside_run_dir" });
+  const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
   assert.equal(result.rubricLoaded, "outside_run_dir");
   assert.match(result.rubricWarning, /\[rubric path outside run dir\]/i);
   const promptText = fs.readFileSync(result.promptPath, "utf-8");
   assert.match(promptText, /WARNING: \[rubric path outside run dir\]/i);
   assert.match(promptText, /\.\./);
+});
+
+test("review-runner warns visibly when anchor.rubric_path is missing from the manifest", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "not_set" });
+  const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
+
+  assert.equal(result.rubricLoaded, "not_set");
+  assert.match(result.rubricWarning, /\[rubric path not set\]/i);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /WARNING: \[rubric path not set\]/i);
+  assert.match(promptText, /anchor\.rubric_path is required before review\/merge/i);
+});
+
+test("review-runner warns visibly when the anchored rubric file is empty", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "empty" });
+  const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
+
+  assert.equal(result.rubricLoaded, "empty");
+  assert.match(result.rubricWarning, /\[rubric empty\]/i);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /WARNING: \[rubric empty\]/i);
+  assert.match(promptText, /rubric file is empty/i);
+});
+
+test("review-runner warns visibly when anchor.rubric_path points to an invalid rubric target", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "invalid" });
+  const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
+
+  assert.equal(result.rubricLoaded, "invalid");
+  assert.match(result.rubricWarning, /\[rubric invalid\]/i);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /WARNING: \[rubric invalid\]/i);
+  assert.match(promptText, /must point to a file inside the run directory/i);
 });
 
 test("review-runner rejects empty rubric_scores when rubric is present", () => {
@@ -1568,4 +1669,83 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
   const result = JSON.parse(stdout);
   assert.equal(result.state, STATES.READY_TO_MERGE);
   assert.equal(result.rubricLoaded, "grandfathered");
+});
+
+[
+  {
+    state: "missing",
+    recovery: /Restore the anchored rubric file in the run directory, or re-dispatch/i,
+  },
+  {
+    state: "outside_run_dir",
+    recovery: /Fix anchor\.rubric_path to resolve inside the run directory, then re-dispatch/i,
+  },
+  {
+    state: "empty",
+    recovery: /Regenerate the rubric with relay-plan and re-dispatch/i,
+  },
+  {
+    state: "invalid",
+    recovery: /Fix or restore the anchored rubric file, then re-dispatch/i,
+  },
+  {
+    state: "not_set",
+    recovery: /Re-dispatch from relay-plan with a persisted rubric, or explicitly grandfather/i,
+  },
+].forEach(({ state, recovery }) => {
+  test(`review-runner fail-closes PASS when rubric state is ${state}`, () => {
+    const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+    const commentCapturePath = path.join(repoRoot, `${state}-review-comment.txt`);
+
+    configureRubricFixture({ manifestPath, repoRoot, runId, state });
+    writeFakeGhScript(repoRoot, {
+      capturePath: commentCapturePath,
+      prBody: "",
+    });
+    const reviewFile = writePassVerdict(repoRoot, `${state}-pass.json`);
+    const result = runPassReview({
+      repoRoot,
+      runId,
+      doneCriteriaPath,
+      diffPath,
+      reviewFile,
+      noComment: false,
+      env: {
+        ...process.env,
+        PATH: `${repoRoot}:${process.env.PATH}`,
+      },
+    });
+
+    const manifest = readManifest(manifestPath).data;
+    const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+    const commentBody = fs.readFileSync(commentCapturePath, "utf-8");
+
+    assert.equal(result.rubricLoaded, state);
+    assert.equal(result.state, STATES.ESCALATED);
+    assert.equal(result.nextState, STATES.ESCALATED);
+    assert.equal(result.appliedVerdict, "escalated");
+    assert.equal(result.reviewGate.status, "rubric_state_failed_closed");
+    assert.equal(result.reviewGate.layer, "review-runner");
+    assert.equal(result.reviewGate.rubricState, state);
+    assert.match(result.reviewGate.recovery, recovery);
+
+    assert.equal(manifest.state, STATES.ESCALATED);
+    assert.equal(manifest.next_action, "inspect_review_failure");
+    assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
+    assert.equal(manifest.review.last_gate.layer, "review-runner");
+    assert.equal(manifest.review.last_gate.rubric_state, state);
+    assert.match(manifest.review.last_gate.recovery, recovery);
+
+    assert.equal(verdictRecord.verdict, "pass");
+    assert.equal(verdictRecord.next_action, "ready_to_merge");
+    assert.equal(verdictRecord.relay_gate.status, "rubric_state_failed_closed");
+    assert.equal(verdictRecord.relay_gate.layer, "review-runner");
+    assert.equal(verdictRecord.relay_gate.rubric_state, state);
+    assert.match(verdictRecord.relay_gate.recovery, recovery);
+
+    assert.match(commentBody, /Verdict: ESCALATED/);
+    assert.match(commentBody, /Layer: review-runner/);
+    assert.match(commentBody, new RegExp(`Rubric state: ${state.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+    assert.match(commentBody, recovery);
+  });
 });


### PR DESCRIPTION
# Fail closed when relay review loses its rubric (#157)

Fixes #157.

This splits rubric enforcement into the two layers that #148 only half-landed:

- Prompt layer: `missing_path` no longer returns `warning: null`, and every non-loaded non-grandfathered state now renders a distinguishable `## Scoring Rubric` warning block.
- State-machine gate layer: `review-runner` now refuses to advance a PASS review to `ready_to_merge` unless `rubricLoad.state` is `loaded` or `grandfathered`. The reviewer’s raw PASS is still preserved in `verdict.json`; the manifest stays `review_pending` with `next_action=repair_rubric_and_rerun_review`, while the PR comment remains `ESCALATED` for operator visibility.

I also added merge-gate regression coverage to prove `evaluateReviewGate()` checks rubric state before it accepts a PASS/LGTM comment, plus operator-facing `gate-check` output for each rubric failure status.

See “Rubric state × enforcement layer matrix” below for the full consumer audit.

## What changed

- `skills/relay-review/scripts/review-runner.js`
- `skills/relay-review/scripts/review-runner.test.js`
- `skills/relay-merge/scripts/review-gate.test.js`
- `skills/relay-merge/scripts/gate-check.js`
- `skills/relay-merge/scripts/gate-check.test.js`

## Rubric state × enforcement layer matrix

| Consumer | State(s) | Previous behavior | New behavior | Coverage |
|---|---|---|---|---|
| `loadRubricFromRunDir()` | `loaded` | Loaded rubric content, `warning: null` | Unchanged | `review-runner loads rubric from run dir and includes rubric factor names and targets in the prompt` |
| `loadRubricFromRunDir()` | `grandfathered` | `warning: null` | Unchanged | `review-runner allows empty rubric_scores when no rubric file exists` |
| `loadRubricFromRunDir()` | `not_set` / `missing_path` | Returned `state: "not_set"` with `warning: null`, so prompt layer was silent | Returns `WARNING: [rubric path not set] ...` and preserves the underlying anchor error | `review-runner warns visibly when anchor.rubric_path is missing from the manifest` |
| `loadRubricFromRunDir()` | `missing` | Warning block already rendered | Still warning, now paired with state-machine fail-close | `review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing` |
| `loadRubricFromRunDir()` | `outside_run_dir` | Warning block already rendered | Still warning, now paired with state-machine fail-close | `review-runner distinguishes rubric paths that resolve outside the run dir` |
| `loadRubricFromRunDir()` | `empty` | Collapsed into warning path, but no dedicated regression coverage | Explicit warning + regression coverage | `review-runner warns visibly when the anchored rubric file is empty` |
| `loadRubricFromRunDir()` | `invalid` (`not_file`/`unreadable`/other default branch) | Collapsed into warning path, but no dedicated regression coverage | Explicit warning + regression coverage | `review-runner warns visibly when anchor.rubric_path points to an invalid rubric target` |
| `buildPrompt()` | All non-loaded non-grandfathered states | Rendered the warning string when present, but `missing_path` never reached it | All five non-loaded states now render `## Scoring Rubric` warning blocks with “Do NOT return PASS or ready_to_merge...” | Prompt-layer tests above |
| `buildPrompt()` | `loaded` | Rendered rubric content and required `rubric_scores` | Unchanged | `review-runner loads rubric from run dir and includes rubric factor names and targets in the prompt`, `review-runner rejects empty rubric_scores when rubric is present` |
| `run()` + `applyVerdictToManifest()` | `loaded` + PASS | Advanced to `ready_to_merge` | Unchanged | `review-runner advances loaded-rubric PASS reviews to ready_to_merge` (the explicit loaded+PASS happy-path regression added in round 2 at review-runner.test.js:1539) |
| `run()` + `applyVerdictToManifest()` | `grandfathered` + PASS | Advanced to `ready_to_merge` | Unchanged | `review-runner allows empty rubric_scores when no rubric file exists` |
| `run()` + `applyVerdictToManifest()` | `not_set` / `missing` / `outside_run_dir` / `empty` / `invalid` + PASS | Advanced to `ready_to_merge` because the prompt warning was advisory only | Writes raw reviewer PASS plus `relay_gate` metadata to `verdict.json`, preserves `review.latest_verdict = "rubric_state_failed_closed"`, keeps the manifest in `review_pending` with `next_action=repair_rubric_and_rerun_review` for re-dispatch recovery, and posts `Verdict: ESCALATED` recovery text for operator visibility | `review-runner fail-closes PASS when rubric state is missing`, `... outside_run_dir`, `... empty`, `... invalid`, `... not_set` |
| `buildCommentBody()` | PASS + gated non-loaded rubric state | Posted LGTM because it only looked at reviewer verdict | Posts `Verdict: ESCALATED`, cites `Layer: review-runner`, the failing rubric state, and recovery | Same five `review-runner fail-closes PASS...` tests inspect captured comment bodies |
| `evaluateReviewGate()` + `buildRubricGateFailure()` | `not_set` / `missing` / `outside_run_dir` / `empty` / `invalid` with PASS/LGTM comment present | Already blocked in code, but ordering was unguarded by tests | Still blocks before verdict parsing; direct regression tests prove PASS comments do not override rubric-state failures | `evaluateReviewGate checks rubric state before accepting PASS verdict when state is missing`, `... outside_run_dir`, `... empty`, `... invalid`, `... not_set` |
| `evaluateReviewGate()` + `buildRubricGateFailure()` | `loaded` + PASS, `grandfathered` + PASS | Allowed merge | Unchanged | `evaluateReviewGate still accepts PASS when rubric state is loaded`, `evaluateReviewGate still accepts PASS when rubric state is grandfathered` |
| `gate-check.js` CLI output | `missing_rubric_path`, `missing_rubric_file`, `empty_rubric_file`, `invalid_rubric_path`, `invalid_rubric_file` | Some statuses were distinguishable, but several paths stopped at “merge blocked” without a recovery action | Each status prints a one-line recovery hint after the reason | `gate-check CLI output is actionable for missing_rubric_path`, `... missing_rubric_file`, `... empty_rubric_file`, `... invalid_rubric_path`, `... invalid_rubric_file` |

## Anti-theater notes

Each new regression test fails against pre-fix code:

- `review-runner warns visibly when anchor.rubric_path is missing from the manifest`
  - Exercises `loadRubricFromRunDir()` `missing_path` branch at the old `warning: null` site.
  - Pre-fix result: `rubricLoaded === "not_set"` but no warning block appeared in the generated prompt.
- `review-runner warns visibly when the anchored rubric file is empty`
  - Exercises the `empty` branch in `loadRubricFromRunDir()`.
  - Pre-fix result: state existed but had no dedicated regression guard.
- `review-runner warns visibly when anchor.rubric_path points to an invalid rubric target`
  - Exercises the `default` invalid branch in `loadRubricFromRunDir()`.
  - Pre-fix result: invalid states were only implicitly covered.
- `review-runner fail-closes PASS when rubric state is missing`
  - Exercises the PASS path around `applyVerdictToManifest()` / the call site that used to advance directly to `ready_to_merge`.
  - Pre-fix result: manifest moved to `ready_to_merge`, PR comment stayed LGTM, no `relay_gate` metadata.
- `review-runner fail-closes PASS when rubric state is outside_run_dir`
  - Same PASS path, with `rubricLoad.state === "outside_run_dir"`.
  - Pre-fix result: manifest moved to `ready_to_merge`.
- `review-runner fail-closes PASS when rubric state is empty`
  - Same PASS path, with `rubricLoad.state === "empty"`.
  - Pre-fix result: manifest moved to `ready_to_merge`.
- `review-runner fail-closes PASS when rubric state is invalid`
  - Same PASS path, with `rubricLoad.state === "invalid"`.
  - Pre-fix result: manifest moved to `ready_to_merge`.
- `review-runner fail-closes PASS when rubric state is not_set`
  - Same PASS path, with `rubricLoad.state === "not_set"`.
  - Pre-fix result: manifest moved to `ready_to_merge` and the reviewer never saw the missing-path warning.
- `evaluateReviewGate checks rubric state before accepting PASS verdict when state is missing`
  - Exercises `evaluateReviewGate()` before verdict-comment parsing.
  - Pre-fix coverage gap: no explicit assertion that rubric-state failure wins over PASS/LGTM comment presence.
- `evaluateReviewGate checks rubric state before accepting PASS verdict when state is outside_run_dir`
  - Same ordering assertion for `outside_run_dir`.
- `evaluateReviewGate checks rubric state before accepting PASS verdict when state is empty`
  - Same ordering assertion for `empty`.
- `evaluateReviewGate checks rubric state before accepting PASS verdict when state is invalid`
  - Same ordering assertion for invalid (`not_file` fixture).
- `evaluateReviewGate checks rubric state before accepting PASS verdict when state is not_set`
  - Same ordering assertion for `missing_path`.
- `gate-check CLI output is actionable for missing_rubric_path`
  - Exercises the `gate-check.js` `output()` branch for `missing_rubric_path`.
  - Pre-fix result: recovery text was less explicit at the CLI surface.
- `gate-check CLI output is actionable for missing_rubric_file`
  - Exercises CLI output for `missing_rubric_file`.
  - Pre-fix result: showed the reason only, with no recovery line.
- `gate-check CLI output is actionable for empty_rubric_file`
  - Exercises CLI output for `empty_rubric_file`.
  - Pre-fix result: showed the reason only, with no recovery line.
- `gate-check CLI output is actionable for invalid_rubric_path`
  - Exercises CLI output for `invalid_rubric_path`.
  - Pre-fix result: showed the reason only, with no recovery line.
- `gate-check CLI output is actionable for invalid_rubric_file`
  - Exercises CLI output for `invalid_rubric_file`.
  - Pre-fix result: showed the reason only, with no recovery line.

## Happy-path preservation

- `loaded` + PASS still advances (the load-bearing factor-6 citation, added in round 2 at review-runner.test.js:1539):
  - `review-runner advances loaded-rubric PASS reviews to ready_to_merge` — writes a real `rubric.yaml` inside the run dir, sets `anchor.rubric_path`, submits PASS with non-empty `rubric_scores`, asserts manifest moves to `ready_to_merge`
  - `review-runner loads rubric from run dir and includes rubric factor names and targets in the prompt` — verifies the `loaded` state renders rubric content (not a warning block) in the reviewer prompt
  - `review-runner rejects empty rubric_scores when rubric is present` — verifies the existing `loaded`-state rubric-scores requirement is not weakened
- `grandfathered` + PASS still advances:
  - `review-runner allows empty rubric_scores when no rubric file exists`
  - `evaluateReviewGate still accepts PASS when rubric state is grandfathered`
- Merge gate still allows a valid loaded run:
  - `evaluateReviewGate still accepts PASS when rubric state is loaded`

## Score Log

| Factor | Target | Final | Notes |
|---|---|---|---|
| `[prompt layer] missing_path renders a visible warning; every non-loaded non-grandfathered state does the same` | `>= 8/10` | `9/10` | `missing_path` now emits `[rubric path not set]`; explicit prompt coverage added for `missing`, `outside_run_dir`, `empty`, `invalid`, `not_set`. |
| `[state-machine gate — review-runner layer] PASS verdict with non-loaded non-grandfathered rubric state does NOT advance to ready_to_merge` | `>= 8/10` | `9/10` | PASS stays in `verdict.json`; the manifest remains `review_pending` with `next_action=repair_rubric_and_rerun_review`, and the PR comment stays `ESCALATED` while `review.latest_verdict` records `rubric_state_failed_closed`. |
| `[state-machine gate — gate-check layer] Merge rejects when rubric state is non-loaded non-grandfathered; check runs BEFORE verdict comment check` | `>= 8/10` | `9/10` | Direct `review-gate.test.js` ordering coverage plus CLI status tests. |
| `[per-state per-layer test coverage, anti-theater] Each non-loaded state is tested at BOTH enforcement layers; tests fail against pre-fix code` | `>= 8/10` | `9/10` | Prompt layer + review-runner layer + merge gate layer are all covered per state, with explicit anti-theater notes above. |
| `[operator communication] Fail-closed status is distinguishable, actionable, and names the recovery path` | `>= 8/10` | `8/10` | Review comments and `gate-check` output now state the layer, rubric state, and recovery. |
| `[consumer audit + happy-path preservation + sibling enumeration] PR body enumerates every rubricLoad/rubricAnchor consumer and each state × layer decision` | `>= 8/10` | `8/10` | Consumer matrix above enumerates each relevant site and cites the preservation tests. |

## Verification

- `node --check skills/relay-review/scripts/review-runner.js`
- `node --check skills/relay-merge/scripts/review-gate.js`
- `node --check skills/relay-merge/scripts/gate-check.js`
- `node --check skills/relay-dispatch/scripts/relay-manifest.js`
- `node --test skills/relay-dispatch/scripts/*.test.js skills/relay-review/scripts/*.test.js skills/relay-merge/scripts/*.test.js skills/relay-intake/scripts/*.test.js skills/relay-plan/scripts/*.test.js`

## Scope boundary

Deferred on purpose:

- #149 `pr_number` resolver strictness
- #150 skip-path audit trail
- #151 grandfather redesign
- #152 repo-slug consistency
- #158 run-id collision
- #160 `paths.repo_root` trust root
- #161 symlink rubric bypass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 루브릭 파일 관련 오류 발생 시 복구 지침을 포함한 상세한 안내 메시지 추가

* **버그 수정**
  * 루브릭 상태가 유효하지 않을 때 부적절한 승인 결정을 방지하는 검증 강화
  * 루브릭 경로 검증 및 파일 무결성 확인 개선

* **테스트**
  * 루브릭 검증 및 게이트 실패 시나리오에 대한 포괄적인 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
