### PR TITLE
relay: harden manifest path trust roots

### DIFF
--- a/docs/issue-160-manifest-path-trust-roots.md
+++ b/docs/issue-160-manifest-path-trust-roots.md
@@ -1,0 +1,40 @@
+# Issue #160: Manifest Path Trust Roots Audit
+
+This change closes the manifest trust-root gap for `paths.repo_root` and `paths.worktree` without widening into resolver or symlink follow-up work.
+
+## Shared Helper
+
+- Added `validateManifestPaths(paths, { expectedRepoRoot, manifestPath, runId, requireWorktree, caller })` in `skills/relay-dispatch/scripts/relay-manifest.js`.
+- `paths.repo_root` now fail-closes unless it matches the caller's expected repo root, or, for manifest-only entry points, the manifest storage path implied by `run_id`.
+- `paths.worktree` now fail-closes unless it is either contained under the trusted repo root or under the relay-owned worktree base for that repo name.
+- `runCleanup()` now re-validates manifest paths before any worktree removal, branch deletion, or prune side effect.
+
+## Consumer Audit
+
+- Fixed: `skills/relay-dispatch/scripts/dispatch.js`
+  Resume now validates manifest-owned repo/worktree paths before reusing the repo root, retained worktree, run directory, or previous-attempts state.
+- Fixed: `skills/relay-review/scripts/review-runner.js`
+  Review preparation now validates the retained checkout before prompt generation, SHA reads, or event journal writes.
+- Fixed: `skills/relay-merge/scripts/gate-check.js`
+  PR-mode manifest resolution now validates manifest paths before PR stamping, run-dir lock creation, or merge-gate evaluation.
+- Fixed: `skills/relay-merge/scripts/finalize-run.js`
+  Merge finalization now validates manifest paths before GitHub operations, review gating, cleanup, or issue close.
+- Fixed: `skills/relay-dispatch/scripts/cleanup-worktrees.js`
+  Janitor cleanup now rejects crafted manifests before cleanup side effects and records a fail-closed result instead.
+- Fixed: `skills/relay-dispatch/scripts/close-run.js`
+  Manual close/recovery now validates manifest paths before state transitions or cleanup.
+- Fixed: `skills/relay-dispatch/scripts/relay-manifest.js`
+  Cleanup helpers now validate manifest paths internally so a raw caller cannot retarget cleanup side effects through manifest data.
+
+## Regression Coverage
+
+- Added manifest-layer unit coverage for valid repo-contained and relay-owned worktrees, plus repo-root mismatch, worktree escape, and manifest-path mismatch rejection.
+- Added consumer regressions showing rejection before side effects for:
+  `dispatch`, `review-runner`, `gate-check`, `finalize-run`, `cleanup-worktrees`, and `close-run`.
+- Existing alias-flow coverage still passes: `review-runner` continues to accept a symlinked repo alias that resolves to the same trusted repo root.
+
+## Explicit Non-Scope
+
+- No symlink hardening beyond preserving existing repo-alias behavior.
+- No resolver/state-machine widening.
+- No reliability-report or planner changes.

--- a/docs/issue-160-manifest-path-trust-roots.md
+++ b/docs/issue-160-manifest-path-trust-roots.md
@@ -14,7 +14,7 @@ This change closes the manifest trust-root gap for `paths.repo_root` and `paths.
 - Fixed: `skills/relay-dispatch/scripts/dispatch.js`
   Resume now validates manifest-owned repo/worktree paths before reusing the repo root, retained worktree, run directory, or previous-attempts state. Explicit `--manifest` resume keeps the manifest storage path as the trust root instead of binding to the caller's cwd repo.
 - Fixed: `skills/relay-review/scripts/review-runner.js`
-  Review preparation now validates the retained checkout before prompt generation, SHA reads, or event journal writes. Explicit `--manifest` review uses the manifest storage path as the repo-root trust source even when `--repo` points at another checkout.
+  Review preparation now validates the retained checkout before prompt generation, SHA reads, or event journal writes. Explicit `--manifest` review uses the manifest storage path as the repo-root trust source even when `--repo` points at another checkout, and the validated repo root now carries through PR/issue resolution, diff loading, PR-body divergence analysis, and review comment writes instead of falling back to the caller cwd.
 - Fixed: `skills/relay-merge/scripts/gate-check.js`
   PR-mode manifest resolution now validates manifest paths before PR stamping, run-dir lock creation, or merge-gate evaluation.
 - Fixed: `skills/relay-merge/scripts/finalize-run.js`

--- a/docs/issue-160-manifest-path-trust-roots.md
+++ b/docs/issue-160-manifest-path-trust-roots.md
@@ -25,6 +25,8 @@ This change closes the manifest trust-root gap for `paths.repo_root` and `paths.
   Manual close/recovery now validates manifest paths before state transitions or cleanup.
 - Fixed: `skills/relay-dispatch/scripts/relay-manifest.js`
   Cleanup helpers now validate manifest paths internally so a raw caller cannot retarget cleanup side effects through manifest data.
+- Unchanged but enumerated: `skills/relay-dispatch/scripts/relay-manifest.js` (`resolveRubricRunDir()` fallback inside `getRubricAnchorStatus()`)
+  This helper still falls back to `data.paths.repo_root` when callers omit `options.repoRoot` and `options.runDir`. That remaining raw reader is outside the `#160` bypass surface: the in-scope dispatch/review/merge consumers now pass a validated repo root or run dir before any filesystem write or GitHub operation, and the only zero-option caller left is the relay-manifest-local `validateTransitionInvariants()` rubric-state read path. No change here in this PR; if rubric-status reads become their own trust boundary, file a follow-up rather than silently widening this fix.
 
 ## Regression Coverage
 

