### PR TITLE
docs: add non-default GitHub host workarounds (stopgap for #198/#199)

### DIFF
--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -91,7 +91,7 @@ On re-dispatch, previous Score Log + reviewer feedback are auto-prepended to the
 | Timeout (with commits) | `completed-with-warning` — check worktree for uncommitted changes, proceed to review |
 | Timeout (no commits) | Increase `--timeout` or split task into smaller pieces |
 | Executor error / no commits | Read result file; revise prompt and re-dispatch |
-| No PR created | Check `git log` in worktree; push manually or re-dispatch |
+| No PR created | Check `git log` in worktree; push manually or re-dispatch. If repo is on a non-default GitHub host, see [non-default-github-host.md](../relay/references/non-default-github-host.md). |
 | Branch conflicts | Resolve in worktree or create fresh worktree from updated main |
 | Network/transient error | Wait 30s, retry once. If it fails again, escalate to user |
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -142,6 +142,10 @@ The runner:
 
 <!-- NOTE: gate-check.js now treats the latest relay-review or relay-review-round comment as authoritative and blocks merge on CHANGES_REQUESTED or ESCALATED. -->
 
+## Non-default GitHub Hosts
+
+If the repository origin is not `github.com` (GitHub Enterprise, self-hosted GitHub), `review-runner.js` may record the wrong `reviewer_login`, causing gate-check to reject the PR with `unauthorized_reviewer`. See [non-default-github-host.md](../relay/references/non-default-github-host.md) for workarounds.
+
 ## Re-dispatch (when issues found)
 
 Use the generated `review-round-N-redispatch.md` artifact as the targeted fix prompt. It already includes the issue list, scope guardrail, and original Done Criteria.

--- a/skills/relay/references/non-default-github-host.md
+++ b/skills/relay/references/non-default-github-host.md
@@ -1,0 +1,53 @@
+> **Stopgap notice**: This page documents workarounds for two known bugs.
+> Remove this file and the links to it when both [#198](https://github.com/sungjunlee/dev-relay/issues/198) and [#199](https://github.com/sungjunlee/dev-relay/issues/199) are closed.
+
+# Non-default GitHub Hosts
+
+Users running relay against a repository whose origin is **not** `github.com` (GitHub Enterprise, self-hosted GitHub) encounter two silent failure modes.
+
+## Symptom 1 — Executor push fails, no PR created
+
+**What happens**: The executor subprocess finishes with a local commit but exits without opening a PR. The outer shell has network access and a valid token for the host, but the dispatch sandbox does not inherit them.
+
+**Root cause**: Tracked in [#198](https://github.com/sungjunlee/dev-relay/issues/198).
+
+**Workaround**: After dispatch exits without a PR, push and open the PR from the outer shell:
+
+```bash
+cd <worktree-path>
+git push -u origin <branch>
+gh pr create --repo <owner>/<repo>
+```
+
+You can find `<worktree-path>` and `<branch>` in the run manifest at `~/.relay/runs/<slug>/<run-id>.md`.
+
+## Symptom 2 — gate-check rejects PR with `unauthorized_reviewer`
+
+**What happens**: `gate-check.js` rejects the PR because `reviewer_login` in the run manifest does not match the authenticated user for the repo's host.
+
+**Root cause**: `review-runner.js` reads `gh`'s *default* host login, not the host-specific login. Tracked in [#199](https://github.com/sungjunlee/dev-relay/issues/199).
+
+**Workaround**: Before running `gate-check.js`, edit the run manifest and set `reviewer_login` to the correct value:
+
+```bash
+# Find the correct login for your host
+gh api user --hostname <host> --jq .login
+
+# Edit the manifest
+MANIFEST=~/.relay/runs/<slug>/<run-id>.md
+# Replace reviewer_login: <wrong-value> with the output above
+```
+
+## Preferred Pre-run Workarounds
+
+To avoid both symptoms upfront, configure `gh` for the non-default host before invoking relay:
+
+```bash
+# Option A: set GH_HOST for the current shell session
+export GH_HOST=<host>
+
+# Option B: switch the active gh account to the correct host
+gh auth switch --hostname <host>
+```
+
+Either option ensures both dispatch and review use the correct host credentials.


### PR DESCRIPTION
Closes #200

Adds `skills/relay/references/non-default-github-host.md` as a shared reference documenting both known failure modes for non-default GitHub hosts, with copy-paste workarounds for each.

Also updates the troubleshooting table in `relay-dispatch/SKILL.md` and adds a short pointer section in `relay-review/SKILL.md` to link to the new reference.

**Changes:**
- `skills/relay/references/non-default-github-host.md` — new file covering Symptom 1 (executor push fails), Symptom 2 (`unauthorized_reviewer`), and preferred pre-run workarounds (`GH_HOST` / `gh auth switch`)
- `skills/relay-dispatch/SKILL.md` — expanded "No PR created" row in troubleshooting table with link to the reference
- `skills/relay-review/SKILL.md` — added "Non-default GitHub Hosts" section pointing to the reference

The file is clearly marked as a stopgap with links to #198 and #199 so removal is obvious once the code fixes land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 비기본 GitHub 호스트에서의 실패 처리 지침 업데이트
  * 비기본 GitHub 호스트 관련 문제 및 해결 방법에 대한 새로운 참고 문서 추가
  * GitHub Enterprise 및 자체 호스팅 환경 사용 시 발생 가능한 문제에 대한 문제 해결 가이드 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->