### PR TITLE
Close terminal exclusion at the exact-PR selector (#170)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -1,3 +1,19 @@
+// ---------------------------------------------------------------------------
+// Resolver selector state-awareness audit table
+// (selector-composition axis enumeration meta-rule — memory/feedback_rubric_fail_closed.md)
+//
+// | Selector                     | State-awareness        | Closed by |
+// | ---------------------------- | ---------------------- | --------- |
+// | filterByBranch               | excludeTerminal opt-in | #149      |
+// | filterByPr                   | composed downstream    | #170      |
+// | filterByBranchPrFallback     | dispatched-only allow  | #168      |
+// | findManifestByRunId          | state-blind by design  | n/a       |
+//
+// When adding a new selector, add a row here AND a top-of-function comment.
+// When fixing a state-machine invariant in selector A, audit every other selector
+// that feeds the same `matches` variable in resolveManifestRecord.
+// ---------------------------------------------------------------------------
+
 const path = require("path");
 const { STATES, listManifestRecords, readManifest, validateRunId } = require("./relay-manifest");
 
@@ -29,6 +45,9 @@ function formatCandidateDetails(records) {
 }
 
 function filterByBranch(records, branch, { excludeTerminal = false } = {}) {
+  // [state-aware] via excludeTerminal opt-in (#149). Callers must opt in for
+  // stale-inheritance-sensitive paths; standalone branch-only resolution does.
+  // Selector-composition audit table at top of file.
   return records.filter((record) => {
     if (record?.data?.git?.working_branch !== branch) {
       return false;
@@ -43,10 +62,15 @@ function filterByBranch(records, branch, { excludeTerminal = false } = {}) {
 }
 
 function filterByPr(records, prNumber) {
+  // [state-aware] via composition with nonTerminalBranchMatches at the branch+PR
+  // call site (#170). Standalone --pr consumers are not currently exposed; if that
+  // changes, audit per #170 / selector-composition meta-rule.
   return records.filter(({ data }) => Number(data?.git?.pr_number || 0) === Number(prNumber));
 }
 
 function filterByBranchPrFallback(records, branch) {
+  // [state-aware whitelist] dispatched + null only (#168). Treat the state axis as a
+  // whitelist, not a blacklist — see memory/feedback_rubric_fail_closed.md.
   return filterByBranch(records, branch, { excludeTerminal: true })
     .filter((record) => {
       // #168: treat the state-machine axis as a whitelist, not a blacklist. Fixing only the state named
@@ -129,6 +153,8 @@ function buildAmbiguousResolutionError(selector, matches) {
 }
 
 function findManifestByRunId(repoRoot, runId) {
+  // [state-blind by design] explicit selectors must resolve EVERY state to keep
+  // operator recovery reachable (#149/#165/#157/#163).
   const normalizedRunId = validateRequestedRunId(runId);
   const matches = listManifestRecords(repoRoot)
     .filter(({ data, manifestPath }) => (
@@ -182,7 +208,14 @@ function resolveManifestRecord({
     const branchMatches = filterByBranch(allRecords, branch);
     const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
     const branchFallbackMatches = filterByBranchPrFallback(allRecords, branch);
-    matches = filterByPr(branchMatches, prNumber);
+    // #170: compose filterByPr with nonTerminalBranchMatches so stale merged/closed
+    // manifests with stored pr_number === prNumber cannot shadow a fresh dispatched+null run.
+    // Selector-composition axis enumeration meta-rule (memory/feedback_rubric_fail_closed.md):
+    // the state-machine axis is a property of EVERY resolver selector; #149 closed it for
+    // filterByBranch, #168 closed it for filterByBranchPrFallback, this commit closes it for
+    // filterByPr at this composition site. branchMatches stays bound for the preserved
+    // candidates list passed into the no-match error.
+    matches = filterByPr(nonTerminalBranchMatches, prNumber);
     if (matches.length === 0) {
       if (nonTerminalBranchMatches.length > 1) {
         throw buildAmbiguousResolutionError({ branch, prNumber }, nonTerminalBranchMatches);

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -242,6 +242,27 @@ function resolveManifestRecord({
     const branchMatches = filterByBranch(allRecords, branch);
     const branchFallbackMatches = filterByBranchPrFallback(allRecords, branch);
     const nonTerminalBranchMatches = filterByBranch(allRecords, branch, { excludeTerminal: true });
+    const terminalExactPrMatches = filterByPr(
+      branchMatches.filter((record) => BRANCH_ONLY_TERMINAL_STATES.has(record?.data?.state)),
+      prNumber
+    );
+    if (
+      terminalExactPrMatches.length > 0
+      && branchFallbackMatches.length === 0
+      && nonTerminalBranchMatches.length === 1
+      && nonTerminalBranchMatches[0]?.data?.state === STATES.REVIEW_PENDING
+    ) {
+      // #170 round 2: once branch+PR resolution has already missed on the non-terminal set,
+      // a mixed terminal exact-PR sibling plus a lone review_pending sibling is the explicit
+      // post-stamp ambiguity called out in the issue. The matching-pr review_pending path
+      // resolves earlier via filterByPr(nonTerminalBranchMatches, prNumber); reaching this block
+      // means the review_pending manifest does NOT carry the caller PR, so do not misclassify it
+      // as stale branch-fallback recovery.
+      throw buildAmbiguousResolutionError(
+        { branch, prNumber },
+        [...terminalExactPrMatches, ...nonTerminalBranchMatches]
+      );
+    }
     const staleFallbackRecord = findStaleNonTerminalBranchFallbackCandidate(nonTerminalBranchMatches);
     return validateManifestRecordRunId(ensureUniqueRecord(matches, { branch, prNumber }, {
       candidates: branchMatches.length > 0 ? branchMatches : [],

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -11,12 +11,14 @@ const {
   createRunId,
   ensureRunLayout,
   readManifest,
+  validateTransition,
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
 const { findManifestByRunId, resolveManifestRecord } = require("./relay-resolver");
 
 const CLOSE_RUN_SCRIPT = path.join(__dirname, "close-run.js");
+const EXACT_PR_COLLISION_PR = 40;
 const NON_TERMINAL_BRANCH_PR_STATES = [
   STATES.DISPATCHED,
   STATES.REVIEW_PENDING,
@@ -273,6 +275,233 @@ test("resolveManifestRecord recovers from terminal-only branch reuse after a fre
   const match = resolveManifestRecord({ repoRoot, branch: "feature-auth", prNumber: 120 });
   assert.equal(match.manifestPath, freshPath);
   assert.equal(match.data.run_id, freshRunId);
+});
+
+test("resolveManifestRecord covers the stored-pr terminal exact-PR collision matrix", async (t) => {
+  const cases = [
+    {
+      label: "merged + matching stored pr + no fresh dispatch",
+      terminalState: STATES.MERGED,
+      freshPrNumber: null,
+      expected: "terminal-only-rejection",
+      // Anti-theater: pre-#170, relay-resolver.js:185 (`matches = filterByPr(branchMatches, 40);`)
+      // returned the merged manifest because branchMatches was terminal-inclusive.
+    },
+    {
+      label: "merged + matching stored pr + fresh dispatched + pr unset",
+      terminalState: STATES.MERGED,
+      freshPrNumber: undefined,
+      expected: "fresh-dispatched-null-pr",
+      // Anti-theater: pre-#170, relay-resolver.js:185 returned the merged manifest before the
+      // dispatched+null branch fallback could recover the fresh run.
+    },
+    {
+      label: "merged + matching stored pr + fresh dispatched + matching pr",
+      terminalState: STATES.MERGED,
+      freshPrNumber: EXACT_PR_COLLISION_PR,
+      expected: "fresh-dispatched-matching-pr",
+      // Anti-theater: pre-#170, filterByPr(branchMatches, 40) kept both manifests and raised
+      // ambiguity. The #170 call-site fix intentionally drops the terminal sibling first, so the
+      // fresh dispatched manifest wins instead of surfacing ambiguity for a stale collision.
+    },
+    {
+      label: "closed + matching stored pr + no fresh dispatch",
+      terminalState: STATES.CLOSED,
+      freshPrNumber: null,
+      expected: "terminal-only-rejection",
+      // Anti-theater: pre-#170, relay-resolver.js:185 returned the closed manifest because
+      // branchMatches still included terminal records on the exact-PR selector path.
+    },
+    {
+      label: "closed + matching stored pr + fresh dispatched + pr unset",
+      terminalState: STATES.CLOSED,
+      freshPrNumber: undefined,
+      expected: "fresh-dispatched-null-pr",
+      // Anti-theater: pre-#170, relay-resolver.js:185 returned the stale closed manifest before
+      // the dispatched+null fallback could rebind resolution to the fresh run.
+    },
+    {
+      label: "closed + matching stored pr + fresh dispatched + matching pr",
+      terminalState: STATES.CLOSED,
+      freshPrNumber: EXACT_PR_COLLISION_PR,
+      expected: "fresh-dispatched-matching-pr",
+      // Anti-theater: pre-#170, filterByPr(branchMatches, 40) surfaced both manifests and stopped
+      // in ambiguity. Post-#170, terminal siblings are excluded before exact-PR matching.
+    },
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.label, () => {
+      const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-stored-pr-collision-"));
+      process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+      const staleRunId = createRunId({
+        branch: "feature-x",
+        timestamp: new Date("2026-04-03T00:00:00.000Z"),
+      });
+      writeManifestRecord(repoRoot, {
+        runId: staleRunId,
+        branch: "feature-x",
+        state: testCase.terminalState,
+        prNumber: EXACT_PR_COLLISION_PR,
+        updatedAt: "2026-04-03T00:00:00.000Z",
+      });
+
+      let freshPath = null;
+      if (testCase.expected !== "terminal-only-rejection") {
+        const freshRunId = createRunId({
+          branch: "feature-x",
+          timestamp: new Date("2026-04-03T00:15:00.000Z"),
+        });
+        freshPath = writeManifestRecord(repoRoot, {
+          runId: freshRunId,
+          branch: "feature-x",
+          state: STATES.DISPATCHED,
+          ...(testCase.freshPrNumber === undefined ? {} : { prNumber: testCase.freshPrNumber }),
+          updatedAt: "2026-04-03T00:15:00.000Z",
+        });
+      }
+
+      if (testCase.expected === "terminal-only-rejection") {
+        assert.throws(
+          () => resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: EXACT_PR_COLLISION_PR }),
+          (error) => {
+            assert.match(error.message, /No relay manifest found for branch 'feature-x' \+ pr '40'/);
+            assert.match(error.message, new RegExp(staleRunId));
+            assert.match(error.message, /Only terminal branch matches exist/);
+            assert.match(error.message, /Create a fresh dispatch for this branch before retrying/);
+            return true;
+          }
+        );
+        return;
+      }
+
+      const match = resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: EXACT_PR_COLLISION_PR });
+      assert.equal(match.manifestPath, freshPath);
+      assert.equal(match.data.state, STATES.DISPATCHED);
+      assert.equal(
+        match.data.git.pr_number,
+        testCase.expected === "fresh-dispatched-matching-pr" ? EXACT_PR_COLLISION_PR : null
+      );
+    });
+  }
+});
+
+test("resolveManifestRecord keeps terminal manifests with stored PR mismatches explicit-only", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-terminal-pr-mismatch-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const staleRunId = createRunId({
+    branch: "feature-x",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const stalePath = writeManifestRecord(repoRoot, {
+    runId: staleRunId,
+    branch: "feature-x",
+    state: STATES.MERGED,
+    prNumber: EXACT_PR_COLLISION_PR,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: EXACT_PR_COLLISION_PR + 1 }),
+    (error) => {
+      assert.match(error.message, /No relay manifest found for branch 'feature-x' \+ pr '41'/);
+      assert.match(error.message, new RegExp(staleRunId));
+      assert.match(error.message, /state=merged, pr=40/);
+      assert.match(error.message, /Only terminal branch matches exist/);
+      assert.match(error.message, /Create a fresh dispatch for this branch before retrying/);
+      return true;
+    }
+  );
+
+  assertExplicitSelectorsResolve(repoRoot, stalePath, staleRunId, STATES.MERGED);
+});
+
+test("resolveManifestRecord keeps merged and closed manifests reachable via explicit selectors", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-terminal-explicit-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const mergedRunId = createRunId({
+    branch: "feature-merged",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  const mergedPath = writeManifestRecord(repoRoot, {
+    runId: mergedRunId,
+    branch: "feature-merged",
+    state: STATES.MERGED,
+    prNumber: EXACT_PR_COLLISION_PR,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+  const closedRunId = createRunId({
+    branch: "feature-closed",
+    timestamp: new Date("2026-04-03T00:10:00.000Z"),
+  });
+  const closedPath = writeManifestRecord(repoRoot, {
+    runId: closedRunId,
+    branch: "feature-closed",
+    state: STATES.CLOSED,
+    prNumber: EXACT_PR_COLLISION_PR + 2,
+    updatedAt: "2026-04-03T00:10:00.000Z",
+  });
+
+  assertExplicitSelectorsResolve(repoRoot, mergedPath, mergedRunId, STATES.MERGED);
+  assertExplicitSelectorsResolve(repoRoot, closedPath, closedRunId, STATES.CLOSED);
+});
+
+test("resolveManifestRecord exercises the #170 stale-terminal recovery flow end-to-end", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-terminal-e2e-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const staleRunId = createRunId({
+    branch: "feature-z",
+    timestamp: new Date("2026-04-03T00:00:00.000Z"),
+  });
+  writeManifestRecord(repoRoot, {
+    runId: staleRunId,
+    branch: "feature-z",
+    state: STATES.MERGED,
+    prNumber: 42,
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  // Anti-theater: pre-#170, relay-resolver.js:185 silently returned this merged manifest, so the
+  // operator never hit the fresh-dispatch recovery path. #170 closes the fourth rung in the
+  // #149 -> #165 -> #168 -> #170 ladder; per memory/feedback_rubric_fail_closed.md's
+  // end-to-end-recovery meta-rule, assert the stale terminal is rejected, close-run cannot help,
+  // and a fresh dispatched run resolves cleanly on the same branch.
+  assert.throws(
+    () => resolveManifestRecord({ repoRoot, branch: "feature-z", prNumber: 42 }),
+    (error) => {
+      assert.match(error.message, /Only terminal branch matches exist/);
+      assert.match(error.message, /Create a fresh dispatch for this branch before retrying/);
+      assert.match(error.message, new RegExp(staleRunId));
+      assert.doesNotMatch(error.message, /Close the stale .* run/);
+      return true;
+    }
+  );
+
+  assert.throws(
+    () => validateTransition(STATES.MERGED, STATES.CLOSED),
+    /Invalid relay state transition: merged -> closed/
+  );
+  assert.throws(
+    () => validateTransition(STATES.CLOSED, STATES.CLOSED),
+    /Invalid relay state transition: closed -> closed/
+  );
+
+  const freshRunId = createRunId({
+    branch: "feature-z",
+    timestamp: new Date("2026-04-03T00:15:00.000Z"),
+  });
+  const freshPath = writeManifestRecord(repoRoot, {
+    runId: freshRunId,
+    branch: "feature-z",
+    state: STATES.DISPATCHED,
+    updatedAt: "2026-04-03T00:15:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "feature-z", prNumber: 42 });
+  assert.equal(match.manifestPath, freshPath);
+  assert.equal(match.data.run_id, freshRunId);
+  assert.equal(match.data.state, STATES.DISPATCHED);
+  assert.equal(match.data.git.pr_number, null);
 });
 
 test("resolveManifestRecord rejects ambiguous non-terminal branch matches and recovers with explicit selectors", () => {

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -282,51 +282,151 @@ test("resolveManifestRecord covers the stored-pr terminal exact-PR collision mat
     {
       label: "merged + matching stored pr + no fresh dispatch",
       terminalState: STATES.MERGED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: null,
       freshPrNumber: null,
-      expected: "terminal-only-rejection",
+      expected: { type: "terminal-only-rejection" },
       // Anti-theater: pre-#170, relay-resolver.js:185 (`matches = filterByPr(branchMatches, 40);`)
       // returned the merged manifest because branchMatches was terminal-inclusive.
     },
     {
       label: "merged + matching stored pr + fresh dispatched + pr unset",
       terminalState: STATES.MERGED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.DISPATCHED,
       freshPrNumber: undefined,
-      expected: "fresh-dispatched-null-pr",
+      expected: {
+        type: "match",
+        state: STATES.DISPATCHED,
+        prNumber: null,
+      },
       // Anti-theater: pre-#170, relay-resolver.js:185 returned the merged manifest before the
       // dispatched+null branch fallback could recover the fresh run.
     },
     {
       label: "merged + matching stored pr + fresh dispatched + matching pr",
       terminalState: STATES.MERGED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.DISPATCHED,
       freshPrNumber: EXACT_PR_COLLISION_PR,
-      expected: "fresh-dispatched-matching-pr",
+      expected: {
+        type: "match",
+        state: STATES.DISPATCHED,
+        prNumber: EXACT_PR_COLLISION_PR,
+      },
       // Anti-theater: pre-#170, filterByPr(branchMatches, 40) kept both manifests and raised
       // ambiguity. The #170 call-site fix intentionally drops the terminal sibling first, so the
       // fresh dispatched manifest wins instead of surfacing ambiguity for a stale collision.
     },
     {
+      label: "merged + matching stored pr + fresh review_pending + matching pr",
+      terminalState: STATES.MERGED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.REVIEW_PENDING,
+      freshPrNumber: EXACT_PR_COLLISION_PR,
+      expected: {
+        type: "match",
+        state: STATES.REVIEW_PENDING,
+        prNumber: EXACT_PR_COLLISION_PR,
+      },
+      // The round-2 ambiguity guard must stay scoped to exact-PR misses. When the fresh
+      // review_pending manifest carries the caller PR, the non-terminal exact-PR selector
+      // still wins directly.
+    },
+    {
+      label: "merged + matching stored pr + fresh review_pending + pr unset",
+      terminalState: STATES.MERGED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.REVIEW_PENDING,
+      freshPrNumber: undefined,
+      expected: {
+        type: "ambiguity",
+        freshState: STATES.REVIEW_PENDING,
+        freshPrLabel: "unset",
+      },
+      // Anti-theater: before the round-2 fix, this exact-PR miss fell through to the stale
+      // review_pending fallback message instead of surfacing the mixed terminal/non-terminal
+      // ambiguity called out in #170.
+    },
+    {
+      label: "merged + matching stored pr + fresh dispatched + pr unset + caller pr miss",
+      terminalState: STATES.MERGED,
+      callerPrNumber: 99,
+      freshState: STATES.DISPATCHED,
+      freshPrNumber: undefined,
+      expected: {
+        type: "match",
+        state: STATES.DISPATCHED,
+        prNumber: null,
+      },
+      // Preserve the #168 whitelist fallback: when exact-PR matching misses entirely,
+      // dispatched+null must still rebind to the fresh run.
+    },
+    {
       label: "closed + matching stored pr + no fresh dispatch",
       terminalState: STATES.CLOSED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: null,
       freshPrNumber: null,
-      expected: "terminal-only-rejection",
+      expected: { type: "terminal-only-rejection" },
       // Anti-theater: pre-#170, relay-resolver.js:185 returned the closed manifest because
       // branchMatches still included terminal records on the exact-PR selector path.
     },
     {
       label: "closed + matching stored pr + fresh dispatched + pr unset",
       terminalState: STATES.CLOSED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.DISPATCHED,
       freshPrNumber: undefined,
-      expected: "fresh-dispatched-null-pr",
+      expected: {
+        type: "match",
+        state: STATES.DISPATCHED,
+        prNumber: null,
+      },
       // Anti-theater: pre-#170, relay-resolver.js:185 returned the stale closed manifest before
       // the dispatched+null fallback could rebind resolution to the fresh run.
     },
     {
       label: "closed + matching stored pr + fresh dispatched + matching pr",
       terminalState: STATES.CLOSED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.DISPATCHED,
       freshPrNumber: EXACT_PR_COLLISION_PR,
-      expected: "fresh-dispatched-matching-pr",
+      expected: {
+        type: "match",
+        state: STATES.DISPATCHED,
+        prNumber: EXACT_PR_COLLISION_PR,
+      },
       // Anti-theater: pre-#170, filterByPr(branchMatches, 40) surfaced both manifests and stopped
       // in ambiguity. Post-#170, terminal siblings are excluded before exact-PR matching.
+    },
+    {
+      label: "closed + matching stored pr + fresh review_pending + matching pr",
+      terminalState: STATES.CLOSED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.REVIEW_PENDING,
+      freshPrNumber: EXACT_PR_COLLISION_PR,
+      expected: {
+        type: "match",
+        state: STATES.REVIEW_PENDING,
+        prNumber: EXACT_PR_COLLISION_PR,
+      },
+      // The fresh review_pending manifest remains authoritative when it carries the caller PR,
+      // even with a stale closed sibling on the same branch.
+    },
+    {
+      label: "closed + matching stored pr + fresh review_pending + pr unset",
+      terminalState: STATES.CLOSED,
+      callerPrNumber: EXACT_PR_COLLISION_PR,
+      freshState: STATES.REVIEW_PENDING,
+      freshPrNumber: undefined,
+      expected: {
+        type: "ambiguity",
+        freshState: STATES.REVIEW_PENDING,
+        freshPrLabel: "unset",
+      },
+      // Anti-theater: before the round-2 fix, this closed+review_pending post-stamp miss also
+      // dropped into stale-fallback recovery instead of naming both candidates.
     },
   ];
 
@@ -347,25 +447,29 @@ test("resolveManifestRecord covers the stored-pr terminal exact-PR collision mat
       });
 
       let freshPath = null;
-      if (testCase.expected !== "terminal-only-rejection") {
-        const freshRunId = createRunId({
+      let freshRunId = null;
+      if (testCase.freshState) {
+        freshRunId = createRunId({
           branch: "feature-x",
           timestamp: new Date("2026-04-03T00:15:00.000Z"),
         });
         freshPath = writeManifestRecord(repoRoot, {
           runId: freshRunId,
           branch: "feature-x",
-          state: STATES.DISPATCHED,
+          state: testCase.freshState,
           ...(testCase.freshPrNumber === undefined ? {} : { prNumber: testCase.freshPrNumber }),
           updatedAt: "2026-04-03T00:15:00.000Z",
         });
       }
 
-      if (testCase.expected === "terminal-only-rejection") {
+      if (testCase.expected.type === "terminal-only-rejection") {
         assert.throws(
-          () => resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: EXACT_PR_COLLISION_PR }),
+          () => resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: testCase.callerPrNumber }),
           (error) => {
-            assert.match(error.message, /No relay manifest found for branch 'feature-x' \+ pr '40'/);
+            assert.match(
+              error.message,
+              new RegExp(`No relay manifest found for branch 'feature-x' \\+ pr '${testCase.callerPrNumber}'`)
+            );
             assert.match(error.message, new RegExp(staleRunId));
             assert.match(error.message, /Only terminal branch matches exist/);
             assert.match(error.message, /Create a fresh dispatch for this branch before retrying/);
@@ -375,13 +479,34 @@ test("resolveManifestRecord covers the stored-pr terminal exact-PR collision mat
         return;
       }
 
-      const match = resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: EXACT_PR_COLLISION_PR });
+      if (testCase.expected.type === "ambiguity") {
+        assert.throws(
+          () => resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: testCase.callerPrNumber }),
+          (error) => {
+            assert.match(error.message, /Ambiguous relay manifest/);
+            assert.match(error.message, /2 candidates/);
+            assert.match(error.message, new RegExp(staleRunId));
+            assert.match(
+              error.message,
+              new RegExp(`state=${escapeRegExp(testCase.terminalState)}, pr=${EXACT_PR_COLLISION_PR}`)
+            );
+            assert.match(error.message, new RegExp(freshRunId));
+            assert.match(
+              error.message,
+              new RegExp(
+                `state=${escapeRegExp(testCase.expected.freshState)}, pr=${testCase.expected.freshPrLabel}`
+              )
+            );
+            return true;
+          }
+        );
+        return;
+      }
+
+      const match = resolveManifestRecord({ repoRoot, branch: "feature-x", prNumber: testCase.callerPrNumber });
       assert.equal(match.manifestPath, freshPath);
-      assert.equal(match.data.state, STATES.DISPATCHED);
-      assert.equal(
-        match.data.git.pr_number,
-        testCase.expected === "fresh-dispatched-matching-pr" ? EXACT_PR_COLLISION_PR : null
-      );
+      assert.equal(match.data.state, testCase.expected.state);
+      assert.equal(match.data.git.pr_number, testCase.expected.prNumber);
     });
   }
 });


### PR DESCRIPTION
## Summary
This keeps the fix on the recommended call-site path instead of widening `filterByPr`'s API: `resolveManifestRecord()` now composes exact-PR matching with `nonTerminalBranchMatches`, while preserving `branchMatches` for candidate/error reporting. I also added the file-level selector audit table plus top-of-function state-awareness comments so the next selector change has to enumerate sibling composition points up front. Closes #170.

## Selector audit table
| Selector | Current state-awareness | Closed by |
| --- | --- | --- |
| `filterByBranch` | `excludeTerminal` opt-in for stale-inheritance-sensitive paths | #149 |
| `filterByPr` | state-aware by composition with `nonTerminalBranchMatches` at the branch+PR call site | #170 |
| `filterByBranchPrFallback` | whitelist: `dispatched + pr_number:null` only | #168 |
| `findManifestByRunId` | state-blind by design so explicit recovery stays reachable | n/a |

## Stored-pr-collision matrix
| Terminal state | Stored PR matches caller | Fresh non-terminal sibling | Verdict |
| --- | --- | --- | --- |
| `merged` | yes | none | reject with `Only terminal branch matches exist` and `Create a fresh dispatch...` |
| `merged` | yes | `dispatched` with `pr_number:null` | resolve the fresh `dispatched` run |
| `merged` | yes | `dispatched` with matching `pr_number` | resolve the fresh `dispatched` run; terminal sibling is intentionally dropped before ambiguity |
| `closed` | yes | none | reject with `Only terminal branch matches exist` and `Create a fresh dispatch...` |
| `closed` | yes | `dispatched` with `pr_number:null` | resolve the fresh `dispatched` run |
| `closed` | yes | `dispatched` with matching `pr_number` | resolve the fresh `dispatched` run; terminal sibling is intentionally dropped before ambiguity |

Controls outside the 6-cell matrix stay covered too: terminal stored-PR mismatches remain explicit-only, merged/closed manifests still resolve via `--run-id` and `--manifest`, and the pre-existing `dispatched + pr_number:null` fallback test remains untouched.

## Consumer audit
| Consumer | Selector shape | Delta |
| --- | --- | --- |
| `dispatch.js:444` | resume via `--run-id` / `--manifest` | no behavior change; explicit selectors stay state-blind |
| `close-run.js:72` | explicit `--run-id` | no behavior change; terminal runs still resolve explicitly and are then rejected by `close-run` itself |
| `update-manifest-state.js:120` | explicit `--run-id` / branch-only without `--pr` | no behavior change; exact-PR narrowing is not exercised here |
| `gate-check.js:86` | PR-mode branch+PR resolution | tightened fail-closed behavior: stale terminal manifests with stamped PRs are dropped before resolution, so `pr_number_stamped` can no longer stamp a stale terminal manifest |
| `finalize-run.js:223,232` | initial resolution plus repo-root re-resolution | explicit selectors are unchanged; branch+PR resolution now fail-closes stale terminal exact-PR reuse instead of binding merge finalization to it |
| `review-runner.js:1037` | branch+PR review context | stale terminal exact-PR reuse now rejects with fresh-dispatch recovery instead of selecting or ambiguating a stale terminal candidate |

## End-to-end recovery flow
`resolveManifestRecord exercises the #170 stale-terminal recovery flow end-to-end` covers the operator path this issue actually wants: a stale terminal manifest with a matching stored PR is rejected, `validateTransition` proves `close-run` cannot revive `merged -> closed` or `closed -> closed`, then a fresh `dispatched` run on the same branch resolves cleanly. The error message intentionally points at creating a fresh dispatch, not at `close-run`, because the stale manifest is already terminal.

## Out-of-scope
- Deferred to #171: run_id leak in the recovery message.
- Deferred to #172: bogus-state recovery dead-end.
- Deferred to #166: concurrent stamping.
- Deferred to #163: recovery dead path lineage.
- Deferred to #160 and #161: `paths.repo_root` trust root / symlink issues.
- Deferred to #158: run_id collision.
- Deferred to #151: grandfather redesign.
- Deferred to #150: skip-path audit.
- Deferred to #152: repo-slug work.
- Deferred to #153: test fixture cleanup.

## Meta-rule lineage
This change applies the selector-composition and end-to-end-recovery rules captured in `memory/feedback_rubric_fail_closed.md`. It closes the next rung in the stale-branch-inheritance ladder surfaced after PR #169 (`c8ebb01`): #149 -> #165 -> #168 -> #170.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* PR 번호가 일치하는 만료된 레코드가 잘못 선택되는 문제를 수정했습니다. 이제 PR 번호 매칭이 활성 브랜치만 대상으로 수행되므로 시스템이 올바른 매니페스트를 선택합니다.

## 테스트
* PR 번호 충돌과 만료된 레코드 복구 시나리오에 대한 테스트 범위를 확대했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->