### PR TITLE
Track acting reviewer analytics separately from assigned roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ roles:
 
 Override the reviewer at review time with `--reviewer` or the `RELAY_REVIEWER` environment variable. That changes the acting reviewer for that round, which is recorded in `review.last_reviewer` and the `review_apply` event payload.
 
+Assigned reviewer analytics stay under `roles.reviewer`. Actual reviewer execution analytics should use `review_apply.reviewer`; `review.last_reviewer` is only the latest-round stamp, not a replacement for the event log.
+
 ## `.worktreeinclude`
 
 Git worktrees don't include gitignored files (`.env`, config, keys). Add a `.worktreeinclude` file to your project root to auto-copy them into worktrees:
@@ -404,9 +406,15 @@ Aggregate metrics from run history:
 ```bash
 node skills/relay-dispatch/scripts/reliability-report.js --repo .
 node skills/relay-dispatch/scripts/reliability-report.js --repo . --json
+node skills/relay-dispatch/scripts/reliability-report.js --repo . --by-role --json
+node skills/relay-dispatch/scripts/reliability-report.js --repo . --by-acting-reviewer --json
 ```
 
 Tracks: resume success rate, median review rounds, stale run count, terminal state distribution.
+
+- `--by-role` groups by assigned manifest bindings such as `roles.reviewer`
+- `--by-acting-reviewer` groups actual review execution from `review_apply.reviewer`
+- runs with recorded review state but missing `review_apply` data are reported explicitly instead of being attributed to the assigned reviewer
 
 ## Works With dev-backlog
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -138,7 +138,7 @@ timestamps:
 | `policy.reviewer_write` | `forbid` — review runner rejects rounds where reviewer mutated files |
 | `anchor.*` | Immutable review scope — prevents drift across rounds |
 | `review.last_reviewed_sha` | Gate-check blocks merge if HEAD has advanced past this |
-| `review.last_reviewer` | Tracks the acting reviewer for the latest round without mutating `roles.reviewer` |
+| `review.last_reviewer` | Tracks the acting reviewer for the latest round without mutating `roles.reviewer`; analytics must still use `review_apply.reviewer` as the round-level source of truth |
 
 ## Event Journal
 
@@ -151,6 +151,8 @@ Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/e
 {"event":"review_apply","timestamp":"...","round":2,"reviewer":"codex","reason":"pass"}
 {"event":"state_transition","timestamp":"...","from":"review_pending","to":"ready_to_merge"}
 ```
+
+For reviewer analytics, `roles.reviewer` answers "who was assigned to review this run?" while `review_apply.reviewer` answers "who actually executed this review round?". Keep them separate. If a run shows review activity in the manifest but lacks `review_apply` reviewer data, report that gap explicitly rather than backfilling from the assigned role binding.
 
 ## Review Round Artifacts
 
@@ -204,4 +206,4 @@ roles: {
 }
 ```
 
-At review time, `--reviewer` (or `RELAY_REVIEWER`) selects the acting reviewer for the round. The assigned `roles.reviewer` binding stays immutable; the acting reviewer is recorded in `review.last_reviewer` and the `review_apply` event payload.
+At review time, `--reviewer` (or `RELAY_REVIEWER`) selects the acting reviewer for the round. The assigned `roles.reviewer` binding stays immutable; the acting reviewer is recorded in `review.last_reviewer` and the `review_apply` event payload. Reporting that compares Codex vs Claude review execution should read `review_apply.reviewer`, not `roles.reviewer`.

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -10,7 +10,10 @@ const args = process.argv.slice(2);
 const RESERVED = { reservedFlags: ["-h"] };
 
 if (hasFlag(args, ["--help", "-h"])) {
-  console.log("Usage: reliability-report.js [--repo <path>] [--stale-hours <hours>] [--json] [--by-actor] [--by-role]");
+  console.log(
+    "Usage: reliability-report.js [--repo <path>] [--stale-hours <hours>] " +
+    "[--json] [--by-actor] [--by-role] [--by-acting-reviewer]"
+  );
   process.exit(0);
 }
 
@@ -49,6 +52,14 @@ function normalizeActorName(value) {
 
 function normalizeRoleName(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+function hasRecordedReviewActivity(data) {
+  return (
+    Number(data?.review?.rounds || 0) > 0
+    || (typeof data?.review?.last_reviewer === "string" && data.review.last_reviewer.trim())
+    || (typeof data?.review?.last_reviewed_sha === "string" && data.review.last_reviewed_sha.trim())
+  );
 }
 
 function buildEmptyRubricInsights() {
@@ -505,6 +516,77 @@ function buildRoleReports({ repoRoot, staleHours, now, manifests, events }) {
   }));
 }
 
