### PR TITLE
fix(relay-dispatch): resolve detached HEAD base branch (#253)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -290,6 +290,48 @@ function git(repoDir, ...gitArgs) {
   return execFileSync("git", ["-C", repoDir, ...gitArgs], { encoding: "utf-8" }).trim();
 }
 
+function isValidBaseBranchName(branch) {
+  return typeof branch === "string" && branch.trim() !== "" && branch.trim() !== "HEAD";
+}
+
+function resolveOriginDefaultBranch(repoDir) {
+  const remoteHeadRef = git(repoDir, "symbolic-ref", "refs/remotes/origin/HEAD");
+  const prefix = "refs/remotes/origin/";
+  if (!remoteHeadRef.startsWith(prefix)) {
+    throw new Error(`origin/HEAD resolved to unexpected ref '${remoteHeadRef}'`);
+  }
+
+  const branch = remoteHeadRef.slice(prefix.length).trim();
+  if (!isValidBaseBranchName(branch)) {
+    throw new Error(`origin/HEAD resolved to invalid branch '${branch || "(empty)"}'`);
+  }
+  return branch;
+}
+
+function resolveBaseBranchForNewDispatch(repoDir) {
+  let detectedBranch = "";
+  try {
+    detectedBranch = git(repoDir, "rev-parse", "--abbrev-ref", "HEAD");
+  } catch {}
+
+  if (isValidBaseBranchName(detectedBranch)) {
+    return detectedBranch;
+  }
+
+  try {
+    const fallbackBranch = resolveOriginDefaultBranch(repoDir);
+    console.error(
+      `[relay-dispatch] base_branch fallback: rev-parse returned '${detectedBranch || "(empty)"}', using origin default '${fallbackBranch}'`
+    );
+    return fallbackBranch;
+  } catch (error) {
+    throw new Error(
+      "unable to determine base branch for new dispatch when repository HEAD is detached. " +
+      `Run 'git remote set-head origin --auto' to repair refs/remotes/origin/HEAD, then retry. (${error.message})`
+    );
+  }
+}
+
 function shellQuote(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
@@ -572,9 +614,7 @@ async function main() {
     if (fs.existsSync(getRunDir(repoRoot, runId))) {
       failRunDirCollision(runId, manifestPath);
     }
-    try {
-      baseBranch = git(repoRoot, "rev-parse", "--abbrev-ref", "HEAD") || "main";
-    } catch {}
+    baseBranch = resolveBaseBranchForNewDispatch(repoRoot);
     if (fs.existsSync(wtPath)) {
       console.error(`Error: worktree path already exists: ${wtPath}`);
       process.exit(1);

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -46,6 +46,53 @@ function setupRepoWithOrigin() {
   return setupRepo();
 }
 
+function configureOriginHead(repoRoot, remoteRoot, branch) {
+  if (branch !== "main") {
+    execFileSync("git", ["checkout", "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+    execFileSync("git", ["push", "-u", "origin", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  }
+  execFileSync("git", ["symbolic-ref", "HEAD", `refs/heads/${branch}`], {
+    cwd: remoteRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  execFileSync("git", ["remote", "set-head", "origin", branch], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+}
+
+function detachHead(repoRoot) {
+  const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+  execFileSync("git", ["checkout", "--detach", headSha], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+}
+
+function setupDetachedHeadRepo({ originHeadBranch } = {}) {
+  const fixture = setupRepo();
+  if (originHeadBranch) {
+    configureOriginHead(fixture.repoRoot, fixture.remoteRoot, originHeadBranch);
+  } else {
+    try {
+      execFileSync("git", ["update-ref", "-d", "refs/remotes/origin/HEAD"], {
+        cwd: fixture.repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+    } catch {}
+  }
+  detachHead(fixture.repoRoot);
+  return fixture;
+}
+
 function createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, branch = "issue-42") {
   const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-foreign-"));
   const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
@@ -1090,6 +1137,67 @@ test("dispatch can resume from --manifest while invoked from an unrelated git re
   assert.equal(second.worktree, first.worktree);
   assert.equal(second.runState, STATES.REVIEW_PENDING);
   assert.equal(readManifest(first.manifestPath).data.state, STATES.REVIEW_PENDING);
+});
+
+test("dispatch remaps detached HEAD to origin default branch before manifest creation (#253)", () => {
+  const { repoRoot, relayHome } = setupDetachedHeadRepo({ originHeadBranch: "trunk" });
+  const { env, ghLogPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/253",
+    },
+  });
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-253-fallback",
+    "--prompt", "exercise detached HEAD fallback",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /\[relay-dispatch\] base_branch fallback:/);
+  assert.match(result.stderr, /using origin default 'trunk'/);
+
+  const parsed = JSON.parse(result.stdout);
+  const manifest = readManifest(parsed.manifestPath).data;
+  assert.equal(manifest.git.base_branch, "trunk");
+  assert.notEqual(manifest.git.base_branch, "HEAD");
+
+  const ghCreateCall = readJsonLines(ghLogPath).find((args) => args[0] === "pr" && args[1] === "create");
+  assert.ok(ghCreateCall, "expected gh pr create call");
+  const baseFlagIndex = ghCreateCall.indexOf("--base");
+  assert.notEqual(baseFlagIndex, -1, "expected --base flag");
+  assert.equal(ghCreateCall[baseFlagIndex + 1], "trunk");
+});
+
+test("dispatch fails closed on detached HEAD when origin HEAD is unresolved before worktree creation (#253)", () => {
+  const { repoRoot, relayHome } = setupDetachedHeadRepo();
+  const env = {
+    ...process.env,
+    PATH: createGitOnlyPath(),
+    RELAY_HOME: relayHome,
+  };
+
+  const result = spawnSync(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-253-fail-closed",
+    "--prompt", "exercise detached HEAD failure",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unable to determine base branch for new dispatch when repository HEAD is detached/i);
+  assert.match(result.stderr, /git remote set-head origin --auto/);
+  assert.equal(listManifestPaths(repoRoot).length, 0);
+  assert.equal(fs.existsSync(path.join(relayHome, "runs")), false);
+  assert.equal(fs.existsSync(path.join(relayHome, "worktrees")), false);
 });
 
 test("dispatch resume fails loudly when the retained worktree is missing", () => {


### PR DESCRIPTION
## Summary

Fixes #253 — dispatch.js previously captured base_branch as the literal string `HEAD` when the orchestrator's working copy was on a detached HEAD, flowing through to `gh pr create --base HEAD` which failed at the very end of the dispatch.

## Change

- When \`git rev-parse --abbrev-ref HEAD\` returns \`HEAD\` or empty, auto-fallback to \`git symbolic-ref refs/remotes/origin/HEAD\` (local, no network) to resolve the repo's default branch.
- Fail-closed if fallback also fails: dispatch exits non-zero BEFORE worktree creation and executor spawn, with an actionable error (recovery command: \`git remote set-head origin --auto\`).
- Removes the old silent \`|| "main"\` default — wrong answer for repos with non-"main" defaults.
- Stderr log line when fallback fires, so post-mortems can see the remap.

## Test plan

- [x] New tests in \`skills/relay-dispatch/scripts/dispatch.test.js\` cover detached-HEAD → fallback and detached-HEAD → fail-closed paths using real git on temp repos.
- [x] Existing dispatch suite passes.

🤖 Generated via /relay (dispatch bf6d78df)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 분리된 HEAD 상태에서 git 브랜치 감지 오류 해결. 이제 원격 저장소의 기본 브랜치를 자동으로 감지합니다.

* **새로운 기능**
  * 에스컬레이션된 실행에 대한 검토자 교체 기능을 추가했습니다. 실행당 최대 1회 교체 제한이 적용됩니다.
  * 교체 이력 및 메타데이터 추적 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->