### PR TITLE
fix(dispatch): raise codex default timeout

### DIFF
--- a/skills/relay-dispatch/scripts/__fixtures__/worktree-runtime/dispatch-dry-run.json
+++ b/skills/relay-dispatch/scripts/__fixtures__/worktree-runtime/dispatch-dry-run.json
@@ -11,7 +11,7 @@
   "resultFile": "/tmp/issue187-fixtures/tmp/dispatch-codex-11111111.txt",
   "stdoutLog": "/tmp/issue187-fixtures/tmp/dispatch-codex-11111111.log",
   "stderrLog": "/tmp/issue187-fixtures/tmp/dispatch-codex-11111111.err",
-  "timeout": 1800,
+  "timeout": 2400,
   "cleanupPolicy": "on_close",
   "worktreeinclude": [],
   "rubricFile": "/tmp/issue187-fixtures/rubric.yaml",

--- a/skills/relay-dispatch/scripts/__fixtures__/worktree-runtime/dispatch-dry-run.txt
+++ b/skills/relay-dispatch/scripts/__fixtures__/worktree-runtime/dispatch-dry-run.txt
@@ -12,5 +12,5 @@ Dry run:
   Register: false
   Result:   /tmp/issue187-fixtures/tmp/dispatch-codex-11111111.txt
   Cleanup:  on_close
-  Timeout:  1800s
+  Timeout:  2400s
   Rubric:   /tmp/issue187-fixtures/rubric.yaml

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -22,7 +22,7 @@
  *   --model-hints <spec>   Persist per-phase model hints (phase=model,...)
  *   --sandbox <mode>       workspace-write | read-only (default: workspace-write)
  *   --copy <file,...>      Additional files to copy
- *   --timeout <seconds>    Exec timeout (default: 1800)
+ *   --timeout <seconds>    Exec timeout (default: 2400 for codex, 1800 for others)
  *   --rubric-file <path>   REQUIRED: copy rubric YAML to run dir (persists for review)
  *   --test-command <cmd>   Record the executor-side test command in execution evidence
  *   --rubric-grandfathered Retired alias; dispatch rejects it
