### PR TITLE
fix(relay-review): emit origin=system marker on max_rounds_exceeded review_apply (#228)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -48,6 +48,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     head_sha: normalizeEventValue(eventData.head_sha),
     round: normalizeEventValue(eventData.round),
     reason: normalizeEventValue(eventData.reason),
+    ...(eventData.origin !== undefined
+      ? { origin: normalizeEventValue(eventData.origin) }
+      : {}),
     ...(eventData.reviewer !== undefined
       ? { reviewer: normalizeEventValue(eventData.reviewer) }
       : {}),

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -157,6 +157,21 @@ test("appendRunEvent persists rubric_status when provided", () => {
   assert.equal(parsed.rubric_status, "missing");
 });
 
+test("appendRunEvent persists origin when provided", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendRunEvent(repoRoot, runId, {
+    event: "review_apply",
+    state_from: "review_pending",
+    state_to: "escalated",
+    reason: "max_rounds_exceeded",
+    origin: "system",
+  });
+
+  const [parsed] = readRunEvents(repoRoot, runId);
+  assert.equal(record.origin, "system");
+  assert.equal(parsed.origin, "system");
+});
+
 test("appendRunEvent persists last_reviewed_sha when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -62,6 +62,17 @@ function hasRecordedReviewActivity(data) {
   );
 }
 
+function isSystemReviewApplyEvent(event) {
+  return event?.event === "review_apply" && event?.origin === "system";
+}
+
+function isLegacyReviewerlessReviewApplyEvent(event) {
+  return (
+    event?.event === "review_apply"
+    && (event?.reviewer === undefined || event?.reviewer === null)
+  );
+}
+
 function buildEmptyRubricInsights() {
   return {
     quality_grade_distribution: null,
@@ -516,22 +527,22 @@ function buildRoleReports({ repoRoot, staleHours, now, manifests, events }) {
   }));
 }
 
-// `review_apply` events without a `reviewer` field are system-emitted state
-// transitions (e.g., review-runner.js's `max_rounds_exceeded` escalation), not
-// rounds any reviewer actually performed. Filtering them here prevents phantom
-// round counts in the "unknown" bucket. Runs whose only review_apply events
-// lack a reviewer still surface as data-integrity signals via
-// `summary.missing_review_apply_run_ids` (since `hasRecordedReviewActivity`
-// will report the run as missing reviewer-tagged events). Events that carry
-// an explicit but empty/whitespace reviewer fall through to
-// `normalizeRoleName` and land in "unknown" so real corrupt-value cases stay
-// visible.
+// `review_apply` can be emitted for a system-forced escalation before any
+// reviewer actually runs. New events mark that path with `origin: "system"`;
+// legacy events are still reviewer-less. Filtering both shapes here prevents
+// phantom round counts in the "unknown" bucket. Runs whose only review_apply
+// events are system-emitted or legacy reviewer-less still surface as
+// data-integrity signals via `summary.missing_review_apply_run_ids` (since
+// `hasRecordedReviewActivity` will report the run as missing reviewer-tagged
+// events). Events that carry an explicit but empty/whitespace reviewer fall
+// through to `normalizeRoleName` and land in "unknown" so real corrupt-value
+// cases stay visible.
 function buildActingReviewerReports({ repoRoot, staleHours, now, manifests, events }) {
   const reviewApplyEvents = events.filter((event) => (
     event.event === "review_apply"
     && event.run_id
-    && event.reviewer !== undefined
-    && event.reviewer !== null
+    && !isSystemReviewApplyEvent(event)
+    && !isLegacyReviewerlessReviewApplyEvent(event)
   ));
   const buckets = new Map();
   const reviewersByRun = new Map();

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -880,12 +880,11 @@ test("reliability-report keeps missing acting reviewer data explicit in text out
   assert.match(stdout, new RegExp(`missing_review_apply_run_ids: ${runMissingReviewApply}`));
 });
 
