### PR TITLE
fix(relay-dispatch): disambiguate clean dispatch outcomes

### DIFF
--- a/docs/relay-scenario-tests.md
+++ b/docs/relay-scenario-tests.md
@@ -45,7 +45,7 @@ Expect:
 - dispatched worktree still exists after the command returns
 - harness explicitly removes the retained worktree during teardown
 
-### 3. Dispatch no-op failure writes manifest and ends in `escalated`
+### 3. Dispatch structured no-op writes manifest and ends in `review_pending`
 
 Command:
 
@@ -56,13 +56,14 @@ python3 skills/relay-dispatch/scripts/smoke_dispatch_scenarios.py
 Scenario:
 
 - create a temp git repo
-- dispatch a worker that inspects only and makes no changes
+- dispatch a worker that inspects only, makes no changes, and exits with a structured no-op summary
 
 Expect:
 
-- command exit code non-zero
-- `runState: escalated`
-- manifest contains `state: 'escalated'`
+- command exit code `0`
+- dispatch status `completed-no-op`
+- `runState: review_pending`
+- manifest contains `state: 'review_pending'`
 - manifest contains `cleanup: 'on_close'`
 - dispatched worktree still exists after the command returns
 - harness explicitly removes the retained worktree during teardown

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1006,9 +1006,8 @@ async function main() {
     uncommitted = git(wtPath, "status", "--porcelain");
   } catch {}
 
-  // Warn if executor produced no output (likely silent failure)
   const stdoutSize = fs.statSync(stdoutLog).size;