--- a/docs/issue-160-manifest-path-trust-roots.md
+++ b/docs/issue-160-manifest-path-trust-roots.md
@@ -12,13 +12,13 @@ This change closes the manifest trust-root gap for `paths.repo_root` and `paths.
 ## Consumer Audit
 
 - Fixed: `skills/relay-dispatch/scripts/dispatch.js`
-  Resume now validates manifest-owned repo/worktree paths before reusing the repo root, retained worktree, run directory, or previous-attempts state.
+  Resume now validates manifest-owned repo/worktree paths before reusing the repo root, retained worktree, run directory, or previous-attempts state. Explicit `--manifest` resume keeps the manifest storage path as the trust root instead of binding to the caller's cwd repo.
 - Fixed: `skills/relay-review/scripts/review-runner.js`
-  Review preparation now validates the retained checkout before prompt generation, SHA reads, or event journal writes.
+  Review preparation now validates the retained checkout before prompt generation, SHA reads, or event journal writes. Explicit `--manifest` review uses the manifest storage path as the repo-root trust source even when `--repo` points at another checkout.
 - Fixed: `skills/relay-merge/scripts/gate-check.js`
   PR-mode manifest resolution now validates manifest paths before PR stamping, run-dir lock creation, or merge-gate evaluation.
 - Fixed: `skills/relay-merge/scripts/finalize-run.js`
-  Merge finalization now validates manifest paths before GitHub operations, review gating, cleanup, or issue close.
+  Merge finalization now validates manifest paths before GitHub operations, review gating, cleanup, or issue close. Explicit `--manifest` finalize trusts the manifest storage path instead of the caller's cwd repo.
 - Fixed: `skills/relay-dispatch/scripts/cleanup-worktrees.js`
   Janitor cleanup now rejects crafted manifests before cleanup side effects and records a fail-closed result instead.
 - Fixed: `skills/relay-dispatch/scripts/close-run.js`

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -19,6 +19,7 @@ const {
   listManifestPaths,
   readManifest,
   runCleanup,
+  validateManifestPaths,
   writeManifest,
 } = require("./relay-manifest");
 const { appendRunEvent } = require("./relay-events");
@@ -98,12 +99,43 @@ function run() {
       closeCommand: `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} --run-id ${JSON.stringify(runId)} --reason ${JSON.stringify("stale_non_terminal_run")}`,
     };
 
+    let normalizedData = data;
+    try {
+      const validatedPaths = validateManifestPaths(data.paths, {
+        expectedRepoRoot: repoRoot,
+        manifestPath,
+        runId: data.run_id,
+        caller: "cleanup-worktrees",
+      });
+      normalizedData = {
+        ...data,
+        paths: {
+          ...(data.paths || {}),
+          repo_root: validatedPaths.repoRoot,
+          worktree: validatedPaths.worktree,
+        },
+      };
+    } catch (error) {
+      const sanitizedError = /run_id must be a single path segment/.test(String(error.message || ""))
+        ? `cleanup-worktrees: manifest ${JSON.stringify(path.basename(manifestPath))} has an invalid stored run_id; inspect the manifest before retrying.`
+        : error.message;
+      result.failed.push({
+        ...baseInfo,
+        nextAction: "inspect_manifest_paths",
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruneRan: false,
+        error: sanitizedError,
+      });
+      continue;
+    }
+
     if (!all && updatedAt && updatedAt > cutoff) {
       result.skipped.push({ ...baseInfo, reason: "recent" });
       continue;
     }
 
-    if (!isTerminalState(data.state)) {
+    if (!isTerminalState(normalizedData.state)) {
       result.staleOpen.push({ ...baseInfo, reason: "non-terminal" });
       continue;
     }
@@ -115,10 +147,10 @@ function run() {
 
     const cleanupResult = runCleanup({
       repoRoot,
-      data,
+      data: normalizedData,
       gitBin,
       dryRun,
-      deleteMergedBranch: data.state === "merged",
+      deleteMergedBranch: normalizedData.state === "merged",
     });
 
     const item = {

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -245,3 +245,43 @@ test("cleanup-worktrees rejects relay-base same-name worktrees before deleting u
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.cleanup.status, "pending");
 });
+
+test("cleanup-worktrees rejects tampered paths.repo_root before cleanup side effects", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const { manifestPath, worktreePath } = writeRun(repoRoot, {
+    branch: "issue-161",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const { attackerRoot } = createUnrelatedRelayOwnedWorktree(repoRoot, "issue-161");
+
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      repo_root: attackerRoot,
+    },
+  }, record.body);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.cleaned.length, 0);
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0].error, /manifest paths\.repo_root/);
+  assert.equal(result.failed[0].worktreeRemoved, false);
+  assert.equal(result.failed[0].branchDeleted, false);
+  assert.equal(result.failed[0].pruneRan, false);
+  assert.equal(fs.existsSync(worktreePath), true, "cleanup-worktrees must reject before removing the retained worktree");
+  assert.equal(branchExists(repoRoot, "issue-161"), true, "cleanup-worktrees must reject before deleting the branch");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.cleanup.status, "pending");
+});

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -53,6 +53,13 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
+function createMissingRelayOwnedWorktree(repoRoot) {
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "missing-"));
+  return path.join(worktreeParent, path.basename(repoRoot));
+}
+
 function writeRun(repoRoot, { branch, state, updatedAt }) {
   const worktreePath = path.join(repoRoot, "wt", branch);
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
@@ -244,6 +251,42 @@ test("cleanup-worktrees rejects relay-base same-name worktrees before deleting u
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.cleanup.status, "pending");
+});
+
+test("cleanup-worktrees rejects missing relay-base same-name worktrees before cleanup side effects", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const { manifestPath, worktreePath } = writeRun(repoRoot, {
+    branch: "issue-160b",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const missingWorktree = createMissingRelayOwnedWorktree(repoRoot);
+
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: missingWorktree,
+    },
+  }, record.body);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.cleaned.length, 0);
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0].error, /manifest paths\.worktree/);
+  assert.equal(fs.existsSync(worktreePath), true, "cleanup-worktrees must fail closed before removing the real worktree");
+  assert.equal(branchExists(repoRoot, "issue-160b"), true);
+  assert.equal(fs.existsSync(missingWorktree), false);
+  assert.equal(readManifest(manifestPath).data.cleanup.status, "pending");
 });
 
 test("cleanup-worktrees rejects tampered paths.repo_root before cleanup side effects", () => {

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -185,3 +185,40 @@ test("cleanup-worktrees does not echo tampered run_id into operator output (#176
   assert.doesNotMatch(textRun.stdout, /\.\.\/victim-run/, "text output must not contain tampered substring");
   assert.match(textRun.stdout, new RegExp(fallbackRunId), "text output should use the manifest basename");
 });
+
+test("cleanup-worktrees rejects crafted manifest worktrees before deleting unrelated checkouts", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const { manifestPath } = writeRun(repoRoot, {
+    branch: "issue-160",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const victimRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-janitor-victim-"));
+  fs.writeFileSync(path.join(victimRoot, "sentinel.txt"), "keep\n", "utf-8");
+
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: victimRoot,
+    },
+  }, record.body);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.cleaned.length, 0);
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0].error, /manifest paths\.worktree/);
+  assert.equal(fs.existsSync(victimRoot), true, "cleanup-worktrees must fail closed before removing the victim checkout");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.cleanup.status, "pending");
+});

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -30,6 +30,29 @@ function setupRepo() {
   return repoRoot;
 }
 
+function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-janitor-foreign-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Janitor Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-janitor-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
+  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
+    cwd: attackerRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, attackerWorktree };
+}
+
 function writeRun(repoRoot, { branch, state, updatedAt }) {
   const worktreePath = path.join(repoRoot, "wt", branch);
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
@@ -186,7 +209,7 @@ test("cleanup-worktrees does not echo tampered run_id into operator output (#176
   assert.match(textRun.stdout, new RegExp(fallbackRunId), "text output should use the manifest basename");
 });
 
-test("cleanup-worktrees rejects crafted manifest worktrees before deleting unrelated checkouts", () => {
+test("cleanup-worktrees rejects relay-base same-name worktrees before deleting unrelated checkouts", () => {
   const repoRoot = setupRepo();
   const updatedAt = "2026-04-01T00:00:00.000Z";
   const { manifestPath } = writeRun(repoRoot, {
@@ -194,15 +217,14 @@ test("cleanup-worktrees rejects crafted manifest worktrees before deleting unrel
     state: STATES.MERGED,
     updatedAt,
   });
-  const victimRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-janitor-victim-"));
-  fs.writeFileSync(path.join(victimRoot, "sentinel.txt"), "keep\n", "utf-8");
+  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot, "issue-160");
 
   const record = readManifest(manifestPath);
   writeManifest(manifestPath, {
     ...record.data,
     paths: {
       ...(record.data.paths || {}),
-      worktree: victimRoot,
+      worktree: attackerWorktree,
     },
   }, record.body);
 
@@ -217,7 +239,8 @@ test("cleanup-worktrees rejects crafted manifest worktrees before deleting unrel
   assert.equal(result.cleaned.length, 0);
   assert.equal(result.failed.length, 1);
   assert.match(result.failed[0].error, /manifest paths\.worktree/);
-  assert.equal(fs.existsSync(victimRoot), true, "cleanup-worktrees must fail closed before removing the victim checkout");
+  assert.equal(fs.existsSync(attackerWorktree), true, "cleanup-worktrees must fail closed before removing the foreign relay worktree");
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.cleanup.status, "pending");

--- a/skills/relay-dispatch/scripts/close-run.js
+++ b/skills/relay-dispatch/scripts/close-run.js
@@ -9,6 +9,7 @@ const {
   runCleanup,
   updateManifestCleanup,
   updateManifestState,
+  validateManifestPaths,
   writeManifest,
 } = require("./relay-manifest");
 const { resolveManifestRecord } = require("./relay-resolver");
@@ -70,11 +71,25 @@ function main() {
   }
 
   const { manifestPath, data, body } = resolveManifestRecord({ repoRoot, runId });
-  if (data.state === STATES.MERGED || data.state === STATES.CLOSED) {
-    throw new Error(`close-run only supports active runs, got '${data.state}'`);
+  const validatedPaths = validateManifestPaths(data.paths, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId: data.run_id,
+    caller: "close-run",
+  });
+  const safeData = {
+    ...data,
+    paths: {
+      ...(data.paths || {}),
+      repo_root: validatedPaths.repoRoot,
+      worktree: validatedPaths.worktree,
+    },
+  };
+  if (safeData.state === STATES.MERGED || safeData.state === STATES.CLOSED) {
+    throw new Error(`close-run only supports active runs, got '${safeData.state}'`);
   }
 
-  let updated = updateManifestState(data, STATES.CLOSED, "manual_cleanup_required");
+  let updated = updateManifestState(safeData, STATES.CLOSED, "manual_cleanup_required");
   let cleanupResult = null;
   if ((updated.policy?.cleanup || "on_close") === "on_close") {
     cleanupResult = runCleanup({
@@ -97,7 +112,7 @@ function main() {
     writeManifest(manifestPath, updated, body);
     appendRunEvent(repoRoot, updated.run_id, {
       event: "close",
-      state_from: data.state,
+      state_from: safeData.state,
       state_to: STATES.CLOSED,
       head_sha: updated.git?.head_sha || null,
       round: updated.review?.rounds || null,
@@ -118,7 +133,7 @@ function main() {
   const result = {
     manifestPath,
     runId: updated.run_id,
-    previousState: data.state,
+    previousState: safeData.state,
     state: updated.state,
     nextAction: updated.next_action,
     reason,
@@ -130,7 +145,7 @@ function main() {
     console.log(JSON.stringify(result, null, 2));
   } else {
     console.log(`Closed relay run: ${manifestPath}`);
-    console.log(`  State:        ${data.state} -> ${updated.state}`);
+    console.log(`  State:        ${safeData.state} -> ${updated.state}`);
     console.log(`  Next action:  ${updated.next_action}`);
     console.log(`  Reason:       ${reason}`);
     console.log(`  Cleanup:      ${cleanupResult.summary.cleanupStatus}`);

--- a/skills/relay-dispatch/scripts/close-run.test.js
+++ b/skills/relay-dispatch/scripts/close-run.test.js
@@ -64,6 +64,29 @@ function setupRepo({ dirtyWorktree = false, state = STATES.REVIEW_PENDING } = {}
   return { repoRoot, manifestPath, runId, worktreePath };
 }
 
+function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-close-foreign-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Close Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-close-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
+  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
+    cwd: attackerRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, attackerWorktree };
+}
+
 test("close-run closes an active run and cleans a clean worktree", () => {
   const { repoRoot, manifestPath, runId, worktreePath } = setupRepo();
 
@@ -155,16 +178,15 @@ test("close-run accepts escalated runs as close targets for manual recovery", ()
   assert.equal(manifest.cleanup.status, "succeeded");
 });
 
-test("close-run rejects crafted manifest worktrees outside the trusted repo before cleanup", () => {
+test("close-run rejects relay-base same-name worktrees before cleanup", () => {
   const { repoRoot, manifestPath, runId } = setupRepo();
-  const victimRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-close-run-victim-"));
-  fs.writeFileSync(path.join(victimRoot, "sentinel.txt"), "keep\n", "utf-8");
+  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot);
   const record = readManifest(manifestPath);
   writeManifest(manifestPath, {
     ...record.data,
     paths: {
       ...(record.data.paths || {}),
-      worktree: victimRoot,
+      worktree: attackerWorktree,
     },
   }, record.body);
 
@@ -180,7 +202,8 @@ test("close-run rejects crafted manifest worktrees outside the trusted repo befo
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /manifest paths\.worktree/);
-  assert.equal(fs.existsSync(victimRoot), true, "close-run must reject before touching the victim checkout");
+  assert.equal(fs.existsSync(attackerWorktree), true, "close-run must reject before touching the foreign relay worktree");
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);

--- a/skills/relay-dispatch/scripts/close-run.test.js
+++ b/skills/relay-dispatch/scripts/close-run.test.js
@@ -87,6 +87,18 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
+function branchExists(repoRoot, branch) {
+  try {
+    execFileSync("git", ["-C", repoRoot, "rev-parse", "--verify", `refs/heads/${branch}`], {
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 test("close-run closes an active run and cleans a clean worktree", () => {
   const { repoRoot, manifestPath, runId, worktreePath } = setupRepo();
 
@@ -204,6 +216,39 @@ test("close-run rejects relay-base same-name worktrees before cleanup", () => {
   assert.match(result.stderr, /manifest paths\.worktree/);
   assert.equal(fs.existsSync(attackerWorktree), true, "close-run must reject before touching the foreign relay worktree");
   assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.cleanup.status, "pending");
+});
+
+test("close-run rejects tampered paths.repo_root before state changes or cleanup side effects", () => {
+  const { repoRoot, manifestPath, runId, worktreePath } = setupRepo();
+  const { attackerRoot } = createUnrelatedRelayOwnedWorktree(repoRoot);
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      repo_root: attackerRoot,
+    },
+  }, record.body);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--reason", "stale_non_terminal_run",
+    "--json",
+  ], {
+    encoding: "utf-8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.repo_root/);
+  assert.equal(fs.existsSync(worktreePath), true, "close-run must reject before removing the retained worktree");
+  assert.equal(branchExists(repoRoot, "issue-42"), true, "close-run must reject before deleting the branch");
+  assert.equal(fs.existsSync(getEventsPath(repoRoot, runId)), false, "close-run must reject before appending lifecycle events");
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);

--- a/skills/relay-dispatch/scripts/close-run.test.js
+++ b/skills/relay-dispatch/scripts/close-run.test.js
@@ -87,6 +87,13 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
+function createMissingRelayOwnedWorktree(repoRoot) {
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "missing-"));
+  return path.join(worktreeParent, path.basename(repoRoot));
+}
+
 function branchExists(repoRoot, branch) {
   try {
     execFileSync("git", ["-C", repoRoot, "rev-parse", "--verify", `refs/heads/${branch}`], {
@@ -216,6 +223,38 @@ test("close-run rejects relay-base same-name worktrees before cleanup", () => {
   assert.match(result.stderr, /manifest paths\.worktree/);
   assert.equal(fs.existsSync(attackerWorktree), true, "close-run must reject before touching the foreign relay worktree");
   assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.cleanup.status, "pending");
+});
+
+test("close-run rejects missing relay-base same-name worktrees before cleanup", () => {
+  const { repoRoot, manifestPath, runId, worktreePath } = setupRepo();
+  const missingWorktree = createMissingRelayOwnedWorktree(repoRoot);
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: missingWorktree,
+    },
+  }, record.body);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--reason", "stale_non_terminal_run",
+    "--json",
+  ], {
+    encoding: "utf-8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.worktree/);
+  assert.equal(fs.existsSync(worktreePath), true, "close-run must fail before touching the real worktree");
+  assert.equal(fs.existsSync(missingWorktree), false);
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);

--- a/skills/relay-dispatch/scripts/close-run.test.js
+++ b/skills/relay-dispatch/scripts/close-run.test.js
@@ -154,3 +154,35 @@ test("close-run accepts escalated runs as close targets for manual recovery", ()
   assert.equal(manifest.state, STATES.CLOSED);
   assert.equal(manifest.cleanup.status, "succeeded");
 });
+
+test("close-run rejects crafted manifest worktrees outside the trusted repo before cleanup", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo();
+  const victimRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-close-run-victim-"));
+  fs.writeFileSync(path.join(victimRoot, "sentinel.txt"), "keep\n", "utf-8");
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: victimRoot,
+    },
+  }, record.body);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--reason", "stale_non_terminal_run",
+    "--json",
+  ], {
+    encoding: "utf-8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.worktree/);
+  assert.equal(fs.existsSync(victimRoot), true, "close-run must reject before touching the victim checkout");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.cleanup.status, "pending");
+});

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -454,7 +454,7 @@ async function main() {
     manifestPath = manifestRecord.manifestPath;
     manifest = manifestRecord.data;
     const validatedPaths = validateManifestPaths(manifest.paths, {
-      expectedRepoRoot: (repoPathRaw || looksLikeGitRepo(repoRoot)) ? repoRoot : undefined,
+      expectedRepoRoot: MANIFEST_INPUT ? undefined : ((repoPathRaw || looksLikeGitRepo(repoRoot)) ? repoRoot : undefined),
       manifestPath,
       runId: manifest.run_id || runId,
       caller: "dispatch resume",

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -72,6 +72,7 @@ const {
   isRubricGrandfathered,
   readPreviousAttempts,
   updateManifestState,
+  validateManifestPaths,
   validateRubricPathContainment,
   writeManifest,
 } = require("./relay-manifest");
@@ -239,6 +240,10 @@ function git(repoDir, ...gitArgs) {
 
 function shellQuote(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+function looksLikeGitRepo(repoPath) {
+  return fs.existsSync(path.join(repoPath, ".git"));
 }
 
 function terminateProcessTree(pid) {
@@ -448,11 +453,25 @@ async function main() {
     });
     manifestPath = manifestRecord.manifestPath;
     manifest = manifestRecord.data;
-    repoRoot = path.resolve(manifest.paths?.repo_root || repoRoot);
+    const validatedPaths = validateManifestPaths(manifest.paths, {
+      expectedRepoRoot: (repoPathRaw || looksLikeGitRepo(repoRoot)) ? repoRoot : undefined,
+      manifestPath,
+      runId: manifest.run_id || runId,
+      caller: "dispatch resume",
+    });
+    repoRoot = validatedPaths.repoRoot;
     projectName = path.basename(repoRoot);
     branch = manifest.git?.working_branch || branch;
     runId = manifest.run_id || runId;
-    wtPath = manifest.paths?.worktree || null;
+    wtPath = validatedPaths.worktree;
+    manifest = {
+      ...manifest,
+      paths: {
+        ...(manifest.paths || {}),
+        repo_root: validatedPaths.repoRoot,
+        worktree: validatedPaths.worktree,
+      },
+    };
     cleanupPolicy = manifest.policy?.cleanup || cleanupPolicy;
     baseBranch = manifest.git?.base_branch || baseBranch;
     issueNumber = manifest.issue?.number || inferIssueNumber(branch);

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -54,6 +54,17 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, branch = "issue-
   return { attackerRoot, attackerWorktree };
 }
 
+function createUnrelatedGitRepo(prefix = "relay-dispatch-manifest-cwd-") {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Dispatch Manifest"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-dispatch-manifest@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "manifest selector\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return repoRoot;
+}
+
 function writeFakeClaude(binDir) {
   const claudePath = path.join(binDir, "claude");
   fs.writeFileSync(claudePath, `#!/usr/bin/env node
