### PR TITLE
ci: add minimal GitHub Actions workflow for node --test (closes #202)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node --test skills/*/scripts/*.test.js


### PR DESCRIPTION
## Summary

Closes #202. Adds `.github/workflows/test.yml` — a single-job GH Actions workflow that runs `node --test skills/*/scripts/*.test.js` on every push to `main` and every PR targeting `main`.

Filed to close a recurring Phase 0 review blocker: reviewer sandboxes (codex, claude adapters) cannot run the suite due to `EPERM` on tempdir writes, so AC items of the form "test_suite_green / independently verifiable" keep stalling rounds (see PR #201 round 3).

## Changes

One file, 17 lines:

```yaml
name: test

on:
  push:
    branches: [main]
  pull_request:
    branches: [main]

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: '22'
      - run: node --test skills/*/scripts/*.test.js
```

## Verification — workflow run on this PR's HEAD

Run: https://github.com/sungjunlee/dev-relay/actions/runs/24553821479 — **success** (all 360 tests pass on ubuntu-latest + Node 22 + the actual PR HEAD).

This is the AC signal: the loop closes. Future PRs will auto-run this workflow; reviewers can cite the Actions tab for `test_suite_green` factors.

## Scope discipline

- No Node matrix.
- No lint / coverage / release step.
- No soft-fail (`continue-on-error`, `|| true`).
- No `schedule` / `workflow_dispatch` / tag triggers.
- No changes under `skills/`, `backlog/`, or any existing file.

## Note — Node.js 20 deprecation warning

The workflow run surfaced a deprecation notice: `actions/checkout@v4` and `actions/setup-node@v4` currently run on Node.js 20, which will be forced to Node 24 by 2026-06-02 and removed 2026-09-16. That is an Actions runtime concern (not this repo's Node 22 test runtime) and will be handled by a future actions/*@v5 upgrade. Flagging it here so it doesn't get lost.

## Unlocks

- Re-review of #201 (issue #153) should now pass `test_suite_green` — the Actions tab on that PR's HEAD provides independently verifiable evidence.
- Future PRs in the #150 / #151 / #152 / #158 / #197 sequence inherit the CI gate automatically.