### PR TITLE
relay-review: recover rubric fail-closed runs via changes_requested

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -176,6 +176,65 @@ test("dispatch reuses the same run and worktree on resume", () => {
   assert.match(events, /"reason":"same_run_resume:completed"/);
 });
 
+test("dispatch resumes rubric fail-closed recovery runs from changes_requested", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-163",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+  assert.equal(first.runState, STATES.REVIEW_PENDING);
+
+  const manifestPath = first.manifestPath;
+  const runId = first.runId;
+  const fixedRubricPath = path.join(repoRoot, "fixed-rubric.yaml");
+  fs.writeFileSync(fixedRubricPath, [
+    "rubric:",
+    "  factors:",
+    "    - name: recovery rubric",
+    "      target: pass",
+  ].join("\n"), "utf-8");
+
+  const record = readManifest(manifestPath);
+  const updated = {
+    ...updateManifestState(record.data, STATES.CHANGES_REQUESTED, "repair_rubric_and_redispatch"),
+    review: {
+      ...(record.data.review || {}),
+      latest_verdict: "rubric_state_failed_closed",
+      last_gate: {
+        status: "rubric_state_failed_closed",
+        layer: "review-runner",
+        rubric_state: "missing",
+        rubric_status: "missing",
+        recovery_command: `node skills/relay-dispatch/scripts/dispatch.js . --run-id ${runId} --prompt-file <task.md> --rubric-file <fixed-rubric.yaml>`,
+        recovery: "Restore or replace the missing rubric, then re-dispatch.",
+        reason: "Rubric file is missing.",
+      },
+    },
+  };
+  writeManifest(manifestPath, updated, record.body);
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", runId,
+    "--prompt", "resume rubric recovery",
+    "--rubric-file", fixedRubricPath,
+    "--json",
+  ], env));
+
+  assert.equal(second.mode, "resume");
+  assert.equal(second.runState, STATES.REVIEW_PENDING);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
+  assert.equal(manifest.review.last_gate.status, "rubric_state_failed_closed");
+});
+
 test("dispatch resume fails loudly when the retained worktree is missing", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -341,6 +341,31 @@ test("gate-check blocks merge when a later review round requests changes", () =>
   assert.match(result.json.issues, /foo\.js:1/);
 });
 