@@ -127,7 +127,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --model-hints      ${modeLabel("--model-hints")} Persist per-phase model hints (phase=model,...)`);
   console.log(`  --sandbox          ${modeLabel("--sandbox")} workspace-write | read-only (default: workspace-write)`);
   console.log(`  --copy <files>     ${modeLabel("--copy")} Additional files to copy (comma-separated)`);
-  console.log(`  --timeout          ${modeLabel("--timeout")} Exec timeout in seconds (default: 1800)`);
+  console.log(`  --timeout          ${modeLabel("--timeout")} Exec timeout in seconds (default: 2400 for codex, 1800 for others)`);
   console.log(`  --rubric-file      ${modeLabel("--rubric-file")} REQUIRED: copy rubric YAML to run dir (persists for review)`);
   console.log(`  --test-command     ${modeLabel("--test-command")} Record the executor-side test command in execution evidence`);
   console.log(`  --rubric-grandfathered  ${modeLabel("--rubric-grandfathered")} Retired alias; remove anchor.rubric_grandfathered manually`);
@@ -151,6 +151,8 @@ const MANIFEST_INPUT = getArg(args, "--manifest", undefined, CLI_ARG_OPTIONS);
 const PROMPT = getArg(args, ["--prompt", "-p"], undefined, CLI_ARG_OPTIONS);
 const PROMPT_FILE = getArg(args, "--prompt-file", undefined, CLI_ARG_OPTIONS);
 const EXECUTOR = getArg(args, ["--executor", "-e"], "codex", CLI_ARG_OPTIONS);
+const DEFAULT_TIMEOUT_BY_EXECUTOR = { codex: 2400, claude: 1800 };
+const defaultTimeout = String(DEFAULT_TIMEOUT_BY_EXECUTOR[EXECUTOR] ?? 1800);
 const MODEL = getArg(args, ["--model", "-m"], undefined, CLI_ARG_OPTIONS);
 const MODEL_HINTS_RAW = getArg(args, "--model-hints", undefined, CLI_ARG_OPTIONS);
 const SANDBOX = getArg(args, "--sandbox", "workspace-write", CLI_ARG_OPTIONS);
@@ -161,7 +163,7 @@ const RUBRIC_GRANDFATHERED = hasCliFlag("--rubric-grandfathered");
 const REQUEST_ID = getArg(args, "--request-id", undefined, CLI_ARG_OPTIONS);
 const LEAF_ID = getArg(args, "--leaf-id", undefined, CLI_ARG_OPTIONS);
 const DONE_CRITERIA_FILE = getArg(args, "--done-criteria-file", undefined, CLI_ARG_OPTIONS);
-const TIMEOUT = parseInt(getArg(args, "--timeout", "1800", CLI_ARG_OPTIONS), 10);
+const TIMEOUT = parseInt(getArg(args, "--timeout", defaultTimeout, CLI_ARG_OPTIONS), 10);
 if (isNaN(TIMEOUT) || TIMEOUT <= 0) {
   console.error("Error: --timeout must be a positive integer");
   process.exit(1);

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -2614,6 +2614,39 @@ test("dispatch dry-run includes rubric file info", () => {
   fs.unlinkSync(rubricFile);
 });
 
+test("dispatch dry-run resolves per-executor timeout defaults and preserves explicit override", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-timeout-default-bin-"));
+  writeFakeCodex(binDir);
+  writeFakeClaude(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const codexDefault = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-timeout-codex-default",
+    "--executor", "codex",
+    "--prompt", "codex timeout default",
+    "--dry-run", "--json",
+  ], env));
+  const claudeDefault = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-timeout-claude-default",
+    "--executor", "claude",
+    "--prompt", "claude timeout default",
+    "--dry-run", "--json",
+  ], env));
+  const codexOverride = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-timeout-codex-override",
+    "--executor", "codex",
+    "--prompt", "codex timeout override",
+    "--timeout", "600",
+    "--dry-run", "--json",
+  ], env));
+
+  assert.equal(codexDefault.timeout, 2400);
+  assert.equal(claudeDefault.timeout, 1800);
+  assert.equal(codexOverride.timeout, 600);
+});
+
 test("dispatch dry-run json matches the frozen fixture", () => {
   const fixtureRun = setupDryRunFixtureRepo();
   const stdout = runDispatch(fixtureRun.repoRoot, [

--- a/skills/relay-dispatch/scripts/worktree-runtime.test.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.test.js
@@ -53,7 +53,7 @@ test("formatDispatchDryRun matches the frozen dispatch text fixture", () => {
     register: false,
     resultFile: "/tmp/issue187-fixtures/tmp/dispatch-codex-11111111.txt",
     cleanupPolicy: "on_close",
-    timeout: 1800,
+    timeout: 2400,
     rubricFile: "/tmp/issue187-fixtures/rubric.yaml",
     worktreePlan: {
       worktree: "/tmp/issue187-fixtures/relay-home/worktrees/11111111/repo",


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋/푸시까지 했습니다.

변경:
- `dispatch.js`에서 `DEFAULT_TIMEOUT_BY_EXECUTOR` lookup 추가
- codex 기본 timeout: `2400`
- claude 및 fallback 기본 timeout: `1800`
- `--timeout 600` 같은 명시 override는 그대로 우선 적용
- JSDoc, `--help`, dry-run fixture, 관련 formatter 테스트 갱신
- dry-run CLI 경로 테스트에 codex 기본값, claude 기본값, codex override 검증 추가

커밋:
- `2c3fdaa fix(dispatch): raise codex default timeout`
- 브랜치: `issue-280`
- 원격 push 완료: `origin/issue-280`

검증:
- `node --test skills/relay-dispatch/scripts/worktree-runtime.test
```

## Score Log

- Run: issue-280-20260424054147722-6f40e157
- Executor: codex
- Branch: issue-280