+function buildActingReviewerReports({ repoRoot, staleHours, now, manifests, events }) {
+  const reviewApplyEvents = events.filter((event) => event.event === "review_apply" && event.run_id);
+  const buckets = new Map();
+  const reviewersByRun = new Map();
+
+  for (const event of reviewApplyEvents) {
+    const reviewerName = normalizeRoleName(event.reviewer);
+    if (!buckets.has(reviewerName)) {
+      buckets.set(reviewerName, {
+        runIds: new Set(),
+        reviewApplyEvents: 0,
+        exclusiveRunIds: new Set(),
+        mixedRunIds: new Set(),
+      });
+    }
+
+    const bucket = buckets.get(reviewerName);
+    bucket.reviewApplyEvents += 1;
+    bucket.runIds.add(event.run_id);
+
+    if (!reviewersByRun.has(event.run_id)) {
+      reviewersByRun.set(event.run_id, new Set());
+    }
+    reviewersByRun.get(event.run_id).add(reviewerName);
+  }
+
+  for (const [runId, reviewerNames] of reviewersByRun.entries()) {
+    const destination = reviewerNames.size > 1 ? "mixedRunIds" : "exclusiveRunIds";
+    for (const reviewerName of reviewerNames) {
+      buckets.get(reviewerName)[destination].add(runId);
+    }
+  }
+
+  const missingRunIds = manifests
+    .map(({ data }) => data)
+    .filter((data) => data?.run_id && hasRecordedReviewActivity(data) && !reviewersByRun.has(data.run_id))
+    .map((data) => data.run_id)
+    .sort((left, right) => left.localeCompare(right));
+
+  const reviewerEntries = [...buckets.entries()].sort(([left], [right]) => left.localeCompare(right));
+
+  return {
+    reviewers: Object.fromEntries(reviewerEntries.map(([reviewerName, bucket]) => {
+      const reviewerManifests = manifests.filter(({ data }) => bucket.runIds.has(data?.run_id));
+      const reviewerEvents = events.filter((event) => bucket.runIds.has(event.run_id));
+      return [reviewerName, {
+        ...buildReport({
+          repoRoot,
+          staleHours,
+          now,
+          manifests: reviewerManifests,
+          events: reviewerEvents,
+        }),
+        acting_review: {
+          review_apply_events: bucket.reviewApplyEvents,
+          review_apply_runs: bucket.runIds.size,
+          exclusive_review_apply_runs: bucket.exclusiveRunIds.size,
+          mixed_review_apply_runs: bucket.mixedRunIds.size,
+        },
+      }];
+    })),
+    summary: {
+      review_apply_events: reviewApplyEvents.length,
+      review_apply_runs: reviewersByRun.size,
+      multi_reviewer_runs: [...reviewersByRun.values()].filter((reviewerNames) => reviewerNames.size > 1).length,
+      missing_review_apply_runs: missingRunIds.length,
+      missing_review_apply_run_ids: missingRunIds,
+    },
+  };
+}
+
 function main() {
   const repoRoot = path.resolve(getArg(args, "--repo", ".", RESERVED));
   const staleHours = parseHours(getArg(args, "--stale-hours", "72", RESERVED));
@@ -518,6 +600,9 @@ function main() {
   }
   if (hasFlag(args, "--by-role")) {
     report.by_role = buildRoleReports({ repoRoot, staleHours, now, manifests, events });
+  }
+  if (hasFlag(args, "--by-acting-reviewer")) {
+    report.by_acting_reviewer = buildActingReviewerReports({ repoRoot, staleHours, now, manifests, events });
   }
 
   if (hasFlag(args, "--json")) {
@@ -576,6 +661,32 @@ function main() {
           `most_stuck_factor=${scopedReport.factor_analysis.most_stuck_factor ?? "n/a"}`
         );
       }
+    }
+  }
+  if (hasFlag(args, "--by-acting-reviewer")) {
+    const actingReviewerEntries = Object.entries(report.by_acting_reviewer?.reviewers || {});
+    const actingReviewerSummary = report.by_acting_reviewer?.summary || {};
+    console.log("  by_acting_reviewer:");
+    if (actingReviewerEntries.length === 0) {
+      console.log("    n/a");
+    }
+    for (const [reviewerName, scopedReport] of actingReviewerEntries) {
+      console.log(
+        `    ${reviewerName}: review_apply_events=${scopedReport.acting_review.review_apply_events} ` +
+        `review_apply_runs=${scopedReport.acting_review.review_apply_runs} ` +
+        `mixed_runs=${scopedReport.acting_review.mixed_review_apply_runs} ` +
+        `manifests=${scopedReport.totals.manifests} events=${scopedReport.totals.events} ` +
+        `most_stuck_factor=${scopedReport.factor_analysis.most_stuck_factor ?? "n/a"}`
+      );
+    }
+    console.log(
+      `    summary: review_apply_events=${actingReviewerSummary.review_apply_events ?? 0} ` +
+      `review_apply_runs=${actingReviewerSummary.review_apply_runs ?? 0} ` +
+      `multi_reviewer_runs=${actingReviewerSummary.multi_reviewer_runs ?? 0} ` +
+      `missing_review_apply_runs=${actingReviewerSummary.missing_review_apply_runs ?? 0}`
+    );
+    if ((actingReviewerSummary.missing_review_apply_run_ids || []).length > 0) {
+      console.log(`    missing_review_apply_run_ids: ${actingReviewerSummary.missing_review_apply_run_ids.join(", ")}`);
     }
   }
 }

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -36,7 +36,15 @@ function setGitActor(repoRoot, actor) {
   execFileSync("git", ["config", "user.name", actor], { cwd: repoRoot, stdio: "pipe" });
 }
 
