### PR TITLE
feat(relay-review): inject repo .gitignore as [PROJECT CONVENTIONS] (#246)

### DIFF
--- a/skills/relay-review/references/reviewer-prompt.md
+++ b/skills/relay-review/references/reviewer-prompt.md
@@ -15,6 +15,14 @@ You are reviewing code you did NOT write. Be objective and thorough.
 [PASTE DONE CRITERIA HERE]
 </task-content>
 
+## Project Conventions
+
+Project conventions below. Do not flag violations of these as issues — files and patterns listed here are intentionally excluded by the project.
+
+<task-content source="project-conventions">
+[PASTE PROJECT CONVENTIONS HERE]
+</task-content>
+
 ## PR Diff
 
 <task-content source="pr-diff">

--- a/skills/relay-review/scripts/review-runner-context.test.js
+++ b/skills/relay-review/scripts/review-runner-context.test.js
@@ -11,9 +11,11 @@ const {
   DEFAULT_ENFORCEMENT_RUBRIC,
 } = require("../../relay-dispatch/scripts/test-support");
 const {
+  loadProjectConventions,
   loadRubricFromRunDir,
   parseRemoteHost,
 } = require("./review-runner/context");
+const { buildPrompt } = require("./review-runner/prompt");
 
 function createRunFixture() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-context-"));
@@ -138,6 +140,42 @@ test("context/loadRubricFromRunDir classifies a malformed rubric path as invalid
   assert.equal(result.state, "invalid");
   assert.equal(result.status, "unreadable");
   assert.match(result.warning, /\[rubric invalid\]/i);
+});
+
+test("context/loadProjectConventions returns empty when .gitignore is missing and omits the prompt section", () => {
+  const { repoRoot } = createRunFixture();
+  assert.equal(loadProjectConventions(repoRoot), "");
+  const prompt = buildPrompt({
+    round: 1, prNumber: 246, branch: "issue-246", issueNumber: 246, doneCriteria: "# Done Criteria\n", doneCriteriaSource: "github-issue",
+    diffText: "diff --git a/a.js b/a.js\n", reviewRepoPath: repoRoot, runDir: null, rubricLoad: { warning: null, content: null },
+  });
+  assert.doesNotMatch(prompt, /## Project Conventions/);
+});
+
+test("context/loadProjectConventions truncates .gitignore at 2KB with marker", () => {
+  const { repoRoot } = createRunFixture();
+  fs.writeFileSync(path.join(repoRoot, ".gitignore"), "a".repeat(2050), "utf-8");
+  assert.equal(loadProjectConventions(repoRoot), `${"a".repeat(2048)}\n# ...truncated at 2KB`);
+});
+
+test("context/loadProjectConventions ignores symlinked .gitignore escaping the repo root", () => {
+  const { repoRoot } = createRunFixture();
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-outside-"));
+  fs.writeFileSync(path.join(outside, "escaped.gitignore"), "*.g.dart\n", "utf-8");
+  fs.symlinkSync(path.join(outside, "escaped.gitignore"), path.join(repoRoot, ".gitignore"));
+  assert.equal(loadProjectConventions(repoRoot), "");
+});
+
+test("context/loadProjectConventions content is injected into buildPrompt", () => {
+  const { repoRoot } = createRunFixture();
+  fs.writeFileSync(path.join(repoRoot, ".gitignore"), "*.g.dart\nbuild/\n", "utf-8");
+  const prompt = buildPrompt({
+    round: 1, prNumber: 246, branch: "issue-246", issueNumber: 246, doneCriteria: "# Done Criteria\n", doneCriteriaSource: "github-issue",
+    diffText: "diff --git a/a.js b/a.js\n", reviewRepoPath: repoRoot, runDir: null, rubricLoad: { warning: null, content: null },
+  });
+  assert.match(prompt, /## Project Conventions/);
+  assert.match(prompt, /Do not flag violations of these as issues/);
+  assert.match(prompt, /\*\.g\.dart\nbuild\//);
 });
 
 test("context/parseRemoteHost preserves the origin parsing matrix", async (t) => {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -159,7 +159,7 @@ function run() {
   );
   const diffText = loadDiff(runRepoPath, prNumber, diffFile);
   const rubricLoad = loadRubricFromRunDir(runDir, data);
-  const promptText = buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricLoad });
+  const promptText = buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, reviewRepoPath, runDir, rubricLoad });
 
   const doneCriteriaPath = path.join(runDir, `review-round-${round}-done-criteria.md`);
   const diffPath = path.join(runDir, `review-round-${round}-diff.patch`);

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -1,5 +1,6 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
+const path = require("path");
 const {
   getCanonicalRepoRoot,
   validateManifestPaths,
@@ -367,6 +368,27 @@ function loadDiff(repoPath, prNumber, diffFile) {
   return gh(repoPath, "pr", "diff", String(prNumber)).trim();
 }
 
+function loadProjectConventions(reviewRepoPath) {
+  const repoRoot = getCanonicalRepoRoot(reviewRepoPath);
+  const conventionsPath = path.join(repoRoot, ".gitignore");
+  try {
+    const realPath = fs.realpathSync(conventionsPath);
+    const relative = path.relative(repoRoot, realPath);
+    if (relative && (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative))) return "";
+    const fd = fs.openSync(realPath, "r");
+    try {
+      const buffer = Buffer.alloc(2048);
+      const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+      const text = buffer.subarray(0, bytes).toString("utf-8");
+      return fs.statSync(realPath).size > buffer.length ? `${text}${text.endsWith("\n") ? "" : "\n"}# ...truncated at 2KB` : text;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return "";
+  }
+}
+
 function formatPriorRoundContext(runDir, round) {
   if (!runDir || round <= 1) return "";
 
@@ -493,6 +515,7 @@ module.exports = {
   isValidHostname,
   loadDiff,
   loadDoneCriteria,
+  loadProjectConventions,
   loadRubricFromRunDir,
   parseRemoteHost,
   resolveContext,

--- a/skills/relay-review/scripts/review-runner/prompt.js
+++ b/skills/relay-review/scripts/review-runner/prompt.js
@@ -1,15 +1,20 @@
 const path = require("path");
 const { REVIEW_VERDICT_JSON_SCHEMA } = require("../review-schema");
 const { readText } = require("./common");
-const { formatPriorRoundContext } = require("./context");
+const { formatPriorRoundContext, loadProjectConventions } = require("./context");
 
 const REVIEWER_PROMPT_PATH = path.join(__dirname, "..", "..", "references", "reviewer-prompt.md");
 
-function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, runDir, rubricLoad }) {
-  const template = readText(REVIEWER_PROMPT_PATH)
+function renderProjectConventions(template, conventions) {
+  if (conventions) return template.replace("[PASTE PROJECT CONVENTIONS HERE]", conventions);
+  return template.replace(/\n## Project Conventions[\s\S]*?<\/task-content>\n(?=\n## PR Diff)/, "\n");
+}
+
+function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, reviewRepoPath, runDir, rubricLoad }) {
+  const template = renderProjectConventions(readText(REVIEWER_PROMPT_PATH)
     .replace("source=\"done-criteria\"", `source="${doneCriteriaSource || "done-criteria"}"`)
     .replace("[PASTE DONE CRITERIA HERE]", doneCriteria)
-    .replace("[PASTE PR DIFF OR FILE PATH HERE]", diffText);
+    .replace("[PASTE PR DIFF OR FILE PATH HERE]", diffText), reviewRepoPath ? loadProjectConventions(reviewRepoPath) : "");
 
   const sections = [
     `# Relay Review Round ${round}`,


### PR DESCRIPTION
## Summary
- Adds `loadProjectConventions(reviewRepoPath)` that reads the reviewed repo's root `.gitignore` capped at 2KB, enforces trust-root containment via `getCanonicalRepoRoot` + `fs.realpathSync`, and injects it into the reviewer prompt as `## Project Conventions`
- Missing/escaping symlinks → empty, no prompt section emitted (avoids bare empty section)
- Framing verbatim: "Do not flag violations of these as issues — files and patterns listed here are intentionally excluded by the project."
- Motivation: 2026-04-20 review loop where Codex flagged `.g.dart missing` in 4 of 9 rounds on a Flutter PR despite `.gitignore` excluding it

## Test plan
- [x] `node --test skills/relay-review/scripts/review-runner-context.test.js` — 4 new tests pass
- [x] Missing `.gitignore` → empty string
- [x] 2KB+ file → truncated with `# ...truncated at 2KB` marker
- [x] Symlink escaping repo root → treated as missing
- [x] Normal `.gitignore` → content appears in `buildPrompt` output under `## Project Conventions`
- [x] All 41 tests across context/prompt/redispatch suites pass

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)