### PR TITLE
relay-dispatch: state-recovery CLI for post-manual-commit / escalated-run recovery (#211)

### DIFF
--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -148,6 +148,35 @@ ${CLAUDE_SKILL_DIR}/scripts/close-run.js --repo . --run-id <run-id> --reason "st
 ${CLAUDE_SKILL_DIR}/scripts/reliability-report.js --repo . --json
 ```
 
+## Operator state recovery
+
+`recover-state.js` advances a relay run's state after an external event (fix commit pushed directly, dispatch stalled, no-op re-dispatch escalated the manifest). Replaces hand-edited `manual_state_override` entries with structured `state_recovery` events and validated transitions.
+
+```bash
+# Fix pushed directly to the PR branch → return to review without re-dispatch
+${CLAUDE_SKILL_DIR}/scripts/recover-state.js --repo . --run-id <id> \
+  --to review_pending --reason "external commit pushed; see <sha>"
+
+# No-op re-dispatch escalated the run → bring it back for a fresh review
+${CLAUDE_SKILL_DIR}/scripts/recover-state.js --repo . --run-id <id> \
+  --to review_pending --force --reason "no-op-dispatch-recovery"
+
+# Hung dispatch → unstick manifest so dispatch --run-id can resume
+${CLAUDE_SKILL_DIR}/scripts/recover-state.js --repo . --run-id <id> \
+  --to changes_requested --force --reason "dispatch hung; operator-killed"
+```
+
+Whitelisted transitions (unlisted pairs are rejected — use the normal dispatch/review/merge flow):
+
+| From | To | Force | Precondition |
+|---|---|---|---|
+| `changes_requested` | `review_pending` | no | fresh commit on branch (HEAD ≠ `review.last_reviewed_sha`) |
+| `escalated` | `review_pending` | yes | — |
+| `escalated` | `changes_requested` | no | — |
+| `dispatched` | `changes_requested` | yes | — |
+
+The script refuses transitions `ALLOWED_TRANSITIONS` already supports — always prefer the normal flow when it applies. Terminal states (`merged`, `closed`) are not recoverable.
+
 ## Caveats
 
 - **Timeout**: Use `--timeout 3600`+ when self-review is included

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// Operator recovery CLI (#211): advance a relay run's state after an external event
+// (fix commit pushed manually, stalled dispatch to recover from, etc.) without the
+// free-text `manual_state_override` hack.
+//
+// Trust model (answers to `references/rubric-trust-model.md` at authoring time):
+//   Q1 (forge): an attacker with manifest write access could forge `last_reviewed_sha`
+//     to pretend a commit exists. Mitigation: the fresh-commit precondition reads
+//     git HEAD on the working branch via execFileSync and compares it to the stored
+//     `last_reviewed_sha`. Attacker cannot forge git HEAD without branch write access
+//     too, which already implies code access.
+//   Q2 (gate): this file; specifically the whitelist check in `main()` and the
+//     fresh-commit precondition in `requireFreshCommitOnBranch()`.
+//   Q3 (external verifier): `git rev-parse` against the working branch's HEAD SHA.
+//     The claim (`review.last_reviewed_sha`) does not self-attest; the gate reads an
+//     independent artifact (git's object db for the branch).
+
+const path = require("path");
+const { execFileSync } = require("child_process");
+const {
+  STATES,
+  forceTransitionState,
+  validateManifestPaths,
+  writeManifest,
+} = require("./relay-manifest");
+const { resolveManifestRecord } = require("./relay-resolver");
+const { appendRunEvent } = require("./relay-events");
+
+// Whitelist: recovery transitions that the normal dispatch/review/merge flow does NOT support.
+// If `ALLOWED_TRANSITIONS` in relay-manifest.js changes, this table must be reviewed — recovery
+// is an opt-in extension, not an override.
+const RECOVERY_TRANSITIONS = Object.freeze([
+  {
+    from: STATES.CHANGES_REQUESTED,
+    to: STATES.REVIEW_PENDING,
+    nextAction: "run_review",
+    requireForce: false,
+    requireFreshCommit: true,
+    resetLastReviewedSha: false,
+    description: "Operator pushed a fix commit directly to the branch instead of re-dispatching.",
+  },
+  {
+    from: STATES.ESCALATED,
+    to: STATES.REVIEW_PENDING,
+    nextAction: "run_review",
+    requireForce: true,
+    requireFreshCommit: false,
+    resetLastReviewedSha: false,
+    description: "Recover an escalated run (typically: re-dispatch was a no-op because the fix already landed).",
+  },
+  {
+    from: STATES.ESCALATED,
+    to: STATES.CHANGES_REQUESTED,
+    nextAction: "await_redispatch",
+    requireForce: false,
+    requireFreshCommit: false,
+    resetLastReviewedSha: false,
+    description: "Go back one step; dispatch --run-id can then resume normally.",
+  },
+  {
+    from: STATES.DISPATCHED,
+    to: STATES.CHANGES_REQUESTED,
+    nextAction: "await_redispatch",
+    requireForce: true,
+    requireFreshCommit: false,
+    resetLastReviewedSha: false,
+    description: "Dispatch hung or operator killed; unstick the manifest so re-dispatch is reachable.",
+  },
+]);
+
+const KNOWN_FLAGS = ["--repo", "--run-id", "--manifest", "--to", "--reason", "--force", "--dry-run", "--json", "--help", "-h"];
+
+function printUsage(stream = console.log) {
+  stream(
+    "Usage: recover-state.js (--repo <path> --run-id <id> | --manifest <path>) --to <state> --reason <text> [--force] [--dry-run] [--json]\n" +
+    "\n" +
+    "Whitelisted recovery transitions:\n" +
+    RECOVERY_TRANSITIONS.map((t) => {
+      const forceFlag = t.requireForce ? " (--force required)" : "";
+      const freshFlag = t.requireFreshCommit ? " (fresh commit required on branch)" : "";
+      return `  ${t.from} -> ${t.to}${forceFlag}${freshFlag}`;
+    }).join("\n")
+  );
+}
+
+function getArg(args, flag) {
+  const index = args.indexOf(flag);
+  if (index === -1 || index + 1 >= args.length) return undefined;
+  const value = args[index + 1];
+  return KNOWN_FLAGS.includes(value) ? undefined : value;
+}
+
+function hasFlag(args, flag) {
+  return args.includes(flag);
+}
+
+function findRecovery(fromState, toState) {
+  return RECOVERY_TRANSITIONS.find((t) => t.from === fromState && t.to === toState) || null;
+}
+
+function formatAllowedSet() {
+  return RECOVERY_TRANSITIONS.map((t) => `${t.from} -> ${t.to}`).join(", ");
+}
+
+function readHeadSha(repoRoot, branch) {
+  const args = branch
+    ? ["-C", repoRoot, "rev-parse", `refs/heads/${branch}`]
+    : ["-C", repoRoot, "rev-parse", "HEAD"];
+  return execFileSync("git", args, { encoding: "utf-8", stdio: "pipe" }).trim();
+}
+
+function requireFreshCommitOnBranch({ repoRoot, manifestData }) {
+  const branch = manifestData?.git?.working_branch;
+  if (!branch) {
+    throw new Error(
+      "Cannot verify fresh commit: manifest has no git.working_branch. " +
+      "Recovery transitions to review_pending from changes_requested require a branch to compare HEAD against."
+    );
+  }
+
+  let currentHead;
+  try {
+    currentHead = readHeadSha(repoRoot, branch);
+  } catch (error) {
+    throw new Error(
+      `Cannot read git HEAD for branch '${branch}' in ${repoRoot}: ${error.message}. ` +
+      "Ensure the branch exists locally (fetch if needed) before running recover-state."
+    );
+  }
+
+  const lastReviewedSha = manifestData?.review?.last_reviewed_sha || null;
+  if (lastReviewedSha && currentHead === lastReviewedSha) {
+    throw new Error(
+      `Refusing recovery: git HEAD for '${branch}' (${currentHead}) equals review.last_reviewed_sha. ` +
+      "No new commits have landed since the last review round. Push the fix commit first, " +
+      "or use --to changes_requested if you intend to re-dispatch."
+    );
+  }
+
+  return { currentHead, lastReviewedSha };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (!args.length || hasFlag(args, "--help") || hasFlag(args, "-h")) {
+    printUsage(console.log);
+    process.exit(hasFlag(args, "--help") || hasFlag(args, "-h") ? 0 : 1);
+  }
+
+  const repoRoot = path.resolve(getArg(args, "--repo") || ".");
+  const runId = getArg(args, "--run-id");
+  const manifestArg = getArg(args, "--manifest");
+  const toState = getArg(args, "--to");
+  const reason = getArg(args, "--reason");
+  const force = hasFlag(args, "--force");
+  const dryRun = hasFlag(args, "--dry-run");
+  const jsonOut = hasFlag(args, "--json");
+
+  if (!runId && !manifestArg) {
+    throw new Error("Provide --run-id or --manifest");
+  }
+  if (!toState) {
+    throw new Error("--to <state> is required");
+  }
+  if (!reason) {
+    throw new Error("--reason <text> is required (audit trail)");
+  }
+
+  const { manifestPath, data, body } = resolveManifestRecord({
+    repoRoot,
+    runId,
+    manifestPath: manifestArg,
+  });
+  const validatedPaths = validateManifestPaths(data.paths, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId: data.run_id,
+    caller: "recover-state",
+  });
+  const safeData = {
+    ...data,
+    paths: {
+      ...(data.paths || {}),
+      repo_root: validatedPaths.repoRoot,
+      worktree: validatedPaths.worktree,
+    },
+  };
+
+  const fromState = safeData.state;
+  const recovery = findRecovery(fromState, toState);
+  if (!recovery) {
+    throw new Error(
+      `Recovery transition '${fromState} -> ${toState}' is not whitelisted. ` +
+      `Allowed: ${formatAllowedSet()}. ` +
+      "Transitions supported by the normal flow are intentionally excluded from this CLI."
+    );
+  }
+  if (recovery.requireForce && !force) {
+    throw new Error(
+      `Recovery transition '${fromState} -> ${toState}' requires --force. ` +
+      `Rationale: ${recovery.description} Re-run with --force to confirm.`
+    );
+  }
+
+  let commitContext = null;
+  if (recovery.requireFreshCommit) {
+    commitContext = requireFreshCommitOnBranch({
+      repoRoot: validatedPaths.repoRoot,
+      manifestData: safeData,
+    });
+  }
+
+  const updated = forceTransitionState(safeData, toState, recovery.nextAction);
+
+  if (recovery.resetLastReviewedSha) {
+    updated.review = { ...(updated.review || {}), last_reviewed_sha: null };
+  }
+
+  if (!dryRun) {
+    writeManifest(manifestPath, updated, body);
+    appendRunEvent(repoRoot, updated.run_id, {
+      event: "state_recovery",
+      state_from: fromState,
+      state_to: toState,
+      head_sha: commitContext?.currentHead || updated.git?.head_sha || null,
+      round: updated.review?.rounds || null,
+      reason,
+      last_reviewed_sha: commitContext?.lastReviewedSha ?? (safeData.review?.last_reviewed_sha || null),
+    });
+  }
+
+  const result = {
+    manifestPath,
+    runId: updated.run_id,
+    previousState: fromState,
+    state: updated.state,
+    nextAction: updated.next_action,
+    reason,
+    force,
+    freshCommit: commitContext,
+    dryRun,
+  };
+
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Recovered relay run: ${manifestPath}`);
+    console.log(`  State:        ${fromState} -> ${updated.state}`);
+    console.log(`  Next action:  ${updated.next_action}`);
+    console.log(`  Reason:       ${reason}`);
+    if (commitContext) {
+      console.log(`  HEAD sha:     ${commitContext.currentHead}`);
+      console.log(`  Prev reviewed: ${commitContext.lastReviewedSha || "(none)"}`);
+    }
+    if (dryRun) console.log("  dry-run:      no changes written");
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { RECOVERY_TRANSITIONS };

