### PR TITLE
relay-dispatch: refuse symlinked rubric paths (closes #161)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -572,6 +572,37 @@ function resolveRubricRunDir(data, options = {}) {
   return path.resolve(getRunDir(repoRoot, validation.runId));
 }
 
+function realpathSyncCompat(targetPath) {
+  return typeof fs.realpathSync.native === "function"
+    ? fs.realpathSync.native(targetPath)
+    : fs.realpathSync(targetPath);
+}
+
+function resolveRealPathCandidate(targetPath) {
+  const pendingSegments = [];
+  let currentPath = targetPath;
+
+  for (;;) {
+    try {
+      const resolvedExistingPath = realpathSyncCompat(currentPath);
+      return pendingSegments.length === 0
+        ? resolvedExistingPath
+        : path.join(resolvedExistingPath, ...pendingSegments);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        throw error;
+      }
+      pendingSegments.unshift(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
 function validateRubricPathContainment(rubricPath, runDir) {
   const normalizedPath = typeof rubricPath === "string" ? rubricPath.trim() : "";
   const resolvedRunDir = typeof runDir === "string" && runDir.trim() !== ""
@@ -586,8 +617,7 @@ function validateRubricPathContainment(rubricPath, runDir) {
   const insideRunDir = Boolean(
     resolvedRunDir &&
     resolvedPath &&
-    resolvedPath !== resolvedRunDir &&
-    resolvedPath.startsWith(`${resolvedRunDir}${path.sep}`)
+    isPathContainedWithin(resolvedRunDir, resolvedPath)
   );
 
   if (!normalizedPath) {
@@ -645,14 +675,108 @@ function validateRubricPathContainment(rubricPath, runDir) {
     };
   }
 
-  return {
-    valid: true,
-    status: "contained",
-    rubricPath: normalizedPath,
-    runDir: resolvedRunDir,
-    resolvedPath,
-    reason: null,
-  };
+  try {
+    // Refuse symlinks outright: rubric.yaml is persisted by dispatch into the run dir, so a symlink indicates tampering rather than a legitimate operator workflow. This also avoids a check/read race on the anchored path itself.
+    const rubricEntry = fs.lstatSync(resolvedPath);
+    if (rubricEntry.isSymbolicLink()) {
+      return {
+        valid: false,
+        status: "symlink_escape",
+        rubricPath: normalizedPath,
+        runDir: resolvedRunDir,
+        resolvedPath,
+        realPath: null,
+        reason: `anchor.rubric_path must not be a symlink (got ${JSON.stringify(normalizedPath)} -> ${JSON.stringify(resolvedPath)}).`,
+      };
+    }
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  try {
+    const realRunDir = resolveRealPathCandidate(resolvedRunDir);
+    const realRubricPath = resolveRealPathCandidate(resolvedPath);
+    if (!isPathContainedWithin(realRunDir, realRubricPath)) {
+      return {
+        valid: false,
+        status: "follows_outside_run_dir",
+        rubricPath: normalizedPath,
+        runDir: resolvedRunDir,
+        resolvedPath,
+        realPath: realRubricPath,
+        reason: `anchor.rubric_path must stay inside the real run directory ${JSON.stringify(realRunDir)} after symlink resolution (got ${JSON.stringify(normalizedPath)} -> ${JSON.stringify(realRubricPath)}).`,
+      };
+    }
+
+    return {
+      valid: true,
+      status: "contained",
+      rubricPath: normalizedPath,
+      runDir: resolvedRunDir,
+      resolvedPath,
+      realPath: realRubricPath,
+      reason: null,
+    };
+  } catch (error) {
+    return {
+      valid: false,
+      status: "run_dir_unavailable",
+      rubricPath: normalizedPath,
+      runDir: resolvedRunDir,
+      resolvedPath,
+      realPath: null,
+      reason: `Unable to resolve the real run directory for anchor.rubric_path=${JSON.stringify(normalizedPath)}: ${summarizeError(error)}`,
+    };
+  }
+}
+
+function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
+  let fd = null;
+  const noFollowFlag = fs.constants.O_NOFOLLOW;
+  const openPath = realPath || targetPath;
+
+  try {
+    if (typeof noFollowFlag === "number") {
+      fd = fs.openSync(openPath, fs.constants.O_RDONLY | noFollowFlag);
+      const stat = fs.fstatSync(fd);
+      if (!stat.isFile()) {
+        const error = new Error(`Not a file: ${openPath}`);
+        error.code = "EINVAL";
+        throw error;
+      }
+      return fs.readFileSync(fd, "utf-8");
+    }
+  } catch (error) {
+    if (fd !== null) {
+      fs.closeSync(fd);
+      fd = null;
+    }
+    if (!["ELOOP", "ENOTSUP", "EINVAL"].includes(error.code)) {
+      throw error;
+    }
+  }
+
+  const rubricEntry = fs.lstatSync(targetPath);
+  if (rubricEntry.isSymbolicLink()) {
+    const error = new Error(`Refusing to read symlinked rubric path: ${targetPath}`);
+    error.code = "ELOOP";
+    throw error;
+  }
+
+  fd = fs.openSync(openPath, fs.constants.O_RDONLY);
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) {
+      const error = new Error(`Not a file: ${openPath}`);
+      error.code = "EINVAL";
+      throw error;
+    }
+    return fs.readFileSync(fd, "utf-8");
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 function getRubricAnchorStatus(data, options = {}) {
@@ -702,17 +826,11 @@ function getRubricAnchorStatus(data, options = {}) {
   }
 
   try {
-    const stat = fs.statSync(containment.resolvedPath);
-    if (!stat.isFile()) {
-      return {
-        ...baseStatus,
-        ...containment,
-        status: "not_file",
-        error: `anchor.rubric_path must point to a file inside the run directory (got ${JSON.stringify(containment.resolvedPath)}).`,
-      };
-    }
-
-    const content = fs.readFileSync(containment.resolvedPath, "utf-8");
+    // Refuse symlinks outright: rubric.yaml is persisted by dispatch into the run dir — a symlink indicates tampering, not a legitimate operator workflow. Avoids TOCTOU between lstat and readFileSync.
+    const content = readTextFileWithoutFollowingSymlinks(
+      containment.resolvedPath,
+      containment.realPath || containment.resolvedPath
+    );
     const trimmedContent = content.trim();
     if (!trimmedContent) {
       return {
@@ -740,6 +858,24 @@ function getRubricAnchorStatus(data, options = {}) {
         ...containment,
         status: "missing",
         error: `rubric file is missing from the run directory: ${containment.resolvedPath}`,
+      };
+    }
+
+    if (error.code === "ELOOP") {
+      return {
+        ...baseStatus,
+        ...containment,
+        status: "symlink_escape",
+        error: `anchor.rubric_path must not be a symlink (got ${JSON.stringify(containment.rubricPath)} -> ${JSON.stringify(containment.resolvedPath)}).`,
+      };
+    }
+
+    if (error.code === "EINVAL") {
+      return {
+        ...baseStatus,
+        ...containment,
+        status: "not_file",
+        error: `anchor.rubric_path must point to a file inside the run directory (got ${JSON.stringify(containment.resolvedPath)}).`,
       };
     }
 

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -578,6 +578,10 @@ function realpathSyncCompat(targetPath) {
     : fs.realpathSync(targetPath);
 }
 
+function isRubricLookupError(error) {
+  return error?.code === "ENOENT" || error?.code === "ENOTDIR";
+}
+
 function resolveRealPathCandidate(targetPath) {
   const pendingSegments = [];
   let currentPath = targetPath;
@@ -589,7 +593,7 @@ function resolveRealPathCandidate(targetPath) {
         ? resolvedExistingPath
         : path.join(resolvedExistingPath, ...pendingSegments);
     } catch (error) {
-      if (error.code !== "ENOENT") {
+      if (!isRubricLookupError(error)) {
         throw error;
       }
 
@@ -690,7 +694,7 @@ function validateRubricPathContainment(rubricPath, runDir) {
       };
     }
   } catch (error) {
-    if (error.code !== "ENOENT") {
+    if (!isRubricLookupError(error)) {
       throw error;
     }
   }

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -683,6 +683,25 @@ test("getRubricAnchorStatus rejects symlinked rubric files even when they target
   });
 });
 
+test("getRubricAnchorStatus fails closed for contained-but-malformed rubric paths", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-malformed-rubric-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  const runId = "issue-42-20260412000008500";
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: malformed\n", "utf-8");
+
+  const result = getRubricAnchorStatus({
+    run_id: runId,
+    anchor: { rubric_path: "rubric.yaml/child" },
+    paths: { repo_root: repoRoot },
+  });
+
+  assert.equal(result.status, "unreadable");
+  assert.equal(result.satisfied, false);
+  assert.match(result.error, /rubric\.yaml\/child/);
+});
+
 test("getRubricAnchorStatus distinguishes parent symlink escapes from lexical outside_run_dir", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-parent-symlink-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -644,6 +644,66 @@ test("getRubricAnchorStatus distinguishes satisfied, empty, outside_run_dir, and
   assert.equal(grandfathered.satisfied, true);
 });
 
+test("getRubricAnchorStatus rejects symlinked rubric files even when they target readable files", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-symlink-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  const outsideTarget = path.join(os.tmpdir(), `relay-outside-rubric-${Date.now()}.yaml`);
+  fs.writeFileSync(outsideTarget, "outside: true\n", "utf-8");
+
+  const sameRunId = "issue-42-20260412000005000";
+  const sameRunLayout = ensureRunLayout(repoRoot, sameRunId);
+  const siblingTarget = path.join(sameRunLayout.runDir, "rubric-copy.yaml");
+  fs.writeFileSync(siblingTarget, "rubric:\n  factors:\n    - name: sibling\n", "utf-8");
+  fs.symlinkSync(siblingTarget, path.join(sameRunLayout.runDir, "rubric.yaml"));
+
+  const otherRunId = "issue-42-20260412000006000";
+  const otherRunTarget = writeRunRubric(repoRoot, otherRunId).fullPath;
+  const linkedRunId = "issue-42-20260412000007000";
+  const linkedRunLayout = ensureRunLayout(repoRoot, linkedRunId);
+  fs.symlinkSync(otherRunTarget, path.join(linkedRunLayout.runDir, "rubric.yaml"));
+
+  const outsideRunId = "issue-42-20260412000008000";
+  const outsideRunLayout = ensureRunLayout(repoRoot, outsideRunId);
+  fs.symlinkSync(outsideTarget, path.join(outsideRunLayout.runDir, "rubric.yaml"));
+
+  [
+    { runId: outsideRunId, label: "outside file" },
+    { runId: linkedRunId, label: "other run rubric" },
+    { runId: sameRunId, label: "same run sibling file" },
+  ].forEach(({ runId, label }) => {
+    const result = getRubricAnchorStatus({
+      run_id: runId,
+      anchor: { rubric_path: "rubric.yaml" },
+      paths: { repo_root: repoRoot },
+    });
+
+    assert.equal(result.status, "symlink_escape", label);
+    assert.equal(result.satisfied, false, label);
+  });
+});
+
+test("getRubricAnchorStatus distinguishes parent symlink escapes from lexical outside_run_dir", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-parent-symlink-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+
+  const runId = "issue-42-20260412000009000";
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-rubric-outside-dir-"));
+  const escapedParent = path.join(runDir, "rubric-link");
+  fs.symlinkSync(outsideDir, escapedParent);
+
+  const result = getRubricAnchorStatus({
+    run_id: runId,
+    anchor: { rubric_path: "rubric-link/rubric.yaml" },
+    paths: { repo_root: repoRoot },
+  });
+
+  assert.equal(result.status, "follows_outside_run_dir");
+  assert.equal(result.satisfied, false);
+  assert.match(result.error, /real run directory/i);
+});
+
 test("updateManifestCleanup records cleanup metadata without changing state", () => {
   const manifest = {
     state: STATES.MERGED,

--- a/skills/relay-merge/scripts/review-gate.js
+++ b/skills/relay-merge/scripts/review-gate.js
@@ -93,6 +93,8 @@ function buildRubricGateFailure(prNumber, rubricAnchor) {
         reason: rubricAnchor.error,
       }, rubricAnchor);
     case "outside_run_dir":
+    case "follows_outside_run_dir":
+    case "symlink_escape":
     case "run_dir_unavailable":
       return withRubricNote({
         status: "invalid_rubric_path",

--- a/skills/relay-merge/scripts/review-gate.test.js
+++ b/skills/relay-merge/scripts/review-gate.test.js
@@ -28,6 +28,9 @@ function createRubricStateFixture(state) {
   } else if (state === "invalid") {
     manifestData.anchor.rubric_path = "rubric-dir";
     fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
+  } else if (state === "malformed") {
+    manifestData.anchor.rubric_path = "rubric.yaml/child";
+    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: malformed\n", "utf-8");
   } else if (state === "symlink_escape") {
     manifestData.anchor.rubric_path = "rubric.yaml";
     const siblingTarget = path.join(runDir, "rubric-copy.yaml");
@@ -81,6 +84,11 @@ function evaluatePassWithRubricState(state) {
     state: "invalid",
     status: "invalid_rubric_file",
     rubricStatus: "not_file",
+  },
+  {
+    state: "malformed",
+    status: "invalid_rubric_file",
+    rubricStatus: "unreadable",
   },
   {
     state: "symlink_escape",

--- a/skills/relay-merge/scripts/review-gate.test.js
+++ b/skills/relay-merge/scripts/review-gate.test.js
@@ -28,6 +28,11 @@ function createRubricStateFixture(state) {
   } else if (state === "invalid") {
     manifestData.anchor.rubric_path = "rubric-dir";
     fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
+  } else if (state === "symlink_escape") {
+    manifestData.anchor.rubric_path = "rubric.yaml";
+    const siblingTarget = path.join(runDir, "rubric-copy.yaml");
+    fs.writeFileSync(siblingTarget, "rubric:\n  factors:\n    - name: symlink\n", "utf-8");
+    fs.symlinkSync(siblingTarget, path.join(runDir, "rubric.yaml"));
   } else if (state === "grandfathered") {
     manifestData.anchor.rubric_grandfathered = true;
   }
@@ -76,6 +81,11 @@ function evaluatePassWithRubricState(state) {
     state: "invalid",
     status: "invalid_rubric_file",
     rubricStatus: "not_file",
+  },
+  {
+    state: "symlink_escape",
+    status: "invalid_rubric_path",
+    rubricStatus: "symlink_escape",
   },
   {
     state: "not_set",

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -1528,6 +1528,7 @@ module.exports = {
   formatIssueList,
   formatPriorVerdictSummary,
   formatScopeDrift,
+  loadRubricFromRunDir,
   parseScoreLog,
   parseReviewVerdict,
   resolveIssueNumber,

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1974,6 +1974,36 @@ test("review-runner warns visibly when anchor.rubric_path points to an invalid r
   assert.match(promptText, /must point to a file inside the run directory/i);
 });
 
+test("loadRubricFromRunDir returns the invalid warning branch when anchor.rubric_path is a symlink", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo();
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  const siblingTarget = path.join(runDir, "rubric-copy.yaml");
+  fs.writeFileSync(siblingTarget, "rubric:\n  factors:\n    - name: sibling\n", "utf-8");
+  fs.symlinkSync(siblingTarget, path.join(runDir, "rubric.yaml"));
+
+  const { data, body } = readManifest(manifestPath);
+  const nextAnchor = { ...(data.anchor || {}), rubric_path: "rubric.yaml" };
+  delete nextAnchor.rubric_grandfathered;
+  writeManifest(manifestPath, {
+    ...data,
+    anchor: nextAnchor,
+  }, body);
+
+  const rubricLoad = JSON.parse(runReviewRunnerModule([
+    `const { loadRubricFromRunDir } = reviewRunner;`,
+    `const result = loadRubricFromRunDir(${JSON.stringify(runDir)}, ${JSON.stringify({
+      ...data,
+      anchor: nextAnchor,
+    })});`,
+    `process.stdout.write(JSON.stringify(result));`,
+  ]));
+
+  assert.equal(rubricLoad.state, "invalid");
+  assert.equal(rubricLoad.status, "symlink_escape");
+  assert.match(rubricLoad.warning, /\[rubric invalid\]/i);
+  assert.match(rubricLoad.warning, /must not be a symlink/i);
+});
+
 test("review-runner rejects empty rubric_scores when rubric is present", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 


### PR DESCRIPTION
## Summary

Closes #161. Trust-root hardening companion to #148 (PR #155) / #156 (PR #159) / #160 (PR #195).

`anchor.rubric_path` previously passed containment via `path.resolve` (lexical only) and was read via `fs.statSync` + `fs.readFileSync` (both follow symlinks). A `rubric.yaml` symlinked to `/etc/passwd` or another run's rubric bypassed both invariants: the reviewer prompt would embed followed content as the rubric for the current run.

This PR refuses rubric symlinks outright at both the containment check and the read path. New statuses `symlink_escape` and `follows_outside_run_dir` propagate through `review-runner.loadRubricFromRunDir` and `review-gate.buildRubricGateFailure` as fail-closed `invalid_rubric_path`.

## Changes

- `skills/relay-dispatch/scripts/relay-manifest.js`
  - New `realpathSyncCompat` / `resolveRealPathCandidate` helpers so containment works for run dirs that don't exist yet at dispatch time.
  - `validateRubricPathContainment` — lstat-detects a symlinked rubric and returns `symlink_escape`; compares realpath of run dir vs realpath of rubric for `follows_outside_run_dir` (parent-segment escape).
  - New `readTextFileWithoutFollowingSymlinks` — opens with `O_RDONLY | O_NOFOLLOW` when available, falls back to lstat-guarded descriptor read otherwise.
  - `getRubricAnchorStatus` read block uses the new reader and maps `ELOOP` → `symlink_escape`.
- `skills/relay-review/scripts/review-runner.js` — exports `loadRubricFromRunDir` for tests. The new statuses hit the existing `default` branch (`state: "invalid"`, visible warning).
- `skills/relay-merge/scripts/review-gate.js` — `buildRubricGateFailure` maps `symlink_escape` + `follows_outside_run_dir` to `invalid_rubric_path` with `readyToMerge=false`.

## Decision documented inline

Rubric symlinks are refused outright rather than contained-realpath-allowed. Rationale (inline comment in `relay-manifest.js`): `rubric.yaml` is persisted by dispatch into the run dir, so a symlink indicates tampering rather than a legitimate operator workflow. Refusing at the check also avoids a TOCTOU window between the lstat and the read.

## Regression tests (all fail pre-fix, proven by stashing only `relay-manifest.js` and re-running)

- `relay-manifest.test.js` — three scenarios using real `fs.symlinkSync`:
  - (a) rubric.yaml → outside-tmp file → `symlink_escape`
  - (b) rubric.yaml → another run's rubric.yaml → `symlink_escape`
  - (c) rubric.yaml → sibling file INSIDE same run dir → `symlink_escape` (stricter default per AC)
  - Plus a parent-segment-symlink scenario that pins `follows_outside_run_dir` separately.
- `review-runner.test.js` — `loadRubricFromRunDir` on a symlinked rubric returns `state: "invalid"` with a visible warning.
- `review-gate.test.js` — `evaluateReviewGate` on the same manifest returns `readyToMerge=false` with `status: "invalid_rubric_path"`.

Pre-fix behavior (with only `relay-manifest.js` reverted):
- manifest symlink tests returned `satisfied` / `missing` instead of `symlink_escape` / `follows_outside_run_dir`
- `loadRubricFromRunDir` returned `loaded` instead of `invalid`
- `evaluateReviewGate` incorrectly returned `lgtm` for the symlink case

## Verification

```
$ node --test skills/*/scripts/*.test.js
# tests 353
# pass 353
# fail 0
```

## Attack surface — symlink vectors across manifest-owned paths

| Path | Vector applies? | Current protection | This PR |
|---|---|---|---|
| `anchor.rubric_path` | Yes (pre-PR) | — | Closed here (lstat + realpath + `O_NOFOLLOW`) |
| `paths.repo_root` | Yes | `sameFilesystemLocation` realpath equality (#160 / PR #195) | Out of scope |
| `paths.worktree` | Yes | `sameFilesystemLocation` + `getWorktreeGitCommonDir` realpath (#160 / PR #195) | Out of scope |
| `events.jsonl` | Yes — still open | `relay-events.js` uses path-based `appendFileSync` / `readFileSync`; follows symlinks | Deferred to follow-up issue |
| `previous-attempts.json` | Yes — still open | `readPreviousAttempts` / `captureAttempt` use path-based `readFileSync` / `writeFileSync`; follows symlinks | Deferred to follow-up issue |

Follow-up issue to be filed post-merge covering `events.jsonl` + `previous-attempts.json` (both are write + read paths inside the run dir that can be replaced with a symlink to redirect operator audit trail / historical verdicts).

## Scope discipline

No changes to:
- `anchor.rubric_grandfathered` semantics (#151 surface)
- `getRepoSlug` / `getRelayHome` (#152 surface)
- Existing grandfather-defaulting test fixtures (#153 surface)
- Skip-path audit trail (#150 surface)
- `createRunId` / atomic rubric write (#158 surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 루브릭 파일의 심볼릭 링크 감지 및 차단 기능 추가
  * 루브릭 경로 포함 검증 강화로 실행 디렉토리 밖으로 나가는 경로 방지
  * 심볼릭 링크 기반의 경로 이스케이프 시나리오에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->