### PR TITLE
fix(relay-review): drop quality_execution_status from reviewer schema (#273)

### DIFF
--- a/skills/relay-review/scripts/invoke-reviewer.test.js
+++ b/skills/relay-review/scripts/invoke-reviewer.test.js
@@ -76,8 +76,13 @@ fs.writeFileSync(resultPath, JSON.stringify({
   assert.match(loggedArgs, /--ephemeral/);
   assert.match(loggedArgs, /--sandbox\nread-only/);
   assert.match(loggedArgs, /--output-schema/);
-  assert.equal(schema.properties.quality_execution_status.enum.includes("missing"), true);
+  assert.equal(schema.properties.quality_execution_status, undefined);
   assert.equal(schema.required.includes("quality_execution_status"), false);
+  assert.deepEqual(
+    Object.keys(schema.properties).sort(),
+    [...schema.required].sort(),
+    "codex response_format requires every property key to be in required"
+  );
   assert.deepEqual(schema.properties.rubric_scores.items.required, [
     "factor",
     "target",

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -114,8 +114,11 @@ const REVIEW_VERDICT_JSON_SCHEMA = {
   properties: REVIEW_VERDICT_PROPERTIES,
 };
 
+const { quality_execution_status: _reviewerExecutionStatusOmitted, ...REVIEWER_VERDICT_PROPERTIES } = REVIEW_VERDICT_PROPERTIES;
+
 const REVIEWER_VERDICT_JSON_SCHEMA = {
-  ...REVIEW_VERDICT_JSON_SCHEMA,
+  type: "object",
+  additionalProperties: false,
   required: [
     "verdict",
     "summary",
@@ -126,6 +129,7 @@ const REVIEWER_VERDICT_JSON_SCHEMA = {
     "rubric_scores",
     "scope_drift",
   ],
+  properties: REVIEWER_VERDICT_PROPERTIES,
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Remove `quality_execution_status` from `REVIEWER_VERDICT_JSON_SCHEMA.properties` so the reviewer-facing schema matches OpenAI's response-format contract (every property must be in `required`).
- `REVIEW_VERDICT_JSON_SCHEMA` (the internal post-processed verdict) continues to include the field — review-runner populates it from execution-evidence after the reviewer returns.
- Invoke-reviewer test now locks in the codex-compat contract: `Object.keys(properties).sort() === required.sort()`. Future property additions that forget `required` will fail-fast.

Fixes #273.

## Impact

Unblocks `relay-review --reviewer codex` on `main`, which has been broken for every review since #267 merged (2026-04-22). Observed today during review of PR #272.

Claude reviewer path is not affected (claude's `--json-schema` tolerates optional properties); but claude reviewer still needs `ANTHROPIC_API_KEY` configured per #259's fail-fast. This PR is necessary but not sufficient to make the review path friction-free.

## Test plan

- [x] `node --test skills/relay-review/scripts/*.test.js skills/relay-dispatch/scripts/*.test.js skills/relay-merge/scripts/*.test.js skills/relay-plan/scripts/*.test.js skills/relay-intake/scripts/*.test.js` — 708/708 pass
- [x] `invoke-reviewer.test.js` lines 79-83: asserts fix + locks in codex-compat invariant
- [ ] Verified by using the fixed reviewer against PR #272 (will happen in the next review cycle after this lands)

## Bootstrap note

Canonical #269 case: this PR fixes the reviewer it would need for review. Landing via direct merge since no healthy reviewer exists pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 리뷰어 응답 스키마 유효성 검사를 강화했습니다.

* **버그 수정**
  * 리뷰어 평가에서 `quality_execution_status` 필드를 제거하고 정의되지 않은 필드를 차단하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->