### PR TITLE
relay-dispatch: route raw run_id through safeFormatRunId in cleanup-worktrees (closes #176)

### DIFF
--- a/docs/issue-176-cleanup-worktrees-raw-runid.md
+++ b/docs/issue-176-cleanup-worktrees-raw-runid.md
@@ -1,0 +1,106 @@
+# Issue 176 Cleanup-Worktrees Raw run_id
+
+## Summary
+
+#176 closes a containment-at-side-path leak in `cleanup-worktrees.js` by reusing the `safeFormatRunId()` helper introduced by PR #175 (`#174`). The two raw `data.run_id` operator-emission sites at `skills/relay-dispatch/scripts/cleanup-worktrees.js:89` (`baseInfo.runId`) and `:98` (`baseInfo.closeCommand`) now route through the shared validator-backed formatter instead of duplicating an inline fallback. Sibling trust roots `paths.repo_root` and `paths.worktree` are explicitly deferred to `#160`.
+
+## Pattern-Break Rationale
+
+This is a containment-at-side-path fix within the already-established `#156` / `#174` / `#177` pattern, not a new ladder rung. The helper already existed, the basename fallback contract already existed, and the issue was that `cleanup-worktrees.js` had drifted from that contract on an operator-facing side path. No new meta-rule surfaces here; `memory/feedback_rubric_fail_closed.md` is not extended by this PR.
+
+## Rules Applied
+
+- Rule 1, enforcement-layer split + trust-root sibling audit: the fix stays on the render path only, while explicitly deferring sibling trust roots `paths.repo_root` / `paths.worktree` to `#160`.
+- Rule 3, recovery-path end-to-end regression: the new CLI regression exercises real JSON output and text output so the operator-facing leak is covered end-to-end.
+- Rule 6, call-site enumeration: every raw `run_id` emission site in `skills/relay-dispatch/scripts/` is enumerated below and classified as fixed, exported, or intentionally unchanged.
+- Rule 7, fail-closed discipline: the render path uses the validator-backed `safeFormatRunId()` fallback instead of re-emitting raw manifest data, while the write-side `appendRunEvent()` path remains fail-closed upstream.
+
+## Call-Site Audit Table
+
+| Site | Delta | Rationale |
+| --- | --- | --- |
+| `cleanup-worktrees.js:89` | **FIXED** | `data.run_id \|\| path.basename(...)` became `safeFormatRunId({ manifestPath, data })`, computed once as `runId` and reused. |
+| `cleanup-worktrees.js:98` | **FIXED** | `closeCommand` now uses the same `runId` variable, preserving the `JSON.stringify(...)` wrapper around `--run-id`. |
+| `cleanup-worktrees.js:136` | **UNCHANGED — fail-closed upstream** | `cleanupResult.updatedData.run_id` feeds `appendRunEvent()`; that path hits `ensureRunLayout()` -> `getRunDir()` -> `requireValidRunId()` in `relay-manifest.js`, so tampered values throw before any write-side effect. |
+| `close-run.js:98` | **UNCHANGED — resolver-validated** | `updated.run_id` descends from `resolveManifestRecord()` at `close-run.js:64`, which validates manifest `run_id` via `validateManifestRecordRunId()` before returning. |
+| `close-run.js:106` | **UNCHANGED — resolver-validated** | Same descent as `:98`; event emission stays behind resolver validation. |
+| `close-run.js:120` | **UNCHANGED — resolver-validated** | Same descent as `:98`; JSON result rendering stays behind resolver validation. |
+| `dispatch.js:454` | **UNCHANGED — resolver-validated** | `manifest.run_id` descends from `resolveManifestRecord()` at `dispatch.js:444`; resume mode inherits the resolver validation contract. |
+| `relay-resolver.js:51` (`formatRunId`) | **UNCHANGED — happy-path renderer** | Inline comment documents that raw stored `run_id` remains available only for validated happy-path rendering; error builders use `safeFormatRunId()`. |
+| `relay-resolver.js:57` (`safeFormatRunId`) | **EXPORTED** | The helper remains single-sourced and is now exported via `module.exports` at `relay-resolver.js:480-486` for `cleanup-worktrees.js` reuse. |
+| `reliability-report.js:89/93/97, 207-214, 292-301, 387/391, 441/445` | **UNCHANGED — event-journal domain** | These uses key aggregate metrics by `event.run_id` / `manifest.data.run_id`; they do not emit per-run operator recovery commands, and the write-side journal path is already validated by `ensureRunLayout()`. |
+
+`grep -nE "\\bdata\\.run_id\\b|\\bdata\\?\\.run_id\\b|\\bmanifest\\.run_id\\b|\\bupdated\\.run_id\\b|\\bupdatedData\\.run_id\\b" skills/relay-dispatch/scripts/*.js | grep -v "\\.test\\.js"` also matches non-emission validator/selector sites at `relay-manifest.js:396` and `relay-resolver.js:252,318`; those are intentionally omitted from the table because they validate or compare `run_id` rather than render it into operator-facing output.
+
+## Rendered Self-Review Grep
+
+```text
+$ grep -n "safeFormatRunId" skills/relay-dispatch/scripts/cleanup-worktrees.js
+25:const { safeFormatRunId } = require("./relay-resolver");
+87:    // safeFormatRunId falls back to the manifest basename on tampered run_id so cleanup still
+89:    const runId = safeFormatRunId({ manifestPath, data });
+
+$ grep -n "safeFormatRunId" skills/relay-dispatch/scripts/relay-resolver.js
+53:  // Error builders must use safeFormatRunId so tampered manifests cannot echo unsafe values (#171/#174).
+57:function safeFormatRunId(record) {
+70:    return `${safeFormatRunId(record)} (state=${state}, pr=${storedPr})`;
+223:  const runId = safeFormatRunId(record);
+305:    `The terminal sibling ${JSON.stringify(safeFormatRunId(terminalCandidate))} is already ${terminalState}, ` +
+307:    `The ${freshState} sibling ${JSON.stringify(safeFormatRunId(freshCandidate))} does not carry the caller PR. ` +
+486:  safeFormatRunId,
+
+$ grep -n "module.exports" skills/relay-dispatch/scripts/relay-resolver.js -A 10
+480:module.exports = {
+481-  filterByBranch,
+482-  filterByPr,
+483-  findManifestByRunId,
+484-  hasStoredPrNumber,
+485-  resolveManifestRecord,
+486-  safeFormatRunId,
+487-};
+
+$ grep -nE "data\.run_id\s*\|\|" skills/relay-dispatch/scripts/cleanup-worktrees.js
+
+$ grep -nE "\bdata\.run_id\b" skills/relay-dispatch/scripts/cleanup-worktrees.js
+
+$ grep -nE "\bdata\.run_id\b|\bdata\?\.run_id\b|\bmanifest\.run_id\b|\bupdated\.run_id\b|\bupdatedData\.run_id\b" skills/relay-dispatch/scripts/*.js | grep -v "\.test\.js"
+skills/relay-dispatch/scripts/cleanup-worktrees.js:136:      appendRunEvent(repoRoot, cleanupResult.updatedData.run_id, {
+skills/relay-dispatch/scripts/close-run.js:98:    appendRunEvent(repoRoot, updated.run_id, {
+skills/relay-dispatch/scripts/close-run.js:106:    appendRunEvent(repoRoot, updated.run_id, {
+skills/relay-dispatch/scripts/close-run.js:120:    runId: updated.run_id,
+skills/relay-dispatch/scripts/dispatch.js:454:    runId = manifest.run_id || runId;
+skills/relay-dispatch/scripts/relay-manifest.js:396:    : data?.run_id;
+skills/relay-dispatch/scripts/relay-resolver.js:54:  return record?.data?.run_id || formatManifestBasename(record);
+skills/relay-dispatch/scripts/relay-resolver.js:58:  const validation = validateRunId(record?.data?.run_id);
+skills/relay-dispatch/scripts/relay-resolver.js:252:  const validation = validateRunId(record?.data?.run_id);
+skills/relay-dispatch/scripts/relay-resolver.js:318:      data?.run_id === normalizedRunId
+skills/relay-dispatch/scripts/reliability-report.js:207:      .filter((manifest) => manifest?.data?.run_id)
+skills/relay-dispatch/scripts/reliability-report.js:208:      .map((manifest) => [manifest.data.run_id, manifest.data])
+skills/relay-dispatch/scripts/reliability-report.js:387:    reviewRuns.set(manifest.data.run_id, Number(manifest.data.review?.max_rounds || 20));
+skills/relay-dispatch/scripts/reliability-report.js:441:        .map(({ data }) => data?.run_id)
+```
+
+## Scope / Out Of Scope
+
+- `paths.repo_root` / `paths.worktree` stay out of scope and remain tracked at `#160`; they are sibling trust roots at the same manifest-schema level, but folding them into this side-path renderer fix would exceed M-size.
+- `reliability-report.js` event-journal consumption stays out of scope; it consumes validated write-side data for aggregate metrics and does not emit per-run operator command strings.
+- `relay-resolver.js` `formatRunId()` stays raw by design for validated happy-path contexts; this PR only exports and reuses `safeFormatRunId()`.
+- `relay-events.js` stays out of scope because it already validates via `ensureRunLayout()` on write.
+- Any rubric-structure change in `relay-plan/SKILL.md` stays out of scope; Phase 0 "Wire What Exists" is complete as of `#140`.
+- Phase 1 items `#141` (Rejection Log) and `#142` (TDD mode) remain deferred pending the observation window in `memory/project_phase1_observation_gate.md`.
+- `phase-0-follow-up` siblings `#166`, `#163`, `#161`, `#158`, `#153`, `#152`, `#151`, and `#150` remain tracked separately and untouched here.
+- Any newly discovered edge case that would require changing `relay-manifest.js` or expanding resolver invariants beyond exporting `safeFormatRunId()` stays out of scope for this PR and should be filed separately rather than folded in.
+
+## Prior Art
+
+- PR #159 (`#156`): added the `run_id` validator and established the single-path-segment trust-root contract.
+- PR #175 (`#174`): added `safeFormatRunId()` and routed resolver error builders through safe candidate rendering so tampered manifests do not echo unsafe `run_id` values.
+- PR #178 (`#177`): applied fail-closed state validation at resolver exclusion sites and documented the current meta-rule stack, including this issue as an explicit follow-up.
+
+## Round Discipline
+
+Any edit that shifts `cleanup-worktrees.js` line numbers, including the import that moved the leak sites from `:88/:94` to `:89/:98`, requires regenerating every pinned source reference in this mirror as the last edit of the round. This follows the same discipline called out in PR #175 round 4, PR #178 round 3, and PR #140 round 2: line-pinned docs are only trustworthy when refreshed from the final post-fix tree.
+
+## Fallback-Is-Defensive Rationale
+
+`safeFormatRunId()` falls back to the manifest filename basename on tampered `run_id` instead of throwing because `cleanup-worktrees` must continue enumerating stale manifests even when one manifest is malformed. The basename lives under the `listManifestPaths()` directory filter inside relay home, so the fallback keeps enumeration bounded to the relay-owned filesystem scope, while `JSON.stringify()` still blocks shell injection at the `closeCommand` site.

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -22,6 +22,7 @@ const {
   writeManifest,
 } = require("./relay-manifest");
 const { appendRunEvent } = require("./relay-events");
+const { safeFormatRunId } = require("./relay-resolver");
 
 const args = process.argv.slice(2);
 
@@ -83,15 +84,18 @@ function run() {
     const updatedAt = Date.parse(data.timestamps?.updated_at || data.timestamps?.created_at || 0);
     const ageHours = updatedAt ? Math.round((now - updatedAt) / (60 * 60 * 1000)) : null;
     const cleanupStatus = data.cleanup?.status || CLEANUP_STATUSES.PENDING;
+    // safeFormatRunId falls back to the manifest basename on tampered run_id so cleanup still
+    // enumerates stale runs defensively; JSON.stringify keeps the closeCommand shell-safe.
+    const runId = safeFormatRunId({ manifestPath, data });
     const baseInfo = {
       manifestPath,
-      runId: data.run_id || path.basename(manifestPath, ".md"),
+      runId,
       state: data.state,
       branch: data.git?.working_branch || null,
       worktree: data.paths?.worktree || null,
       ageHours,
       cleanupStatus,
-      closeCommand: `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} --run-id ${JSON.stringify(data.run_id || path.basename(manifestPath, ".md"))} --reason ${JSON.stringify("stale_non_terminal_run")}`,
+      closeCommand: `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} --run-id ${JSON.stringify(runId)} --reason ${JSON.stringify("stale_non_terminal_run")}`,
     };
 
     if (!all && updatedAt && updatedAt > cutoff) {

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -16,6 +16,7 @@ const {
 } = require("./relay-manifest");
 
 const SCRIPT = path.join(__dirname, "cleanup-worktrees.js");
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-janitor-"));
@@ -134,4 +135,53 @@ test("cleanup-worktrees reports stale open runs without deleting them", () => {
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.cleanup.status, "pending");
   assert.equal(manifest.next_action, "run_review");
+});
+
+test("cleanup-worktrees does not echo tampered run_id into operator output (#176)", () => {
+  // Anti-theater: without the #176 safeFormatRunId reuse at cleanup-worktrees.js:88/:94,
+  // the tampered run_id leaks into result.staleOpen[*].runId and the closeCommand --run-id.
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const { manifestPath } = writeRun(repoRoot, {
+    branch: "issue-999",
+    state: STATES.REVIEW_PENDING,
+    updatedAt,
+  });
+  const fallbackRunId = path.basename(manifestPath, ".md");
+  const { data: tamperedManifest, body } = readManifest(manifestPath);
+  tamperedManifest.run_id = "../victim-run";
+  writeManifest(manifestPath, tamperedManifest, body);
+
+  const jsonRun = spawnSync(
+    process.execPath,
+    [SCRIPT, "--repo", repoRoot, "--all", "--json"],
+    { cwd: PROJECT_ROOT, encoding: "utf-8" }
+  );
+  assert.equal(jsonRun.status, 0, jsonRun.stderr);
+
+  const result = JSON.parse(jsonRun.stdout);
+  const allEntries = [
+    ...result.cleaned,
+    ...result.failed,
+    ...result.staleOpen,
+    ...result.skipped,
+  ];
+  assert.ok(allEntries.length > 0, "fixture should produce at least one entry");
+  for (const entry of allEntries) {
+    assert.doesNotMatch(entry.runId, /\.\.\/victim-run/, "runId field must not contain tampered substring");
+    assert.equal(entry.runId, fallbackRunId, "runId field should fall back to the manifest basename");
+    if (entry.closeCommand) {
+      assert.doesNotMatch(entry.closeCommand, /\.\.\/victim-run/, "closeCommand must not contain tampered substring");
+      assert.match(entry.closeCommand, new RegExp(fallbackRunId), "closeCommand uses basename fallback");
+    }
+  }
+
+  const textRun = spawnSync(
+    process.execPath,
+    [SCRIPT, "--repo", repoRoot, "--all"],
+    { cwd: PROJECT_ROOT, encoding: "utf-8" }
+  );
+  assert.equal(textRun.status, 0, textRun.stderr);
+  assert.doesNotMatch(textRun.stdout, /\.\.\/victim-run/, "text output must not contain tampered substring");
+  assert.match(textRun.stdout, new RegExp(fallbackRunId), "text output should use the manifest basename");
 });

--- a/skills/relay-dispatch/scripts/relay-resolver.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.js
@@ -483,4 +483,5 @@ module.exports = {
   findManifestByRunId,
   hasStoredPrNumber,
   resolveManifestRecord,
+  safeFormatRunId,
 };


### PR DESCRIPTION
## Summary

Closes #176 (MED, `phase-0-follow-up`). `skills/relay-dispatch/scripts/cleanup-worktrees.js` echoed raw `data.run_id` into operator-facing output at lines 88 (`baseInfo.runId`) and 94 (`baseInfo.closeCommand`), so a tampered manifest with `run_id: "../victim-run"` leaked into JSON output, text output, and the suggested `close-run.js --run-id` shell string. `JSON.stringify` already blocked shell injection, but the containment invariant established by #156 / #174 / #177 was inconsistent at this side path.

Both emission sites now route through the single shared `safeFormatRunId({ manifestPath, data })` helper (now exported from `relay-resolver.js`). Sibling trust roots (`paths.repo_root`, `paths.worktree`) are explicitly deferred to #160.

## Acceptance Criteria

- [x] `cleanup-worktrees.js:88` (`baseInfo.runId`) routes through `safeFormatRunId(record)` — no inline ternary remains.
- [x] `cleanup-worktrees.js:94` (`baseInfo.closeCommand`) reuses the SAME `runId` variable (computed once per iteration).
- [x] `safeFormatRunId` added to `relay-resolver.js` `module.exports` (:486). No duplicate implementation anywhere.
- [x] New regression test in `cleanup-worktrees.test.js` — tampered `run_id: "../victim-run"` fixture; real-CLI invocation; asserts JSON + text channels clean; asserts basename fallback present. Fails against pre-fix code (scope comment cites pre-fix `:88/:94`).
- [x] `docs/issue-176-cleanup-worktrees-raw-runid.md` created with summary, audit table, rendered self-review grep, scope, prior art, round discipline, fallback rationale.
- [x] Full relay test suite: 322/322 pass (+1 new regression test).
- [x] Sibling trust roots (`paths.repo_root`, `paths.worktree`) explicit OUT-OF-SCOPE — tracked at #160.

## Rubric Factor Self-Scores

| Factor | Tier | Score | Notes |
|--------|------|-------|-------|
| Sanitation at source (helper reuse, no reinvention) | contract | 9/10 | Both sites route through exported `safeFormatRunId`; single `runId` variable used twice; zero inline ternaries remain. |
| Render-level output sanitation (JSON + text + closeCommand) | contract | 9/10 | All four `result.*` arrays + text lines :165/:169 + closeCommand shell string carry validated value. |
| End-to-end tampered-manifest regression test (rule 3) | contract | 9/10 | Spawned real CLI for both JSON and text modes; asserts tampered substring absent AND basename fallback present; scope comment cites pre-fix `:88/:94` and issue #176. |
| Call-site + sibling-script enumeration (rule 6) | contract | 9/10 | Audit table with 10 rows covering all raw-`run_id` emission sites across `skills/relay-dispatch/scripts/`; each UNCHANGED row cites upstream validator by file:line. |
| Trust-root sibling discipline + fail-closed fallback (rule 1 + 7) | quality | 9/10 | `paths.repo_root`/`paths.worktree` deferred to #160; non-throwing fallback documented as defensive-by-design; one-line inline comment explaining intent. |
| Docs mirror + self-review grep + line-number drift guard | quality | 9/10 | `docs/issue-176-*.md` includes every required section; rendered grep quoted verbatim from PR head (lines :89/:98 post-fix); round-discipline paragraph cites #174 rd4 / #177 rd3 / #140 rd2 pattern. |

## Score Log

| Round | Verdict | Notes |
|-------|---------|-------|
| 1 (dispatch) | self-eval PASS | All 6 factors ≥ 9/10; single iteration from executor; 1 commit; 4 files changed. |

## Out-of-scope (repeated verbatim from docs mirror)

- `#160` — `paths.repo_root` / `paths.worktree` sibling trust-root validation (deferred).
- `#166` — gate-check pr_number concurrency (next-session default after #176).
- `#163`, `#161`, `#158`, `#153`, `#152`, `#151`, `#150` — `phase-0-follow-up` deferred.
- `#141`, `#142` — Phase 1 items deferred pending 2-week observation window (tentative re-eval ~2026-04-28 per `memory/project_phase1_observation_gate.md`).
- `reliability-report.js` event-journal consumption — write-side validated at `ensureRunLayout`; read-side aggregate metrics.
- `relay-resolver.js:51` (`formatRunId`) — happy-path renderer kept raw intentionally.

## Docs mirror

See [`docs/issue-176-cleanup-worktrees-raw-runid.md`](../blob/issue-176/docs/issue-176-cleanup-worktrees-raw-runid.md) for the full audit table, rendered self-review grep output, and prior-art pointers (#156 / #174 / #177).

## Test plan

- [x] `node --test skills/relay-intake/scripts/*.test.js skills/relay-plan/scripts/*.test.js skills/relay-dispatch/scripts/*.test.js skills/relay-review/scripts/*.test.js skills/relay-merge/scripts/*.test.js` → 322/322 pass.
- [x] `node --check skills/relay-dispatch/scripts/cleanup-worktrees.js && node --check skills/relay-dispatch/scripts/relay-resolver.js` → exit 0.
- [x] New tampered-manifest regression in `cleanup-worktrees.test.js` passes.
- [x] `grep -nE "data\.run_id\s*\|\|" skills/relay-dispatch/scripts/cleanup-worktrees.js` → 0 matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)