### PR TITLE
fix(relay-review): fail-fast claude --bare auth probe with actionable error (#257)

### DIFF
--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -65,7 +65,7 @@ Supported built-in adapters:
 
 Notes:
 - `codex` uses a read-only structured-output adapter and must return a full two-phase verdict.
-- `claude` requires an authenticated local Claude CLI session.
+- `claude --bare` uses a separate token from the interactive Claude OAuth session; for `--reviewer claude` (direct or reviewer-swap), set `ANTHROPIC_API_KEY` or run `claude login --api-key`.
 - Model precedence for reviewer invocation is `--reviewer-model` -> `manifest.model_hints.review` -> reviewer default.
 - When the runner invokes the reviewer itself, it records a `review_invoke` event with the effective `model` value (or `null` when unset).
 

--- a/skills/relay-review/scripts/invoke-reviewer-claude.js
+++ b/skills/relay-review/scripts/invoke-reviewer-claude.js
@@ -12,6 +12,7 @@ const { summarizeFailure, ensureJsonText } = require("./reviewer-helpers");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
+const CLAUDE_AUTH_PATTERNS = [/not logged/i, /please run \/login/i];
 
 if (!args.length || args.includes("--help") || args.includes("-h")) {
   console.log("Usage: invoke-reviewer-claude.js --repo <path> --prompt-file <path> [--model <name>] [--json]");
@@ -20,6 +21,45 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
 
 const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
 const hasFlag = (flag) => sharedHasFlag(args, flag);
+
+function isClaudeBareAuthError(text) {
+  const normalized = String(text || "").trim();
+  return normalized ? CLAUDE_AUTH_PATTERNS.some((pattern) => pattern.test(normalized)) : false;
+}
+
+function buildClaudeAuthError() {
+  return new Error(
+    "claude --bare mode is not authenticated. It uses a separate token from the interactive Claude OAuth session. Set ANTHROPIC_API_KEY or run `claude login --api-key` before using `--reviewer claude` (directly or via reviewer-swap). See skills/relay-review/SKILL.md."
+  );
+}
+
+function probeClaudeAuth(claudeBin, repoPath) {
+  const probeArgs = ["-p", "--bare", "--no-session-persistence", "ping"];
+  let probeOutput;
+
+  try {
+    probeOutput = execFileSync(claudeBin, probeArgs, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    }).trim();
+  } catch (error) {
+    const output = [String(error.stdout || ""), String(error.stderr || ""), error.message]
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    if (isClaudeBareAuthError(output)) {
+      throw buildClaudeAuthError();
+    }
+    throw new Error(`Claude reviewer auth probe failed: ${summarizeFailure(error)}`);
+  }
+
+  if (isClaudeBareAuthError(probeOutput)) {
+    throw buildClaudeAuthError();
+  }
+}
 
 function main() {
   const repoPath = path.resolve(getArg("--repo") || ".");
@@ -30,6 +70,8 @@ function main() {
   if (!promptFile) {
     throw new Error("--prompt-file is required");
   }
+
+  probeClaudeAuth(claudeBin, repoPath);
 
   const promptText = fs.readFileSync(promptFile, "utf-8").trim();
   const fullPrompt = [

--- a/skills/relay-review/scripts/invoke-reviewer.test.js
+++ b/skills/relay-review/scripts/invoke-reviewer.test.js
@@ -161,3 +161,37 @@ process.stdout.write(JSON.stringify({
   assert.match(loggedArgs, /--allowedTools=Read/);
   assert.match(loggedArgs, /Return a passing review\./);
 });
+
+test("claude adapter fails fast with an auth setup error before JSON parsing", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-claude-auth-"));
+  const fakeClaude = writeExecutable(fakeDir, "fake-claude.js", `#!/usr/bin/env node
+process.stdout.write("Not logged in · Please run /login\\n");
+process.exit(1);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CLAUDE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CLAUDE_BIN: fakeClaude },
+    });
+    assert.fail("expected invoke-reviewer-claude.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  assert.notEqual(error.status, 0);
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /not authenticated/i);
+  assert.match(stderr, /ANTHROPIC_API_KEY|claude login --api-key/);
+  assert.doesNotMatch(stderr, /did not return valid JSON/);
+});


### PR DESCRIPTION
## Summary

- Adds `probeClaudeAuth()` to `invoke-reviewer-claude.js`, invoked at the top of `main()` before prompt-file read and prompt assembly. When the probe detects `Not logged in` / `Please run /login`, it throws an actionable error naming the problem and pointing at `ANTHROPIC_API_KEY` / `claude login --api-key` / the SKILL.md section.
- Happy path unchanged: all existing flags, schema, and stdout shape preserved. Probe adds one light pre-flight call (~1-2s when authenticated, fast-fail when not).
- `skills/relay-review/SKILL.md` expands the vague "authenticated local Claude CLI session" note to name the separate `--bare` token requirement and the concrete fix.
- Option 2 + Option 1 from the issue body. Option 3 (skip-merge tier-3 fallback) explicitly out of scope.

## Why this matters

Matches the 2026-04-21 incident from PR #256: codex reviewer returned `escalated` (sandbox EPERM blocking `node --test`), the PR #254 reviewer-swap path was invoked, and it fell apart on the opaque JSON-parse error. This fix restores the reviewer-swap as a usable recovery path — the very purpose PR #254 was built for.

## Test plan

- [x] `node --test skills/relay-review/scripts/invoke-reviewer.test.js` — 4/4 pass, new test asserts (a) non-zero exit, (b) stderr contains `not authenticated` + fix pointer, (c) stderr does NOT contain `did not return valid JSON`
- [x] `node --test skills/relay-review/scripts/*.test.js skills/relay-dispatch/scripts/*.test.js` — 534/534 pass
- [x] Existing `--bare` / `--no-session-persistence` / `--allowedTools=Read` assertions still hold
- [x] No new runtime dependencies; no changes to `reviewer-helpers.js` or `review-runner.js`

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * Claude 어댑터 인증 설정 방법 업데이트: `ANTHROPIC_API_KEY` 환경 변수 설정 또는 `claude login --api-key` 명령어 실행 방법 안내

* **버그 수정**
  * Claude bare 모드 인증 사전 검증 추가: 리뷰 실행 전 인증 상태를 확인하여 더 명확한 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->