### PR TITLE
Harden escalated manifest branch fallback (#165)

### DIFF
--- a/skills/relay-dispatch/scripts/close-run.js
+++ b/skills/relay-dispatch/scripts/close-run.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Operator recovery path for stale escalated runs (#165): close the stale run here,
+// then retry resolution or re-dispatch with an explicit selector.
 
 const path = require("path");
 const {

--- a/skills/relay-dispatch/scripts/close-run.test.js
+++ b/skills/relay-dispatch/scripts/close-run.test.js
@@ -18,7 +18,7 @@ const {
 
 const SCRIPT = path.join(__dirname, "close-run.js");
 
-function setupRepo({ dirtyWorktree = false } = {}) {
+function setupRepo({ dirtyWorktree = false, state = STATES.REVIEW_PENDING } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-close-run-"));
   const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   process.env.RELAY_HOME = relayHome;
@@ -56,6 +56,9 @@ function setupRepo({ dirtyWorktree = false } = {}) {
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
   manifest.anchor.rubric_grandfathered = true;
   manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  if (state === STATES.ESCALATED) {
+    manifest = updateManifestState(manifest, STATES.ESCALATED, "inspect_review_failure");
+  }
   writeManifest(manifestPath, manifest);
 
   return { repoRoot, manifestPath, runId, worktreePath };
@@ -128,4 +131,26 @@ test("close-run keeps dirty worktrees and records manual cleanup follow-up", () 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.CLOSED);
   assert.equal(manifest.cleanup.status, "failed");
+});
+
+test("close-run accepts escalated runs as close targets for manual recovery", () => {
+  const { repoRoot, manifestPath, runId, worktreePath } = setupRepo({ state: STATES.ESCALATED });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--reason", "stale_escalated_run",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.previousState, STATES.ESCALATED);
+  assert.equal(result.state, STATES.CLOSED);
+  assert.equal(result.cleanup.cleanupStatus, "succeeded");
+  assert.equal(fs.existsSync(worktreePath), false);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.CLOSED);
+  assert.equal(manifest.cleanup.status, "succeeded");
 });

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -2,6 +2,12 @@ const path = require("path");
 const { STATES, listManifestRecords, readManifest, validateRunId } = require("./relay-manifest");
 
 const BRANCH_ONLY_TERMINAL_STATES = new Set([STATES.MERGED, STATES.CLOSED]);
+const BRANCH_PR_FALLBACK_INELIGIBLE_STATES = new Set([
+  ...BRANCH_ONLY_TERMINAL_STATES,
+  // #165: branch+PR fallback must not inherit stale escalated runs with no stored PR.
+  // Operators can still inspect/recover them explicitly via --run-id/--manifest.
+  STATES.ESCALATED,
+]);
 
 function formatSelector({ runId, manifestPath, branch, prNumber }) {
   if (manifestPath) return `manifest '${manifestPath}'`;
@@ -46,8 +52,35 @@ function filterByPr(records, prNumber) {
   return records.filter(({ data }) => Number(data?.git?.pr_number || 0) === Number(prNumber));
 }
 
+function filterByBranchPrFallback(records, branch) {
+  return filterByBranch(records, branch)
+    .filter((record) => !BRANCH_PR_FALLBACK_INELIGIBLE_STATES.has(record?.data?.state));
+}
+
 function hasStoredPrNumber(record) {
   return record?.data?.git?.pr_number !== undefined && record?.data?.git?.pr_number !== null;
+}
+
+function findStaleEscalatedBranchFallbackCandidate(records) {
+  if (records.length !== 1) {
+    return null;
+  }
+  const [record] = records;
+  if (record?.data?.state !== STATES.ESCALATED || hasStoredPrNumber(record)) {
+    return null;
+  }
+  return record;
+}
+
+function buildCloseRunCommand(repoRoot, runId, reason) {
+  return `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} ` +
+    `--run-id ${JSON.stringify(runId)} --reason ${JSON.stringify(reason)}`;
+}
+
+function buildEscalatedRecoveryMessage(repoRoot, record) {
+  const runId = formatRunId(record);
+  return `Close the stale escalated run via ${buildCloseRunCommand(repoRoot, runId, "stale_escalated_run")} ` +
+    `before retrying, or inspect it explicitly via --run-id ${JSON.stringify(runId)}.`;
 }
 
 function validateRequestedRunId(runId) {
@@ -142,13 +175,13 @@ function resolveManifestRecord({
   let matches = allRecords;
   if (branch && prNumber !== undefined && prNumber !== null) {
     const branchMatches = filterByBranch(allRecords, branch);
-    const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    const branchFallbackMatches = filterByBranchPrFallback(allRecords, branch);
     matches = filterByPr(branchMatches, prNumber);
     if (matches.length === 0) {
-      if (nonTerminalBranchMatches.length === 1 && !hasStoredPrNumber(nonTerminalBranchMatches[0])) {
-        matches = nonTerminalBranchMatches;
-      } else if (nonTerminalBranchMatches.length > 1) {
-        throw buildAmbiguousResolutionError({ branch, prNumber }, nonTerminalBranchMatches);
+      if (branchFallbackMatches.length === 1 && !hasStoredPrNumber(branchFallbackMatches[0])) {
+        matches = branchFallbackMatches;
+      } else if (branchFallbackMatches.length > 1) {
+        throw buildAmbiguousResolutionError({ branch, prNumber }, branchFallbackMatches);
       }
     }
   } else if (branch) {
@@ -167,11 +200,14 @@ function resolveManifestRecord({
 
   if (branch && prNumber !== undefined && prNumber !== null && matches.length === 0) {
     const branchMatches = filterByBranch(allRecords, branch);
-    const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    const branchFallbackMatches = filterByBranchPrFallback(allRecords, branch);
+    const staleEscalatedRecord = findStaleEscalatedBranchFallbackCandidate(branchMatches);
     return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch, prNumber }, {
       candidates: branchMatches.length > 0 ? branchMatches : [],
-      terminalOnly: branchMatches.length > 0 && nonTerminalBranchMatches.length === 0,
-      recovery: branchMatches.length > 0 && nonTerminalBranchMatches.length === 0
+      terminalOnly: branchMatches.length > 0 && branchFallbackMatches.length === 0 && !staleEscalatedRecord,
+      recovery: staleEscalatedRecord
+        ? buildEscalatedRecoveryMessage(repoRoot, staleEscalatedRecord)
+        : branchMatches.length > 0 && branchFallbackMatches.length === 0
         ? "Create a fresh dispatch for this branch before retrying."
         : "Pass --run-id <id> or --manifest <path> explicitly if you meant an existing run.",
     }));

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -48,7 +48,11 @@ function filterByPr(records, prNumber) {
 
 function filterByBranchPrFallback(records, branch) {
   return filterByBranch(records, branch, { excludeTerminal: true })
-    .filter((record) => !(record?.data?.state === STATES.ESCALATED && !hasStoredPrNumber(record)));
+    .filter((record) => {
+      // #165: `escalated + pr_number:null` stays recoverable via explicit selectors, but branch+PR fallback
+      // only exists for stale-inheritance scenarios on reused branches, so this path must treat that case as terminal.
+      return !(record?.data?.state === STATES.ESCALATED && !hasStoredPrNumber(record));
+    });
 }
 
 function hasStoredPrNumber(record) {

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -2,12 +2,6 @@ const path = require("path");
 const { STATES, listManifestRecords, readManifest, validateRunId } = require("./relay-manifest");
 
 const BRANCH_ONLY_TERMINAL_STATES = new Set([STATES.MERGED, STATES.CLOSED]);
-const BRANCH_PR_FALLBACK_INELIGIBLE_STATES = new Set([
-  ...BRANCH_ONLY_TERMINAL_STATES,
-  // #165: branch+PR fallback must not inherit stale escalated runs with no stored PR.
-  // Operators can still inspect/recover them explicitly via --run-id/--manifest.
-  STATES.ESCALATED,
-]);
 
 function formatSelector({ runId, manifestPath, branch, prNumber }) {
   if (manifestPath) return `manifest '${manifestPath}'`;
@@ -53,8 +47,8 @@ function filterByPr(records, prNumber) {
 }
 
 function filterByBranchPrFallback(records, branch) {
-  return filterByBranch(records, branch)
-    .filter((record) => !BRANCH_PR_FALLBACK_INELIGIBLE_STATES.has(record?.data?.state));
+  return filterByBranch(records, branch, { excludeTerminal: true })
+    .filter((record) => !(record?.data?.state === STATES.ESCALATED && !hasStoredPrNumber(record)));
 }
 
 function hasStoredPrNumber(record) {
@@ -201,13 +195,14 @@ function resolveManifestRecord({
   if (branch && prNumber !== undefined && prNumber !== null && matches.length === 0) {
     const branchMatches = filterByBranch(allRecords, branch);
     const branchFallbackMatches = filterByBranchPrFallback(allRecords, branch);
-    const staleEscalatedRecord = findStaleEscalatedBranchFallbackCandidate(branchMatches);
+    const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    const staleEscalatedRecord = findStaleEscalatedBranchFallbackCandidate(nonTerminalBranchMatches);
     return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch, prNumber }, {
       candidates: branchMatches.length > 0 ? branchMatches : [],
-      terminalOnly: branchMatches.length > 0 && branchFallbackMatches.length === 0 && !staleEscalatedRecord,
+      terminalOnly: branchMatches.length > 0 && nonTerminalBranchMatches.length === 0,
       recovery: staleEscalatedRecord
         ? buildEscalatedRecoveryMessage(repoRoot, staleEscalatedRecord)
-        : branchMatches.length > 0 && branchFallbackMatches.length === 0
+        : branchMatches.length > 0 && nonTerminalBranchMatches.length === 0
         ? "Create a fresh dispatch for this branch before retrying."
         : "Pass --run-id <id> or --manifest <path> explicitly if you meant an existing run.",
     }));

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -336,6 +336,8 @@ test("resolveManifestRecord keeps escalated stored-pr mismatches recoverable via
     updatedAt: "2026-04-03T00:00:00.000Z",
   });
 
+  // Anti-theater: this still enters the branch+PR miss path, but the manifest has a stored PR.
+  // The #165 fix must stay scoped to stale `escalated + pr_number: unset` fallback only.
   assert.throws(
     () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
     (error) => {
@@ -387,6 +389,8 @@ test("resolveManifestRecord rejects stale escalated branch fallback and names cl
     updatedAt: "2026-04-03T00:00:00.000Z",
   });
 
+  // Anti-theater: before #165, `filterByPr(branchMatches, 120)` returned no match and the old
+  // single-record branch fallback rebound this stale `escalated + pr_number: unset` manifest to PR 120.
   assert.throws(
     () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
     (error) => {
@@ -415,6 +419,8 @@ test("resolveManifestRecord keeps escalated manifests addressable by matching pr
     updatedAt: "2026-04-03T00:00:00.000Z",
   });
 
+  // Anti-theater: this is the preserved branch+PR selector. Even after #165 blocks stale branch-only
+  // fallback, a true `filterByPr(branchMatches, 120)` match must still return the escalated manifest.
   const match = resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 });
   assert.equal(match.manifestPath, manifestPath);
   assert.equal(match.data.state, STATES.ESCALATED);
@@ -435,6 +441,8 @@ test("resolveManifestRecord keeps escalated manifests addressable by explicit se
     updatedAt: "2026-04-03T00:00:00.000Z",
   });
 
+  // Anti-theater: legitimate escalated recovery is explicit. `--run-id` and `--manifest` never relied
+  // on the stale branch+PR fallback, so the #165 exclusion must not strand an operator resuming the run.
   const runIdMatch = resolveManifestRecord({ repoRoot, runId });
   assert.equal(runIdMatch.manifestPath, manifestPath);
   assert.equal(runIdMatch.data.state, STATES.ESCALATED);
@@ -459,6 +467,8 @@ test("resolveManifestRecord recovers from stale escalated fallback after close-r
     updatedAt: "2026-04-03T00:00:00.000Z",
   });
 
+  // Anti-theater: before #165, this first branch+PR lookup would have silently selected `staleRunId`,
+  // so the operator never reached the close-run / re-dispatch recovery flow exercised below.
   assert.throws(
     () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
     new RegExp(escapeRegExp(`--run-id ${JSON.stringify(staleRunId)}`))

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -9,10 +10,17 @@ const {
   createManifestSkeleton,
   createRunId,
   ensureRunLayout,
+  readManifest,
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
 const { findManifestByRunId, resolveManifestRecord } = require("./relay-resolver");
+
+const CLOSE_RUN_SCRIPT = path.join(__dirname, "close-run.js");
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function ensureFixtureRubric(runDir, rubricPath) {
   if (
@@ -38,6 +46,7 @@ function writeManifestRecord(repoRoot, options = {}) {
   prNumber,
   grandfathered = true,
   rubricPath,
+  cleanupPolicy = "on_close",
   updatedAt = "2026-04-03T00:00:00.000Z",
   } = options;
   const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
@@ -51,6 +60,7 @@ function writeManifestRecord(repoRoot, options = {}) {
     orchestrator: "codex",
     executor: "codex",
     reviewer: "claude",
+    cleanupPolicy,
   });
 
   manifest.anchor.rubric_grandfathered = grandfathered;
@@ -260,7 +270,7 @@ test("resolveManifestRecord rejects ambiguous non-terminal branch matches and re
   const secondPath = writeManifestRecord(repoRoot, {
     runId: secondRunId,
     branch: "feature-foo",
-    state: STATES.ESCALATED,
+    state: STATES.CHANGES_REQUESTED,
     updatedAt: "2026-04-03T00:10:00.000Z",
   });
 
@@ -329,8 +339,58 @@ test("resolveManifestRecord preserves dispatch-before-PR fallback for a single n
   assert.equal(match.data.run_id, runId);
 });
 
-test("resolveManifestRecord keeps escalated runs eligible for branch-only resolution", () => {
-  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-"));
+test("resolveManifestRecord rejects stale escalated branch fallback and names close-run plus --run-id recovery", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-stale-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const closeCommand = `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} --run-id ${JSON.stringify(runId)} --reason ${JSON.stringify("stale_escalated_run")}`;
+  writeManifestRecord(repoRoot, {
+    runId,
+    branch: "feature-auth",
+    state: STATES.ESCALATED,
+    cleanupPolicy: "manual",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
+    (error) => {
+      assert.match(error.message, /No relay manifest found for branch 'feature-auth' \+ pr '120'/);
+      assert.match(error.message, new RegExp(runId));
+      assert.match(error.message, /state=escalated, pr=unset/);
+      assert.match(error.message, new RegExp(escapeRegExp(closeCommand)));
+      assert.match(error.message, new RegExp(escapeRegExp(`--run-id ${JSON.stringify(runId)}`)));
+      return true;
+    }
+  );
+});
+
+test("resolveManifestRecord keeps escalated manifests addressable by matching pr_number", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-pr-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const manifestPath = writeManifestRecord(repoRoot, {
+    runId,
+    branch: "feature-auth",
+    state: STATES.ESCALATED,
+    prNumber: 120,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 });
+  assert.equal(match.manifestPath, manifestPath);
+  assert.equal(match.data.state, STATES.ESCALATED);
+  assert.equal(match.data.git.pr_number, 120);
+});
+
+test("resolveManifestRecord keeps escalated manifests addressable by explicit selectors", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-explicit-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const runId = createRunId({
     branch: "issue-42",
@@ -343,7 +403,58 @@ test("resolveManifestRecord keeps escalated runs eligible for branch-only resolu
     updatedAt: "2026-04-03T00:00:00.000Z",
   });
 
-  const match = resolveManifestRecord({ repoRoot, branch: "issue-42" });
-  assert.equal(match.manifestPath, manifestPath);
-  assert.equal(match.data.state, STATES.ESCALATED);
+  const runIdMatch = resolveManifestRecord({ repoRoot, runId });
+  assert.equal(runIdMatch.manifestPath, manifestPath);
+  assert.equal(runIdMatch.data.state, STATES.ESCALATED);
+
+  const manifestMatch = resolveManifestRecord({ repoRoot, manifestPath });
+  assert.equal(manifestMatch.manifestPath, manifestPath);
+  assert.equal(manifestMatch.data.state, STATES.ESCALATED);
+});
+
+test("resolveManifestRecord recovers from stale escalated fallback after close-run and fresh dispatch", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-recovery-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const staleRunId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const staleManifestPath = writeManifestRecord(repoRoot, {
+    runId: staleRunId,
+    branch: "feature-auth",
+    state: STATES.ESCALATED,
+    cleanupPolicy: "manual",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
+    new RegExp(escapeRegExp(`--run-id ${JSON.stringify(staleRunId)}`))
+  );
+
+  execFileSync("node", [
+    CLOSE_RUN_SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", staleRunId,
+    "--reason", "stale_escalated_run",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const staleManifest = readManifest(staleManifestPath).data;
+  assert.equal(staleManifest.state, STATES.CLOSED);
+
+  const freshRunId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:15:00.000Z"),
+  });
+  const freshPath = writeManifestRecord(repoRoot, {
+    runId: freshRunId,
+    branch: "feature-auth",
+    cleanupPolicy: "manual",
+    updatedAt: "2026-04-03T00:15:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 });
+  assert.equal(match.manifestPath, freshPath);
+  assert.equal(match.data.run_id, freshRunId);
 });

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -321,6 +321,38 @@ test("resolveManifestRecord rejects stored pr_number mismatch and recovers with 
   assert.equal(recovered.manifestPath, manifestPath);
 });
 
+test("resolveManifestRecord keeps escalated stored-pr mismatches recoverable via explicit selectors", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-escalated-pr-mismatch-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = createRunId({
+    branch: "feature-auth",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const manifestPath = writeManifestRecord(repoRoot, {
+    runId,
+    branch: "feature-auth",
+    state: STATES.ESCALATED,
+    prNumber: 100,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 }),
+    (error) => {
+      assert.match(error.message, /No relay manifest found for branch 'feature-auth' \+ pr '120'/);
+      assert.match(error.message, new RegExp(runId));
+      assert.match(error.message, /state=escalated, pr=100/);
+      assert.match(error.message, /Pass --run-id <id> or --manifest <path> explicitly/);
+      assert.doesNotMatch(error.message, /Only terminal branch matches exist/);
+      assert.doesNotMatch(error.message, /Create a fresh dispatch for this branch before retrying/);
+      return true;
+    }
+  );
+
+  const recovered = resolveManifestRecord({ repoRoot, runId });
+  assert.equal(recovered.manifestPath, manifestPath);
+});
+
 test("resolveManifestRecord preserves dispatch-before-PR fallback for a single non-terminal manifest without stored pr_number", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-pr-fallback-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));


### PR DESCRIPTION
## Summary

Close the BLOCKER codex surfaced in the post-merge challenge of PR #164 (#149): stale `escalated` manifests with `git.pr_number: null` were still silently inheritable via branch reuse — the exact bypass #149 was filed to close.

Fix is narrow: `resolveManifestRecord`'s branch+PR fallback now excludes `escalated` manifests from implicit branch reuse, while explicit `--run-id` / `--manifest` resolution still returns escalated manifests unchanged. The stale-escalated no-match path now emits concrete recovery text with both exact commands (`close-run.js` and `--run-id`).

Fixes #165.

## What changed

- `skills/relay-dispatch/scripts/relay-resolver.js` — predicate tightening at the branch-only fallback scope, with inline rationale citing #165.
- `skills/relay-dispatch/scripts/relay-resolver.test.js` — 3 new regression tests + 1 end-to-end recovery test.
- `skills/relay-dispatch/scripts/close-run.test.js` — direct proof that `close-run` already accepts escalated and transitions it to `closed`.

## Regression coverage

- Stale escalated + branch/prNumber → rejection with actionable recovery text naming both commands.
- Escalated + matching stored PR → still resolving (legitimate case preserved).
- Escalated + explicit selector (`--run-id` / `--manifest`) → still resolving.
- End-to-end: stale escalated → `close-run` → fresh dispatch → successful re-resolution.
- Close-run accepts escalated and transitions to closed (state-machine invariant).

## Verification

- `node --check skills/relay-dispatch/scripts/relay-resolver.js && node --check skills/relay-dispatch/scripts/close-run.js && node --check skills/relay-dispatch/scripts/relay-manifest.js`
- `node --test skills/relay-dispatch/scripts/*.test.js skills/relay-review/scripts/*.test.js skills/relay-merge/scripts/*.test.js skills/relay-intake/scripts/*.test.js skills/relay-plan/scripts/*.test.js`

## Scope boundary

Deferred on purpose:
- #166 (concurrent gate-check stamping — different concurrency concern, low priority)
- #163 (review-runner recovery path — different module)
- #160 (paths.repo_root trust root — different layer)
- #161 (symlink rubric bypass)
- #158 (run-id collision)
- #150 / #151 / #152 / #153

## Batch 1.5 status after this PR

With #165 closed, the Batch 1.5 invariant holds end-to-end:
- file exists (✅ #148) + path contained (✅ #148) + run_id validated (✅ #156) + reviewer fail-closed (✅ #157) + no stale-branch inheritance (✅ #149 + this PR). Phase 0.2 (#139) unblocked pending final codex challenge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 오래된 확대된 실행(stale escalated run)을 자동으로 종료하고 정리하는 복구 지시가 추가되어, 해당 실행이 닫히고 작업 디렉터리가 제거됩니다.
  * 분기+PR 선택 시 부적격 항목을 제외해 더 정확한 폴백 후보를 선택하도록 개선되었습니다.

* **테스트**
  * 확대된 실행 처리 및 종료·정리 절차에 대한 포괄적인 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->