### PR TITLE
Tighten manifest resolution for reused branches (#149)

### DIFF
--- a/docs/issue-149-manifest-resolution-audit-2026-04-12.md
+++ b/docs/issue-149-manifest-resolution-audit-2026-04-12.md
@@ -1,0 +1,21 @@
+# Issue 149 Manifest Resolution Consumer Audit
+
+Scope: `resolveManifestRecord()` changed branch and PR matching semantics. This audit records every current consumer, the selector shape it uses, the failure behavior operators see, and the test that verifies the recovery path.
+
+## Caller Audit
+
+| Consumer | Selector shape | Failure behavior | Operator recovery | Verification |
+| --- | --- | --- | --- | --- |
+| `skills/relay-dispatch/scripts/dispatch.js` | `--manifest` or `--run-id` only during same-run resume | Missing manifest aborts before executor dispatch | Retry with the correct explicit selector | `dispatch.test.js`: `dispatch resume fails when --run-id does not resolve` |
+| `skills/relay-dispatch/scripts/close-run.js` | `--run-id` only | Missing manifest aborts before any state transition or cleanup | Retry with the correct `--run-id` | `close-run.test.js`: `close-run fails when --run-id does not resolve` |
+| `skills/relay-dispatch/scripts/update-manifest-state.js` | `--manifest`, `--run-id`, or `--branch` | Ambiguous branch lookup errors instead of mutating an arbitrary run | Re-run with `--run-id` or `--manifest` | `update-manifest-state.test.js`: `update-manifest-state surfaces ambiguous branch resolution with explicit recovery guidance` |
+| `skills/relay-review/scripts/review-runner.js` | `--manifest`, `--run-id`, or `--branch` + `--pr` | Terminal-only branch reuse fails closed before review prep starts | Create a fresh dispatch or pass an explicit selector for the intended active run | `review-runner.test.js`: `review-runner fails closed when branch+PR resolution only finds a stale terminal manifest` |
+| `skills/relay-merge/scripts/gate-check.js` | PR mode resolves by `branch` + `pr` from `gh pr view` | Resolver failure is surfaced as `manifest_resolution_failed`; first successful legacy resolution stamps `git.pr_number` once | Fresh-dispatch when only terminal runs exist; otherwise rerun after explicit resolution or allow the first-resolution stamp | `gate-check.test.js`: `gate-check PR mode fails closed when only a stale merged manifest exists on the reused branch`, `gate-check resolves and stamps a historical legacy manifest sample with pr_number=null` |
+| `skills/relay-merge/scripts/finalize-run.js` | `--manifest`, `--run-id`, or `--branch` + `--pr` | Terminal-only branch reuse blocks merge finalization before any `gh pr merge` call | Create a fresh dispatch or rerun with an explicit selector for the intended active run | `finalize-run.test.js`: `finalize-run fails closed when branch+PR resolution only finds a stale terminal manifest` |
+
+## Historical Compatibility Sample
+
+- Source manifest sampled on 2026-04-12: `~/.relay/runs/finjuice-9621f35f/issue-401-20260412015920920.md`
+- Source rubric sampled on 2026-04-12: `~/.relay/runs/finjuice-9621f35f/issue-401-20260412015920920/rubric.yaml`
+- Bundle equivalent: `skills/relay-merge/scripts/__fixtures__/historical-issue-401/`
+- Verified behavior: a real legacy manifest with `git.pr_number: null` and `anchor.rubric_path: rubric.yaml` still resolves in PR mode, stamps `git.pr_number = 401`, and records a single `pr_number_stamped` event.

--- a/skills/relay-dispatch/scripts/close-run.test.js
+++ b/skills/relay-dispatch/scripts/close-run.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -85,6 +85,27 @@ test("close-run closes an active run and cleans a clean worktree", () => {
   const events = fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8");
   assert.match(events, /"event":"close"/);
   assert.match(events, /"event":"cleanup_result"/);
+});
+
+test("close-run fails when --run-id does not resolve", () => {
+  const { repoRoot } = setupRepo();
+  const missingRunId = createRunId({
+    branch: "issue-42",
+    timestamp: new Date("2026-04-03T08:30:00.000Z"),
+  });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", missingRunId,
+    "--reason", "stale_non_terminal_run",
+    "--json",
+  ], {
+    encoding: "utf-8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, new RegExp(`No relay manifest found for run_id '${missingRunId}'`));
 });
 
 test("close-run keeps dirty worktrees and records manual cleanup follow-up", () => {

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -8,6 +8,7 @@ const path = require("path");
 const {
   STATES,
   captureAttempt,
+  createRunId,
   getEventsPath,
   getRunDir,
   listManifestPaths,
@@ -204,6 +205,30 @@ test("dispatch resume fails loudly when the retained worktree is missing", () =>
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /retained worktree is missing/);
   assert.equal(listManifestPaths(repoRoot).length, 1);
+});
+
+test("dispatch resume fails when --run-id does not resolve", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const missingRunId = createRunId({
+    branch: "issue-42",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    repoRoot,
+    "--run-id", missingRunId,
+    "--prompt", "resume",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: relayHome },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, new RegExp(`No relay manifest found for run_id '${missingRunId}'`));
 });
 
 test("dispatch with --executor claude creates worktree and collects result", () => {

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -1,5 +1,7 @@
 const path = require("path");
-const { listManifestRecords, readManifest, validateRunId } = require("./relay-manifest");
+const { STATES, listManifestRecords, readManifest, validateRunId } = require("./relay-manifest");
+
+const BRANCH_ONLY_TERMINAL_STATES = new Set([STATES.MERGED, STATES.CLOSED]);
 
 function formatSelector({ runId, manifestPath, branch, prNumber }) {
   if (manifestPath) return `manifest '${manifestPath}'`;
@@ -10,8 +12,34 @@ function formatSelector({ runId, manifestPath, branch, prNumber }) {
   return parts.join(" + ") || "selector";
 }
 
-function filterByBranch(records, branch) {
-  return records.filter(({ data }) => data?.git?.working_branch === branch);
+function formatRunId(record) {
+  return record?.data?.run_id || path.basename(record?.manifestPath || "unknown", ".md");
+}
+
+function formatCandidateRunIds(records) {
+  return records.map((record) => formatRunId(record)).join(", ");
+}
+
+function formatCandidateDetails(records) {
+  return records.map((record) => {
+    const state = record?.data?.state || "unknown";
+    const storedPr = hasStoredPrNumber(record) ? record.data.git.pr_number : "unset";
+    return `${formatRunId(record)} (state=${state}, pr=${storedPr})`;
+  }).join(", ");
+}
+
+function filterByBranch(records, branch, { excludeTerminal = false } = {}) {
+  return records.filter((record) => {
+    if (record?.data?.git?.working_branch !== branch) {
+      return false;
+    }
+    // #149: branch-only resolution must ignore merged/closed runs; escalated stays eligible because
+    // operators can recover by closing and re-dispatching (#163), so only true terminal states are excluded.
+    if (excludeTerminal && BRANCH_ONLY_TERMINAL_STATES.has(record?.data?.state)) {
+      return false;
+    }
+    return true;
+  });
 }
 
 function filterByPr(records, prNumber) {
@@ -40,6 +68,28 @@ function validateManifestRecordRunId(record) {
   return record;
 }
 
+function buildNoManifestError(selector, { candidates = [], terminalOnly = false, recovery } = {}) {
+  const parts = [`No relay manifest found for ${formatSelector(selector)}.`];
+  if (candidates.length > 0) {
+    parts.push(`Branch candidates: ${formatCandidateDetails(candidates)}.`);
+  }
+  if (terminalOnly) {
+    parts.push("Only terminal branch matches exist; create a fresh dispatch for this branch before retrying.");
+  }
+  if (recovery) {
+    parts.push(recovery);
+  }
+  return new Error(parts.join(" "));
+}
+
+function buildAmbiguousResolutionError(selector, matches) {
+  return new Error(
+    `Ambiguous relay manifest for ${formatSelector(selector)} (${matches.length} candidates): ` +
+    `${formatCandidateRunIds(matches)}. Pass --manifest <path> or --run-id <id> explicitly. ` +
+    "Close stale runs via close-run.js --run-id <id> before retrying if needed."
+  );
+}
+
 function findManifestByRunId(repoRoot, runId) {
   const normalizedRunId = validateRequestedRunId(runId);
   const matches = listManifestRecords(repoRoot)
@@ -54,15 +104,12 @@ function findManifestByRunId(repoRoot, runId) {
   return matches[0] ? validateManifestRecordRunId(matches[0]) : null;
 }
 
-function ensureUniqueRecord(matches, selector) {
+function ensureUniqueRecord(matches, selector, options = {}) {
   if (matches.length === 0) {
-    throw new Error(`No relay manifest found for ${formatSelector(selector)}`);
+    throw buildNoManifestError(selector, options);
   }
   if (matches.length > 1) {
-    const details = matches
-      .map(({ data }) => data?.run_id || "unknown")
-      .join(", ");
-    throw new Error(`Ambiguous relay manifest for ${formatSelector(selector)}: ${details}`);
+    throw buildAmbiguousResolutionError(selector, matches);
   }
   return matches[0];
 }
@@ -94,17 +141,40 @@ function resolveManifestRecord({
   const allRecords = listManifestRecords(repoRoot);
   let matches = allRecords;
   if (branch && prNumber !== undefined && prNumber !== null) {
-    matches = filterByPr(filterByBranch(allRecords, branch), prNumber);
+    const branchMatches = filterByBranch(allRecords, branch);
+    const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    matches = filterByPr(branchMatches, prNumber);
     if (matches.length === 0) {
-      const branchMatches = filterByBranch(allRecords, branch);
-      if (branchMatches.length === 1 && !hasStoredPrNumber(branchMatches[0])) {
-        matches = branchMatches;
+      if (nonTerminalBranchMatches.length === 1 && !hasStoredPrNumber(nonTerminalBranchMatches[0])) {
+        matches = nonTerminalBranchMatches;
+      } else if (nonTerminalBranchMatches.length > 1) {
+        throw buildAmbiguousResolutionError({ branch, prNumber }, nonTerminalBranchMatches);
       }
     }
   } else if (branch) {
-    matches = filterByBranch(allRecords, branch);
+    const branchMatches = filterByBranch(allRecords, branch);
+    matches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch }, {
+      candidates: branchMatches.length > 0 ? branchMatches : [],
+      terminalOnly: branchMatches.length > 0 && matches.length === 0,
+      recovery: branchMatches.length > 0 && matches.length === 0
+        ? "Pass --run-id <id> or --manifest <path> explicitly if you meant an existing active run."
+        : undefined,
+    }));
   } else if (prNumber !== undefined && prNumber !== null) {
     matches = filterByPr(allRecords, prNumber);
+  }
+
+  if (branch && prNumber !== undefined && prNumber !== null && matches.length === 0) {
+    const branchMatches = filterByBranch(allRecords, branch);
+    const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch, prNumber }, {
+      candidates: branchMatches.length > 0 ? branchMatches : [],
+      terminalOnly: branchMatches.length > 0 && nonTerminalBranchMatches.length === 0,
+      recovery: branchMatches.length > 0 && nonTerminalBranchMatches.length === 0
+        ? "Create a fresh dispatch for this branch before retrying."
+        : "Pass --run-id <id> or --manifest <path> explicitly if you meant an existing run.",
+    }));
   }
 
   return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch, prNumber }));

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -14,14 +14,33 @@ const {
 } = require("./relay-manifest");
 const { findManifestByRunId, resolveManifestRecord } = require("./relay-resolver");
 
-function writeReviewPendingManifest(repoRoot, {
+function ensureFixtureRubric(runDir, rubricPath) {
+  if (
+    typeof rubricPath !== "string"
+    || rubricPath.trim() === ""
+    || path.isAbsolute(rubricPath)
+    || rubricPath.split(/[\\/]+/).includes("..")
+  ) {
+    return;
+  }
+  const fullPath = path.join(runDir, rubricPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, "rubric:\n  factors:\n    - name: resolver fixture\n", "utf-8");
+}
+
+function writeManifestRecord(repoRoot, options = {}) {
+  const {
   runId,
   storedRunId = runId,
   branch = "issue-42",
   issueNumber = 42,
+  state = STATES.REVIEW_PENDING,
+  prNumber,
+  grandfathered = true,
+  rubricPath,
   updatedAt = "2026-04-03T00:00:00.000Z",
-} = {}) {
-  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  } = options;
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
   let manifest = createManifestSkeleton({
     repoRoot,
     runId,
@@ -33,10 +52,46 @@ function writeReviewPendingManifest(repoRoot, {
     executor: "codex",
     reviewer: "claude",
   });
-  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
-  manifest.anchor.rubric_grandfathered = true;
-  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+
+  manifest.anchor.rubric_grandfathered = grandfathered;
+  if (rubricPath !== undefined) {
+    manifest.anchor.rubric_path = rubricPath;
+  }
+  ensureFixtureRubric(runDir, rubricPath);
+
+  if (state !== STATES.DRAFT) {
+    manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  }
+  if ([
+    STATES.REVIEW_PENDING,
+    STATES.CHANGES_REQUESTED,
+    STATES.READY_TO_MERGE,
+    STATES.ESCALATED,
+    STATES.MERGED,
+    STATES.CLOSED,
+  ].includes(state)) {
+    manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  }
+  if (state === STATES.CHANGES_REQUESTED) {
+    manifest = updateManifestState(manifest, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+  }
+  if ([STATES.READY_TO_MERGE, STATES.MERGED].includes(state)) {
+    manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  }
+  if (state === STATES.ESCALATED) {
+    manifest = updateManifestState(manifest, STATES.ESCALATED, "inspect_review_failure");
+  }
+  if (state === STATES.MERGED) {
+    manifest = updateManifestState(manifest, STATES.MERGED, "manual_cleanup_required");
+  }
+  if (state === STATES.CLOSED) {
+    manifest = updateManifestState(manifest, STATES.CLOSED, "done");
+  }
+
   manifest.run_id = storedRunId;
+  if (Object.prototype.hasOwnProperty.call(options, "prNumber")) {
+    manifest.git.pr_number = prNumber;
+  }
   manifest.timestamps.updated_at = updatedAt;
   manifest.timestamps.created_at = updatedAt;
   writeManifest(manifestPath, manifest);
@@ -60,7 +115,7 @@ test("findManifestByRunId rejects invalid run_id selectors before scanning manif
 test("resolveManifestRecord rejects non-conforming run_id selectors", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-shape-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
-  writeReviewPendingManifest(repoRoot, {
+  writeManifestRecord(repoRoot, {
     runId: createRunId({
       branch: "issue-42",
       timestamp: new Date("2026-04-03T00:00:00.000Z"),
@@ -76,7 +131,7 @@ test("resolveManifestRecord rejects non-conforming run_id selectors", () => {
 test("resolveManifestRecord rejects manifests whose stored run_id is invalid", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-invalid-manifest-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
-  writeReviewPendingManifest(repoRoot, {
+  writeManifestRecord(repoRoot, {
     runId: createRunId({
       branch: "issue-42",
       timestamp: new Date("2026-04-03T00:05:00.000Z"),
@@ -89,4 +144,206 @@ test("resolveManifestRecord rejects manifests whose stored run_id is invalid", (
     () => resolveManifestRecord({ repoRoot, branch: "issue-42" }),
     /has invalid run_id: run_id must be a single path segment/
   );
+});
+
+test("resolveManifestRecord returns the fresh non-terminal manifest on a reused branch instead of stale merged state", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-reused-branch-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  writeManifestRecord(repoRoot, {
+    runId: createRunId({
+      branch: "feature-auth",
+      timestamp: new Date("2026-04-03T00:00:00.000Z"),
+    }),
+    branch: "feature-auth",
+    state: STATES.MERGED,
+    rubricPath: "stale-rubric.yaml",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+  const freshRunId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:10:00.000Z"),
+  });
+  const freshPath = writeManifestRecord(repoRoot, {
+    runId: freshRunId,
+    branch: "feature-auth",
+    grandfathered: false,
+    rubricPath: "fresh-rubric.yaml",
+    updatedAt: "2026-04-03T00:10:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 });
+  assert.equal(match.manifestPath, freshPath);
+  assert.equal(match.data.run_id, freshRunId);
+  assert.equal(match.data.anchor.rubric_path, "fresh-rubric.yaml");
+  assert.notEqual(match.data.anchor.rubric_grandfathered, true);
+});
+
+test("resolveManifestRecord rejects stale terminal-only branch reuse and names the fresh-dispatch recovery", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-terminal-only-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const staleRunId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  writeManifestRecord(repoRoot, {
+    runId: staleRunId,
+    branch: "feature-auth",
+    state: STATES.MERGED,
+    rubricPath: "stale-rubric.yaml",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
+    (error) => {
+      assert.match(error.message, /No relay manifest found for branch 'feature-auth' \+ pr '120'/);
+      assert.match(error.message, new RegExp(staleRunId));
+      assert.match(error.message, /Only terminal branch matches exist/);
+      assert.match(error.message, /Create a fresh dispatch for this branch before retrying/);
+      return true;
+    }
+  );
+});
+
+test("resolveManifestRecord recovers from terminal-only branch reuse after a fresh dispatch", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-terminal-recovery-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  writeManifestRecord(repoRoot, {
+    runId: createRunId({
+      branch: "feature-auth",
+      timestamp: new Date("2026-04-03T00:00:00.000Z"),
+    }),
+    branch: "feature-auth",
+    state: STATES.CLOSED,
+    rubricPath: "stale-rubric.yaml",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
+    /Create a fresh dispatch/
+  );
+
+  const freshRunId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:15:00.000Z"),
+  });
+  const freshPath = writeManifestRecord(repoRoot, {
+    runId: freshRunId,
+    branch: "feature-auth",
+    grandfathered: false,
+    rubricPath: "fresh-rubric.yaml",
+    updatedAt: "2026-04-03T00:15:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 });
+  assert.equal(match.manifestPath, freshPath);
+  assert.equal(match.data.run_id, freshRunId);
+});
+
+test("resolveManifestRecord rejects ambiguous non-terminal branch matches and recovers with explicit selectors", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-ambiguous-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const firstRunId = createRunId({
+    branch: "feature-foo",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const secondRunId = createRunId({
+    branch: "feature-foo",
+    timestamp: new Date("2026-04-03T00:10:00.000Z"),
+  });
+  const firstPath = writeManifestRecord(repoRoot, {
+    runId: firstRunId,
+    branch: "feature-foo",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+  const secondPath = writeManifestRecord(repoRoot, {
+    runId: secondRunId,
+    branch: "feature-foo",
+    state: STATES.ESCALATED,
+    updatedAt: "2026-04-03T00:10:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-foo", prNumber: 120 }),
+    (error) => {
+      assert.match(error.message, /Ambiguous relay manifest/);
+      assert.match(error.message, /2 candidates/);
+      assert.match(error.message, new RegExp(firstRunId));
+      assert.match(error.message, new RegExp(secondRunId));
+      assert.match(error.message, /Pass --manifest <path> or --run-id <id> explicitly/);
+      return true;
+    }
+  );
+
+  const runIdMatch = resolveManifestRecord({ repoRoot, runId: secondRunId });
+  assert.equal(runIdMatch.manifestPath, secondPath);
+  const manifestMatch = resolveManifestRecord({ repoRoot, manifestPath: firstPath });
+  assert.equal(manifestMatch.manifestPath, firstPath);
+});
+
+test("resolveManifestRecord rejects stored pr_number mismatch and recovers with explicit run_id", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-pr-mismatch-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const manifestPath = writeManifestRecord(repoRoot, {
+    runId,
+    branch: "feature-auth",
+    prNumber: 100,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
+    (error) => {
+      assert.match(error.message, /No relay manifest found for branch 'feature-auth' \+ pr '120'/);
+      assert.match(error.message, new RegExp(runId));
+      assert.match(error.message, /pr=100/);
+      assert.match(error.message, /Pass --run-id <id> or --manifest <path> explicitly/);
+      return true;
+    }
+  );
+
+  const recovered = resolveManifestRecord({ repoRoot, runId });
+  assert.equal(recovered.manifestPath, manifestPath);
+});
+
+test("resolveManifestRecord preserves dispatch-before-PR fallback for a single non-terminal manifest without stored pr_number", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-pr-fallback-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = createRunId({
+    branch: "issue-42",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const manifestPath = writeManifestRecord(repoRoot, {
+    runId,
+    branch: "issue-42",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "issue-42", prNumber: 120 });
+  assert.equal(match.manifestPath, manifestPath);
+  assert.equal(match.data.run_id, runId);
+});
+
+test("resolveManifestRecord keeps escalated runs eligible for branch-only resolution", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = createRunId({
+    branch: "issue-42",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const manifestPath = writeManifestRecord(repoRoot, {
+    runId,
+    branch: "issue-42",
+    state: STATES.ESCALATED,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "issue-42" });
+  assert.equal(match.manifestPath, manifestPath);
+  assert.equal(match.data.state, STATES.ESCALATED);
 });

--- a/skills/relay-dispatch/scripts/update-manifest-state.test.js
+++ b/skills/relay-dispatch/scripts/update-manifest-state.test.js
@@ -77,6 +77,34 @@ test("resolveManifestRecord rejects ambiguous branch lookup", () => {
   );
 });
 
+test("update-manifest-state surfaces ambiguous branch resolution with explicit recovery guidance", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-update-ambiguous-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  writeReviewPendingManifest(repoRoot, createRunId({
+    branch: "issue-42",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  }), "issue-42", "2026-04-03T00:00:00.000Z");
+  writeReviewPendingManifest(repoRoot, createRunId({
+    branch: "issue-42",
+    timestamp: new Date("2026-04-03T00:10:00.000Z"),
+  }), "issue-42", "2026-04-03T00:10:00.000Z");
+
+  assert.throws(
+    () => execFileSync("node", [
+      SCRIPT,
+      "--repo", repoRoot,
+      "--branch", "issue-42",
+      "--state", STATES.READY_TO_MERGE,
+      "--json",
+    ], { encoding: "utf-8", stdio: "pipe" }),
+    (error) => {
+      assert.match(String(error.stderr), /Ambiguous relay manifest/);
+      assert.match(String(error.stderr), /Pass --manifest <path> or --run-id <id> explicitly/);
+      return true;
+    }
+  );
+});
+
 test("resolveManifestRecord rejects conflicting branch and PR selectors", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-find-conflict-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));

--- a/skills/relay-merge/scripts/__fixtures__/historical-issue-401/manifest.md
+++ b/skills/relay-merge/scripts/__fixtures__/historical-issue-401/manifest.md
@@ -1,0 +1,56 @@
+---
+relay_version: 2
+run_id: 'issue-401-20260412015920920'
+state: 'review_pending'
+next_action: 'run_review'
+issue:
+  number: 401
+  source: 'github'
+git:
+  base_branch: 'main'
+  working_branch: 'issue-401'
+  pr_number: null
+  head_sha: '60537db0a4f164deb5815ca0fd2bce24e10a3bbc'
+roles:
+  orchestrator: 'unknown'
+  executor: 'codex'
+  reviewer: 'unknown'
+paths:
+  repo_root: '/Users/sjlee/workspace/active/finance-stack/finjuice'
+  worktree: '/Users/sjlee/.relay/worktrees/1c708046/finjuice'
+policy:
+  merge: 'manual_after_lgtm'
+  cleanup: 'on_close'
+  reviewer_write: 'forbid'
+anchor:
+  done_criteria_source: 'issue'
+  rubric_source: 'manifest'
+  rubric_path: 'rubric.yaml'
+review:
+  rounds: 0
+  max_rounds: 20
+  latest_verdict: 'pending'
+  repeated_issue_count: 0
+  last_reviewed_sha: null
+cleanup:
+  status: 'pending'
+  last_attempted_at: null
+  cleaned_at: null
+  worktree_removed: false
+  branch_deleted: false
+  prune_ran: false
+  error: null
+environment:
+  node_version: 'v22.17.0'
+  main_sha: '60537db0a4f164deb5815ca0fd2bce24e10a3bbc'
+  lockfile_hash: null
+  dispatch_ts: '2026-04-12T01:59:22.430Z'
+timestamps:
+  created_at: '2026-04-12T01:59:22.431Z'
+  updated_at: '2026-04-12T02:08:00.890Z'
+---
+# Notes
+
+## Context
+
+## Review History

--- a/skills/relay-merge/scripts/__fixtures__/historical-issue-401/rubric.yaml
+++ b/skills/relay-merge/scripts/__fixtures__/historical-issue-401/rubric.yaml
@@ -1,0 +1,27 @@
+task: "feat: Core conditions engine (contains, not_contains, is, regex + AND/OR)"
+issue: 401
+size: M
+
+factors:
+  - name: backward_compatibility
+    weight: 30
+    pass: |
+      - Existing match/fields rules load and produce identical results
+      - No changes to existing TagRule fields (match, fields still work)
+      - _check_pattern_match() still called for legacy rules
+      - `finjuice tag --dry-run` produces zero changes on existing data
+    fail: |
+      - Any existing test breaks
+      - Legacy rules silently ignored or produce different tags
+
+  - name: conditions_engine
+    weight: 25
+    pass: |
+      - Condition dataclass with field, op, value
+      - 6 operators: contains, not_contains, is, is_not, starts_with, regex
+      - _check_conditions() evaluates list with AND (default) and OR (logic: any)
+      - Each operator has dedicated unit test
+    fail: |
+      - Missing operator implementation
+      - AND/OR logic incorrect
+      - Regex errors not caught gracefully

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -264,6 +264,37 @@ test("finalize-run rejects invalid manifest run_id before merge finalization", (
   assert.equal(branchExists(repoRoot, branch), true);
 });
 
+test("finalize-run fails closed when branch+PR resolution only finds a stale terminal manifest", () => {
+  const { repoRoot, manifestPath, branch } = setupRepo();
+  const record = readManifest(manifestPath);
+  const staleManifest = {
+    ...updateManifestState(record.data, STATES.MERGED, "manual_cleanup_required"),
+    git: {
+      ...(record.data.git || {}),
+      pr_number: null,
+    },
+  };
+  writeManifest(manifestPath, staleManifest, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }), (error) => {
+    assert.match(String(error.stderr), /Only terminal branch matches exist/);
+    assert.match(String(error.stderr), /Create a fresh dispatch for this branch before retrying/);
+    return true;
+  });
+
+  assert.equal(readManifest(manifestPath).data.git.pr_number, null);
+});
+
 test("finalize-run resumes cleanup when the PR is already merged", () => {
   const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
   const logPath = path.join(repoRoot, "gh.log");

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -26,7 +26,8 @@
 
 const { execFileSync } = require("child_process");
 const { buildSkipComment, evaluateReviewGate } = require("./review-gate");
-const { getRunDir } = require("../../relay-dispatch/scripts/relay-manifest");
+const { getRunDir, writeManifest } = require("../../relay-dispatch/scripts/relay-manifest");
+const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 
 // ---------------------------------------------------------------------------
@@ -82,11 +83,37 @@ function gh(...ghArgs) {
 
 function tryResolveManifestForPr(prNumber, headRefName) {
   try {
-    return resolveManifestRecord({
+    const manifestRecord = resolveManifestRecord({
       repoRoot: process.cwd(),
       prNumber,
       branch: headRefName || undefined,
     });
+    const numericPrNumber = Number(prNumber);
+    if (
+      Number.isInteger(numericPrNumber)
+      && numericPrNumber >= 0
+      && (manifestRecord.data?.git?.pr_number === undefined || manifestRecord.data?.git?.pr_number === null)
+    ) {
+      const repoRoot = manifestRecord.data?.paths?.repo_root || process.cwd();
+      const updatedData = {
+        ...manifestRecord.data,
+        git: {
+          ...(manifestRecord.data?.git || {}),
+          pr_number: numericPrNumber,
+        },
+      };
+      writeManifest(manifestRecord.manifestPath, updatedData, manifestRecord.body);
+      appendRunEvent(repoRoot, updatedData.run_id, {
+        event: "pr_number_stamped",
+        state_from: updatedData.state,
+        state_to: updatedData.state,
+        head_sha: updatedData.git?.head_sha || null,
+        round: updatedData.review?.rounds || null,
+        reason: `Stamped git.pr_number=${numericPrNumber} during gate-check PR resolution`,
+      });
+      return { ...manifestRecord, data: updatedData };
+    }
+    return manifestRecord;
   } catch (error) {
     return { error };
   }

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -5,10 +5,13 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const {
+  STATES,
   createManifestSkeleton,
   createRunId,
   getManifestPath,
   getRunDir,
+  readManifest,
+  updateManifestState,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 
@@ -79,7 +82,39 @@ process.exit(1);
   fs.chmodSync(ghPath, 0o755);
 }
 
-function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git = {}, rubricContent, storedRunId } = {}) {
+function applyManifestState(manifest, state) {
+  if (!state || state === STATES.DRAFT) {
+    return manifest;
+  }
+
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  if ([STATES.REVIEW_PENDING, STATES.ESCALATED, STATES.MERGED, STATES.CLOSED].includes(state)) {
+    manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  }
+  if (state === STATES.ESCALATED) {
+    manifest = updateManifestState(manifest, STATES.ESCALATED, "inspect_review_failure");
+  }
+  if (state === STATES.MERGED) {
+    manifest = updateManifestState(
+      updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge"),
+      STATES.MERGED,
+      "manual_cleanup_required"
+    );
+  }
+  if (state === STATES.CLOSED) {
+    manifest = updateManifestState(manifest, STATES.CLOSED, "done");
+  }
+  return manifest;
+}
+
+function writeLiveManifest(repoRoot, relayHome, {
+  anchor = {},
+  review = {},
+  git = {},
+  rubricContent,
+  storedRunId,
+  state = null,
+} = {}) {
   process.env.RELAY_HOME = relayHome;
   const runId = createRunId({
     issueNumber: 40,
@@ -87,7 +122,13 @@ function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git 
     timestamp: new Date("2026-04-12T01:00:00.000Z"),
   });
   const manifestPath = getManifestPath(repoRoot, runId);
-  const manifest = {
+  const runDir = getRunDir(repoRoot, runId);
+  if (looksLikeContainedRubricPath(anchor.rubric_path) && rubricContent !== false) {
+    const fullPath = path.join(runDir, anchor.rubric_path);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, rubricContent || "rubric:\n  factors:\n    - name: live gate check\n", "utf-8");
+  }
+  let manifest = {
     ...createManifestSkeleton({
       repoRoot,
       runId,
@@ -117,17 +158,12 @@ function writeLiveManifest(repoRoot, relayHome, { anchor = {}, review = {}, git 
   if (typeof storedRunId === "string") {
     manifest.run_id = storedRunId;
   }
+  manifest = applyManifestState(manifest, state);
   writeManifest(manifestPath, manifest);
-  const runDir = getRunDir(repoRoot, runId);
-  if (looksLikeContainedRubricPath(anchor.rubric_path) && rubricContent !== false) {
-    const fullPath = path.join(runDir, anchor.rubric_path);
-    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-    fs.writeFileSync(fullPath, rubricContent || "rubric:\n  factors:\n    - name: live gate check\n", "utf-8");
-  }
   return { manifestPath, runId, runDir };
 }
 
-function runGateCheckLive({ manifest, prViewPayload, rubricContent, json = true, afterManifestSetup = null }) {
+function createLiveGateFixture({ manifest, rubricContent, afterManifestSetup = null }) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-check-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
   const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-bin-")));
@@ -136,18 +172,21 @@ function runGateCheckLive({ manifest, prViewPayload, rubricContent, json = true,
   if (typeof afterManifestSetup === "function") {
     afterManifestSetup({ ...liveManifest, repoRoot, relayHome, binDir });
   }
+  return { ...liveManifest, repoRoot, relayHome, binDir };
+}
 
+function runGateCheckWithFixture(fixture, { prViewPayload, json = true } = {}) {
   const result = spawnSync("node", [
     SCRIPT,
     "40",
     ...(json ? ["--json"] : []),
   ], {
-    cwd: repoRoot,
+    cwd: fixture.repoRoot,
     encoding: "utf-8",
     env: {
       ...process.env,
-      RELAY_HOME: relayHome,
-      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: fixture.relayHome,
+      PATH: `${fixture.binDir}:${process.env.PATH}`,
       FAKE_GH_PR_VIEW_JSON: JSON.stringify(prViewPayload),
     },
   });
@@ -157,8 +196,13 @@ function runGateCheckLive({ manifest, prViewPayload, rubricContent, json = true,
     stdout: result.stdout,
     stderr: result.stderr,
     json: json && result.stdout ? JSON.parse(result.stdout) : null,
-    relayHome,
+    ...fixture,
   };
+}
+
+function runGateCheckLive({ manifest, prViewPayload, rubricContent, json = true, afterManifestSetup = null }) {
+  const fixture = createLiveGateFixture({ manifest, rubricContent, afterManifestSetup });
+  return runGateCheckWithFixture(fixture, { prViewPayload, json });
 }
 
 function buildPassingReviewPayload() {
@@ -495,6 +539,84 @@ test("gate-check resolves the manifest in PR mode and rejects missing anchor.rub
   assert.equal(result.status, 1);
   assert.equal(result.json.status, "missing_rubric_path");
   assert.equal(result.json.readyToMerge, false);
+});
+
+test("gate-check stamps git.pr_number on first successful PR-mode resolution and does not re-stamp", () => {
+  const fixture = createLiveGateFixture({
+    manifest: {
+      state: STATES.REVIEW_PENDING,
+      anchor: {
+        rubric_path: "rubric.yaml",
+        rubric_grandfathered: false,
+      },
+      review: {
+        reviewer_login: "trusted-reviewer",
+        last_reviewed_sha: "abc123",
+      },
+      git: {
+        pr_number: null,
+      },
+    },
+  });
+
+  const first = runGateCheckWithFixture(fixture, {
+    prViewPayload: buildPassingReviewPayload(),
+  });
+  assert.equal(first.status, 0);
+  assert.equal(first.json.status, "lgtm");
+
+  let stored = readManifest(fixture.manifestPath).data;
+  assert.equal(stored.git.pr_number, 40);
+
+  let events = fs.readFileSync(path.join(fixture.runDir, "events.jsonl"), "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.event === "pr_number_stamped");
+  assert.equal(events.length, 1);
+  assert.match(events[0].reason, /git\.pr_number=40/);
+
+  const second = runGateCheckWithFixture(fixture, {
+    prViewPayload: buildPassingReviewPayload(),
+  });
+  assert.equal(second.status, 0);
+  assert.equal(second.json.status, "lgtm");
+
+  stored = readManifest(fixture.manifestPath).data;
+  assert.equal(stored.git.pr_number, 40);
+  events = fs.readFileSync(path.join(fixture.runDir, "events.jsonl"), "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.event === "pr_number_stamped");
+  assert.equal(events.length, 1);
+});
+
+test("gate-check PR mode fails closed when only a stale merged manifest exists on the reused branch", () => {
+  const result = runGateCheckLive({
+    manifest: {
+      state: STATES.MERGED,
+      anchor: {
+        rubric_grandfathered: true,
+      },
+      review: {
+        reviewer_login: "trusted-reviewer",
+        last_reviewed_sha: "abc123",
+      },
+      git: {
+        pr_number: null,
+      },
+    },
+    prViewPayload: buildPassingReviewPayload(),
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "manifest_resolution_failed");
+  assert.equal(result.json.readyToMerge, false);
+  assert.match(result.json.reason, /Only terminal branch matches exist/);
+  assert.match(result.json.reason, /Create a fresh dispatch/);
 });
 
 test("gate-check blocks merge when the anchored rubric file is missing at merge time", () => {

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -16,6 +16,7 @@ const {
 } = require("../../relay-dispatch/scripts/relay-manifest");
 
 const SCRIPT = path.join(__dirname, "gate-check.js");
+const HISTORICAL_FIXTURE_DIR = path.join(__dirname, "__fixtures__", "historical-issue-401");
 
 function looksLikeContainedRubricPath(rubricPath) {
   return typeof rubricPath === "string"
@@ -205,9 +206,55 @@ function runGateCheckLive({ manifest, prViewPayload, rubricContent, json = true,
   return runGateCheckWithFixture(fixture, { prViewPayload, json });
 }
 
-function buildPassingReviewPayload() {
+function createHistoricalLegacyFixture() {
+  const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-historical-")));
+  const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-bin-")));
+  process.env.RELAY_HOME = relayHome;
+  writeFakeGh(binDir);
+
+  const sourceManifestPath = path.join(HISTORICAL_FIXTURE_DIR, "manifest.md");
+  const sourceRubricPath = path.join(HISTORICAL_FIXTURE_DIR, "rubric.yaml");
+  const { data, body } = readManifest(sourceManifestPath);
+  const manifestPath = getManifestPath(repoRoot, data.run_id);
+  const runDir = getRunDir(repoRoot, data.run_id);
+
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.copyFileSync(sourceRubricPath, path.join(runDir, "rubric.yaml"));
+
+  writeManifest(manifestPath, {
+    ...data,
+    issue: {
+      ...(data.issue || {}),
+      number: 401,
+    },
+    git: {
+      ...(data.git || {}),
+      base_branch: "main",
+      working_branch: "issue-401",
+      pr_number: null,
+      head_sha: "abc123",
+    },
+    review: {
+      ...(data.review || {}),
+      rounds: 1,
+      latest_verdict: "pass",
+      reviewer_login: "trusted-reviewer",
+      last_reviewed_sha: "abc123",
+    },
+    paths: {
+      ...(data.paths || {}),
+      repo_root: repoRoot,
+      worktree: path.join(repoRoot, "worktree"),
+    },
+  }, body);
+
+  return { repoRoot, relayHome, binDir, manifestPath, runDir, runId: data.run_id };
+}
+
+function buildPassingReviewPayload({ headRefName = "issue-40" } = {}) {
   return {
-    headRefName: "issue-40",
+    headRefName,
     comments: [
       {
         body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
@@ -592,6 +639,41 @@ test("gate-check stamps git.pr_number on first successful PR-mode resolution and
     .map((line) => JSON.parse(line))
     .filter((entry) => entry.event === "pr_number_stamped");
   assert.equal(events.length, 1);
+});
+
+test("gate-check resolves and stamps a historical legacy manifest sample with pr_number=null", () => {
+  const fixture = createHistoricalLegacyFixture();
+  const result = spawnSync("node", [
+    SCRIPT,
+    "401",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      RELAY_HOME: fixture.relayHome,
+      PATH: `${fixture.binDir}:${process.env.PATH}`,
+      FAKE_GH_PR_VIEW_JSON: JSON.stringify(buildPassingReviewPayload({ headRefName: "issue-401" })),
+    },
+  });
+
+  assert.equal(result.status, 0);
+  const json = JSON.parse(result.stdout);
+  assert.equal(json.status, "lgtm");
+  assert.equal(json.readyToMerge, true);
+
+  const stored = readManifest(fixture.manifestPath).data;
+  assert.equal(stored.git.pr_number, 401);
+
+  const events = fs.readFileSync(path.join(fixture.runDir, "events.jsonl"), "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.event === "pr_number_stamped");
+  assert.equal(events.length, 1);
+  assert.match(events[0].reason, /git\.pr_number=401/);
 });
 
 test("gate-check PR mode fails closed when only a stale merged manifest exists on the reused branch", () => {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -436,6 +436,38 @@ test("review-runner rejects invalid manifest run_id before creating a sibling ru
   assert.equal(fs.existsSync(victimRunDir), false);
 });
 
+test("review-runner fails closed when branch+PR resolution only finds a stale terminal manifest", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
+  const record = readManifest(manifestPath);
+  const staleManifest = {
+    ...updateManifestState(
+      updateManifestState(record.data, STATES.READY_TO_MERGE, "await_explicit_merge"),
+      STATES.MERGED,
+      "manual_cleanup_required"
+    ),
+    git: {
+      ...(record.data.git || {}),
+      pr_number: null,
+    },
+  };
+  writeManifest(manifestPath, staleManifest, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
+    assert.match(String(error.stderr), /Only terminal branch matches exist/);
+    assert.match(String(error.stderr), /Create a fresh dispatch for this branch before retrying/);
+    return true;
+  });
+});
+
 test("changes_requested verdict creates a re-dispatch artifact", () => {
   const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
   const reviewFile = writeVerdict(repoRoot, "changes.json", {


### PR DESCRIPTION
Closes #149.

## Summary
This closes the stale-branch manifest inheritance bypass in `resolveManifestRecord` when a branch is reused for a new PR. The fix adds three layers of defense:

- strict `pr_number` matching whenever the caller provides `prNumber`
- terminal-state exclusion for branch-only resolution (`merged` / `closed` only; `escalated` stays recoverable)
- explicit ambiguity rejection with operator recovery text instead of heuristic or silent fallback

## What Changed
- `skills/relay-dispatch/scripts/relay-resolver.js`
- `skills/relay-merge/scripts/gate-check.js`
- `skills/relay-dispatch/scripts/relay-resolver.test.js`
- `skills/relay-merge/scripts/gate-check.test.js`

Resolver changes:
- Imported `STATES` from `relay-manifest.js` and excluded only `STATES.MERGED` / `STATES.CLOSED` from branch-only candidate sets.
- Preserved the narrow dispatch-before-PR fallback only for a single non-terminal branch match with no stored `git.pr_number`.
- Upgraded no-match and ambiguity errors to include candidate run IDs plus explicit `--manifest` / `--run-id` recovery guidance.

Gate changes:
- In PR mode, `gate-check.js` now stamps `git.pr_number` on the resolved manifest when it is `null`/`undefined`.
- The stamp is idempotent and logged via `appendRunEvent(..., { event: "pr_number_stamped" })`.
- Existing stored `git.pr_number` values are never overwritten.

## Anti-Theater Evidence
- Reused branch with stale merged run plus fresh active run: pre-fix `resolveManifestRecord` saw two branch matches and never entered the narrow fallback, so it threw instead of selecting the fresh run. The new terminal filter removes the merged run from the fallback candidate set and returns the fresh manifest.
- Reused branch with only a stale merged run and no stored `pr_number`: pre-fix the `branchMatches.length === 1 && !hasStoredPrNumber(...)` path returned the stale terminal manifest, which could carry `rubric_grandfathered` or `rubric_path` into a new PR. The new code excludes terminal states and errors with fresh-dispatch recovery text.
- Two concurrent non-terminal manifests on the same branch: pre-fix `branch + pr` resolution fell through to a generic no-match error. The new code throws an explicit ambiguity error listing both run IDs and naming `--manifest` / `--run-id` recovery.
- Stored `pr_number` mismatch (`100` vs caller `120`): pre-fix rejection was generic. The new error names the branch, requested PR, candidate run ID, stored PR, and the explicit `--run-id` recovery path.
- `gate-check` PR mode with only a stale merged manifest: pre-fix the resolver could return the stale grandfathered run and allow LGTM to pass. The new path fails closed as `manifest_resolution_failed` and names the fresh-dispatch recovery.
- `gate-check` first-resolution marker: pre-fix no stamp or audit event was written. The new tests verify one `pr_number_stamped` event on first resolution and zero duplicate events on repeat runs.
- Preservation check: the narrow single-manifest/no-`pr_number` fallback still works. This is intentionally the compatibility case, not a regression trap.

## Consumer Audit
| Consumer | Selector shape | Decision | Failure surfacing |
| --- | --- | --- | --- |
| `skills/relay-dispatch/scripts/dispatch.js` | `--manifest` / `--run-id` resume only | Not a boundary for this issue; explicit selectors only | direct CLI error |
| `skills/relay-dispatch/scripts/close-run.js` | `--run-id` only | Not a boundary; explicit selector only | direct CLI error |
| `skills/relay-dispatch/scripts/update-manifest-state.js` | `--run-id` or `--branch` | Fixed centrally via shared resolver; `--branch` now gets terminal exclusion / ambiguity text | direct CLI error |
| `skills/relay-merge/scripts/gate-check.js` | PR number + head branch | Fixed here and in shared resolver; now also stamps `git.pr_number` on first successful PR-mode resolution | surfaced as `manifest_resolution_failed` JSON / CLI output |
| `skills/relay-merge/scripts/finalize-run.js` | `--manifest` / `--run-id` / optional `--branch` + `--pr` | Fixed centrally via shared resolver for branch/PR lookups; no file-local selector logic change required | direct CLI error |
| `skills/relay-review/scripts/review-runner.js` | `--manifest` / `--run-id` / derived branch+PR via `resolveContext()` | Fixed centrally via shared resolver; audit confirmed it can reach the branch/PR path even though most flows use explicit selectors | direct CLI error / review runner abort |
| `findManifestByRunId()` | internal leaf helper only | Not a separate runtime boundary; only consumed inside `relay-resolver.js` | n/a |

No additional runtime consumers showed up in the repo grep beyond the set above. Deferred scope remains unchanged: #150, #151, #152, #158, #160, #161, and #163 stay separate.

## Backward Compatibility
Sampled existing manifests under `~/.relay/runs/dev-relay-778886da/` against the patched resolver:

- `issue-138` + PR `147` -> `issue-138-20260412044608184`
- `issue-148` + PR `155` -> `issue-148-20260412072649097`
- `issue-156` + PR `159` -> `issue-156-20260412101412608`
- Current fallback-path sample: `issue-149` manifest has `git.pr_number: null`, and `resolveManifestRecord({ branch: "issue-149", prNumber: 999 })` still resolves `issue-149-20260412130914692`

No manifest edits were required for those sampled runs.

## Validation
- `node --check skills/relay-dispatch/scripts/relay-resolver.js && node --check skills/relay-merge/scripts/gate-check.js && node --check skills/relay-dispatch/scripts/relay-manifest.js`
- `node --test skills/relay-dispatch/scripts/*.test.js skills/relay-review/scripts/*.test.js skills/relay-merge/scripts/*.test.js skills/relay-intake/scripts/*.test.js skills/relay-plan/scripts/*.test.js`

## Score Log
| Factor | Score |
| --- | --- |
| `[strict-match — leaf] resolveManifestRecord requires pr_number match when prNumber argument is provided` | 9/10 |
| `[terminal-state exclusion — companion enforcement] Branch-only resolution excludes merged/closed manifests` | 9/10 |
| `[ambiguity rejection — explicit-operator-intervention] Multiple non-terminal manifests on same branch errors with actionable message` | 9/10 |
| `[per-scenario anti-theater test coverage] Regression tests cover re-used branch, concurrent manifests, mismatch rejection` | 9/10 |
| `[first-resolution marker + backward compat] gate-check stamps pr_number on first successful PR-mode resolution; existing single-manifest runs keep working` | 9/10 |
| `[end-to-end recovery + surface audit] Operator recovery paths from resolver failures are named AND executable end-to-end; PR body enumerates every consumer` | 9/10 |

## Scope Boundary
Related but intentionally not bundled here:
- #163 covers broader resolver recovery-flow follow-through beyond the named operator guidance and executable tests added here.
- #150, #151, #152, #158, #160, and #161 remain out of scope for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * PR 번호 자동 스탬핑 기능이 추가되었습니다.

* **버그 수정**
  * 매니페스트 해결 실패 시 더 상세한 오류 메시지와 복구 지침을 제공합니다.
  * 터미널 상태(병합/종료됨) 필터링 옵션으로 브랜치 재사용 처리가 개선되었습니다.
  * 모호한 매니페스트 후보 해석 시 명확한 오류 지표가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->