@@ -256,6 +267,41 @@ test("dispatch resumes rubric fail-closed recovery runs from changes_requested",
   assert.equal(manifest.state, STATES.REVIEW_PENDING);
   assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
   assert.equal(manifest.review.last_gate.status, "rubric_state_failed_closed");
+});
+
+test("dispatch can resume from --manifest while invoked from an unrelated git repo", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const selectorRepo = createUnrelatedGitRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-manifest-resume",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  const updated = updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+  writeManifest(first.manifestPath, updated, record.body);
+
+  const second = JSON.parse(execFileSync("node", [SCRIPT, selectorRepo,
+    "--manifest", first.manifestPath,
+    "--prompt", "resume via manifest selector",
+    "--json",
+  ], {
+    cwd: selectorRepo,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env,
+  }));
+
+  assert.equal(second.mode, "resume");
+  assert.equal(second.runId, first.runId);
+  assert.equal(second.worktree, first.worktree);
+  assert.equal(second.runState, STATES.REVIEW_PENDING);
+  assert.equal(readManifest(first.manifestPath).data.state, STATES.REVIEW_PENDING);
 });
 
 test("dispatch resume fails loudly when the retained worktree is missing", () => {

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -331,7 +331,7 @@ test("dispatch resume fails loudly when the retained worktree is missing", () =>
   });
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /retained worktree is missing/);
+  assert.match(result.stderr, /(retained worktree is missing|manifest paths\.worktree)/);
   assert.equal(listManifestPaths(repoRoot).length, 1);
 });
 

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -290,6 +290,53 @@ test("dispatch resume fails when --run-id does not resolve", () => {
   assert.match(result.stderr, new RegExp(`No relay manifest found for run_id '${missingRunId}'`));
 });
 
