### PR TITLE
fix: resolve branch-configured remote before git push (#229)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch-publish.js
+++ b/skills/relay-dispatch/scripts/dispatch-publish.js
@@ -52,8 +52,22 @@ function buildPrBody({ resultPreview, runId, executor, branch }) {
   ].join("\n");
 }
 
+function resolveBranchRemote(execFile, wtPath, branch) {
+  if (!branch) return "origin";
+  try {
+    const result = execFile(
+      "git",
+      ["-C", wtPath, "config", "--get", `branch.${branch}.remote`],
+      { encoding: "utf-8", stdio: "pipe" },
+    );
+    const name = String(result || "").trim();
+    return name || "origin";
+  } catch {
+    return "origin";
+  }
+}
+
 async function pushAndOpenPR({
-  repoRoot,
   wtPath,
   branch,
   baseBranch,
@@ -78,8 +92,10 @@ async function pushAndOpenPR({
     throw new Error(`gh_pr_list_failed: ${formatExecError(error)}`);
   }
 
+  const remoteName = resolveBranchRemote(execFile, wtPath, branch);
+
   try {
-    execFile("git", ["-C", wtPath, "push", "-u", "origin", branch], gitOpts);
+    execFile("git", ["-C", wtPath, "push", "-u", remoteName, branch], gitOpts);
   } catch (error) {
     throw new Error(`git_push_failed: ${formatExecError(error)}`);
   }
@@ -124,4 +140,5 @@ module.exports = {
   formatExecError,
   parsePrNumber,
   pushAndOpenPR,
+  resolveBranchRemote,
 };

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -17,7 +17,7 @@ const {
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
-const { buildPrBody, pushAndOpenPR } = require("./dispatch-publish");
+const { buildPrBody, pushAndOpenPR, resolveBranchRemote } = require("./dispatch-publish");
 const { evaluateReviewGate } = require("../../relay-merge/scripts/review-gate");
 const { createEnforcementFixture } = require("./test-support");
 
@@ -264,13 +264,29 @@ function readJsonLines(filePath) {
     .map((line) => JSON.parse(line));
 }
 
-function createExecFileMock({ existingPrNumber = null, prCreateUrl = null, gitPushError = null, prCreateError = null, gitLogOutput = "fake: dispatch publish" } = {}) {
+function createExecFileMock({
+  existingPrNumber = null,
+  prCreateUrl = null,
+  gitPushError = null,
+  prCreateError = null,
+  gitLogOutput = "fake: dispatch publish",
+  branchRemote = "origin",
+  branchRemoteError = false,
+} = {}) {
   const calls = [];
   const execFile = (command, args, options) => {
     calls.push({ command, args: [...args], options });
 
     if (command === "gh" && args[0] === "pr" && args[1] === "list") {
       return existingPrNumber === null ? "" : `${existingPrNumber}\n`;
+    }
+    if (command === "git" && args.includes("config")) {
+      if (branchRemoteError) {
+        const error = new Error("git config lookup failed");
+        error.stderr = Buffer.from("branch has no configured remote\n");
+        throw error;
+      }
+      return branchRemote ? `${branchRemote}\n` : "";
     }
     if (command === "git" && args.includes("push")) {
       if (gitPushError) {
@@ -1548,8 +1564,12 @@ test("pushAndOpenPR uses the injected execFile seam for happy-path publication",
     ["gh", ["pr", "list"]],
     ["git", ["-C", "/tmp/repo-worktree"]],
     ["git", ["-C", "/tmp/repo-worktree"]],
+    ["git", ["-C", "/tmp/repo-worktree"]],
     ["gh", ["pr", "create"]],
   ]);
+  const pushCall = calls.find(({ command, args }) => command === "git" && args.includes("push"));
+  assert.ok(pushCall, "expected git push call");
+  assert.deepEqual(pushCall.args, ["-C", "/tmp/repo-worktree", "push", "-u", "origin", "issue-198"]);
 
   const createCall = calls.find(({ command, args }) => command === "gh" && args[0] === "pr" && args[1] === "create");
   assert.ok(createCall, "expected gh pr create call");
@@ -1628,6 +1648,86 @@ test("pushAndOpenPR surfaces injected gh pr create failures", async () => {
     }),
     /gh_pr_create_failed: simulated gh pr create failure/
   );
+});
+
+test("pushAndOpenPR pushes to the branch-configured remote when it is not origin (#229)", async () => {
+  const { execFile, calls } = createExecFileMock({
+    prCreateUrl: "https://github.com/acme/dev-relay/pull/400",
+    gitLogOutput: "fix: resolve upstream remote",
+    branchRemote: "upstream",
+  });
+
+  const result = await pushAndOpenPR({
+    wtPath: "/tmp/repo-worktree",
+    branch: "issue-229-fork",
+    baseBranch: "main",
+    resultPreview: "Fork-remote publication.",
+    runId: "issue-229-fork-run",
+    executor: "codex",
+    execFile,
+  });
+
+  assert.deepEqual(result, { prNumber: 400, createdByUs: true });
+
+  const configCall = calls.find(({ command, args }) => command === "git" && args.includes("config"));
+  assert.ok(configCall, "expected git config lookup for branch remote");
+  assert.deepEqual(configCall.args, [
+    "-C", "/tmp/repo-worktree",
+    "config", "--get", "branch.issue-229-fork.remote",
+  ]);
+
+  const pushCall = calls.find(({ command, args }) => command === "git" && args.includes("push"));
+  assert.ok(pushCall, "expected git push call");
+  assert.deepEqual(pushCall.args, ["-C", "/tmp/repo-worktree", "push", "-u", "upstream", "issue-229-fork"]);
+});
+
+test("pushAndOpenPR falls back to origin when the branch has no configured remote (#229)", async () => {
+  const { execFile, calls } = createExecFileMock({
+    prCreateUrl: "https://github.com/acme/dev-relay/pull/401",
+    branchRemote: "",
+  });
+
+  await pushAndOpenPR({
+    wtPath: "/tmp/repo-worktree",
+    branch: "issue-229-no-config",
+    baseBranch: "main",
+    resultPreview: "No branch.<name>.remote configured.",
+    runId: "issue-229-no-config-run",
+    executor: "codex",
+    execFile,
+  });
+
+  const pushCall = calls.find(({ command, args }) => command === "git" && args.includes("push"));
+  assert.ok(pushCall, "expected git push call");
+  assert.deepEqual(pushCall.args, ["-C", "/tmp/repo-worktree", "push", "-u", "origin", "issue-229-no-config"]);
+});
+
+test("pushAndOpenPR falls back to origin when git config lookup fails (#229)", async () => {
+  const { execFile, calls } = createExecFileMock({
+    prCreateUrl: "https://github.com/acme/dev-relay/pull/402",
+    branchRemoteError: true,
+  });
+
+  await pushAndOpenPR({
+    wtPath: "/tmp/repo-worktree",
+    branch: "issue-229-config-fail",
+    baseBranch: "main",
+    resultPreview: "git config exits non-zero.",
+    runId: "issue-229-config-fail-run",
+    executor: "codex",
+    execFile,
+  });
+
+  const pushCall = calls.find(({ command, args }) => command === "git" && args.includes("push"));
+  assert.ok(pushCall, "expected git push call");
+  assert.deepEqual(pushCall.args, ["-C", "/tmp/repo-worktree", "push", "-u", "origin", "issue-229-config-fail"]);
+});
+
+test("resolveBranchRemote returns origin when branch is missing or empty (#229)", () => {
+  const { execFile, calls } = createExecFileMock();
+  assert.equal(resolveBranchRemote(execFile, "/tmp/repo-worktree", ""), "origin");
+  assert.equal(resolveBranchRemote(execFile, "/tmp/repo-worktree", null), "origin");
+  assert.equal(calls.length, 0, "no git config lookup for empty branch name");
 });
 
 test("dispatch pushes the branch and opens a PR from the orchestrator on success", () => {


### PR DESCRIPTION
## Summary

- `dispatch-publish.js` hardcoded `origin` when pushing; broke fork workflows and any setup where the branch's upstream is not `origin`.
- Add `resolveBranchRemote` helper that reads `branch.<name>.remote` (same pattern as `finalize-run.js:163`), falls back to `origin` for empty config or lookup error.
- Drop the unused `repoRoot` param from `pushAndOpenPR`.

Closes #229.

## Test plan

- [x] `node --test skills/relay-dispatch/scripts/dispatch.test.js` → 73/73 pass
- [x] Full suite: `node --test skills/*/scripts/*.test.js` → 626/626 pass
- [x] New regression tests:
  - push targets non-origin upstream when configured (#229)
  - falls back to origin when `branch.<name>.remote` is empty
  - falls back to origin when git config lookup errors
  - `resolveBranchRemote` short-circuits when branch is null/empty

## Out of scope

- Extracting a shared remote-resolution helper between `dispatch-publish.js` and `finalize-run.js`. Kept inline to stay focused; can be folded into #232 (cli-args consolidation / shared helpers) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Git 분기 구성에 맞게 올바른 원격 저장소로 푸시하도록 개선했습니다. 이제 기본 "origin" 대신 분기별로 설정된 원격 저장소를 자동으로 인식하고 사용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->