+test("gate-check preserves rubric fail-closed recovery details from a changes_requested review round", () => {
+  const result = runGateCheckDryRun([
+    "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+    [
+      "<!-- relay-review-round -->",
+      "## Relay Review Round 2",
+      "Verdict: CHANGES_REQUESTED",
+      "Summary: review-runner fail-closed on the rubric anchor.",
+      "Reviewer verdict: PASS (next_action=ready_to_merge)",
+      "Gate status: rubric_state_failed_closed",
+      "Layer: review-runner",
+      "Rubric state: missing (anchor status: missing)",
+      "Recovery command: node skills/relay-dispatch/scripts/dispatch.js . --run-id issue-163-20260412010000000 --prompt-file <task.md> --rubric-file <fixed-rubric.yaml>",
+      "Issues:",
+      "- Rubric gate failed closed: Rubric file is missing. Restore or replace the missing rubric, then run `node skills/relay-dispatch/scripts/dispatch.js . --run-id issue-163-20260412010000000 --prompt-file <task.md> --rubric-file <fixed-rubric.yaml>`.",
+    ].join("\n"),
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "changes_requested");
+  assert.equal(result.json.readyToMerge, false);
+  assert.match(result.json.issues, /Rubric gate failed closed/);
+  assert.match(result.json.issues, /dispatch\.js \. --run-id issue-163-20260412010000000/);
+});
+
 test("gate-check blocks stale LGTM comments when a newer commit exists", () => {
   const result = runGateCheckDryRun({
     comments: [

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -914,8 +914,8 @@ function toEscalatedVerdict(baseVerdict, summary) {
   };
 }
 
-function buildRubricRecoveryCommand(runId) {
-  return `node skills/relay-dispatch/scripts/dispatch.js . --run-id ${runId} --prompt-file <task.md> --rubric-file <fixed-rubric.yaml>`;
+function buildRubricRecoveryCommand(runId, redispatchPath) {
+  return `node skills/relay-dispatch/scripts/dispatch.js . --run-id ${runId} --prompt-file ${redispatchPath} --rubric-file <fixed-rubric.yaml>`;
 }
 
 function buildRubricGateRedispatchPrompt(gateFailure, doneCriteria, doneCriteriaSource) {
@@ -949,12 +949,12 @@ function buildRubricGateRedispatchPrompt(gateFailure, doneCriteria, doneCriteria
  * `review.latest_verdict="rubric_state_failed_closed"` records that the raw
  * reviewer PASS was blocked by review-runner rubric enforcement.
  */
-function buildReviewRunnerRubricGateFailure(runId, rubricLoad) {
+function buildReviewRunnerRubricGateFailure(runId, redispatchPath, rubricLoad) {
   if (!rubricLoad || RUBRIC_PASS_THROUGH_STATES.has(rubricLoad.state)) {
     return null;
   }
 
-  const recoveryCommand = buildRubricRecoveryCommand(runId);
+  const recoveryCommand = buildRubricRecoveryCommand(runId, redispatchPath);
   const rerunReviewStep = "After the re-dispatch completes, rerun relay-review.";
   let recovery;
   switch (rubricLoad.state) {
@@ -1365,8 +1365,9 @@ function run() {
       `Repeated identical review issues hit ${repeatedIssueCount} consecutive rounds.`
     );
   }
+  const rubricGateRedispatchPath = path.join(runDir, `review-round-${round}-redispatch.md`);
   const rubricGateFailure = verdict.verdict === "pass"
-    ? buildReviewRunnerRubricGateFailure(data.run_id, rubricLoad)
+    ? buildReviewRunnerRubricGateFailure(data.run_id, rubricGateRedispatchPath, rubricLoad)
     : null;
   const verdictPath = path.join(runDir, `review-round-${round}-verdict.json`);
   const verdictRecord = rubricGateFailure
@@ -1387,7 +1388,9 @@ function run() {
 
   let redispatchPath = null;
   if (verdict.verdict === "changes_requested" || rubricGateFailure) {
-    redispatchPath = path.join(runDir, `review-round-${round}-redispatch.md`);
+    redispatchPath = rubricGateFailure
+      ? rubricGateRedispatchPath
+      : path.join(runDir, `review-round-${round}-redispatch.md`);
     const redispatchPrompt = rubricGateFailure
       ? buildRubricGateRedispatchPrompt(rubricGateFailure, doneCriteria, doneCriteriaSource)
       : buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource);

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -589,15 +589,17 @@ function appendCommentWarnings(commentBody, warnings = []) {
 function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } = {}) {
   if (gateFailure) {
     return appendCommentWarnings([
-      REVIEW_MARKER,
-      "## Relay Review",
-      "Verdict: ESCALATED",
+      REVIEW_ROUND_MARKER,
+      `## Relay Review Round ${round}`,
+      "Verdict: CHANGES_REQUESTED",
       `Summary: ${gateFailure.summary}`,
-      `Rounds: ${round}`,
       `Reviewer verdict: ${String(verdict.verdict || "unknown").toUpperCase()} (next_action=${verdict.next_action || "unknown"})`,
+      `Gate status: ${gateFailure.status}`,
       `Layer: ${gateFailure.layer}`,
       `Rubric state: ${gateFailure.rubricState} (anchor status: ${gateFailure.rubricStatus})`,
-      `Recovery: ${gateFailure.recovery}`,
+      `Recovery command: ${gateFailure.recoveryCommand}`,
+      "Issues:",
+      `- Rubric gate failed closed: ${gateFailure.reason}. ${gateFailure.recovery}`,
     ].join("\n"), warnings);
   }
 
@@ -912,37 +914,64 @@ function toEscalatedVerdict(baseVerdict, summary) {
   };
 }
 
+function buildRubricRecoveryCommand(runId) {
+  return `node skills/relay-dispatch/scripts/dispatch.js . --run-id ${runId} --prompt-file <task.md> --rubric-file <fixed-rubric.yaml>`;
+}
+
+function buildRubricGateRedispatchPrompt(gateFailure, doneCriteria, doneCriteriaSource) {
+  return [
+    "Rubric recovery re-dispatch",
+    "",
+    "relay-review failed closed on the rubric anchor, not on the code diff.",
+    "",
+    `Gate status: ${gateFailure.status}`,
+    `Rubric state: ${gateFailure.rubricState} (anchor status: ${gateFailure.rubricStatus})`,
+    `Reason: ${gateFailure.reason}`,
+    `Recovery command: ${gateFailure.recoveryCommand}`,
+    "",
+    "Instructions:",
+    "- Fix the rubric anchor or supply a replacement rubric with --rubric-file.",
+    "- Keep the accepted task scope unchanged while re-dispatching.",
+    "- After the re-dispatch completes, rerun relay-review on the same run.",
+    "",
+    `Done Criteria source: ${doneCriteriaSource}`,
+    "Done Criteria:",
+    doneCriteria,
+  ].join("\n");
+}
+
 /**
- * Rubric fail-closed keeps `data.state` unchanged downstream instead of forcing
- * `escalated` so operators can repair the rubric and resume with
- * `dispatch --run-id`, matching the dispatcher's recoverable
- * `review_pending` / `changes_requested` re-dispatch flow.
- * `next_action=repair_rubric_and_rerun_review` tells the operator to fix the
- * anchored rubric state before rerunning relay-review, and
+ * Rubric fail-closed moves the run into `changes_requested` so the documented
+ * `dispatch --run-id` recovery command remains executable without widening
+ * dispatcher resume rules for arbitrary `review_pending` runs.
+ * `next_action=repair_rubric_and_redispatch` tells the operator to fix the
+ * anchored rubric state, re-dispatch the run, then rerun relay-review, and
  * `review.latest_verdict="rubric_state_failed_closed"` records that the raw
  * reviewer PASS was blocked by review-runner rubric enforcement.
  */
-function buildReviewRunnerRubricGateFailure(rubricLoad) {
+function buildReviewRunnerRubricGateFailure(runId, rubricLoad) {
   if (!rubricLoad || RUBRIC_PASS_THROUGH_STATES.has(rubricLoad.state)) {
     return null;
   }
 
+  const recoveryCommand = buildRubricRecoveryCommand(runId);
+  const rerunReviewStep = "After the re-dispatch completes, rerun relay-review.";
   let recovery;
   switch (rubricLoad.state) {
     case "not_set":
-      recovery = "Re-dispatch from relay-plan with a persisted rubric, or explicitly grandfather a pre-rubric run before rerunning relay-review.";
+      recovery = `Persist a rubric for this run, then run \`${recoveryCommand}\`. ${rerunReviewStep}`;
       break;
     case "missing":
-      recovery = "Restore the anchored rubric file in the run directory, or re-dispatch with a persisted rubric before rerunning relay-review.";
+      recovery = `Restore or replace the missing rubric, then run \`${recoveryCommand}\`. ${rerunReviewStep}`;
       break;
     case "outside_run_dir":
-      recovery = "Fix anchor.rubric_path to resolve inside the run directory, then re-dispatch before rerunning relay-review.";
+      recovery = `Replace the escaped rubric anchor with a contained rubric, then run \`${recoveryCommand}\`. ${rerunReviewStep}`;
       break;
     case "empty":
-      recovery = "Regenerate the rubric with relay-plan and re-dispatch before rerunning relay-review.";
+      recovery = `Regenerate the empty rubric, then run \`${recoveryCommand}\`. ${rerunReviewStep}`;
       break;
     default:
-      recovery = "Fix or restore the anchored rubric file, then re-dispatch before rerunning relay-review.";
+      recovery = `Fix or replace the rubric anchor, then run \`${recoveryCommand}\`. ${rerunReviewStep}`;
       break;
   }
 
@@ -952,6 +981,7 @@ function buildReviewRunnerRubricGateFailure(rubricLoad) {
     rubricState: rubricLoad.state,
     rubricStatus: rubricLoad.status,
     reason: rubricLoad.error || "Rubric is not loaded.",
+    recoveryCommand,
     recovery,
     summary: `review-runner fail-closed: rubricLoad.state='${rubricLoad.state}' blocked ready_to_merge despite reviewer PASS. ${recovery}`,
   };
@@ -976,8 +1006,8 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
 
   if (verdict.verdict === "pass") {
     if (rubricGateFailure) {
-      nextState = data.state;
-      nextAction = "repair_rubric_and_rerun_review";
+      nextState = STATES.CHANGES_REQUESTED;
+      nextAction = "repair_rubric_and_redispatch";
       latestVerdict = rubricGateFailure.status;
     } else {
       nextState = STATES.READY_TO_MERGE;
@@ -1015,6 +1045,7 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
         layer: rubricGateFailure.layer,
         rubric_state: rubricGateFailure.rubricState,
         rubric_status: rubricGateFailure.rubricStatus,
+        recovery_command: rubricGateFailure.recoveryCommand,
         recovery: rubricGateFailure.recovery,
         reason: rubricGateFailure.reason,
       } : null,
@@ -1335,7 +1366,7 @@ function run() {
     );
   }
   const rubricGateFailure = verdict.verdict === "pass"
-    ? buildReviewRunnerRubricGateFailure(rubricLoad)
+    ? buildReviewRunnerRubricGateFailure(data.run_id, rubricLoad)
     : null;
   const verdictPath = path.join(runDir, `review-round-${round}-verdict.json`);
   const verdictRecord = rubricGateFailure
@@ -1347,6 +1378,7 @@ function run() {
         rubric_state: rubricGateFailure.rubricState,
         rubric_status: rubricGateFailure.rubricStatus,
         reason: rubricGateFailure.reason,
+        recovery_command: rubricGateFailure.recoveryCommand,
         recovery: rubricGateFailure.recovery,
       },
     }
@@ -1354,9 +1386,12 @@ function run() {
   writeText(verdictPath, `${JSON.stringify(verdictRecord, null, 2)}\n`);
 
   let redispatchPath = null;
-  if (verdict.verdict === "changes_requested") {
+  if (verdict.verdict === "changes_requested" || rubricGateFailure) {
     redispatchPath = path.join(runDir, `review-round-${round}-redispatch.md`);
-    writeText(redispatchPath, `${buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource)}\n`);
+    const redispatchPrompt = rubricGateFailure
+      ? buildRubricGateRedispatchPrompt(rubricGateFailure, doneCriteria, doneCriteriaSource)
+      : buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource);
+    writeText(redispatchPath, `${redispatchPrompt}\n`);
   }
 
   const { warnings: divergenceWarnings, eventPayload: divergencePayload } = buildScoreDivergenceAnalysis(
@@ -1424,13 +1459,14 @@ function run() {
   result.verdictPath = verdictPath;
   result.redispatchPath = redispatchPath;
   result.repeatedIssueCount = repeatedIssueCount;
-  result.appliedVerdict = rubricGateFailure ? "escalated" : verdict.verdict;
+  result.appliedVerdict = rubricGateFailure ? "changes_requested" : verdict.verdict;
   result.reviewGate = rubricGateFailure ? {
     status: rubricGateFailure.status,
     layer: rubricGateFailure.layer,
     rubricState: rubricGateFailure.rubricState,
     rubricStatus: rubricGateFailure.rubricStatus,
     reason: rubricGateFailure.reason,
+    recoveryCommand: rubricGateFailure.recoveryCommand,
     recovery: rubricGateFailure.recovery,
   } : null;
 

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1847,7 +1847,10 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
     assert.equal(result.reviewGate.status, "rubric_state_failed_closed");
     assert.equal(result.reviewGate.layer, "review-runner");
     assert.equal(result.reviewGate.rubricState, state);
-    assert.match(result.reviewGate.recoveryCommand, new RegExp(`--run-id ${runId}`));
+    assert.match(
+      result.reviewGate.recoveryCommand,
+      new RegExp(`--run-id ${runId} --prompt-file ${result.redispatchPath.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}`)
+    );
     assert.match(result.reviewGate.recovery, recovery);
 
     assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
@@ -1855,7 +1858,10 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
     assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
     assert.equal(manifest.review.last_gate.layer, "review-runner");
     assert.equal(manifest.review.last_gate.rubric_state, state);
-    assert.match(manifest.review.last_gate.recovery_command, new RegExp(`--run-id ${runId}`));
+    assert.match(
+      manifest.review.last_gate.recovery_command,
+      new RegExp(`--run-id ${runId} --prompt-file ${result.redispatchPath.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}`)
+    );
     assert.match(manifest.review.last_gate.recovery, recovery);
 
     assert.equal(verdictRecord.verdict, "pass");
@@ -1863,14 +1869,22 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
     assert.equal(verdictRecord.relay_gate.status, "rubric_state_failed_closed");
     assert.equal(verdictRecord.relay_gate.layer, "review-runner");
     assert.equal(verdictRecord.relay_gate.rubric_state, state);
-    assert.match(verdictRecord.relay_gate.recovery_command, new RegExp(`--run-id ${runId}`));
+    assert.match(
+      verdictRecord.relay_gate.recovery_command,
+      new RegExp(`--run-id ${runId} --prompt-file ${result.redispatchPath.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}`)
+    );
     assert.match(verdictRecord.relay_gate.recovery, recovery);
 
     assert.match(commentBody, /Verdict: CHANGES_REQUESTED/);
     assert.match(commentBody, /Gate status: rubric_state_failed_closed/);
     assert.match(commentBody, /Layer: review-runner/);
     assert.match(commentBody, new RegExp(`Rubric state: ${state.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
-    assert.match(commentBody, new RegExp(`Recovery command: node skills/relay-dispatch/scripts/dispatch\\.js \\. --run-id ${runId}`));
+    assert.match(
+      commentBody,
+      new RegExp(
+        `Recovery command: node skills/relay-dispatch/scripts/dispatch\\.js \\. --run-id ${runId} --prompt-file ${result.redispatchPath.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}`
+      )
+    );
     assert.match(commentBody, recovery);
   });
 });

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -17,6 +17,7 @@ const {
 const { readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
 
 const SCRIPT = path.join(__dirname, "review-runner.js");
+const DISPATCH_SCRIPT = path.join(__dirname, "../../relay-dispatch/scripts/dispatch.js");
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-runner-"));
@@ -248,6 +249,32 @@ process.exit(1);
 `, "utf-8");
   fs.chmodSync(filePath, 0o755);
   return filePath;
+}
+
+function writeFakeCodex(binDir) {
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+const fileName = fs.existsSync(cwd + "/first.txt") ? "resume.txt" : "first.txt";
+fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
+fs.writeFileSync(output, "ok\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
 }
 
 test("prepare-only writes a prompt bundle without changing manifest state", () => {
@@ -1766,23 +1793,23 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
 [
   {
     state: "missing",
-    recovery: /Restore the anchored rubric file in the run directory, or re-dispatch/i,
+    recovery: /Restore or replace the missing rubric, then run `node skills\/relay-dispatch\/scripts\/dispatch\.js \. --run-id/i,
   },
   {
     state: "outside_run_dir",
-    recovery: /Fix anchor\.rubric_path to resolve inside the run directory, then re-dispatch/i,
+    recovery: /Replace the escaped rubric anchor with a contained rubric, then run `node skills\/relay-dispatch\/scripts\/dispatch\.js \. --run-id/i,
   },
   {
     state: "empty",
-    recovery: /Regenerate the rubric with relay-plan and re-dispatch/i,
+    recovery: /Regenerate the empty rubric, then run `node skills\/relay-dispatch\/scripts\/dispatch\.js \. --run-id/i,
   },
   {
     state: "invalid",
-    recovery: /Fix or restore the anchored rubric file, then re-dispatch/i,
+    recovery: /Fix or replace the rubric anchor, then run `node skills\/relay-dispatch\/scripts\/dispatch\.js \. --run-id/i,
   },
   {
     state: "not_set",
-    recovery: /Re-dispatch from relay-plan with a persisted rubric, or explicitly grandfather/i,
+    recovery: /Persist a rubric for this run, then run `node skills\/relay-dispatch\/scripts\/dispatch\.js \. --run-id/i,
   },
 ].forEach(({ state, recovery }) => {
   test(`review-runner fail-closes PASS when rubric state is ${state}`, () => {
@@ -1813,19 +1840,22 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
     const commentBody = fs.readFileSync(commentCapturePath, "utf-8");
 
     assert.equal(result.rubricLoaded, state);
-    assert.equal(result.state, STATES.REVIEW_PENDING);
-    assert.equal(result.nextState, STATES.REVIEW_PENDING);
-    assert.equal(result.appliedVerdict, "escalated");
+    assert.equal(result.state, STATES.CHANGES_REQUESTED);
+    assert.equal(result.nextState, STATES.CHANGES_REQUESTED);
+    assert.equal(result.appliedVerdict, "changes_requested");
+    assert.ok(result.redispatchPath);
     assert.equal(result.reviewGate.status, "rubric_state_failed_closed");
     assert.equal(result.reviewGate.layer, "review-runner");
     assert.equal(result.reviewGate.rubricState, state);
+    assert.match(result.reviewGate.recoveryCommand, new RegExp(`--run-id ${runId}`));
     assert.match(result.reviewGate.recovery, recovery);
 
-    assert.equal(manifest.state, STATES.REVIEW_PENDING);
-    assert.equal(manifest.next_action, "repair_rubric_and_rerun_review");
+    assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+    assert.equal(manifest.next_action, "repair_rubric_and_redispatch");
     assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
     assert.equal(manifest.review.last_gate.layer, "review-runner");
     assert.equal(manifest.review.last_gate.rubric_state, state);
+    assert.match(manifest.review.last_gate.recovery_command, new RegExp(`--run-id ${runId}`));
     assert.match(manifest.review.last_gate.recovery, recovery);
 
     assert.equal(verdictRecord.verdict, "pass");
@@ -1833,11 +1863,98 @@ test("review-runner allows empty rubric_scores when no rubric file exists", () =
     assert.equal(verdictRecord.relay_gate.status, "rubric_state_failed_closed");
     assert.equal(verdictRecord.relay_gate.layer, "review-runner");
     assert.equal(verdictRecord.relay_gate.rubric_state, state);
+    assert.match(verdictRecord.relay_gate.recovery_command, new RegExp(`--run-id ${runId}`));
     assert.match(verdictRecord.relay_gate.recovery, recovery);
 
-    assert.match(commentBody, /Verdict: ESCALATED/);
+    assert.match(commentBody, /Verdict: CHANGES_REQUESTED/);
+    assert.match(commentBody, /Gate status: rubric_state_failed_closed/);
     assert.match(commentBody, /Layer: review-runner/);
     assert.match(commentBody, new RegExp(`Rubric state: ${state.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+    assert.match(commentBody, new RegExp(`Recovery command: node skills/relay-dispatch/scripts/dispatch\\.js \\. --run-id ${runId}`));
     assert.match(commentBody, recovery);
   });
+});
+
+test("review-runner fail-closed path can re-dispatch with a fixed rubric and pass the next review", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "missing" });
+
+  const firstReviewFile = writePassVerdict(repoRoot, "missing-pass.json");
+  const firstRound = runPassReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    reviewFile: firstReviewFile,
+  });
+  assert.equal(firstRound.state, STATES.CHANGES_REQUESTED);
+  assert.ok(firstRound.redispatchPath);
+
+  const fixedRubricPath = path.join(repoRoot, "fixed-rubric.yaml");
+  fs.writeFileSync(fixedRubricPath, [
+    "rubric:",
+    "  factors:",
+    "    - name: API pagination",
+    "      target: \">= 8/10\"",
+  ].join("\n"), "utf-8");
+
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-codex-bin-"));
+  writeFakeCodex(binDir);
+  const dispatchResult = JSON.parse(execFileSync("node", [
+    DISPATCH_SCRIPT,
+    repoRoot,
+    "--run-id", runId,
+    "--prompt-file", firstRound.redispatchPath,
+    "--rubric-file", fixedRubricPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+  }));
+
+  assert.equal(dispatchResult.mode, "resume");
+  assert.equal(dispatchResult.runState, STATES.REVIEW_PENDING);
+
+  const secondReviewFile = writeVerdict(repoRoot, "loaded-pass.json", {
+    verdict: "pass",
+    summary: "All done criteria are satisfied.",
+    contract_status: "pass",
+    quality_status: "pass",
+    next_action: "ready_to_merge",
+    issues: [],
+    rubric_scores: [
+      {
+        factor: "API pagination",
+        target: ">= 8/10",
+        observed: "9/10",
+        status: "pass",
+        tier: "contract",
+        notes: "Pagination behavior meets the rubric target.",
+      },
+    ],
+    scope_drift: { creep: [], missing: [] },
+  });
+  const secondRound = runPassReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    reviewFile: secondReviewFile,
+  });
+
+  assert.equal(secondRound.round, 2);
+  assert.equal(secondRound.rubricLoaded, "loaded");
+  assert.equal(secondRound.state, STATES.READY_TO_MERGE);
+  assert.equal(secondRound.nextState, STATES.READY_TO_MERGE);
+  assert.equal(secondRound.appliedVerdict, "pass");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.equal(manifest.next_action, "await_explicit_merge");
+  assert.equal(manifest.review.latest_verdict, "lgtm");
+  assert.equal(manifest.review.last_gate, null);
 });


### PR DESCRIPTION
## Summary
- move rubric fail-closed PASS handling onto the existing `changes_requested` recovery path
- preserve `review.latest_verdict = rubric_state_failed_closed` while generating a real redispatch artifact and operator command
- add regression coverage for fail-close -> re-dispatch -> re-review and gate-check recovery messaging

## Testing
- node --test skills/relay-dispatch/scripts/dispatch.test.js
- node --test skills/relay-review/scripts/review-runner.test.js
- node --test skills/relay-merge/scripts/gate-check.test.js

Closes #163.
