### PR TITLE
feat(relay-merge): add --force-finalize-nonready operator escape hatch

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/lifecycle.js
+++ b/skills/relay-dispatch/scripts/manifest/lifecycle.js
@@ -92,6 +92,24 @@ function forceTransitionState(data, toState, nextAction) {
   };
 }
 
+function forceUpdateManifestState(data, toState, nextAction, { reason, operator } = {}) {
+  if (typeof reason !== "string" || !reason.trim()) {
+    throw new Error("forceUpdateManifestState requires reason");
+  }
+
+  const updated = forceTransitionState(data, toState, nextAction);
+  return {
+    ...updated,
+    last_force: {
+      ts: nowIso(),
+      from_state: data.state,
+      to_state: toState,
+      reason,
+      operator: operator || null,
+    },
+  };
+}
+
 function isTerminalState(state) {
   return state === STATES.MERGED || state === STATES.CLOSED;
 }
@@ -99,6 +117,7 @@ function isTerminalState(state) {
 module.exports = {
   ALLOWED_TRANSITIONS,
   STATES,
+  forceUpdateManifestState,
   forceTransitionState,
   isTerminalState,
   updateManifestState,

--- a/skills/relay-dispatch/scripts/manifest/lifecycle.test.js
+++ b/skills/relay-dispatch/scripts/manifest/lifecycle.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const {
   STATES,
+  forceUpdateManifestState,
   validateTransitionInvariants,
   forceTransitionState,
   validateTransition,
@@ -209,5 +210,31 @@ test("manifest/lifecycle forceTransitionState keeps recovery edges but still enf
   assert.throws(
     () => forceTransitionState({ state: "bogus", timestamps: {} }, STATES.REVIEW_PENDING, "run_review"),
     /Unknown relay state/
+  );
+});
+
+test("manifest/lifecycle forceUpdateManifestState annotates last_force while bypassing the transition matrix", () => {
+  const updated = forceUpdateManifestState(
+    { state: STATES.ESCALATED, timestamps: {} },
+    STATES.MERGED,
+    "manual_cleanup_required",
+    { reason: "operator override", operator: "Relay Lifecycle Test" }
+  );
+
+  assert.equal(updated.state, STATES.MERGED);
+  assert.equal(updated.next_action, "manual_cleanup_required");
+  assert.equal(updated.last_force.from_state, STATES.ESCALATED);
+  assert.equal(updated.last_force.to_state, STATES.MERGED);
+  assert.equal(updated.last_force.reason, "operator override");
+  assert.equal(updated.last_force.operator, "Relay Lifecycle Test");
+
+  assert.throws(
+    () => forceUpdateManifestState(
+      { state: STATES.ESCALATED, timestamps: {} },
+      STATES.MERGED,
+      "manual_cleanup_required",
+      { reason: "   " }
+    ),
+    /forceUpdateManifestState requires reason/
   );
 });

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -60,6 +60,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.last_reviewed_sha !== undefined
       ? { last_reviewed_sha: normalizeEventValue(eventData.last_reviewed_sha) }
       : {}),
+    ...(eventData.pr_number !== undefined
+      ? { pr_number: normalizeEventValue(eventData.pr_number) }
+      : {}),
     ...(eventData.model !== undefined
       ? { model: normalizeEventValue(eventData.model) }
       : {}),

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -188,6 +188,22 @@ test("appendRunEvent persists last_reviewed_sha when provided", () => {
   assert.equal(parsed.last_reviewed_sha, "cafef00d");
 });
 
+test("appendRunEvent persists pr_number when provided", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendRunEvent(repoRoot, runId, {
+    event: "force_finalize",
+    state_from: "escalated",
+    state_to: "merged",
+    head_sha: "deadbeef",
+    reason: "operator override",
+    pr_number: 123,
+  });
+
+  const [parsed] = readRunEvents(repoRoot, runId);
+  assert.equal(record.pr_number, 123);
+  assert.equal(parsed.pr_number, 123);
+});
+
 test("appendRunEvent omits last_reviewed_sha when absent", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {

--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -60,6 +60,29 @@ node ${CLAUDE_SKILL_DIR}/scripts/finalize-run.js --repo . --run-id "$RUN_ID" --s
 
 `finalize-run.js --skip-review` bypasses reviewer invocation, so `model_hints.review` is a non-consumer on that path.
 
+#### Operator-only force finalize for non-ready runs
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/finalize-run.js --repo . --run-id "$RUN_ID" \
+  --force-finalize-nonready --reason "reviewer-swap exhausted, diff clean per manual inspection" --json
+```
+
+Use this only when an operator has independently checked that the PR is mergeable but the manifest cannot reach `ready_to_merge`.
+Typical cases: state stuck at `escalated` with a clean diff; reviewer-swap unavailable; manifest/PR state desync.
+This path is loud on purpose: it records a `force_finalize` event before merge and writes `last_force` into the manifest.
+`--force-finalize-nonready` requires `--reason <non-empty-text>`.
+`--dry-run` is observation-only on this path: it does not append `force_finalize`.
+
+Do not use it for retry loops.
+Do not use it as a test shortcut.
+Do not use it to paper over a wrong manifest state that should be repaired instead.
+
+Audit every use:
+
+```bash
+jq 'select(.event == "force_finalize")' ~/.relay/runs/<repo-slug>/<run-id>/events.jsonl
+```
+
 ### 2. Sprint file update (if available)
 
 If `backlog/sprints/` has an active sprint file, update it. If no sprint file exists, skip this step.

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 /**
  * Merge a ready relay run, then finalize cleanup and manifest metadata.
+ * Operator-only escape hatch: `--force-finalize-nonready --reason <text>`
+ * bypasses the manifest state gate for non-terminal runs, emits a loud
+ * `force_finalize` audit event, and records `last_force` in the manifest
+ * before the merge side effect.
  *
  * Usage:
  *   ./finalize-run.js --repo <path> --run-id <id> [options]
@@ -15,6 +19,9 @@
  *   --pr <number>          Pull request number (optional when stored in manifest)
  *   --merge-method <name>  squash | merge | rebase (default: squash)
  *   --skip-review <reason> Bypass the fresh-review gate with an audit reason
+ *   --force-finalize-nonready
+ *                          Operator-only: bypass non-ready state gate
+ *   --reason <text>        Required with --force-finalize-nonready
  *   --skip-merge           Skip the PR merge step and run cleanup only
  *   --no-issue-close       Skip linked issue close
  *   --dry-run              Print what would happen without writing
@@ -32,9 +39,14 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
   STATES,
+  forceUpdateManifestState,
   updateManifestState,
 } = require("../../relay-dispatch/scripts/manifest/lifecycle");
-const { summarizeError, writeManifest } = require("../../relay-dispatch/scripts/manifest/store");
+const {
+  getActorName,
+  summarizeError,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/manifest/store");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
 const { runCleanup } = require("../../relay-dispatch/scripts/manifest/cleanup");
@@ -49,6 +61,7 @@ const {
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
   "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method", "--skip-review",
+  "--force-finalize-nonready", "--reason",
   "--skip-merge", "--no-issue-close", "--dry-run", "--json", "--help", "-h",
 ];
 
@@ -63,6 +76,9 @@ if (!args.length || args.includes("--help") || args.includes("-h")) {
   console.log("  --pr <number>          Pull request number (optional when stored in manifest)");
   console.log("  --merge-method <name>  squash | merge | rebase (default: squash)");
   console.log("  --skip-review <reason> Bypass the fresh-review gate with an audit reason");
+  console.log("  --force-finalize-nonready");
+  console.log("                         Operator-only: bypass non-ready state gate");
+  console.log("  --reason <text>        Required with --force-finalize-nonready");
   console.log("  --skip-merge           Skip the PR merge step and run cleanup only");
   console.log("  --no-issue-close       Skip linked issue close");
   console.log("  --dry-run              Print what would happen without writing");
@@ -153,6 +169,20 @@ function fetchPrMergeState(ghBin, repoPath, prNumber) {
   };
 }
 
+function assertPreMergeSafety(preMerge, prNumber) {
+  if (preMerge.mergeable === "CONFLICTING") {
+    throw new Error(
+      `PR #${prNumber} has merge conflicts with the base branch. Resolve conflicts and push, then retry.`
+    );
+  }
+  if (preMerge.failing.length > 0) {
+    const names = preMerge.failing.map((c) => c.name || c.context || "unknown").join(", ");
+    throw new Error(
+      `PR #${prNumber} has failing CI checks: ${names}. Fix these before merging.`
+    );
+  }
+}
+
 function resolveRemoteName(gitBin, repoPath, branch) {
   if (!branch) return null;
   try {
@@ -226,12 +256,17 @@ function main() {
   let prNumber = parsePositiveInt(getArg("--pr"), "--pr");
   const mergeMethod = getArg("--merge-method") || "squash";
   const skipReviewReason = getArg("--skip-review");
+  const forceFinalizeNonready = hasFlag("--force-finalize-nonready");
+  const forceFinalizeReason = getArg("--reason");
   const dryRun = hasFlag("--dry-run");
   const skipMerge = hasFlag("--skip-merge");
   const skipIssueClose = hasFlag("--no-issue-close");
   const jsonOut = hasFlag("--json");
   const ghBin = process.env.RELAY_GH_BIN || "gh";
   const gitBin = process.env.RELAY_GIT_BIN || "git";
+  if (forceFinalizeNonready && !String(forceFinalizeReason || "").trim()) {
+    throw new Error("--force-finalize-nonready requires --reason <non-empty-text>");
+  }
 
   let branch = getArg("--branch");
   let manifestRecord = resolveManifestRecord({
@@ -278,19 +313,35 @@ function main() {
       worktree: validatedPaths.worktree,
     },
   };
+  const FORCE_FINALIZE_ALLOWED_STATES = new Set([
+    STATES.DRAFT,
+    STATES.DISPATCHED,
+    STATES.REVIEW_PENDING,
+    STATES.CHANGES_REQUESTED,
+    STATES.ESCALATED,
+    STATES.READY_TO_MERGE,
+  ]);
   prNumber = prNumber || safeData.git?.pr_number || null;
   branch = resolveBranch(ghBin, repoPath, prNumber, branch, safeData);
   if (!skipMerge && !prNumber) {
     throw new Error("PR number is required for merge finalization");
   }
+  if (forceFinalizeNonready && (safeData.state === STATES.MERGED || safeData.state === STATES.CLOSED)) {
+    throw new Error(`force-finalize cannot be used from terminal state ${safeData.state}`);
+  }
+  if (forceFinalizeNonready && !FORCE_FINALIZE_ALLOWED_STATES.has(safeData.state)) {
+    throw new Error(`force-finalize cannot be used from state ${safeData.state}`);
+  }
   if (skipMerge && safeData.state !== STATES.MERGED) {
     throw new Error("--skip-merge can only be used for runs that are already in the merged state");
   }
-  if (!skipMerge && safeData.state !== STATES.READY_TO_MERGE) {
+  if (!skipMerge && !forceFinalizeNonready && safeData.state !== STATES.READY_TO_MERGE) {
     if (safeData.state !== STATES.MERGED) {
       throw new Error(`Expected relay run to be ${STATES.READY_TO_MERGE} before merge, got ${safeData.state}`);
     }
   }
+  const mergeAllowed = !skipMerge && (safeData.state === STATES.READY_TO_MERGE || forceFinalizeNonready);
+  const operatorName = getActorName(repoPath);
 
   let updated = safeData;
   let mergePerformed = false;
@@ -303,33 +354,35 @@ function main() {
   let issueClosed = false;
   let issueCloseWarning = null;
   let reviewGate = null;
+  let currentHeadSha = safeData.git?.head_sha || null;
   const skipReviewRubricAudit = summarizeRubricAuditForSkip(safeData, {
     runDir: getRunDir(validatedPaths.repoRoot, safeData.run_id),
   });
   const skipReviewRubricStatus = skipReviewRubricAudit.rubricStatus;
 
-  if (!skipMerge && safeData.state === STATES.READY_TO_MERGE) {
+  if (mergeAllowed) {
+    currentHeadSha = git(gitBin, validatedPaths.worktree, "rev-parse", "HEAD");
     if (skipReviewReason) {
-      reviewGate = buildSkipReviewGateFailure(prNumber, skipReviewRubricAudit);
-      if (reviewGate) {
+      const skipReviewFailure = buildSkipReviewGateFailure(prNumber, skipReviewRubricAudit);
+      if (skipReviewFailure) {
         if (!dryRun) {
           appendRunEvent(repoPath, safeData.run_id, {
             event: "merge_blocked",
             state_from: safeData.state,
             state_to: safeData.state,
-            head_sha: safeData.git?.head_sha || null,
+            head_sha: currentHeadSha,
             round: safeData.review?.rounds || null,
-            reason: reviewGate.status,
+            reason: skipReviewFailure.status,
           });
         }
-        throw new Error(`Fresh review gate failed: ${reviewGate.status}`);
+        throw new Error(`Fresh review gate failed: ${skipReviewFailure.status}`);
       }
       reviewGate = {
         status: "skipped",
         pr: prNumber,
         reason: skipReviewReason,
         rubricStatus: skipReviewRubricStatus,
-        readyToMerge: true,
+        readyToMerge: safeData.state === STATES.READY_TO_MERGE,
       };
       if (!dryRun) {
         const skipComment = buildSkipComment(skipReviewReason, skipReviewRubricAudit);
@@ -337,14 +390,14 @@ function main() {
           event: "skip_review",
           state_from: safeData.state,
           state_to: safeData.state,
-          head_sha: safeData.git?.head_sha || null,
+          head_sha: currentHeadSha,
           round: safeData.review?.rounds || null,
           reason: skipReviewReason,
           rubric_status: skipReviewRubricStatus,
         });
         gh(ghBin, repoPath, "pr", "comment", String(prNumber), "--body", skipComment);
       }
-    } else {
+    } else if (safeData.state === STATES.READY_TO_MERGE) {
       const preMerge = fetchPreMergeContext(ghBin, repoPath, prNumber);
       reviewGate = evaluateReviewGate({
         prNumber,
@@ -360,29 +413,33 @@ function main() {
             event: "merge_blocked",
             state_from: safeData.state,
             state_to: safeData.state,
-            head_sha: reviewGate.latestCommit || safeData.git?.head_sha || null,
+            head_sha: reviewGate.latestCommit || currentHeadSha,
             round: safeData.review?.rounds || null,
             reason: reviewGate.status,
           });
         }
         throw new Error(`Fresh review gate failed: ${reviewGate.status}`);
       }
-      // CI status and merge conflict check (from the same API call)
-      if (preMerge.mergeable === "CONFLICTING") {
-        throw new Error(
-          `PR #${prNumber} has merge conflicts with the base branch. Resolve conflicts and push, then retry.`
-        );
-      }
-      if (preMerge.failing.length > 0) {
-        const names = preMerge.failing.map((c) => c.name || c.context || "unknown").join(", ");
-        throw new Error(
-          `PR #${prNumber} has failing CI checks: ${names}. Fix these before merging.`
-        );
-      }
+      assertPreMergeSafety(preMerge, prNumber);
+    } else if (forceFinalizeNonready) {
+      const preMerge = fetchPreMergeContext(ghBin, repoPath, prNumber);
+      assertPreMergeSafety(preMerge, prNumber);
     }
   }
 
-  if (!skipMerge && safeData.state === STATES.READY_TO_MERGE) {
+  if (mergeAllowed) {
+    if (forceFinalizeNonready && !dryRun) {
+      appendRunEvent(repoPath, safeData.run_id, {
+        event: "force_finalize",
+        state_from: safeData.state,
+        state_to: STATES.MERGED,
+        head_sha: currentHeadSha,
+        round: safeData.review?.rounds || null,
+        reason: forceFinalizeReason,
+        pr_number: prNumber,
+        last_reviewed_sha: safeData.review?.last_reviewed_sha,
+      });
+    }
 
     prMergeState = dryRun ? prMergeState : fetchPrMergeState(ghBin, repoPath, prNumber);
     if (!dryRun && prMergeState.state !== "MERGED") {
@@ -426,7 +483,7 @@ function main() {
             event: "merge_blocked",
             state_from: safeData.state,
             state_to: safeData.state,
-            head_sha: reviewGate?.latestCommit || safeData.git?.head_sha || null,
+            head_sha: reviewGate?.latestCommit || currentHeadSha,
             round: safeData.review?.rounds || null,
             reason: "removed_from_merge_queue",
           });
@@ -440,7 +497,7 @@ function main() {
           event: "merge_blocked",
           state_from: safeData.state,
           state_to: safeData.state,
-          head_sha: reviewGate?.latestCommit || safeData.git?.head_sha || null,
+          head_sha: reviewGate?.latestCommit || currentHeadSha,
           round: safeData.review?.rounds || null,
           reason: `merge_queue_timeout:${prMergeState.state || "unknown"}`,
         });
@@ -459,12 +516,17 @@ function main() {
     } else {
       remoteBranchDeleted = true;
     }
-    updated = updateManifestState(updated, STATES.MERGED, "manual_cleanup_required");
+    updated = forceFinalizeNonready
+      ? forceUpdateManifestState(updated, STATES.MERGED, "manual_cleanup_required", {
+        reason: forceFinalizeReason,
+        operator: operatorName,
+      })
+      : updateManifestState(updated, STATES.MERGED, "manual_cleanup_required");
     updated = {
       ...updated,
       git: {
         ...(updated.git || {}),
-        head_sha: reviewGate?.latestCommit || updated.review?.last_reviewed_sha || updated.git?.head_sha || null,
+        head_sha: currentHeadSha || reviewGate?.latestCommit || updated.review?.last_reviewed_sha || updated.git?.head_sha || null,
       },
     };
     if (!dryRun) {
@@ -539,6 +601,8 @@ function main() {
     issueCloseWarning,
     cleanup: cleanupResult.summary,
     dryRun,
+    forceFinalized: forceFinalizeNonready,
+    forceFinalizeReason: forceFinalizeNonready ? forceFinalizeReason : null,
   };
 
   if (jsonOut) {

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -18,10 +18,81 @@ const { readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
 const { createEnforcementFixture } = require("../../relay-dispatch/scripts/test-support");
 
 const SCRIPT = path.join(__dirname, "finalize-run.js");
+const DEFAULT_COMMIT_DATE = "2026-04-03T08:00:00Z";
+const DEFAULT_REVIEW_COMMENT = {
+  body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+  createdAt: DEFAULT_COMMIT_DATE,
+};
+
+function buildManifestForState(manifest, targetState) {
+  switch (targetState) {
+    case STATES.DRAFT:
+      return manifest;
+    case STATES.DISPATCHED:
+      return updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+    case STATES.REVIEW_PENDING: {
+      const dispatched = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+      const reviewPending = updateManifestState(dispatched, STATES.REVIEW_PENDING, "run_review");
+      return {
+        ...reviewPending,
+        review: {
+          ...(reviewPending.review || {}),
+          last_reviewed_sha: reviewPending.git?.head_sha || null,
+          latest_verdict: "pending",
+          rounds: 1,
+        },
+      };
+    }
+    case STATES.CHANGES_REQUESTED: {
+      const reviewPending = buildManifestForState(manifest, STATES.REVIEW_PENDING);
+      const requested = updateManifestState(reviewPending, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+      return {
+        ...requested,
+        review: {
+          ...(requested.review || {}),
+          latest_verdict: "changes_requested",
+        },
+      };
+    }
+    case STATES.READY_TO_MERGE: {
+      const reviewPending = buildManifestForState(manifest, STATES.REVIEW_PENDING);
+      const ready = updateManifestState(reviewPending, STATES.READY_TO_MERGE, "await_explicit_merge");
+      return {
+        ...ready,
+        review: {
+          ...(ready.review || {}),
+          latest_verdict: "lgtm",
+        },
+      };
+    }
+    case STATES.ESCALATED: {
+      const reviewPending = buildManifestForState(manifest, STATES.REVIEW_PENDING);
+      const escalated = updateManifestState(reviewPending, STATES.ESCALATED, "inspect_review_failure");
+      return {
+        ...escalated,
+        review: {
+          ...(escalated.review || {}),
+          latest_verdict: "escalated",
+        },
+      };
+    }
+    case STATES.MERGED: {
+      const ready = buildManifestForState(manifest, STATES.READY_TO_MERGE);
+      return updateManifestState(ready, STATES.MERGED, "manual_cleanup_required");
+    }
+    case STATES.CLOSED: {
+      const ready = buildManifestForState(manifest, STATES.READY_TO_MERGE);
+      return updateManifestState(ready, STATES.CLOSED, "done");
+    }
+    default:
+      throw new Error(`Unsupported fixture manifest state: ${targetState}`);
+  }
+}
 
 function setupRepo({
   dirtyWorktree = false,
   enforcementState = "loaded",
+  manifestState = STATES.READY_TO_MERGE,
 } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-finalize-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
@@ -66,19 +137,14 @@ function setupRepo({
     executor: "codex",
     reviewer: "codex",
   });
-  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
   manifest.anchor = createEnforcementFixture({
     repoRoot,
     runId,
     state: enforcementState,
   }).anchor;
-  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
-  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
   manifest.git.pr_number = 123;
   manifest.git.head_sha = headSha;
-  manifest.review.last_reviewed_sha = headSha;
-  manifest.review.latest_verdict = "lgtm";
-  manifest.review.rounds = 1;
+  manifest = buildManifestForState(manifest, manifestState);
   writeManifest(manifestPath, manifest);
 
   return { repoRoot, manifestPath, branch, worktreePath, headSha, runId };
@@ -265,6 +331,273 @@ function runFinalizeSkipReview({
     events: readRunEvents(fixture.repoRoot, fixture.runId),
   };
 }
+
+function execFinalize(fixture, {
+  extraArgs = [],
+  ghOptions = {},
+  env = {},
+  selectorArgs = ["--repo", fixture.repoRoot, "--branch", fixture.branch],
+  cwd = fixture.repoRoot,
+} = {}) {
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [],
+    commits: [
+      {
+        oid: fixture.headSha,
+        committedDate: DEFAULT_COMMIT_DATE,
+      },
+    ],
+    ...ghOptions,
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    ...selectorArgs,
+    "--pr", "123",
+    ...extraArgs,
+    "--json",
+  ], {
+    cwd,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh, ...env },
+  });
+
+  return {
+    ...fixture,
+    logPath,
+    result: JSON.parse(stdout),
+    events: readRunEvents(fixture.repoRoot, fixture.runId),
+  };
+}
+
+test("finalize-run force-finalize merges an escalated run with an auditable event trail", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+  const forceReason = "reviewer-swap exhausted, diff clean per manual inspection";
+  const { result, events, repoRoot, manifestPath, branch, worktreePath, logPath, headSha } = execFinalize(fixture, {
+    extraArgs: ["--force-finalize-nonready", "--reason", forceReason],
+  });
+
+  const forceEvent = events.find((entry) => entry.event === "force_finalize");
+  const mergeEvent = events.find((entry) => entry.event === "merge_finalize");
+  const manifest = readManifest(manifestPath).data;
+
+  assert.equal(result.previousState, STATES.ESCALATED);
+  assert.equal(result.state, STATES.MERGED);
+  assert.equal(result.forceFinalized, true);
+  assert.equal(result.forceFinalizeReason, forceReason);
+  assert.equal(forceEvent?.state_from, STATES.ESCALATED);
+  assert.equal(forceEvent?.state_to, STATES.MERGED);
+  assert.equal(forceEvent?.reason, forceReason);
+  assert.equal(forceEvent?.pr_number, 123);
+  assert.equal(forceEvent?.last_reviewed_sha, headSha);
+  assert.equal(forceEvent?.head_sha, headSha);
+  assert.equal(mergeEvent?.state_to, STATES.MERGED);
+  assert.equal(manifest.state, STATES.MERGED);
+  assert.equal(manifest.last_force.reason, forceReason);
+  assert.equal(manifest.last_force.from_state, STATES.ESCALATED);
+  assert.equal(manifest.last_force.to_state, STATES.MERGED);
+  assert.equal(fs.existsSync(worktreePath), false);
+  assert.equal(branchExists(repoRoot, branch), false);
+  assert.equal(remoteBranchExists(repoRoot, branch), false);
+  assert.match(fs.readFileSync(logPath, "utf-8"), /pr merge 123 --squash/);
+});
+
+for (const sourceState of [
+  STATES.REVIEW_PENDING,
+  STATES.CHANGES_REQUESTED,
+  STATES.DISPATCHED,
+  STATES.DRAFT,
+]) {
+  test(`finalize-run force-finalize merges a ${sourceState} run`, () => {
+    const fixture = setupRepo({ manifestState: sourceState });
+    const { result, events, manifestPath } = execFinalize(fixture, {
+      extraArgs: ["--force-finalize-nonready", "--reason", `operator override from ${sourceState}`],
+    });
+
+    const forceEvent = events.find((entry) => entry.event === "force_finalize");
+    const manifest = readManifest(manifestPath).data;
+
+    assert.equal(result.previousState, sourceState);
+    assert.equal(result.state, STATES.MERGED);
+    assert.equal(forceEvent?.state_from, sourceState);
+    assert.equal(forceEvent?.state_to, STATES.MERGED);
+    assert.equal(forceEvent?.head_sha, fixture.headSha);
+    assert.equal(manifest.state, STATES.MERGED);
+    assert.equal(manifest.last_force.from_state, sourceState);
+    assert.equal(manifest.last_force.to_state, STATES.MERGED);
+  });
+}
+
+test("finalize-run force-finalize from ready_to_merge still emits a force audit event", () => {
+  const fixture = setupRepo({ manifestState: STATES.READY_TO_MERGE });
+  const forceReason = "operator requested explicit audit trail";
+  const { result, events, manifestPath } = execFinalize(fixture, {
+    extraArgs: ["--force-finalize-nonready", "--reason", forceReason],
+    ghOptions: {
+      comments: [DEFAULT_REVIEW_COMMENT],
+    },
+  });
+
+  const forceEvent = events.find((entry) => entry.event === "force_finalize");
+  const mergeEvent = events.find((entry) => entry.event === "merge_finalize");
+  const manifest = readManifest(manifestPath).data;
+
+  assert.equal(result.previousState, STATES.READY_TO_MERGE);
+  assert.equal(result.state, STATES.MERGED);
+  assert.equal(forceEvent?.state_from, STATES.READY_TO_MERGE);
+  assert.equal(forceEvent?.reason, forceReason);
+  assert.equal(mergeEvent?.state_to, STATES.MERGED);
+  assert.equal(manifest.last_force.reason, forceReason);
+  assert.equal(manifest.last_force.from_state, STATES.READY_TO_MERGE);
+});
+
+test("finalize-run rejects force-finalize from merged without mutating audit state", () => {
+  const fixture = setupRepo({ manifestState: STATES.MERGED });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--manifest", fixture.manifestPath,
+    "--pr", "123",
+    "--force-finalize-nonready",
+    "--reason", "stuck",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }), (error) => {
+    assert.match(String(error.stderr), /force-finalize cannot be used from terminal state merged/);
+    return true;
+  });
+
+  const manifest = readManifest(fixture.manifestPath).data;
+  assert.equal(manifest.state, STATES.MERGED);
+  assert.equal("last_force" in manifest, false);
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  assert.equal(fs.existsSync(fixture.worktreePath), true);
+  assert.equal(branchExists(fixture.repoRoot, fixture.branch), true);
+});
+
+test("finalize-run rejects force-finalize from closed without mutating audit state", () => {
+  const fixture = setupRepo({ manifestState: STATES.CLOSED });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--manifest", fixture.manifestPath,
+    "--pr", "123",
+    "--force-finalize-nonready",
+    "--reason", "stuck",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }), (error) => {
+    assert.match(String(error.stderr), /force-finalize cannot be used from terminal state closed/);
+    return true;
+  });
+
+  const manifest = readManifest(fixture.manifestPath).data;
+  assert.equal(manifest.state, STATES.CLOSED);
+  assert.equal("last_force" in manifest, false);
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  assert.equal(fs.existsSync(fixture.worktreePath), true);
+  assert.equal(branchExists(fixture.repoRoot, fixture.branch), true);
+});
+
+test("finalize-run rejects force-finalize without --reason before any side effect", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--force-finalize-nonready",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }), (error) => {
+    assert.match(String(error.stderr), /--force-finalize-nonready requires --reason <non-empty-text>/);
+    return true;
+  });
+
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.ESCALATED);
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  assert.equal(fs.existsSync(fixture.worktreePath), true);
+  assert.equal(branchExists(fixture.repoRoot, fixture.branch), true);
+  assert.equal(remoteBranchExists(fixture.repoRoot, fixture.branch), true);
+  assert.equal(fs.existsSync(path.join(fixture.repoRoot, "gh.log")), false);
+});
+
+test("finalize-run rejects force-finalize with a whitespace-only --reason", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--force-finalize-nonready",
+    "--reason", "   ",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }), (error) => {
+    assert.match(String(error.stderr), /--force-finalize-nonready requires --reason <non-empty-text>/);
+    return true;
+  });
+
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.ESCALATED);
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  assert.equal(fs.existsSync(fixture.worktreePath), true);
+  assert.equal(branchExists(fixture.repoRoot, fixture.branch), true);
+});
+
+test("finalize-run force-finalize dry-run is observation-only and does not append audit events", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+  const { result } = execFinalize(fixture, {
+    extraArgs: ["--force-finalize-nonready", "--reason", "dry-run check", "--dry-run"],
+  });
+
+  assert.equal(result.dryRun, true);
+  assert.equal(result.forceFinalized, true);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.ESCALATED);
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  assert.equal(fs.existsSync(fixture.worktreePath), true);
+  assert.equal(branchExists(fixture.repoRoot, fixture.branch), true);
+  assert.equal(remoteBranchExists(fixture.repoRoot, fixture.branch), true);
+});
+
+test("finalize-run combined skip-review and force-finalize emits both audit events", () => {
+  const fixture = setupRepo({ manifestState: STATES.REVIEW_PENDING });
+  const { result, events, logPath, manifestPath } = execFinalize(fixture, {
+    extraArgs: [
+      "--force-finalize-nonready",
+      "--reason", "stuck",
+      "--skip-review", "no reviewer",
+    ],
+  });
+
+  const skipEvent = events.find((entry) => entry.event === "skip_review");
+  const forceEvent = events.find((entry) => entry.event === "force_finalize");
+  const manifest = readManifest(manifestPath).data;
+  const ghLog = fs.readFileSync(logPath, "utf-8");
+
+  assert.equal(result.state, STATES.MERGED);
+  assert.equal(skipEvent?.reason, "no reviewer");
+  assert.equal(forceEvent?.reason, "stuck");
+  assert.equal(forceEvent?.state_from, STATES.REVIEW_PENDING);
+  assert.equal(manifest.last_force.reason, "stuck");
+  assert.match(ghLog, /pr comment 123 --body/);
+  assert.match(ghLog, /pr merge 123 --squash/);
+});
 
 test("finalize-run merges and cleans a ready run", () => {
   const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();


### PR DESCRIPTION
## Dispatch Summary

```text
[finalize-run.js](/Users/sjlee/.relay/worktrees/bd4b226b/dev-relay/skills/relay-merge/scripts/finalize-run.js), [lifecycle.js](/Users/sjlee/.relay/worktrees/bd4b226b/dev-relay/skills/relay-dispatch/scripts/manifest/lifecycle.js), [relay-events.js](/Users/sjlee/.relay/worktrees/bd4b226b/dev-relay/skills/relay-dispatch/scripts/relay-events.js), [SKILL.md](/Users/sjlee/.relay/worktrees/bd4b226b/dev-relay/skills/relay-merge/SKILL.md)에 반영했습니다. `--force-finalize-nonready --reason <text>`를 추가했고, non-em
```

## Score Log

- Run: issue-262-20260422134202812-4b46ff2e
- Executor: codex
- Branch: issue-262