### PR TITLE
docs: slim relay-plan/SKILL.md from 382 to 146 lines via references/ (#233)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -25,57 +25,23 @@ If relay-intake already produced a handoff brief, treat that file as the source 
 
 ### 1.5 Read historical signal
 
-Before designing the rubric, read the relay reliability history:
+Before designing the rubric, read relay reliability history:
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/reliability-report.js --repo . --json
 ```
 
-**Informational only:** the `historical_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use this `reliability-report.js` input to tighten factor wording, calibration examples, and review guidance; the existing rubric structure, grading logic, and dispatch eligibility are unchanged.
-
-Focus on the current producer fields:
-
-| Historical signal field | Read from | Planning use |
-|-------------------------|-----------|--------------|
-| `historical_signal.stuck_factors` | `factor_analysis.most_stuck_factor` plus every entry in `factor_analysis.factors` where `met_rate < 1.0` or `avg_rounds_to_met >= 3` | Surface factors that historically stall so the rubric names the weak spot directly |
-| `historical_signal.divergence_hotspots` | `rubric_insights.divergence_hotspots` (top 3 by `occurrences`, carrying `factor_pattern`, `avg_delta`, and `recommendation` verbatim) | Surface disagreement hotspots so the rubric tightens examples or adds automation where useful |
-| `historical_signal.avg_rounds` | `rubric_insights.tier_effectiveness.contract.avg_rounds_to_met`, `rubric_insights.tier_effectiveness.quality.avg_rounds_to_met`, and `metrics.median_rounds_to_ready` | Calibrate how sharp the contract vs quality checks need to be |
-
-If the report returns valid JSON but there are no prior runs (`manifests: 0`, `events: 0`), treat that as empty history rather than an error.
-
-| Case | Planner handling |
-|------|------------------|
-| No prior runs / empty history | `Empty-data state — historical signal not available, proceed to rubric design.` Render each `historical_signal.*` field as `no historical data available`. |
-| Malformed manifest or event data | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Use the first stderr line (with any leading `Error:` prefix stripped) as `<cause>` and still render each `historical_signal.*` field as `no historical data available`. |
-| Any other non-zero exit (missing script, broken dependency, runtime error) | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Surface the first stderr line (with any leading `Error:` prefix stripped) when present, otherwise the exit code, then continue rubric design. |
+Use `historical_signal.stuck_factors`, `historical_signal.divergence_hotspots`, and `historical_signal.avg_rounds` to tighten factor wording, calibration examples, and review guidance. The signal does not gate dispatch, alter state transitions, or modify rubric structure. Empty-history and failure cases are rendered as `no historical data available`. Full field mapping + case handling: `references/signals.md` § Historical signal.
 
 ### 1.6 Read probe quality signals
 
-Before designing the rubric, read the repo-local quality signals:
+Before designing the rubric, read repo-local quality signals:
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
 ```
 
-**Informational only:** the `probe_signal.*` output does not gate dispatch, does not alter state transitions, and does not modify rubric structure. Use the signal to inform rubric design, prerequisite naming, and Available Tools context; the planner picks what fits the task, the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
-
-Focus on the current producer fields:
-
-| Probe signal field | Read from | Planning use |
-|--------------------|-----------|--------------|
-| `probe_signal.test_infra` | `project_tools.frameworks` filtered to test runners (`jest`, `vitest`, `mocha`, `playwright`, `@playwright/test`, `cypress`, `pytest`) | Use the detected runner to inform a prerequisite or automated factor when it fits the task; the signal informs the choice, it does not require one |
-| `probe_signal.lint_format` | `project_tools.frameworks` filtered to linters/formatters (`eslint`, `prettier`, `ruff`, `black`, `isort`, `pylint`) | Reuse the detected hygiene tool in prerequisites when that keeps the rubric grounded to repo-native checks |
-| `probe_signal.type_check` | `project_tools.frameworks` filtered to type checkers (`typescript`, `mypy`) plus `project_tools.scripts` commands containing `tsc --noEmit` or `mypy` | Prefer an existing type-check command such as `tsc --noEmit` or `mypy --strict` when it matches the task and repo conventions |
-| `probe_signal.ci` | `project_tools.ci` from `.github/workflows/*.yml` and `.github/workflows/*.yaml` | Reference detected CI workflows in the dispatch prompt's Available Tools context when that helps explain what automation already exists |
-| `probe_signal.scripts` | `project_tools.scripts` (top 5 by name order) | Pick an existing script as the prerequisite command rather than inventing a new one when the repo already exposes the right check |
-
-Optional additional fields such as `probe_signal.bundlers`, `probe_signal.a11y`, `probe_signal.bundle_size`, or `probe_signal.security` may be surfaced when present. Omit them when absent; the baseline five fields above stay fixed.
-
-| Case | Planner handling |
-|------|------------------|
-| No signals detected | `Probe signal: no quality infra detected.` Render each `probe_signal.*` field as `no quality infra detected`. This is acceptable, not an error. |
-| Probe failure / `agent_probe_error` present | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Use the first stderr line (with any leading `Error:` prefix stripped), the `agent_probe_error` string, or the exit code as `<cause>`, then continue rubric design. |
-| Malformed JSON on stdout | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Surface the parse error and continue rubric design. |
+Use `probe_signal.test_infra`, `probe_signal.lint_format`, `probe_signal.type_check`, `probe_signal.ci`, and `probe_signal.scripts` to inform rubric design, prerequisite naming, and Available Tools context. The planner picks what fits the task — the signal exposes data, it does not pick for them. No-signal and failure cases are rendered as `no quality infra detected`. Full field mapping + case handling: `references/signals.md` § Probe signal.
 
 ### 2. Build the rubric
 
@@ -83,31 +49,21 @@ Use the guided interview (`references/rubric-design-guide.md`) to derive factors
 
 ```yaml
 rubric:
-  setup: "npm install && npm start &"    # run before checks (if needed)
-  baseline: "npm run metrics > baseline.json"  # capture before-state (if delta metrics used)
+  setup: "npm install && npm start &"              # run before checks (if needed)
+  baseline: "npm run metrics > baseline.json"      # capture before-state (if delta metrics used)
 
-  # Prerequisites: hygiene checks. Gate — must ALL pass before factor evaluation.
-  # As many as needed. Do NOT count toward factor totals.
-  prerequisites:
+  prerequisites:                                    # repo-wide hygiene; must all pass; uncounted
     - command: "npm test"
       target: "exit 0"
     - command: "npx tsc --noEmit"
       target: "exit 0"
 
-  # Factors: substantive checks only (contract + quality tiers).
-  factors:
+  factors:                                          # substantive checks (contract + quality)
     - name: API returns cursor-paginated response
       tier: contract
       type: automated
       command: "curl -s localhost:3000/api/items?limit=10 | jq '.next_cursor'"
       target: "non-null cursor string"
-      weight: required
-
-    - name: Rate limiting enforced
-      tier: contract
-      type: automated
-      command: "for i in $(seq 1 110); do curl -s -o /dev/null -w '%{http_code}' ...; done | tail -1"
-      target: "429"
       weight: required
 
     - name: Pagination robustness
@@ -126,31 +82,7 @@ rubric:
       weight: required
 ```
 
-### Tier definitions
-
-Use the same tier judgment questions everywhere:
-
-| Tier | Question | Placement | Examples |
-|------|----------|-----------|----------|
-| **Hygiene** | "Would this check apply to ANY PR in this repo?" | `prerequisites` | `npm test`, `tsc --noEmit`, `eslint` |
-| **Contract** | "Does this verify a SPECIFIC AC item is implemented?" | `factors` | endpoint returns paginated response, config includes new field |
-| **Quality** | "Does this probe HOW well it was designed/implemented?" | `factors` | error recovery strategy, abstraction boundaries, failure mode differentiation |
-
-**Contract = "is it there?"**  
-**Quality = "is it good?"**
-
-| Type | How scored |
-|------|-----------|
-| **automated** | Run command, check output/exit code. Measure the actual outcome, not a proxy. |
-| **evaluated** | Agent reads code and scores 1-10. `criteria` lists what to check (multi-line, detailed). `scoring_guide` provides 3 calibration anchors (low/mid/high) so executor and reviewer share the same scale. Think like a domain expert, not a checklist. |
-
-| Weight | Rule |
-|--------|------|
-| **required** | Must meet target before PR. No cross-factor compensation — each evaluated independently. |
-| **best-effort** | Note in PR if below target |
-**`setup`** / **`baseline`**: Run setup commands before checks; capture baseline for delta metrics (run BEFORE changes).
-**`criteria`**: Multi-line, specific bullets — not "good error handling" but "timeouts on external calls, retry with backoff."
-**`scoring_guide`**: Three anchors (low/mid/high) — each tells the executor what to fix next. Shared scale between executor and reviewer. Optional `fix_hint` adds prescriptive transition guidance (low→mid, mid→high) for when descriptive anchors alone leave the executor stuck.
+Tier classification (hygiene / contract / quality), `type` = `automated` vs `evaluated`, and `weight` = `required` vs `best-effort`: see `references/rubric-design-guide.md` § Guided Interview. `setup`/`baseline` run before checks; `criteria` must be specific bullets; `scoring_guide` provides three anchors (low/mid/high) that executor and reviewer share.
 
 ### Domain references (for expert perspective)
 
@@ -167,206 +99,42 @@ Consult `references/rubric-*.md` for specialist thinking. Design factors from AC
 
 ### Trust-model audit factor (auth-boundary tasks)
 
-Before finalizing a rubric, check whether the task crosses an **auth boundary** in the relay runtime. Triggers:
-
-- Label: `phase-0-follow-up`, or
-- Keywords in the issue / AC: trust root, anchor, invariant, grandfather, validate, forge, bypass, gate-check, auth-boundary, or any `validateTransition*` / `validateManifest*` / `evaluateReviewGate` callsite, or
-- Operator judgment: the task touches manifest fields that feed filesystem / GitHub / state-transition operations.
-
-If triggered, follow `references/rubric-trust-model.md` and answer three questions; each yes becomes a named factor, not a criterion bullet:
-
-1. **Who can forge a claim?** — authentication factor distinct from any schema-acceptance factor.
-2. **Where is the gate?** — exact `file:function` call site, not "the gate layer".
-3. **What independently verifies the claim?** — external reference the gate reads; self-attestation does not count.
-
-Put the answers (factor names + gate sites) in the PR body under `### Trust-model audit` before dispatch. A rubric that triggered the check but left any of the three unanswered is Grade D (dispatch blocked, revise).
-
-This reference sharpens `rubric-security.md` rather than replacing it — use both.
+If the task crosses an auth boundary (label `phase-0-follow-up`; keywords trust root, anchor, invariant, grandfather, validate, forge, bypass, gate-check, auth-boundary; or any `validateTransition*` / `validateManifest*` / `evaluateReviewGate` callsite), follow `references/rubric-trust-model.md`. Each of the three questions (who forges? where is the gate? what verifies?) becomes a **named factor**, not a criterion bullet. Record the answers under `### Trust-model audit` in the PR body before dispatch. This reference sharpens `rubric-security.md` — use both.
 
 ### 3. Validate the rubric
 
-Before dispatch, verify:
+Quick gate before dispatch:
 
-- [ ] Prerequisites gate: automated checks for repo-wide hygiene (if any) are in `prerequisites`, not `factors`
-- [ ] No hygiene in factors: every factor passes the tier test ("would this fail for a different task in this repo?" — if no, it's hygiene)
-- [ ] Contract minimum met: ≥ {size-based min} contract-tier factors
-- [ ] Quality minimum met: ≥ {size-based min} quality-tier factors
-- [ ] ≥ 1 automated check exists across prerequisites + factors
-- [ ] All automated check commands are immutable (executor cannot modify)
-- [ ] Every evaluated factor has `scoring_guide` with low/mid/high anchors
-- [ ] Criteria are specific ("timeouts on external calls") not vague ("good error handling")
-- [ ] Criteria reference discoverable artifacts (file paths, function names, code patterns with examples), not abstractions ("follows conventions"); if the executor would need to read 5+ files to understand the criterion, ground it or convert it to an automated check
-- [ ] Targets are concrete ("≥ 8/10", "< 200ms") not relative ("good", "fast")
-- [ ] Automated checks measure outcomes not proxies
+- Prerequisites hold repo-wide hygiene only; factors stay substantive (tier test)
+- Contract/Quality tier minimums met for task size (S/M/L/XL)
+- ≥ 1 automated check across prerequisites + factors
+- Every evaluated factor has `scoring_guide` with low/mid/high anchors
+- Criteria are specific and reference discoverable artifacts; targets are concrete
 
-### Factor Count Rules
-
-Prerequisites (hygiene): as many as needed, uncounted. Factors (contract + quality): no hard cap, warning at 8+.
-
-| Size | Contract min | Quality min | Substantive total | Recommended |
-|------|--------------|-------------|-------------------|-------------|
-| S (1-2 AC) | ≥ 1 | ≥ 1 | 2+ | ~3 |
-| M (3-4 AC) | ≥ 2 | ≥ 1 | 3+ | ~5 |
-| L (5-6 AC) | ≥ 2 | ≥ 2 | 4+ | ~6 |
-| XL (7+ AC) | ≥ 3 | ≥ 2 | 5+ | ~8 |
-
-### Rubric Quality Card
-
-Summarize the rubric before dispatch so weak calibration is visible:
-
-The `Probe signal` lines below are rendered from `probe-executor-env.js --project-only --json` and stay informational only.
-
-```text
-Synthetic populated signal example
----------------------------------
-Prerequisites count: 2
-Contract factors: 2
-Quality factors: 2
-Substantive total: 4
-Quality ratio: 50%
-Auto coverage: 3 / 6 checks automated across prerequisites + factors
-Calibration status: skipped (S/M task)
-Risk signals: none
-Historical signal:
-historical_signal.stuck_factors: Docs (met_rate=0.5, avg_rounds_to_met=3); Coverage (met_rate=0.6667, avg_rounds_to_met=1.5)
-historical_signal.divergence_hotspots: Coverage (avg_delta=2.5, recommendation=Executor scores trend higher than review; tighten examples or add automation.); Docs (avg_delta=-2, recommendation=Reviewer scores trend higher than executor; check whether the factor is underspecified.)
-historical_signal.avg_rounds: contract.avg_rounds_to_met=1.5; quality.avg_rounds_to_met=1; metrics.median_rounds_to_ready=3
-Probe signal:
-probe_signal.test_infra: jest
-probe_signal.lint_format: eslint, prettier
-probe_signal.type_check: typescript, tsc --noEmit
-probe_signal.ci: GitHub Actions (ci.yml)
-probe_signal.scripts: npm run lint, npm run test, npm run typecheck
-Grade: A
-Action: dispatch allowed
-
-No-history + no-signal example
-------------------------------
-Prerequisites count: 2
-Contract factors: 2
-Quality factors: 2
-Substantive total: 4
-Quality ratio: 50%
-Auto coverage: 3 / 6 checks automated across prerequisites + factors
-Calibration status: skipped (S/M task)
-Risk signals: none
-Historical signal: Empty-data state — historical signal not available, proceed to rubric design.
-historical_signal.stuck_factors: no historical data available
-historical_signal.divergence_hotspots: no historical data available
-historical_signal.avg_rounds: no historical data available
-Probe signal: no quality infra detected.
-probe_signal.test_infra: no quality infra detected
-probe_signal.lint_format: no quality infra detected
-probe_signal.type_check: no quality infra detected
-probe_signal.ci: no quality infra detected
-probe_signal.scripts: no quality infra detected
-Grade: A
-Action: dispatch allowed
-
-Fallback example
-----------------
-Prerequisites count: 2
-Contract factors: 2
-Quality factors: 2
-Substantive total: 4
-Quality ratio: 50%
-Auto coverage: 3 / 6 checks automated across prerequisites + factors
-Calibration status: skipped (S/M task)
-Risk signals: none
-Historical signal: Reliability report unavailable: Unexpected end of JSON input. Proceeding without historical signal.
-historical_signal.stuck_factors: no historical data available
-historical_signal.divergence_hotspots: no historical data available
-historical_signal.avg_rounds: no historical data available
-Probe signal: Probe signals unavailable: probe timed out after 30s. Proceeding without probe signal.
-probe_signal.test_infra: no quality infra detected
-probe_signal.lint_format: no quality infra detected
-probe_signal.type_check: no quality infra detected
-probe_signal.ci: no quality infra detected
-probe_signal.scripts: no quality infra detected
-Grade: A
-Action: dispatch allowed
-```
-
-#### Grading logic
-
-Apply downgrade checks first (`D`, then `C`), then assign `A` or `B`.
-
-| Grade | Criteria | Action |
-|-------|----------|--------|
-| **A** | Tier minimum met + quality ratio ≥ 40% + every evaluated factor has `scoring_guide` + criteria grounded to discoverable artifacts | Dispatch allowed |
-| **B** | Tier minimum met + quality ratio ≥ 25% + every evaluated factor has `scoring_guide` | Dispatch allowed, but note weaker quality coverage |
-| **C** | Tier minimum met, but quality is only at the exact size-based minimum OR exactly 1 evaluated factor is missing `scoring_guide` | Warning before dispatch |
-| **D** | Any tier minimum violated OR hygiene check left in `factors` | Dispatch blocked, revise first |
-
-Grade D means stop and revise the rubric first. Grade C means warn before dispatch and make the tradeoff explicit.
-
-#### Risk signals
-
-| Signal | Trigger condition |
-|--------|-------------------|
-| `low_quality_ratio` | Quality ratio < 25% |
-| `no_automated_factor` | Zero automated checks across prerequisites + factors |
-| `ungrounded_criteria` | Criteria refer to abstractions instead of discoverable artifacts |
-| `vague_criteria` | Criteria contain "good", "proper", "clean", or "appropriate" |
-| `proxy_metric` | Automated checks measure effort or process instead of outcome |
-| `high_factor_count` | 8+ substantive factors |
-| `all_contract` | Zero quality coverage beyond the size-based minimum |
-
-Any check fails → revise. See `references/rubric-design-guide.md` for fix patterns.
+Full validation checklist, factor count rules, Rubric Quality Card examples, grading (A/B/C/D), and risk signals: `references/rubric-validation.md`. Grade D = revise before dispatch; Grade C = warn and make the tradeoff explicit.
 
 ### 3.5 Review the rubric (L/XL tasks)
 
-For 5+ AC items, stress-test the rubric before dispatch. **Max 1 round**, then proceed.
+- **S/M (1-4 AC)**: skip
+- **L (5-6 AC)**: stress-test (max 1 round) — subagent games rubric (gaming vectors, coverage gaps, disappear test, Padding Test)
+- **XL (7+ or cross-domain)**: stress-test + calibration simulation (parallel)
 
-| Size | AC count | Review |
-|------|----------|--------|
-| S/M | 1-4 | Skip |
-| L | 5-6 | Stress-test: subagent games rubric (gaming vectors, coverage gaps, disappear test, Padding Test) |
-| XL | 7+ or cross-domain | Stress-test + calibration simulation (parallel) |
-
-Skip: S/M tasks, re-dispatches with iteration history, all-automated rubrics. Full protocol + prompt templates: `references/rubric-stress-test.md`
+Skip: re-dispatches with iteration history, all-automated rubrics. Full protocol + prompt templates: `references/rubric-stress-test.md`.
 
 ### 4. Generate dispatch prompt
 
-Take the base template (`relay/references/prompt-template.md`) and add these sections:
+Take the base template (`../relay/references/prompt-template.md`) and append:
 
-- **Setup**: setup commands from rubric
-- **Scoring Rubric**: automated checks table + evaluated factors table
-- **Iteration Protocol** (autoloop-style measure-fix-keep):
-  ```
-  BEFORE LOOP: Run baseline if defined. RULE: Do NOT modify automated check commands.
-  LOOP (max 5 iterations):
-    0. PREREQUISITE GATE: Run all prerequisite checks. Any fails → fix before proceeding. Prerequisites are not scored, just pass/fail.
-    1. Run ALL automated checks + self-evaluate ALL evaluated factors, record scores
-    2. REGRESSION CHECK: Any factor previously marked locked now below target?
-       → Revert this iteration's changes (git reset to previous commit)
-       → Re-attempt with constraint: "Maintain [factor] at [score] while improving [target factor]"
-       → Regression persists after 1 re-attempt → flag both factors, escalate
-    3. Append to Score Log — mark factors that meet target as locked
-    4. All required meet target → adversarial self-review:
-       - Review as if you did NOT write this code and are seeing it for the first time
-       - For each automated check: could the target be met by a shortcut that misses the intent?
-         (e.g., stubbed endpoint returns fast but does nothing; test modified to always pass)
-       - For each evaluated factor: re-read scoring_guide "high" — does it genuinely apply?
-       - Check: stubs, TODOs, hardcoded values, test manipulation, placeholder returns
-       → All clear → PR
-       → Issues found → fix → re-score → PR
-    5. Else → lowest required factor → if fix_hint exists, apply it as the starting fix → ONE focused change → commit → repeat
-    6. Stuck detection (any trigger → best-effort: note in PR, continue | required: stop, create PR with partial progress):
-       a) Single-factor stall: same factor below target for 3 consecutive iterations
-       b) Oscillation: any two factors alternate regression across 4+ iterations
-       c) Plateau: no required factor improved toward target over 2 consecutive iterations
-  ```
-- **Score Log**: iteration scores table in PR description (reviewer re-scores independently):
-  ```
-  | Factor | Target | Baseline | Iter 1 | Iter 2 | Final | Status |
-  |--------|--------|----------|--------|--------|-------|--------|
-  ```
-  Status: `—` (not met), `locked` (met target — must not regress in subsequent iterations)
+- **Setup** — setup commands from rubric
+- **Scoring Rubric** — automated checks table + evaluated factors table
+- **Iteration Protocol** — measure-fix-keep loop with regression check, adversarial self-review, and stuck detection
+- **Score Log** — iteration scores table appended to the PR description (reviewer re-scores independently)
+
+Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 
 ### 5. Dispatch
 
-Write the rubric YAML to a temp file alongside the dispatch prompt. This is REQUIRED: every relay dispatch must pass `--rubric-file` so the rubric is persisted at `anchor.rubric_path` for review and merge gates.
+Write the rubric YAML to a temp file alongside the dispatch prompt. Every relay dispatch must pass `--rubric-file` so the rubric is persisted at `anchor.rubric_path` for review and merge gates.
 
 ```bash
 ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
@@ -375,8 +143,4 @@ ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
 
 ## When to use
 
-- **Use it**: All tasks dispatched via relay — rubric depth scales with task size
-- **S/M tasks**: Lightweight rubric (1-5 factors), skip stress-test
-- **L/XL tasks**: Detailed rubric with stress-test and calibration
-- **Re-dispatch**: Previous Score Log + reviewer feedback are automatically prepended to the prompt (see `relay-dispatch` docs)
-- **Full rubric guide**: `references/rubric-design-guide.md`
+All tasks dispatched via relay. S/M = lightweight rubric (1-5 factors), skip stress-test. L/XL = detailed rubric with stress-test and calibration. Re-dispatches automatically prepend previous Score Log + reviewer feedback to the prompt (see `relay-dispatch` docs). Full rubric guide: `references/rubric-design-guide.md`.

--- a/skills/relay-plan/references/iteration-protocol.md
+++ b/skills/relay-plan/references/iteration-protocol.md
@@ -1,0 +1,41 @@
+# Iteration Protocol
+
+The measure-fix-keep loop that every dispatch prompt must include. Take the base template at `../../relay/references/prompt-template.md` and append the sections listed in `SKILL.md` § 4 — this file holds the full text of the iteration loop and the Score Log table format.
+
+## Iteration Protocol (autoloop-style measure-fix-keep)
+
+```
+BEFORE LOOP: Run baseline if defined. RULE: Do NOT modify automated check commands.
+LOOP (max 5 iterations):
+  0. PREREQUISITE GATE: Run all prerequisite checks. Any fails → fix before proceeding. Prerequisites are not scored, just pass/fail.
+  1. Run ALL automated checks + self-evaluate ALL evaluated factors, record scores
+  2. REGRESSION CHECK: Any factor previously marked locked now below target?
+     → Revert this iteration's changes (git reset to previous commit)
+     → Re-attempt with constraint: "Maintain [factor] at [score] while improving [target factor]"
+     → Regression persists after 1 re-attempt → flag both factors, escalate
+  3. Append to Score Log — mark factors that meet target as locked
+  4. All required meet target → adversarial self-review:
+     - Review as if you did NOT write this code and are seeing it for the first time
+     - For each automated check: could the target be met by a shortcut that misses the intent?
+       (e.g., stubbed endpoint returns fast but does nothing; test modified to always pass)
+     - For each evaluated factor: re-read scoring_guide "high" — does it genuinely apply?
+     - Check: stubs, TODOs, hardcoded values, test manipulation, placeholder returns
+     → All clear → PR
+     → Issues found → fix → re-score → PR
+  5. Else → lowest required factor → if fix_hint exists, apply it as the starting fix → ONE focused change → commit → repeat
+  6. Stuck detection (any trigger → best-effort: note in PR, continue | required: stop, create PR with partial progress):
+     a) Single-factor stall: same factor below target for 3 consecutive iterations
+     b) Oscillation: any two factors alternate regression across 4+ iterations
+     c) Plateau: no required factor improved toward target over 2 consecutive iterations
+```
+
+## Score Log
+
+Executor appends one row per iteration to the PR description. Reviewer re-scores independently.
+
+```
+| Factor | Target | Baseline | Iter 1 | Iter 2 | Final | Status |
+|--------|--------|----------|--------|--------|-------|--------|
+```
+
+Status: `—` (not met), `locked` (met target — must not regress in subsequent iterations).

--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -1,0 +1,134 @@
+# Rubric Validation, Grading, and Quality Card
+
+This reference holds the step-3 validation detail that used to live inline in `SKILL.md`. Apply it between `## 2. Build the rubric` and `## 4. Generate dispatch prompt`.
+
+## Validate the rubric (full checklist)
+
+Before dispatch, verify:
+
+- [ ] Prerequisites gate: automated checks for repo-wide hygiene (if any) are in `prerequisites`, not `factors`
+- [ ] No hygiene in factors: every factor passes the tier test ("would this fail for a different task in this repo?" — if no, it's hygiene)
+- [ ] Contract minimum met: ≥ {size-based min} contract-tier factors
+- [ ] Quality minimum met: ≥ {size-based min} quality-tier factors
+- [ ] ≥ 1 automated check exists across prerequisites + factors
+- [ ] All automated check commands are immutable (executor cannot modify)
+- [ ] Every evaluated factor has `scoring_guide` with low/mid/high anchors
+- [ ] Criteria are specific ("timeouts on external calls") not vague ("good error handling")
+- [ ] Criteria reference discoverable artifacts (file paths, function names, code patterns with examples), not abstractions ("follows conventions"); if the executor would need to read 5+ files to understand the criterion, ground it or convert it to an automated check
+- [ ] Targets are concrete ("≥ 8/10", "< 200ms") not relative ("good", "fast")
+- [ ] Automated checks measure outcomes not proxies
+
+## Factor count rules
+
+Prerequisites (hygiene): as many as needed, uncounted. Factors (contract + quality): no hard cap, warning at 8+.
+
+| Size | Contract min | Quality min | Substantive total | Recommended |
+|------|--------------|-------------|-------------------|-------------|
+| S (1-2 AC) | ≥ 1 | ≥ 1 | 2+ | ~3 |
+| M (3-4 AC) | ≥ 2 | ≥ 1 | 3+ | ~5 |
+| L (5-6 AC) | ≥ 2 | ≥ 2 | 4+ | ~6 |
+| XL (7+ AC) | ≥ 3 | ≥ 2 | 5+ | ~8 |
+
+## Rubric Quality Card
+
+Summarize the rubric before dispatch so weak calibration is visible.
+
+The `Probe signal` lines below are rendered from `probe-executor-env.js --project-only --json` and stay informational only (see `signals.md`).
+
+```text
+Synthetic populated signal example
+---------------------------------
+Prerequisites count: 2
+Contract factors: 2
+Quality factors: 2
+Substantive total: 4
+Quality ratio: 50%
+Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Calibration status: skipped (S/M task)
+Risk signals: none
+Historical signal:
+historical_signal.stuck_factors: Docs (met_rate=0.5, avg_rounds_to_met=3); Coverage (met_rate=0.6667, avg_rounds_to_met=1.5)
+historical_signal.divergence_hotspots: Coverage (avg_delta=2.5, recommendation=Executor scores trend higher than review; tighten examples or add automation.); Docs (avg_delta=-2, recommendation=Reviewer scores trend higher than executor; check whether the factor is underspecified.)
+historical_signal.avg_rounds: contract.avg_rounds_to_met=1.5; quality.avg_rounds_to_met=1; metrics.median_rounds_to_ready=3
+Probe signal:
+probe_signal.test_infra: jest
+probe_signal.lint_format: eslint, prettier
+probe_signal.type_check: typescript, tsc --noEmit
+probe_signal.ci: GitHub Actions (ci.yml)
+probe_signal.scripts: npm run lint, npm run test, npm run typecheck
+Grade: A
+Action: dispatch allowed
+
+No-history + no-signal example
+------------------------------
+Prerequisites count: 2
+Contract factors: 2
+Quality factors: 2
+Substantive total: 4
+Quality ratio: 50%
+Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Calibration status: skipped (S/M task)
+Risk signals: none
+Historical signal: Empty-data state — historical signal not available, proceed to rubric design.
+historical_signal.stuck_factors: no historical data available
+historical_signal.divergence_hotspots: no historical data available
+historical_signal.avg_rounds: no historical data available
+Probe signal: no quality infra detected.
+probe_signal.test_infra: no quality infra detected
+probe_signal.lint_format: no quality infra detected
+probe_signal.type_check: no quality infra detected
+probe_signal.ci: no quality infra detected
+probe_signal.scripts: no quality infra detected
+Grade: A
+Action: dispatch allowed
+
+Fallback example
+----------------
+Prerequisites count: 2
+Contract factors: 2
+Quality factors: 2
+Substantive total: 4
+Quality ratio: 50%
+Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Calibration status: skipped (S/M task)
+Risk signals: none
+Historical signal: Reliability report unavailable: Unexpected end of JSON input. Proceeding without historical signal.
+historical_signal.stuck_factors: no historical data available
+historical_signal.divergence_hotspots: no historical data available
+historical_signal.avg_rounds: no historical data available
+Probe signal: Probe signals unavailable: probe timed out after 30s. Proceeding without probe signal.
+probe_signal.test_infra: no quality infra detected
+probe_signal.lint_format: no quality infra detected
+probe_signal.type_check: no quality infra detected
+probe_signal.ci: no quality infra detected
+probe_signal.scripts: no quality infra detected
+Grade: A
+Action: dispatch allowed
+```
+
+## Grading logic
+
+Apply downgrade checks first (`D`, then `C`), then assign `A` or `B`.
+
+| Grade | Criteria | Action |
+|-------|----------|--------|
+| **A** | Tier minimum met + quality ratio ≥ 40% + every evaluated factor has `scoring_guide` + criteria grounded to discoverable artifacts | Dispatch allowed |
+| **B** | Tier minimum met + quality ratio ≥ 25% + every evaluated factor has `scoring_guide` | Dispatch allowed, but note weaker quality coverage |
+| **C** | Tier minimum met, but quality is only at the exact size-based minimum OR exactly 1 evaluated factor is missing `scoring_guide` | Warning before dispatch |
+| **D** | Any tier minimum violated OR hygiene check left in `factors` | Dispatch blocked, revise first |
+
+Grade D means stop and revise the rubric first. Grade C means warn before dispatch and make the tradeoff explicit.
+
+## Risk signals
+
+| Signal | Trigger condition |
+|--------|-------------------|
+| `low_quality_ratio` | Quality ratio < 25% |
+| `no_automated_factor` | Zero automated checks across prerequisites + factors |
+| `ungrounded_criteria` | Criteria refer to abstractions instead of discoverable artifacts |
+| `vague_criteria` | Criteria contain "good", "proper", "clean", or "appropriate" |
+| `proxy_metric` | Automated checks measure effort or process instead of outcome |
+| `high_factor_count` | 8+ substantive factors |
+| `all_contract` | Zero quality coverage beyond the size-based minimum |
+
+Any check fails → revise. See `rubric-design-guide.md` for fix patterns.

--- a/skills/relay-plan/references/signals.md
+++ b/skills/relay-plan/references/signals.md
@@ -1,0 +1,59 @@
+# Planner Input Signals
+
+Two informational signals feed into rubric design during `relay-plan` steps 1.5 and 1.6. Both are read-only inputs; neither gates dispatch, alters state transitions, or modifies rubric structure. They inform factor wording, prerequisite naming, and Available Tools context only.
+
+## Historical signal — `reliability-report.js`
+
+Command:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/reliability-report.js --repo . --json
+```
+
+Field mapping (current producers):
+
+| `historical_signal.*` field | Read from | Planning use |
+|-----------------------------|-----------|--------------|
+| `stuck_factors` | `factor_analysis.most_stuck_factor` plus every entry in `factor_analysis.factors` where `met_rate < 1.0` or `avg_rounds_to_met >= 3` | Surface factors that historically stall so the rubric names the weak spot directly |
+| `divergence_hotspots` | `rubric_insights.divergence_hotspots` (top 3 by `occurrences`, carrying `factor_pattern`, `avg_delta`, and `recommendation` verbatim) | Surface executor/reviewer disagreement hotspots so the rubric tightens examples or adds automation |
+| `avg_rounds` | `rubric_insights.tier_effectiveness.contract.avg_rounds_to_met`, `rubric_insights.tier_effectiveness.quality.avg_rounds_to_met`, and `metrics.median_rounds_to_ready` | Calibrate how sharp the contract vs quality checks need to be |
+
+If the report returns valid JSON but there are no prior runs (`manifests: 0`, `events: 0`), treat that as empty history rather than an error.
+
+Case handling:
+
+| Case | Planner handling |
+|------|------------------|
+| No prior runs / empty history | `Empty-data state — historical signal not available, proceed to rubric design.` Render each `historical_signal.*` field as `no historical data available`. |
+| Malformed manifest or event data | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Use the first stderr line (with any leading `Error:` prefix stripped) as `<cause>` and still render each `historical_signal.*` field as `no historical data available`. |
+| Any other non-zero exit (missing script, broken dependency, runtime error) | `Reliability report unavailable: <cause>. Proceeding without historical signal.` Surface the first stderr line (with any leading `Error:` prefix stripped) when present, otherwise the exit code, then continue rubric design. |
+
+## Probe signal — `probe-executor-env.js`
+
+Command:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
+```
+
+The planner picks what fits the task; the signal does not pick for them. No autonomy scoring, no auto-calibration of rubric depth — data exposure only.
+
+Field mapping (current producers):
+
+| `probe_signal.*` field | Read from | Planning use |
+|------------------------|-----------|--------------|
+| `test_infra` | `project_tools.frameworks` filtered to test runners (`jest`, `vitest`, `mocha`, `playwright`, `@playwright/test`, `cypress`, `pytest`) | Use the detected runner to inform a prerequisite or automated factor when it fits the task; the signal informs the choice, it does not require one |
+| `lint_format` | `project_tools.frameworks` filtered to linters/formatters (`eslint`, `prettier`, `ruff`, `black`, `isort`, `pylint`) | Reuse the detected hygiene tool in prerequisites when that keeps the rubric grounded to repo-native checks |
+| `type_check` | `project_tools.frameworks` filtered to type checkers (`typescript`, `mypy`) plus `project_tools.scripts` commands containing `tsc --noEmit` or `mypy` | Prefer an existing type-check command such as `tsc --noEmit` or `mypy --strict` when it matches the task and repo conventions |
+| `ci` | `project_tools.ci` from `.github/workflows/*.yml` and `.github/workflows/*.yaml` | Reference detected CI workflows in the dispatch prompt's Available Tools context when that helps explain what automation already exists |
+| `scripts` | `project_tools.scripts` (top 5 by name order) | Pick an existing script as the prerequisite command rather than inventing a new one when the repo already exposes the right check |
+
+Optional additional fields such as `probe_signal.bundlers`, `probe_signal.a11y`, `probe_signal.bundle_size`, or `probe_signal.security` may be surfaced when present. Omit them when absent; the baseline five fields above stay fixed.
+
+Case handling:
+
+| Case | Planner handling |
+|------|------------------|
+| No signals detected | `Probe signal: no quality infra detected.` Render each `probe_signal.*` field as `no quality infra detected`. This is acceptable, not an error. |
+| Probe failure / `agent_probe_error` present | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Use the first stderr line (with any leading `Error:` prefix stripped), the `agent_probe_error` string, or the exit code as `<cause>`, then continue rubric design. |
+| Malformed JSON on stdout | `Probe signals unavailable: <cause>. Proceeding without probe signal.` Surface the parse error and continue rubric design. |


### PR DESCRIPTION
## Summary

`skills/relay-plan/SKILL.md` was 382 lines — 2.5× over the 150-line `CLAUDE.md` guideline. Move rubric detail to existing + new `references/` files while preserving trigger keywords, the 1-5 step skeleton, and enough inline detail (YAML example, domain-references table, dispatch command) to cover the 80% path without loading references.

New reference files:
- `references/signals.md` — historical + probe signal field mappings, case handling (empty / malformed / missing), producer commands
- `references/rubric-validation.md` — full validation checklist, factor count rules, Rubric Quality Card examples (populated / no-history / fallback), A/B/C/D grading logic, risk signals
- `references/iteration-protocol.md` — measure-fix-keep loop text + Score Log table format (the dispatch-prompt appendix)

Existing references still own:
- `rubric-design-guide.md` — tier / automated-vs-evaluated / required-vs-best-effort classification
- `rubric-trust-model.md` — auth-boundary audit
- `rubric-stress-test.md` — L/XL stress-test protocol

## Test plan

- [x] `node --test skills/*/scripts/*.test.js` — 633/633 (no runtime changes)
- [x] `wc -l skills/relay-plan/SKILL.md` → 146 (under the 150 guideline)
- [x] All linked reference files exist in `skills/relay-plan/references/`
- [x] Referenced section names (`rubric-design-guide.md § Guided Interview`, etc.) match the target files

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)