### PR TITLE
feat(relay-review): analyze-flip-flop-pattern measurement script (#270 Phase A)

### DIFF
--- a/skills/relay-review/references/issue-270-phase-a-evidence.md
+++ b/skills/relay-review/references/issue-270-phase-a-evidence.md
@@ -1,0 +1,14 @@
+# Issue #270 Phase A Comment Evidence
+
+Phase A Markdown report presence for the issue #270 measurement gate is reviewable at:
+
+- Comment URL: https://github.com/sungjunlee/dev-relay/issues/270#issuecomment-4300825484
+- Issue URL: https://github.com/sungjunlee/dev-relay/issues/270
+- Author: `sungjunlee`
+- Posted at: `2026-04-23T00:26:34Z`
+- Posting command: `node skills/relay-review/scripts/analyze-flip-flop-pattern.js --post-comment --issue 270`
+- Script recorded in the comment: `skills/relay-review/scripts/analyze-flip-flop-pattern.js@ab5dcfb`
+- Required sections present in the comment: Totals, Flip-flop classification, Decision metric, Recommendation, Per-run breakdown
+- Decision metric recorded in the comment: 90%, recommendation `>=20% -> proceed to Phase B`
+
+Round 4 verification used `gh issue view 270 --json url,title,state,comments` and the GitHub issue-comment connector for `sungjunlee/dev-relay#270`.

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.js
@@ -1,0 +1,672 @@
+#!/usr/bin/env node
+/**
+ * Phase A measurement for issue #270:
+ * scan recent relay runs, detect rubric-factor flip-flops, and measure how
+ * often they look progressive-shaped versus thrash-shaped.
+ *
+ * Buckets:
+ * - progressive-shaped: at least one flip-flop factor trace and
+ *   review.repeated_issue_count === 0
+ * - thrash-shaped: at least one flip-flop factor trace and
+ *   review.repeated_issue_count >= 1
+ * - no_flip_flop: no factor shows >=2 pass/fail transitions inside any
+ *   3-round sliding window
+ * - data_gap: the run cannot be classified confidently because required input
+ *   is missing or invalid (for example missing manifest, invalid verdict JSON,
+ *   or missing review.repeated_issue_count)
+ *
+ * Decision gate: if progressive / (progressive + thrash) >= 20%, Phase B is
+ * worth building. Otherwise deprioritize. Context: issue #270.
+ */
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const {
+  getRunsBase,
+  validateRunId,
+} = require("../../relay-dispatch/scripts/manifest/paths");
+const { readManifest } = require("../../relay-dispatch/scripts/manifest/store");
+
+const DEFAULT_WINDOW_DAYS = 30;
+const PASS_FAIL_STATUSES = new Set(["pass", "fail"]);
+const DATA_GAP = "data_gap";
+const KNOWN_FLAGS = new Set([
+  "--print",
+  "--post-comment",
+  "--issue",
+  "--window-days",
+  "--runs-dir",
+  "--help",
+  "-h",
+]);
+
+function parsePositiveInt(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    issueNumber: null,
+    postComment: false,
+    print: true,
+    runsDir: getRunsBase(),
+    windowDays: DEFAULT_WINDOW_DAYS,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--print":
+        options.print = true;
+        break;
+      case "--post-comment":
+        options.postComment = true;
+        break;
+      case "--issue":
+        index += 1;
+        if (index >= args.length) throw new Error("--issue requires a value");
+        options.issueNumber = parsePositiveInt(args[index], "--issue");
+        break;
+      case "--window-days":
+        index += 1;
+        if (index >= args.length) throw new Error("--window-days requires a value");
+        options.windowDays = parsePositiveInt(args[index], "--window-days");
+        break;
+      case "--runs-dir":
+        index += 1;
+        if (index >= args.length) throw new Error("--runs-dir requires a value");
+        options.runsDir = path.resolve(args[index]);
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        if (arg.startsWith("--") || arg.startsWith("-")) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+        throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+  }
+
+  if (options.postComment && !options.issueNumber) {
+    throw new Error("--post-comment requires --issue <N>");
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log("Usage: analyze-flip-flop-pattern.js [options]");
+  console.log("");
+  console.log("Scan recent relay review runs and measure whether flip-flops look progressive or thrashy.");
+  console.log("");
+  console.log("Options:");
+  console.log("  --print               Emit the markdown report to stdout (default)");
+  console.log("  --post-comment        Post the same markdown report to a GitHub issue comment");
+  console.log("  --issue <N>           GitHub issue number to use with --post-comment");
+  console.log(`  --window-days <N>     Scan runs whose latest artifact mtime is within the last N days (default: ${DEFAULT_WINDOW_DAYS})`);
+  console.log("  --runs-dir <path>     Override the relay runs base directory (default: ~/.relay/runs)");
+  console.log("  --help, -h            Show this help text");
+}
+
+function normalizeStatus(status) {
+  return String(status || "").trim().toLowerCase();
+}
+
+function normalizeFactor(factor) {
+  return String(factor || "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function summarizeExecError(error) {
+  const stderr = String(error.stderr || "").trim();
+  const stdout = String(error.stdout || "").trim();
+  return stderr || stdout || error.message;
+}
+
+function getRepoRoot() {
+  return path.resolve(__dirname, "../../..");
+}
+
+function getScriptRelativePath() {
+  return path.relative(getRepoRoot(), __filename).replace(/\\/g, "/");
+}
+
+function getCommitShort(repoRoot) {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function listImmediateDirectories(rootDir) {
+  if (!fs.existsSync(rootDir)) return [];
+  return fs.readdirSync(rootDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(rootDir, entry.name));
+}
+
+function listFilesRecursive(rootPath) {
+  const stat = fs.statSync(rootPath);
+  if (!stat.isDirectory()) return [rootPath];
+
+  const files = [];
+  for (const entry of fs.readdirSync(rootPath, { withFileTypes: true })) {
+    const entryPath = path.join(rootPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursive(entryPath));
+      continue;
+    }
+    files.push(entryPath);
+  }
+  return files;
+}
+
+function getLatestArtifactMtimeMs(runDir) {
+  const artifactPaths = listFilesRecursive(runDir);
+  if (artifactPaths.length === 0) {
+    return fs.statSync(runDir).mtimeMs;
+  }
+  return artifactPaths.reduce((latest, artifactPath) => {
+    return Math.max(latest, fs.statSync(artifactPath).mtimeMs);
+  }, 0);
+}
+
+function extractRoundNumber(fileName) {
+  const match = fileName.match(/^review-round-(\d+)-verdict\.json$/);
+  return match ? Number(match[1]) : null;
+}
+
+function listVerdictFiles(runDir) {
+  if (!fs.existsSync(runDir)) return [];
+  return fs.readdirSync(runDir)
+    .map((fileName) => ({ fileName, round: extractRoundNumber(fileName) }))
+    .filter((entry) => Number.isInteger(entry.round))
+    .sort((left, right) => left.round - right.round)
+    .map((entry) => path.join(runDir, entry.fileName));
+}
+
+function loadManifestIndex(slugDir) {
+  const manifestIndex = new Map();
+  for (const entry of fs.readdirSync(slugDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    const runId = path.basename(entry.name, ".md");
+    if (!validateRunId(runId).valid) continue;
+    const manifestPath = path.join(slugDir, entry.name);
+    try {
+      const parsed = readManifest(manifestPath);
+      manifestIndex.set(runId, {
+        body: parsed.body,
+        data: parsed.data,
+        error: null,
+        manifestPath,
+        runId,
+      });
+    } catch (error) {
+      manifestIndex.set(runId, {
+        body: null,
+        data: null,
+        error,
+        manifestPath,
+        runId,
+      });
+    }
+  }
+  return manifestIndex;
+}
+
+function loadVerdictRounds(verdictPaths) {
+  const rounds = [];
+  const errors = [];
+
+  for (const verdictPath of verdictPaths) {
+    const round = extractRoundNumber(path.basename(verdictPath));
+    try {
+      rounds.push({
+        round,
+        verdict: JSON.parse(fs.readFileSync(verdictPath, "utf-8")),
+        verdictPath,
+      });
+    } catch (error) {
+      errors.push({
+        error,
+        reason: "invalid_verdict_json",
+        round,
+        verdictPath,
+      });
+    }
+  }
+
+  rounds.sort((left, right) => left.round - right.round);
+  return { errors, rounds };
+}
+
+function buildFactorTraceMap(rounds) {
+  const traceMap = new Map();
+
+  for (const roundRecord of rounds) {
+    const roundFactorMap = new Map();
+    const rubricScores = Array.isArray(roundRecord.verdict?.rubric_scores)
+      ? roundRecord.verdict.rubric_scores
+      : [];
+
+    for (const score of rubricScores) {
+      const factorKey = normalizeFactor(score?.factor);
+      if (!factorKey) continue;
+      roundFactorMap.set(factorKey, {
+        factor: String(score.factor || "").trim() || factorKey,
+        status: normalizeStatus(score.status),
+      });
+    }
+
+    for (const [factorKey, score] of roundFactorMap.entries()) {
+      if (!traceMap.has(factorKey)) {
+        traceMap.set(factorKey, { factor: score.factor, entries: [] });
+      }
+      const trace = traceMap.get(factorKey);
+      trace.factor = score.factor || trace.factor;
+      trace.entries.push({
+        round: roundRecord.round,
+        status: score.status,
+      });
+    }
+  }
+
+  return [...traceMap.values()].sort((left, right) => left.factor.localeCompare(right.factor));
+}
+
+function countPassFailTransitions(entries) {
+  const passFailEntries = entries.filter((entry) => PASS_FAIL_STATUSES.has(entry.status));
+  let transitions = 0;
+  for (let index = 1; index < passFailEntries.length; index += 1) {
+    if (passFailEntries[index - 1].status !== passFailEntries[index].status) {
+      transitions += 1;
+    }
+  }
+  return {
+    transitions,
+    traceEntries: passFailEntries,
+  };
+}
+
+function formatTrace(entries) {
+  return entries.map((entry) => `r${entry.round}:${entry.status}`).join(" -> ");
+}
+
+function findFlipFactors(rounds) {
+  if (rounds.length === 0) return [];
+  const maxRound = rounds.reduce((memo, round) => Math.max(memo, round.round), 0);
+  return buildFactorTraceMap(rounds).flatMap((trace) => {
+    for (let startRound = 1; startRound <= maxRound - 2; startRound += 1) {
+      const windowEntries = trace.entries.filter((entry) => (
+        entry.round >= startRound && entry.round <= startRound + 2
+      ));
+      const flip = countPassFailTransitions(windowEntries);
+      if (flip.transitions >= 2) {
+        return [{
+          factor: trace.factor,
+          traceEntries: flip.traceEntries,
+          traceLabel: formatTrace(flip.traceEntries),
+        }];
+      }
+    }
+    return [];
+  });
+}
+
+function resolveManifestData(manifestRecord, expectedRunId) {
+  if (!manifestRecord) {
+    return {
+      dataGapReason: "missing_manifest",
+      manifestData: null,
+      repeatedIssueCount: null,
+    };
+  }
+
+  if (manifestRecord.error) {
+    return {
+      dataGapReason: "invalid_manifest",
+      manifestData: null,
+      repeatedIssueCount: null,
+    };
+  }
+
+  if (manifestRecord.data?.run_id && manifestRecord.data.run_id !== expectedRunId) {
+    return {
+      dataGapReason: "manifest_run_id_mismatch",
+      manifestData: manifestRecord.data,
+      repeatedIssueCount: null,
+    };
+  }
+
+  const repeatedIssueCount = manifestRecord.data?.review?.repeated_issue_count;
+  if (repeatedIssueCount === undefined) {
+    return {
+      dataGapReason: "missing_repeated_issue_count",
+      manifestData: manifestRecord.data,
+      repeatedIssueCount: null,
+    };
+  }
+
+  if (!Number.isInteger(Number(repeatedIssueCount)) || Number(repeatedIssueCount) < 0) {
+    return {
+      dataGapReason: "invalid_repeated_issue_count",
+      manifestData: manifestRecord.data,
+      repeatedIssueCount: null,
+    };
+  }
+
+  return {
+    dataGapReason: null,
+    manifestData: manifestRecord.data,
+    repeatedIssueCount: Number(repeatedIssueCount),
+  };
+}
+
+function classifyRun(candidate) {
+  const verdictLoad = loadVerdictRounds(candidate.verdictPaths);
+  const manifest = resolveManifestData(candidate.manifestRecord, candidate.runId);
+  const flipFactors = verdictLoad.errors.length > 0 ? [] : findFlipFactors(verdictLoad.rounds);
+
+  let dataGapReason = manifest.dataGapReason;
+  if (!dataGapReason && verdictLoad.errors.length > 0) {
+    dataGapReason = verdictLoad.errors[0].reason;
+  }
+
+  let bucket = "no_flip_flop";
+  if (dataGapReason) {
+    bucket = DATA_GAP;
+  } else if (flipFactors.length > 0) {
+    bucket = manifest.repeatedIssueCount === 0 ? "progressive-shaped" : "thrash-shaped";
+  }
+
+  return {
+    bucket,
+    dataGapReason,
+    flipFactors,
+    latestMtimeMs: candidate.latestMtimeMs,
+    latestMtimeIso: new Date(candidate.latestMtimeMs).toISOString(),
+    manifestPath: candidate.manifestRecord?.manifestPath || null,
+    prNumber: manifest.manifestData?.git?.pr_number ?? null,
+    repeatedIssueCount: manifest.repeatedIssueCount,
+    roundCount: candidate.verdictPaths.length,
+    runDir: candidate.runDir,
+    runId: candidate.runId,
+    slug: candidate.slug,
+    verdictPaths: candidate.verdictPaths,
+  };
+}
+
+function countBySlug(records) {
+  const counts = new Map();
+  for (const record of records) {
+    counts.set(record.slug, (counts.get(record.slug) || 0) + 1);
+  }
+  return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right));
+}
+
+function formatPercentage(value) {
+  if (value === null || value === undefined) return "n/a";
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : `${rounded.toFixed(1)}`;
+}
+
+function summarizeDecisionMetric(classificationCounts) {
+  const progressive = classificationCounts["progressive-shaped"];
+  const thrash = classificationCounts["thrash-shaped"];
+  const denominator = progressive + thrash;
+
+  if (denominator === 0) {
+    return {
+      denominator,
+      percentage: null,
+      recommendationLabel: "`n/a - no flip-flop runs in window` -> deprioritize (insufficient signal)",
+    };
+  }
+
+  const percentage = (progressive / denominator) * 100;
+  return {
+    denominator,
+    percentage,
+    recommendationLabel: percentage >= 20
+      ? "`>=20% -> proceed to Phase B`"
+      : "`<20% -> deprioritize`",
+  };
+}
+
+function analyzeRuns({ now = new Date(), runsDir = getRunsBase(), windowDays = DEFAULT_WINDOW_DAYS } = {}) {
+  const anchorDate = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(anchorDate.getTime())) {
+    throw new Error(`Invalid anchor date: ${JSON.stringify(now)}`);
+  }
+
+  const resolvedRunsDir = path.resolve(runsDir);
+  const windowStartMs = anchorDate.getTime() - (windowDays * 24 * 60 * 60 * 1000);
+  const recentRuns = [];
+  const inScopeRuns = [];
+
+  for (const slugDir of listImmediateDirectories(resolvedRunsDir)) {
+    const slug = path.basename(slugDir);
+    const manifestIndex = loadManifestIndex(slugDir);
+    for (const runDir of listImmediateDirectories(slugDir)) {
+      const runId = path.basename(runDir);
+      if (!validateRunId(runId).valid) continue;
+
+      const latestMtimeMs = getLatestArtifactMtimeMs(runDir);
+      if (latestMtimeMs < windowStartMs) continue;
+
+      const verdictPaths = listVerdictFiles(runDir);
+      const candidate = {
+        latestMtimeMs,
+        manifestRecord: manifestIndex.get(runId) || null,
+        runDir,
+        runId,
+        slug,
+        verdictPaths,
+      };
+
+      recentRuns.push(candidate);
+      if (verdictPaths.length < 2) continue;
+      inScopeRuns.push(classifyRun(candidate));
+    }
+  }
+
+  const classificationCounts = {
+    "progressive-shaped": 0,
+    "thrash-shaped": 0,
+    "no_flip_flop": 0,
+    [DATA_GAP]: 0,
+  };
+
+  for (const run of inScopeRuns) {
+    classificationCounts[run.bucket] += 1;
+  }
+
+  const metric = summarizeDecisionMetric(classificationCounts);
+  const bucketPriority = {
+    "progressive-shaped": 0,
+    "thrash-shaped": 1,
+    [DATA_GAP]: 2,
+    "no_flip_flop": 3,
+  };
+  inScopeRuns.sort((left, right) => {
+    const bucketDelta = bucketPriority[left.bucket] - bucketPriority[right.bucket];
+    if (bucketDelta !== 0) return bucketDelta;
+    return right.latestMtimeMs - left.latestMtimeMs;
+  });
+
+  return {
+    anchorIso: anchorDate.toISOString(),
+    classificationCounts,
+    commitShort: getCommitShort(getRepoRoot()),
+    decisionMetric: metric,
+    recentRunsBySlug: countBySlug(recentRuns),
+    recentRunsCount: recentRuns.length,
+    runs: inScopeRuns,
+    runsDir: resolvedRunsDir,
+    scriptPath: getScriptRelativePath(),
+    windowDays,
+    windowEndIso: anchorDate.toISOString(),
+    windowStartIso: new Date(windowStartMs).toISOString(),
+  };
+}
+
+function escapeTableCell(value) {
+  return String(value)
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
+}
+
+function formatBySlug(bySlug) {
+  if (bySlug.length === 0) return "none";
+  return bySlug.map(([slug, count]) => `${slug}: ${count}`).join(", ");
+}
+
+function formatBucketLabel(run) {
+  if (run.bucket !== DATA_GAP || !run.dataGapReason) return run.bucket;
+  return `${run.bucket} (${run.dataGapReason})`;
+}
+
+function formatRepeatedIssueCount(run) {
+  if (run.repeatedIssueCount !== null && run.repeatedIssueCount !== undefined) {
+    return String(run.repeatedIssueCount);
+  }
+  return "missing";
+}
+
+function renderBreakdownRows(runs) {
+  if (runs.length === 0) {
+    return ["| _none_ | - | - | - | - | - | - |"];
+  }
+
+  return runs.map((run) => {
+    const flippedFactor = run.flipFactors.length
+      ? run.flipFactors.map((flip) => escapeTableCell(flip.factor)).join("<br>")
+      : "-";
+    const statusTrace = run.flipFactors.length
+      ? run.flipFactors.map((flip) => escapeTableCell(flip.traceLabel)).join("<br>")
+      : "-";
+    const pr = run.prNumber === null || run.prNumber === undefined ? "n/a" : String(run.prNumber);
+
+    return [
+      `| ${escapeTableCell(run.runId)}`,
+      `${escapeTableCell(run.slug)}`,
+      `${escapeTableCell(pr)}`,
+      `${flippedFactor}`,
+      `${statusTrace}`,
+      `${escapeTableCell(formatRepeatedIssueCount(run))}`,
+      `${escapeTableCell(formatBucketLabel(run))} |`,
+    ].join(" | ");
+  });
+}
+
+function renderReport(summary) {
+  const decisionMetric = summary.decisionMetric.percentage === null
+    ? "n/a"
+    : `${formatPercentage(summary.decisionMetric.percentage)}%`;
+
+  return [
+    "# Flip-flop pattern scan — #270 Phase A",
+    "",
+    `**Scan window**: ${summary.windowStartIso} → ${summary.windowEndIso} (last ${summary.windowDays}d, anchored at ${summary.anchorIso})`,
+    `**Script**: ${summary.scriptPath}@${summary.commitShort}`,
+    "",
+    "## Totals",
+    `- Runs scanned (all slugs): ${summary.recentRunsCount}`,
+    `- Runs with ≥2 rounds: ${summary.runs.length}`,
+    `- By slug: ${formatBySlug(summary.recentRunsBySlug)}`,
+    "",
+    "## Flip-flop classification",
+    `- progressive-shaped: ${summary.classificationCounts["progressive-shaped"]}`,
+    `- thrash-shaped: ${summary.classificationCounts["thrash-shaped"]}`,
+    `- no_flip_flop: ${summary.classificationCounts.no_flip_flop}`,
+    `- data_gap: ${summary.classificationCounts.data_gap}`,
+    "",
+    "## Decision metric",
+    `progressive / (progressive + thrash) = **${decisionMetric}**`,
+    "",
+    `**Recommendation**: ${summary.decisionMetric.recommendationLabel}`,
+    "",
+    "## Per-run breakdown",
+    "| run_id | slug | PR | flipped factor | status trace | repeated_issue_count | bucket |",
+    "|---|---|---|---|---|---|---|",
+    ...renderBreakdownRows(summary.runs),
+  ].join("\n");
+}
+
+function postIssueComment({ body, issueNumber, repoRoot }) {
+  try {
+    execFileSync("gh", ["issue", "comment", String(issueNumber), "--body-file", "-"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      input: body,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    throw new Error(`gh issue comment failed: ${summarizeExecError(error)}`);
+  }
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return null;
+  }
+
+  const summary = analyzeRuns({
+    runsDir: options.runsDir,
+    windowDays: options.windowDays,
+  });
+  const report = renderReport(summary);
+
+  if (options.print) {
+    process.stdout.write(`${report}\n`);
+  }
+
+  if (options.postComment) {
+    postIssueComment({
+      body: report,
+      issueNumber: options.issueNumber,
+      repoRoot: getRepoRoot(),
+    });
+  }
+
+  return { report, summary };
+}
+
+if (require.main === module) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  DEFAULT_WINDOW_DAYS,
+  analyzeRuns,
+  countPassFailTransitions,
+  findFlipFactors,
+  formatTrace,
+  loadManifestIndex,
+  loadVerdictRounds,
+  parseArgs,
+  postIssueComment,
+  renderReport,
+  resolveManifestData,
+  runCli,
+};

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.js
@@ -12,8 +12,8 @@
  * - no_flip_flop: no factor shows >=2 pass/fail transitions inside any
  *   3-round sliding window
  * - data_gap: the run cannot be classified confidently because required input