-function writeRun(repoRoot, { runId, state, rounds, updatedAt }) {
+function writeRun(repoRoot, {
+  runId,
+  state,
+  rounds,
+  updatedAt,
+  reviewer = "codex",
+  lastReviewer = null,
+  lastReviewedSha = null,
+}) {
   initGitRepo(repoRoot);
   const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
   let manifest = createManifestSkeleton({
@@ -48,7 +56,7 @@ function writeRun(repoRoot, { runId, state, rounds, updatedAt }) {
     worktreePath: path.join(repoRoot, "wt", runId),
     orchestrator: "codex",
     executor: "codex",
-    reviewer: "codex",
+    reviewer,
   });
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
   if (state !== STATES.DISPATCHED) {
@@ -63,6 +71,8 @@ function writeRun(repoRoot, { runId, state, rounds, updatedAt }) {
     manifest = updateManifestState(manifest, STATES.MERGED, "done");
   }
   manifest.review.rounds = rounds;
+  manifest.review.last_reviewer = lastReviewer;
+  manifest.review.last_reviewed_sha = lastReviewedSha;
   manifest.timestamps.created_at = updatedAt;
   manifest.timestamps.updated_at = updatedAt;
   writeManifest(manifestPath, manifest);
@@ -682,4 +692,190 @@ test("reliability-report adds role-level grouping when --by-role is set", () => 
   assert.equal(report.by_role.executor.claude.totals.events, 1);
   assert.equal(report.by_role.reviewer.codex.totals.manifests, 1);
   assert.equal(report.by_role.reviewer.claude.totals.manifests, 1);
+});
+
+test("reliability-report adds acting reviewer grouping without mutating assigned reviewer analytics", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-by-acting-reviewer-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runAssignedAndActingCodex = createRunId({
+    branch: "run-assigned-and-acting-codex",
+    timestamp: new Date("2026-04-12T08:00:00.000Z"),
+  });
+  const runAssignedCodexActingClaude = createRunId({
+    branch: "run-assigned-codex-acting-claude",
+    timestamp: new Date("2026-04-12T08:00:01.000Z"),
+  });
+  const runMixedActingReviewers = createRunId({
+    branch: "run-mixed-acting-reviewers",
+    timestamp: new Date("2026-04-12T08:00:02.000Z"),
+  });
+  const runMissingReviewApply = createRunId({
+    branch: "run-missing-review-apply",
+    timestamp: new Date("2026-04-12T08:00:03.000Z"),
+  });
+
+  writeRun(repoRoot, {
+    runId: runAssignedAndActingCodex,
+    state: STATES.READY_TO_MERGE,
+    rounds: 2,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewer: "codex",
+    lastReviewedSha: "codex222",
+  });
+  writeRun(repoRoot, {
+    runId: runAssignedCodexActingClaude,
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 1,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewer: "claude",
+    lastReviewedSha: "claude111",
+  });
+  writeRun(repoRoot, {
+    runId: runMixedActingReviewers,
+    state: STATES.READY_TO_MERGE,
+    rounds: 2,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewer: "claude",
+    lastReviewedSha: "mixed222",
+  });
+  writeRun(repoRoot, {
+    runId: runMissingReviewApply,
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 1,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewer: "claude",
+    lastReviewedSha: "missing111",
+  });
+
+  appendRunEvent(repoRoot, runAssignedAndActingCodex, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 1,
+    reviewer: "codex",
+    reason: "changes_requested",
+  });
+  appendRunEvent(repoRoot, runAssignedAndActingCodex, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.READY_TO_MERGE,
+    round: 2,
+    reviewer: "codex",
+    reason: "pass",
+  });
+  appendRunEvent(repoRoot, runAssignedCodexActingClaude, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 1,
+    reviewer: "claude",
+    reason: "changes_requested",
+  });
+  appendRunEvent(repoRoot, runMixedActingReviewers, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 1,
+    reviewer: "codex",
+    reason: "changes_requested",
+  });
+  appendRunEvent(repoRoot, runMixedActingReviewers, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.READY_TO_MERGE,
+    round: 2,
+    reviewer: "claude",
+    reason: "pass",
+  });
+
+  const stdout = execFileSync(
+    "node",
+    [SCRIPT, "--repo", repoRoot, "--json", "--by-role", "--by-acting-reviewer"],
+    { encoding: "utf-8" }
+  );
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(Object.keys(report.by_role.reviewer), ["codex"]);
+  assert.deepEqual(Object.keys(report.by_acting_reviewer.reviewers), ["claude", "codex"]);
+
+  assert.equal(report.by_role.reviewer.codex.totals.manifests, 4);
+
+  assert.deepEqual(report.by_acting_reviewer.reviewers.codex.acting_review, {
+    review_apply_events: 3,
+    review_apply_runs: 2,
+    exclusive_review_apply_runs: 1,
+    mixed_review_apply_runs: 1,
+  });
+  assert.equal(report.by_acting_reviewer.reviewers.codex.totals.manifests, 2);
+
+  assert.deepEqual(report.by_acting_reviewer.reviewers.claude.acting_review, {
+    review_apply_events: 2,
+    review_apply_runs: 2,
+    exclusive_review_apply_runs: 1,
+    mixed_review_apply_runs: 1,
+  });
+  assert.equal(report.by_acting_reviewer.reviewers.claude.totals.manifests, 2);
+
+  assert.deepEqual(report.by_acting_reviewer.summary, {
+    review_apply_events: 5,
+    review_apply_runs: 3,
+    multi_reviewer_runs: 1,
+    missing_review_apply_runs: 1,
+    missing_review_apply_run_ids: [runMissingReviewApply],
+  });
+});
+
+test("reliability-report keeps missing acting reviewer data explicit in text output", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-acting-reviewer-text-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runActingClaude = createRunId({
+    branch: "run-acting-claude",
+    timestamp: new Date("2026-04-12T08:10:00.000Z"),
+  });
+  const runMissingReviewApply = createRunId({
+    branch: "run-missing-review-apply",
+    timestamp: new Date("2026-04-12T08:10:01.000Z"),
+  });
+
+  writeRun(repoRoot, {
+    runId: runActingClaude,
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 1,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewer: "claude",
+    lastReviewedSha: "claude111",
+  });
+  writeRun(repoRoot, {
+    runId: runMissingReviewApply,
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 1,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewer: "claude",
+    lastReviewedSha: "missing111",
+  });
+
+  appendRunEvent(repoRoot, runActingClaude, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 1,
+    reviewer: "claude",
+    reason: "changes_requested",
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--by-acting-reviewer"], { encoding: "utf-8" });
+
+  assert.match(stdout, /by_acting_reviewer:/);
+  assert.match(stdout, /claude: review_apply_events=1 review_apply_runs=1 mixed_runs=0 manifests=1 events=1/);
+  assert.match(stdout, /summary: review_apply_events=1 review_apply_runs=1 multi_reviewer_runs=0 missing_review_apply_runs=1/);
+  assert.match(stdout, new RegExp(`missing_review_apply_run_ids: ${runMissingReviewApply}`));
 });


### PR DESCRIPTION
## Summary
- add a separate acting-reviewer analytics slice to reliability-report
- keep --by-role assigned-role based and derive acting reviewer metrics from review_apply events
- document assigned reviewer vs acting reviewer semantics and cover mixed and missing acting-reviewer data in tests

## Testing
- node --test skills/relay-dispatch/scripts/reliability-report.test.js
- node --test skills/relay-plan/scripts/reliability-report-consumer.test.js

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리뷰 담당자 분석을 위한 새로운 CLI 플래그 추가 (연기자별 리뷰 리포트 생성).
  * 검토 데이터 누락 시 명시적 보고 기능 추가.

* **문서**
  * 지정된 리뷰어 대 실제 리뷰어 분석의 데이터 키 구분에 대한 설명 강화.
  * 새로운 리포트 CLI 플래그 사용 예제 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->