### PR TITLE
relay-review: auto-escalate rubric factor flip-flops

### DIFF
--- a/skills/relay-review/scripts/review-runner-redispatch.test.js
+++ b/skills/relay-review/scripts/review-runner-redispatch.test.js
@@ -8,6 +8,7 @@ const {
   buildRubricGateRedispatchPrompt,
   buildRubricRecoveryCommand,
   buildReviewRunnerRubricGateFailure,
+  computeFactorStatusFlips,
   computeRepeatedIssueCount,
   detectChurnGrowth,
   scanPriorVerdicts,
@@ -102,6 +103,30 @@ test("redispatch/scanPriorVerdicts does not invoke the callback when no prior ve
   scanPriorVerdicts(runDir, 1, () => { calls += 1; });
   scanPriorVerdicts(runDir, 3, () => { calls += 1; });
   assert.equal(calls, 0);
+});
+
+test("redispatch/computeFactorStatusFlips detects pass-fail-pass with normalized factor names", () => {
+  const runDir = tempRunDir();
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: " Behavior ", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "behavior", status: "fail" }] }), "utf-8");
+  const flips = computeFactorStatusFlips(runDir, 3, { rubric_scores: [{ factor: "BEHAVIOR", status: "pass" }] });
+  assert.deepEqual(flips, [{ factor: "BEHAVIOR", trace: ["pass", "fail", "pass"] }]);
+});
+
+test("redispatch/computeFactorStatusFlips ignores two-round changes and not_run gaps", () => {
+  const runDir = tempRunDir();
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "behavior", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "behavior", status: "not_run" }] }), "utf-8");
+  const flips = computeFactorStatusFlips(runDir, 3, { rubric_scores: [{ factor: "behavior", status: "fail" }] });
+  assert.deepEqual(flips, []);
+});
+
+test("redispatch/computeFactorStatusFlips ignores factors that change in different rounds", () => {
+  const runDir = tempRunDir();
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "A", status: "pass" }, { factor: "B", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "A", status: "fail" }, { factor: "B", status: "pass" }] }), "utf-8");
+  const flips = computeFactorStatusFlips(runDir, 3, { rubric_scores: [{ factor: "A", status: "fail" }, { factor: "B", status: "fail" }] });
+  assert.deepEqual(flips, []);
 });
 
 test("redispatch/buildReviewRunnerRubricGateFailure preserves the fail-closed recovery matrix", async (t) => {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -25,6 +25,7 @@ const {
   buildRedispatchPrompt,
   buildReviewRunnerRubricGateFailure,
   buildRubricGateRedispatchPrompt,
+  computeFactorStatusFlips,
   computeRepeatedIssueCount,
   detectChurnGrowth,
   toEscalatedVerdict,
@@ -241,6 +242,13 @@ function run() {
     verdict = toEscalatedVerdict(
       verdict,
       `Repeated identical review issues hit ${repeatedIssueCount} consecutive rounds.`
+    );
+  }
+  const factorFlips = computeFactorStatusFlips(runDir, round, verdict);
+  if (factorFlips.length) {
+    verdict = toEscalatedVerdict(
+      verdict,
+      factorFlips.map(({ factor, trace }) => `Rubric factor '${factor}' status flipped across 3 rounds (trace: ${trace.join("→")}). Owner decision required — reviewer cannot converge autonomously.`).join("; ")
     );
   }
 

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1576,6 +1576,24 @@ test("repeated identical issues escalate on the third consecutive round", () => 
   assert.equal(manifest.review.repeated_issue_count, 0);
 });
 
+test("rubric factor flip-flops escalate even when the reviewer returns pass", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "Behavior", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "behavior", status: "fail" }] }), "utf-8");
+  updateManifestRecord(manifestPath, (data) => ({ ...data, review: { ...(data.review || {}), rounds: 2 } }));
+  const reviewFile = writeVerdict(repoRoot, "flip-pass.json", {
+    verdict: "pass", summary: "Looks good.", contract_status: "pass", quality_status: "pass", next_action: "ready_to_merge", issues: [],
+    rubric_scores: [{ factor: "BEHAVIOR", target: ">= 1/1", observed: "1/1", status: "pass", tier: "contract", notes: "Recovered." }],
+    scope_drift: { creep: [], missing: [] },
+  });
+  const result = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123", "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath, "--review-file", reviewFile, "--no-comment", "--json"], { encoding: "utf-8" }));
+  const verdict = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  assert.equal(result.state, STATES.ESCALATED);
+  assert.equal(verdict.verdict, "escalated");
+  assert.equal(verdict.summary, "Rubric factor 'BEHAVIOR' status flipped across 3 rounds (trace: pass→fail→pass). Owner decision required — reviewer cannot converge autonomously.");
+});
+
 test("formatPriorVerdictSummary produces correct round numbers and rubric summaries", () => {
   // Module-level argv parsing prevents direct require(), so use a helper script
   // that sets process.argv before requiring the module.
@@ -1903,6 +1921,23 @@ test("buildRedispatchPrompt omits churn WARNING when churnGrowth is null", () =>
   const out = execFileSync("node", [helperPath], { encoding: "utf-8" });
   assert.ok(!out.includes("WARNING"));
   assert.ok(!out.includes("Apply minimal"));
+});
+
+test("buildRedispatchPrompt includes prior-round factor flips", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "redispatch-factor-flips-"));
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "Behavior", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "behavior", status: "fail" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-3-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "BEHAVIOR", status: "pass" }] }), "utf-8");
+  const helperPath = path.join(os.tmpdir(), `redispatch-flips-${Date.now()}.js`);
+  fs.writeFileSync(helperPath, [
+    `process.argv = ["node", "helper.js", "--repo", "/dev/null", "--branch", "x", "--pr", "1"];`,
+    `const { buildRedispatchPrompt } = require(${JSON.stringify(SCRIPT)});`,
+    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high" }], scope_drift: { creep: [], missing: [] } };`,
+    `process.stdout.write(buildRedispatchPrompt(verdict, "AC: do X", ${JSON.stringify(runDir)}, 4, null));`,
+  ].join("\n"), "utf-8");
+  const out = execFileSync("node", [helperPath], { encoding: "utf-8" });
+  assert.match(out, /Prior-round factor flips \(reviewer cannot converge on these — do NOT re-flag as blocker; owner decision needed\):/);
+  assert.match(out, /- BEHAVIOR: pass→fail→pass/);
 });
 
 test("review-runner loads rubric from run dir and includes rubric factor names and targets in the prompt", () => {

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { formatIssueList, formatScopeDrift } = require("./comment");
 const { formatPriorVerdictSummary } = require("./prompt");
 
+const FLIP_STATES = new Set(["pass", "fail"]);
 const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded"]);
 
 function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource) {
@@ -23,6 +24,14 @@ function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth
     const priorSummary = formatPriorVerdictSummary(priorVerdicts);
     if (priorSummary) {
       sections.push("", priorSummary);
+    }
+    const factorFlips = listPriorFactorStatusFlips(runDir, round);
+    if (factorFlips.length) {
+      sections.push(
+        "",
+        "Prior-round factor flips (reviewer cannot converge on these — do NOT re-flag as blocker; owner decision needed):",
+        ...factorFlips.map(({ factor, trace }) => `- ${factor}: ${trace.join("→")}`)
+      );
     }
   }
 
@@ -129,6 +138,53 @@ function computeRepeatedIssueCount(runDir, round, issues) {
   return count;
 }
 
+function mapRubricStatuses(verdict) {
+  return new Map((Array.isArray(verdict?.rubric_scores) ? verdict.rubric_scores : [])
+    .map((score) => [normalizeFingerprintPart(score.factor), { factor: score.factor, status: score.status }]));
+}
+
+function isFlipTrace(trace) {
+  return trace.length === 3
+    && trace.every((status) => FLIP_STATES.has(status))
+    && trace[0] === trace[2]
+    && trace[0] !== trace[1];
+}
+
+function collectFactorStatusFlips(verdicts) {
+  const [first, second, third] = verdicts.map(mapRubricStatuses);
+  return [...third.entries()].flatMap(([key, current]) => {
+    const trace = [first.get(key)?.status, second.get(key)?.status, current.status];
+    return isFlipTrace(trace) ? [{ factor: current.factor, trace }] : [];
+  });
+}
+
+function computeFactorStatusFlips(runDir, round, currentVerdict) {
+  const priorVerdicts = [];
+  scanPriorVerdicts(runDir, round, (verdict, verdictRound) => {
+    if (verdictRound < round - 2) return false;
+    priorVerdicts.push(verdict);
+  });
+  return priorVerdicts.length < 2 ? [] : collectFactorStatusFlips([priorVerdicts[1], priorVerdicts[0], currentVerdict]);
+}
+
+function hasConsecutiveRounds(entries, index) {
+  return index >= 2
+    && entries[index - 2].round + 1 === entries[index - 1].round
+    && entries[index - 1].round + 1 === entries[index].round;
+}
+
+function listPriorFactorStatusFlips(runDir, round) {
+  const priorVerdicts = [];
+  scanPriorVerdicts(runDir, round, (verdict, verdictRound) => priorVerdicts.push({ round: verdictRound, verdict }));
+  priorVerdicts.reverse();
+  const flips = priorVerdicts.reduce((memo, _entry, index, entries) => {
+    if (!hasConsecutiveRounds(entries, index)) return memo;
+    for (const flip of collectFactorStatusFlips(entries.slice(index - 2, index + 1).map((entry) => entry.verdict))) memo.set(normalizeFingerprintPart(flip.factor), flip);
+    return memo;
+  }, new Map());
+  return [...flips.values()];
+}
+
 function toEscalatedVerdict(baseVerdict, summary) {
   return {
     ...baseVerdict,
@@ -216,6 +272,7 @@ module.exports = {
   buildReviewRunnerRubricGateFailure,
   buildRubricGateRedispatchPrompt,
   buildRubricRecoveryCommand,
+  computeFactorStatusFlips,
   computeRepeatedIssueCount,
   detectChurnGrowth,
   fingerprintIssue,


### PR DESCRIPTION
## Summary
- add rubric-factor flip detection across the current round and two prior rounds using the shared prior-verdict walker
- escalate verdicts when a factor oscillates pass/fail/pass or fail/pass/fail and surface prior-round flips in redispatch prompts
- cover flip escalation, historical prompt context, and regression behavior with review-runner tests

## Testing
- node --test skills/relay-review/scripts/review-runner-redispatch.test.js
- node --test skills/relay-review/scripts/review-runner-context.test.js
- node --test skills/relay-review/scripts/review-runner-prompt.test.js
- node --test skills/relay-review/scripts/review-runner.test.js