### PR TITLE
relay-plan: consume probe quality signals in rubric design (closes #140)

### DIFF
--- a/docs/issue-140-probe-signal-consumer.md
+++ b/docs/issue-140-probe-signal-consumer.md
@@ -1,0 +1,192 @@
+# Issue 140 Probe Signal Consumer
+
+## Summary
+
+#140 closes Phase 0.3 of `/Users/sjlee/workspace/active/harness-stack/dev-relay/docs/agentic-patterns-adoption.md` by making [`skills/relay-plan/SKILL.md`](../skills/relay-plan/SKILL.md) consume `probe-executor-env.js --project-only --json` before rubric design, surface detected quality signals inside the Rubric Quality Card, and document named empty/fallback handling without changing rubric grading or dispatch behavior. Data exposure only per AC4. This PR closes Phase 0 ("Wire What Exists") — after merge, all three Phase 0 issues (`#148/#139/#140`) have landed.
+
+## Pattern-Break Rationale
+
+This PR is the Phase 0.3 planner consumer. It is not another rung in the `#149 -> #177` resolver-hardening ladder and it is not a sibling-axis follow-up to a prior fail-closed bypass.
+
+The post-merge challenge scope here is narrowed to #140's own invariants:
+
+1. Consumption reachability: `relay-plan/SKILL.md` reads `probe-executor-env.js . --project-only --json` before rubric design.
+2. Fallback reachability: no-signal, surfaced-cause fallback, and generic non-zero failure are all distinguishable.
+3. Scope containment: probe-signal consumption stays inside `relay-plan`.
+4. AC4 data-exposure-only discipline: probe signals inform prerequisites/examples only; they do not change rubric structure, grading, dispatch eligibility, or autonomy scoring.
+
+No sibling-axis probes from the resolver ladder apply. The review-bundle visibility gap is the same as #139: relay-review does not read the PR body, so the evidence for #140 lives in this tracked mirror.
+
+## Rules Applied
+
+Rules 3, 6, and 7 are directly load-bearing on this PR. Rules 1 and 4 are indirectly load-bearing through AC4's data-exposure-only guard. Rules 2 and 5 were consulted to keep the consumer bounded to the current probe contract and adjacent-path audit.
+
+| Rule | Summary form | Application in #140 |
+| --- | --- | --- |
+| 1. Enforcement-layer tagging | Separate visible guidance from enforcement/gating. | Indirectly load-bearing: `probe_signal.*` is exposed in planner guidance only and explicitly does not gate dispatch, alter state transitions, or modify rubric structure. |
+| 2. Trust-root companion factors | When a value is a trust root, keep its companion assumptions explicit. | Consulted: the consumer reads only the documented `project_tools.*` probe output and adds the `project_tools.ci` sibling additively instead of inventing alternate sources. |
+| 3. Sibling-field enumeration + end-to-end recovery-test extension | Enumerate sibling inputs and test the full documented recovery path. | Directly load-bearing: the consumer enumerates `project_tools.frameworks`, `project_tools.scripts`, and `project_tools.ci`, and the regression tests cover empty data, surfaced-cause fallback, and generic non-zero failure. |
+| 4. State-machine-axis whitelist | Treat stateful enforcement as a whitelist, not a silent catch-all. | Indirectly load-bearing: probe signals stay off the state-machine axis entirely, which is the AC4 safety boundary for this PR. |
+| 5. Selector-composition axis enumeration | Audit adjacent selectors/consumers that feed the same outcome. | Consulted: the audit delta explicitly checks adjacent planner/dispatch/review/merge paths and keeps new consumption isolated to `relay-plan`. |
+| 6. Call-site extension meta-rule | Audit every call site of the affected behavior, not just the one that surfaced the gap. | Directly load-bearing: the probe is consumed at both planner call sites that matter here, the pre-rubric read step and the Rubric Quality Card rendering contract. |
+| 7. Fail-closed state-validation meta-rule | Error paths must validate and name the failure cause rather than fail open. | Directly load-bearing: probe failure renders `Probe signals unavailable: <cause>. Proceeding without probe signal.` with the surfaced cause preserved. |
+
+## Consumer Audit Delta
+
+| Path | Status | Delta under #140 |
+| --- | --- | --- |
+| `skills/relay-plan/SKILL.md` | **MODIFIED** | Adds `### 1.6 Read probe quality signals` at lines 52-78 and adds the `Probe signal` subsection inside the Quality Card examples at lines 195-269. |
+| `skills/relay-plan/scripts/probe-executor-env-consumer.js` | **ADDED** | Planner-side consumer helper that reads the project-only probe, derives the five `probe_signal.*` fields, and renders the named fallback contract without blocking dispatch. |
+| `skills/relay-plan/scripts/probe-executor-env-consumer.test.js` | **ADDED** | Three separate regression tests covering no-signal, surfaced-cause fallback, and generic non-zero failure. |
+| `skills/relay-plan/scripts/probe-executor-env.js` | **MODIFIED** | Adds additive `project_tools.ci` detection from `.github/workflows/*.yml|*.yaml`; existing `scripts` / `frameworks` producer fields stay unchanged. |
+| `skills/relay-plan/scripts/probe-executor-env.test.js` | **MODIFIED** | Adds CI workflow detection coverage and updates empty-shape expectations to include `ci: []`. |
+| `skills/relay-dispatch/SKILL.md` | **UNCHANGED** | No new probe consumer logic added. The required cross-skill grep for `probe-executor-env` is empty. |
+| `skills/relay-review/scripts/review-runner.js` | **UNCHANGED** | Review still does not consume probe signals; the evidence lives in this mirror doc. |
+| `skills/relay-merge/scripts/finalize-run.js` | **UNCHANGED** | Merge flow remains independent of probe-signal consumption. |
+
+## Probe-Extension Choice
+
+Path X was taken. `skills/relay-plan/scripts/probe-executor-env.js` now scans `.github/workflows/*.yml` and `.github/workflows/*.yaml` into `project_tools.ci`, which lets the Quality Card render the literal AC2 example shape (`probe_signal.ci: GitHub Actions (...)`) without deferring a repo-local signal that was already cheap to expose. The change is additive only: `project_tools.scripts` and `project_tools.frameworks` are unchanged, and the planner consumer still treats every detected signal as informational only.
+
+## Deferred-Issue Inventory
+
+- `#176` - deferred; tracked in `#176`.
+- `#166` - deferred; tracked in `#166`.
+- `#163` - deferred; tracked in `#163`.
+- `#160` - deferred; tracked in `#160`.
+- `#161` - deferred; tracked in `#161`.
+- `#158` - deferred; tracked in `#158`.
+- `#151` - deferred; tracked in `#151`.
+- `#150` - deferred; tracked in `#150`.
+- `#152` - deferred; tracked in `#152`.
+- `#153` - deferred; tracked in `#153`.
+
+## Self-Review Grep
+
+```text
+$ grep -n "probe-executor-env" skills/relay-plan/SKILL.md
+57:node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
+199:The `Probe signal` lines below are rendered from `probe-executor-env.js --project-only --json` and stay informational only.
+
+$ grep -n "probe_signal\." skills/relay-plan/SKILL.md
+60:**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+66:| `probe_signal.test_infra` | `project_tools.frameworks` filtered to test runners (`jest`, `vitest`, `mocha`, `playwright`, `@playwright/test`, `cypress`, `pytest`) | Use the detected runner to inform a prerequisite or automated factor when it fits the task; the signal informs the choice, it does not require one |
+67:| `probe_signal.lint_format` | `project_tools.frameworks` filtered to linters/formatters (`eslint`, `prettier`, `ruff`, `black`, `isort`, `pylint`) | Reuse the detected hygiene tool in prerequisites when that keeps the rubric grounded to repo-native checks |
+68:| `probe_signal.type_check` | `project_tools.frameworks` filtered to type checkers (`typescript`, `mypy`) plus `project_tools.scripts` commands containing `tsc --noEmit` or `mypy` | Prefer an existing type-check command such as `tsc --noEmit` or `mypy --strict` when it matches the task and repo conventions |
+69:| `probe_signal.ci` | `project_tools.ci` from `.github/workflows/*.yml` and `.github/workflows/*.yaml` | Reference detected CI workflows in the dispatch prompt's Available Tools context when that helps explain what automation already exists |
+70:| `probe_signal.scripts` | `project_tools.scripts` (top 5 by name order) | Pick an existing script as the prerequisite command rather than inventing a new one when the repo already exposes the right check |
+72:Optional additional fields such as `probe_signal.bundlers`, `probe_signal.a11y`, `probe_signal.bundle_size`, or `probe_signal.security` may be surfaced when present. Omit them when absent; the baseline five fields above stay fixed.
+76:| No signals detected | `Probe signal: no quality infra detected.` Render each `probe_signal.*` field as `no quality infra detected`. This is acceptable, not an error. |
+217:probe_signal.test_infra: jest
+218:probe_signal.lint_format: eslint, prettier
+219:probe_signal.type_check: typescript, tsc --noEmit
+220:probe_signal.ci: GitHub Actions (ci.yml)
+221:probe_signal.scripts: npm run lint, npm run test, npm run typecheck
+240:probe_signal.test_infra: no quality infra detected
+241:probe_signal.lint_format: no quality infra detected
+242:probe_signal.type_check: no quality infra detected
+243:probe_signal.ci: no quality infra detected
+244:probe_signal.scripts: no quality infra detected
+263:probe_signal.test_infra: no quality infra detected
+264:probe_signal.lint_format: no quality infra detected
+265:probe_signal.type_check: no quality infra detected
+266:probe_signal.ci: no quality infra detected
+267:probe_signal.scripts: no quality infra detected
+
+$ grep -n "does not gate dispatch" skills/relay-plan/SKILL.md
+34:**Informational only:** the `historical_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use this `reliability-report.js` input to tighten factor wording, calibration examples, and review guidance; the existing rubric structure, grading logic, and dispatch eligibility are unchanged.
+60:**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+
+$ grep -n "does not alter state transitions" skills/relay-plan/SKILL.md
+34:**Informational only:** the `historical_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use this `reliability-report.js` input to tighten factor wording, calibration examples, and review guidance; the existing rubric structure, grading logic, and dispatch eligibility are unchanged.
+60:**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+
+$ grep -n "does not modify rubric structure" skills/relay-plan/SKILL.md
+34:**Informational only:** the `historical_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use this `reliability-report.js` input to tighten factor wording, calibration examples, and review guidance; the existing rubric structure, grading logic, and dispatch eligibility are unchanged.
+60:**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+
+$ grep -nE "(autonomy|auto-?calibrate)" skills/relay-plan/SKILL.md
+60:**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+
+$ grep -n "no quality infra detected" skills/relay-plan/SKILL.md
+76:| No signals detected | `Probe signal: no quality infra detected.` Render each `probe_signal.*` field as `no quality infra detected`. This is acceptable, not an error. |
+239:Probe signal: no quality infra detected.
+240:probe_signal.test_infra: no quality infra detected
+241:probe_signal.lint_format: no quality infra detected
+242:probe_signal.type_check: no quality infra detected
+243:probe_signal.ci: no quality infra detected
+244:probe_signal.scripts: no quality infra detected
+263:probe_signal.test_infra: no quality infra detected
+264:probe_signal.lint_format: no quality infra detected
+265:probe_signal.type_check: no quality infra detected
+266:probe_signal.ci: no quality infra detected
+267:probe_signal.scripts: no quality infra detected
+
+$ grep -rn "probe-executor-env" skills/relay-dispatch/SKILL.md skills/relay-review/SKILL.md skills/relay-merge/SKILL.md skills/relay-intake/SKILL.md skills/relay/SKILL.md
+
+$ grep -n "Rubric Quality Card" skills/relay-plan/SKILL.md
+195:### Rubric Quality Card
+```
+
+## Rendered Examples
+
+The Quality Card examples below use the same scaffold as `relay-plan/SKILL.md`. The historical section is empty-data in both cases because neither the synthetic fixture repo nor this isolated PR worktree carries prior relay run history under `RELAY_HOME`; the probe section is the axis under test for #140.
+
+**Example A — Synthetic fixture — dev-relay itself has no scripts / frameworks / CI; this rendering demonstrates the populated form against a simulated Node.js repo.**
+
+```text
+Prerequisites count: 2
+Contract factors: 2
+Quality factors: 2
+Substantive total: 4
+Quality ratio: 50%
+Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Calibration status: skipped (S/M task)
+Risk signals: none
+Historical signal: Empty-data state — historical signal not available, proceed to rubric design.
+historical_signal.stuck_factors: no historical data available
+historical_signal.divergence_hotspots: no historical data available
+historical_signal.avg_rounds: no historical data available
+Probe signal:
+probe_signal.test_infra: jest
+probe_signal.lint_format: eslint, prettier
+probe_signal.type_check: typescript, tsc --noEmit
+probe_signal.ci: GitHub Actions (ci.yml)
+probe_signal.scripts: npm run lint, npm run test, npm run typecheck
+Grade: A
+Action: dispatch allowed
+```
+
+**Example B — Live no-signals render from `node skills/relay-plan/scripts/probe-executor-env.js . --project-only --json` on the PR branch.**
+
+```text
+Prerequisites count: 2
+Contract factors: 2
+Quality factors: 2
+Substantive total: 4
+Quality ratio: 50%
+Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Calibration status: skipped (S/M task)
+Risk signals: none
+Historical signal: Empty-data state — historical signal not available, proceed to rubric design.
+historical_signal.stuck_factors: no historical data available
+historical_signal.divergence_hotspots: no historical data available
+historical_signal.avg_rounds: no historical data available
+Probe signal: no quality infra detected.
+probe_signal.test_infra: no quality infra detected
+probe_signal.lint_format: no quality infra detected
+probe_signal.type_check: no quality infra detected
+probe_signal.ci: no quality infra detected
+probe_signal.scripts: no quality infra detected
+Grade: A
+Action: dispatch allowed
+```
+
+## Phase 0 Completion Framing
+
+Phase 0 ("Wire What Exists") is complete after #140 merges. No Phase 0 residual consumer work remains. Phase 1 (TDD mode, rejection log) is tracked under a separate milestone and is NOT a Phase 0 follow-up.
+
+## Cross-Links
+
+- Phase 0.3 design source: `/Users/sjlee/workspace/active/harness-stack/dev-relay/docs/agentic-patterns-adoption.md:79-86`.
+- Sprint progress anchor: `/Users/sjlee/workspace/active/harness-stack/dev-relay/backlog/sprints/2026-04-agentic-patterns-phase-0.md:37`.

--- a/docs/issue-140-probe-signal-consumer.md
+++ b/docs/issue-140-probe-signal-consumer.md
@@ -44,9 +44,24 @@ Rules 3, 6, and 7 are directly load-bearing on this PR. Rules 1 and 4 are indire
 | `skills/relay-review/scripts/review-runner.js` | **UNCHANGED** | Review still does not consume probe signals; the evidence lives in this mirror doc. |
 | `skills/relay-merge/scripts/finalize-run.js` | **UNCHANGED** | Merge flow remains independent of probe-signal consumption. |
 
+Additional adjacent-path rows required by factor 4:
+
+| Consumer | Selector usage | Delta under #140 | Re-tested or deferred |
+| --- | --- | --- | --- |
+| `skills/relay-plan/scripts/reliability-report-consumer.js` | #139 historical-signal consumer | **UNCHANGED** — independent consumer, no coupling to probe signals | Covered by #139's own tests |
+| `skills/relay-plan/scripts/reliability-report-consumer.test.js` | #139 historical-signal consumer tests | **UNCHANGED** | Covered by #139's own suite |
+| `skills/relay-intake/**` | Intake skill | **UNCHANGED** — intake does not consume probe signals under #140 | n/a |
+| `skills/relay/**` | Umbrella relay skill | **UNCHANGED** — does not consume probe signals under #140 | n/a |
+
 ## Probe-Extension Choice
 
 Path X was taken. `skills/relay-plan/scripts/probe-executor-env.js` now scans `.github/workflows/*.yml` and `.github/workflows/*.yaml` into `project_tools.ci`, which lets the Quality Card render the literal AC2 example shape (`probe_signal.ci: GitHub Actions (...)`) without deferring a repo-local signal that was already cheap to expose. The change is additive only: `project_tools.scripts` and `project_tools.frameworks` are unchanged, and the planner consumer still treats every detected signal as informational only.
+
+## Out-of-Scope / Deferred
+
+- **autonomy scoring / auto-calibration** — EXPLICITLY DEFERRED. AC4 draws the line; anything that reads as "if signal X → decision Y" belongs to Phase 2.1 / 2.2, not Phase 0.3. No follow-up issue; this is an intentional non-goal.
+- **Non-`--project-only` agent-probe path** — EXPLICITLY DEFERRED. The agent probe (codex/claude `PROBE_PROMPT`) is consumed today by dispatch infra for tool availability context; keeping it there is part of the scope guard. #140 consumes only the `--project-only` output for rubric design.
+- **anti-temptation guard** — if during implementation or review a real producer bug surfaces in `probe-executor-env.js` outside #140's scope, the executor FILES A NEW ISSUE rather than folding in. Scope creep is the iteration-4 / #174 trap; it cannot be deferred post-hoc.
 
 ## Deferred-Issue Inventory
 
@@ -127,6 +142,15 @@ $ grep -rn "probe-executor-env" skills/relay-dispatch/SKILL.md skills/relay-revi
 $ grep -n "Rubric Quality Card" skills/relay-plan/SKILL.md
 195:### Rubric Quality Card
 ```
+
+## Line-number drift discipline
+
+**Line-number drift discipline.** The Section 1.6 insertion shifts every downstream SKILL.md line number — most visibly the `Rubric Quality Card` block (previously `:167-222` on the post-#139 tree, now `:195-269` on this PR's head). Every future review round that edits `skills/relay-plan/SKILL.md` MUST regenerate the pinned references in this docs mirror as the LAST edit of the round. The #174 round 4 / #177 round 3-4 / #139 round 2 drift pattern showed that round-2 content shifts silently invalidate round-1 line numbers; treat regeneration as a round-discipline rule, not an afterthought.
+
+Regeneration steps:
+1. Re-run `grep -n "Rubric Quality Card" skills/relay-plan/SKILL.md` and update the quoted line number.
+2. Re-run every self-review grep command in the section above and replace the recorded output verbatim.
+3. Confirm every `skills/relay-plan/SKILL.md:<N>` reference in this mirror resolves to the expected content on PR head.
 
 ## Rendered Examples
 

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -49,6 +49,34 @@ If the report returns valid JSON but there are no prior runs (`manifests: 0`, `e
 | Malformed manifest or event data | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Use the first stderr line as `<cause>` and still render each `historical_signal.*` field as `no historical data available`. |
 | Any other non-zero exit (missing script, broken dependency, runtime error) | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Surface the first stderr line when present, otherwise the exit code, then continue rubric design. |
 
+### 1.6 Read probe quality signals
+
+Before designing the rubric, read the repo-local quality signals:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
+```
+
+**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+
+Focus on the current producer fields:
+
+| Probe signal field | Read from | Planning use |
+|--------------------|-----------|--------------|
+| `probe_signal.test_infra` | `project_tools.frameworks` filtered to test runners (`jest`, `vitest`, `mocha`, `playwright`, `@playwright/test`, `cypress`, `pytest`) | Use the detected runner to inform a prerequisite or automated factor when it fits the task; the signal informs the choice, it does not require one |
+| `probe_signal.lint_format` | `project_tools.frameworks` filtered to linters/formatters (`eslint`, `prettier`, `ruff`, `black`, `isort`, `pylint`) | Reuse the detected hygiene tool in prerequisites when that keeps the rubric grounded to repo-native checks |
+| `probe_signal.type_check` | `project_tools.frameworks` filtered to type checkers (`typescript`, `mypy`) plus `project_tools.scripts` commands containing `tsc --noEmit` or `mypy` | Prefer an existing type-check command such as `tsc --noEmit` or `mypy --strict` when it matches the task and repo conventions |
+| `probe_signal.ci` | `project_tools.ci` from `.github/workflows/*.yml` and `.github/workflows/*.yaml` | Reference detected CI workflows in the dispatch prompt's Available Tools context when that helps explain what automation already exists |
+| `probe_signal.scripts` | `project_tools.scripts` (top 5 by name order) | Pick an existing script as the prerequisite command rather than inventing a new one when the repo already exposes the right check |
+
+Optional additional fields such as `probe_signal.bundlers`, `probe_signal.a11y`, `probe_signal.bundle_size`, or `probe_signal.security` may be surfaced when present. Omit them when absent; the baseline five fields above stay fixed.
+
+| Case | Planner handling |
+|------|------------------|
+| No signals detected | `Probe signal: no quality infra detected.` Render each `probe_signal.*` field as `no quality infra detected`. This is acceptable, not an error. |
+| Probe failure / `agent_probe_error` present | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Use the first stderr line, the `agent_probe_error` string, or the exit code as `<cause>`, then continue rubric design. |
+| Malformed JSON on stdout | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Surface the parse error and continue rubric design. |
+
 ### 2. Build the rubric
 
 Use the guided interview (`references/rubric-design-guide.md`) to derive factors from AC, or convert directly:
@@ -168,9 +196,11 @@ Prerequisites (hygiene): as many as needed, uncounted. Factors (contract + quali
 
 Summarize the rubric before dispatch so weak calibration is visible:
 
+The `Probe signal` lines below are rendered from `probe-executor-env.js --project-only --json` and stay informational only.
+
 ```text
-Populated history example
--------------------------
+Synthetic populated signal example
+---------------------------------
 Prerequisites count: 2
 Contract factors: 2
 Quality factors: 2
@@ -183,11 +213,17 @@ Historical signal:
 historical_signal.stuck_factors: Docs (met_rate=0.5, avg_rounds_to_met=3); Coverage (met_rate=0.6667, avg_rounds_to_met=1.5)
 historical_signal.divergence_hotspots: Coverage (avg_delta=2.5, recommendation=Executor scores trend higher than review; tighten examples or add automation.); Docs (avg_delta=-2, recommendation=Reviewer scores trend higher than executor; check whether the factor is underspecified.)
 historical_signal.avg_rounds: contract.avg_rounds_to_met=1.5; quality.avg_rounds_to_met=1; metrics.median_rounds_to_ready=3
+Probe signal:
+probe_signal.test_infra: jest
+probe_signal.lint_format: eslint, prettier
+probe_signal.type_check: typescript, tsc --noEmit
+probe_signal.ci: GitHub Actions (ci.yml)
+probe_signal.scripts: npm run lint, npm run test, npm run typecheck
 Grade: A
 Action: dispatch allowed
 
-No-history example
-------------------
+No-history + no-signal example
+------------------------------
 Prerequisites count: 2
 Contract factors: 2
 Quality factors: 2
@@ -200,6 +236,12 @@ Historical signal: Empty-data state — historical signal not available, proceed
 historical_signal.stuck_factors: no historical data available
 historical_signal.divergence_hotspots: no historical data available
 historical_signal.avg_rounds: no historical data available
+Probe signal: no quality infra detected.
+probe_signal.test_infra: no quality infra detected
+probe_signal.lint_format: no quality infra detected
+probe_signal.type_check: no quality infra detected
+probe_signal.ci: no quality infra detected
+probe_signal.scripts: no quality infra detected
 Grade: A
 Action: dispatch allowed
 
@@ -217,6 +259,12 @@ Historical signal: Reliability report unavailable: Unexpected end of JSON input.
 historical_signal.stuck_factors: no historical data available
 historical_signal.divergence_hotspots: no historical data available
 historical_signal.avg_rounds: no historical data available
+Probe signal: Probe signals unavailable: probe timed out after 30s. Proceeding without probe signal.
+probe_signal.test_infra: no quality infra detected
+probe_signal.lint_format: no quality infra detected
+probe_signal.type_check: no quality infra detected
+probe_signal.ci: no quality infra detected
+probe_signal.scripts: no quality infra detected
 Grade: A
 Action: dispatch allowed
 ```

--- a/skills/relay-plan/scripts/probe-executor-env-consumer.js
+++ b/skills/relay-plan/scripts/probe-executor-env-consumer.js
@@ -1,0 +1,192 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const NO_QUALITY_INFRA_TEXT = "no quality infra detected";
+
+const TEST_RUNNERS = new Set([
+  "jest",
+  "vitest",
+  "mocha",
+  "playwright",
+  "@playwright/test",
+  "cypress",
+  "pytest",
+]);
+
+const LINT_FORMAT_TOOLS = new Set([
+  "eslint",
+  "prettier",
+  "ruff",
+  "black",
+  "isort",
+  "pylint",
+]);
+
+const TYPE_CHECK_TOOLS = new Set([
+  "typescript",
+  "mypy",
+]);
+
+function buildDefaultCommand(repoRoot) {
+  return {
+    command: process.execPath,
+    args: [
+      path.join(__dirname, "probe-executor-env.js"),
+      repoRoot,
+      "--project-only",
+      "--json",
+    ],
+  };
+}
+
+function formatFailureCause(error) {
+  const stderr = typeof error?.stderr === "string" ? error.stderr.trim() : "";
+  if (stderr) {
+    const [firstLine] = stderr.split("\n");
+    if (firstLine) {
+      return firstLine.replace(/^Error:\s*/, "").trim();
+    }
+  }
+
+  if (typeof error?.status === "number") {
+    return `exit code ${error.status}`;
+  }
+
+  if (typeof error?.message === "string" && error.message.trim()) {
+    return error.message.trim();
+  }
+
+  return "unknown failure";
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function listOrFallback(values) {
+  return values.length > 0 ? values.join(", ") : NO_QUALITY_INFRA_TEXT;
+}
+
+function normalizeFrameworkNames(frameworks) {
+  if (!Array.isArray(frameworks)) return [];
+  return frameworks
+    .map((entry) => (typeof entry?.name === "string" ? entry.name : null))
+    .filter(Boolean);
+}
+
+function normalizeScripts(scripts) {
+  if (!Array.isArray(scripts)) return [];
+  return scripts.filter((entry) => entry && typeof entry === "object");
+}
+
+function extractTypeCheckSignals(projectTools) {
+  const frameworks = normalizeFrameworkNames(projectTools?.frameworks)
+    .filter((name) => TYPE_CHECK_TOOLS.has(name));
+  const scripts = normalizeScripts(projectTools?.scripts)
+    .map((script) => {
+      const command = typeof script.command === "string" ? script.command : "";
+      const name = typeof script.name === "string" ? script.name : "";
+      if (/tsc\s+--noEmit/.test(command)) return "tsc --noEmit";
+      if (/\bmypy\b/.test(command)) return command.trim();
+      if (/\bmypy\b/.test(name)) return name.trim();
+      return null;
+    })
+    .filter(Boolean);
+
+  return listOrFallback(unique([...frameworks, ...scripts]));
+}
+
+function extractCiSignals(projectTools) {
+  const ciWorkflows = Array.isArray(projectTools?.ci)
+    ? projectTools.ci
+      .map((entry) => (typeof entry?.name === "string" ? entry.name : null))
+      .filter(Boolean)
+    : [];
+  if (ciWorkflows.length === 0) {
+    return NO_QUALITY_INFRA_TEXT;
+  }
+
+  return `GitHub Actions (${ciWorkflows.join(", ")})`;
+}
+
+function extractScriptSignals(projectTools) {
+  const scripts = normalizeScripts(projectTools?.scripts)
+    .map((script) => (typeof script.name === "string" ? script.name : null))
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, 5);
+
+  return listOrFallback(scripts);
+}
+
+function extractProbeSignals(projectTools) {
+  const frameworkNames = normalizeFrameworkNames(projectTools?.frameworks);
+
+  return {
+    test_infra: listOrFallback(unique(frameworkNames.filter((name) => TEST_RUNNERS.has(name)))),
+    lint_format: listOrFallback(unique(frameworkNames.filter((name) => LINT_FORMAT_TOOLS.has(name)))),
+    type_check: extractTypeCheckSignals(projectTools),
+    ci: extractCiSignals(projectTools),
+    scripts: extractScriptSignals(projectTools),
+  };
+}
+
+function renderProbeSignalSection(result) {
+  const lines = [];
+  if (result.status === "unavailable") {
+    lines.push(`Probe signal: Probe signals unavailable: ${result.cause}. Proceeding without probe signal.`);
+  } else if (result.empty_signal) {
+    lines.push(`Probe signal: ${NO_QUALITY_INFRA_TEXT}.`);
+  } else {
+    lines.push("Probe signal:");
+  }
+
+  lines.push(`probe_signal.test_infra: ${result.probe_signal.test_infra}`);
+  lines.push(`probe_signal.lint_format: ${result.probe_signal.lint_format}`);
+  lines.push(`probe_signal.type_check: ${result.probe_signal.type_check}`);
+  lines.push(`probe_signal.ci: ${result.probe_signal.ci}`);
+  lines.push(`probe_signal.scripts: ${result.probe_signal.scripts}`);
+  return lines;
+}
+
+function readProbeSignals(repoRoot, command = buildDefaultCommand(repoRoot)) {
+  try {
+    const stdout = execFileSync(command.command, command.args, {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const probe = JSON.parse(stdout);
+
+    if (typeof probe?.agent_probe_error === "string" && probe.agent_probe_error.trim()) {
+      return {
+        status: "unavailable",
+        cause: probe.agent_probe_error.trim(),
+        probe_signal: extractProbeSignals({}),
+      };
+    }
+
+    const probeSignal = extractProbeSignals(probe?.project_tools);
+    const emptySignal = Object.values(probeSignal).every((value) => value === NO_QUALITY_INFRA_TEXT);
+
+    return {
+      status: "available",
+      empty_signal: emptySignal,
+      probe,
+      probe_signal: probeSignal,
+    };
+  } catch (error) {
+    return {
+      status: "unavailable",
+      cause: formatFailureCause(error),
+      probe_signal: extractProbeSignals({}),
+    };
+  }
+}
+
+module.exports = {
+  NO_QUALITY_INFRA_TEXT,
+  buildDefaultCommand,
+  readProbeSignals,
+  renderProbeSignalSection,
+};

--- a/skills/relay-plan/scripts/probe-executor-env-consumer.test.js
+++ b/skills/relay-plan/scripts/probe-executor-env-consumer.test.js
@@ -1,0 +1,97 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const {
+  NO_QUALITY_INFRA_TEXT,
+  readProbeSignals,
+  renderProbeSignalSection,
+} = require("./probe-executor-env-consumer");
+
+const PROBE_SCRIPT = path.join(__dirname, "probe-executor-env.js");
+
+function runProbeScript(repoRoot) {
+  return spawnSync(process.execPath, [PROBE_SCRIPT, repoRoot, "--project-only", "--json"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+}
+
+test("consumer renders the no-signals state as an acceptable empty-quality card section", () => {
+  // Failure-mode axis A: empty probe data is not an error fallback.
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-no-signal-"));
+
+  const result = runProbeScript(repoRoot);
+  assert.equal(result.status, 0, result.stderr);
+
+  const probe = JSON.parse(result.stdout);
+  assert.deepEqual(probe.project_tools, {
+    scripts: [],
+    frameworks: [],
+    ci: [],
+  });
+
+  const probeSignal = readProbeSignals(repoRoot);
+  assert.equal(probeSignal.status, "available");
+  assert.equal(probeSignal.empty_signal, true);
+
+  const rendered = renderProbeSignalSection(probeSignal).join("\n");
+  assert.match(rendered, /Probe signal: no quality infra detected\./);
+  assert.match(rendered, new RegExp(`probe_signal\\.test_infra: ${NO_QUALITY_INFRA_TEXT}`));
+  assert.match(rendered, new RegExp(`probe_signal\\.lint_format: ${NO_QUALITY_INFRA_TEXT}`));
+  assert.match(rendered, new RegExp(`probe_signal\\.type_check: ${NO_QUALITY_INFRA_TEXT}`));
+  assert.match(rendered, new RegExp(`probe_signal\\.ci: ${NO_QUALITY_INFRA_TEXT}`));
+  assert.match(rendered, new RegExp(`probe_signal\\.scripts: ${NO_QUALITY_INFRA_TEXT}`));
+  assert.doesNotMatch(rendered, /Probe signals unavailable:/);
+});
+
+test("consumer surfaces the agent probe error cause when a stub producer returns it", () => {
+  // Failure-mode axis B: surfaced cause from producer output must stay visible.
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-probe-error-"));
+  const probeSignal = readProbeSignals(repoRoot, {
+    command: process.execPath,
+    args: [
+      "-e",
+      [
+        "process.stdout.write(JSON.stringify({",
+        "  executor: null,",
+        `  repo: ${JSON.stringify(repoRoot)},`,
+        "  agent_tools_raw: null,",
+        "  agent_probe_error: 'probe timed out after 30s',",
+        "  project_tools: { scripts: [], frameworks: [], ci: [] }",
+        "}));",
+      ].join("\n"),
+    ],
+  });
+
+  assert.equal(probeSignal.status, "unavailable");
+  assert.equal(probeSignal.cause, "probe timed out after 30s");
+
+  const rendered = renderProbeSignalSection(probeSignal).join("\n");
+  assert.match(
+    rendered,
+    /Probe signal: Probe signals unavailable: probe timed out after 30s\. Proceeding without probe signal\./
+  );
+});
+
+test("consumer falls back cleanly on a generic non-zero command and does not block dispatch", () => {
+  // Failure-mode axis C: non-zero producer exits must stay informational only.
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-probe-failure-"));
+  const probeSignal = readProbeSignals(repoRoot, {
+    command: process.execPath,
+    args: ["-e", "process.stderr.write('script missing\\n'); process.exit(7);"],
+  });
+
+  assert.equal(probeSignal.status, "unavailable");
+  assert.equal(probeSignal.cause, "script missing");
+
+  const rendered = renderProbeSignalSection(probeSignal).join("\n");
+  assert.match(
+    rendered,
+    /Probe signal: Probe signals unavailable: script missing\. Proceeding without probe signal\./
+  );
+  assert.doesNotMatch(rendered, /dispatch blocked/i);
+});

--- a/skills/relay-plan/scripts/probe-executor-env.js
+++ b/skills/relay-plan/scripts/probe-executor-env.js
@@ -147,14 +147,30 @@ function scanPyproject(repoPath) {
   }
 }
 
+function scanCiWorkflows(repoPath) {
+  const workflowsDir = path.join(repoPath, ".github", "workflows");
+  if (!fs.existsSync(workflowsDir)) return [];
+
+  try {
+    return fs.readdirSync(workflowsDir)
+      .filter((name) => /\.ya?ml$/i.test(name))
+      .sort((left, right) => left.localeCompare(right))
+      .map((name) => ({ name, source: ".github/workflows" }));
+  } catch {
+    return [];
+  }
+}
+
 function scanProjectTools(repoPath) {
   const pkg = scanPackageJson(repoPath);
   const makeTargets = scanMakefile(repoPath);
   const pyTools = scanPyproject(repoPath);
+  const ci = scanCiWorkflows(repoPath);
 
   return {
     scripts: [...pkg.scripts, ...makeTargets],
     frameworks: [...pkg.devDeps, ...pyTools],
+    ci,
   };
 }
 
@@ -250,6 +266,11 @@ function run({ repoPath, executor, timeout, projectOnly, jsonOut }) {
     if (projectTools.scripts.length > 0) {
       console.log(`\nProject scripts:`);
       projectTools.scripts.forEach((t) => console.log(`  ${t.name} (${t.source})`));
+    }
+
+    if (projectTools.ci.length > 0) {
+      console.log(`\nCI workflows:`);
+      projectTools.ci.forEach((t) => console.log(`  ${t.name} (${t.source})`));
     }
   }
 }

--- a/skills/relay-plan/scripts/probe-executor-env.test.js
+++ b/skills/relay-plan/scripts/probe-executor-env.test.js
@@ -67,11 +67,26 @@ test("scanProjectTools extracts pyproject.toml tools", () => {
   assert.ok(result.frameworks.some((f) => f.name === "ruff"));
 });
 
+test("scanProjectTools detects GitHub Actions workflows", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-ci-"));
+  const workflowsDir = path.join(repoRoot, ".github", "workflows");
+  fs.mkdirSync(workflowsDir, { recursive: true });
+  fs.writeFileSync(path.join(workflowsDir, "ci.yml"), "name: CI\n", "utf-8");
+  fs.writeFileSync(path.join(workflowsDir, "nightly.yaml"), "name: Nightly\n", "utf-8");
+
+  const result = scanProjectTools(repoRoot);
+  assert.deepEqual(result.ci, [
+    { name: "ci.yml", source: ".github/workflows" },
+    { name: "nightly.yaml", source: ".github/workflows" },
+  ]);
+});
+
 test("scanProjectTools handles missing files gracefully", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-empty-"));
   const result = scanProjectTools(repoRoot);
   assert.deepEqual(result.scripts, []);
   assert.deepEqual(result.frameworks, []);
+  assert.deepEqual(result.ci, []);
 });
 
 test("scanProjectTools handles malformed package.json gracefully", () => {
@@ -80,6 +95,7 @@ test("scanProjectTools handles malformed package.json gracefully", () => {
   const result = scanProjectTools(repoRoot);
   assert.deepEqual(result.scripts, []);
   assert.deepEqual(result.frameworks, []);
+  assert.deepEqual(result.ci, []);
 });
 
 test("scanProjectTools merges results from package.json + Makefile + pyproject.toml", () => {
@@ -96,6 +112,7 @@ test("scanProjectTools merges results from package.json + Makefile + pyproject.t
   assert.ok(result.scripts.some((s) => s.name === "make lint" && s.source === "Makefile"));
   assert.ok(result.frameworks.some((f) => f.name === "jest" && f.source === "package.json"));
   assert.ok(result.frameworks.some((f) => f.name === "pytest" && f.source === "pyproject.toml"));
+  assert.deepEqual(result.ci, []);
 });
 
 // ---------------------------------------------------------------------------
@@ -152,6 +169,7 @@ test("CLI --project-only works without executor", () => {
   assert.equal(output.executor, null);
   assert.ok(output.project_tools.scripts.some((s) => s.name === "npm run test"));
   assert.ok(output.project_tools.frameworks.some((f) => f.name === "jest"));
+  assert.deepEqual(output.project_tools.ci, []);
 });
 
 test("CLI requires --executor when not --project-only", () => {


### PR DESCRIPTION
## Summary

Closes #140 (Phase 0.3 of `docs/agentic-patterns-adoption.md`). Makes `skills/relay-plan/SKILL.md` read `probe-executor-env.js --project-only --json` before designing a rubric and surfaces detected quality signals in the Rubric Quality Card via `probe_signal.test_infra` / `probe_signal.lint_format` / `probe_signal.type_check` / `probe_signal.ci` / `probe_signal.scripts`. Data exposure only per AC4 — no autonomy scoring, no auto-calibration, no dispatch gating.

**Phase 0 completion:** after this PR merges, all three "Wire What Exists" issues (#148 rubric persistence + #139 reliability-report consumption + #140 probe consumption) have landed.

## Probe-extension path

**Path X chosen** — extended `skills/relay-plan/scripts/probe-executor-env.js` with an additive `scanCiWorkflows(repoPath)` helper and a new `project_tools.ci` field. Existing `project_tools.scripts` and `project_tools.frameworks` shapes are unchanged (backward-compatible). One new test added to `probe-executor-env.test.js` covering CI detection on a fixture repo.

## AC Checklist

- [x] AC1 — `relay-plan` SKILL.md: probe output includes quality signals section (new Section 1.6, inserted between #139's Section 1.5 and "Build the rubric").
- [x] AC2 — Rubric Quality Card surfaces detected signals with AC2-style category labels (test infra, lint, CI, etc.) via `probe_signal.*` fields.
- [x] AC3 — Planner can reference signals when designing prerequisites — the new step includes an explicit planning-use column mapping each field to a concrete rubric action.
- [x] AC4 — No autonomy scoring, no auto-calibration of rubric depth — data exposure only. Three required phrases (`does not gate dispatch`, `does not alter state transitions`, `does not modify rubric structure`) appear verbatim in the new step alongside an explicit anti-autonomy denial.
- [x] AC5 — No signals → "no quality infra detected" fallback (AC5 verbatim); probe failure → cause-surfacing fallback text with no silent error swallowing.

## Rubric self-scores (5 factors, 3 contract + 2 quality, M-size)

| Tier | Factor | Target | Self-score |
|------|--------|--------|-----------|
| contract | consumption step + data-exposure-only guard (AC1 + AC4) | ≥ 8/10 | 9/10 |
| contract | Quality Card `probe_signal.*` named fields (AC2 + AC3) | ≥ 8/10 | 9/10 |
| contract | fallback reachability + failure-mode matrix (AC5, rule 3) + additive CI extension | ≥ 8/10 | 9/10 |
| quality | out-of-scope discipline + consumer audit (rules 6+7) + Phase 0.3 completion framing | ≥ 8/10 | 8/10 |
| quality | worked-example pair + **synthetic-label guard** + line-number drift guard | ≥ 8/10 | 8/10 |

Prerequisites: `node --test skills/*/scripts/*.test.js` → green (all 5 suites). `node --check skills/relay-plan/scripts/probe-executor-env.js` → exit 0.

## Score Log

| Factor | Target | Iter 1 | Status |
|--------|--------|--------|--------|
| consumption step (AC1+AC4) | ≥ 8/10 | 9 | locked |
| Quality Card fields (AC2+AC3) | ≥ 8/10 | 9 | locked |
| fallback + additive CI extension | ≥ 8/10 | 9 | locked |
| out-of-scope + Phase 0.3 framing | ≥ 8/10 | 8 | locked |
| synthetic-label + drift guard | ≥ 8/10 | 8 | locked |

## Files

- `skills/relay-plan/SKILL.md` (+56/-4): new Section 1.6 "Read probe quality signals" between Sections 1.5 and 2; `Probe signal:` subsection in the Rubric Quality Card above `Grade:` below the #139 `Historical signal:` block; three documented failure modes with cause-surfacing fallback text; explicit AC4 anti-autonomy denial.
- `skills/relay-plan/scripts/probe-executor-env.js` (+21): additive `scanCiWorkflows` helper + `project_tools.ci` field. Existing shapes unchanged.
- `skills/relay-plan/scripts/probe-executor-env.test.js` (+18): new CI-detection test on fixture with dummy workflow.
- `skills/relay-plan/scripts/probe-executor-env-consumer.js` (+192): consumer helper — parses the probe JSON, groups TOOL_PACKAGES into the five named categories, renders Quality Card subsection, produces cause-surfacing fallback text.
- `skills/relay-plan/scripts/probe-executor-env-consumer.test.js` (+97): three separate `test(...)` calls — Test A no-signals, Test B probe-failure-with-cause, Test C script-missing/non-zero — each with inline axis comment.
- `docs/issue-140-probe-signal-consumer.md` (+192, new): review-contract mirror — summary + Phase 0 completion note, pattern-break rationale, memory rules applied, consumer-audit delta table, probe-extension path choice rationale, deferred-issue inventory, self-review grep output verbatim, rendered examples (SYNTHETIC populated + LIVE no-signals), cross-links to Phase 0.3 and sprint Progress log.

## Out of scope (deferred, tracked separately)

- Autonomy scoring / auto-calibration of any kind — AC4 draws the line; belongs to Phase 2.1 / 2.2.
- Agent-probe path (non-`--project-only`) — stays with dispatch infra.
- `#176` — cleanup-worktrees.js raw `run_id` leak (MED).
- `#166 / #163 / #160 / #161 / #158 / #151 / #150 / #152 / #153` — all deferred.
- `skills/relay-plan/scripts/reliability-report-consumer.js` and its tests — #139's consumer is independent.
- `skills/relay-review/**`, `skills/relay-merge/**`, `skills/relay-intake/**` — not consumers of probe signals under #140.

## Worked examples

Rendered in `docs/issue-140-probe-signal-consumer.md`:

- **Example A (SYNTHETIC)**: simulated Node.js repo with jest + eslint + typescript + 1 GitHub Actions workflow. Explicitly labeled synthetic because dev-relay itself has no scripts/frameworks/CI.
- **Example B (LIVE)**: live probe against dev-relay on this PR's head — shows all five `probe_signal.*` fields rendering `no quality infra detected` (AC5 verbatim).

## Test plan

- [x] `node --test skills/relay-intake/scripts/*.test.js` → green
- [x] `node --test skills/relay-plan/scripts/*.test.js` → green
- [x] `node --test skills/relay-dispatch/scripts/*.test.js` → green
- [x] `node --test skills/relay-review/scripts/*.test.js` → green
- [x] `node --test skills/relay-merge/scripts/*.test.js` → green
- [x] Self-review greps run; output mirrored into `docs/issue-140-probe-signal-consumer.md`
- [x] Line-number drift guard — all pinned references regenerated from the final post-fix tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트 품질 인프라 메타데이터(테스트, 린팅, 타입 체크, CI, 스크립트)를 표시하는 프로브 신호 기능 추가
  * GitHub Actions 워크플로우 자동 감지 기능 추가

* **문서**
  * 프로브 신호 기능에 대한 상세 구현 문서 추가
  * 품질 카드 렌더링 예시 업데이트

* **테스트**
  * 프로브 신호 소비자 및 실행기에 대한 포괄적인 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->