### PR TITLE
docs: document manifest facade + cross-skill import intent (#235)

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -184,6 +184,42 @@ Each round produces files under `~/.relay/runs/<repo-slug>/<run-id>/`:
 | `review-round-N-redispatch.md` | Fix prompt (when changes requested) |
 | `review-round-N-policy-violation.txt` | If reviewer mutated code |
 
+## Module Boundaries (and what they are NOT)
+
+Two patterns look like inconsistencies but are intentional. Both are pinned by tests; mechanical "unification" would break working design.
+
+### `skills/*/` is a packaging boundary, not a runtime boundary
+
+`skills/` exists so users can install individual skills via `npx skills add sungjunlee/dev-relay/<skill>`. At runtime, the boundary is purely how files are packaged — Node imports routinely cross it.
+
+Current cross-skill imports:
+
+| Importer | Imports from |
+|----------|--------------|
+| `skills/relay-merge/scripts/gate-check.js` | `relay-review/scripts/review-runner/{context,redispatch}.js`, `relay-dispatch/scripts/manifest/lifecycle.js` |
+| `skills/relay-review/scripts/review-runner.js` | `relay-dispatch/scripts/manifest/{lifecycle,paths,store}.js`, `relay-dispatch/scripts/relay-events.js` |
+| `skills/relay-intake/scripts/relay-request.js` | `relay-dispatch/scripts/relay-manifest.js` (facade — see below) |
+| Consumers of `cli-args.js` and `reviewer-helpers.js` | see [Shared utilities (cross-skill)](#shared-utilities-cross-skill) |
+
+Placement rule for new shared helpers: the skill most often invoked as a dependency hosts the module. Today `relay-dispatch` hosts `cli-args.js`; `relay-review` hosts `reviewer-helpers.js`. Do not introduce a neutral top-level directory — it would contradict the packaging-not-runtime rule above.
+
+### `relay-manifest.js` is a compatibility facade
+
+`skills/relay-dispatch/scripts/relay-manifest.js` is a 17-line re-export-only module that spreads seven `manifest/*` submodules:
+
+```js
+module.exports = { ...paths, ...store, ...lifecycle, ...rubric, ...cleanup, ...attempts, ...environment };
+```
+
+Convention (from [#188 manifest boundary split](../docs/issue-188-manifest-boundary-split.md)):
+
+- **Runtime code** imports direct submodules: `require("./manifest/lifecycle")`. The docs list every runtime caller and its narrow submodule set.
+- **Compatibility tests** (e.g. `relay-manifest.test.js`, `dispatch.test.js`, `close-run.test.js`) and **out-of-scope runtime callers** (today: `relay-intake/scripts/relay-request.js`) continue to import via the facade. Each retained consumer is catalogued in the boundary-split doc with the reason it stayed.
+
+Enforcement: [`manifest-direct-imports.test.js`](../skills/relay-dispatch/scripts/manifest-direct-imports.test.js) asserts the facade stays ≤40 lines with zero function declarations and transitively runs every `manifest/*.test.js`. If the facade regains logic — or if submodules fall out of test — that file fails.
+
+Do not "simplify" the facade by collapsing submodules back into it or by force-migrating the remaining facade consumers. Both moves regress the boundary the test pins.
+
 ## Extending
 
 ### Adding a new executor

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -1,3 +1,6 @@
+// Compatibility facade — see `references/architecture.md` § Module Boundaries.
+// Runtime code imports `./manifest/<submodule>` directly; this file exists for
+// legacy public-surface tests and deferred consumers (#188).
 const paths = require("./manifest/paths");
 const store = require("./manifest/store");
 const lifecycle = require("./manifest/lifecycle");


### PR DESCRIPTION
## Summary

- New "Module Boundaries (and what they are NOT)" section in `references/architecture.md` codifying two intentional patterns flagged by the 2026-04-18 retro:
  1. `skills/*/` is a packaging boundary, not a runtime boundary — cross-skill imports are fine and catalogued
  2. `relay-manifest.js` is a 17-line compat facade; runtime uses direct submodule imports, enforced by `manifest-direct-imports.test.js`
- Links out to `docs/issue-188-manifest-boundary-split.md` for the full history + retained-consumers matrix
- Pointer comment at the top of `skills/relay-dispatch/scripts/relay-manifest.js` redirecting a reader who lands there first

## Test plan

- [x] `node --test skills/*/scripts/*.test.js` — 633/633 (no logic changed)
- [x] `manifest-direct-imports.test.js` still passes — facade is 20 lines, cap is 40

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)