### PR TITLE
feat(relay-review): reviewer-swap recovery from escalated state (#249)

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/lifecycle.js
+++ b/skills/relay-dispatch/scripts/manifest/lifecycle.js
@@ -17,7 +17,7 @@ const ALLOWED_TRANSITIONS = Object.freeze({
   [STATES.REVIEW_PENDING]: new Set([STATES.CHANGES_REQUESTED, STATES.READY_TO_MERGE, STATES.ESCALATED, STATES.CLOSED]),
   [STATES.CHANGES_REQUESTED]: new Set([STATES.DISPATCHED, STATES.CLOSED]),
   [STATES.READY_TO_MERGE]: new Set([STATES.MERGED, STATES.CLOSED]),
-  [STATES.ESCALATED]: new Set([STATES.CLOSED]),
+  [STATES.ESCALATED]: new Set([STATES.REVIEW_PENDING, STATES.CLOSED]),
   [STATES.MERGED]: new Set(),
   [STATES.CLOSED]: new Set(),
 });
@@ -45,6 +45,15 @@ function validateTransitionInvariants(data, fromState, toState) {
       throw new Error(
         `Cannot transition dispatched -> review_pending because ${rubricAnchor.error} ` +
         "Generate the rubric with relay-plan and dispatch with --rubric-file."
+      );
+    }
+  }
+  if (fromState === STATES.ESCALATED && toState === STATES.REVIEW_PENDING) {
+    const swapCount = Number(data.review?.reviewer_swap_count || 0);
+    if (swapCount >= 1) {
+      throw new Error(
+        `Cannot transition escalated -> review_pending: reviewer_swap_count=${swapCount} (max 1 per run). ` +
+        "Use close-run.js --reason to close, or start a new run."
       );
     }
   }

--- a/skills/relay-dispatch/scripts/manifest/lifecycle.test.js
+++ b/skills/relay-dispatch/scripts/manifest/lifecycle.test.js
@@ -19,7 +19,7 @@ const EXPECTED_TRANSITIONS = Object.freeze({
   [STATES.REVIEW_PENDING]: new Set([STATES.CHANGES_REQUESTED, STATES.READY_TO_MERGE, STATES.ESCALATED, STATES.CLOSED]),
   [STATES.CHANGES_REQUESTED]: new Set([STATES.DISPATCHED, STATES.CLOSED]),
   [STATES.READY_TO_MERGE]: new Set([STATES.MERGED, STATES.CLOSED]),
-  [STATES.ESCALATED]: new Set([STATES.CLOSED]),
+  [STATES.ESCALATED]: new Set([STATES.REVIEW_PENDING, STATES.CLOSED]),
   [STATES.MERGED]: new Set(),
   [STATES.CLOSED]: new Set(),
 });
