### PR TITLE
Clarify finalize review bypass help

### DIFF
--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -90,6 +90,11 @@ if (!args.length || helpRequested) {
   console.log(`  --no-issue-close       ${modeLabel("--no-issue-close")} Skip linked issue close`);
   console.log(`  --dry-run              ${modeLabel("--dry-run")} Print what would happen without writing`);
   console.log(`  --json                 ${modeLabel("--json")} Output JSON`);
+  console.log("\nReview-bypass decision tree:");
+  console.log("  State is 'review_pending' + you want to skip review:     --skip-review <reason>");
+  console.log("  State is 'changes_requested' + reviewer-bundle limit:    --force-finalize-nonready --reason <text>");
+  console.log("  State is 'escalated' + dispatch-level failure resolved:  --force-finalize-nonready --reason <text>");
+  console.log("  State is 'ready_to_merge':                               neither - just run finalize-run");
   process.exit(helpRequested ? 0 : 1);
 }
 

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -24,6 +24,20 @@ const DEFAULT_REVIEW_COMMENT = {
   createdAt: DEFAULT_COMMIT_DATE,
 };
 
+test("finalize-run help includes review-bypass decision tree", () => {
+  const result = spawnSync("node", [SCRIPT, "--help"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Review-bypass decision tree/);
+  assert.ok(result.stdout.split(/\r?\n/).some((line) => (
+    line.includes("State is 'review_pending'")
+    && line.includes("--skip-review <reason>")
+  )));
+});
+
 function buildManifestForState(manifest, targetState) {
   switch (targetState) {
     case STATES.DRAFT:


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋했습니다: `63abae3 Clarify finalize review bypass help`

변경 범위는 두 파일뿐입니다.

```text
skills/relay-merge/scripts/finalize-run.js      |  5 +++++
skills/relay-merge/scripts/finalize-run.test.js | 14 ++++++++++++++
2 files changed, 19 insertions(+)
```

새 `--help` 섹션은 [finalize-run.js](/Users/sjlee/.relay/worktrees/12eb3b7c/dev-relay/skills/relay-merge/scripts/finalize-run.js:93)에 추가했습니다.

```text
Review-bypass decision tree:
  State is 'review_pending' + you want to skip review:     --skip-rev
```

## Score Log

- Run: issue-279-20260424053236783-cf3c0095
- Executor: codex
- Branch: issue-279