### PR TITLE
relay: refuse symlinked events.jsonl and previous-attempts.json (#197)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -206,11 +206,16 @@ function appendScoreDivergence(repoRoot, runId, { round, divergences } = {}) {
 
 function readRunEvents(repoRoot, runId) {
   const eventsPath = getEventsPath(repoRoot, runId);
-  if (!fs.existsSync(eventsPath)) return [];
+  // Do NOT short-circuit on fs.existsSync — existsSync follows symlinks, so a
+  // dangling symlink at eventsPath would return false and we'd silently
+  // return []. That's exactly the fail-open class #157/#197 prohibit. Let
+  // the safe reader handle the symlink check; distinguish ENOENT (truly
+  // missing) from ELOOP (symlink refused) in the catch.
   let rawText;
   try {
     rawText = readTextFileWithoutFollowingSymlinks(eventsPath);
   } catch (error) {
+    if (error.code === "ENOENT") return [];
     if (error.code === "ELOOP") {
       throw new Error(
         `Refusing to read symlinked events.jsonl at ${eventsPath}: ${error.message}`

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -1,10 +1,26 @@
 const fs = require("fs");
 const {
+  appendTextFileWithoutFollowingSymlinks,
   ensureRunLayout,
   getEventsPath,
   getActorName,
   getRunsDir,
+  readTextFileWithoutFollowingSymlinks,
 } = require("./relay-manifest");
+
+function appendEventLine(repoRoot, runId, record) {
+  const eventsPath = getEventsPath(repoRoot, runId);
+  try {
+    appendTextFileWithoutFollowingSymlinks(eventsPath, `${JSON.stringify(record)}\n`);
+  } catch (error) {
+    if (error.code === "ELOOP") {
+      throw new Error(
+        `Refusing to append to symlinked events.jsonl at ${eventsPath}: ${error.message}`
+      );
+    }
+    throw error;
+  }
+}
 
 const ALLOWED_ITERATION_STATUSES = new Set(["pass", "fail", "not_run"]);
 const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
@@ -39,7 +55,7 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
   };
 
-  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  appendEventLine(repoRoot, runId, record);
   return record;
 }
 
@@ -87,7 +103,7 @@ function appendIterationScore(repoRoot, runId, { round, scores } = {}) {
     })),
   };
 
-  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  appendEventLine(repoRoot, runId, record);
   return record;
 }
 
@@ -137,7 +153,7 @@ function appendRubricQuality(repoRoot, runId, data = {}) {
     task_size: data.task_size,
   };
 
-  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  appendEventLine(repoRoot, runId, record);
   return record;
 }
 
@@ -184,14 +200,25 @@ function appendScoreDivergence(repoRoot, runId, { round, divergences } = {}) {
     })),
   };
 
-  fs.appendFileSync(getEventsPath(repoRoot, runId), `${JSON.stringify(record)}\n`, "utf-8");
+  appendEventLine(repoRoot, runId, record);
   return record;
 }
 
 function readRunEvents(repoRoot, runId) {
   const eventsPath = getEventsPath(repoRoot, runId);
   if (!fs.existsSync(eventsPath)) return [];
-  return fs.readFileSync(eventsPath, "utf-8")
+  let rawText;
+  try {
+    rawText = readTextFileWithoutFollowingSymlinks(eventsPath);
+  } catch (error) {
+    if (error.code === "ELOOP") {
+      throw new Error(
+        `Refusing to read symlinked events.jsonl at ${eventsPath}: ${error.message}`
+      );
+    }
+    throw error;
+  }
+  return rawText
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -330,3 +330,45 @@ test("appendScoreDivergence rejects a missing factor", () => {
     divergences: [createDivergence({ factor: "   " })],
   }), /divergences\[0\]\.factor is required/);
 });
+
+// ---------------------------------------------------------------------------
+// #197 — events.jsonl symlink trust-root refusal
+// ---------------------------------------------------------------------------
+
+test("appendRunEvent refuses when events.jsonl is replaced with a symlink", () => {
+  const { repoRoot, runId } = createContext();
+  // Seed the run layout with a legit first event.
+  appendRunEvent(repoRoot, runId, { event: "plan" });
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  const victim = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-victim-")), "victim.jsonl");
+  fs.writeFileSync(victim, "pre-existing victim content\n", "utf-8");
+
+  fs.rmSync(eventsPath);
+  fs.symlinkSync(victim, eventsPath);
+
+  assert.throws(
+    () => appendRunEvent(repoRoot, runId, { event: "dispatch" }),
+    /Refusing to (append to|open) symlinked/i
+  );
+  // Victim file must not have been mutated.
+  assert.equal(fs.readFileSync(victim, "utf-8"), "pre-existing victim content\n");
+});
+
+test("readRunEvents refuses when events.jsonl is a symlink", () => {
+  const { repoRoot, runId } = createContext();
+  appendRunEvent(repoRoot, runId, { event: "plan" });
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  const foreignDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-foreign-"));
+  const foreignEvents = path.join(foreignDir, "foreign-events.jsonl");
+  fs.writeFileSync(foreignEvents, '{"event":"spoofed","run_id":"other"}\n', "utf-8");
+
+  fs.rmSync(eventsPath);
+  fs.symlinkSync(foreignEvents, eventsPath);
+
+  assert.throws(
+    () => readRunEvents(repoRoot, runId),
+    /Refusing to (read|open) symlinked/i
+  );
+});

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -372,3 +372,43 @@ test("readRunEvents refuses when events.jsonl is a symlink", () => {
     /Refusing to (read|open) symlinked/i
   );
 });
