### PR TITLE
[codex] Add bootstrap artifact reconciliation

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -119,6 +119,13 @@ cleanup:
 timestamps:
   created_at: "2026-04-03T12:00:00.000Z"
   updated_at: "2026-04-03T13:30:00.000Z"
+
+# Optional; present only when relay-reconcile-artifact is used.
+bootstrap_exempt:
+  enabled: true
+  artifact_path: ~/.relay/runs/project-abcd1234/issue-42-20260403120000000/execution-evidence.json
+  writer_pr: 267
+  reason: "this run predates the artifact writer"
 ---
 
 # Notes
@@ -139,10 +146,34 @@ timestamps:
 | `anchor.*` | Immutable review scope — prevents drift across rounds |
 | `review.last_reviewed_sha` | Gate-check blocks merge if HEAD has advanced past this |
 | `review.last_reviewer` | Tracks the acting reviewer for the latest round without mutating `roles.reviewer`; analytics must still use `review_apply.reviewer` as the round-level source of truth |
+| `bootstrap_exempt.*` | Optional operator-declared reconciliation for runs that predate an artifact writer but are closed after that writer lands |
+
+### Bootstrap exemptions
+
+`bootstrap_exempt` is absent for normal runs. It is populated only by `relay-reconcile-artifact`, which exists for bootstrap cases where a run cannot satisfy a newly introduced artifact requirement because the run itself produced that writer.
+
+Shape:
+
+```yaml
+bootstrap_exempt:
+  enabled: true
+  artifact_path: <path to the reconciled artifact contract>
+  writer_pr: <pull request number that introduced the writer>
+  reason: <operator audit reason>
+```
+
+Semantics:
+
+- `enabled: true` marks the run as a structured bootstrap exemption; analytics must count this field, not reason-string prefixes.
+- `artifact_path` records the artifact contract that the run predates or reconciles.
+- `writer_pr` records the PR that introduced the writer or artifact contract.
+- `reason` remains an operator-readable audit explanation.
+- Re-running `relay-reconcile-artifact` with identical fields against the already merged exempt run is a no-op and does not append another event.
+- Existing manifests without this field remain valid and load as non-exempt runs.
 
 ## Event Journal
 
-Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `model`, `before`, `after`):
+Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `pr_number`, `bootstrap_exempt`, `model`, `before`, `after`):
 
 ```jsonl
 {"ts":"2026-04-18T12:00:00.000Z","event":"dispatch_start","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"draft","state_to":"dispatched","head_sha":"abc123","round":null,"reason":"new_dispatch","model":"gpt-5-codex"}
@@ -163,7 +194,7 @@ Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/e
 | `state_recovery` | `relay-dispatch/scripts/recover-state.js` |
 | `review_invoke` | `relay-review/scripts/review-runner/reviewer-invoke.js` |
 | `review_apply` | `relay-review/scripts/review-runner.js`, `reviewer-invoke.js` |
-| `pr_number_stamped`, `merge_blocked`, `skip_review`, `merge_finalize`, `cleanup_result` | `relay-merge/scripts/finalize-run.js`, `gate-check.js` |
+| `pr_number_stamped`, `merge_blocked`, `skip_review`, `force_finalize`, `merge_finalize`, `cleanup_result` | `relay-merge/scripts/finalize-run.js`, `relay-reconcile-artifact.js`, `gate-check.js` |
 | `request_persisted`, `proposal_presented`, `question_asked`, `question_answered`, `proposal_accepted`, `proposal_edited`, `relay_ready_handoff_persisted` | `relay-intake/scripts/relay-request.js` |
 
 There is no standalone `state_transition` event — state changes ride on the lifecycle event that caused them (`state_from`/`state_to` fields on `dispatch_start`, `dispatch_result`, `review_apply`, `merge_finalize`, etc.).

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -63,6 +63,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.pr_number !== undefined
       ? { pr_number: normalizeEventValue(eventData.pr_number) }
       : {}),
+    ...(eventData.bootstrap_exempt !== undefined
+      ? { bootstrap_exempt: eventData.bootstrap_exempt === true }
+      : {}),
     ...(eventData.model !== undefined
       ? { model: normalizeEventValue(eventData.model) }
       : {}),

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -457,6 +457,7 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
   return {
     repoRoot,
     staleHours,
+    bootstrap_exempt_runs: manifests.filter(({ data }) => data?.bootstrap_exempt?.enabled === true).length,
     totals: {
       manifests: manifests.length,
       events: events.length,

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -44,6 +44,7 @@ function writeRun(repoRoot, {
   reviewer = "codex",
   lastReviewer = null,
   lastReviewedSha = null,
+  bootstrapExempt = null,
 }) {
   initGitRepo(repoRoot);
   const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
@@ -73,6 +74,9 @@ function writeRun(repoRoot, {
   manifest.review.rounds = rounds;
   manifest.review.last_reviewer = lastReviewer;
   manifest.review.last_reviewed_sha = lastReviewedSha;
+  if (bootstrapExempt) {
+    manifest.bootstrap_exempt = bootstrapExempt;
+  }
   manifest.timestamps.created_at = updatedAt;
   manifest.timestamps.updated_at = updatedAt;
   writeManifest(manifestPath, manifest);
@@ -97,6 +101,12 @@ test("reliability-report derives the core scorecard from manifests and events", 
     state: STATES.MERGED,
     rounds: 4,
     updatedAt: recentTs,
+    bootstrapExempt: {
+      enabled: true,
+      artifact_path: "execution-evidence.json",
+      writer_pr: 267,
+      reason: "run predates artifact writer",
+    },
   });
   writeRun(repoRoot, {
     runId: runStaleOpen,
@@ -155,6 +165,7 @@ test("reliability-report derives the core scorecard from manifests and events", 
   assert.equal(report.metrics.max_rounds_enforcement_rate, 1);
   assert.equal(report.metrics.median_rounds_to_ready, 3);
   assert.equal(report.metrics.stale_open_runs_72h, 1);
+  assert.equal(report.bootstrap_exempt_runs, 1);
 });
 
 test("reliability-report aggregates model_per_phase from dispatch and review events", () => {

--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -83,6 +83,18 @@ Audit every use:
 jq 'select(.event == "force_finalize")' ~/.relay/runs/<repo-slug>/<run-id>/events.jsonl
 ```
 
