### PR TITLE
feat(dispatch): scale codex reasoning effort by rubric size (#287)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -57,6 +57,9 @@ const FLAGS = [
   { flag: "--prompt", aliases: ["-p"], kind: VALUE, mode: MODE_VERBATIM, valueName: "<text>", rationale: "Operator-supplied prompt text; keep the literal argv token." },
   { flag: "--prompt-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied prompt path; keep the literal argv token." },
   { flag: "--reason", kind: VALUE, mode: MODE_VERBATIM, valueName: "<text>", rationale: "Audit reason text must be recorded exactly and must not be blank." },
+  { flag: "--reasoning", kind: VALUE, mode: MODE_PARSED, valueName: "<level>",
+    allowedValues: ["none", "minimal", "low", "medium", "high", "xhigh"],
+    rationale: "Codex reasoning_effort override; closed selector over codex CLI levels." },
   { flag: "--register", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--repeated-issue-count", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Numeric review field; flag-like following tokens should mean the value is missing." },
   { flag: "--repo", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied repository path; keep the literal argv token." },
@@ -103,7 +106,7 @@ const COMMAND_FLAGS = {
   ],
   dispatch: [
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
-    "--model", "--model-hints", "--sandbox", "--copy", "--timeout", "--rubric-file",
+    "--model", "--model-hints", "--sandbox", "--copy", "--timeout", "--reasoning", "--rubric-file",
     "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
     "--done-criteria-file", "--register", "--no-cleanup", "--dry-run", "--json", "--help",
   ],

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -23,6 +23,7 @@
  *   --sandbox <mode>       workspace-write | read-only (default: workspace-write)
  *   --copy <file,...>      Additional files to copy
  *   --timeout <seconds>    Exec timeout (default: 2400 for codex, 1800 for others)
+ *   --reasoning <level>    Codex reasoning effort override (default by rubric size: S=medium, M=high, L/XL=xhigh)
  *   --rubric-file <path>   REQUIRED: copy rubric YAML to run dir (persists for review)
  *   --test-command <cmd>   Record the executor-side test command in execution evidence
  *   --rubric-grandfathered Retired alias; dispatch rejects it
@@ -104,7 +105,7 @@ const args = process.argv.slice(2);
 
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
-  "--model", "-m", "--model-hints", "--sandbox", "--copy", "--timeout", "--rubric-file", "--test-command", "--rubric-grandfathered",
+  "--model", "-m", "--model-hints", "--sandbox", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
   "--request-id", "--leaf-id", "--done-criteria-file",
   "--register", "--no-cleanup", "--dry-run", "--json", "--help", "-h",
 ];
@@ -128,6 +129,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --sandbox          ${modeLabel("--sandbox")} workspace-write | read-only (default: workspace-write)`);
   console.log(`  --copy <files>     ${modeLabel("--copy")} Additional files to copy (comma-separated)`);
   console.log(`  --timeout          ${modeLabel("--timeout")} Exec timeout in seconds (default: 2400 for codex, 1800 for others)`);
+  console.log(`  --reasoning        ${modeLabel("--reasoning")} Codex reasoning effort (default by rubric size: S=medium, M=high, L/XL=xhigh)`);
   console.log(`  --rubric-file      ${modeLabel("--rubric-file")} REQUIRED: copy rubric YAML to run dir (persists for review)`);
   console.log(`  --test-command     ${modeLabel("--test-command")} Record the executor-side test command in execution evidence`);
   console.log(`  --rubric-grandfathered  ${modeLabel("--rubric-grandfathered")} Retired alias; remove anchor.rubric_grandfathered manually`);
@@ -152,9 +154,11 @@ const PROMPT = getArg(args, ["--prompt", "-p"], undefined, CLI_ARG_OPTIONS);
 const PROMPT_FILE = getArg(args, "--prompt-file", undefined, CLI_ARG_OPTIONS);
 const EXECUTOR = getArg(args, ["--executor", "-e"], "codex", CLI_ARG_OPTIONS);
 const DEFAULT_TIMEOUT_BY_EXECUTOR = { codex: 2400, claude: 1800 };
+const DEFAULT_REASONING_BY_SIZE = { S: "medium", M: "high", L: "xhigh", XL: "xhigh" };
 const defaultTimeout = String(DEFAULT_TIMEOUT_BY_EXECUTOR[EXECUTOR] ?? 1800);
 const MODEL = getArg(args, ["--model", "-m"], undefined, CLI_ARG_OPTIONS);
 const MODEL_HINTS_RAW = getArg(args, "--model-hints", undefined, CLI_ARG_OPTIONS);
+const REASONING_OVERRIDE = getArg(args, "--reasoning", undefined, CLI_ARG_OPTIONS);
 const SANDBOX = getArg(args, "--sandbox", "workspace-write", CLI_ARG_OPTIONS);
 const COPY_FILES = getArg(args, "--copy", "", CLI_ARG_OPTIONS).split(",").filter(Boolean);
 const RUBRIC_FILE = getArg(args, "--rubric-file", undefined, CLI_ARG_OPTIONS);
@@ -508,6 +512,19 @@ function resolveEffectiveDispatchModel({ cliModel, manifestModelHints, cliModelH
   return null;
 }
 
+function extractRubricSize(rubricPath) {
+  if (!rubricPath || !fs.existsSync(rubricPath)) return null;
+  const rubricText = fs.readFileSync(rubricPath, "utf-8");
+  const match = rubricText.match(/^size:\s*["']?([A-Za-z]+)["']?\s*$/m);
+  return match ? match[1].toUpperCase() : null;
+}
+
+function resolveReasoningEffort({ override, rubricPath }) {
+  if (override) return override;
+  const rubricSize = extractRubricSize(rubricPath);
+  return DEFAULT_REASONING_BY_SIZE[rubricSize] || "xhigh";
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -841,6 +858,14 @@ async function main() {
 
   let cmd, execArgs;
   let execCwd;
+  const reasoningRunDir = getRunDir(repoRoot, runId);
+  const rubricPathForReasoning = manifest?.anchor?.rubric_path
+    ? path.join(reasoningRunDir, manifest.anchor.rubric_path)
+    : null;
+  const resolvedReasoningEffort = resolveReasoningEffort({
+    override: REASONING_OVERRIDE,
+    rubricPath: rubricPathForReasoning,
+  });
 
   // Prepend non-interactive directive so the model doesn't wait for approval
   // (e.g. brainstorming HARD-GATE or design-confirmation patterns).
@@ -853,6 +878,7 @@ async function main() {
   if (EXECUTOR === "codex") {
     cmd = "codex";
     execArgs = ["exec", "-C", wtPath, "--full-auto", "--color", "never", "-o", resultFile];
+    execArgs.push("-c", `model_reasoning_effort=${resolvedReasoningEffort}`);
     if (effectiveDispatchModel) execArgs.push("-m", effectiveDispatchModel);
     execArgs.push("--sandbox", SANDBOX);
     execArgs.push(execPrompt);

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -521,6 +521,8 @@ function extractRubricSize(rubricPath) {
 
 function resolveReasoningEffort({ override, rubricPath }) {
   if (override) return override;
+  // Defensive-only: enforceRubricPersistence() guarantees new dispatch runs have
+  // a rubric before argv construction, but keep the resolver safe standalone.
   const rubricSize = extractRubricSize(rubricPath);
   return DEFAULT_REASONING_BY_SIZE[rubricSize] || "xhigh";
 }

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -1192,9 +1192,9 @@ test("dispatch --reasoning overrides rubric-size codex reasoning effort", () => 
   assert.equal(reasoningArgValue(args), "model_reasoning_effort=low");
 });
 
-test("dispatch falls back to xhigh codex reasoning when rubric size is unavailable or unrecognized", () => {
-  const noRubric = captureCodexReasoning({
-    branch: "issue-reasoning-no-rubric",
+test("dispatch falls back to xhigh codex reasoning when rubric size is missing or unrecognized", () => {
+  const injectedRubricWithoutSize = captureCodexReasoning({
+    branch: "issue-reasoning-injected-rubric-without-size",
   });
   const noSize = captureCodexReasoning({
     branch: "issue-reasoning-no-size",
@@ -1205,7 +1205,7 @@ test("dispatch falls back to xhigh codex reasoning when rubric size is unavailab
     rubricText: "size: \"WEIRD\"\nrubric:\n  factors: []\n",
   });
 
-  assert.equal(reasoningArgValue(noRubric), "model_reasoning_effort=xhigh");
+  assert.equal(reasoningArgValue(injectedRubricWithoutSize), "model_reasoning_effort=xhigh");
   assert.equal(reasoningArgValue(noSize), "model_reasoning_effort=xhigh");
   assert.equal(reasoningArgValue(weirdSize), "model_reasoning_effort=xhigh");
 });

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -210,6 +210,33 @@ fs.writeFileSync(output, "ok\\n", "utf-8");
   return codexPath;
 }
 
+function writeArgCaptureClaude(binDir, capturePath) {
+  ensureDefaultFakeGh(binDir);
+  const claudePath = path.join(binDir, "claude");
+  fs.writeFileSync(claudePath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("claude-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "-p") {
+  process.stderr.write("unsupported fake claude invocation");
+  process.exit(1);
+}
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(args), "utf-8");
+const cwd = process.cwd();
+const fileName = "captured-claude.txt";
+fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
+process.stdout.write("ok\\n");
+`, "utf-8");
+  fs.chmodSync(claudePath, 0o755);
+  return claudePath;
+}
+
 function writeNoOpCodex(binDir) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -995,6 +1022,7 @@ test("dispatch precedence D1 regression: CLI override beats manifest hint in exe
     "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
+    "-c", "model_reasoning_effort=xhigh",
     "-m", "sonnet",
     "--sandbox", "workspace-write",
     buildDispatchExecPrompt(taskPrompt),
@@ -1026,6 +1054,7 @@ test("dispatch precedence D2 regression: CLI override works when manifest hint i
     "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
+    "-c", "model_reasoning_effort=xhigh",
     "-m", "sonnet",
     "--sandbox", "workspace-write",
     buildDispatchExecPrompt(taskPrompt),
@@ -1058,6 +1087,7 @@ test("dispatch precedence D3 regression: manifest hint supplies the effective mo
     "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
+    "-c", "model_reasoning_effort=xhigh",
     "-m", "opus",
     "--sandbox", "workspace-write",
     buildDispatchExecPrompt(taskPrompt),
@@ -1093,6 +1123,7 @@ test("dispatch precedence D4 regression: executor argv stays byte-identical when
     "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
+    "-c", "model_reasoning_effort=xhigh",
     "--sandbox", "workspace-write",
     buildDispatchExecPrompt(taskPrompt),
   ]);
@@ -1100,6 +1131,108 @@ test("dispatch precedence D4 regression: executor argv stays byte-identical when
   const events = readJsonLines(getEventsPath(repoRoot, result.runId));
   const dispatchStart = events.find((event) => event.event === "dispatch_start");
   assert.equal(dispatchStart.model, null);
+});
+
+function writeTempRubric(contents) {
+  const rubricFile = path.join(os.tmpdir(), `relay-rubric-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`);
+  fs.writeFileSync(rubricFile, contents, "utf-8");
+  return rubricFile;
+}
+
+function reasoningArgValue(args) {
+  const index = args.indexOf("-c");
+  return index === -1 ? null : args[index + 1];
+}
+
+function captureCodexReasoning({ branch, rubricText = null, extraArgs = [] }) {
+  const { repoRoot, relayHome } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-${branch}.json`);
+  writeArgCaptureCodex(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const rubricArgs = [];
+  if (rubricText !== null) {
+    rubricArgs.push("--rubric-file", writeTempRubric(rubricText));
+  }
+  runDispatch(repoRoot, [
+    "-b", branch,
+    "--prompt", `reasoning dispatch ${branch}`,
+    ...rubricArgs,
+    ...extraArgs,
+    "--json",
+  ], env);
+  return JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+}
+
+test("dispatch scales codex reasoning effort by rubric size", () => {
+  for (const [size, expected] of [
+    ["S", "medium"],
+    ["M", "high"],
+    ["L", "xhigh"],
+    ["XL", "xhigh"],
+  ]) {
+    const args = captureCodexReasoning({
+      branch: `issue-reasoning-size-${size.toLowerCase()}`,
+      rubricText: `size: "${size}"\nrubric:\n  factors: []\n`,
+    });
+    assert.equal(reasoningArgValue(args), `model_reasoning_effort=${expected}`);
+  }
+});
+
+test("dispatch --reasoning overrides rubric-size codex reasoning effort", () => {
+  const args = captureCodexReasoning({
+    branch: "issue-reasoning-override",
+    rubricText: "size: \"L\"\nrubric:\n  factors: []\n",
+    extraArgs: ["--reasoning", "low"],
+  });
+  assert.equal(reasoningArgValue(args), "model_reasoning_effort=low");
+});
+
+test("dispatch falls back to xhigh codex reasoning when rubric size is unavailable or unrecognized", () => {
+  const noRubric = captureCodexReasoning({
+    branch: "issue-reasoning-no-rubric",
+  });
+  const noSize = captureCodexReasoning({
+    branch: "issue-reasoning-no-size",
+    rubricText: "rubric:\n  factors: []\n",
+  });
+  const weirdSize = captureCodexReasoning({
+    branch: "issue-reasoning-weird-size",
+    rubricText: "size: \"WEIRD\"\nrubric:\n  factors: []\n",
+  });
+
+  assert.equal(reasoningArgValue(noRubric), "model_reasoning_effort=xhigh");
+  assert.equal(reasoningArgValue(noSize), "model_reasoning_effort=xhigh");
+  assert.equal(reasoningArgValue(weirdSize), "model_reasoning_effort=xhigh");
+});
+
+test("dispatch leaves claude executor argv untouched by rubric-size reasoning", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-claude-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-claude-reasoning.json`);
+  writeArgCaptureClaude(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const rubricFile = writeTempRubric("size: \"S\"\nrubric:\n  factors: []\n");
+
+  runDispatch(repoRoot, [
+    "-b", "issue-reasoning-claude",
+    "--executor", "claude",
+    "--prompt", "claude reasoning dispatch",
+    "--rubric-file", rubricFile,
+    "--json",
+  ], env);
+
+  const args = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.equal(args.includes("-c"), false);
+  assert.equal(args.some((arg) => arg.startsWith("model_reasoning_effort=")), false);
 });
 
 test("dispatch dry-run resolves effective_dispatch_model from model hints and emits zero events", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋/푸시까지 끝냈습니다.

변경 사항:
- `dispatch.js`: `DEFAULT_REASONING_BY_SIZE` 추가 (`S=medium`, `M=high`, `L/XL=xhigh`)
- `--reasoning <level>` override 추가
- Codex executor에만 `"-c", "model_reasoning_effort=<level>"` argv 주입
- Claude executor argv는 그대로 유지
- `cli-schema.js`에 `--reasoning` allowed values 등록
- dispatch 테스트에 size별 매핑, override, fallback, Claude 미적용 케이스 추가

검증:
- `node --test skills/relay-dispatch/scripts/dispatch.test.js skills/relay-dispatch/scripts/cli-schema.test.js` 통과
- `node --test
```

## Score Log

- Run: issue-287-20260424073512430-5185d8ae
- Executor: codex
- Branch: issue-287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- dispatch 명령에 `--reasoning` 플래그 추가 (여러 구성 가능한 노력 수준 지원)
- 프로젝트 크기 분류를 기반으로 추론 설정 자동 결정
- 사용자가 기본값을 커스텀 추론 사양으로 재정의 가능
- dispatch 실행 중 세밀한 추론 노력 관리 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->