+
+test("readRunEvents refuses dangling symlinks instead of silently returning []", () => {
+  // #197 fail-closed: a dangling symlink at events.jsonl must NOT be treated
+  // as "file missing" (existsSync follows links and would say "missing").
+  const { repoRoot, runId } = createContext();
+  appendRunEvent(repoRoot, runId, { event: "plan" });
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  fs.rmSync(eventsPath);
+  // Point at a path that does not exist — dangling symlink.
+  fs.symlinkSync("/nonexistent-relay-target-xyz", eventsPath);
+
+  assert.throws(
+    () => readRunEvents(repoRoot, runId),
+    /Refusing to (read|open) symlinked/i
+  );
+});
+
+test("appendRunEvent refuses dangling symlinks (no silent create-through)", () => {
+  // #197 defense-in-depth: on platforms without O_NOFOLLOW, the previous
+  // fallback used existsSync and would have called openSync(O_CREAT) through
+  // a dangling symlink. This test proves the behavior on any platform — the
+  // fallback in openForWriteWithoutFollowingSymlinks refuses dangling links.
+  const { repoRoot, runId } = createContext();
+  // Seed layout (without an events.jsonl yet).
+  appendRunEvent(repoRoot, runId, { event: "plan" });
+
+  const eventsPath = getEventsPath(repoRoot, runId);
+  fs.rmSync(eventsPath);
+  const victimDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-dangling-"));
+  const victimTarget = path.join(victimDir, "victim.jsonl");
+  // Dangling: victimTarget does not exist yet.
+  fs.symlinkSync(victimTarget, eventsPath);
+
+  assert.throws(
+    () => appendRunEvent(repoRoot, runId, { event: "dispatch" }),
+    /Refusing to (append to|open) symlinked/i
+  );
+  assert.equal(fs.existsSync(victimTarget), false, "victim target must not have been created through the symlink");
+});

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1002,40 +1002,52 @@ function validateRubricPathContainment(rubricPath, runDir) {
   }
 }
 
+// Self-thrown code when the target is not a regular file (FIFO, socket,
+// directory, device). Distinct from kernel-level EINVAL so the outer
+// swallow list (for platforms that raise EINVAL on O_NOFOLLOW) can't be
+// confused with "we already verified this is not a regular file".
+const ERR_NOT_REGULAR_FILE = "ENOT_REGULAR_FILE";
+
 function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
-  let fd = null;
   const noFollowFlag = fs.constants.O_NOFOLLOW;
+  // O_NONBLOCK prevents open(O_RDONLY) from blocking on a writer-less FIFO
+  // while we're verifying the target is a regular file. Regular files are
+  // unaffected. Falls back to 0 on platforms that don't expose it.
+  const nonBlockFlag = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
   const openPath = realPath || targetPath;
 
