### PR TITLE
relay-plan: document Error: prefix stripping in fallback cause rendering (closes #181)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -46,8 +46,8 @@ If the report returns valid JSON but there are no prior runs (`manifests: 0`, `e
 | Case | Planner handling |
 |------|------------------|
 | No prior runs / empty history | `Empty-data state — historical signal not available, proceed to rubric design.` Render each `historical_signal.*` field as `no historical data available`. |
-| Malformed manifest or event data | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Use the first stderr line as `<cause>` and still render each `historical_signal.*` field as `no historical data available`. |
-| Any other non-zero exit (missing script, broken dependency, runtime error) | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Surface the first stderr line when present, otherwise the exit code, then continue rubric design. |
+| Malformed manifest or event data | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Use the first stderr line (with any leading `Error:` prefix stripped) as `<cause>` and still render each `historical_signal.*` field as `no historical data available`. |
+| Any other non-zero exit (missing script, broken dependency, runtime error) | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Surface the first stderr line (with any leading `Error:` prefix stripped) when present, otherwise the exit code, then continue rubric design. |
 
 ### 1.6 Read probe quality signals
 
@@ -74,7 +74,7 @@ Optional additional fields such as `probe_signal.bundlers`, `probe_signal.a11y`,
 | Case | Planner handling |
 |------|------------------|
 | No signals detected | `Probe signal: no quality infra detected.` Render each `probe_signal.*` field as `no quality infra detected`. This is acceptable, not an error. |
-| Probe failure / `agent_probe_error` present | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Use the first stderr line, the `agent_probe_error` string, or the exit code as `<cause>`, then continue rubric design. |
+| Probe failure / `agent_probe_error` present | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Use the first stderr line (with any leading `Error:` prefix stripped), the `agent_probe_error` string, or the exit code as `<cause>`, then continue rubric design. |
 | Malformed JSON on stdout | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Surface the parse error and continue rubric design. |
 
 ### 2. Build the rubric


### PR DESCRIPTION
## Summary

Close #181 by aligning `skills/relay-plan/SKILL.md` with the actual fallback cause-rendering behavior implemented in both consumers. Docs-only fix — no code, no tests.

## Scope correction

The original #181 issue body claimed the drift was probe-consumer-specific and that `reliability-report-consumer.js` did NOT strip the `Error:` prefix. Verification against current code shows both consumers share an identical `formatFailureCause` helper that strips `Error:` — the drift is symmetrical. This PR closes the real contract drift in both SKILL.md sections.

## Changes

Three table-row edits in `skills/relay-plan/SKILL.md`:

- Line 49 — § 1.5 \"Malformed manifest or event data\" (reliability-report)
- Line 50 — § 1.5 \"Any other non-zero exit\" (reliability-report)
- Line 77 — § 1.6 \"Probe failure / agent_probe_error present\" (probe)

Each \"first stderr line\" phrase gains \"(with any leading `Error:` prefix stripped)\" so the documented fallback contract matches what `formatFailureCause` actually produces.

## Why Option B (doc-to-code), not Option A (code-to-doc)

- The stripping is reasonable UX: it avoids \"unavailable: Error: X\" double-prefix when stderr carries `Error:` and the adapter prepends \"unavailable:\".
- Option A would require editing both consumers + both test files while leaving two parallel helpers with identical logic — larger surface, no functional gain.
- Both consumer helpers are in lockstep today; a future shared helper extraction (deferred per adoption doc: \"DRY at 2 consumers is premature\") stays open.

## Out of scope (explicitly not touched)

- #176, #166, #163, #160, #161, #158, #151, #150, #152, #153
- Phase 2/3 backlog items
- `skills/relay-plan/scripts/probe-executor-env-consumer.js`
- `skills/relay-plan/scripts/reliability-report-consumer.js`
- Consumer `.test.js` files

## Test plan

- [x] \`node --test skills/*/scripts/*.test.js\` → 321/321 green (pre + post)
- [x] `git diff` shows only the three intended lines
- [x] No consumer/test file edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 오류 메시지에서 중복된 "Error:" 접두사를 제거하여 더 명확한 오류 정보 표시
  
* **문서**
  * 신뢰도 이력 및 프로브 품질 신호 처리 동작 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->