--- a/skills/relay-dispatch/scripts/recover-state.test.js
+++ b/skills/relay-dispatch/scripts/recover-state.test.js
@@ -1,0 +1,239 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  getEventsPath,
+  readManifest,
+  updateManifestState,
+  writeManifest,
+} = require("./relay-manifest");
+const {
+  createGrandfatheredRubricAnchor,
+  registerGrandfatheredRubricMigration,
+} = require("./test-support");
+
+const SCRIPT = path.join(__dirname, "recover-state.js");
+
+// Runs the manifest through DRAFT -> DISPATCHED -> REVIEW_PENDING -> desired end state.
+// After REVIEW_PENDING the fixture records review.last_reviewed_sha = <initial HEAD on branch>
+// so tests can simulate "no fresh commits" vs "fresh commit landed" scenarios.
+function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211" } = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-recover-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  process.env.RELAY_HOME = relayHome;
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Recover Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-recover@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const runId = createRunId({ branch, timestamp: new Date("2026-04-17T13:00:00.000Z") });
+  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 211,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_grandfathered = createGrandfatheredRubricAnchor({
+    actor: "recover-state-test",
+  });
+  registerGrandfatheredRubricMigration(runId, {
+    applied_at: manifest.anchor.rubric_grandfathered.applied_at,
+    reason: manifest.anchor.rubric_grandfathered.reason,
+  });
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+
+  // Record the current HEAD as if review round 1 just completed.
+  const initialHead = execFileSync("git", ["-C", repoRoot, "rev-parse", `refs/heads/${branch}`], {
+    encoding: "utf-8",
+  }).trim();
+  manifest.review = { ...manifest.review, last_reviewed_sha: initialHead, rounds: 1 };
+
+  if (state === STATES.CHANGES_REQUESTED) {
+    manifest = updateManifestState(manifest, STATES.CHANGES_REQUESTED, "await_redispatch");
+  } else if (state === STATES.ESCALATED) {
+    manifest = updateManifestState(manifest, STATES.ESCALATED, "inspect_review_failure");
+  } else if (state === STATES.DISPATCHED) {
+    manifest = { ...manifest, state: STATES.DISPATCHED, next_action: "await_dispatch_result" };
+  }
+
+  writeManifest(manifestPath, manifest);
+
+  return { repoRoot, manifestPath, runId, worktreePath, branch, initialHead };
+}
+
+function addCommitOnBranch(worktreePath, branch, filename = "fix.txt") {
+  // Commit inside the worktree so we don't disturb main's checkout state.
+  const existing = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], {
+    encoding: "utf-8",
+  }).trim();
+  fs.writeFileSync(path.join(worktreePath, filename), "fix\n", "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", filename], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", "fix"], { encoding: "utf-8", stdio: "pipe" });
+  const newHead = execFileSync("git", ["-C", worktreePath, "rev-parse", `refs/heads/${branch}`], {
+    encoding: "utf-8",
+  }).trim();
+  assert.notEqual(newHead, existing);
+  return newHead;
+}
+
+test("changes_requested -> review_pending succeeds after a fresh commit", () => {
+  const { repoRoot, manifestPath, runId, worktreePath, branch, initialHead } = setupRepo({ state: STATES.CHANGES_REQUESTED });
+  const newHead = addCommitOnBranch(worktreePath, branch);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "external commit pushed directly",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.previousState, STATES.CHANGES_REQUESTED);
+  assert.equal(result.nextAction, "run_review");
+  assert.equal(result.freshCommit.currentHead, newHead);
+  assert.equal(result.freshCommit.lastReviewedSha, initialHead);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.next_action, "run_review");
+  assert.equal(manifest.review.last_reviewed_sha, initialHead, "recovery must NOT auto-reset last_reviewed_sha");
+
+  const events = fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8");
+  assert.match(events, /"event":"state_recovery"/);
+  assert.match(events, new RegExp(`"state_from":"${STATES.CHANGES_REQUESTED}"`));
+  assert.match(events, new RegExp(`"state_to":"${STATES.REVIEW_PENDING}"`));
+  assert.match(events, new RegExp(`"head_sha":"${newHead}"`));
+  assert.match(events, new RegExp(`"last_reviewed_sha":"${initialHead}"`));
+});
+
+test("changes_requested -> review_pending fails when HEAD equals last_reviewed_sha", () => {
+  const { repoRoot, runId } = setupRepo({ state: STATES.CHANGES_REQUESTED });
+  // No fresh commit added.
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "trying without a fresh commit",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /equals review\.last_reviewed_sha/);
+  assert.match(result.stderr, /Push the fix commit first/);
+});
+
+test("escalated -> review_pending requires --force; succeeds with --force", () => {
+  const { repoRoot, runId, manifestPath } = setupRepo({ state: STATES.ESCALATED });
+
+  const refused = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "external-commit landed outside dispatch",
+    "--json",
+  ], { encoding: "utf-8" });
+  assert.notEqual(refused.status, 0);
+  assert.match(refused.stderr, /requires --force/);
+
+  const accepted = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "external-commit landed outside dispatch",
+    "--force",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(accepted);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.force, true);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+});
+
+test("unlisted transition (dispatched -> merged) rejected with allowed set listed", () => {
+  const { repoRoot, runId } = setupRepo({ state: STATES.DISPATCHED });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.MERGED,
+    "--reason", "trying to sneak through",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, new RegExp(`Recovery transition '${STATES.DISPATCHED} -> ${STATES.MERGED}' is not whitelisted`));
+  assert.match(result.stderr, /Allowed: /);
+  // All four whitelisted transitions must appear in the allowed list.
+  assert.match(result.stderr, new RegExp(`${STATES.CHANGES_REQUESTED} -> ${STATES.REVIEW_PENDING}`));
+  assert.match(result.stderr, new RegExp(`${STATES.ESCALATED} -> ${STATES.REVIEW_PENDING}`));
+  assert.match(result.stderr, new RegExp(`${STATES.ESCALATED} -> ${STATES.CHANGES_REQUESTED}`));
+  assert.match(result.stderr, new RegExp(`${STATES.DISPATCHED} -> ${STATES.CHANGES_REQUESTED}`));
+});
+
+test("--reason is required", () => {
+  const { repoRoot, runId } = setupRepo({ state: STATES.ESCALATED });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.CHANGES_REQUESTED,
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--reason <text> is required/);
+});
+
+test("escalated -> changes_requested succeeds without --force (alias for 'go back')", () => {
+  const { repoRoot, runId, manifestPath } = setupRepo({ state: STATES.ESCALATED });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.CHANGES_REQUESTED,
+    "--reason", "no-op dispatch escalated; returning to changes_requested for re-dispatch",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.CHANGES_REQUESTED);
+  assert.equal(result.nextAction, "await_redispatch");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+});

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -53,6 +53,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.rubric_status !== undefined
       ? { rubric_status: normalizeEventValue(eventData.rubric_status) }
       : {}),