-  const noOutput = stdoutSize === 0 && !resultText;
+  const hasResult = resultText !== "";
 
   // Detect approval-wait: executor stopped to ask for confirmation instead of working.
   const BLOCKED_PATTERNS = [
@@ -1026,13 +1025,17 @@ async function main() {
     error = error || `executor blocked on approval: ${resultText.split("\n")[0].slice(0, 120)}`;
   } else if (execResult.timedOut && hasWork) {
     status = "completed-with-warning";
-  } else if (exitCode === 0 && (noOutput || !hasWork)) {
+  } else if (exitCode === 0 && hasResult && !gitLog && !uncommitted) {
+    status = "completed-no-op";
+  } else if (exitCode === 0 && hasResult && !gitLog && uncommitted) {
+    status = "completed-uncommitted";
+  } else if (exitCode === 0 && gitLog) {
+    status = "completed";
+  } else if (exitCode === 0 && (stdoutSize === 0 || !hasResult)) {
     status = "failed";
     error = error || "executor produced no output and no changes (silent failure)";
-  } else if (exitCode === 0) {
-    status = "completed";
   } else {
-    status = "failed";
+    status = exitCode === 0 ? "completed" : "failed";
   }
 
   let prNumber = manifest.git?.pr_number ?? manifest.github?.pr_number ?? null;

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1006,7 +1006,6 @@ async function main() {
     uncommitted = git(wtPath, "status", "--porcelain");
   } catch {}
 
-  const stdoutSize = fs.statSync(stdoutLog).size;
   const hasResult = resultText !== "";
 
   // Detect approval-wait: executor stopped to ask for confirmation instead of working.
@@ -1023,17 +1022,17 @@ async function main() {
   if (looksBlocked) {
     status = "failed";
     error = error || `executor blocked on approval: ${resultText.split("\n")[0].slice(0, 120)}`;
+  } else if (!hasResult) {
+    status = "failed";
+    error = error || "executor produced no structured result file or summary (silent failure)";
   } else if (execResult.timedOut && hasWork) {
     status = "completed-with-warning";
-  } else if (exitCode === 0 && hasResult && !gitLog && !uncommitted) {
+  } else if (exitCode === 0 && !gitLog && !uncommitted) {
     status = "completed-no-op";
-  } else if (exitCode === 0 && hasResult && !gitLog && uncommitted) {
+  } else if (exitCode === 0 && !gitLog && uncommitted) {
     status = "completed-uncommitted";
   } else if (exitCode === 0 && gitLog) {
     status = "completed";
-  } else if (exitCode === 0 && (stdoutSize === 0 || !hasResult)) {
-    status = "failed";
-    error = error || "executor produced no output and no changes (silent failure)";
   } else {
     status = exitCode === 0 ? "completed" : "failed";
   }

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -224,7 +224,48 @@ if (args[0] !== "exec") {
   process.exit(1);
 }
 const output = args[args.indexOf("-o") + 1];
-fs.writeFileSync(output, "ok\\n", "utf-8");
+fs.writeFileSync(output, "already applied\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
+function writeSilentCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
+function writeUncommittedCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+fs.appendFileSync(cwd + "/README.md", "dirty\\n", "utf-8");
+fs.writeFileSync(output, "work completed without commit\\n", "utf-8");
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
@@ -366,6 +407,10 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-push-pr-bin-"));
   if (codexMode === "noop") {
     writeNoOpCodex(binDir);
+  } else if (codexMode === "silent") {
+    writeSilentCodex(binDir);
+  } else if (codexMode === "uncommitted") {
+    writeUncommittedCodex(binDir);
   } else {
     writeFakeCodex(binDir);
   }
@@ -374,12 +419,35 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
   const ghStatePath = path.join(root, "gh-state.json");
   const ghLogPath = path.join(root, "gh-log.jsonl");
   const execLogPath = path.join(root, "exec-log.jsonl");
+  const pushPrCountPath = path.join(root, "push-pr-count.txt");
   fs.writeFileSync(ghStatePath, JSON.stringify(ghState), "utf-8");
+  fs.writeFileSync(pushPrCountPath, "0", "utf-8");
 
   const preloadPath = writePreloadScript(root, "dispatch-push-pr-preload.js", `
 const fs = require("fs");
+const Module = require("module");
 const childProcess = require("child_process");
+const originalLoad = Module._load;
 const originalExecFileSync = childProcess.execFileSync;
+Module._load = function patchedLoad(request, parent, isMain) {
+  const loaded = originalLoad.apply(this, arguments);
+  if (request === "./dispatch-publish" || request.endsWith("/dispatch-publish")) {
+    return {
+      ...loaded,
+      async pushAndOpenPR(...args) {
+        const countPath = process.env.RELAY_TEST_PUSH_PR_COUNT;
+        if (countPath) {
+          const current = fs.existsSync(countPath)
+            ? Number(fs.readFileSync(countPath, "utf-8")) || 0
+            : 0;
+          fs.writeFileSync(countPath, String(current + 1), "utf-8");
+        }
+        return loaded.pushAndOpenPR(...args);
+      },
+    };
+  }
+  return loaded;
+};
 childProcess.execFileSync = function patchedExecFileSync(command, args, options) {
   const argv = Array.isArray(args) ? args : [];
   const logPath = process.env.RELAY_TEST_EXEC_LOG;
@@ -435,10 +503,11 @@ childProcess.execFileSync = function patchedExecFileSync(command, args, options)
     RELAY_TEST_GH_STATE: ghStatePath,
     RELAY_TEST_GH_LOG: ghLogPath,
     RELAY_TEST_EXEC_LOG: execLogPath,
+    RELAY_TEST_PUSH_PR_COUNT: pushPrCountPath,
     ...(failGitPush ? { RELAY_TEST_FAIL_GIT_PUSH: "1" } : {}),
   }, preloadPath);
 
-  return { env, ghLogPath, execLogPath, ghStatePath };
+  return { env, ghLogPath, execLogPath, ghStatePath, pushPrCountPath };
 }
 
 function createGitOnlyPath() {
@@ -2013,14 +2082,14 @@ test("dispatch skips PR creation when the branch already has an open PR", () => 
   assert.deepEqual(ghCalls.map((args) => args.slice(0, 2)), [["pr", "list"]]);
 });
 
-test("dispatch silent-failure path skips orchestrator push and PR creation when no commits were made", () => {
+test("dispatch silent failure escalates when executor exits cleanly without stdout or result file", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
-  const { env, ghLogPath, execLogPath } = createPushPrTestEnv({
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
     relayHome,
     ghState: {
       prCreateUrl: "https://github.com/acme/dev-relay/pull/324",
     },
-    codexMode: "noop",
+    codexMode: "silent",
   });
 
   const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
@@ -2038,8 +2107,101 @@ test("dispatch silent-failure path skips orchestrator push and PR creation when 
   assert.equal(result.status, "failed");
   assert.equal(result.runState, STATES.ESCALATED);
   assert.match(result.error, /silent failure/);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.ESCALATED);
+  assert.equal(fs.existsSync(result.resultFile), false);
   assert.deepEqual(readJsonLines(ghLogPath), []);
   assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch marks verified no-op runs as completed-no-op and skips orchestrator publication", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/325",
+    },
+    codexMode: "noop",
+  });
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-263-noop",
+    "--prompt", "nothing to do",
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed-no-op");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.equal(result.commits, "");
+  assert.equal(result.uncommitted, null);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch marks uncommitted result runs as completed-uncommitted and skips orchestrator publication", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/326",
+    },
+    codexMode: "uncommitted",
+  });
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-263-uncommitted",
+    "--prompt", "work without commit",
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed-uncommitted");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.equal(result.commits, "");
+  assert.match(result.uncommitted, /README\.md/);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch uses result-file presence to distinguish silent failure from verified no-op", () => {
+  const silentFixture = setupRepoWithOrigin();
+  const silentEnv = createPushPrTestEnv({
+    relayHome: silentFixture.relayHome,
+    codexMode: "silent",
+  });
+  const silentProc = spawnSync("node", [SCRIPT, silentFixture.repoRoot, ...withRequiredRubric([
+    "-b", "issue-263-silent-pair",
+    "--prompt", "same inputs without result file",
+    "--json",
+  ])], {
+    cwd: silentFixture.repoRoot,
+    encoding: "utf-8",
+    env: silentEnv.env,
+  });
+  assert.notEqual(silentProc.status, 0);
+  const silentResult = JSON.parse(silentProc.stdout);
+
+  const noOpFixture = setupRepoWithOrigin();
+  const noOpEnv = createPushPrTestEnv({
+    relayHome: noOpFixture.relayHome,
+    codexMode: "noop",
+  });
+  const noOpResult = JSON.parse(runDispatch(noOpFixture.repoRoot, [
+    "-b", "issue-263-noop-pair",
+    "--prompt", "same inputs with result file",
+    "--json",
+  ], noOpEnv.env));
+
+  assert.equal(silentResult.status, "failed");
+  assert.equal(noOpResult.status, "completed-no-op");
+  assert.equal(fs.existsSync(silentResult.resultFile), false);
+  assert.equal(fs.existsSync(noOpResult.resultFile), true);
 });
 
 test("re-dispatch prompt includes previous iteration history", () => {

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -248,6 +248,31 @@ if (args[0] !== "exec") {
   return codexPath;
 }
 
+function writeCommittedNoResultCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const cwd = args[args.indexOf("-C") + 1];
+const fileName = "commit-no-result.txt";
+fs.writeFileSync(cwd + "/" + fileName, "commit without result\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "commit without result"], { stdio: "pipe" });
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
 function writeUncommittedCodex(binDir) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -266,6 +291,28 @@ const cwd = args[args.indexOf("-C") + 1];
 const output = args[args.indexOf("-o") + 1];
 fs.appendFileSync(cwd + "/README.md", "dirty\\n", "utf-8");
 fs.writeFileSync(output, "work completed without commit\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
+function writePartialNoResultCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const cwd = args[args.indexOf("-C") + 1];
+fs.appendFileSync(cwd + "/README.md", "partial without result\\n", "utf-8");
+setTimeout(() => {}, 60000);
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
@@ -409,8 +456,12 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
     writeNoOpCodex(binDir);
   } else if (codexMode === "silent") {
     writeSilentCodex(binDir);
+  } else if (codexMode === "commit-no-result") {
+    writeCommittedNoResultCodex(binDir);
   } else if (codexMode === "uncommitted") {
     writeUncommittedCodex(binDir);
+  } else if (codexMode === "partial-no-result") {
+    writePartialNoResultCodex(binDir);
   } else {
     writeFakeCodex(binDir);
   }
@@ -2110,6 +2161,78 @@ test("dispatch silent failure escalates when executor exits cleanly without stdo
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.state, STATES.ESCALATED);
   assert.equal(fs.existsSync(result.resultFile), false);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch escalates committed work when the executor omits the structured result file", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/325",
+    },
+    codexMode: "commit-no-result",
+  });
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-263-commit-no-result",
+    "--prompt", "commit work but skip the structured result file",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.match(result.error, /structured result|silent failure/i);
+  assert.match(result.commits, /commit without result/);
+  assert.equal(result.uncommitted, null);
+  assert.equal(fs.existsSync(result.resultFile), false);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.ESCALATED);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch escalates partial timed-out work when the executor omits the structured result file", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/326",
+    },
+    codexMode: "partial-no-result",
+  });
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-263-partial-no-result",
+    "--prompt", "leave partial work without a structured result file",
+    "--timeout", "1",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.match(result.error, /timed out/);
+  assert.equal(result.commits, "");
+  assert.match(result.uncommitted, /README\.md/);
+  assert.match(result.uncommittedDiff, /README\.md/);
+  assert.equal(fs.existsSync(result.resultFile), false);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.ESCALATED);
   assert.deepEqual(readJsonLines(ghLogPath), []);
   assert.deepEqual(readJsonLines(execLogPath), []);
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);

--- a/skills/relay-dispatch/scripts/smoke_dispatch_scenarios.py
+++ b/skills/relay-dispatch/scripts/smoke_dispatch_scenarios.py
@@ -32,14 +32,28 @@ def init_repo(name: str) -> pathlib.Path:
     return repo
 
 
-def read_dispatch_metadata(stdout: str) -> tuple[str | None, str | None, str | None]:
+def write_rubric(repo: pathlib.Path) -> pathlib.Path:
+    rubric = repo.parent / "smoke-rubric.yaml"
+    rubric.write_text(
+        "rubric:\n"
+        "  factors:\n"
+        "    - name: smoke validation\n"
+        "      target: command exits cleanly\n",
+        encoding="utf-8",
+    )
+    return rubric
+
+
+def read_dispatch_metadata(stdout: str) -> tuple[str | None, str | None, str | None, str | None]:
+    status_match = re.search(r"--- Dispatch ([a-z-]+) \(", stdout)
     manifest_match = re.search(r"Manifest: (.+)", stdout)
     state_match = re.search(r"Run state: ([a-z_]+)", stdout)
     worktree_match = re.search(r"Worktree: (.+)", stdout)
+    dispatch_status = status_match.group(1).strip() if status_match else None
     manifest_path = manifest_match.group(1).strip() if manifest_match else None
     run_state = state_match.group(1).strip() if state_match else None
     worktree_path = worktree_match.group(1).strip() if worktree_match else None
-    return manifest_path, run_state, worktree_path
+    return dispatch_status, manifest_path, run_state, worktree_path
 
 
 def cleanup_worktree(repo: pathlib.Path, worktree_path: str | None) -> bool:
@@ -54,21 +68,35 @@ def cleanup_worktree(repo: pathlib.Path, worktree_path: str | None) -> bool:
 
 def scenario_success() -> dict:
     repo = init_repo("relay-smoke-success")
+    rubric = write_rubric(repo)
     prompt = (
         "In this repository, create a file named smoke.txt with the single line ok. "
         "Commit the change. Do not open a pull request."
     )
     result = run(
-        ["node", str(DISPATCH), str(repo), "-b", "issue-7", "--prompt", prompt, "--timeout", "300"],
+        [
+            "node",
+            str(DISPATCH),
+            str(repo),
+            "-b",
+            "issue-7",
+            "--prompt",
+            prompt,
+            "--timeout",
+            "300",
+            "--rubric-file",
+            str(rubric),
+        ],
         ROOT,
     )
-    manifest_path, run_state, worktree_path = read_dispatch_metadata(result.stdout)
+    dispatch_status, manifest_path, run_state, worktree_path = read_dispatch_metadata(result.stdout)
     manifest_text = pathlib.Path(manifest_path).read_text(encoding="utf-8") if manifest_path else ""
     smoke_exists = (repo / ".relay").exists()
     branch_tip = run(["git", "rev-parse", "--verify", "issue-7"], repo).stdout.strip()
     worktree_exists = pathlib.Path(worktree_path).exists() if worktree_path else False
     passed = (
         result.returncode == 0
+        and dispatch_status == "completed"
         and run_state == "review_pending"
         and "state: 'review_pending'" in manifest_text
         and bool(branch_tip)
@@ -79,6 +107,7 @@ def scenario_success() -> dict:
         "name": "success_with_commit",
         "passed": passed,
         "returncode": result.returncode,
+        "dispatch_status": dispatch_status,
         "run_state": run_state,
         "manifest_path": manifest_path,
         "worktree_path": worktree_path,
@@ -94,34 +123,49 @@ def scenario_success() -> dict:
     return output
 
 
-def scenario_noop_failure() -> dict:
+def scenario_noop_review_pending() -> dict:
     repo = init_repo("relay-smoke-fail")
+    rubric = write_rubric(repo)
     prompt = (
         "Inspect the repository but do not change any files, do not create any commits, "
         "and do not open a pull request."
     )
     result = run(
-        ["node", str(DISPATCH), str(repo), "-b", "issue-8", "--prompt", prompt, "--timeout", "180"],
+        [
+            "node",
+            str(DISPATCH),
+            str(repo),
+            "-b",
+            "issue-8",
+            "--prompt",
+            prompt,
+            "--timeout",
+            "180",
+            "--rubric-file",
+            str(rubric),
+        ],
         ROOT,
     )
-    manifest_path, run_state, worktree_path = read_dispatch_metadata(result.stdout)
+    dispatch_status, manifest_path, run_state, worktree_path = read_dispatch_metadata(result.stdout)
     manifest_text = pathlib.Path(manifest_path).read_text(encoding="utf-8") if manifest_path else ""
     worktree_exists = pathlib.Path(worktree_path).exists() if worktree_path else False
     passed = (
-        result.returncode != 0
-        and run_state == "escalated"
-        and "state: 'escalated'" in manifest_text
+        result.returncode == 0
+        and dispatch_status == "completed-no-op"
+        and run_state == "review_pending"
+        and "state: 'review_pending'" in manifest_text
         and "cleanup: 'on_close'" in manifest_text
         and worktree_exists
     )
     output = {
-        "name": "noop_escalates",
+        "name": "noop_review_pending",
         "passed": passed,
         "returncode": result.returncode,
+        "dispatch_status": dispatch_status,
         "run_state": run_state,
         "manifest_path": manifest_path,
         "worktree_path": worktree_path,
-        "manifest_contains_escalated": "state: 'escalated'" in manifest_text,
+        "manifest_contains_review_pending": "state: 'review_pending'" in manifest_text,
         "manifest_contains_on_close_cleanup": "cleanup: 'on_close'" in manifest_text,
         "worktree_exists_after_dispatch": worktree_exists,
         "stdout_tail": result.stdout[-1200:],
@@ -134,7 +178,7 @@ def scenario_noop_failure() -> dict:
 def main() -> None:
     report = {
         "success_with_commit": scenario_success(),
-        "noop_escalates": scenario_noop_failure(),
+        "noop_review_pending": scenario_noop_review_pending(),
     }
     report["all_passed"] = all(item["passed"] for item in report.values())
     print(json.dumps(report, indent=2))


### PR DESCRIPTION
## Dispatch Summary

```text
변경 완료했습니다. [dispatch.js](/Users/sjlee/.relay/worktrees/366d9643/dev-relay/skills/relay-dispatch/scripts/dispatch.js:1021)에서 `resultText !== ""`를 기준으로 `completed-no-op`와 `completed-uncommitted`를 분리했고, `failed`만 `escalated`로 가는 기존 lifecycle 분기는 그대로 유지했습니다. `pushAndOpenPR` 게이트도 byte-identical로 유지됐습니다: `if ((status === "completed" || status === "completed-with-warning") && !DRY_RUN && gitLog) {` ([dispatch.js](/Users/sjlee/.relay/worktrees/366d9643/dev-relay/skills/relay-dispatch/scripts/dispatch.js
```

## Score Log

- Run: issue-263-20260422130045225-8b41a3ac
- Executor: codex
- Branch: issue-263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 변경사항이 없는 경우(no-op) 처리 개선: 이제 실패가 아닌 "완료-미작동" 상태로 올바르게 보고됩니다.
  * 구조화된 결과 파일 기반의 더 정확한 상태 분류 로직 적용.
  * 침묵 실패와 검증된 미작동 상태의 구분 강화.

* **개선 사항**
  * git 활동 및 결과 파일 존재 여부에 따른 세분화된 상태 보고.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->