@@ -106,9 +106,8 @@ test("manifest/lifecycle validateTransitionInvariants only gates dispatched -> r
   const states = Object.values(STATES);
   for (const fromState of states) {
     for (const toState of states) {
-      if (fromState === STATES.DISPATCHED && toState === STATES.REVIEW_PENDING) {
-        continue;
-      }
+      if (fromState === STATES.DISPATCHED && toState === STATES.REVIEW_PENDING) continue;
+      if (fromState === STATES.ESCALATED && toState === STATES.REVIEW_PENDING) continue;
       assert.doesNotThrow(
         () => validateTransitionInvariants({}, fromState, toState),
         `${fromState} -> ${toState} should remain invariant-free`
@@ -125,6 +124,27 @@ test("manifest/lifecycle validateTransitionInvariants only gates dispatched -> r
       STATES.REVIEW_PENDING
     ),
     /rubric file is missing/
+  );
+});
+
+test("manifest/lifecycle validateTransitionInvariants gates escalated -> review_pending on reviewer_swap_count", () => {
+  assert.doesNotThrow(() => validateTransitionInvariants(
+    { review: { reviewer_swap_count: 0 } },
+    STATES.ESCALATED,
+    STATES.REVIEW_PENDING
+  ));
+  assert.doesNotThrow(() => validateTransitionInvariants(
+    {},
+    STATES.ESCALATED,
+    STATES.REVIEW_PENDING
+  ));
+  assert.throws(
+    () => validateTransitionInvariants(
+      { review: { reviewer_swap_count: 1 } },
+      STATES.ESCALATED,
+      STATES.REVIEW_PENDING
+    ),
+    /reviewer_swap_count=1 \(max 1 per run\)/
   );
 });
 

--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -226,6 +226,7 @@ function createManifestSkeleton({
       latest_verdict: "pending",
       repeated_issue_count: 0,
       last_reviewed_sha: null,
+      reviewer_swap_count: 0,
     },
     cleanup: createCleanupSkeleton(),
     environment: environment || {

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -66,6 +66,15 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.after !== undefined
       ? { after: normalizeEventValue(eventData.after) }
       : {}),
+    ...(eventData.from_reviewer !== undefined
+      ? { from_reviewer: normalizeEventValue(eventData.from_reviewer) }
+      : {}),
+    ...(eventData.to_reviewer !== undefined
+      ? { to_reviewer: normalizeEventValue(eventData.to_reviewer) }
+      : {}),
+    ...(eventData.reviewer_swap_count !== undefined
+      ? { reviewer_swap_count: normalizeEventValue(eventData.reviewer_swap_count) }
+      : {}),
   };
 
   appendEventLine(repoRoot, runId, record);

--- a/skills/relay-review/scripts/review-runner-reviewer-swap.test.js
+++ b/skills/relay-review/scripts/review-runner-reviewer-swap.test.js
@@ -1,0 +1,103 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { STATES } = require("../../relay-dispatch/scripts/manifest/lifecycle");
+const { ensureRunLayout, getEventsPath } = require("../../relay-dispatch/scripts/manifest/paths");
+const { createManifestSkeleton, readManifest, writeManifest } = require("../../relay-dispatch/scripts/manifest/store");
+const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
+
+function setupEscalatedRun({ lastReviewer = "codex", swapCount = 0 } = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-swap-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Review Swap"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-swap@example.com"], { cwd: repoRoot, stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const runId = "issue-249-20260421120000000";
+  const { manifestPath } = ensureRunLayout(repoRoot, runId);
+
+  const manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-249",
+    baseBranch: "main",
+    issueNumber: 249,
+    worktreePath: path.join(repoRoot, "wt", "issue-249"),
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: lastReviewer,
+  });
+  const escalated = {
+    ...manifest,
+    state: STATES.ESCALATED,
+    next_action: "inspect_review_failure",
+    review: {
+      ...(manifest.review || {}),
+      rounds: 1,
+      last_reviewer: lastReviewer,
+      reviewer_swap_count: swapCount,
+    },
+  };
+  writeManifest(manifestPath, escalated, "");
+  return { data: escalated, manifestPath, repoRoot, runId };
+}
+
+test("reviewer-swap/returns data unchanged when state is not escalated", () => {
+  const { data, manifestPath, repoRoot } = setupEscalatedRun();
+  const pending = { ...data, state: STATES.REVIEW_PENDING };
+  const result = maybeSwapReviewer(pending, "claude", "", manifestPath, repoRoot);
+  assert.equal(result, pending);
+});
+
+test("reviewer-swap/returns data unchanged when no --reviewer is provided", () => {
+  const { data, manifestPath, repoRoot } = setupEscalatedRun();
+  const result = maybeSwapReviewer(data, null, "", manifestPath, repoRoot);
+  assert.equal(result, data);
+});
+
+test("reviewer-swap/transitions escalated -> review_pending with different reviewer", () => {
+  const { data, manifestPath, repoRoot, runId } = setupEscalatedRun({ lastReviewer: "codex" });
+  const swapped = maybeSwapReviewer(data, "claude", "", manifestPath, repoRoot);
+  assert.equal(swapped.state, STATES.REVIEW_PENDING);
+  assert.equal(swapped.next_action, "run_review");
+  assert.equal(swapped.review.reviewer_swap_count, 1);
+  assert.equal(swapped.review.last_reviewer, "codex");
+
+  const persisted = readManifest(manifestPath).data;
+  assert.equal(persisted.state, STATES.REVIEW_PENDING);
+  assert.equal(persisted.review.reviewer_swap_count, 1);
+
+  const events = fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const swapEvent = events.find((event) => event.event === "reviewer_swap");
+  assert.ok(swapEvent, "reviewer_swap event should be appended");
+  assert.equal(swapEvent.from_reviewer, "codex");
+  assert.equal(swapEvent.to_reviewer, "claude");
+  assert.equal(swapEvent.state_from, STATES.ESCALATED);
+  assert.equal(swapEvent.state_to, STATES.REVIEW_PENDING);
+});
+
+test("reviewer-swap/rejects same-reviewer retry", () => {
+  const { data, manifestPath, repoRoot } = setupEscalatedRun({ lastReviewer: "codex" });
+  assert.throws(
+    () => maybeSwapReviewer(data, "codex", "", manifestPath, repoRoot),
+    /matches review\.last_reviewer/
+  );
+});
+
+test("reviewer-swap/rejects a second swap after the quota is used", () => {
+  const { data, manifestPath, repoRoot } = setupEscalatedRun({ lastReviewer: "codex", swapCount: 1 });
+  assert.throws(
+    () => maybeSwapReviewer(data, "claude", "", manifestPath, repoRoot),
+    /reviewer_swap_count=1 \(max 1 per run\)/
+  );
+});

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -32,6 +32,7 @@ const {
 } = require("./review-runner/redispatch");
 const { applyPolicyViolationToManifest, applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { loadReviewText, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
+const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
@@ -113,7 +114,10 @@ function run() {
     branchArg,
     prArg
   );
-  const { data, body, manifestPath } = manifest;
+  const { body, manifestPath } = manifest;
+  let { data } = manifest;
+
+  data = maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath);
 
   if (data.state !== STATES.REVIEW_PENDING) {
     throw new Error(`Review runner requires state=review_pending, got '${data.state}'`);

--- a/skills/relay-review/scripts/review-runner/reviewer-swap.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-swap.js
@@ -1,0 +1,36 @@
+const { STATES, forceTransitionState } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
+const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
+const { appendRunEvent } = require("../../../relay-dispatch/scripts/relay-events");
+const { resolveReviewerName } = require("./reviewer-invoke");
+
+function maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath) {
+  if (data.state !== STATES.ESCALATED) return data;
+  if (!reviewerArg) return data;
+
+  const newReviewerName = resolveReviewerName(data, reviewerArg);
+  const lastReviewer = data.review?.last_reviewer || null;
+  if (newReviewerName === lastReviewer) {
+    throw new Error(
+      `Reviewer-swap requires a different reviewer; --reviewer '${newReviewerName}' matches review.last_reviewer. ` +
+      "Pass a different adapter (e.g., --reviewer claude) or close the run."
+    );
+  }
+
+  const swappedManifest = forceTransitionState(data, STATES.REVIEW_PENDING, "run_review");
+  swappedManifest.review = {
+    ...(swappedManifest.review || {}),
+    reviewer_swap_count: Number(data.review?.reviewer_swap_count || 0) + 1,
+  };
+  writeManifest(manifestPath, swappedManifest, body);
+  appendRunEvent(runRepoPath, data.run_id, {
+    event: "reviewer_swap",
+    state_from: STATES.ESCALATED,
+    state_to: STATES.REVIEW_PENDING,
+    from_reviewer: lastReviewer,
+    to_reviewer: newReviewerName,
+    reviewer_swap_count: swappedManifest.review.reviewer_swap_count,
+  });
+  return swappedManifest;
+}
+
+module.exports = { maybeSwapReviewer };


### PR DESCRIPTION
## Summary
- Opens a bounded recovery path for \`escalated\` runs: operator can rerun \`review-runner.js --reviewer <different-name>\` once per run to transition \`escalated → review_pending\` and retry with a different reviewer adapter
- Chosen approach: reviewer-swap (Option 3 from #249 triage). Rejected auto-downgrade (Option 2) because it relies on verdict-semantic heuristics that risk misclassifying legitimate verification-category issues
- Bounded at \`reviewer_swap_count < 1\` per run (tracked in manifest). Second swap and same-reviewer retries are both rejected with actionable error messages
- Unblocks the relay-review dogfooding loop that #244/#245/#246/#247 had to skip-merge around

## Changes
- \`manifest/lifecycle.js\` — allow \`ESCALATED → REVIEW_PENDING\`; invariant gates on \`reviewer_swap_count\`
- \`manifest/store.js\` — new \`review.reviewer_swap_count\` field (default 0) in skeleton
- \`relay-events.js\` — optional event fields: \`from_reviewer\`, \`to_reviewer\`, \`reviewer_swap_count\`
- \`review-runner.js\` — call \`maybeSwapReviewer()\` before the \`state=review_pending\` check
- \`review-runner/reviewer-swap.js\` (new) — swap logic
- \`review-runner-reviewer-swap.test.js\` (new) — 5 tests covering the matrix

## Test plan
- [x] \`node --test skills/relay-review/scripts/review-runner-reviewer-swap.test.js\` — 5 tests (non-escalated passthrough, no --reviewer passthrough, successful swap + event audit, same-reviewer block, second-swap block)
- [x] \`node --test skills/relay-dispatch/scripts/manifest/lifecycle.test.js\` — existing matrix test updated for the new transition; new invariant test on \`reviewer_swap_count\` guard
- [x] Full suite: 560/560 tests pass across relay-dispatch + relay-review

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 에스컬레이션된 리뷰에서 검토자 변경 기능 추가
  * 실행당 최대 1회의 검토자 변경 제한 적용
  * 검토자 변경 이벤트 추적 및 로깅 기능 포함

* **개선사항**
  * 검토자 변경 시 시스템 상태 자동 전환
  * 동일 검토자로의 변경 시도 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->