-  try {
-    if (typeof noFollowFlag === "number") {
-      fd = fs.openSync(openPath, fs.constants.O_RDONLY | noFollowFlag);
+  if (typeof noFollowFlag === "number") {
+    let fd = null;
+    try {
+      fd = fs.openSync(openPath, fs.constants.O_RDONLY | noFollowFlag | nonBlockFlag);
+    } catch (error) {
+      // Kernel-level rejections — fall through to the lstat-guarded fallback.
+      // Other errors (notably ENOENT) propagate to the caller.
+      if (!["ELOOP", "ENOTSUP", "EINVAL"].includes(error.code)) {
+        throw error;
+      }
+    }
+    if (fd !== null) {
       try {
         const stat = fs.fstatSync(fd);
         if (!stat.isFile()) {
-          const error = new Error(`Not a file: ${openPath}`);
-          error.code = "EINVAL";
+          // Use a distinct code from the kernel-reject set above — if we
+          // reused "EINVAL" here, the outer swallow-and-fall-back logic
+          // would kick in and the fallback path would reopen the FIFO /
+          // socket / device with plain O_RDONLY, which can block (FIFO)
+          // or have side effects (device). ENOT_REGULAR_FILE is non-POSIX
+          // and therefore never confused with a kernel response.
+          const error = new Error(`Not a regular file: ${openPath}`);
+          error.code = ERR_NOT_REGULAR_FILE;
           throw error;
         }
-        // Pre-fix: this `return fs.readFileSync(fd, ...)` did NOT close the
-        // fd on success because the outer catch only runs on throw. Wrap in
-        // try/finally so the fd is closed on both the success and throw
-        // paths. Matters more now that readRunEvents / readPreviousAttempts
-        // route through this helper on every call.
         return fs.readFileSync(fd, "utf-8");
       } finally {
         fs.closeSync(fd);
-        fd = null;
       }
     }
-  } catch (error) {
-    if (fd !== null) {
-      fs.closeSync(fd);
-      fd = null;
-    }
-    if (!["ELOOP", "ENOTSUP", "EINVAL"].includes(error.code)) {
-      throw error;
-    }
+    // fd === null here means we caught ELOOP/ENOTSUP/EINVAL above. Fall
+    // through to the lstat-guarded fallback below.
   }
 
   const targetEntry = fs.lstatSync(targetPath);
@@ -1044,13 +1056,21 @@ function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
     error.code = "ELOOP";
     throw error;
   }
+  if (!targetEntry.isFile()) {
+    // Non-regular target without crossing through open() — we already know
+    // from lstat it's not a symlink and not a regular file. Refuse before
+    // we open, to avoid blocking on a reader-less FIFO.
+    const error = new Error(`Not a regular file: ${targetPath}`);
+    error.code = ERR_NOT_REGULAR_FILE;
+    throw error;
+  }
 
-  fd = fs.openSync(openPath, fs.constants.O_RDONLY);
+  const fd = fs.openSync(openPath, fs.constants.O_RDONLY | nonBlockFlag);
   try {
     const stat = fs.fstatSync(fd);
     if (!stat.isFile()) {
-      const error = new Error(`Not a file: ${openPath}`);
-      error.code = "EINVAL";
+      const error = new Error(`Not a regular file: ${openPath}`);
+      error.code = ERR_NOT_REGULAR_FILE;
       throw error;
     }
     return fs.readFileSync(fd, "utf-8");
@@ -1295,7 +1315,7 @@ function getRubricAnchorStatus(data, options = {}) {
       };
     }
 
-    if (error.code === "EINVAL") {
+    if (error.code === "EINVAL" || error.code === ERR_NOT_REGULAR_FILE) {
       return {
         ...baseStatus,
         ...containment,

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1028,9 +1028,9 @@ function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
     }
   }
 
-  const rubricEntry = fs.lstatSync(targetPath);
-  if (rubricEntry.isSymbolicLink()) {
-    const error = new Error(`Refusing to read symlinked rubric path: ${targetPath}`);
+  const targetEntry = fs.lstatSync(targetPath);
+  if (targetEntry.isSymbolicLink()) {
+    const error = new Error(`Refusing to read symlinked path: ${targetPath}`);
     error.code = "ELOOP";
     throw error;
   }
@@ -1044,6 +1044,69 @@ function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
       throw error;
     }
     return fs.readFileSync(fd, "utf-8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// Opens targetPath for writing without following symlinks. On platforms that
+// expose O_NOFOLLOW the kernel refuses the open atomically; on platforms
+// without it, we lstat first and refuse if the existing entry is a symlink
+// (best-effort fallback — a small TOCTOU window is unavoidable there).
+//
+// `mode` is "w" (truncate/create) or "a" (append/create). All writes use
+// 0o600 as the file mode on creation.
+function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
+  const modeFlags = {
+    w: fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC,
+    a: fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND,
+  };
+  const flags = modeFlags[mode];
+  if (flags === undefined) {
+    throw new Error(`openForWriteWithoutFollowingSymlinks: invalid mode ${mode}`);
+  }
+  const noFollowFlag = fs.constants.O_NOFOLLOW;
+
+  if (typeof noFollowFlag === "number") {
+    try {
+      return fs.openSync(targetPath, flags | noFollowFlag, 0o600);
+    } catch (error) {
+      if (error.code === "ELOOP") {
+        const wrapped = new Error(`Refusing to open symlinked path: ${targetPath}`);
+        wrapped.code = "ELOOP";
+        throw wrapped;
+      }
+      if (!["ENOTSUP", "EINVAL"].includes(error.code)) {
+        throw error;
+      }
+      // fall through to the lstat-guarded fallback below
+    }
+  }
+
+  if (fs.existsSync(targetPath)) {
+    const entry = fs.lstatSync(targetPath);
+    if (entry.isSymbolicLink()) {
+      const error = new Error(`Refusing to open symlinked path: ${targetPath}`);
+      error.code = "ELOOP";
+      throw error;
+    }
+  }
+  return fs.openSync(targetPath, flags, 0o600);
+}
+
+function appendTextFileWithoutFollowingSymlinks(targetPath, text) {
+  const fd = openForWriteWithoutFollowingSymlinks(targetPath, "a");
+  try {
+    fs.writeSync(fd, text);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function writeTextFileWithoutFollowingSymlinks(targetPath, text) {
+  const fd = openForWriteWithoutFollowingSymlinks(targetPath, "w");
+  try {
+    fs.writeSync(fd, text);
   } finally {
     fs.closeSync(fd);
   }
@@ -1479,8 +1542,21 @@ function getAttemptsPath(repoRoot, runId) {
 function readPreviousAttempts(repoRoot, runId) {
   const attemptsPath = getAttemptsPath(repoRoot, runId);
   if (!fs.existsSync(attemptsPath)) return [];
+  let rawText;
   try {
-    return JSON.parse(fs.readFileSync(attemptsPath, "utf-8"));
+    rawText = readTextFileWithoutFollowingSymlinks(attemptsPath);
+  } catch (error) {
+    // Symlink refusal must surface — do not silently fall through to [], which
+    // would mask a trust-root attack (same failure class as #157 fail-open).
+    if (error.code === "ELOOP") {
+      throw new Error(
+        `Refusing to read symlinked previous-attempts.json at ${attemptsPath}: ${error.message}`
+      );
+    }
+    throw error;
+  }
+  try {
+    return JSON.parse(rawText);
   } catch {
     console.error(`Warning: corrupted previous-attempts.json at ${attemptsPath}, ignoring`);
     return [];
@@ -1505,7 +1581,19 @@ function captureAttempt(repoRoot, runId, attemptData) {
     failed_approaches: attemptData.failed_approaches || [],
   };
   attempts.push(record);
-  fs.writeFileSync(getAttemptsPath(repoRoot, runId), JSON.stringify(attempts, null, 2), "utf-8");
+  try {
+    writeTextFileWithoutFollowingSymlinks(
+      getAttemptsPath(repoRoot, runId),
+      JSON.stringify(attempts, null, 2)
+    );
+  } catch (error) {
+    if (error.code === "ELOOP") {
+      throw new Error(
+        `Refusing to write symlinked previous-attempts.json at ${getAttemptsPath(repoRoot, runId)}: ${error.message}`
+      );
+    }
+    throw error;
+  }
   return record;
 }
 
@@ -1574,6 +1662,7 @@ module.exports = {
   NOTES_TEMPLATE,
   RELAY_VERSION,
   STATES,
+  appendTextFileWithoutFollowingSymlinks,
   captureAttempt,
   collectEnvironmentSnapshot,
   compareEnvironmentSnapshot,
@@ -1603,6 +1692,7 @@ module.exports = {
   parseFrontmatter,
   readManifest,
   readPreviousAttempts,
+  readTextFileWithoutFollowingSymlinks,
   runCleanup,
   summarizeError,
   updateManifestCleanup,
@@ -1613,4 +1703,5 @@ module.exports = {
   validateTransition,
   validateTransitionInvariants,
   writeManifest,
+  writeTextFileWithoutFollowingSymlinks,
 };

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1089,13 +1089,16 @@ function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
 // After opening an fd, verify it refers to a regular file — not a FIFO,
 // socket, device, or directory. Mirrors the check in the read helper. Opens
 // on a FIFO can block the writer; opens on a socket/device can have
-// side-effects we don't want. Closes the fd and throws EINVAL otherwise.
+// side-effects we don't want. Closes the fd and throws ENOT_REGULAR_FILE
+// (non-POSIX, distinct from kernel EINVAL) so the outer catch below does
+// NOT swallow it as a fallback trigger — same fix as the read helper
+// (round-4 codex finding, now mirrored on the write side per round-5).
 function gateWritableFd(fd, targetPath) {
   const stat = fs.fstatSync(fd);
   if (!stat.isFile()) {
     fs.closeSync(fd);
     const error = new Error(`Not a regular file: ${targetPath}`);
-    error.code = "EINVAL";
+    error.code = ERR_NOT_REGULAR_FILE;
     throw error;
   }
   return fd;

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1010,13 +1010,23 @@ function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
   try {
     if (typeof noFollowFlag === "number") {
       fd = fs.openSync(openPath, fs.constants.O_RDONLY | noFollowFlag);
-      const stat = fs.fstatSync(fd);
-      if (!stat.isFile()) {
-        const error = new Error(`Not a file: ${openPath}`);
-        error.code = "EINVAL";
-        throw error;
+      try {
+        const stat = fs.fstatSync(fd);
+        if (!stat.isFile()) {
+          const error = new Error(`Not a file: ${openPath}`);
+          error.code = "EINVAL";
+          throw error;
+        }
+        // Pre-fix: this `return fs.readFileSync(fd, ...)` did NOT close the
+        // fd on success because the outer catch only runs on throw. Wrap in
+        // try/finally so the fd is closed on both the success and throw
+        // paths. Matters more now that readRunEvents / readPreviousAttempts
+        // route through this helper on every call.
+        return fs.readFileSync(fd, "utf-8");
+      } finally {
+        fs.closeSync(fd);
+        fd = null;
       }
-      return fs.readFileSync(fd, "utf-8");
     }
   } catch (error) {
     if (fd !== null) {
@@ -1056,6 +1066,21 @@ function readTextFileWithoutFollowingSymlinks(targetPath, realPath) {
 //
 // `mode` is "w" (truncate/create) or "a" (append/create). All writes use
 // 0o600 as the file mode on creation.
+// After opening an fd, verify it refers to a regular file — not a FIFO,
+// socket, device, or directory. Mirrors the check in the read helper. Opens
+// on a FIFO can block the writer; opens on a socket/device can have
+// side-effects we don't want. Closes the fd and throws EINVAL otherwise.
+function gateWritableFd(fd, targetPath) {
+  const stat = fs.fstatSync(fd);
+  if (!stat.isFile()) {
+    fs.closeSync(fd);
+    const error = new Error(`Not a regular file: ${targetPath}`);
+    error.code = "EINVAL";
+    throw error;
+  }
+  return fd;
+}
+
 function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
   const modeFlags = {
     w: fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC,
@@ -1066,10 +1091,15 @@ function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
     throw new Error(`openForWriteWithoutFollowingSymlinks: invalid mode ${mode}`);
   }
   const noFollowFlag = fs.constants.O_NOFOLLOW;
+  // O_NONBLOCK prevents `open(O_WRONLY)` from blocking on a FIFO with no
+  // reader. Regular-file writes are unaffected. Not every platform defines
+  // it (Windows), so fall back to 0 (no-op) when unavailable.
+  const nonBlockFlag = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
 
   if (typeof noFollowFlag === "number") {
     try {
-      return fs.openSync(targetPath, flags | noFollowFlag, 0o600);
+      const fd = fs.openSync(targetPath, flags | noFollowFlag | nonBlockFlag, 0o600);
+      return gateWritableFd(fd, targetPath);
     } catch (error) {
       if (error.code === "ELOOP") {
         const wrapped = new Error(`Refusing to open symlinked path: ${targetPath}`);
@@ -1102,13 +1132,13 @@ function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
     }
     // Existing regular file — open normally. A small TOCTOU window between
     // lstat and open is unavoidable on platforms without O_NOFOLLOW.
-    return fs.openSync(targetPath, flags, 0o600);
+    return gateWritableFd(fs.openSync(targetPath, flags | nonBlockFlag, 0o600), targetPath);
   }
   // No entry at the path — create atomically with O_EXCL so an attacker
   // dropping a symlink between our lstat and open loses the race (EEXIST
   // instead of creating through the link).
   try {
-    return fs.openSync(targetPath, flags | fs.constants.O_EXCL, 0o600);
+    return gateWritableFd(fs.openSync(targetPath, flags | fs.constants.O_EXCL | nonBlockFlag, 0o600), targetPath);
   } catch (error) {
     if (error.code === "EEXIST") {
       const raced = fs.lstatSync(targetPath);
@@ -1117,7 +1147,7 @@ function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
         wrapped.code = "ELOOP";
         throw wrapped;
       }
-      return fs.openSync(targetPath, flags, 0o600);
+      return gateWritableFd(fs.openSync(targetPath, flags | nonBlockFlag, 0o600), targetPath);
     }
     throw error;
   }

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1083,15 +1083,44 @@ function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
     }
   }
 
-  if (fs.existsSync(targetPath)) {
-    const entry = fs.lstatSync(targetPath);
-    if (entry.isSymbolicLink()) {
+  // Non-O_NOFOLLOW fallback (primarily Windows). Do NOT use fs.existsSync
+  // here — existsSync follows symlinks, so a dangling symlink would report
+  // "missing" and the subsequent open(O_CREAT, ...) would create through it.
+  // Use lstatSync unconditionally and treat ENOENT as the true "missing"
+  // signal.
+  let existingStat = null;
+  try {
+    existingStat = fs.lstatSync(targetPath);
+  } catch (statError) {
+    if (statError.code !== "ENOENT") throw statError;
+  }
+  if (existingStat) {
+    if (existingStat.isSymbolicLink()) {
       const error = new Error(`Refusing to open symlinked path: ${targetPath}`);
       error.code = "ELOOP";
       throw error;
     }
+    // Existing regular file — open normally. A small TOCTOU window between
+    // lstat and open is unavoidable on platforms without O_NOFOLLOW.
+    return fs.openSync(targetPath, flags, 0o600);
   }
-  return fs.openSync(targetPath, flags, 0o600);
+  // No entry at the path — create atomically with O_EXCL so an attacker
+  // dropping a symlink between our lstat and open loses the race (EEXIST
+  // instead of creating through the link).
+  try {
+    return fs.openSync(targetPath, flags | fs.constants.O_EXCL, 0o600);
+  } catch (error) {
+    if (error.code === "EEXIST") {
+      const raced = fs.lstatSync(targetPath);
+      if (raced.isSymbolicLink()) {
+        const wrapped = new Error(`Refusing to open symlinked path: ${targetPath}`);
+        wrapped.code = "ELOOP";
+        throw wrapped;
+      }
+      return fs.openSync(targetPath, flags, 0o600);
+    }
+    throw error;
+  }
 }
 
 function appendTextFileWithoutFollowingSymlinks(targetPath, text) {
@@ -1541,13 +1570,16 @@ function getAttemptsPath(repoRoot, runId) {
 
 function readPreviousAttempts(repoRoot, runId) {
   const attemptsPath = getAttemptsPath(repoRoot, runId);
-  if (!fs.existsSync(attemptsPath)) return [];
+  // Do NOT short-circuit on fs.existsSync — existsSync follows symlinks, so a
+  // dangling symlink at attemptsPath would return false and we'd silently
+  // return []. That repeats the #157 fail-open class that #197 closes. Let
+  // the safe reader handle the symlink check; distinguish ENOENT (truly
+  // missing) from ELOOP (symlink refused).
   let rawText;
   try {
     rawText = readTextFileWithoutFollowingSymlinks(attemptsPath);
   } catch (error) {
-    // Symlink refusal must surface — do not silently fall through to [], which
-    // would mask a trust-root attack (same failure class as #157 fail-open).
+    if (error.code === "ENOENT") return [];
     if (error.code === "ELOOP") {
       throw new Error(
         `Refusing to read symlinked previous-attempts.json at ${attemptsPath}: ${error.message}`

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1153,10 +1153,31 @@ function openForWriteWithoutFollowingSymlinks(targetPath, mode) {
   }
 }
 
+// fs.writeSync may write fewer bytes than requested (short write) and the
+// caller is responsible for looping on the returned count. Short writes
+// are very unlikely on the small run-dir files we target, but a truncated
+// events.jsonl record or half-written previous-attempts.json would be
+// silently corrupt if we didn't handle it — drain the buffer ourselves.
+function writeAllSync(fd, text, targetPath) {
+  const buffer = Buffer.from(text, "utf-8");
+  let offset = 0;
+  while (offset < buffer.length) {
+    const written = fs.writeSync(fd, buffer, offset, buffer.length - offset);
+    if (written <= 0) {
+      const error = new Error(
+        `writeSync made no progress writing to ${targetPath} at offset ${offset}/${buffer.length}`
+      );
+      error.code = "EIO";
+      throw error;
+    }
+    offset += written;
+  }
+}
+
 function appendTextFileWithoutFollowingSymlinks(targetPath, text) {
   const fd = openForWriteWithoutFollowingSymlinks(targetPath, "a");
   try {
-    fs.writeSync(fd, text);
+    writeAllSync(fd, text, targetPath);
   } finally {
     fs.closeSync(fd);
   }
@@ -1165,7 +1186,7 @@ function appendTextFileWithoutFollowingSymlinks(targetPath, text) {
 function writeTextFileWithoutFollowingSymlinks(targetPath, text) {
   const fd = openForWriteWithoutFollowingSymlinks(targetPath, "w");
   try {
-    fs.writeSync(fd, text);
+    writeAllSync(fd, text, targetPath);
   } finally {
     fs.closeSync(fd);
   }

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -1303,3 +1303,53 @@ test("writeTextFileWithoutFollowingSymlinks creates a new file when the target i
   assert.equal(fs.readFileSync(target, "utf-8"), '[{"ok":true}]');
   assert.equal(fs.lstatSync(target).isSymbolicLink(), false);
 });
+
+test("appendTextFileWithoutFollowingSymlinks refuses a dangling symlink at target", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-append-dangling-"));
+  const target = path.join(dir, "events.jsonl");
+  const danglingTarget = path.join(dir, "does-not-exist.jsonl");
+  fs.symlinkSync(danglingTarget, target);
+
+  assert.throws(
+    () => appendTextFileWithoutFollowingSymlinks(target, "malicious\n"),
+    /Refusing to open symlinked path/
+  );
+  assert.equal(fs.existsSync(danglingTarget), false, "dangling target must not have been created through the symlink");
+});
+
+test("appendTextFileWithoutFollowingSymlinks creates a new file when the target is truly absent", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-append-create-"));
+  const target = path.join(dir, "events.jsonl");
+  appendTextFileWithoutFollowingSymlinks(target, "{\"event\":\"one\"}\n");
+  appendTextFileWithoutFollowingSymlinks(target, "{\"event\":\"two\"}\n");
+  assert.equal(
+    fs.readFileSync(target, "utf-8"),
+    "{\"event\":\"one\"}\n{\"event\":\"two\"}\n"
+  );
+  assert.equal(fs.lstatSync(target).isSymbolicLink(), false);
+});
+
+test("write helpers refuse a FIFO at the target path (POSIX only)", { skip: process.platform === "win32" }, () => {
+  // Defense-in-depth: trust-root protection isn't only about symlinks. A FIFO
+  // dropped at the target path could block `open(O_WRONLY)` forever waiting
+  // for a reader, or a socket/device could have side-effects. The helpers
+  // use O_NONBLOCK on POSIX and gate the fd with fstat+isFile.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-fifo-"));
+  const target = path.join(dir, "events.jsonl");
+  execFileSync("mkfifo", [target], { stdio: "pipe" });
+
+  // With O_NONBLOCK, open(O_WRONLY) on a reader-less FIFO fails with ENXIO
+  // on Linux/macOS — that's an acceptable refusal (attacker attempt blocked)
+  // even though it doesn't go through our ELOOP path. Alternately, if the
+  // platform opens it (with a reader attached, hypothetically), the fstat
+  // gate inside gateWritableFd catches it with EINVAL. Either way, no
+  // writeSync lands on the FIFO.
+  assert.throws(
+    () => appendTextFileWithoutFollowingSymlinks(target, "x\n"),
+    (error) => ["EINVAL", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
+  );
+  assert.throws(
+    () => writeTextFileWithoutFollowingSymlinks(target, "x"),
+    (error) => ["EINVAL", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
+  );
+});

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -1353,3 +1353,34 @@ test("write helpers refuse a FIFO at the target path (POSIX only)", { skip: proc
     (error) => ["EINVAL", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
   );
 });
+
+test("write helpers loop on short writes so records are never truncated", () => {
+  // fs.writeSync may return fewer bytes than requested. For regular disk
+  // files this is rare, but when it happens (page-cache pressure, signal
+  // interruption, future fs overlay), a truncated JSONL record would
+  // silently corrupt events.jsonl or previous-attempts.json.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-short-write-"));
+  const target = path.join(dir, "attempts.json");
+  const payload = '[{"dispatch_number":1,"score_log":"AB"}]';
+
+  const realWriteSync = fs.writeSync;
+  let calls = 0;
+  fs.writeSync = function patchedWriteSync(fd, buffer, offset, length, position) {
+    calls += 1;
+    // On the first call, write only 5 bytes of the requested length — a
+    // deliberate short write. Subsequent calls complete the remainder.
+    if (calls === 1 && Buffer.isBuffer(buffer)) {
+      const partial = Math.min(5, length);
+      return realWriteSync.call(fs, fd, buffer, offset, partial, position);
+    }
+    return realWriteSync.apply(fs, arguments);
+  };
+  try {
+    writeTextFileWithoutFollowingSymlinks(target, payload);
+  } finally {
+    fs.writeSync = realWriteSync;
+  }
+
+  assert.equal(fs.readFileSync(target, "utf-8"), payload, "full payload must land on disk despite the short write");
+  assert.ok(calls >= 2, "short-write path must have been exercised");
+});

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -1384,3 +1384,29 @@ test("write helpers loop on short writes so records are never truncated", () => 
   assert.equal(fs.readFileSync(target, "utf-8"), payload, "full payload must land on disk despite the short write");
   assert.ok(calls >= 2, "short-write path must have been exercised");
 });
+
+const { readTextFileWithoutFollowingSymlinks } = require("./relay-manifest");
+
+test("read helper refuses a FIFO at the target path (POSIX only)", { skip: process.platform === "win32" }, () => {
+  // Round-4 codex catch: on platforms with O_NOFOLLOW, a FIFO would pass the
+  // O_NOFOLLOW check (it's not a symlink), and the fstat+isFile guard inside
+  // the primary branch was self-throwing EINVAL — which the outer catch then
+  // swallowed, falling through to the lstat path which would reopen the FIFO
+  // without O_NOFOLLOW. That path can block on open(O_RDONLY) waiting for a
+  // writer, or worse, have side-effects on devices.
+  //
+  // The fix uses a distinct ENOT_REGULAR_FILE code so the outer catch does
+  // NOT swallow it, and adds O_NONBLOCK so the open(O_RDONLY) returns
+  // immediately for non-regular files. Either path is an acceptable refusal.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-read-fifo-"));
+  const target = path.join(dir, "events.jsonl");
+  execFileSync("mkfifo", [target], { stdio: "pipe" });
+
+  assert.throws(
+    () => readTextFileWithoutFollowingSymlinks(target),
+    (error) =>
+      error.code === "ENOT_REGULAR_FILE"
+      || error.code === "ENXIO"
+      || /Not a regular file/.test(error.message)
+  );
+});

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -1134,3 +1134,69 @@ test("manifest round-trips with environment block", () => {
   assert.equal(parsed.data.environment.lockfile_hash, "sha256:aabbccdd");
   assert.equal(parsed.data.environment.dispatch_ts, "2026-04-06T04:00:00.000Z");
 });
+
+// ---------------------------------------------------------------------------
+// #197 — previous-attempts.json symlink trust-root refusal
+// ---------------------------------------------------------------------------
+
+test("readPreviousAttempts refuses when previous-attempts.json is a symlink", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-symlink-attempts-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-attempts-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  const runId = "issue-197-20260417000000000";
+
+  // Seed a first legit attempt so the file exists.
+  captureAttempt(repoRoot, runId, { score_log: "first attempt" });
+  const attemptsPath = findAttemptsFile(process.env.RELAY_HOME);
+
+  const foreignDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-attempts-foreign-"));
+  const foreignAttempts = path.join(foreignDir, "foreign-attempts.json");
+  fs.writeFileSync(foreignAttempts, '[{"score_log":"spoofed"}]', "utf-8");
+
+  fs.rmSync(attemptsPath);
+  fs.symlinkSync(foreignAttempts, attemptsPath);
+
+  // Must NOT silently fall back to [] — symlink refusal surfaces as a thrown
+  // error (fail-closed, per #157 class avoidance).
+  assert.throws(
+    () => readPreviousAttempts(repoRoot, runId),
+    /Refusing to (read|open) symlinked previous-attempts\.json/i
+  );
+});
+
+test("captureAttempt refuses when previous-attempts.json is a symlink", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-symlink-capture-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-capture-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  const runId = "issue-197-20260417000000001";
+
+  captureAttempt(repoRoot, runId, { score_log: "first attempt" });
+  const attemptsPath = findAttemptsFile(process.env.RELAY_HOME);
+
+  const victimDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-attempts-victim-"));
+  const victim = path.join(victimDir, "victim.json");
+  fs.writeFileSync(victim, "original victim content", "utf-8");
+
+  fs.rmSync(attemptsPath);
+  fs.symlinkSync(victim, attemptsPath);
+
+  assert.throws(
+    () => captureAttempt(repoRoot, runId, { score_log: "second attempt" }),
+    /Refusing to (read|write|open) symlinked previous-attempts\.json/i
+  );
+  // Victim file must not have been mutated — whether the refusal fires on the
+  // read-before-append path or on the write path, the net effect is identical.
+  assert.equal(fs.readFileSync(victim, "utf-8"), "original victim content");
+});
+
+function findAttemptsFile(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const found = findAttemptsFile(full);
+      if (found) return found;
+    }
+    if (entry.name === "previous-attempts.json") return full;
+  }
+  return null;
+}

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -1342,15 +1342,15 @@ test("write helpers refuse a FIFO at the target path (POSIX only)", { skip: proc
   // on Linux/macOS — that's an acceptable refusal (attacker attempt blocked)
   // even though it doesn't go through our ELOOP path. Alternately, if the
   // platform opens it (with a reader attached, hypothetically), the fstat
-  // gate inside gateWritableFd catches it with EINVAL. Either way, no
-  // writeSync lands on the FIFO.
+  // gate inside gateWritableFd catches it with ENOT_REGULAR_FILE. Either
+  // way, no writeSync lands on the FIFO.
   assert.throws(
     () => appendTextFileWithoutFollowingSymlinks(target, "x\n"),
-    (error) => ["EINVAL", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
+    (error) => ["ENOT_REGULAR_FILE", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
   );
   assert.throws(
     () => writeTextFileWithoutFollowingSymlinks(target, "x"),
-    (error) => ["EINVAL", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
+    (error) => ["ENOT_REGULAR_FILE", "ENXIO"].includes(error.code) || /Not a regular file/.test(error.message)
   );
 });
 

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -1200,3 +1200,106 @@ function findAttemptsFile(dir) {
   }
   return null;
 }
+
+test("readPreviousAttempts refuses dangling symlinks instead of silently returning []", () => {
+  // #197 fail-closed: dangling symlink must NOT be treated as "file missing".
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-dangling-read-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-dangling-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  const runId = "issue-197-20260417000000002";
+
+  // Seed one attempt so the run layout exists, then remove the file and
+  // replace it with a dangling symlink.
+  captureAttempt(repoRoot, runId, { score_log: "first attempt" });
+  const attemptsPath = findAttemptsFile(process.env.RELAY_HOME);
+  fs.rmSync(attemptsPath);
+  fs.symlinkSync("/nonexistent-relay-attempts-target-xyz", attemptsPath);
+
+  assert.throws(
+    () => readPreviousAttempts(repoRoot, runId),
+    /Refusing to (read|open) symlinked previous-attempts\.json/i
+  );
+});
+
+test("captureAttempt refuses dangling symlinks (no create-through on write)", () => {
+  // Proves the write helper also refuses dangling symlinks — defense-in-depth
+  // for platforms without O_NOFOLLOW where the pre-fix existsSync fallback
+  // would have happily created through the link.
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-manifest-dangling-write-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-dangling-w-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  const runId = "issue-197-20260417000000003";
+
+  captureAttempt(repoRoot, runId, { score_log: "first attempt" });
+  const attemptsPath = findAttemptsFile(process.env.RELAY_HOME);
+
+  const victimDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-attempts-dangling-"));
+  const victimTarget = path.join(victimDir, "victim.json");
+  fs.rmSync(attemptsPath);
+  fs.symlinkSync(victimTarget, attemptsPath);
+
+  assert.throws(
+    () => captureAttempt(repoRoot, runId, { score_log: "second attempt" }),
+    /Refusing to (read|write|open) symlinked previous-attempts\.json/i
+  );
+  assert.equal(fs.existsSync(victimTarget), false, "victim must not have been created through the symlink");
+});
+
+// Direct unit tests for the shared write helpers — prove that the write path
+// itself (independent of captureAttempt's read-then-write sequencing) refuses
+// symlinks. Exported via relay-manifest.
+const {
+  appendTextFileWithoutFollowingSymlinks,
+  writeTextFileWithoutFollowingSymlinks,
+} = require("./relay-manifest");
+
+test("appendTextFileWithoutFollowingSymlinks refuses an existing symlink at target", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-append-symlink-"));
+  const target = path.join(dir, "events.jsonl");
+  const victim = path.join(dir, "victim.jsonl");
+  fs.writeFileSync(victim, "pre-existing\n", "utf-8");
+  fs.symlinkSync(victim, target);
+
+  assert.throws(
+    () => appendTextFileWithoutFollowingSymlinks(target, "malicious\n"),
+    /Refusing to open symlinked path/
+  );
+  assert.equal(fs.readFileSync(victim, "utf-8"), "pre-existing\n");
+});
+
+test("writeTextFileWithoutFollowingSymlinks refuses an existing symlink at target", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-write-symlink-"));
+  const target = path.join(dir, "attempts.json");
+  const victim = path.join(dir, "victim.json");
+  fs.writeFileSync(victim, "pre-existing", "utf-8");
+  fs.symlinkSync(victim, target);
+
+  assert.throws(
+    () => writeTextFileWithoutFollowingSymlinks(target, '[{"spoofed":true}]'),
+    /Refusing to open symlinked path/
+  );
+  assert.equal(fs.readFileSync(victim, "utf-8"), "pre-existing");
+});
+
+test("writeTextFileWithoutFollowingSymlinks refuses a dangling symlink at target", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-write-dangling-"));
+  const target = path.join(dir, "attempts.json");
+  const danglingTarget = path.join(dir, "does-not-exist.json");
+  fs.symlinkSync(danglingTarget, target);
+
+  assert.throws(
+    () => writeTextFileWithoutFollowingSymlinks(target, '[{"ok":true}]'),
+    /Refusing to open symlinked path/
+  );
+  assert.equal(fs.existsSync(danglingTarget), false, "dangling target must not have been created through the symlink");
+});
+
+test("writeTextFileWithoutFollowingSymlinks creates a new file when the target is truly absent", () => {
+  // Regression check: make sure the "no entry at path" code path still works
+  // end-to-end and produces a regular file with the expected content.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-write-create-"));
+  const target = path.join(dir, "attempts.json");
+  writeTextFileWithoutFollowingSymlinks(target, '[{"ok":true}]');
+  assert.equal(fs.readFileSync(target, "utf-8"), '[{"ok":true}]');
+  assert.equal(fs.lstatSync(target).isSymbolicLink(), false);
+});


### PR DESCRIPTION
## Summary

Closes #197. Extends the trust-root guard added by [#196](https://github.com/sungjunlee/dev-relay/pull/196) (rubric_path) to the two other manifest-owned run-dir paths that still followed symlinks:

- `events.jsonl` — 4× `fs.appendFileSync` + 1× `fs.readFileSync` in `relay-events.js`
- `previous-attempts.json` — `fs.readFileSync` + `fs.writeFileSync` in `relay-manifest.js`

An attacker with write access to the run directory could redirect the audit trail or use `captureAttempt` as an arbitrary-write primitive by symlinking either file.

## Changes

- `relay-manifest.js`
  - New `openForWriteWithoutFollowingSymlinks(path, mode)` using `O_NOFOLLOW` with an lstat-guarded fallback on platforms that don't expose the flag
  - New `appendTextFileWithoutFollowingSymlinks` and `writeTextFileWithoutFollowingSymlinks` built on top
  - `readPreviousAttempts` now reads via the symlink-safe helper and **does not** fall back to `[]` on ELOOP (explicit fail-closed — avoids the #157 class that #161 closed for rubric_path)
  - `captureAttempt` writes via the symlink-safe helper
  - Generalized the existing `readTextFileWithoutFollowingSymlinks` error message from "symlinked rubric path" to "symlinked path" (same function, broader call sites)
- `relay-events.js`
  - New `appendEventLine` wrapper funnels all 4 append call sites through the safe helper
  - `readRunEvents` uses the safe reader

## Tests

4 new regression tests with real `fs.symlinkSync`:

- `appendRunEvent` refuses when `events.jsonl` is a symlink (victim file is not mutated)
- `readRunEvents` refuses when `events.jsonl` is a symlink
- `readPreviousAttempts` refuses on symlink (explicitly asserts it does **not** silently return `[]`)
- `captureAttempt` refuses on symlink (victim file unchanged)

Full suite: **377 tests pass** (4 new).

## Acceptance criteria (from #197)

- [x] `relay-events.js` reads and writes `events.jsonl` without following symlinks (via descriptor opened with `O_NOFOLLOW`, with lstat fallback)
- [x] `previous-attempts.json` read and write use the same pattern
- [x] Symlink refusal surfaces through existing failure paths, not silent `{}`/`[]` fallthrough
- [x] Regression tests using real `fs.symlinkSync` for each file
- [x] `node --test skills/*/scripts/*.test.js` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 파일 작업의 보안이 강화되어 불안전한 파일 접근을 방지합니다.
  * 파일 읽기 및 쓰기 작업의 오류 처리가 개선되었습니다.

* **Tests**
  * 보안 관련 파일 작업 시나리오에 대한 종합 테스트가 추가되었습니다.
  * 파일 시스템 안정성과 신뢰성 검증을 위한 테스트 커버리지가 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->