-test("reliability-report --by-acting-reviewer skips system-emitted review_apply events with no reviewer field", () => {
-  // review-runner.js emits `review_apply` with no reviewer field on the
-  // `max_rounds_exceeded` escalation path. Counting those as rounds performed
-  // by an "unknown" reviewer inflates phantom counts on every escalated run.
-  // The aggregator must treat missing-reviewer events as system transitions
-  // and surface affected runs via `missing_review_apply_run_ids` instead.
+test("reliability-report --by-acting-reviewer skips system-marked review_apply events", () => {
+  // New producer shape: review-runner.js marks the `max_rounds_exceeded`
+  // escalation path with `origin: "system"` and still omits `reviewer`.
+  // The aggregator must exclude those events from acting-reviewer buckets
+  // while keeping the run visible via `missing_review_apply_run_ids`.
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-acting-system-emitted-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   initGitRepo(repoRoot, "Relay Test");
@@ -917,6 +916,7 @@ test("reliability-report --by-acting-reviewer skips system-emitted review_apply 
     state_to: STATES.ESCALATED,
     round: 20,
     reason: "max_rounds_exceeded",
+    origin: "system",
   });
   appendRunEvent(repoRoot, runNormal, {
     event: "review_apply",
@@ -941,6 +941,66 @@ test("reliability-report --by-acting-reviewer skips system-emitted review_apply 
   assert.equal(report.by_acting_reviewer.reviewers.codex.acting_review.review_apply_runs, 1);
 
   // Escalated run surfaces as a missing_review_apply_run (data-integrity signal).
+  assert.equal(report.by_acting_reviewer.summary.review_apply_events, 1);
+  assert.equal(report.by_acting_reviewer.summary.review_apply_runs, 1);
+  assert.equal(report.by_acting_reviewer.summary.missing_review_apply_runs, 1);
+  assert.deepEqual(report.by_acting_reviewer.summary.missing_review_apply_run_ids, [runEscalated]);
+});
+
+test("reliability-report --by-acting-reviewer still skips legacy reviewer-less review_apply events", () => {
+  // Backward compatibility: older events predate `origin: "system"` and only
+  // omit `reviewer`. Keep filtering those until stored history ages out.
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-acting-legacy-reviewerless-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runEscalated = createRunId({ branch: "run-escalated", timestamp: new Date("2026-04-12T09:10:00.000Z") });
+  const runNormal = createRunId({ branch: "run-normal", timestamp: new Date("2026-04-12T09:10:01.000Z") });
+
+  writeRun(repoRoot, {
+    runId: runEscalated,
+    state: STATES.ESCALATED,
+    rounds: 20,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewedSha: "legacy111",
+  });
+  writeRun(repoRoot, {
+    runId: runNormal,
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 1,
+    updatedAt: recentTs,
+    reviewer: "codex",
+    lastReviewedSha: "normal222",
+  });
+
+  appendRunEvent(repoRoot, runEscalated, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.ESCALATED,
+    round: 20,
+    reason: "max_rounds_exceeded",
+  });
+  appendRunEvent(repoRoot, runNormal, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 1,
+    reviewer: "codex",
+    reason: "changes_requested",
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--json",
+    "--by-acting-reviewer",
+  ], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(Object.keys(report.by_acting_reviewer.reviewers).sort(), ["codex"]);
+  assert.equal(report.by_acting_reviewer.reviewers.codex.acting_review.review_apply_events, 1);
+  assert.equal(report.by_acting_reviewer.reviewers.codex.acting_review.review_apply_runs, 1);
   assert.equal(report.by_acting_reviewer.summary.review_apply_events, 1);
   assert.equal(report.by_acting_reviewer.summary.review_apply_runs, 1);
   assert.equal(report.by_acting_reviewer.summary.missing_review_apply_runs, 1);

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -151,6 +151,8 @@ function run() {
       head_sha: reviewedHeadSha,
       round: Number(data.review?.rounds || 0),
       reason: "max_rounds_exceeded",
+      // No reviewer round executed here; mark the system-forced transition explicitly.
+      origin: "system",
     });
     throw new Error(`Review round cap exceeded: next round ${round} would exceed max_rounds=${maxRounds}`);
   }

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1527,6 +1527,7 @@ test("review runner enforces max_rounds before starting a new round", () => {
   assert.equal(manifest.state, STATES.ESCALATED);
   assert.equal(manifest.review.latest_verdict, "max_rounds_exceeded");
   assert.equal(reviewApplyEvent?.origin, "system");
+  assert.equal(reviewApplyEvent?.state_to, STATES.ESCALATED);
   assert.equal("reviewer" in reviewApplyEvent, false);
 });
 

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1522,8 +1522,12 @@ test("review runner enforces max_rounds before starting a new round", () => {
   ], { encoding: "utf-8", stdio: "pipe" }), /Review round cap exceeded/);
 
   const manifest = readManifest(manifestPath).data;
+  const events = readRunEvents(repoRoot, runId);
+  const reviewApplyEvent = [...events].reverse().find((event) => event.event === "review_apply");
   assert.equal(manifest.state, STATES.ESCALATED);
   assert.equal(manifest.review.latest_verdict, "max_rounds_exceeded");
+  assert.equal(reviewApplyEvent?.origin, "system");
+  assert.equal("reviewer" in reviewApplyEvent, false);
 });
 
 test("repeated identical issues escalate on the third consecutive round", () => {


### PR DESCRIPTION
## Summary

- `review-runner.js` max_rounds_exceeded branch now emits `origin: "system"` on the `review_apply` event so consumers have an affirmative system-origin signal instead of keying off the absence of a `reviewer` field.
- `relay-events.js` passes `origin` through into the event journal.
- `reliability-report.js` filters on the new marker first, legacy reviewer-less events second. `summary.missing_review_apply_run_ids` semantics preserved — escalated-only runs still surface.
- Reviewer-run emission (`review-runner.js:~322`) unchanged. Only the escalation site (`review-runner.js:~148`) receives the system marker.
- Option A (minimal-diff marker) chosen over Option B (split event type) per issue body. Option B remains available as follow-up.

## Audit

Only the escalation site at `review-runner.js:~148` receives the system marker; the reviewer-run emission at `:~322` is unchanged. No other system-forced `review_apply` paths exist today.

## Test plan
- [x] `node --test skills/relay-review/scripts/*.test.js skills/relay-dispatch/scripts/*.test.js` — 535/535 pass
- [x] New test: producer emits `origin: "system"` and no `reviewer` field on escalation
- [x] New test: consumer filters system-emitted events from reviewer buckets; run still surfaces in `missing_review_apply_run_ids`
- [x] Legacy-shape test: events with no marker and no reviewer behave as they do today

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시스템이 강제한 검토 에스컬레이션을 명확하게 추적할 수 있도록 이벤트 원본 정보 추가
  * 향상된 신뢰성 리포트로 시스템 강제 에스컬레이션과 레거시 검토 요청 구분

* **테스트**
  * 새로운 이벤트 원본 필드 검증 테스트 추가
  * 시스템 강제 에스컬레이션 처리 테스트 강화
  * 레거시 호환성 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->