+#### Bootstrap artifact reconciliation
+
+When a run predates an artifact writer that the run itself introduced, use the structured reconciliation command instead of encoding that fact in a force-finalize reason:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/relay-reconcile-artifact.js --repo . --run-id "$RUN_ID" \
+  --artifact-path "~/.relay/runs/<repo-slug>/<run-id>/execution-evidence.json" \
+  --writer-pr 267 --reason "run predates the artifact writer" --json
+```
+
+This stamps `bootstrap_exempt` in the manifest, emits `force_finalize` with `bootstrap_exempt: true`, and marks the run merged without invoking the PR merge path.
+
 ### 2. Sprint file update (if available)
 
 If `backlog/sprints/` has an active sprint file, update it. If no sprint file exists, skip this step.

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -64,6 +64,7 @@ const KNOWN_FLAGS = [
   "--force-finalize-nonready", "--reason",
   "--skip-merge", "--no-issue-close", "--dry-run", "--json", "--help", "-h",
 ];
+const LEGACY_BOOTSTRAP_REASON_PREFIX = /^\s*bootstrap:/i;
 
 if (!args.length || args.includes("--help") || args.includes("-h")) {
   console.log("Usage: finalize-run.js (--repo <path> --run-id <id> | --repo <path> --pr <number> | --manifest <path>) [options]");
@@ -96,6 +97,10 @@ function parsePositiveInt(value, label) {
     throw new Error(`${label} must be a positive integer`);
   }
   return parsed;
+}
+
+function hasLegacyBootstrapReasonPrefix(reason) {
+  return LEGACY_BOOTSTRAP_REASON_PREFIX.exec(String(reason || "")) !== null;
 }
 
 function gh(ghBin, repoPath, ...ghArgs) {
@@ -266,6 +271,12 @@ function main() {
   const gitBin = process.env.RELAY_GIT_BIN || "git";
   if (forceFinalizeNonready && !String(forceFinalizeReason || "").trim()) {
     throw new Error("--force-finalize-nonready requires --reason <non-empty-text>");
+  }
+  if (forceFinalizeNonready && hasLegacyBootstrapReasonPrefix(forceFinalizeReason)) {
+    console.error(
+      "Warning: bootstrap-prefixed --force-finalize-nonready reasons are deprecated. " +
+      "Use relay-reconcile-artifact --artifact-path <path> --writer-pr <pr> --reason <reason>."
+    );
   }
 
   let branch = getArg("--branch");

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -372,6 +372,36 @@ function execFinalize(fixture, {
   };
 }
 
+function spawnForceFinalize(fixture, reason) {
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [],
+    commits: [
+      {
+        oid: fixture.headSha,
+        committedDate: DEFAULT_COMMIT_DATE,
+      },
+    ],
+  });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--force-finalize-nonready",
+    "--reason", reason,
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  });
+
+  return { ...fixture, logPath, result };
+}
+
 test("finalize-run force-finalize merges an escalated run with an auditable event trail", () => {
   const fixture = setupRepo({ manifestState: STATES.ESCALATED });
   const forceReason = "reviewer-swap exhausted, diff clean per manual inspection";
@@ -391,6 +421,7 @@ test("finalize-run force-finalize merges an escalated run with an auditable even
   assert.equal(forceEvent?.state_to, STATES.MERGED);
   assert.equal(forceEvent?.reason, forceReason);
   assert.equal(forceEvent?.pr_number, 123);
+  assert.equal("bootstrap_exempt" in forceEvent, false);
   assert.equal(forceEvent?.last_reviewed_sha, headSha);
   assert.equal(forceEvent?.head_sha, headSha);
   assert.equal(mergeEvent?.state_to, STATES.MERGED);
@@ -402,6 +433,27 @@ test("finalize-run force-finalize merges an escalated run with an auditable even
   assert.equal(branchExists(repoRoot, branch), false);
   assert.equal(remoteBranchExists(repoRoot, branch), false);
   assert.match(fs.readFileSync(logPath, "utf-8"), /pr merge 123 --squash/);
+});
+
+test("finalize-run warns but succeeds for legacy bootstrap-prefixed force-finalize reasons", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+  const { result } = spawnForceFinalize(fixture, "Bootstrap: this PR introduces the writer");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /relay-reconcile-artifact/);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.state, STATES.MERGED);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.MERGED);
+});
+
+test("finalize-run does not warn for non-bootstrap force-finalize reasons", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+  const { result } = spawnForceFinalize(fixture, "operator override after manual review");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /relay-reconcile-artifact/);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.state, STATES.MERGED);
 });
 
 for (const sourceState of [

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Reconcile a bootstrap artifact writer run that predates the artifact it now
+ * needs for normal merge finalization.
+ *
+ * Usage:
+ *   relay-reconcile-artifact --repo <path> --run-id <id> --artifact-path <path> --writer-pr <int> --reason <text> [options]
+ *   relay-reconcile-artifact --manifest <path> --artifact-path <path> --writer-pr <int> --reason <text> [options]
+ *
+ * Options:
+ *   --repo <path>          Repository root (default: .)
+ *   --run-id <id>          Relay run identifier
+ *   --manifest <path>      Explicit manifest path
+ *   --branch <name>        Resolve an active run by branch
+ *   --pr <number>          Resolve an active run by stored PR number
+ *   --artifact-path <path> Required artifact path being reconciled
+ *   --writer-pr <int>      Required PR number that introduced the writer
+ *   --reason <text>        Required audit reason
+ *   --skip-review <reason> Optional audit event for intentional review bypass
+ *   --json                 Output JSON
+ *   --help, -h             Show usage
+ */
+
+const path = require("path");
+const fs = require("fs");
+const {
+  getCanonicalRepoRoot,
+  validateManifestPaths,
+} = require("../../relay-dispatch/scripts/manifest/paths");
+const {
+  STATES,
+  forceUpdateManifestState,
+} = require("../../relay-dispatch/scripts/manifest/lifecycle");
+const {
+  getActorName,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/manifest/store");
+const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
+const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
+const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = [
+  "--repo", "--run-id", "--manifest", "--branch", "--pr",
+  "--artifact-path", "--writer-pr", "--reason", "--skip-review",
+  "--json", "--help", "-h",
+];
+
+if (!args.length || args.includes("--help") || args.includes("-h")) {
+  console.log("Usage: relay-reconcile-artifact (--repo <path> --run-id <id> | --manifest <path>) --artifact-path <path> --writer-pr <int> --reason <text> [options]");
+  console.log("\nMark a non-terminal bootstrap run merged after its required artifact writer lands.");
+  console.log("\nOptions:");
+  console.log("  --repo <path>          Repository root (default: .)");
+  console.log("  --run-id <id>          Relay run identifier");
+  console.log("  --manifest <path>      Explicit manifest path");
+  console.log("  --branch <name>        Resolve an active run by branch");
+  console.log("  --pr <number>          Resolve an active run by stored PR number");
+  console.log("  --artifact-path <path> Required artifact path being reconciled");
+  console.log("  --writer-pr <int>      Required PR number that introduced the writer");
+  console.log("  --reason <text>        Required audit reason");
+  console.log("  --skip-review <reason> Optional audit event for intentional review bypass");
+  console.log("  --json                 Output JSON");
+  process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
+}
+
+const getArg = (flag, fallback) => sharedGetArg(args, flag, fallback, { reservedFlags: KNOWN_FLAGS });
+const hasFlag = (flag) => sharedHasFlag(args, flag);
+
+function requireNonEmptyArg(flag, label) {
+  const value = getArg(flag);
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} is required`);
+  }
+  return value.trim();
+}
+
+function parsePositiveInt(value, label) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} is required`);
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function looksLikeGitRepo(repoPath) {
+  return fs.existsSync(path.join(repoPath, ".git"));
+}
+
+function getExpectedManifestRepoRoot(repoPath, repoArg) {
+  if (!repoArg && !looksLikeGitRepo(repoPath)) {
+    return undefined;
+  }
+  return getCanonicalRepoRoot(repoPath);
+}
+
+function sameBootstrapExemption(data, { artifactPath, writerPr, reason }) {
+  const existing = data?.bootstrap_exempt || {};
+  return (
+    existing.enabled === true
+    && existing.artifact_path === artifactPath
+    && Number(existing.writer_pr) === writerPr
+    && existing.reason === reason
+  );
+}
+
+function main() {
+  const artifactPath = requireNonEmptyArg("--artifact-path", "--artifact-path <path>");
+  const writerPr = parsePositiveInt(getArg("--writer-pr"), "--writer-pr <int>");
+  const reason = requireNonEmptyArg("--reason", "--reason <text>");
+  const skipReviewReason = getArg("--skip-review");
+  if (hasFlag("--skip-review") && !String(skipReviewReason || "").trim()) {
+    throw new Error("--skip-review <reason> is required when --skip-review is used");
+  }
+
+  const repoArg = getArg("--repo");
+  let repoPath = path.resolve(repoArg || ".");
+  const manifestArg = getArg("--manifest");
+  const runId = getArg("--run-id");
+  const branch = getArg("--branch");
+  const prNumber = getArg("--pr") === undefined
+    ? undefined
+    : parsePositiveInt(getArg("--pr"), "--pr");
+  const jsonOut = hasFlag("--json");
+
+  let manifestRecord = resolveManifestRecord({
+    repoRoot: repoPath,
+    manifestPath: manifestArg,
+    runId,
+    branch,
+    prNumber,
+    includeTerminal: true,
+  });
+  const selectorExpectedRepoRoot = manifestArg
+    ? undefined
+    : getExpectedManifestRepoRoot(repoPath, repoArg);
+  let validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
+    expectedRepoRoot: selectorExpectedRepoRoot,
+    manifestPath: manifestRecord.manifestPath,
+    runId: manifestRecord.data?.run_id,
+    caller: "relay-reconcile-artifact",
+  });
+  repoPath = validatedPaths.repoRoot;
+  if ((manifestArg || runId) && !repoArg) {
+    manifestRecord = resolveManifestRecord({
+      repoRoot: repoPath,
+      manifestPath: manifestArg,
+      runId,
+      branch,
+      prNumber,
+      includeTerminal: true,
+    });
+    validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
+      expectedRepoRoot: manifestArg ? undefined : repoPath,
+      manifestPath: manifestRecord.manifestPath,
+      runId: manifestRecord.data?.run_id,
+      caller: "relay-reconcile-artifact",
+    });
+  }
+
+  const { manifestPath, data, body } = manifestRecord;
+  const safeData = {
+    ...data,
+    paths: {
+      ...(data.paths || {}),
+      repo_root: validatedPaths.repoRoot,
+      worktree: validatedPaths.worktree,
+    },
+  };
+
+  if (safeData.state === STATES.CLOSED) {
+    throw new Error(`force-finalize cannot be used from terminal state ${safeData.state}`);
+  }
+  const requestedBootstrapExemption = {
+    enabled: true,
+    artifact_path: artifactPath,
+    writer_pr: writerPr,
+    reason,
+  };
+  if (safeData.state === STATES.MERGED) {
+    if (sameBootstrapExemption(safeData, { artifactPath, writerPr, reason })) {
+      const result = {
+        manifestPath,
+        previousState: safeData.state,
+        state: safeData.state,
+        nextAction: safeData.next_action,
+        bootstrapExempt: true,
+        artifactPath,
+        writerPr,
+        reason,
+        skipReviewReason: skipReviewReason || null,
+        idempotent: true,
+      };
+      if (jsonOut) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Bootstrap artifact already reconciled: ${manifestPath}`);
+      }
+      return;
+    }
+    throw new Error(`force-finalize cannot be used from terminal state ${safeData.state}`);
+  }
+
+  const operatorName = getActorName(repoPath);
+  const updated = forceUpdateManifestState({
+    ...safeData,
+    bootstrap_exempt: requestedBootstrapExemption,
+  }, STATES.MERGED, "manual_cleanup_required", {
+    reason,
+    operator: operatorName,
+  });
+
+  if (skipReviewReason) {
+    appendRunEvent(repoPath, safeData.run_id, {
+      event: "skip_review",
+      state_from: safeData.state,
+      state_to: safeData.state,
+      head_sha: safeData.git?.head_sha || null,
+      round: safeData.review?.rounds || null,
+      reason: skipReviewReason,
+      pr_number: writerPr,
+    });
+  }
+  appendRunEvent(repoPath, safeData.run_id, {
+    event: "force_finalize",
+    state_from: safeData.state,
+    state_to: STATES.MERGED,
+    head_sha: safeData.git?.head_sha || null,
+    round: safeData.review?.rounds || null,
+    reason,
+    pr_number: writerPr,
+    last_reviewed_sha: safeData.review?.last_reviewed_sha,
+    bootstrap_exempt: true,
+  });
+  writeManifest(manifestPath, updated, body);
+
+  const result = {
+    manifestPath,
+    previousState: safeData.state,
+    state: updated.state,
+    nextAction: updated.next_action,
+    bootstrapExempt: true,
+    artifactPath,
+    writerPr,
+    reason,
+    skipReviewReason: skipReviewReason || null,
+    idempotent: false,
+  };
+
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Reconciled bootstrap artifact run: ${manifestPath}`);
+    console.log(`  State:         ${safeData.state} -> ${updated.state}`);
+    console.log(`  Artifact path: ${artifactPath}`);
+    console.log(`  Writer PR:     #${writerPr}`);
+    console.log(`  Next action:   ${updated.next_action}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.test.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.test.js
@@ -1,0 +1,268 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  readManifest,
+  updateManifestState,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
+const { createEnforcementFixture } = require("../../relay-dispatch/scripts/test-support");
+
+const SCRIPT = path.join(__dirname, "relay-reconcile-artifact.js");
+const REPORT_SCRIPT = path.join(__dirname, "../../relay-dispatch/scripts/reliability-report.js");
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Reconcile Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-reconcile@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+}
+
+function buildManifestForState(manifest, targetState) {
+  switch (targetState) {
+    case STATES.DRAFT:
+      return manifest;
+    case STATES.DISPATCHED:
+      return updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+    case STATES.REVIEW_PENDING: {
+      const dispatched = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+      const reviewPending = updateManifestState(dispatched, STATES.REVIEW_PENDING, "run_review");
+      return {
+        ...reviewPending,
+        review: {
+          ...(reviewPending.review || {}),
+          rounds: 1,
+          latest_verdict: "pending",
+          last_reviewed_sha: reviewPending.git?.head_sha || null,
+        },
+      };
+    }
+    case STATES.READY_TO_MERGE: {
+      const reviewPending = buildManifestForState(manifest, STATES.REVIEW_PENDING);
+      const ready = updateManifestState(reviewPending, STATES.READY_TO_MERGE, "await_explicit_merge");
+      return {
+        ...ready,
+        review: {
+          ...(ready.review || {}),
+          latest_verdict: "lgtm",
+        },
+      };
+    }
+    case STATES.MERGED: {
+      const ready = buildManifestForState(manifest, STATES.READY_TO_MERGE);
+      return updateManifestState(ready, STATES.MERGED, "done");
+    }
+    case STATES.CLOSED: {
+      const ready = buildManifestForState(manifest, STATES.READY_TO_MERGE);
+      return updateManifestState(ready, STATES.CLOSED, "done");
+    }
+    default:
+      throw new Error(`Unsupported fixture manifest state: ${targetState}`);
+  }
+}
+
+function setupRun({
+  manifestState = STATES.REVIEW_PENDING,
+  bootstrapExempt = null,
+} = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-reconcile-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot);
+
+  const branch = "issue-269";
+  const runId = createRunId({
+    branch,
+    timestamp: new Date("2026-04-20T09:00:00.000Z"),
+  });
+  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 269,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+  }).anchor;
+  manifest.git.pr_number = 1269;
+  manifest.git.head_sha = "abc123def456";
+  manifest = buildManifestForState(manifest, manifestState);
+  if (bootstrapExempt) {
+    manifest.bootstrap_exempt = bootstrapExempt;
+  }
+  writeManifest(manifestPath, manifest);
+
+  return { repoRoot, runId, manifestPath, branch, worktreePath };
+}
+
+function runReconcile(fixture, {
+  artifactPath = "execution-evidence.json",
+  writerPr = "267",
+  reason = "run predates the artifact writer",
+  extraArgs = [],
+  selectorArgs = ["--repo", fixture.repoRoot, "--run-id", fixture.runId],
+} = {}) {
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    ...selectorArgs,
+    "--artifact-path", artifactPath,
+    "--writer-pr", writerPr,
+    "--reason", reason,
+    ...extraArgs,
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  return JSON.parse(stdout);
+}
+
+function spawnReconcile(fixture, args) {
+  return spawnSync("node", [SCRIPT, "--repo", fixture.repoRoot, "--run-id", fixture.runId, ...args, "--json"], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+}
+
+test("relay-reconcile-artifact stamps bootstrap exemption, emits force event, and reports count", () => {
+  const fixture = setupRun();
+  const artifactPath = "artifacts/execution-evidence.json";
+  const result = runReconcile(fixture, { artifactPath, writerPr: "267" });
+  const manifest = readManifest(fixture.manifestPath).data;
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  const forceEvent = events.find((event) => event.event === "force_finalize");
+  const report = JSON.parse(execFileSync("node", [
+    REPORT_SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--json",
+  ], { encoding: "utf-8" }));
+
+  assert.equal(result.previousState, STATES.REVIEW_PENDING);
+  assert.equal(result.state, STATES.MERGED);
+  assert.equal(result.bootstrapExempt, true);
+  assert.equal(result.artifactPath, artifactPath);
+  assert.equal(result.writerPr, 267);
+  assert.equal(manifest.state, STATES.MERGED);
+  assert.deepEqual(manifest.bootstrap_exempt, {
+    enabled: true,
+    artifact_path: artifactPath,
+    writer_pr: 267,
+    reason: "run predates the artifact writer",
+  });
+  assert.equal(manifest.last_force.from_state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.last_force.to_state, STATES.MERGED);
+  assert.equal(manifest.last_force.reason, "run predates the artifact writer");
+  assert.equal(forceEvent?.bootstrap_exempt, true);
+  assert.equal(forceEvent?.state_from, STATES.REVIEW_PENDING);
+  assert.equal(forceEvent?.state_to, STATES.MERGED);
+  assert.equal(forceEvent?.pr_number, 267);
+  assert.equal(report.bootstrap_exempt_runs, 1);
+});
+
+test("relay-reconcile-artifact is idempotent for identical already-exempt merged manifests", () => {
+  const fixture = setupRun();
+  runReconcile(fixture);
+  const firstEvents = readRunEvents(fixture.repoRoot, fixture.runId);
+  const result = runReconcile(fixture, {
+    selectorArgs: ["--manifest", fixture.manifestPath],
+  });
+  const secondEvents = readRunEvents(fixture.repoRoot, fixture.runId);
+
+  assert.equal(result.idempotent, true);
+  assert.equal(result.state, STATES.MERGED);
+  assert.equal(firstEvents.length, 1);
+  assert.deepEqual(secondEvents, firstEvents);
+});
+
+for (const terminalState of [STATES.MERGED, STATES.CLOSED]) {
+  test(`relay-reconcile-artifact rejects non-exempt terminal state ${terminalState}`, () => {
+    const fixture = setupRun({ manifestState: terminalState });
+    const result = spawnReconcile(fixture, [
+      "--artifact-path", "execution-evidence.json",
+      "--writer-pr", "267",
+      "--reason", "operator checked artifact writer",
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, new RegExp(`force-finalize cannot be used from terminal state ${terminalState}`));
+    const manifest = readManifest(fixture.manifestPath).data;
+    assert.equal(manifest.state, terminalState);
+    assert.equal("bootstrap_exempt" in manifest, false);
+    assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  });
+}
+
+for (const { name, args, pattern } of [
+  {
+    name: "missing artifact path",
+    args: ["--writer-pr", "267", "--reason", "operator checked"],
+    pattern: /--artifact-path <path> is required/,
+  },
+  {
+    name: "empty artifact path",
+    args: ["--artifact-path", "", "--writer-pr", "267", "--reason", "operator checked"],
+    pattern: /--artifact-path <path> is required/,
+  },
+  {
+    name: "missing writer PR",
+    args: ["--artifact-path", "execution-evidence.json", "--reason", "operator checked"],
+    pattern: /--writer-pr <int> is required/,
+  },
+  {
+    name: "empty writer PR",
+    args: ["--artifact-path", "execution-evidence.json", "--writer-pr", "", "--reason", "operator checked"],
+    pattern: /--writer-pr <int> is required/,
+  },
+]) {
+  test(`relay-reconcile-artifact rejects ${name} before mutation`, () => {
+    const fixture = setupRun();
+    const result = spawnReconcile(fixture, args);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, pattern);
+    const manifest = readManifest(fixture.manifestPath).data;
+    assert.equal(manifest.state, STATES.REVIEW_PENDING);
+    assert.equal("bootstrap_exempt" in manifest, false);
+    assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  });
+}
+
+test("relay-reconcile-artifact skip-review is additive with bootstrap reconciliation", () => {
+  const fixture = setupRun();
+  const result = runReconcile(fixture, {
+    extraArgs: ["--skip-review", "manual artifact audit"],
+  });
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  const skipEvent = events.find((event) => event.event === "skip_review");
+  const forceEvent = events.find((event) => event.event === "force_finalize");
+  const manifest = readManifest(fixture.manifestPath).data;
+
+  assert.equal(result.state, STATES.MERGED);
+  assert.equal(result.skipReviewReason, "manual artifact audit");
+  assert.equal(skipEvent?.reason, "manual artifact audit");
+  assert.equal(skipEvent?.state_from, STATES.REVIEW_PENDING);
+  assert.equal(skipEvent?.state_to, STATES.REVIEW_PENDING);
+  assert.equal(forceEvent?.bootstrap_exempt, true);
+  assert.equal(manifest.bootstrap_exempt.enabled, true);
+});


### PR DESCRIPTION
## Summary

Closes #269.

- Add `relay-reconcile-artifact.js` under `relay-merge/scripts` because the command is finalize-adjacent: it force-finalizes a manifest to `merged` without invoking the PR merge path.
- Stamp structured `bootstrap_exempt` manifest metadata, emit `force_finalize` with `bootstrap_exempt: true`, and count `bootstrap_exempt_runs` in `reliability-report --json`.
- Warn on legacy `--force-finalize-nonready --reason` values that use the old bootstrap-prefixed convention while leaving that path successful for non-bootstrap escapes.

## Notes

- The reconcile command routes the state change through `forceUpdateManifestState`.
- Identical re-runs against an already merged bootstrap-exempt manifest are no-ops and do not append duplicate events.
- `cli-args.js` is untouched; this stays disjoint from #271.

## Validation

- `grep -rn "forceTransitionState\|updateManifestState" skills/relay-merge/scripts/relay-reconcile-artifact.js`
- `grep -rn "forceUpdateManifestState" skills/relay-merge/scripts/relay-reconcile-artifact.js`
- `grep -rn "bootstrap:" skills/ | grep -v test | grep -v __fixtures__`
- `node --test skills/relay-merge/scripts/relay-reconcile-artifact.test.js`
- `node --test skills/relay-merge/scripts/finalize-run.test.js`
- `node --test skills/relay-dispatch/scripts/reliability-report.test.js`
- `node --test skills/relay-dispatch/scripts/relay-events.test.js`
- `node --test skills/relay-*/scripts/*.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `relay-reconcile-artifact` 명령어 추가: 아티팩트 작성자가 도입되기 전의 실행을 처리하기 위한 새로운 단계별 조정 도구
  * `bootstrap_exempt` 매니페스트 필드 추가: 실행을 부트스트랩 요구사항에서 면제할 수 있는 기능
  * 신뢰성 보고서에 bootstrap 면제 실행 추적 기능 추가

* **문서**
  * 아티팩트 조정 워크플로우 및 사용 지침 업데이트

* **버그 수정**
  * 레거시 bootstrap 형식의 사용 중단 경고 추가 및 새로운 명령어로의 마이그레이션 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->