### PR TITLE
refactor(relay-review): add scanPriorVerdicts walker (#244)

### DIFF
--- a/skills/relay-review/scripts/review-runner-redispatch.test.js
+++ b/skills/relay-review/scripts/review-runner-redispatch.test.js
@@ -10,6 +10,7 @@ const {
   buildReviewRunnerRubricGateFailure,
   computeRepeatedIssueCount,
   detectChurnGrowth,
+  scanPriorVerdicts,
 } = require("./review-runner/redispatch");
 
 function tempRunDir() {
@@ -49,6 +50,37 @@ test("redispatch/computeRepeatedIssueCount only counts consecutive identical cha
 
   assert.equal(computeRepeatedIssueCount(runDir, 4, [issue]), 1);
   assert.equal(computeRepeatedIssueCount(runDir, 3, [issue]), 3);
+});
+
+test("redispatch/scanPriorVerdicts walks reverse-chronological rounds and skips missing files", () => {
+  const runDir = tempRunDir();
+  for (const round of [1, 3, 4]) {
+    fs.writeFileSync(path.join(runDir, `review-round-${round}-verdict.json`), JSON.stringify({ verdict: `round-${round}` }), "utf-8");
+  }
+  const rounds = [];
+  scanPriorVerdicts(runDir, 5, (_verdict, round) => rounds.push(round));
+  assert.deepEqual(rounds, [4, 3, 1]);
+});
+
+test("redispatch/scanPriorVerdicts only stops on false", () => {
+  const runDir = tempRunDir();
+  for (const round of [1, 2, 3]) {
+    fs.writeFileSync(path.join(runDir, `review-round-${round}-verdict.json`), JSON.stringify({ verdict: `round-${round}` }), "utf-8");
+  }
+  const rounds = [];
+  scanPriorVerdicts(runDir, 4, (_verdict, round) => {
+    rounds.push(round);
+    return round === 2 ? false : null;
+  });
+  assert.deepEqual(rounds, [3, 2]);
+});
+
+test("redispatch/scanPriorVerdicts does not invoke the callback when no prior verdicts exist", () => {
+  const runDir = tempRunDir();
+  let calls = 0;
+  scanPriorVerdicts(runDir, 1, () => { calls += 1; });
+  scanPriorVerdicts(runDir, 3, () => { calls += 1; });
+  assert.equal(calls, 0);
 });
 
 test("redispatch/buildReviewRunnerRubricGateFailure preserves the fail-closed recovery matrix", async (t) => {

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -370,20 +370,18 @@ function loadDiff(repoPath, prNumber, diffFile) {
 function formatPriorRoundContext(runDir, round) {
   if (!runDir || round <= 1) return "";
 
-  const { readPriorVerdicts } = require("./redispatch");
+  const { scanPriorVerdicts } = require("./redispatch");
   const { formatIssueList } = require("./comment");
 
-  const verdicts = readPriorVerdicts(runDir, round);
-  if (!verdicts.length) return "";
-
-  const lines = verdicts.map((verdict, index) => {
-    const roundNum = verdicts.length - index;
+  const lines = [];
+  scanPriorVerdicts(runDir, round, (verdict, roundNum) => {
     const parts = [`### Round ${roundNum}: ${verdict.verdict}`, verdict.summary];
     if (Array.isArray(verdict.issues) && verdict.issues.length) {
       parts.push("Issues flagged:", formatIssueList(verdict.issues));
     }
-    return parts.join("\n");
+    lines.push(parts.join("\n"));
   });
+  if (!lines.length) return "";
 
   return ["## Prior Round Context", "", "Verify whether prior issues were resolved.", "", ...lines].join("\n");
 }

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -96,20 +96,33 @@ function readPriorVerdicts(runDir, currentRound) {
   return verdicts;
 }
 
+/**
+ * Calls `onVerdict(verdict, roundNum)` for each prior verdict from newest round
+ * to oldest. Return `false` to stop iteration early; any other return continues.
+ */
+function scanPriorVerdicts(runDir, currentRound, onVerdict) {
+  const verdicts = readPriorVerdicts(runDir, currentRound);
+  for (let round = currentRound - 1, index = 0; round >= 1 && index < verdicts.length; round -= 1) {
+    if (!fs.existsSync(path.join(runDir, `review-round-${round}-verdict.json`))) continue;
+    if (onVerdict(verdicts[index], round) === false) return;
+    index += 1;
+  }
+}
+
 function computeRepeatedIssueCount(runDir, round, issues) {
   if (!issues.length) return 0;
 
   let repeating = new Set(issues.map(fingerprintIssue));
   let count = 1;
-  for (const verdict of readPriorVerdicts(runDir, round)) {
+  scanPriorVerdicts(runDir, round, (verdict) => {
     if (verdict.verdict !== "changes_requested" || !Array.isArray(verdict.issues) || verdict.issues.length === 0) {
-      break;
+      return false;
     }
     const prior = new Set(verdict.issues.map(fingerprintIssue));
     repeating = new Set([...repeating].filter((entry) => prior.has(entry)));
-    if (repeating.size === 0) break;
+    if (repeating.size === 0) return false;
     count += 1;
-  }
+  });
   return count;
 }
 
@@ -205,5 +218,6 @@ module.exports = {
   fingerprintIssue,
   normalizeFingerprintPart,
   readPriorVerdicts,
+  scanPriorVerdicts,
   toEscalatedVerdict,
 };


### PR DESCRIPTION
## Summary
- Adds single-pass `scanPriorVerdicts(runDir, round, onVerdict)` walker in `review-runner/redispatch.js` — callback emission, reverse-chronological, `false` stops iteration
- Refactors `computeRepeatedIssueCount` and `formatPriorRoundContext` to use the walker; `readPriorVerdicts` retained for `buildRedispatchPrompt`
- Foundation for flip-flop detection (#247) — avoids a 4th independent walk of prior verdicts

## Test plan
- [x] `node --test skills/relay-review/scripts/review-runner-redispatch.test.js` — 15 tests (12 existing + 3 new)
- [x] `node --test skills/relay-review/scripts/review-runner-context.test.js` — passes unchanged
- [x] `node --test skills/relay-review/scripts/review-runner-prompt.test.js` — passes unchanged
- [x] New tests cover: reverse-chronological iteration (with missing rounds), early-exit on `false`, empty rounds → no callback

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 판정 검색 동작에 대한 새로운 테스트 케이스 추가

* **리팩토링**
  * 이전 검토 라운드 처리 로직을 개선하여 코드 유지보수성 향상
  * 판정 검색 프로세스를 최적화하여 시스템 효율성 증대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->