### PR TITLE
tests: add enforcement-path coverage and fixture audit (closes #153)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -746,36 +746,23 @@ test("dispatch dry-run includes rubric file info", () => {
   fs.unlinkSync(rubricFile);
 });
 
-test("dispatch with empty --rubric-file is rejected at dispatch-time; post-dispatch empty rubric still fails downstream gate", () => {
-  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+test("dispatched run whose persisted rubric is empty fails closed at the review gate", () => {
+  // #153 enforcement-path coverage — negative case the #147 suite missed
+  // (originating findings: #148 file-existence/containment invariant,
+  // #149 manifest resolution stricture, #151 grandfather-provenance scope).
   //
-  // Two-part test pinning the defense-in-depth layering #148 landed:
-  //   (a) Dispatch-time enforcement (#148 / PR #155): an empty --rubric-file is
-  //       rejected before the manifest transitions to review_pending.
-  //   (b) Post-dispatch downstream enforcement: if an attacker truncates the
-  //       persisted rubric.yaml after a valid dispatch, evaluateReviewGate still
-  //       catches it with status=empty_rubric_file.
+  // Contract: a dispatched run whose rubric.yaml is empty must NOT pass the
+  // downstream review/merge gate. This test simulates post-dispatch rubric
+  // truncation (operator tampering or stale state) and verifies
+  // evaluateReviewGate returns status=empty_rubric_file / readyToMerge=false.
+  // Dispatch-time rejection of empty --rubric-file is #148's territory and is
+  // intentionally NOT re-tested here.
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
 
-  // (a) Empty --rubric-file rejected at dispatch.
-  const emptyRubricFile = path.join(os.tmpdir(), `relay-empty-rubric-${Date.now()}.yaml`);
-  fs.writeFileSync(emptyRubricFile, "   \n", "utf-8");
-  assert.throws(
-    () => runDispatch(repoRoot, [
-      "-b", "issue-empty-rubric",
-      "--prompt", "empty rubric test",
-      "--rubric-file", emptyRubricFile,
-      "--json",
-    ], env),
-    /rubric file is empty/i,
-  );
-  fs.unlinkSync(emptyRubricFile);
-
-  // (b) Valid dispatch, then post-dispatch truncation, then downstream gate.
   const validRubricFile = path.join(os.tmpdir(), `relay-valid-rubric-${Date.now()}.yaml`);
   fs.writeFileSync(validRubricFile, "rubric:\n  factors:\n    - name: ok\n      target: pass\n", "utf-8");
   const result = JSON.parse(runDispatch(repoRoot, [

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -10,12 +10,15 @@ const {
   captureAttempt,
   createRunId,
   getEventsPath,
+  getRubricAnchorStatus,
   getRunDir,
   listManifestPaths,
   readManifest,
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
+const { evaluateReviewGate } = require("../../relay-merge/scripts/review-gate");
+const { createEnforcementFixture } = require("./test-support");
 
 const SCRIPT = path.join(__dirname, "dispatch.js");
 
@@ -118,6 +121,8 @@ fs.writeFileSync(output, "ok\\n", "utf-8");
 }
 
 function withRequiredRubric(args) {
+  // AUTO-INJECT ENFORCEMENT RUBRIC — this is the contract side, NOT a grandfather bypass.
+  // Tests that specifically cover rubric-missing scenarios must NOT use this helper.
   if (args.includes("--rubric-file") || args.includes("--rubric-grandfathered")) {
     return args;
   }
@@ -739,6 +744,69 @@ test("dispatch dry-run includes rubric file info", () => {
   assert.equal(result.rubricFile, rubricFile);
 
   fs.unlinkSync(rubricFile);
+});
+
+test("dispatch with empty --rubric-file is rejected at dispatch-time; post-dispatch empty rubric still fails downstream gate", () => {
+  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  //
+  // Two-part test pinning the defense-in-depth layering #148 landed:
+  //   (a) Dispatch-time enforcement (#148 / PR #155): an empty --rubric-file is
+  //       rejected before the manifest transitions to review_pending.
+  //   (b) Post-dispatch downstream enforcement: if an attacker truncates the
+  //       persisted rubric.yaml after a valid dispatch, evaluateReviewGate still
+  //       catches it with status=empty_rubric_file.
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  // (a) Empty --rubric-file rejected at dispatch.
+  const emptyRubricFile = path.join(os.tmpdir(), `relay-empty-rubric-${Date.now()}.yaml`);
+  fs.writeFileSync(emptyRubricFile, "   \n", "utf-8");
+  assert.throws(
+    () => runDispatch(repoRoot, [
+      "-b", "issue-empty-rubric",
+      "--prompt", "empty rubric test",
+      "--rubric-file", emptyRubricFile,
+      "--json",
+    ], env),
+    /rubric file is empty/i,
+  );
+  fs.unlinkSync(emptyRubricFile);
+
+  // (b) Valid dispatch, then post-dispatch truncation, then downstream gate.
+  const validRubricFile = path.join(os.tmpdir(), `relay-valid-rubric-${Date.now()}.yaml`);
+  fs.writeFileSync(validRubricFile, "rubric:\n  factors:\n    - name: ok\n      target: pass\n", "utf-8");
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-truncated-rubric",
+    "--prompt", "truncation test",
+    "--rubric-file", validRubricFile,
+    "--json",
+  ], env));
+  assert.equal(result.status, "completed");
+  fs.unlinkSync(validRubricFile);
+
+  createEnforcementFixture({
+    repoRoot,
+    runId: result.runId,
+    manifestPath: result.manifestPath,
+    state: "empty",
+  });
+  const manifest = readManifest(result.manifestPath).data;
+  const runDir = getRunDir(repoRoot, result.runId);
+  const rubricAnchor = getRubricAnchorStatus(manifest, { runDir });
+  const gate = evaluateReviewGate({
+    prNumber: 123,
+    comments: [],
+    commits: [],
+    manifestData: manifest,
+    runDir,
+  });
+
+  assert.equal(rubricAnchor.status, "empty");
+  assert.equal(gate.status, "empty_rubric_file");
+  assert.equal(gate.readyToMerge, false);
 });
 
 test("dispatch stores request linkage and frozen done criteria anchor in manifest", () => {

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -16,6 +16,7 @@ const {
   writeManifest,
 } = require("./relay-manifest");
 const { findManifestByRunId, resolveManifestRecord } = require("./relay-resolver");
+const { createEnforcementFixture } = require("./test-support");
 
 const CLOSE_RUN_SCRIPT = path.join(__dirname, "close-run.js");
 const EXACT_PR_COLLISION_PR = 40;
@@ -44,20 +45,6 @@ function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function ensureFixtureRubric(runDir, rubricPath) {
-  if (
-    typeof rubricPath !== "string"
-    || rubricPath.trim() === ""
-    || path.isAbsolute(rubricPath)
-    || rubricPath.split(/[\\/]+/).includes("..")
-  ) {
-    return;
-  }
-  const fullPath = path.join(runDir, rubricPath);
-  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-  fs.writeFileSync(fullPath, "rubric:\n  factors:\n    - name: resolver fixture\n", "utf-8");
-}
-
 function writeManifestRecord(repoRoot, options = {}) {
   const {
   runId,
@@ -66,12 +53,12 @@ function writeManifestRecord(repoRoot, options = {}) {
   issueNumber = 42,
   state = STATES.REVIEW_PENDING,
   prNumber,
-  grandfathered = true,
-  rubricPath,
+  grandfathered = false,
+  rubricPath = "rubric.yaml",
   cleanupPolicy = "on_close",
   updatedAt = "2026-04-03T00:00:00.000Z",
   } = options;
-  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  const { manifestPath } = ensureRunLayout(repoRoot, runId);
   let manifest = createManifestSkeleton({
     repoRoot,
     runId,
@@ -84,12 +71,18 @@ function writeManifestRecord(repoRoot, options = {}) {
     reviewer: "claude",
     cleanupPolicy,
   });
-
-  manifest.anchor.rubric_grandfathered = grandfathered;
-  if (rubricPath !== undefined) {
-    manifest.anchor.rubric_path = rubricPath;
-  }
-  ensureFixtureRubric(runDir, rubricPath);
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: grandfathered ? "loaded" : (
+      typeof rubricPath === "string" && path.isAbsolute(rubricPath)
+        ? "outside_run_dir"
+        : (rubricPath === "rubric-dir" ? "invalid" : "loaded")
+    ),
+    grandfather: grandfathered,
+    rubricPath,
+    rubricContent: "rubric:\n  factors:\n    - name: resolver fixture\n",
+  }).anchor;
 
   if (state !== STATES.DRAFT) {
     manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
@@ -344,6 +337,40 @@ test("resolveManifestRecord returns the fresh non-terminal manifest on a reused 
   assert.equal(match.data.run_id, freshRunId);
   assert.equal(match.data.anchor.rubric_path, "fresh-rubric.yaml");
   assert.notEqual(match.data.anchor.rubric_grandfathered, true);
+});
+
+test("resolveManifestRecord does not inherit a terminal run when a reused branch has a fresh PR match", () => {
+  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-branch-reuse-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  writeManifestRecord(repoRoot, {
+    runId: createRunId({
+      branch: "issue-100",
+      timestamp: new Date("2026-04-03T00:00:00.000Z"),
+    }),
+    branch: "issue-100",
+    state: STATES.MERGED,
+    prNumber: 100,
+    rubricPath: "merged-rubric.yaml",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+  const freshRunId = createRunId({
+    branch: "issue-100",
+    timestamp: new Date("2026-04-03T00:10:00.000Z"),
+  });
+  const freshPath = writeManifestRecord(repoRoot, {
+    runId: freshRunId,
+    branch: "issue-100",
+    state: STATES.DISPATCHED,
+    prNumber: 120,
+    rubricPath: "fresh-rubric.yaml",
+    updatedAt: "2026-04-03T00:10:00.000Z",
+  });
+
+  const match = resolveManifestRecord({ repoRoot, branch: "issue-100", prNumber: 120 });
+  assert.equal(match.manifestPath, freshPath);
+  assert.equal(match.data.run_id, freshRunId);
+  assert.equal(match.data.git.pr_number, 120);
 });
 
 test("resolveManifestRecord rejects stale terminal-only branch reuse and names the fresh-dispatch recovery", () => {

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -367,10 +367,18 @@ test("resolveManifestRecord does not inherit a terminal run when a reused branch
     updatedAt: "2026-04-03T00:10:00.000Z",
   });
 
-  const match = resolveManifestRecord({ repoRoot, branch: "issue-100", prNumber: 120 });
-  assert.equal(match.manifestPath, freshPath);
-  assert.equal(match.data.run_id, freshRunId);
-  assert.equal(match.data.git.pr_number, 120);
+  // Exact-PR match: resolver must prefer the fresh non-terminal run.
+  const withPr = resolveManifestRecord({ repoRoot, branch: "issue-100", prNumber: 120 });
+  assert.equal(withPr.manifestPath, freshPath);
+  assert.equal(withPr.data.run_id, freshRunId);
+  assert.equal(withPr.data.git.pr_number, 120);
+
+  // Branch-only resolution (no prNumber): BRANCH_ONLY_TERMINAL_STATES must
+  // filter out the MERGED run, so the non-terminal dispatched run is returned.
+  // This sub-assertion is what the anti-theater stub targets.
+  const branchOnly = resolveManifestRecord({ repoRoot, branch: "issue-100" });
+  assert.equal(branchOnly.manifestPath, freshPath);
+  assert.equal(branchOnly.data.run_id, freshRunId);
 });
 
 test("resolveManifestRecord rejects stale terminal-only branch reuse and names the fresh-dispatch recovery", () => {

--- a/skills/relay-dispatch/scripts/relay-resolver.test.js
+++ b/skills/relay-dispatch/scripts/relay-resolver.test.js
@@ -340,7 +340,7 @@ test("resolveManifestRecord returns the fresh non-terminal manifest on a reused 
 });
 
 test("resolveManifestRecord does not inherit a terminal run when a reused branch has a fresh PR match", () => {
-  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  // #153 enforcement-path coverage — originating findings: #148 file-existence/containment, #149 manifest resolution, #151 grandfather provenance
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-resolver-branch-reuse-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   writeManifestRecord(repoRoot, {

--- a/skills/relay-dispatch/scripts/test-support.js
+++ b/skills/relay-dispatch/scripts/test-support.js
@@ -1,0 +1,97 @@
+const fs = require("fs");
+const path = require("path");
+
+const {
+  ensureRunLayout,
+  readManifest,
+  writeManifest,
+} = require("./relay-manifest");
+
+const DEFAULT_RUBRIC_PATH = "rubric.yaml";
+const DEFAULT_ENFORCEMENT_RUBRIC = [
+  "rubric:",
+  "  factors:",
+  "    - name: Default enforcement rubric",
+  "      target: \">= 1/1\"",
+].join("\n");
+
+function createEnforcementFixture({
+  repoRoot,
+  runId,
+  manifestPath = null,
+  state = "loaded",
+  grandfather = false,
+  rubricPath = undefined,
+  rubricContent = DEFAULT_ENFORCEMENT_RUBRIC,
+  anchorOverrides = {},
+} = {}) {
+  if (!repoRoot || !runId) {
+    throw new Error("createEnforcementFixture requires repoRoot and runId");
+  }
+
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  fs.rmSync(path.join(runDir, DEFAULT_RUBRIC_PATH), { recursive: true, force: true });
+  fs.rmSync(path.join(runDir, "rubric-dir"), { recursive: true, force: true });
+
+  let nextAnchor = {
+    ...anchorOverrides,
+  };
+  delete nextAnchor.rubric_grandfathered;
+  delete nextAnchor.rubric_path;
+
+  if (grandfather) {
+    nextAnchor.rubric_grandfathered = true;
+  } else {
+    switch (state) {
+      case "loaded":
+      case "missing":
+      case "empty":
+        nextAnchor.rubric_path = rubricPath ?? DEFAULT_RUBRIC_PATH;
+        break;
+      case "outside_run_dir":
+        nextAnchor.rubric_path = rubricPath ?? "../escape.yaml";
+        break;
+      case "invalid":
+        nextAnchor.rubric_path = rubricPath ?? "rubric-dir";
+        break;
+      case "not_set":
+        break;
+      default:
+        throw new Error(`Unsupported createEnforcementFixture state: ${state}`);
+    }
+  }
+
+  if (grandfather) {
+    // Explicit legacy bypass only; callers must opt in so enforcement remains the default.
+  } else if (state === "loaded") {
+    const fullPath = path.join(runDir, nextAnchor.rubric_path);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, rubricContent, "utf-8");
+  } else if (state === "empty") {
+    const fullPath = path.join(runDir, nextAnchor.rubric_path);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, "   \n", "utf-8");
+  } else if (state === "invalid") {
+    fs.mkdirSync(path.join(runDir, nextAnchor.rubric_path), { recursive: true });
+  }
+
+  if (manifestPath) {
+    const record = readManifest(manifestPath);
+    writeManifest(manifestPath, {
+      ...record.data,
+      anchor: nextAnchor,
+    }, record.body);
+  }
+
+  return {
+    runDir,
+    anchor: nextAnchor,
+    rubricPath: nextAnchor.rubric_path || null,
+    rubricContent,
+  };
+}
+
+module.exports = {
+  DEFAULT_ENFORCEMENT_RUBRIC,
+  createEnforcementFixture,
+};

--- a/skills/relay-dispatch/scripts/test-support.js
+++ b/skills/relay-dispatch/scripts/test-support.js
@@ -77,10 +77,29 @@ function createEnforcementFixture({
 
   if (manifestPath) {
     const record = readManifest(manifestPath);
+    // Merge into the existing persisted anchor so unrelated fields
+    // (done_criteria_path, done_criteria_source, rubric_source, etc.)
+    // are preserved. Only the rubric-related keys are owned by this helper.
+    const existingAnchor = record.data.anchor || {};
+    const mergedAnchor = { ...existingAnchor, ...nextAnchor };
+    if (grandfather) {
+      delete mergedAnchor.rubric_path;
+    } else {
+      delete mergedAnchor.rubric_grandfathered;
+      if (state === "not_set") {
+        delete mergedAnchor.rubric_path;
+      }
+    }
     writeManifest(manifestPath, {
       ...record.data,
-      anchor: nextAnchor,
+      anchor: mergedAnchor,
     }, record.body);
+    return {
+      runDir,
+      anchor: mergedAnchor,
+      rubricPath: mergedAnchor.rubric_path || null,
+      rubricContent,
+    };
   }
 
   return {

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -14,6 +14,7 @@ const {
   updateManifestState,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
+const { createEnforcementFixture } = require("../../relay-dispatch/scripts/test-support");
 
 const SCRIPT = path.join(__dirname, "finalize-run.js");
 
@@ -62,7 +63,11 @@ function setupRepo({ dirtyWorktree = false } = {}) {
     reviewer: "codex",
   });
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
-  manifest.anchor.rubric_grandfathered = true;
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+  }).anchor;
   manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
   manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
   manifest.git.pr_number = 123;

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -531,7 +531,7 @@ test("gate-check passes review from authorized author when reviewer_login is set
 });
 
 test("gate-check live PR mode blocks merge when anchor.rubric_path points to a missing file", () => {
-  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  // #153 enforcement-path coverage — originating findings: #148 file-existence/containment, #149 manifest resolution, #151 grandfather provenance
   const fixture = createLiveGateFixture({
     manifest: {
       state: STATES.REVIEW_PENDING,

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -14,6 +14,7 @@ const {
   updateManifestState,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
+const { createEnforcementFixture } = require("../../relay-dispatch/scripts/test-support");
 
 const SCRIPT = path.join(__dirname, "gate-check.js");
 const HISTORICAL_FIXTURE_DIR = path.join(__dirname, "__fixtures__", "historical-issue-401");
@@ -529,11 +530,45 @@ test("gate-check passes review from authorized author when reviewer_login is set
   assert.equal(result.json.readyToMerge, true);
 });
 
+test("gate-check live PR mode blocks merge when anchor.rubric_path points to a missing file", () => {
+  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  const fixture = createLiveGateFixture({
+    manifest: {
+      state: STATES.REVIEW_PENDING,
+      anchor: {
+        rubric_path: "rubric.yaml",
+      },
+      review: {
+        reviewer_login: "trusted-reviewer",
+        last_reviewed_sha: "abc123",
+      },
+      git: {
+        pr_number: 40,
+      },
+    },
+  });
+  createEnforcementFixture({
+    repoRoot: fixture.repoRoot,
+    runId: fixture.runId,
+    manifestPath: fixture.manifestPath,
+    state: "missing",
+  });
+
+  const result = runGateCheckWithFixture(fixture, {
+    prViewPayload: buildPassingReviewPayload(),
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.json.status, "missing_rubric_file");
+  assert.equal(result.json.readyToMerge, false);
+  assert.equal(result.json.rubricStatus, "missing");
+});
+
 test("gate-check rejects manifests whose stored run_id is invalid", () => {
   const result = runGateCheckLive({
     manifest: {
       anchor: {
-        rubric_grandfathered: true,
+        rubric_path: "rubric.yaml",
       },
       storedRunId: "../victim-gate-run",
     },
@@ -555,7 +590,7 @@ test("gate-check rejects crafted manifest repo roots before stamping or merge ga
   const result = runGateCheckLive({
     manifest: {
       anchor: {
-        rubric_grandfathered: true,
+        rubric_path: "rubric.yaml",
       },
       state: STATES.REVIEW_PENDING,
     },
@@ -587,7 +622,7 @@ test("gate-check rejects relay-base same-name worktrees before stamping or merge
   const fixture = createLiveGateFixture({
     manifest: {
       anchor: {
-        rubric_grandfathered: true,
+        rubric_path: "rubric.yaml",
       },
       state: STATES.REVIEW_PENDING,
     },
@@ -1124,7 +1159,7 @@ test("gate-check PR mode fails closed when only a stale merged manifest exists o
     manifest: {
       state: STATES.MERGED,
       anchor: {
-        rubric_grandfathered: true,
+        rubric_path: "rubric.yaml",
       },
       review: {
         reviewer_login: "trusted-reviewer",
@@ -1149,7 +1184,7 @@ test("gate-check PR mode with headRefName:null fails closed via standalone --pr 
     manifest: {
       state: STATES.MERGED,
       anchor: {
-        rubric_grandfathered: true,
+        rubric_path: "rubric.yaml",
       },
       review: {
         reviewer_login: "trusted-reviewer",
@@ -1486,6 +1521,7 @@ test("gate-check allows grandfathered runs and surfaces the note", () => {
     manifest: {
       run_id: "issue-40-20260412010000000",
       anchor: {
+        // GRANDFATHER FIXTURE — remove after migration complete per #151
         rubric_grandfathered: true,
       },
       review: {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -15,6 +15,10 @@ const {
   readManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
 const { readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
+const {
+  DEFAULT_ENFORCEMENT_RUBRIC,
+  createEnforcementFixture,
+} = require("../../relay-dispatch/scripts/test-support");
 
 const SCRIPT = path.join(__dirname, "review-runner.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "../../relay-dispatch/scripts/dispatch.js");
@@ -52,13 +56,12 @@ function setupRepo() {
     reviewer: "claude",
   });
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
-  manifest = {
-    ...manifest,
-    anchor: {
-      ...(manifest.anchor || {}),
-      rubric_grandfathered: true,
-    },
-  };
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+    rubricContent: DEFAULT_ENFORCEMENT_RUBRIC,
+  }).anchor;
   manifest = {
     ...manifest,
     git: {
@@ -130,40 +133,14 @@ function updateManifestRecord(manifestPath, updater) {
 }
 
 function configureRubricFixture({ manifestPath, repoRoot, runId, state }) {
-  const runDir = ensureRunLayout(repoRoot, runId).runDir;
-  fs.rmSync(path.join(runDir, "rubric.yaml"), { recursive: true, force: true });
-  fs.rmSync(path.join(runDir, "rubric-dir"), { recursive: true, force: true });
-
-  updateManifestRecord(manifestPath, (data) => {
-    const anchor = { ...(data.anchor || {}) };
-    delete anchor.rubric_grandfathered;
-    delete anchor.rubric_path;
-
-    if (state === "loaded" || state === "missing" || state === "empty") {
-      anchor.rubric_path = "rubric.yaml";
-    } else if (state === "outside_run_dir") {
-      anchor.rubric_path = "../escape.yaml";
-    } else if (state === "invalid") {
-      anchor.rubric_path = "rubric-dir";
-    } else if (state === "grandfathered") {
-      anchor.rubric_grandfathered = true;
-    }
-
-    return {
-      ...data,
-      anchor,
-    };
-  });
-
-  if (state === "loaded") {
-    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: API pagination\n      target: \">= 8/10\"\n", "utf-8");
-  } else if (state === "empty") {
-    fs.writeFileSync(path.join(runDir, "rubric.yaml"), "   \n", "utf-8");
-  } else if (state === "invalid") {
-    fs.mkdirSync(path.join(runDir, "rubric-dir"), { recursive: true });
-  }
-
-  return runDir;
+  return createEnforcementFixture({
+    repoRoot,
+    runId,
+    manifestPath,
+    state: state === "grandfathered" ? "loaded" : state,
+    grandfather: state === "grandfathered",
+    rubricContent: "rubric:\n  factors:\n    - name: API pagination\n      target: \">= 8/10\"\n",
+  }).runDir;
 }
 
 function writeVerdict(repoRoot, name, verdict) {
@@ -180,9 +157,22 @@ function writePassVerdict(repoRoot, name = "pass.json") {
     quality_status: "pass",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
+}
+
+function defaultRubricScores() {
+  return [
+    {
+      factor: "Default enforcement rubric",
+      target: ">= 1/1",
+      observed: "1/1",
+      status: "pass",
+      tier: "contract",
+      notes: "The enforcement fixture rubric remained satisfied.",
+    },
+  ];
 }
 
 function prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath }) {
@@ -484,7 +474,7 @@ test("pass verdict moves review_pending to ready_to_merge", () => {
     quality_status: "pass",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -524,7 +514,7 @@ test("pass verdict rejects quality_status=not_run", () => {
     quality_status: "not_run",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -769,7 +759,7 @@ test("changes_requested verdict creates a re-dispatch artifact", () => {
         severity: "high",
       },
     ],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1064,7 +1054,7 @@ test("reviewer-script invocation can drive a round without --review-file", () =>
     quality_status: "pass",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1110,7 +1100,7 @@ test("invalid pass verdict is rejected", () => {
         severity: "low",
       },
     ],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1204,7 +1194,7 @@ test("pass verdict with not_done scope_drift entry is rejected", () => {
     quality_status: "pass",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: {
       creep: [],
       missing: [{ criteria: "Add smoke.txt", status: "not_done" }],
@@ -1233,7 +1223,7 @@ test("pass verdict with partial scope_drift entry is rejected", () => {
     quality_status: "pass",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: {
       creep: [],
       missing: [{ criteria: "Add smoke.txt", status: "partial" }],
@@ -1262,7 +1252,7 @@ test("invalid scope_drift missing status is rejected", () => {
     quality_status: "not_run",
     next_action: "changes_requested",
     issues: [{ title: "Missing", body: "Not implemented", file: "x.js", line: 1, category: "contract", severity: "high" }],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: {
       creep: [],
       missing: [{ criteria: "Add smoke.txt", status: "unknown" }],
@@ -1291,7 +1281,7 @@ test("changes_requested verdict with scope_drift includes drift in redispatch", 
     quality_status: "not_run",
     next_action: "changes_requested",
     issues: [{ title: "Creep", body: "Unrelated change", file: "extra.js", line: 1, category: "scope", severity: "medium" }],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: {
       creep: [{ file: "extra.js", reason: "Not in Done Criteria" }],
       missing: [
@@ -1332,7 +1322,7 @@ test("reviewer write policy violation escalates the manifest", () => {
     quality_status: "pass",
     next_action: "ready_to_merge",
     issues: [],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1383,7 +1373,7 @@ process.stdout.write(JSON.stringify({
     category: "contract",
     severity: "high"
   }],
-  rubric_scores: [],
+  rubric_scores: ${JSON.stringify(defaultRubricScores())},
   scope_drift: { creep: [], missing: [] }
 }));
 `, "utf-8");
@@ -1450,7 +1440,7 @@ test("repeated identical issues escalate on the third consecutive round", () => 
         severity: "high",
       },
     ],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1578,7 +1568,7 @@ test("round 2 review prompt contains Prior Round Context section", () => {
       category: "contract",
       severity: "high",
     }],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1636,7 +1626,7 @@ test("round 2 redispatch artifact contains prior round summary", () => {
       category: "contract",
       severity: "high",
     }],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1669,7 +1659,7 @@ test("round 2 redispatch artifact contains prior round summary", () => {
       category: "contract",
       severity: "high",
     }],
-    rubric_scores: [],
+    rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
   });
 
@@ -1911,10 +1901,18 @@ test("review-runner advances loaded-rubric PASS reviews to ready_to_merge", () =
 });
 
 test("review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing", () => {
+  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 
   configureRubricFixture({ manifestPath, repoRoot, runId, state: "missing" });
+  const rubricLoad = JSON.parse(runReviewRunnerModule([
+    `const { loadRubricFromRunDir } = reviewRunner;`,
+    `const result = loadRubricFromRunDir(${JSON.stringify(ensureRunLayout(repoRoot, runId).runDir)}, ${JSON.stringify(readManifest(manifestPath).data)});`,
+    `process.stdout.write(JSON.stringify(result));`,
+  ]));
   const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
+  assert.equal(rubricLoad.state, "missing");
+  assert.match(rubricLoad.warning, /\[rubric missing\]/i);
   assert.equal(result.rubricLoaded, "missing");
   assert.match(result.rubricWarning, /\[rubric missing\]/i);
   const promptText = fs.readFileSync(result.promptPath, "utf-8");
@@ -1923,16 +1921,34 @@ test("review-runner warns visibly when anchor.rubric_path is set but the rubric 
   assert.match(promptText, /Do NOT return PASS or ready_to_merge/i);
 });
 
-test("review-runner distinguishes rubric paths that resolve outside the run dir", () => {
-  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+test("review-runner surfaces containment warnings for parent-relative and absolute rubric paths", async (t) => {
+  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  for (const rubricPath of ["../escape.yaml", "/etc/passwd"]) {
+    await t.test(rubricPath, () => {
+      const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+      createEnforcementFixture({
+        repoRoot,
+        runId,
+        manifestPath,
+        state: "outside_run_dir",
+        rubricPath,
+      });
+      const rubricLoad = JSON.parse(runReviewRunnerModule([
+        `const { loadRubricFromRunDir } = reviewRunner;`,
+        `const result = loadRubricFromRunDir(${JSON.stringify(ensureRunLayout(repoRoot, runId).runDir)}, ${JSON.stringify(readManifest(manifestPath).data)});`,
+        `process.stdout.write(JSON.stringify(result));`,
+      ]));
+      const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
+      const promptText = fs.readFileSync(result.promptPath, "utf-8");
 
-  configureRubricFixture({ manifestPath, repoRoot, runId, state: "outside_run_dir" });
-  const result = prepareReviewRun({ repoRoot, runId, doneCriteriaPath, diffPath });
-  assert.equal(result.rubricLoaded, "outside_run_dir");
-  assert.match(result.rubricWarning, /\[rubric path outside run dir\]/i);
-  const promptText = fs.readFileSync(result.promptPath, "utf-8");
-  assert.match(promptText, /WARNING: \[rubric path outside run dir\]/i);
-  assert.match(promptText, /\.\./);
+      assert.equal(rubricLoad.state, "outside_run_dir");
+      assert.match(rubricLoad.warning, /\[rubric path outside run dir\]/i);
+      assert.equal(result.rubricLoaded, "outside_run_dir");
+      assert.match(result.rubricWarning, /\[rubric path outside run dir\]/i);
+      assert.match(promptText, /WARNING: \[rubric path outside run dir\]/i);
+      assert.match(promptText, new RegExp(rubricPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    });
+  }
 });
 
 test("review-runner warns visibly when anchor.rubric_path is missing from the manifest", () => {
@@ -1979,6 +1995,7 @@ test("loadRubricFromRunDir returns the invalid warning branch when anchor.rubric
   const runDir = ensureRunLayout(repoRoot, runId).runDir;
   const siblingTarget = path.join(runDir, "rubric-copy.yaml");
   fs.writeFileSync(siblingTarget, "rubric:\n  factors:\n    - name: sibling\n", "utf-8");
+  fs.rmSync(path.join(runDir, "rubric.yaml"), { force: true });
   fs.symlinkSync(siblingTarget, path.join(runDir, "rubric.yaml"));
 
   const { data, body } = readManifest(manifestPath);
@@ -2045,8 +2062,15 @@ test("review-runner rejects empty rubric_scores when rubric is present", () => {
 
 test("review-runner allows empty rubric_scores when no rubric file exists", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  updateManifestRecord(manifestPath, (data) => ({
+    ...data,
+    anchor: {
+      // GRANDFATHER FIXTURE — remove after migration complete per #151
+      rubric_grandfathered: true,
+    },
+  }));
+  fs.rmSync(path.join(ensureRunLayout(repoRoot, runId).runDir, "rubric.yaml"), { force: true });
 
-  // No rubric file, no rubric_path in manifest; setupRepo marks the run grandfathered.
   const reviewFile = writeVerdict(repoRoot, "no-rubric-pass.json", {
     verdict: "pass",
     summary: "All done criteria are satisfied.",

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1901,7 +1901,7 @@ test("review-runner advances loaded-rubric PASS reviews to ready_to_merge", () =
 });
 
 test("review-runner warns visibly when anchor.rubric_path is set but the rubric file is missing", () => {
-  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  // #153 enforcement-path coverage — originating findings: #148 file-existence/containment, #149 manifest resolution, #151 grandfather provenance
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
 
   configureRubricFixture({ manifestPath, repoRoot, runId, state: "missing" });
@@ -1922,7 +1922,7 @@ test("review-runner warns visibly when anchor.rubric_path is set but the rubric 
 });
 
 test("review-runner surfaces containment warnings for parent-relative and absolute rubric paths", async (t) => {
-  // #153 enforcement-path coverage (#138 fixture-default-grandfathered remediation)
+  // #153 enforcement-path coverage — originating findings: #148 file-existence/containment, #149 manifest resolution, #151 grandfather provenance
   for (const rubricPath of ["../escape.yaml", "/etc/passwd"]) {
     await t.test(rubricPath, () => {
       const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();


### PR DESCRIPTION
## Summary

Closes #153. Remediation for the post-#147 (issue #138) observation that the rubric-mandatory test suite defaulted most fixtures to grandfathered mode or auto-injected rubrics, so the tests proved the bypass paths worked rather than the enforcement paths.

This PR is **test-only**. No production behavior changes. Anchors on already-shipped contracts from #148 (PR #155), #149 (PR #164), and #161 (PR #196).

**Rebased on main** (2026-04-17) to pick up the new CI workflow from #202 / PR #203. New HEAD: `7e73a986536cb2bcf5203dd9aaad54e5593ed45e`.

## Changes

### New shared helper
- `skills/relay-dispatch/scripts/test-support.js` — `createEnforcementFixture({ repoRoot, runId, state, grandfather, rubricPath, rubricContent, anchorOverrides, manifestPath })`. Defaults to `state: "loaded"` and `grandfather: false`.

### 5 new enforcement-path tests
Each tagged `// #153 enforcement-path coverage — originating findings: #148 file-existence/containment, #149 manifest resolution, #151 grandfather provenance`.

| # | File | Test | Pins |
|---|---|---|---|
| 1 | `review-runner.test.js:1903` | missing rubric file surfaces visible warning in prompt | `loadRubricFromRunDir` → `state=missing` + `[rubric missing]` warning |
| 2 | `review-runner.test.js:1925` | `..` / absolute rubric path surfaces containment warning | `outside_run_dir` + `[rubric path outside run dir]` |
| 3 | `gate-check.test.js:533` | live PR mode with missing rubric file blocks merge | `missing_rubric_file` + `readyToMerge=false` |
| 4 | `relay-resolver.test.js:342` | merged run A does not shadow fresh run B on reused branch | exact-PR match AND branch-only resolution both return run B |
| 5 | `dispatch.test.js:749` | post-dispatch truncated rubric fails downstream review gate | `evaluateReviewGate` → `empty_rubric_file` + `readyToMerge=false` |

Dispatch-time rejection of empty `--rubric-file` (already shipped in #148) is intentionally NOT re-tested here to respect scope.

### Fixture audit

| File | Before | After |
|---|---|---|
| `review-runner.test.js:setupRepo` | `rubric_grandfathered: true` default | `createEnforcementFixture({state: "loaded"})` |
| `review-runner.test.js:configureRubricFixture` | inline rubric setup | wraps `createEnforcementFixture` |
| `review-runner.test.js:2068` | inline `rubric_grandfathered: true` (test ABOUT grandfathering) | kept; tagged `// GRANDFATHER FIXTURE — remove after migration complete per #151` |
| `finalize-run.test.js:65` | `manifest.anchor.rubric_grandfathered = true` | enforcement rubric via helper |
| `relay-resolver.test.js:writeManifestRecord` | `grandfathered = true` default | `grandfathered = false` default, enforcement rubric content |
| `gate-check.test.js:1524` | inline `rubric_grandfathered: true` (test ABOUT grandfathering) | kept; tagged `// GRANDFATHER FIXTURE — remove after migration complete per #151` |
| `dispatch.test.js:withRequiredRubric` | silent auto-inject | auto-inject kept with header comment distinguishing it from grandfather bypass |

`relay-manifest.test.js` grandfather use sites (5 lines) are outside the #153 audit scope per AC — that file tests the manifest layer itself where grandfather exercises an intentional manifest-contract branch. #151 will rewrite those when it lands.

## Scope discipline

- **Production code unchanged.** A dispatch iteration tried to loosen `dispatch.js` + `relay-manifest.js` to persist empty rubrics through `review_pending`; that was scope creep into #148 and was reverted. Test (5) now pins only the downstream gate failure path.
- No #151 migration work, no symlink rework from #161, no fold-in from #150/#152/#158.

## Anti-theater proof (all executed)

For each test, a stub was applied to the listed production module in a scratch copy, the targeted test(s) were run, and production was restored. All 5 targeted tests failed under their stubs, confirming regression coverage is real.

| Test | Stub applied | Result with stub | Evidence |
|---|---|---|---|
| 1 missing-rubric prompt | `loadRubricFromRunDir` short-circuits to `{state: "loaded", content: ""}` | `not ok — warns visibly when anchor.rubric_path is set but the rubric file is missing` | Executed |
| 2 `..` / absolute path | `validateRubricPathContainment` returns `{valid: true}` at entry | `not ok 43 — surfaces containment warnings for parent-relative and absolute rubric paths` | Executed |
| 3 gate-check missing file | `evaluateReviewGate` returns `lgtm` unconditionally | `not ok — live PR mode blocks merge when anchor.rubric_path points to a missing file` | Executed |
| 4 branch-reuse resolver | `BRANCH_ONLY_TERMINAL_STATES = new Set()` (terminal filter disabled) | `not ok 8 — resolveManifestRecord does not inherit a terminal run when a reused branch has a fresh PR match` | Executed |
| 5 empty-rubric downstream gate | `getRubricAnchorStatus` treats empty as `satisfied` | `not ok — dispatched run whose persisted rubric is empty fails closed at the review gate` | Executed |

For test 4, the branch-only sub-assertion was added specifically so the `BRANCH_ONLY_TERMINAL_STATES` stub actually exercises this test (the earlier exact-PR-only version was protected by PR-match shortcut and would not have surfaced terminal-filter regressions).

## Verification

**CI workflow run against this PR's HEAD**: https://github.com/sungjunlee/dev-relay/actions/runs/24553949343 — **success** (360 tests pass on ubuntu-latest + Node 22 + the actual PR HEAD `7e73a986536cb2bcf5203dd9aaad54e5593ed45e`).

Local mirror:
```
$ node --test skills/*/scripts/*.test.js
# tests 360
# pass 360
# fail 0
```

Before this PR: 355 tests (post-#196 merge). After: 360 (5 new enforcement-path tests). No `.skip` / `.only` introduced.

## Grep audit

```
$ grep -n "rubric_grandfathered: true" skills/*/scripts/*.test.js
skills/relay-dispatch/scripts/relay-manifest.test.js:528   # manifest-layer grandfather tests (outside #153 AC scope)
skills/relay-dispatch/scripts/relay-manifest.test.js:544
skills/relay-dispatch/scripts/relay-manifest.test.js:576
skills/relay-dispatch/scripts/relay-manifest.test.js:585
skills/relay-dispatch/scripts/relay-manifest.test.js:640
skills/relay-merge/scripts/gate-check.test.js:1525         # GRANDFATHER FIXTURE tagged
skills/relay-review/scripts/review-runner.test.js:2069     # GRANDFATHER FIXTURE tagged
```

All remaining non-test-support `rubric_grandfathered: true` use sites are either tagged or in files outside #153's AC audit set.