- *   is missing or invalid (for example missing manifest, invalid verdict JSON,
- *   or missing review.repeated_issue_count)
+ *   is missing or invalid (for example missing manifest, missing verdict round,
+ *   invalid verdict JSON, or missing review.repeated_issue_count)
  *
  * Decision gate: if progressive / (progressive + thrash) >= 20%, Phase B is
  * worth building. Otherwise deprioritize. Context: issue #270.
@@ -253,11 +253,29 @@ function loadVerdictRounds(verdictPaths) {
   return { errors, rounds };
 }
 
-function findVerdictRoundGap(verdictPaths) {
+function getRecordedReviewRoundCount(manifestRecord, expectedRunId) {
+  if (!manifestRecord || manifestRecord.error) return null;
+  if (manifestRecord.data?.run_id && manifestRecord.data.run_id !== expectedRunId) return null;
+
+  const rounds = manifestRecord.data?.review?.rounds;
+  if (rounds === undefined || rounds === null) return null;
+  if (!Number.isInteger(Number(rounds)) || Number(rounds) < 0) return null;
+  return Number(rounds);
+}
+
+function findVerdictRoundGap(verdictPaths, expectedRoundCount = null) {
   const rounds = verdictPaths
     .map((verdictPath) => extractRoundNumber(path.basename(verdictPath)))
     .filter((round) => Number.isInteger(round))
     .sort((left, right) => left - right);
+
+  if (expectedRoundCount !== null && expectedRoundCount !== undefined) {
+    const roundSet = new Set(rounds);
+    for (let round = 1; round <= expectedRoundCount; round += 1) {
+      if (!roundSet.has(round)) return round;
+    }
+    return null;
+  }
 
   if (rounds.length < 2) return null;
   if (rounds[0] !== 1) return 1;
@@ -393,7 +411,11 @@ function resolveManifestData(manifestRecord, expectedRunId) {
 }
 
 function classifyRun(candidate) {
-  const missingVerdictRound = findVerdictRoundGap(candidate.verdictPaths);
+  const recordedRoundCount = candidate.recordedRoundCount ?? getRecordedReviewRoundCount(
+    candidate.manifestRecord,
+    candidate.runId
+  );
+  const missingVerdictRound = findVerdictRoundGap(candidate.verdictPaths, recordedRoundCount);
   const verdictLoad = loadVerdictRounds(candidate.verdictPaths);
   const manifest = resolveManifestData(candidate.manifestRecord, candidate.runId);
   const flipFactors = missingVerdictRound || verdictLoad.errors.length > 0
@@ -424,7 +446,7 @@ function classifyRun(candidate) {
     manifestPath: candidate.manifestRecord?.manifestPath || null,
     prNumber: manifest.manifestData?.git?.pr_number ?? null,
     repeatedIssueCount: manifest.repeatedIssueCount,
-    roundCount: candidate.verdictPaths.length,
+    roundCount: recordedRoundCount ?? candidate.verdictPaths.length,
     missingVerdictRound,
     runDir: candidate.runDir,
     runId: candidate.runId,
@@ -443,8 +465,7 @@ function countBySlug(records) {
 
 function formatPercentage(value) {
   if (value === null || value === undefined) return "n/a";
-  const rounded = Math.round(value * 10) / 10;
-  return Number.isInteger(rounded) ? `${rounded}` : `${rounded.toFixed(1)}`;
+  return `${Math.round(value)}`;
 }
 
 function summarizeDecisionMetric(classificationCounts) {
@@ -492,9 +513,12 @@ function analyzeRuns({ now = new Date(), runsDir = getRunsBase(), windowDays = D
       if (latestMtimeMs < windowStartMs) continue;
 
       const verdictPaths = listVerdictFiles(runDir);
+      const manifestRecord = manifestIndex.get(runId) || null;
+      const recordedRoundCount = getRecordedReviewRoundCount(manifestRecord, runId);
       const candidate = {
         latestMtimeMs,
-        manifestRecord: manifestIndex.get(runId) || null,
+        manifestRecord,
+        recordedRoundCount,
         runDir,
         runId,
         slug,
@@ -502,7 +526,7 @@ function analyzeRuns({ now = new Date(), runsDir = getRunsBase(), windowDays = D
       };
 
       recentRuns.push(candidate);
-      if (verdictPaths.length < 2) continue;
+      if ((recordedRoundCount ?? verdictPaths.length) < 2) continue;
       inScopeRuns.push(classifyRun(candidate));
     }
   }

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.js
@@ -17,6 +17,10 @@
  *
  * Decision gate: if progressive / (progressive + thrash) >= 20%, Phase B is
  * worth building. Otherwise deprioritize. Context: issue #270.
+ *
+ * Re-run before any Phase B go/no-go decision, after new multi-round relay
+ * review data enters the last-30-days window, or whenever reusing an older
+ * issue #270 report would make the decision gate stale.
  */
 const { execFileSync } = require("child_process");
 const fs = require("fs");

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.js
@@ -253,6 +253,23 @@ function loadVerdictRounds(verdictPaths) {
   return { errors, rounds };
 }
 
+function findVerdictRoundGap(verdictPaths) {
+  const rounds = verdictPaths
+    .map((verdictPath) => extractRoundNumber(path.basename(verdictPath)))
+    .filter((round) => Number.isInteger(round))
+    .sort((left, right) => left - right);
+
+  if (rounds.length < 2) return null;
+  if (rounds[0] !== 1) return 1;
+
+  for (let index = 1; index < rounds.length; index += 1) {
+    const expectedRound = rounds[index - 1] + 1;
+    if (rounds[index] !== expectedRound) return expectedRound;
+  }
+
+  return null;
+}
+
 function buildFactorTraceMap(rounds) {
   const traceMap = new Map();
 
@@ -376,11 +393,17 @@ function resolveManifestData(manifestRecord, expectedRunId) {
 }
 
 function classifyRun(candidate) {
+  const missingVerdictRound = findVerdictRoundGap(candidate.verdictPaths);
   const verdictLoad = loadVerdictRounds(candidate.verdictPaths);
   const manifest = resolveManifestData(candidate.manifestRecord, candidate.runId);
-  const flipFactors = verdictLoad.errors.length > 0 ? [] : findFlipFactors(verdictLoad.rounds);
+  const flipFactors = missingVerdictRound || verdictLoad.errors.length > 0
+    ? []
+    : findFlipFactors(verdictLoad.rounds);
 
   let dataGapReason = manifest.dataGapReason;
+  if (!dataGapReason && missingVerdictRound) {
+    dataGapReason = "missing_verdict_round";
+  }
   if (!dataGapReason && verdictLoad.errors.length > 0) {
     dataGapReason = verdictLoad.errors[0].reason;
   }
@@ -402,6 +425,7 @@ function classifyRun(candidate) {
     prNumber: manifest.manifestData?.git?.pr_number ?? null,
     repeatedIssueCount: manifest.repeatedIssueCount,
     roundCount: candidate.verdictPaths.length,
+    missingVerdictRound,
     runDir: candidate.runDir,
     runId: candidate.runId,
     slug: candidate.slug,

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.test.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.test.js
@@ -1,0 +1,275 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  analyzeRuns,
+  parseArgs,
+  renderReport,
+} = require("./analyze-flip-flop-pattern");
+
+const SCRIPT_PATH = path.join(__dirname, "analyze-flip-flop-pattern.js");
+const FIXTURES_DIR = path.join(__dirname, "fixtures", "analyze-flip-flop-pattern");
+
+function loadFixtureSpec(name) {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, `${name}.json`), "utf-8"));
+}
+
+function writeManifest(manifestPath, { prNumber, repeatedIssueCount, omitRepeatedIssueCount }, runId) {
+  const lines = [
+    "---",
+    "relay_version: 2",
+    `run_id: '${runId}'`,
+    "git:",
+    `  pr_number: ${prNumber === null || prNumber === undefined ? "null" : prNumber}`,
+    "review:",
+  ];
+
+  if (!omitRepeatedIssueCount) {
+    lines.push(`  repeated_issue_count: ${repeatedIssueCount}`);
+  }
+
+  lines.push(
+    "paths:",
+    "  repo_root: '/tmp/fake-repo'",
+    "  worktree: '/tmp/fake-worktree'",
+    "timestamps:",
+    "  created_at: '2026-04-20T00:00:00.000Z'",
+    "  updated_at: '2026-04-20T00:00:00.000Z'",
+    "---",
+    "# Notes",
+    ""
+  );
+
+  fs.writeFileSync(manifestPath, lines.join("\n"), "utf-8");
+}
+
+function writeVerdict(verdictPath, roundSpec) {
+  if (roundSpec.raw) {
+    fs.writeFileSync(verdictPath, roundSpec.raw, "utf-8");
+    return;
+  }
+
+  const rubric_scores = (roundSpec.rubricScores || []).map(([factor, status]) => ({
+    factor,
+    target: ">= 1/1",
+    observed: `${factor} ${status}`,
+    status,
+    tier: "contract",
+    notes: `${factor} is ${status}`,
+  }));
+
+  fs.writeFileSync(verdictPath, JSON.stringify({
+    verdict: roundSpec.verdict || "changes_requested",
+    rubric_scores,
+  }, null, 2), "utf-8");
+}
+
+function setIsoMtime(targetPath, isoText) {
+  const date = new Date(isoText);
+  fs.utimesSync(targetPath, date, date);
+}
+
+function materializeFixture(name) {
+  const spec = loadFixtureSpec(name);
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-flip-flop-pattern-"));
+  const runsDir = path.join(rootDir, "runs");
+  fs.mkdirSync(runsDir, { recursive: true });
+
+  for (const run of spec.runs) {
+    const slugDir = path.join(runsDir, run.slug);
+    const runDir = path.join(slugDir, run.runId);
+    fs.mkdirSync(runDir, { recursive: true });
+
+    if (run.manifest !== false) {
+      const manifestPath = path.join(slugDir, `${run.runId}.md`);
+      writeManifest(manifestPath, run.manifest, run.runId);
+      setIsoMtime(manifestPath, run.latestMtime);
+    }
+
+    for (const round of run.rounds) {
+      const verdictPath = path.join(runDir, `review-round-${round.round}-verdict.json`);
+      writeVerdict(verdictPath, round);
+      setIsoMtime(verdictPath, run.latestMtime);
+    }
+  }
+
+  return {
+    now: spec.now,
+    rootDir,
+    runsDir,
+  };
+}
+
+function findRun(summary, runId) {
+  return summary.runs.find((run) => run.runId === runId);
+}
+
+function createFakeGhCapture() {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-fake-gh-"));
+  const binDir = path.join(rootDir, "bin");
+  const capturePath = path.join(rootDir, "capture.json");
+  const ghPath = path.join(binDir, "gh");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(ghPath, [
+    "#!/usr/bin/env node",
+    "const fs = require('fs');",
+    "const input = fs.readFileSync(0, 'utf8');",
+    `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({ argv: process.argv.slice(2), cwd: process.cwd(), input }, null, 2));`,
+  ].join("\n"), { mode: 0o755 });
+  return { binDir, capturePath };
+}
+
+test("analyze-flip-flop-pattern/parseArgs keeps the default print mode and validates post-comment requirements", () => {
+  const parsed = parseArgs(["--window-days", "14"]);
+  assert.equal(parsed.print, true);
+  assert.equal(parsed.windowDays, 14);
+
+  assert.throws(
+    () => parseArgs(["--post-comment"]),
+    /requires --issue <N>/
+  );
+});
+
+test("analyze-flip-flop-pattern classifies progressive, thrash, no-flip, and data-gap runs from the baseline fixture", () => {
+  const fixture = materializeFixture("baseline");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  assert.equal(summary.recentRunsCount, 10);
+  assert.equal(summary.runs.length, 9);
+  assert.deepEqual(summary.classificationCounts, {
+    "progressive-shaped": 2,
+    "thrash-shaped": 1,
+    "no_flip_flop": 3,
+    data_gap: 3,
+  });
+  assert.equal(summary.decisionMetric.denominator, 3);
+  assert.equal(summary.decisionMetric.percentage, (2 / 3) * 100);
+});
+
+test("analyze-flip-flop-pattern ignores not_run and missing-factor gaps when looking for flip-flops", () => {
+  const fixture = materializeFixture("baseline");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  assert.equal(findRun(summary, "issue-205-20260420010505050-ee55ff66").bucket, "no_flip_flop");
+  assert.equal(findRun(summary, "issue-206-20260420010606060-ff66aa77").bucket, "no_flip_flop");
+});
+
+test("analyze-flip-flop-pattern detects a sliding-window flip that only appears in rounds 2-4", () => {
+  const fixture = materializeFixture("baseline");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  const run = findRun(summary, "issue-207-20260420010707070-aa77bb88");
+  assert.equal(run.bucket, "progressive-shaped");
+  assert.deepEqual(run.flipFactors.map((flip) => flip.traceLabel), ["r2:pass -> r3:fail -> r4:pass"]);
+});
+
+test("analyze-flip-flop-pattern excludes old runs and one-round runs from the in-scope denominator", () => {
+  const fixture = materializeFixture("baseline");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  assert.equal(findRun(summary, "issue-208-20260301010808080-bb88cc99"), undefined);
+  assert.equal(findRun(summary, "issue-209-20260420010909090-cc99ddaa"), undefined);
+});
+
+test("analyze-flip-flop-pattern records explicit data-gap reasons for missing repeated_issue_count, missing manifest, and invalid verdict JSON", () => {
+  const fixture = materializeFixture("baseline");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  assert.equal(findRun(summary, "issue-204-20260420010404040-dd44ee55").dataGapReason, "missing_repeated_issue_count");
+  assert.equal(findRun(summary, "issue-210-20260420011010100-ddaaeebb").dataGapReason, "missing_manifest");
+  assert.equal(findRun(summary, "issue-211-20260420011111110-eebbffcc").dataGapReason, "invalid_verdict_json");
+});
+
+test("analyze-flip-flop-pattern renderReport emits the required headings and percentage output", () => {
+  const fixture = materializeFixture("baseline");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+  const report = renderReport(summary);
+
+  assert.match(report, /^# Flip-flop pattern scan — #270 Phase A/m);
+  assert.match(report, /## Totals/);
+  assert.match(report, /## Flip-flop classification/);
+  assert.match(report, /## Decision metric/);
+  assert.match(report, /## Per-run breakdown/);
+  assert.match(report, /progressive \/ \(progressive \+ thrash\) = \*\*66\.7%\*\*/);
+  assert.match(report, /\*\*Recommendation\*\*: `>=20% -> proceed to Phase B`/);
+});
+
+test("analyze-flip-flop-pattern renderReport uses n/a when there are no flip-flop runs in the window", () => {
+  const fixture = materializeFixture("no-flips");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+  const report = renderReport(summary);
+
+  assert.equal(summary.decisionMetric.denominator, 0);
+  assert.equal(summary.decisionMetric.percentage, null);
+  assert.match(report, /progressive \/ \(progressive \+ thrash\) = \*\*n\/a\*\*/);
+  assert.match(report, /\*\*Recommendation\*\*: `n\/a - no flip-flop runs in window` -> deprioritize \(insufficient signal\)/);
+});
+
+test("analyze-flip-flop-pattern CLI --help lists every supported flag", () => {
+  const output = execFileSync("node", [SCRIPT_PATH, "--help"], {
+    cwd: __dirname,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  for (const flag of ["--print", "--post-comment", "--issue", "--window-days", "--runs-dir", "--help"]) {
+    assert.match(output, new RegExp(flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
+test("analyze-flip-flop-pattern CLI --post-comment sends the rendered report to gh issue comment", () => {
+  const fixture = materializeFixture("baseline");
+  const fakeGh = createFakeGhCapture();
+  const output = execFileSync("node", [
+    SCRIPT_PATH,
+    "--runs-dir", fixture.runsDir,
+    "--window-days", "30",
+    "--post-comment",
+    "--issue", "270",
+  ], {
+    cwd: __dirname,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${fakeGh.binDir}:${process.env.PATH}`,
+    },
+    stdio: "pipe",
+  });
+
+  const capture = JSON.parse(fs.readFileSync(fakeGh.capturePath, "utf-8"));
+  assert.match(output, /^# Flip-flop pattern scan — #270 Phase A/m);
+  assert.deepEqual(capture.argv, ["issue", "comment", "270", "--body-file", "-"]);
+  assert.match(capture.input, /^# Flip-flop pattern scan — #270 Phase A/m);
+});

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.test.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.test.js
@@ -204,6 +204,48 @@ test("analyze-flip-flop-pattern records explicit data-gap reasons for missing re
   assert.equal(findRun(summary, "issue-211-20260420011111110-eebbffcc").dataGapReason, "invalid_verdict_json");
 });
 
+test("analyze-flip-flop-pattern classifies missing verdict-file round gaps as data_gap", () => {
+  const fixture = materializeFixture("corner-cases");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  const run = findRun(summary, "issue-401-20260422040101010-aabbccdd");
+  assert.equal(run.bucket, "data_gap");
+  assert.equal(run.dataGapReason, "missing_verdict_round");
+  assert.equal(run.missingVerdictRound, 2);
+  assert.deepEqual(run.flipFactors, []);
+});
+
+test("analyze-flip-flop-pattern reports mixed flip and stable factors without inventing stable-factor flips", () => {
+  const fixture = materializeFixture("corner-cases");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  const run = findRun(summary, "issue-402-20260422040202020-bbccddee");
+  assert.equal(run.bucket, "progressive-shaped");
+  assert.deepEqual(run.flipFactors.map((flip) => flip.factor), ["Behavior"]);
+  assert.deepEqual(run.flipFactors.map((flip) => flip.traceLabel), ["r1:pass -> r2:fail -> r3:pass"]);
+});
+
+test("analyze-flip-flop-pattern ignores skipped statuses when counting pass/fail transitions", () => {
+  const fixture = materializeFixture("corner-cases");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  const run = findRun(summary, "issue-403-20260422040303030-ccddeeff");
+  assert.equal(run.bucket, "no_flip_flop");
+  assert.deepEqual(run.flipFactors, []);
+});
+
 test("analyze-flip-flop-pattern renderReport emits the required headings and percentage output", () => {
   const fixture = materializeFixture("baseline");
   const summary = analyzeRuns({

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.test.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.test.js
@@ -18,7 +18,7 @@ function loadFixtureSpec(name) {
   return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, `${name}.json`), "utf-8"));
 }
 
-function writeManifest(manifestPath, { prNumber, repeatedIssueCount, omitRepeatedIssueCount }, runId) {
+function writeManifest(manifestPath, { prNumber, repeatedIssueCount, omitRepeatedIssueCount, rounds }, runId) {
   const lines = [
     "---",
     "relay_version: 2",
@@ -26,6 +26,7 @@ function writeManifest(manifestPath, { prNumber, repeatedIssueCount, omitRepeate
     "git:",
     `  pr_number: ${prNumber === null || prNumber === undefined ? "null" : prNumber}`,
     "review:",
+    `  rounds: ${rounds}`,
   ];
 
   if (!omitRepeatedIssueCount) {
@@ -86,7 +87,12 @@ function materializeFixture(name) {
 
     if (run.manifest !== false) {
       const manifestPath = path.join(slugDir, `${run.runId}.md`);
-      writeManifest(manifestPath, run.manifest, run.runId);
+      const roundNumbers = run.rounds.map((round) => round.round);
+      const manifest = {
+        ...run.manifest,
+        rounds: run.manifest.rounds ?? Math.max(...roundNumbers, 0),
+      };
+      writeManifest(manifestPath, manifest, run.runId);
       setIsoMtime(manifestPath, run.latestMtime);
     }
 
@@ -219,6 +225,22 @@ test("analyze-flip-flop-pattern classifies missing verdict-file round gaps as da
   assert.deepEqual(run.flipFactors, []);
 });
 
+test("analyze-flip-flop-pattern classifies terminal missing manifest rounds as data_gap", () => {
+  const fixture = materializeFixture("corner-cases");
+  const summary = analyzeRuns({
+    now: fixture.now,
+    runsDir: fixture.runsDir,
+    windowDays: 30,
+  });
+
+  const run = findRun(summary, "issue-404-20260422040404040-ddeeffaa");
+  assert.equal(run.bucket, "data_gap");
+  assert.equal(run.dataGapReason, "missing_verdict_round");
+  assert.equal(run.missingVerdictRound, 3);
+  assert.equal(run.roundCount, 3);
+  assert.deepEqual(run.flipFactors, []);
+});
+
 test("analyze-flip-flop-pattern reports mixed flip and stable factors without inventing stable-factor flips", () => {
   const fixture = materializeFixture("corner-cases");
   const summary = analyzeRuns({
@@ -260,7 +282,7 @@ test("analyze-flip-flop-pattern renderReport emits the required headings and per
   assert.match(report, /## Flip-flop classification/);
   assert.match(report, /## Decision metric/);
   assert.match(report, /## Per-run breakdown/);
-  assert.match(report, /progressive \/ \(progressive \+ thrash\) = \*\*66\.7%\*\*/);
+  assert.match(report, /progressive \/ \(progressive \+ thrash\) = \*\*67%\*\*/);
   assert.match(report, /\*\*Recommendation\*\*: `>=20% -> proceed to Phase B`/);
 });
 

--- a/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/baseline.json
+++ b/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/baseline.json
@@ -1,0 +1,308 @@
+{
+  "now": "2026-04-23T12:00:00.000Z",
+  "runs": [
+    {
+      "slug": "alpha-11111111",
+      "runId": "issue-201-20260420010101010-aa11bb22",
+      "latestMtime": "2026-04-20T10:00:00.000Z",
+      "manifest": {
+        "prNumber": 201,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"],
+            ["Security", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "alpha-11111111",
+      "runId": "issue-202-20260420010202020-bb22cc33",
+      "latestMtime": "2026-04-20T11:00:00.000Z",
+      "manifest": {
+        "prNumber": 202,
+        "repeatedIssueCount": 2
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Forensics", "fail"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Forensics", "pass"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Forensics", "fail"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "alpha-11111111",
+      "runId": "issue-203-20260420010303030-cc33dd44",
+      "latestMtime": "2026-04-20T12:00:00.000Z",
+      "manifest": {
+        "prNumber": 203,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "alpha-11111111",
+      "runId": "issue-204-20260420010404040-dd44ee55",
+      "latestMtime": "2026-04-20T13:00:00.000Z",
+      "manifest": {
+        "prNumber": 204,
+        "omitRepeatedIssueCount": true
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "beta-22222222",
+      "runId": "issue-205-20260420010505050-ee55ff66",
+      "latestMtime": "2026-04-21T09:00:00.000Z",
+      "manifest": {
+        "prNumber": 205,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "not_run"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "beta-22222222",
+      "runId": "issue-206-20260420010606060-ff66aa77",
+      "latestMtime": "2026-04-21T10:00:00.000Z",
+      "manifest": {
+        "prNumber": 206,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Other", "pass"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "beta-22222222",
+      "runId": "issue-207-20260420010707070-aa77bb88",
+      "latestMtime": "2026-04-21T11:00:00.000Z",
+      "manifest": {
+        "prNumber": 207,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        },
+        {
+          "round": 4,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "beta-22222222",
+      "runId": "issue-208-20260301010808080-bb88cc99",
+      "latestMtime": "2026-03-01T11:00:00.000Z",
+      "manifest": {
+        "prNumber": 208,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "beta-22222222",
+      "runId": "issue-209-20260420010909090-cc99ddaa",
+      "latestMtime": "2026-04-21T12:00:00.000Z",
+      "manifest": {
+        "prNumber": 209,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "gamma-33333333",
+      "runId": "issue-210-20260420011010100-ddaaeebb",
+      "latestMtime": "2026-04-22T09:00:00.000Z",
+      "manifest": false,
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "gamma-33333333",
+      "runId": "issue-211-20260420011111110-eebbffcc",
+      "latestMtime": "2026-04-22T10:00:00.000Z",
+      "manifest": {
+        "prNumber": 211,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "raw": "{ invalid json"
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/corner-cases.json
+++ b/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/corner-cases.json
@@ -90,6 +90,30 @@
           ]
         }
       ]
+    },
+    {
+      "slug": "epsilon-55555555",
+      "runId": "issue-404-20260422040404040-ddeeffaa",
+      "latestMtime": "2026-04-22T13:00:00.000Z",
+      "manifest": {
+        "prNumber": 404,
+        "repeatedIssueCount": 0,
+        "rounds": 3
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        }
+      ]
     }
   ]
 }

--- a/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/corner-cases.json
+++ b/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/corner-cases.json
@@ -1,0 +1,95 @@
+{
+  "now": "2026-04-23T12:00:00.000Z",
+  "runs": [
+    {
+      "slug": "epsilon-55555555",
+      "runId": "issue-401-20260422040101010-aabbccdd",
+      "latestMtime": "2026-04-22T10:00:00.000Z",
+      "manifest": {
+        "prNumber": 401,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "epsilon-55555555",
+      "runId": "issue-402-20260422040202020-bbccddee",
+      "latestMtime": "2026-04-22T11:00:00.000Z",
+      "manifest": {
+        "prNumber": 402,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"],
+            ["Security", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"],
+            ["Security", "pass"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "pass"],
+            ["Security", "pass"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "epsilon-55555555",
+      "runId": "issue-403-20260422040303030-ccddeeff",
+      "latestMtime": "2026-04-22T12:00:00.000Z",
+      "manifest": {
+        "prNumber": 403,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "skipped"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        },
+        {
+          "round": 4,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/no-flips.json
+++ b/skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/no-flips.json
@@ -1,0 +1,74 @@
+{
+  "now": "2026-04-23T12:00:00.000Z",
+  "runs": [
+    {
+      "slug": "delta-44444444",
+      "runId": "issue-301-20260422010101010-1122aabb",
+      "latestMtime": "2026-04-22T10:00:00.000Z",
+      "manifest": {
+        "prNumber": 301,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "delta-44444444",
+      "runId": "issue-302-20260422010202020-2233bbcc",
+      "latestMtime": "2026-04-22T11:00:00.000Z",
+      "manifest": {
+        "prNumber": 302,
+        "repeatedIssueCount": 1
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Behavior", "pass"]
+          ]
+        },
+        {
+          "round": 2,
+          "rubricScores": [
+            ["Behavior", "not_run"]
+          ]
+        },
+        {
+          "round": 3,
+          "rubricScores": [
+            ["Behavior", "fail"]
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "delta-44444444",
+      "runId": "issue-303-20260422010303030-3344ccdd",
+      "latestMtime": "2026-04-22T12:00:00.000Z",
+      "manifest": {
+        "prNumber": 303,
+        "repeatedIssueCount": 0
+      },
+      "rounds": [
+        {
+          "round": 1,
+          "rubricScores": [
+            ["Only round", "pass"]
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Phase A measurement for issue #270 — analysis-only tooling to decide whether Phase B (finding-lineage + explainable-escalation) is worth shipping.

- Scans `~/.relay/runs/` within a configurable window (default 30d) and classifies each multi-round review run into `progressive-shaped | thrash-shaped | no_flip_flop | data_gap`.
- Decision metric = `progressive / (progressive + thrash)`. Gate = 20%.
- `--print` (default) emits the markdown report to stdout; `--post-comment --issue <N>` posts it via `gh issue comment`.

Chose `skills/relay-review/scripts/analyze-flip-flop-pattern.js` over a repo-root `scripts/reports/` path because the concept is reviewer-facing (factor traces, verdict-file layout, `repeated_issue_count` live in the reviewer's world).

## Phase A finding

Running against the operator's local `~/.relay/runs/` (last 30 days):

- Runs scanned: 198
- Runs with ≥2 rounds: 78
- progressive-shaped: **18**
- thrash-shaped: **2**
- no_flip_flop: 47
- data_gap: 11
- **Decision metric: 90%** → `>=20% -> proceed to Phase B`

Pattern is broadly distributed across slugs (dev-relay, beopjalal, finjuice, tamgu-note), not an artifact of a single project. PR #267 itself appears as a progressive-shaped entry (factor `f3_sha_binding_enforcement`, trace `r1:fail → r2:pass → r3:fail`).

Report comment posted on #270.

## Scope

Allowed-whitelist diff only:

- `skills/relay-review/scripts/analyze-flip-flop-pattern.js` (new)
- `skills/relay-review/scripts/analyze-flip-flop-pattern.test.js` (10 tests)
- `skills/relay-review/scripts/fixtures/analyze-flip-flop-pattern/{baseline,no-flips}.json`

**Explicitly NOT touched** (per Phase A scope fence in #270 and rubric `f4_scope_isolation`):

- `skills/relay-review/scripts/review-runner.js`
- `skills/relay-review/scripts/review-runner/*.js`
- `skills/relay-review/scripts/invoke-reviewer-*.js`
- `skills/relay-review/references/reviewer-prompt.md`, `evaluate-criteria.md`
- No `lineage` / `relates_to` / `escalation_decision` schema fields

## Test plan

- [x] `node --test skills/relay-review/scripts/analyze-flip-flop-pattern.test.js` — 10/10 pass
- [x] `node --test skills/relay-review/scripts/*.test.js skills/relay-dispatch/scripts/*.test.js skills/relay-merge/scripts/*.test.js` — 718/718 pass (baseline was 708; +10 for the new script)
- [x] `node skills/relay-review/scripts/analyze-flip-flop-pattern.js --print` runs end-to-end against real `~/.relay/runs/`
- [x] `node skills/relay-review/scripts/analyze-flip-flop-pattern.js --post-comment --issue 270` (run by orchestrator — codex sandbox blocked `api.github.com`)
- [x] `git diff --stat main...HEAD` stays within the scope whitelist

Part of #268. Dispatchable-in-parallel siblings: #269 (bootstrap_exempt) and #271 (CLI flag schema) after this decision lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 릴레이 실행의 플립-플롭 패턴 분석 CLI 도구 추가
  * 마크다운 형식의 분석 보고서 생성 지원
  * GitHub 이슈에 분석 결과 자동 게시 기능 추가

* **Tests**
  * 분석 도구의 동작을 검증하는 포괄적 테스트 스위트 추가
  * 다양한 시나리오를 위한 테스트 픽스처 데이터 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->