+test("dispatch resume rejects crafted manifest repo roots before touching an unrelated repo", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-160",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+  const manifestPath = first.manifestPath;
+  const runId = first.runId;
+
+  const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-attacker-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Attacker"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "attacker@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "attacker\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    paths: {
+      ...(record.data.paths || {}),
+      repo_root: attackerRoot,
+      worktree: path.join(attackerRoot, "wt", "issue-160"),
+    },
+  }, record.body);
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", runId, "--prompt", "resume", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.repo_root/);
+  assert.equal(fs.existsSync(path.join(attackerRoot, "first.txt")), false, "dispatch must reject before writing into the attacker repo");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+});
+
 test("dispatch with --executor claude creates worktree and collects result", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -31,6 +31,29 @@ function setupRepo() {
   return { repoRoot, relayHome };
 }
 
+function createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, branch = "issue-42") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-foreign-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Dispatch Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-dispatch-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  const relayWorktrees = path.join(relayHome, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
+  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
+    cwd: attackerRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, attackerWorktree };
+}
+
 function writeFakeClaude(binDir) {
   const claudePath = path.join(binDir, "claude");
   fs.writeFileSync(claudePath, `#!/usr/bin/env node
@@ -335,6 +358,40 @@ test("dispatch resume rejects crafted manifest repo roots before touching an unr
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+});
+
+test("dispatch resume rejects relay-base same-name worktrees from a different repo before reuse", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-160",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, "issue-160");
+  const record = readManifest(first.manifestPath);
+  writeManifest(first.manifestPath, {
+    ...updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: attackerWorktree,
+    },
+  }, record.body);
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--prompt", "resume", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.worktree/);
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "resume.txt")), false, "dispatch must reject before reusing the foreign relay worktree");
+  assert.equal(readManifest(first.manifestPath).data.state, STATES.CHANGES_REQUESTED);
 });
 
 test("dispatch with --executor claude creates worktree and collects result", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -505,8 +505,8 @@ function validateManifestPaths(paths, {
   const expectedGitCommonDir = getWorktreeGitCommonDir(repoRoot) || path.join(repoRoot, ".git");
   const relayOwnedWorktree = relayOwnedWorktreeCandidate
     && (
-      !fs.existsSync(worktree)
-      || (() => {
+      fs.existsSync(worktree)
+      && (() => {
         const worktreeGitCommonDir = getWorktreeGitCommonDir(worktree);
         return worktreeGitCommonDir
           && (

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -502,7 +502,7 @@ function validateManifestPaths(paths, {
   const repoContainedWorktree = isPathContainedWithin(repoRoot, worktree);
   const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
     && path.basename(worktree) === path.basename(repoRoot);
-  const expectedGitCommonDir = path.join(repoRoot, ".git");
+  const expectedGitCommonDir = getWorktreeGitCommonDir(repoRoot) || path.join(repoRoot, ".git");
   const relayOwnedWorktree = relayOwnedWorktreeCandidate
     && (
       !fs.existsSync(worktree)

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -22,6 +22,17 @@ function getRunsBase() {
   return process.env.RELAY_RUNS_BASE || path.join(getRelayHome(), "runs");
 }
 
+function getRelayWorktreeBase() {
+  const base = process.env.RELAY_WORKTREE_BASE || path.join(getRelayHome(), "worktrees");
+  if (!path.isAbsolute(base)) {
+    throw new Error(
+      `RELAY_WORKTREE_BASE must be an absolute path, got: ${JSON.stringify(base)}. ` +
+      `Either set RELAY_WORKTREE_BASE explicitly or ensure RELAY_HOME resolves to an absolute path.`
+    );
+  }
+  return path.resolve(base);
+}
+
 function getRepoSlug(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {
     throw new Error(`getRepoSlug requires a non-empty repoRoot path, got: ${JSON.stringify(repoRoot)}`);
@@ -362,6 +373,119 @@ function listManifestRecords(repoRoot) {
   return listManifestPaths(repoRoot)
     .map((manifestPath) => ({ manifestPath, ...readManifest(manifestPath) }))
     .sort((left, right) => sortKeyForManifest(right).localeCompare(sortKeyForManifest(left)));
+}
+
+function isPathContainedWithin(basePath, candidatePath, { allowEqual = false } = {}) {
+  if (!basePath || !candidatePath) return false;
+  const resolvedBase = path.resolve(basePath);
+  const resolvedCandidate = path.resolve(candidatePath);
+  const relative = path.relative(resolvedBase, resolvedCandidate);
+  if (relative === "") {
+    return allowEqual;
+  }
+  return relative !== ".."
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+function sameFilesystemLocation(leftPath, rightPath) {
+  if (!leftPath || !rightPath) return false;
+  try {
+    return fs.realpathSync.native(leftPath) === fs.realpathSync.native(rightPath);
+  } catch {
+    return false;
+  }
+}
+
+function validateManifestPaths(paths, {
+  expectedRepoRoot,
+  manifestPath,
+  runId,
+  requireWorktree = false,
+  caller = "relay manifest consumer",
+} = {}) {
+  if (!paths || typeof paths !== "object" || Array.isArray(paths)) {
+    throw new Error(`${caller}: manifest paths must be an object`);
+  }
+
+  const repoRootRaw = typeof paths.repo_root === "string" ? paths.repo_root.trim() : "";
+  if (!repoRootRaw) {
+    throw new Error(`${caller}: manifest paths.repo_root must be a non-empty path`);
+  }
+
+  const repoRoot = path.resolve(repoRootRaw);
+  const normalizedExpectedRepoRoot = typeof expectedRepoRoot === "string" && expectedRepoRoot.trim() !== ""
+    ? path.resolve(expectedRepoRoot)
+    : null;
+  const normalizedManifestPath = typeof manifestPath === "string" && manifestPath.trim() !== ""
+    ? path.resolve(manifestPath)
+    : null;
+  const normalizedRunId = requireValidRunId(
+    runId ?? paths.run_id ?? (() => {
+      throw new Error(`${caller}: run_id is required to validate manifest paths`);
+    })()
+  );
+
+  if (
+    normalizedExpectedRepoRoot
+    && repoRoot !== normalizedExpectedRepoRoot
+    && !sameFilesystemLocation(repoRoot, normalizedExpectedRepoRoot)
+  ) {
+    throw new Error(
+      `${caller}: manifest paths.repo_root ${JSON.stringify(repoRoot)} does not match the expected repo root ` +
+      `${JSON.stringify(normalizedExpectedRepoRoot)}. Refusing to trust manifest-owned repo paths.`
+    );
+  }
+
+  if (normalizedManifestPath) {
+    const expectedManifestPath = getManifestPath(repoRoot, normalizedRunId);
+    if (normalizedManifestPath !== expectedManifestPath) {
+      throw new Error(
+        `${caller}: manifest paths.repo_root ${JSON.stringify(repoRoot)} does not match the manifest storage path ` +
+        `${JSON.stringify(normalizedManifestPath)} for run ${JSON.stringify(normalizedRunId)}. ` +
+        `Expected ${JSON.stringify(expectedManifestPath)}.`
+      );
+    }
+  } else if (!normalizedExpectedRepoRoot) {
+    throw new Error(
+      `${caller}: validateManifestPaths requires either expectedRepoRoot or manifestPath when validating ` +
+      `repo_root for run ${JSON.stringify(normalizedRunId)}.`
+    );
+  }
+
+  const worktreeRaw = typeof paths.worktree === "string" ? paths.worktree.trim() : "";
+  if (!worktreeRaw) {
+    if (requireWorktree) {
+      throw new Error(`${caller}: manifest paths.worktree must be set`);
+    }
+    return {
+      repoRoot,
+      worktree: null,
+      worktreeLocation: "missing",
+      relayWorktreeBase: getRelayWorktreeBase(),
+    };
+  }
+
+  const worktree = path.resolve(worktreeRaw);
+  const relayWorktreeBase = getRelayWorktreeBase();
+  const repoContainedWorktree = isPathContainedWithin(repoRoot, worktree);
+  const relayOwnedWorktree = isPathContainedWithin(relayWorktreeBase, worktree)
+    && path.basename(worktree) === path.basename(repoRoot);
+
+  if (!repoContainedWorktree && !relayOwnedWorktree) {
+    throw new Error(
+      `${caller}: manifest paths.worktree ${JSON.stringify(worktree)} is not contained under the expected repo root ` +
+      `${JSON.stringify(repoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +
+      `for repo ${JSON.stringify(path.basename(repoRoot))}.`
+    );
+  }
+
+  return {
+    repoRoot,
+    worktree,
+    worktreeLocation: repoContainedWorktree ? "repo_root" : "relay_worktree",
+    relayWorktreeBase,
+  };
 }
 
 function validateTransition(fromState, toState) {
@@ -772,9 +896,22 @@ function isTerminalState(state) {
 }
 
 function runCleanup({ repoRoot, data, gitBin = "git", dryRun = false, deleteMergedBranch = false }) {
+  const validatedPaths = validateManifestPaths(data?.paths, {
+    expectedRepoRoot: repoRoot,
+    runId: data?.run_id,
+    caller: "runCleanup",
+  });
+  const normalizedData = {
+    ...data,
+    paths: {
+      ...(data?.paths || {}),
+      repo_root: validatedPaths.repoRoot,
+      worktree: validatedPaths.worktree,
+    },
+  };
   const attemptedAt = nowIso();
-  const worktreePath = data.paths?.worktree || null;
-  const branch = data.git?.working_branch || null;
+  const worktreePath = normalizedData.paths?.worktree || null;
+  const branch = normalizedData.git?.working_branch || null;
   const worktreeStatus = readWorktreeStatus(gitBin, worktreePath);
   const branchExistsBefore = localBranchExists(gitBin, repoRoot, branch);
   const errors = [];
@@ -828,12 +965,12 @@ function runCleanup({ repoRoot, data, gitBin = "git", dryRun = false, deleteMerg
     ? "done"
     : "manual_cleanup_required";
 
-  const updatedData = updateManifestCleanup(data, {
+  const updatedData = updateManifestCleanup(normalizedData, {
     status: cleanupStatus,
     last_attempted_at: attemptedAt,
     cleaned_at: cleanupStatus === CLEANUP_STATUSES.SUCCEEDED
       ? attemptedAt
-      : (data.cleanup?.cleaned_at || null),
+      : (normalizedData.cleanup?.cleaned_at || null),
     worktree_removed: worktreeRemoved,
     branch_deleted: branchDeleted,
     prune_ran: pruneRan,
@@ -1000,6 +1137,7 @@ module.exports = {
   summarizeError,
   updateManifestCleanup,
   updateManifestState,
+  validateManifestPaths,
   validateRubricPathContainment,
   validateRunId,
   validateTransition,

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -397,6 +397,37 @@ function sameFilesystemLocation(leftPath, rightPath) {
   }
 }
 
+function getWorktreeGitCommonDir(worktreePath) {
+  if (!worktreePath || !fs.existsSync(worktreePath)) {
+    return null;
+  }
+  try {
+    const gitEntry = path.join(worktreePath, ".git");
+    if (!fs.existsSync(gitEntry)) {
+      return null;
+    }
+    const gitEntryStat = fs.statSync(gitEntry);
+    if (gitEntryStat.isDirectory()) {
+      return path.resolve(gitEntry);
+    }
+
+    const gitEntryText = fs.readFileSync(gitEntry, "utf-8").trim();
+    const gitDirPrefix = "gitdir:";
+    if (!gitEntryText.startsWith(gitDirPrefix)) {
+      return null;
+    }
+    const gitDir = path.resolve(worktreePath, gitEntryText.slice(gitDirPrefix.length).trim());
+    const commonDirPath = path.join(gitDir, "commondir");
+    if (!fs.existsSync(commonDirPath)) {
+      return gitDir;
+    }
+    const commonDirText = fs.readFileSync(commonDirPath, "utf-8").trim();
+    return commonDirText ? path.resolve(gitDir, commonDirText) : gitDir;
+  } catch {
+    return null;
+  }
+}
+
 function validateManifestPaths(paths, {
   expectedRepoRoot,
   manifestPath,
@@ -469,14 +500,27 @@ function validateManifestPaths(paths, {
   const worktree = path.resolve(worktreeRaw);
   const relayWorktreeBase = getRelayWorktreeBase();
   const repoContainedWorktree = isPathContainedWithin(repoRoot, worktree);
-  const relayOwnedWorktree = isPathContainedWithin(relayWorktreeBase, worktree)
+  const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
     && path.basename(worktree) === path.basename(repoRoot);
+  const expectedGitCommonDir = path.join(repoRoot, ".git");
+  const relayOwnedWorktree = relayOwnedWorktreeCandidate
+    && (
+      !fs.existsSync(worktree)
+      || (() => {
+        const worktreeGitCommonDir = getWorktreeGitCommonDir(worktree);
+        return worktreeGitCommonDir
+          && (
+            worktreeGitCommonDir === expectedGitCommonDir
+            || sameFilesystemLocation(worktreeGitCommonDir, expectedGitCommonDir)
+          );
+      })()
+    );
 
   if (!repoContainedWorktree && !relayOwnedWorktree) {
     throw new Error(
       `${caller}: manifest paths.worktree ${JSON.stringify(worktree)} is not contained under the expected repo root ` +
       `${JSON.stringify(repoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +
-      `for repo ${JSON.stringify(path.basename(repoRoot))}.`
+      `that is bound to ${JSON.stringify(expectedGitCommonDir)} for repo ${JSON.stringify(path.basename(repoRoot))}.`
     );
   }
 

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -35,6 +35,35 @@ function initGitRepo(repoRoot, actor = "Relay Test") {
   execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
 }
 
+function createCommittedRepo(repoRoot, actor = "Relay Test") {
+  initGitRepo(repoRoot, actor);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function createRelayOwnedWorktree(repoRoot, branch = "issue-42") {
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "relay-owned-"));
+  const worktreePath = path.join(worktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  return worktreePath;
+}
+
+function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-foreign-repo-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  createCommittedRepo(attackerRoot, "Relay Foreign");
+  const worktreePath = createRelayOwnedWorktree(attackerRoot, branch);
+  fs.writeFileSync(path.join(worktreePath, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, worktreePath };
+}
+
 function writeRunRubric(repoRoot, runId, rubricPath = "rubric.yaml", content = "rubric:\n  factors:\n    - name: manifest\n") {
   const { runDir } = ensureRunLayout(repoRoot, runId);
   const fullPath = path.join(runDir, rubricPath);
@@ -171,6 +200,7 @@ test("getRunDir and getManifestPath reject invalid run_id before path derivation
 test("validateManifestPaths accepts repo-contained and relay-owned worktrees", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-paths-ok-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  createCommittedRepo(repoRoot, "Relay Paths");
   const runId = "issue-42-20260402103000500";
   const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
 
@@ -187,7 +217,7 @@ test("validateManifestPaths accepts repo-contained and relay-owned worktrees", (
   assert.equal(repoContained.worktree, path.join(repoRoot, "wt", "issue-42"));
   assert.equal(repoContained.worktreeLocation, "repo_root");
 
-  const relayOwnedWorktree = path.join(process.env.RELAY_HOME, "worktrees", "abc123", path.basename(repoRoot));
+  const relayOwnedWorktree = createRelayOwnedWorktree(repoRoot);
   const relayOwned = validateManifestPaths({
     repo_root: repoRoot,
     worktree: relayOwnedWorktree,
@@ -236,6 +266,17 @@ test("validateManifestPaths rejects mismatched repo roots, escaped worktrees, an
     runId,
     caller: "relay-manifest.test manifest mismatch",
   }), /does not match the manifest storage path/);
+
+  const { worktreePath: unrelatedRelayWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot);
+  assert.throws(() => validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: unrelatedRelayWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test unrelated relay-owned worktree",
+  }), /is not contained under the expected repo root/);
 });
 
 test("manifest round-trips through frontmatter helpers", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -229,6 +229,25 @@ test("validateManifestPaths accepts repo-contained and relay-owned worktrees", (
   });
   assert.equal(relayOwned.worktree, relayOwnedWorktree);
   assert.equal(relayOwned.worktreeLocation, "relay_worktree");
+
+  const linkedRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-linked-root-"));
+  execFileSync("git", ["worktree", "add", linkedRepoRoot, "-b", "issue-42-linked-root"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  const linkedManifestPath = ensureRunLayout(linkedRepoRoot, runId).manifestPath;
+  const linkedRelayOwnedWorktree = createRelayOwnedWorktree(linkedRepoRoot, "issue-42-linked-relay");
+  const linkedRelayOwned = validateManifestPaths({
+    repo_root: linkedRepoRoot,
+    worktree: linkedRelayOwnedWorktree,
+  }, {
+    expectedRepoRoot: linkedRepoRoot,
+    manifestPath: linkedManifestPath,
+    runId,
+    caller: "relay-manifest.test linked relay-owned",
+  });
+  assert.equal(linkedRelayOwned.worktree, linkedRelayOwnedWorktree);
+  assert.equal(linkedRelayOwned.worktreeLocation, "relay_worktree");
 });
 
 test("validateManifestPaths rejects mismatched repo roots, escaped worktrees, and manifest-path mismatches", () => {

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -64,6 +64,13 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, worktreePath };
 }
 
+function createMissingRelayOwnedWorktree(repoRoot) {
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "relay-missing-"));
+  return path.join(worktreeParent, path.basename(repoRoot));
+}
+
 function writeRunRubric(repoRoot, runId, rubricPath = "rubric.yaml", content = "rubric:\n  factors:\n    - name: manifest\n") {
   const { runDir } = ensureRunLayout(repoRoot, runId);
   const fullPath = path.join(runDir, rubricPath);
@@ -256,6 +263,7 @@ test("validateManifestPaths rejects mismatched repo roots, escaped worktrees, an
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const runId = "issue-42-20260402103000600";
   const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  const missingRelayOwnedWorktree = createMissingRelayOwnedWorktree(repoRoot);
 
   assert.throws(() => validateManifestPaths({
     repo_root: attackerRoot,
@@ -275,6 +283,16 @@ test("validateManifestPaths rejects mismatched repo roots, escaped worktrees, an
     manifestPath,
     runId,
     caller: "relay-manifest.test escaped worktree",
+  }), /is not contained under the expected repo root/);
+
+  assert.throws(() => validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: missingRelayOwnedWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test missing relay-owned worktree",
   }), /is not contained under the expected repo root/);
 
   assert.throws(() => validateManifestPaths({

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -24,6 +24,7 @@ const {
   readPreviousAttempts,
   updateManifestCleanup,
   updateManifestState,
+  validateManifestPaths,
   validateRunId,
   writeManifest,
 } = require("./relay-manifest");
@@ -165,6 +166,76 @@ test("getRunDir and getManifestPath reject invalid run_id before path derivation
     () => getManifestPath(repoRoot, "issue-42\\20260412000000000"),
     /run_id must be a single path segment/
   );
+});
+
+test("validateManifestPaths accepts repo-contained and relay-owned worktrees", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-paths-ok-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = "issue-42-20260402103000500";
+  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+
+  const repoContained = validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: path.join(repoRoot, "wt", "issue-42"),
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test repo-contained",
+  });
+  assert.equal(repoContained.repoRoot, path.resolve(repoRoot));
+  assert.equal(repoContained.worktree, path.join(repoRoot, "wt", "issue-42"));
+  assert.equal(repoContained.worktreeLocation, "repo_root");
+
+  const relayOwnedWorktree = path.join(process.env.RELAY_HOME, "worktrees", "abc123", path.basename(repoRoot));
+  const relayOwned = validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: relayOwnedWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test relay-owned",
+  });
+  assert.equal(relayOwned.worktree, relayOwnedWorktree);
+  assert.equal(relayOwned.worktreeLocation, "relay_worktree");
+});
+
+test("validateManifestPaths rejects mismatched repo roots, escaped worktrees, and manifest-path mismatches", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-paths-bad-"));
+  const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-paths-attacker-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = "issue-42-20260402103000600";
+  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+
+  assert.throws(() => validateManifestPaths({
+    repo_root: attackerRoot,
+    worktree: path.join(attackerRoot, "wt", "issue-42"),
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test mismatched repo",
+  }), /does not match the expected repo root/);
+
+  assert.throws(() => validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: attackerRoot,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test escaped worktree",
+  }), /is not contained under the expected repo root/);
+
+  assert.throws(() => validateManifestPaths({
+    repo_root: attackerRoot,
+    worktree: path.join(attackerRoot, "wt", path.basename(attackerRoot)),
+  }, {
+    manifestPath,
+    runId,
+    caller: "relay-manifest.test manifest mismatch",
+  }), /does not match the manifest storage path/);
 });
 
 test("manifest round-trips through frontmatter helpers", () => {

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -23,11 +23,13 @@
  */
 
 const { execFileSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 const {
   getRunDir,
   STATES,
   updateManifestState,
+  validateManifestPaths,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
@@ -93,6 +95,10 @@ function git(gitBin, repoPath, ...gitArgs) {
     encoding: "utf-8",
     stdio: "pipe",
   }).trim();
+}
+
+function looksLikeGitRepo(repoPath) {
+  return fs.existsSync(path.join(repoPath, ".git"));
 }
 
 function resolveBranch(ghBin, repoPath, prNumber, branchArg, manifestData) {
@@ -228,8 +234,14 @@ function main() {
     prNumber,
     includeTerminal: skipMerge,
   });
-  if ((manifestArg || runId) && !repoArg && manifestRecord.data.paths?.repo_root) {
-    repoPath = path.resolve(manifestRecord.data.paths.repo_root);
+  let validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
+    expectedRepoRoot: (repoArg || looksLikeGitRepo(repoPath)) ? repoPath : undefined,
+    manifestPath: manifestRecord.manifestPath,
+    runId: manifestRecord.data?.run_id,
+    caller: "finalize-run",
+  });
+  repoPath = validatedPaths.repoRoot;
+  if ((manifestArg || runId) && !repoArg) {
     manifestRecord = resolveManifestRecord({
       repoRoot: repoPath,
       manifestPath: manifestArg,
@@ -238,24 +250,38 @@ function main() {
       prNumber,
       includeTerminal: skipMerge,
     });
+    validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
+      expectedRepoRoot: repoPath,
+      manifestPath: manifestRecord.manifestPath,
+      runId: manifestRecord.data?.run_id,
+      caller: "finalize-run",
+    });
   }
 
   const { manifestPath, data, body } = manifestRecord;
-  prNumber = prNumber || data.git?.pr_number || null;
-  branch = resolveBranch(ghBin, repoPath, prNumber, branch, data);
+  const safeData = {
+    ...data,
+    paths: {
+      ...(data.paths || {}),
+      repo_root: validatedPaths.repoRoot,
+      worktree: validatedPaths.worktree,
+    },
+  };
+  prNumber = prNumber || safeData.git?.pr_number || null;
+  branch = resolveBranch(ghBin, repoPath, prNumber, branch, safeData);
   if (!skipMerge && !prNumber) {
     throw new Error("PR number is required for merge finalization");
   }
-  if (skipMerge && data.state !== STATES.MERGED) {
+  if (skipMerge && safeData.state !== STATES.MERGED) {
     throw new Error("--skip-merge can only be used for runs that are already in the merged state");
   }
-  if (!skipMerge && data.state !== STATES.READY_TO_MERGE) {
-    if (data.state !== STATES.MERGED) {
-      throw new Error(`Expected relay run to be ${STATES.READY_TO_MERGE} before merge, got ${data.state}`);
+  if (!skipMerge && safeData.state !== STATES.READY_TO_MERGE) {
+    if (safeData.state !== STATES.MERGED) {
+      throw new Error(`Expected relay run to be ${STATES.READY_TO_MERGE} before merge, got ${safeData.state}`);
     }
   }
 
-  let updated = data;
+  let updated = safeData;
   let mergePerformed = false;
   let mergeRecovered = false;
   let prMergeState = dryRun ? { state: "MERGED", mergeCommitSha: null } : null;
@@ -267,7 +293,7 @@ function main() {
   let issueCloseWarning = null;
   let reviewGate = null;
 
-  if (!skipMerge && data.state === STATES.READY_TO_MERGE) {
+  if (!skipMerge && safeData.state === STATES.READY_TO_MERGE) {
     if (skipReviewReason) {
       reviewGate = {
         status: "skipped",
@@ -284,18 +310,18 @@ function main() {
         prNumber,
         comments: preMerge.comments,
         commits: preMerge.commits,
-        manifestData: data,
-        expectedReviewerLogin: data.review?.reviewer_login || null,
-        runDir: getRunDir(data.paths?.repo_root || repoPath, data.run_id),
+        manifestData: safeData,
+        expectedReviewerLogin: safeData.review?.reviewer_login || null,
+        runDir: getRunDir(validatedPaths.repoRoot, safeData.run_id),
       });
       if (!reviewGate.readyToMerge) {
         if (!dryRun) {
-          appendRunEvent(repoPath, data.run_id, {
+          appendRunEvent(repoPath, safeData.run_id, {
             event: "merge_blocked",
-            state_from: data.state,
-            state_to: data.state,
-            head_sha: reviewGate.latestCommit || data.git?.head_sha || null,
-            round: data.review?.rounds || null,
+            state_from: safeData.state,
+            state_to: safeData.state,
+            head_sha: reviewGate.latestCommit || safeData.git?.head_sha || null,
+            round: safeData.review?.rounds || null,
             reason: reviewGate.status,
           });
         }
@@ -316,7 +342,7 @@ function main() {
     }
   }
 
-  if (!skipMerge && data.state === STATES.READY_TO_MERGE) {
+  if (!skipMerge && safeData.state === STATES.READY_TO_MERGE) {
 
     prMergeState = dryRun ? prMergeState : fetchPrMergeState(ghBin, repoPath, prNumber);
     if (!dryRun && prMergeState.state !== "MERGED") {
@@ -356,12 +382,12 @@ function main() {
         prMergeState = fetchPrMergeState(ghBin, repoPath, prNumber);
         if (prMergeState.state === "MERGED") break;
         if (prMergeState.state === "OPEN") {
-          appendRunEvent(repoPath, data.run_id, {
+          appendRunEvent(repoPath, safeData.run_id, {
             event: "merge_blocked",
-            state_from: data.state,
-            state_to: data.state,
-            head_sha: reviewGate?.latestCommit || data.git?.head_sha || null,
-            round: data.review?.rounds || null,
+            state_from: safeData.state,
+            state_to: safeData.state,
+            head_sha: reviewGate?.latestCommit || safeData.git?.head_sha || null,
+            round: safeData.review?.rounds || null,
             reason: "removed_from_merge_queue",
           });
           throw new Error(
@@ -370,12 +396,12 @@ function main() {
         }
       }
       if (prMergeState.state !== "MERGED") {
-        appendRunEvent(repoPath, data.run_id, {
+        appendRunEvent(repoPath, safeData.run_id, {
           event: "merge_blocked",
-          state_from: data.state,
-          state_to: data.state,
-          head_sha: reviewGate?.latestCommit || data.git?.head_sha || null,
-          round: data.review?.rounds || null,
+          state_from: safeData.state,
+          state_to: safeData.state,
+          head_sha: reviewGate?.latestCommit || safeData.git?.head_sha || null,
+          round: safeData.review?.rounds || null,
           reason: `merge_queue_timeout:${prMergeState.state || "unknown"}`,
         });
         const totalWaitMin = Math.round((MERGE_QUEUE_POLL_INTERVAL_MS * MERGE_QUEUE_MAX_POLLS) / 60000);
@@ -402,9 +428,9 @@ function main() {
       },
     };
     if (!dryRun) {
-      appendRunEvent(repoPath, data.run_id, {
+      appendRunEvent(repoPath, safeData.run_id, {
         event: "merge_finalize",
-        state_from: data.state,
+        state_from: safeData.state,
         state_to: STATES.MERGED,
         head_sha: updated.git?.head_sha || null,
         round: updated.review?.rounds || null,
@@ -454,7 +480,7 @@ function main() {
 
   const result = {
     manifestPath,
-    previousState: data.state,
+    previousState: safeData.state,
     state: updated.state,
     nextAction: updated.next_action,
     branch,
@@ -479,7 +505,7 @@ function main() {
     console.log(JSON.stringify(result, null, 2));
   } else {
     console.log(`Finalized relay run: ${manifestPath}`);
-    console.log(`  State:        ${data.state} -> ${updated.state}`);
+    console.log(`  State:        ${safeData.state} -> ${updated.state}`);
     console.log(`  Next action:  ${updated.next_action}`);
     console.log(`  Merge:        ${mergePerformed ? `performed (${mergeMethod})` : (skipMerge ? "skipped" : "already merged")}`);
     if (!skipMerge) {

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -234,8 +234,11 @@ function main() {
     prNumber,
     includeTerminal: skipMerge,
   });
+  const selectorExpectedRepoRoot = manifestArg
+    ? undefined
+    : ((repoArg || looksLikeGitRepo(repoPath)) ? repoPath : undefined);
   let validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
-    expectedRepoRoot: (repoArg || looksLikeGitRepo(repoPath)) ? repoPath : undefined,
+    expectedRepoRoot: selectorExpectedRepoRoot,
     manifestPath: manifestRecord.manifestPath,
     runId: manifestRecord.data?.run_id,
     caller: "finalize-run",
@@ -251,7 +254,7 @@ function main() {
       includeTerminal: skipMerge,
     });
     validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
-      expectedRepoRoot: repoPath,
+      expectedRepoRoot: manifestArg ? undefined : repoPath,
       manifestPath: manifestRecord.manifestPath,
       runId: manifestRecord.data?.run_id,
       caller: "finalize-run",

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -98,6 +98,17 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
+function createUnrelatedGitRepo(prefix = "relay-finalize-manifest-cwd-") {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Finalize Manifest"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-finalize-manifest@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "manifest selector\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return repoRoot;
+}
+
 function branchExists(repoRoot, branch) {
   try {
     execFileSync("git", ["-C", repoRoot, "rev-parse", "--verify", `refs/heads/${branch}`], {
@@ -750,8 +761,9 @@ test("finalize-run preserves dirty worktrees and records manual cleanup follow-u
   assert.match(manifest.cleanup.error, /dirty worktree/);
 });
 
-test("finalize-run can derive the repo root from --manifest alone", () => {
+test("finalize-run can derive the repo root from --manifest alone even from an unrelated git repo", () => {
   const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
+  const selectorRepo = createUnrelatedGitRepo();
   const logPath = path.join(repoRoot, "gh.log");
   const fakeGh = writeFakeGh(logPath, {
     comments: [
@@ -774,7 +786,7 @@ test("finalize-run can derive the repo root from --manifest alone", () => {
     "--pr", "123",
     "--json",
   ], {
-    cwd: os.tmpdir(),
+    cwd: selectorRepo,
     encoding: "utf-8",
     stdio: "pipe",
     env: { ...process.env, RELAY_GH_BIN: fakeGh },

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -265,6 +265,56 @@ test("finalize-run rejects invalid manifest run_id before merge finalization", (
   assert.equal(branchExists(repoRoot, branch), true);
 });
 
+test("finalize-run rejects crafted manifest repo roots before merge or cleanup side effects", () => {
+  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
+  const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-finalize-attacker-"));
+  const logPath = path.join(repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      {
+        oid: headSha,
+        committedDate: "2026-04-03T08:00:00Z",
+      },
+    ],
+  });
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      repo_root: attackerRoot,
+      worktree: path.join(attackerRoot, "wt", "issue-42"),
+    },
+  }, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  }), (error) => {
+    assert.match(String(error.stderr), /manifest paths\.repo_root/);
+    return true;
+  });
+
+  assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
+  assert.equal(branchExists(repoRoot, branch), true);
+  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.equal(fs.existsSync(logPath), false);
+});
+
 test("finalize-run fails closed when branch+PR resolution only finds a stale terminal manifest", () => {
   const { repoRoot, manifestPath, branch } = setupRepo();
   const record = readManifest(manifestPath);

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -75,6 +75,29 @@ function setupRepo({ dirtyWorktree = false } = {}) {
   return { repoRoot, manifestPath, branch, worktreePath, headSha };
 }
 
+function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-finalize-foreign-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Finalize Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-finalize-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
+  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
+    cwd: attackerRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, attackerWorktree };
+}
+
 function branchExists(repoRoot, branch) {
   try {
     execFileSync("git", ["-C", repoRoot, "rev-parse", "--verify", `refs/heads/${branch}`], {
@@ -310,6 +333,56 @@ test("finalize-run rejects crafted manifest repo roots before merge or cleanup s
   });
 
   assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
+  assert.equal(branchExists(repoRoot, branch), true);
+  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.equal(fs.existsSync(logPath), false);
+});
+
+test("finalize-run rejects relay-base same-name worktrees before merge or cleanup side effects", () => {
+  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
+  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot, branch);
+  const logPath = path.join(repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      {
+        oid: headSha,
+        committedDate: "2026-04-03T08:00:00Z",
+      },
+    ],
+  });
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: attackerWorktree,
+    },
+  }, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  }), (error) => {
+    assert.match(String(error.stderr), /manifest paths\.worktree/);
+    return true;
+  });
+
+  assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
   assert.equal(branchExists(repoRoot, branch), true);
   assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
   assert.equal(fs.existsSync(logPath), false);

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -98,6 +98,13 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
+function createMissingRelayOwnedWorktree(repoRoot) {
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "missing-"));
+  return path.join(worktreeParent, path.basename(repoRoot));
+}
+
 function createUnrelatedGitRepo(prefix = "relay-finalize-manifest-cwd-") {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -395,6 +402,56 @@ test("finalize-run rejects relay-base same-name worktrees before merge or cleanu
   assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
   assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
   assert.equal(branchExists(repoRoot, branch), true);
+  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.equal(fs.existsSync(logPath), false);
+});
+
+test("finalize-run rejects missing relay-base same-name worktrees before merge or cleanup side effects", () => {
+  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
+  const missingWorktree = createMissingRelayOwnedWorktree(repoRoot);
+  const logPath = path.join(repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      {
+        oid: headSha,
+        committedDate: "2026-04-03T08:00:00Z",
+      },
+    ],
+  });
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: missingWorktree,
+    },
+  }, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  }), (error) => {
+    assert.match(String(error.stderr), /manifest paths\.worktree/);
+    return true;
+  });
+
+  assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
+  assert.equal(branchExists(repoRoot, branch), true);
+  assert.equal(fs.existsSync(missingWorktree), false);
   assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
   assert.equal(fs.existsSync(logPath), false);
 });

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -28,7 +28,13 @@ const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const { buildSkipComment, evaluateReviewGate } = require("./review-gate");
-const { STATES, getRunDir, readManifest, writeManifest } = require("../../relay-dispatch/scripts/relay-manifest");
+const {
+  STATES,
+  getRunDir,
+  readManifest,
+  validateManifestPaths,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/relay-manifest");
 const { appendRunEvent, readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 
@@ -137,7 +143,13 @@ function waitForPrNumberStampLock(lockPath) {
 }
 
 function stampPrNumberUnderLock(manifestRecord, numericPrNumber) {
-  const repoRoot = manifestRecord.data?.paths?.repo_root || process.cwd();
+  const validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
+    expectedRepoRoot: process.cwd(),
+    manifestPath: manifestRecord.manifestPath,
+    runId: manifestRecord.data?.run_id,
+    caller: "gate-check PR stamping",
+  });
+  const repoRoot = validatedPaths.repoRoot;
   const runDir = getRunDir(repoRoot, manifestRecord.data?.run_id);
   const lockPath = path.join(runDir, PR_NUMBER_STAMP_LOCK_NAME);
   let lockFd = null;
@@ -357,7 +369,21 @@ function main() {
     }
     manifestData = manifestRecord.data;
     try {
-      runDir = getRunDir(manifestData.paths?.repo_root || process.cwd(), manifestData.run_id);
+      const validatedPaths = validateManifestPaths(manifestData.paths, {
+        expectedRepoRoot: process.cwd(),
+        manifestPath: manifestRecord.manifestPath,
+        runId: manifestData.run_id,
+        caller: "gate-check",
+      });
+      manifestData = {
+        ...manifestData,
+        paths: {
+          ...(manifestData.paths || {}),
+          repo_root: validatedPaths.repoRoot,
+          worktree: validatedPaths.worktree,
+        },
+      };
+      runDir = getRunDir(validatedPaths.repoRoot, manifestData.run_id);
     } catch (error) {
       output({
         status: "manifest_resolution_failed",

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { spawn, spawnSync } = require("child_process");
+const { execFileSync, spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -217,6 +217,29 @@ function createLiveGateFixture({ manifest, rubricContent, afterManifestSetup = n
     afterManifestSetup({ ...liveManifest, repoRoot, relayHome, binDir });
   }
   return { ...liveManifest, repoRoot, relayHome, binDir };
+}
+
+function createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, branch = "issue-40") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-foreign-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Gate Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-gate-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  const relayWorktrees = path.join(relayHome, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
+  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
+    cwd: attackerRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, attackerWorktree };
 }
 
 function buildStampLockEnv({ timeoutMs = 75, pollMs = 5 } = {}) {
@@ -558,6 +581,40 @@ test("gate-check rejects crafted manifest repo roots before stamping or merge ga
   assert.equal(result.json.status, "manifest_resolution_failed");
   assert.equal(result.json.readyToMerge, false);
   assert.match(result.json.reason, /manifest paths\.repo_root/);
+});
+
+test("gate-check rejects relay-base same-name worktrees before stamping or merge gating", () => {
+  const fixture = createLiveGateFixture({
+    manifest: {
+      anchor: {
+        rubric_grandfathered: true,
+      },
+      state: STATES.REVIEW_PENDING,
+    },
+  });
+  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(fixture.repoRoot, fixture.relayHome);
+  const record = readManifest(fixture.manifestPath);
+  writeManifest(fixture.manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: attackerWorktree,
+    },
+  }, record.body);
+
+  const result = runGateCheckWithFixture(fixture, {
+    prViewPayload: {
+      comments: [],
+      commits: [],
+      headRefName: "issue-40",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "manifest_resolution_failed");
+  assert.equal(result.json.readyToMerge, false);
+  assert.match(result.json.reason, /manifest paths\.worktree/);
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
 });
 
 test("gate-check skips unauthorized and uses authorized review when both exist", () => {

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -527,6 +527,39 @@ test("gate-check rejects manifests whose stored run_id is invalid", () => {
   assert.equal(fs.existsSync(path.join(result.relayHome, "runs", "victim-gate-run")), false);
 });
 
+test("gate-check rejects crafted manifest repo roots before stamping or merge gating", () => {
+  const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-attacker-"));
+  const result = runGateCheckLive({
+    manifest: {
+      anchor: {
+        rubric_grandfathered: true,
+      },
+      state: STATES.REVIEW_PENDING,
+    },
+    afterManifestSetup: ({ manifestPath }) => {
+      const record = readManifest(manifestPath);
+      writeManifest(manifestPath, {
+        ...record.data,
+        paths: {
+          ...(record.data.paths || {}),
+          repo_root: attackerRoot,
+          worktree: path.join(attackerRoot, "wt", "dev-relay"),
+        },
+      }, record.body);
+    },
+    prViewPayload: {
+      comments: [],
+      commits: [],
+      headRefName: "issue-40",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "manifest_resolution_failed");
+  assert.equal(result.json.readyToMerge, false);
+  assert.match(result.json.reason, /manifest paths\.repo_root/);
+});
+
 test("gate-check skips unauthorized and uses authorized review when both exist", () => {
   const result = runGateCheckDryRun({
     comments: [

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -39,6 +39,7 @@ const {
   getRunDir,
   readManifest,
   updateManifestState,
+  validateManifestPaths,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
@@ -150,6 +151,10 @@ function readText(filePath) {
 function writeText(filePath, text) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, text, "utf-8");
+}
+
+function looksLikeGitRepo(repoPath) {
+  return fs.existsSync(path.join(repoPath, ".git"));
 }
 
 function resolvePrForBranch(repoPath, branch) {
@@ -1072,15 +1077,34 @@ function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg) {
     branch,
     prNumber,
   });
+  const validatedPaths = validateManifestPaths(manifest.data?.paths, {
+    expectedRepoRoot: looksLikeGitRepo(repoPath) ? repoPath : undefined,
+    manifestPath: manifest.manifestPath,
+    runId: manifest.data?.run_id,
+    requireWorktree: true,
+    caller: "review-runner",
+  });
   branch = branch || manifest.data?.git?.working_branch || null;
   prNumber = prNumber || manifest.data?.git?.pr_number || null;
   if (!prNumber && branch) {
     prNumber = resolvePrForBranch(repoPath, branch);
   }
   const issueNumber = resolveIssueNumber(repoPath, prNumber, branch, manifest.data);
-  const reviewRepoPath = path.resolve(manifest.data?.paths?.worktree || repoPath);
+  const reviewRepoPath = validatedPaths.worktree;
+  const runRepoPath = validatedPaths.repoRoot;
+  const normalizedManifest = {
+    ...manifest,
+    data: {
+      ...(manifest.data || {}),
+      paths: {
+        ...(manifest.data?.paths || {}),
+        repo_root: validatedPaths.repoRoot,
+        worktree: validatedPaths.worktree,
+      },
+    },
+  };
 
-  return { branch, prNumber, issueNumber, manifest, reviewRepoPath };
+  return { branch, prNumber, issueNumber, manifest: normalizedManifest, reviewRepoPath, runRepoPath };
 }
 
 function postComment(repoPath, prNumber, commentBody) {
@@ -1182,7 +1206,7 @@ function run() {
   const noComment = hasFlag("--no-comment");
   const jsonOut = hasFlag("--json");
 
-  const { branch, prNumber, issueNumber, manifest, reviewRepoPath } = resolveContext(
+  const { branch, prNumber, issueNumber, manifest, reviewRepoPath, runRepoPath } = resolveContext(
     repoPath,
     manifestPathArg,
     runIdArg,
@@ -1200,7 +1224,6 @@ function run() {
 
   const round = Number(data.review?.rounds || 0) + 1;
   const maxRounds = Number(data.review?.max_rounds || 20);
-  const runRepoPath = path.resolve(data.paths?.repo_root || repoPath);
   const runDir = getRunDir(runRepoPath, data.run_id);
   ensureRunLayout(runRepoPath, data.run_id);
   let reviewedHeadSha = null;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -1078,7 +1078,7 @@ function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg) {
     prNumber,
   });
   const validatedPaths = validateManifestPaths(manifest.data?.paths, {
-    expectedRepoRoot: looksLikeGitRepo(repoPath) ? repoPath : undefined,
+    expectedRepoRoot: manifestPathArg ? undefined : (looksLikeGitRepo(repoPath) ? repoPath : undefined),
     manifestPath: manifest.manifestPath,
     runId: manifest.data?.run_id,
     requireWorktree: true,

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -1086,12 +1086,12 @@ function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg) {
   });
   branch = branch || manifest.data?.git?.working_branch || null;
   prNumber = prNumber || manifest.data?.git?.pr_number || null;
-  if (!prNumber && branch) {
-    prNumber = resolvePrForBranch(repoPath, branch);
-  }
-  const issueNumber = resolveIssueNumber(repoPath, prNumber, branch, manifest.data);
-  const reviewRepoPath = validatedPaths.worktree;
   const runRepoPath = validatedPaths.repoRoot;
+  if (!prNumber && branch) {
+    prNumber = resolvePrForBranch(runRepoPath, branch);
+  }
+  const issueNumber = resolveIssueNumber(runRepoPath, prNumber, branch, manifest.data);
+  const reviewRepoPath = validatedPaths.worktree;
   const normalizedManifest = {
     ...manifest,
     data: {
@@ -1252,13 +1252,13 @@ function run() {
   }
 
   const { text: doneCriteria, source: doneCriteriaSource } = loadDoneCriteria(
-    repoPath,
+    runRepoPath,
     issueNumber,
     prNumber,
     doneCriteriaFile,
     data
   );
-  const diffText = loadDiff(repoPath, prNumber, diffFile);
+  const diffText = loadDiff(runRepoPath, prNumber, diffFile);
   const rubricLoad = loadRubricFromRunDir(runDir, data);
   const promptText = buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricLoad });
 
@@ -1421,7 +1421,7 @@ function run() {
   }
 
   const { warnings: divergenceWarnings, eventPayload: divergencePayload } = buildScoreDivergenceAnalysis(
-    loadPrBody(repoPath, prNumber),
+    loadPrBody(runRepoPath, prNumber),
     verdict.rubric_scores
   );
   const commentBody = buildCommentBody(verdict, round, {
@@ -1429,7 +1429,7 @@ function run() {
     gateFailure: rubricGateFailure,
   });
   if (!noComment) {
-    postComment(repoPath, prNumber, commentBody);
+    postComment(runRepoPath, prNumber, commentBody);
     result.commentPosted = true;
   }
 

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -515,6 +515,42 @@ test("review-runner rejects relay-base same-name worktrees before preparing prom
 
   assert.equal(fs.existsSync(path.join(attackerWorktree, "review-round-1-prompt.md")), false);
   assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
+});
+
+test("review-runner rejects tampered paths.repo_root before prepare-only prompt side effects", () => {
+  const { repoRoot, worktreePath, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const { attackerRoot } = createUnrelatedRelayOwnedWorktree(repoRoot);
+  const record = readManifest(manifestPath);
+  const runDir = getRunsDir(repoRoot);
+  const actualPromptPath = path.join(runDir, runId, "review-round-1-prompt.md");
+  const actualDiffPath = path.join(runDir, runId, "review-round-1-diff.patch");
+  const attackerRunDir = path.join(getRunsDir(attackerRoot), runId);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      repo_root: attackerRoot,
+    },
+  }, record.body);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.repo_root/);
+  assert.equal(fs.existsSync(actualPromptPath), false, "prepare-only must reject before writing the prompt bundle");
+  assert.equal(fs.existsSync(actualDiffPath), false, "prepare-only must reject before writing the diff bundle");
+  assert.equal(fs.existsSync(attackerRunDir), false, "prepare-only must not create a run dir under the tampered repo_root");
+  assert.equal(fs.existsSync(worktreePath), true, "prepare-only must reject before touching the retained checkout");
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
 });
 
 test("review-runner fails closed when branch+PR resolution only finds a stale terminal manifest", () => {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -285,6 +285,82 @@ process.exit(1);
   return filePath;
 }
 
+function writeManifestOnlyGhScript(binDir, { trustedRepoRoot, capturePath, issueBody, diffText, prBody }) {
+  const filePath = path.join(binDir, "gh");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const cwd = fs.realpathSync(process.cwd());
+const trustedRepoRoot = ${JSON.stringify(fs.realpathSync(trustedRepoRoot))};
+const capturePath = ${JSON.stringify(capturePath)};
+const issueBody = ${JSON.stringify(issueBody)};
+const diffText = ${JSON.stringify(diffText)};
+const prBody = ${JSON.stringify(prBody)};
+const args = process.argv.slice(2);
+
+if (cwd !== trustedRepoRoot) {
+  process.stderr.write("gh invoked from unexpected cwd: " + cwd);
+  process.exit(19);
+}
+
+if (args[0] === "pr" && args[1] === "list") {
+  process.stdout.write(JSON.stringify([{ number: 123 }]));
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({
+    number: 42,
+    title: "Manifest-selected issue",
+    body: issueBody,
+  }));
+  process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "diff") {
+  process.stdout.write(diffText);
+  process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "view") {
+  const jsonIndex = args.indexOf("--json");
+  const fields = jsonIndex === -1 ? "" : args[jsonIndex + 1];
+  if (fields === "closingIssuesReferences,body,headRefName") {
+    process.stdout.write(JSON.stringify({
+      closingIssuesReferences: [{ number: 42 }],
+      body: prBody,
+      headRefName: "issue-42",
+    }));
+    process.exit(0);
+  }
+  if (fields === "body") {
+    process.stdout.write(JSON.stringify({ body: prBody }));
+    process.exit(0);
+  }
+  if (fields === "title,body,number") {
+    process.stdout.write(JSON.stringify({
+      number: 123,
+      title: "Manifest-selected PR",
+      body: prBody,
+    }));
+    process.exit(0);
+  }
+}
+
+if (args[0] === "pr" && args[1] === "comment") {
+  const bodyIndex = args.indexOf("--body");
+  const body = bodyIndex !== -1 ? args[bodyIndex + 1] : "";
+  fs.writeFileSync(capturePath, body, "utf-8");
+  process.exit(0);
+}
+
+process.stderr.write("Unsupported gh invocation: " + args.join(" "));
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
 function writeFakeCodex(binDir) {
   const codexPath = path.join(binDir, "codex");
   fs.writeFileSync(codexPath, `#!/usr/bin/env node
@@ -520,6 +596,61 @@ test("review-runner can prepare from --manifest when --repo points at an unrelat
   assert.ok(result.diffPath.startsWith(canonicalRunDir));
   assert.equal(result.reviewRepoPath, worktreePath);
   assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
+});
+
+test("review-runner manifest-only rounds keep gh-backed reads and comments on the validated repo root", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo();
+  const selectorRepo = createUnrelatedGitRepo();
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-"));
+  const commentCapturePath = path.join(repoRoot, "manifest-only-comment.txt");
+  const reviewFile = writePassVerdict(repoRoot, "manifest-only-pass.json");
+  writeManifestOnlyGhScript(fakeBin, {
+    trustedRepoRoot: repoRoot,
+    capturePath: commentCapturePath,
+    issueBody: "## Done Criteria\n\n- Keep gh operations bound to the manifest repo\n",
+    diffText: "diff --git a/smoke.txt b/smoke.txt\n+ok\n",
+    prBody: [
+      "## Score Log",
+      "",
+      "| Factor | Target | Baseline | Iter 1 | Final | Status |",
+      "|--------|--------|----------|--------|-------|--------|",
+      "| Coverage | >= 8 | — | 9 | 9 | locked |",
+    ].join("\n"),
+  });
+
+  updateManifestRecord(manifestPath, (data) => ({
+    ...data,
+    issue: {},
+    git: {
+      ...(data.git || {}),
+      pr_number: null,
+    },
+  }));
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", selectorRepo,
+    "--manifest", manifestPath,
+    "--review-file", reviewFile,
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+    },
+  });
+
+  const result = JSON.parse(stdout);
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(result.prNumber, 123);
+  assert.equal(result.issueNumber, 42);
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.commentPosted, true);
+  assert.match(fs.readFileSync(commentCapturePath, "utf-8"), /LGTM/);
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.equal(manifest.git.pr_number, 123);
+  assert.equal(manifest.review.latest_verdict, "lgtm");
 });
 
 test("review-runner rejects relay-base same-name worktrees before preparing prompts in an unrelated checkout", () => {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -78,6 +78,29 @@ function setupRepo() {
   return { repoRoot, worktreePath, manifestPath, runId, doneCriteriaPath, diffPath };
 }
 
+function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
+  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-foreign-"));
+  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
+  fs.mkdirSync(attackerRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Review Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-review-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
+  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
+  fs.mkdirSync(relayWorktrees, { recursive: true });
+  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
+  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
+  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
+    cwd: attackerRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
+  return { attackerRoot, attackerWorktree };
+}
+
 function setReviewPending(manifestPath) {
   const { data, body } = readManifest(manifestPath);
   let updated = data;
@@ -464,16 +487,15 @@ test("review-runner rejects invalid manifest run_id before creating a sibling ru
   assert.equal(fs.existsSync(victimRunDir), false);
 });
 
-test("review-runner rejects crafted manifest worktrees before preparing prompts in an unrelated checkout", () => {
+test("review-runner rejects relay-base same-name worktrees before preparing prompts in an unrelated checkout", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
-  const victimRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-victim-"));
-  fs.writeFileSync(path.join(victimRoot, "sentinel.txt"), "keep\n", "utf-8");
+  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot);
   const record = readManifest(manifestPath);
   writeManifest(manifestPath, {
     ...record.data,
     paths: {
       ...(record.data.paths || {}),
-      worktree: victimRoot,
+      worktree: attackerWorktree,
     },
   }, record.body);
 
@@ -491,7 +513,8 @@ test("review-runner rejects crafted manifest worktrees before preparing prompts 
     return true;
   });
 
-  assert.equal(fs.existsSync(path.join(victimRoot, "review-round-1-prompt.md")), false);
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "review-round-1-prompt.md")), false);
+  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
 });
 
 test("review-runner fails closed when branch+PR resolution only finds a stale terminal manifest", () => {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -464,6 +464,36 @@ test("review-runner rejects invalid manifest run_id before creating a sibling ru
   assert.equal(fs.existsSync(victimRunDir), false);
 });
 
+test("review-runner rejects crafted manifest worktrees before preparing prompts in an unrelated checkout", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const victimRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-victim-"));
+  fs.writeFileSync(path.join(victimRoot, "sentinel.txt"), "keep\n", "utf-8");
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: victimRoot,
+    },
+  }, record.body);
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
+    assert.match(String(error.stderr), /manifest paths\.worktree/);
+    return true;
+  });
+
+  assert.equal(fs.existsSync(path.join(victimRoot, "review-round-1-prompt.md")), false);
+});
+
 test("review-runner fails closed when branch+PR resolution only finds a stale terminal manifest", () => {
   const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
   const record = readManifest(manifestPath);

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -101,6 +101,17 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
+function createUnrelatedGitRepo(prefix = "relay-review-manifest-cwd-") {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Review Manifest"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-review-manifest@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "manifest selector\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return repoRoot;
+}
+
 function setReviewPending(manifestPath) {
   const { data, body } = readManifest(manifestPath);
   let updated = data;
@@ -485,6 +496,30 @@ test("review-runner rejects invalid manifest run_id before creating a sibling ru
     return true;
   });
   assert.equal(fs.existsSync(victimRunDir), false);
+});
+
+test("review-runner can prepare from --manifest when --repo points at an unrelated git repo", () => {
+  const { repoRoot, manifestPath, runId, worktreePath, doneCriteriaPath, diffPath } = setupRepo();
+  const selectorRepo = createUnrelatedGitRepo();
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", selectorRepo,
+    "--manifest", manifestPath,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" });
+
+  const result = JSON.parse(stdout);
+  const canonicalRunDir = path.join(getRunsDir(repoRoot), runId);
+  assert.equal(result.prepareOnly, true);
+  assert.ok(result.promptPath.startsWith(canonicalRunDir));
+  assert.ok(result.diffPath.startsWith(canonicalRunDir));
+  assert.equal(result.reviewRepoPath, worktreePath);
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
 });
 
 test("review-runner rejects relay-base same-name worktrees before preparing prompts in an unrelated checkout", () => {


### PR DESCRIPTION
## Summary
- close #160 by centralizing manifest path trust validation in `validateManifestPaths(paths, { expectedRepoRoot, manifestPath, runId, requireWorktree, caller })`
- fail closed when `paths.repo_root` does not match the trusted repo root or manifest storage location, and when `paths.worktree` is outside the trusted repo or is not a real relay-owned checkout bound to the same git common dir
- mirror the consumer audit into `docs/issue-160-manifest-path-trust-roots.md` so relay-review can inspect it from the diff

## Consumer Audit
- Fixed: `skills/relay-dispatch/scripts/dispatch.js` — resume now validates manifest-owned repo/worktree paths before reusing the repo root, retained worktree, run directory, or previous-attempts state. Explicit `--manifest` resume keeps the manifest storage path as the trust root instead of binding to the caller's cwd repo.
- Fixed: `skills/relay-review/scripts/review-runner.js` — manifest-only review now validates the retained checkout before prompt generation, SHA reads, or event journal writes, and carries the validated repo root through PR/issue resolution, diff loading, PR-body divergence analysis, and PR comment writes.
- Fixed: `skills/relay-merge/scripts/gate-check.js` — PR-mode manifest resolution now validates manifest paths before PR stamping, run-dir lock creation, or merge-gate evaluation.
- Fixed: `skills/relay-merge/scripts/finalize-run.js` — merge finalization now validates manifest paths before GitHub operations, review gating, cleanup, or issue close. Explicit `--manifest` finalize trusts the manifest storage path instead of the caller's cwd repo.
- Fixed: `skills/relay-dispatch/scripts/cleanup-worktrees.js` — janitor cleanup now rejects crafted manifests before cleanup side effects and records a fail-closed result instead.
- Fixed: `skills/relay-dispatch/scripts/close-run.js` — manual close/recovery now validates manifest paths before state transitions or cleanup.
- Fixed: `skills/relay-dispatch/scripts/relay-manifest.js` cleanup helpers — cleanup helpers now validate manifest paths internally so a raw caller cannot retarget cleanup side effects through manifest data, and missing relay-base same-name paths are no longer accepted as proof of relay ownership.
- Unchanged but enumerated: `skills/relay-dispatch/scripts/relay-manifest.js` (`resolveRubricRunDir()` fallback inside `getRubricAnchorStatus()`) — this helper still falls back to `data.paths.repo_root` when callers omit `options.repoRoot` and `options.runDir`. That raw reader remains out of scope for `#160`: the in-scope dispatch/review/merge consumers now pass a validated repo root or run dir before any filesystem write or GitHub operation, and the only zero-option caller left is the relay-manifest-local `validateTransitionInvariants()` rubric-state read path. If rubric-status reads become their own trust boundary, file a follow-up rather than silently widening this PR.

## Tests
- added crafted-manifest regressions for spoofed `paths.repo_root` / `paths.worktree` across the affected consumers, including missing relay-base same-name worktree variants on cleanup-side callers
- `node --test skills/*/scripts/*.test.js` (`349` pass / `0` fail)