+    ...(eventData.last_reviewed_sha !== undefined
+      ? { last_reviewed_sha: normalizeEventValue(eventData.last_reviewed_sha) }
+      : {}),
   };
 
   appendEventLine(repoRoot, runId, record);

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -157,6 +157,34 @@ test("appendRunEvent persists rubric_status when provided", () => {
   assert.equal(parsed.rubric_status, "missing");
 });
 
+test("appendRunEvent persists last_reviewed_sha when provided", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendRunEvent(repoRoot, runId, {
+    event: "state_recovery",
+    state_from: "changes_requested",
+    state_to: "review_pending",
+    head_sha: "deadbeef",
+    reason: "external commit",
+    last_reviewed_sha: "cafef00d",
+  });
+
+  const [parsed] = readRunEvents(repoRoot, runId);
+  assert.equal(record.last_reviewed_sha, "cafef00d");
+  assert.equal(parsed.last_reviewed_sha, "cafef00d");
+});
+
+test("appendRunEvent omits last_reviewed_sha when absent", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendRunEvent(repoRoot, runId, {
+    event: "dispatch",
+    state_from: "draft",
+    state_to: "dispatched",
+    reason: "start",
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(record, "last_reviewed_sha"), false);
+});
+
 test("appendIterationScore requires run_id", () => {
   const { repoRoot } = createContext();
   assert.throws(() => appendIterationScore(repoRoot, "", {

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1369,6 +1369,28 @@ function updateManifestState(data, toState, nextAction) {
   };
 }
 
+// Operator-recovery path: skips ALLOWED_TRANSITIONS but keeps state-enum + invariant checks.
+// Only `recover-state.js` should call this; its own whitelist is the authority on which
+// recovery transitions are allowed.
+function forceTransitionState(data, toState, nextAction) {
+  if (!Object.values(STATES).includes(data.state)) {
+    throw new Error(`Unknown relay state: ${data.state}`);
+  }
+  if (!Object.values(STATES).includes(toState)) {
+    throw new Error(`Unknown relay state: ${toState}`);
+  }
+  validateTransitionInvariants(data, data.state, toState);
+  return {
+    ...data,
+    state: toState,
+    next_action: nextAction,
+    timestamps: {
+      ...(data.timestamps || {}),
+      updated_at: nowIso(),
+    },
+  };
+}
+
 function validateCleanupStatus(status) {
   if (!Object.values(CLEANUP_STATUSES).includes(status)) {
     throw new Error(`Unknown relay cleanup status: ${status}`);
@@ -1808,6 +1830,7 @@ module.exports = {
   validateRunId,
   validateTransition,
   validateTransitionInvariants,
+  forceTransitionState,
   writeManifest,
   writeTextFileWithoutFollowingSymlinks,
 };

--- a/skills/relay-dispatch/scripts/relay-manifest.test.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.test.js
@@ -558,6 +558,30 @@ test("updateManifestState allows valid transitions and rejects invalid ones", ()
   );
 });
 
+test("forceTransitionState bypasses ALLOWED_TRANSITIONS but keeps enum + invariant checks", () => {
+  const { forceTransitionState } = require("./relay-manifest");
+  const manifest = {
+    state: STATES.CHANGES_REQUESTED,
+    next_action: "await_redispatch",
+    timestamps: { created_at: "2026-04-17T13:00:00Z", updated_at: "2026-04-17T13:00:00Z" },
+  };
+
+  // changes_requested -> review_pending is NOT in ALLOWED_TRANSITIONS but forceTransitionState allows it.
+  const recovered = forceTransitionState(manifest, STATES.REVIEW_PENDING, "run_review");
+  assert.equal(recovered.state, STATES.REVIEW_PENDING);
+  assert.equal(recovered.next_action, "run_review");
+
+  // Unknown state values are still rejected (enum check preserved).
+  assert.throws(
+    () => forceTransitionState(manifest, "not_a_state", "???"),
+    /Unknown relay state/
+  );
+  assert.throws(
+    () => forceTransitionState({ ...manifest, state: "bogus" }, STATES.REVIEW_PENDING, "run_review"),
+    /Unknown relay state/
+  );
+});
+
 test("updateManifestState rejects dispatched -> review_pending when anchor.rubric_path is missing", () => {
   const manifest = {
     run_id: "issue-42-20260412000000000",


### PR DESCRIPTION
## Summary

Closes #211. Adds `skills/relay-dispatch/scripts/recover-state.js` — a CLI that advances a relay run's state after an external event (fix pushed directly to the PR branch, hung dispatch, no-op re-dispatch that escalated the manifest). Replaces hand-edited \`manual_state_override\` event lines with a structured \`state_recovery\` event written via the shared \`appendRunEvent\` helper.

## Whitelisted recovery transitions

Unlisted from→to pairs are rejected; the CLI refuses anything \`ALLOWED_TRANSITIONS\` already supports.

| From | To | Force | Precondition |
|---|---|---|---|
| \`changes_requested\` | \`review_pending\` | no | fresh commit (HEAD ≠ \`review.last_reviewed_sha\`) |
| \`escalated\` | \`review_pending\` | yes | — |
| \`escalated\` | \`changes_requested\` | no | — |
| \`dispatched\` | \`changes_requested\` | yes | — |

Terminal states (\`merged\`, \`closed\`) are not recoverable.

## Trust-model audit

Applied the #210 / \`references/rubric-trust-model.md\` checklist at authoring time:

- **Q1 (forge)**: an attacker with manifest write access could forge \`review.last_reviewed_sha\` to pretend a commit exists. Mitigation: the fresh-commit gate reads \`git rev-parse refs/heads/<branch>\` via \`execFileSync\` and compares to the stored value. Attacker cannot forge git HEAD without branch write access, which already implies code access. — factor enforced at \`recover-state.js:requireFreshCommitOnBranch\`.
- **Q2 (gate)**: \`recover-state.js:main\` for the whitelist match; \`recover-state.js:requireFreshCommitOnBranch\` for the precondition.
- **Q3 (external verifier)**: git's object DB for the working branch. The claim (\`review.last_reviewed_sha\`) does not self-attest; the gate reads an independent artifact.

Recovery transitions are opt-in extensions, not overrides. The new \`forceTransitionState\` helper skips \`ALLOWED_TRANSITIONS\` but keeps the state-enum check and \`validateTransitionInvariants\` (rubric-anchor etc.).

## Touchpoints

- **NEW** \`skills/relay-dispatch/scripts/recover-state.js\` — CLI + frozen \`RECOVERY_TRANSITIONS\` whitelist.
- **NEW** \`skills/relay-dispatch/scripts/recover-state.test.js\` — 6 tests covering the AC matrix.
- \`skills/relay-dispatch/scripts/relay-manifest.js\` — new \`forceTransitionState\` export; JSDoc notes it is for \`recover-state.js\` only.
- \`skills/relay-dispatch/scripts/relay-manifest.test.js\` — regression test for \`forceTransitionState\` (bypasses ALLOWED_TRANSITIONS, preserves enum + invariant checks).
- \`skills/relay-dispatch/scripts/relay-events.js\` — \`last_reviewed_sha\` optional passthrough (same pattern \`#150\` used for \`rubric_status\`).
- \`skills/relay-dispatch/scripts/relay-events.test.js\` — two new tests: persists when provided, omits when absent.
- \`skills/relay-dispatch/SKILL.md\` — new \"Operator state recovery\" section.

## Out of scope (per issue)

- No changes to \`ALLOWED_TRANSITIONS\`.
- No recovery for terminal states.
- No automation of \"no-op re-dispatch\" detection in \`dispatch.js\`.
- No GUI/TUI.

## Acceptance Criteria

From #211:

- [x] New script \`skills/relay-dispatch/scripts/recover-state.js\` with the CLI contract.
- [x] 4-entry whitelist; unlisted transitions rejected with a message naming the allowed set.
- [x] Precondition for \`changes_requested → review_pending\`: reads PR HEAD SHA, compares against \`review.last_reviewed_sha\`; refuses if equal.
- [x] \`--force\` required for \`escalated → review_pending\` and \`dispatched → changes_requested\`.
- [x] Structured event via shared \`appendRunEvent\` (not raw \`fs.appendFileSync\`).
- [x] Regression tests (a)–(e) as specified.
- [x] \`SKILL.md\` documents the new script.
- [ ] CI green (GitHub Actions workflow from #202 will run on push).

## Test plan

- [x] 6/6 new \`recover-state.test.js\` tests pass.
- [x] 3/3 new tests in \`relay-manifest.test.js\` + \`relay-events.test.js\` pass.
- [x] All 393 tests across the 5 relay skills pass unchanged (\`relay-intake\` 21/21, \`relay-plan\` 19/19, \`relay-dispatch\` 216/216, \`relay-review\` 61/61, \`relay-merge\` 76/76).
- [ ] One live recovery run after merge: use \`recover-state.js\` on the next PR where a fix is pushed directly to the branch, and compare the new \`state_recovery\` event against past \`manual_state_override\` entries for shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)