### PR TITLE
refactor: share summarizeFailure + ensureJsonText between reviewer adapters (#234)

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -225,6 +225,9 @@ Current shared helpers:
 | Module | Owner | Consumers |
 |--------|-------|-----------|
 | `skills/relay-dispatch/scripts/cli-args.js` | relay-dispatch | `review-runner.js`, `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `finalize-run.js`, `persist-request.js`, `probe-executor-env.js` |
+| `skills/relay-review/scripts/reviewer-helpers.js` | relay-review | `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js` |
+
+`reviewer-helpers.js` is scoped to `summarizeFailure` and `ensureJsonText`. The two reviewer adapters intentionally keep divergent execution contracts (Claude uses `--json-schema` + stdout recovery; Codex uses temp schema/result files + `--ephemeral` + sandbox), so a full adapter factory would hide meaningful differences and make it harder to add a third executor. See item 5 under "Adding a new reviewer adapter" above.
 
 Call sites take a local-wrapper pattern so inline flag lists (`KNOWN_FLAGS`) keep acting as fail-closed `reservedFlags`:
 

--- a/skills/relay-review/scripts/invoke-reviewer-claude.js
+++ b/skills/relay-review/scripts/invoke-reviewer-claude.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const path = require("path");
 const { REVIEW_VERDICT_JSON_SCHEMA } = require("./review-schema");
 const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
+const { summarizeFailure, ensureJsonText } = require("./reviewer-helpers");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
@@ -19,20 +20,6 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
 
 const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
 const hasFlag = (flag) => sharedHasFlag(args, flag);
-
-function summarizeFailure(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
-}
-
-function ensureJsonText(text, label) {
-  try {
-    JSON.parse(text);
-  } catch (error) {
-    throw new Error(`${label} did not return valid JSON: ${error.message}`);
-  }
-}
 
 function main() {
   const repoPath = path.resolve(getArg("--repo") || ".");

--- a/skills/relay-review/scripts/invoke-reviewer-codex.js
+++ b/skills/relay-review/scripts/invoke-reviewer-codex.js
@@ -9,6 +9,7 @@ const os = require("os");
 const path = require("path");
 const { REVIEW_VERDICT_JSON_SCHEMA } = require("./review-schema");
 const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
+const { summarizeFailure, ensureJsonText } = require("./reviewer-helpers");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
@@ -25,20 +26,6 @@ function readNonEmptyFile(filePath) {
   if (!fs.existsSync(filePath)) return null;
   const text = fs.readFileSync(filePath, "utf-8").trim();
   return text || null;
-}
-
-function summarizeFailure(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
-}
-
-function ensureJsonText(text, label) {
-  try {
-    JSON.parse(text);
-  } catch (error) {
-    throw new Error(`${label} did not return valid JSON: ${error.message}`);
-  }
 }
 
 function main() {

--- a/skills/relay-review/scripts/reviewer-helpers.js
+++ b/skills/relay-review/scripts/reviewer-helpers.js
@@ -1,0 +1,15 @@
+function summarizeFailure(error) {
+  const stderr = String(error.stderr || "").trim();
+  const stdout = String(error.stdout || "").trim();
+  return stderr || stdout || error.message;
+}
+
+function ensureJsonText(text, label) {
+  try {
+    JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} did not return valid JSON: ${error.message}`);
+  }
+}
+
+module.exports = { summarizeFailure, ensureJsonText };

--- a/skills/relay-review/scripts/reviewer-helpers.test.js
+++ b/skills/relay-review/scripts/reviewer-helpers.test.js
@@ -1,0 +1,68 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { summarizeFailure, ensureJsonText } = require("./reviewer-helpers");
+
+test("summarizeFailure prefers stderr when both streams are populated", () => {
+  // Anti-theater: rejects a naive `error.stdout || error.message` helper because callers surface
+  // stderr first — that's where codex/claude write the actionable failure reason.
+  const summary = summarizeFailure({
+    stderr: "  boom\n",
+    stdout: "noise\n",
+    message: "command failed",
+  });
+  assert.equal(summary, "boom");
+});
+
+test("summarizeFailure falls back to stdout when stderr is empty", () => {
+  // Anti-theater: an empty stderr (buffer exists but trims to "") must not short-circuit the
+  // `||` chain; real failures frequently land on stdout when the reviewer CLI crashes late.
+  const summary = summarizeFailure({
+    stderr: "   \n",
+    stdout: "partial response",
+    message: "command failed",
+  });
+  assert.equal(summary, "partial response");
+});
+
+test("summarizeFailure falls back to message when both streams are empty", () => {
+  // Anti-theater: callers rely on a non-empty return so they can wrap it with `reviewer failed:
+  // ${summary}`. Returning "" would produce a dangling colon.
+  const summary = summarizeFailure({
+    stderr: "",
+    stdout: undefined,
+    message: "spawn ENOENT",
+  });
+  assert.equal(summary, "spawn ENOENT");
+});
+
+test("summarizeFailure handles missing stream buffers without throwing", () => {
+  // Anti-theater: `error.stderr` can be undefined when the child process is killed before I/O;
+  // the helper must coerce to string rather than assuming `.trim()` exists.
+  const summary = summarizeFailure({ message: "killed" });
+  assert.equal(summary, "killed");
+});
+
+test("ensureJsonText is silent when the text is valid JSON", () => {
+  // Anti-theater: the helper must not mutate or return the parsed value — it only validates.
+  // Returning a parsed object would tempt callers to use it and duplicate `JSON.parse` later.
+  assert.doesNotThrow(() => ensureJsonText('{"verdict":"pass"}', "Claude reviewer"));
+});
+
+test("ensureJsonText throws with label prefix when the text is not valid JSON", () => {
+  // Anti-theater: the label ("Claude reviewer" / "Codex reviewer") must appear in the thrown
+  // message so the operator can tell which adapter produced the bad output.
+  assert.throws(
+    () => ensureJsonText("not-json", "Codex reviewer"),
+    /^Error: Codex reviewer did not return valid JSON:/
+  );
+});
+
+test("ensureJsonText rejects empty-string input", () => {
+  // Anti-theater: JSON.parse("") throws, which is what we want — an empty recovery buffer must
+  // not be treated as a valid verdict. Guard against a future change that pre-checks emptiness.
+  assert.throws(
+    () => ensureJsonText("", "Claude reviewer"),
+    /did not return valid JSON/
+  );
+});


### PR DESCRIPTION
## Summary

- Extract `summarizeFailure` and `ensureJsonText` from `invoke-reviewer-claude.js` and `invoke-reviewer-codex.js` into a new shared module `skills/relay-review/scripts/reviewer-helpers.js`
- Adapter execution logic stays inline per adapter — Claude and Codex have intentionally divergent contracts (`--json-schema` + stdout vs. temp files + `--ephemeral` + sandbox). NOT a factory, per issue scope
- `architecture.md` "Shared utilities" table gains a row for the new module with a one-liner on why only utilities — not adapter execution — are shared

## Test plan

- [x] `node --test skills/*/scripts/*.test.js` — 633/633 (626 baseline + 7 new unit tests for the shared helpers)
- [x] Existing `invoke-reviewer.test.js` adapter tests still pass without modification

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)