### PR TITLE
refactor: consolidate getArg/hasFlag onto shared cli-args module (#232)

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -195,6 +195,26 @@ Each round produces files under `~/.relay/runs/<repo-slug>/<run-id>/`:
 3. It must write a JSON verdict to `--output-file` matching the schema in `review-schema.js`
 4. `review-runner.js` auto-discovers adapters by naming convention: `invoke-reviewer-<name>.js`
 
+### Shared utilities (cross-skill)
+
+Small, pure utilities that multiple skills import live under `skills/relay-dispatch/scripts/` alongside the runtime modules they share kinship with — not in a neutral top-level directory. `skills/` packages independent publishable skills, but at runtime the skill boundary is packaging only (see retro: `gate-check.js` → relay-review internals, `review-runner.js` → relay-dispatch internals). Placement rule: the skill most often invoked as a dependency hosts the shared helper.
+
+Current shared helpers:
+
+| Module | Owner | Consumers |
+|--------|-------|-----------|
+| `skills/relay-dispatch/scripts/cli-args.js` | relay-dispatch | `review-runner.js`, `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `finalize-run.js`, `persist-request.js`, `probe-executor-env.js` |
+
+Call sites take a local-wrapper pattern so inline flag lists (`KNOWN_FLAGS`) keep acting as fail-closed `reservedFlags`:
+
+```js
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
+```
+
+This keeps behavior identical to the original inline helpers while centralizing the `--*` look-alike guard and the reserved-flag handling.
+
 ### Role binding
 
 Roles are set at manifest creation time in `createManifestSkeleton()`:

--- a/skills/relay-intake/scripts/persist-request.js
+++ b/skills/relay-intake/scripts/persist-request.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 
 const { persistRequestContract } = require("./relay-request");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--contract-file", "--json", "--help", "-h"];
@@ -15,16 +16,8 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
   process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
 }
 
-function getArg(flag) {
-  const index = args.indexOf(flag);
-  if (index === -1 || index + 1 >= args.length) return undefined;
-  const value = args[index + 1];
-  return KNOWN_FLAGS.includes(value) ? undefined : value;
-}
-
-function hasFlag(flag) {
-  return args.includes(flag);
-}
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
 
 const repoRoot = path.resolve(getArg("--repo") || ".");
 const contractFile = getArg("--contract-file");

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -38,6 +38,7 @@ const { summarizeError, writeManifest } = require("../../relay-dispatch/scripts/
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
 const { runCleanup } = require("../../relay-dispatch/scripts/manifest/cleanup");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 const {
   buildSkipReviewGateFailure,
   buildSkipComment,
@@ -69,16 +70,8 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
   process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
 }
 
-function getArg(flag) {
-  const index = args.indexOf(flag);
-  if (index === -1 || index + 1 >= args.length) return undefined;
-  const value = args[index + 1];
-  return KNOWN_FLAGS.includes(value) ? undefined : value;
-}
-
-function hasFlag(flag) {
-  return args.includes(flag);
-}
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
 
 function parsePositiveInt(value, label) {
   if (value === undefined) return undefined;

--- a/skills/relay-plan/scripts/probe-executor-env.js
+++ b/skills/relay-plan/scripts/probe-executor-env.js
@@ -16,6 +16,7 @@
 const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 // ---------------------------------------------------------------------------
 // CLI (only when run directly)
@@ -37,17 +38,12 @@ function parseCli(argv) {
     process.exit(0);
   }
 
-  function getArg(flags, fallback) {
-    for (const flag of Array.isArray(flags) ? flags : [flags]) {
-      const idx = args.indexOf(flag);
-      if (idx !== -1 && idx + 1 < args.length && !KNOWN_FLAGS.includes(args[idx + 1])) {
-        return args[idx + 1];
-      }
-    }
-    return fallback;
-  }
-  const hasFlag = (f) => args.includes(f);
+  const getArg = (flags, fallback) => sharedGetArg(args, flags, fallback, { reservedFlags: KNOWN_FLAGS });
+  const hasFlag = (flag) => sharedHasFlag(args, flag);
 
+  // Positional repo-path parsing is local to this script — the shared helper
+  // is flag-only. We still use `KNOWN_FLAGS` to walk flag/value pairs so the
+  // first unconsumed non-flag argv slot becomes the repo path.
   const consumedIndices = new Set();
   for (let i = 0; i < args.length; i++) {
     if (KNOWN_FLAGS.includes(args[i]) && !["--project-only", "--json", "--help", "-h"].includes(args[i])) {

--- a/skills/relay-review/scripts/invoke-reviewer-claude.js
+++ b/skills/relay-review/scripts/invoke-reviewer-claude.js
@@ -7,6 +7,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { REVIEW_VERDICT_JSON_SCHEMA } = require("./review-schema");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
@@ -16,16 +17,8 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
   process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
 }
 
-function getArg(flag) {
-  const index = args.indexOf(flag);
-  if (index === -1 || index + 1 >= args.length) return undefined;
-  const value = args[index + 1];
-  return KNOWN_FLAGS.includes(value) ? undefined : value;
-}
-
-function hasFlag(flag) {
-  return args.includes(flag);
-}
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
 
 function summarizeFailure(error) {
   const stderr = String(error.stderr || "").trim();

--- a/skills/relay-review/scripts/invoke-reviewer-codex.js
+++ b/skills/relay-review/scripts/invoke-reviewer-codex.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { REVIEW_VERDICT_JSON_SCHEMA } = require("./review-schema");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
@@ -17,16 +18,8 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
   process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
 }
 
-function getArg(flag) {
-  const index = args.indexOf(flag);
-  if (index === -1 || index + 1 >= args.length) return undefined;
-  const value = args[index + 1];
-  return KNOWN_FLAGS.includes(value) ? undefined : value;
-}
-
-function hasFlag(flag) {
-  return args.includes(flag);
-}
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
 
 function readNonEmptyFile(filePath) {
   if (!fs.existsSync(filePath)) return null;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -31,6 +31,7 @@ const {
 } = require("./review-runner/redispatch");
 const { applyPolicyViolationToManifest, applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { loadReviewText, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
@@ -61,16 +62,8 @@ if (require.main === module && (!args.length || args.includes("--help") || args.
   process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
 }
 
-function getArg(flag) {
-  const index = args.indexOf(flag);
-  if (index === -1 || index + 1 >= args.length) return undefined;
-  const value = args[index + 1];
-  return KNOWN_FLAGS.includes(value) ? undefined : value;
-}
-
-function hasFlag(flag) {
-  return args.includes(flag);
-}
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
 
 function printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState, prepareOnly, prNumber, promptPath, redispatchPath, result, updatedManifest, verdictPath }) {
   if (jsonOut) {


### PR DESCRIPTION
## Summary

- Drop inline `getArg`/`hasFlag` duplicates in 6 scripts across 5 skills; each now imports from `skills/relay-dispatch/scripts/cli-args.js` via a local-wrapper pattern that keeps each script's `KNOWN_FLAGS` acting as `reservedFlags`.
- `probe-executor-env.js` is a partial migration — positional repo-path parsing stays local since the shared helper is flag-only.
- Placement decision: keep `cli-args.js` under `skills/relay-dispatch/scripts/`. Cross-skill imports are established (retro "do not touch" list); relay-dispatch is the most imported skill, so shared helpers congregate there. Documented under "Shared utilities (cross-skill)" in `references/architecture.md`.

Closes #232.

## Test plan

- [x] `node --test skills/*/scripts/*.test.js` → 626/626 pass
- [x] `node --test skills/relay-dispatch/scripts/manifest/*.test.js` → 28/28 pass (nested manifest tests)
- [x] Diff review: each consolidation is behavior-preserving — `{ reservedFlags: KNOWN_FLAGS }` reproduces the old `KNOWN_FLAGS.includes(value) ? undefined : value` guard exactly, and the shared helper's `--*` look-alike guard is a *tightening*, not a widening.

## Notes

- #234 (reviewer adapter small-utils consolidation) builds on this — once merged, `summarizeFailure` and `ensureJsonText` can follow the same cross-skill import pattern.
- Full adapter factory is explicitly off the table per retro (Claude/Codex execution contracts diverge: `--json-schema` + stdout vs temp files + `--ephemeral` + sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)