### PR TITLE
Recover issue-284-rebrand-evidence (issue-284-20260424123227660-5b267d17)

### DIFF
--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -51,7 +51,7 @@ function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebr
     return { skipped: "no_existing_evidence" };
   }
   if (!/^[0-9a-f]{40}$/.test(newHeadSha || "")) {
-    throw new Error("newHeadSha must be a 40-character lowercase hex SHA");
+    return { skipped: "rejected_bad_sha", reason: "newHeadSha must be a 40-character lowercase hex SHA" };
   }
 
   const existing = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -45,10 +45,41 @@ function writeExecutionEvidence(runDir, evidence, options = {}) {
   return finalPath;
 }
 
+function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebrand", reason } = {}) {
+  const evidencePath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
+  if (!fs.existsSync(evidencePath)) {
+    return { skipped: "no_existing_evidence" };
+  }
+  if (!/^[0-9a-f]{40}$/.test(newHeadSha || "")) {
+    throw new Error("newHeadSha must be a 40-character lowercase hex SHA");
+  }
+
+  const existing = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  if (existing.head_sha === newHeadSha) {
+    return { skipped: "sha_unchanged" };
+  }
+
+  const previousSha = existing.head_sha;
+  writeExecutionEvidence(runDir, {
+    ...existing,
+    head_sha: newHeadSha,
+    recorded_by: recordedBy,
+    rebrand: {
+      previous_head_sha: previousSha,
+      previous_recorded_by: existing.recorded_by,
+      reason,
+      recorded_at: new Date().toISOString(),
+    },
+  });
+
+  return { rewritten: true, previousSha, newHeadSha };
+}
+
 module.exports = {
   EXECUTION_EVIDENCE_FILENAME,
   EXECUTION_EVIDENCE_SCHEMA_VERSION,
   buildExecutionEvidence,
   hashFileSha256,
+  rebrandEvidence,
   writeExecutionEvidence,
 };

--- a/skills/relay-dispatch/scripts/execution-evidence.test.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.test.js
@@ -161,3 +161,22 @@ test("rebrandEvidence skips unchanged SHA without rewriting", () => {
   });
   assert.equal(fs.readFileSync(evidencePath, "utf-8"), before);
 });
+
+test("rebrandEvidence returns structured rejected outcome for invalid SHA without rewriting", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-bad-sha-"));
+  const evidencePath = writeExecutionEvidence(runDir, {
+    schema_version: 1,
+    head_sha: "d".repeat(40),
+    test_command: "node --test",
+    test_result_hash: "unspecified",
+    test_result_summary: "unspecified",
+    recorded_at: "2026-04-22T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  });
+  const before = fs.readFileSync(evidencePath, "utf-8");
+
+  const result = rebrandEvidence(runDir, { newHeadSha: "not-a-sha" });
+  assert.equal(result.skipped, "rejected_bad_sha");
+  assert.match(result.reason, /40-character lowercase hex/);
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), before);
+});

--- a/skills/relay-dispatch/scripts/execution-evidence.test.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.test.js
@@ -8,6 +8,7 @@ const {
   EXECUTION_EVIDENCE_FILENAME,
   buildExecutionEvidence,
   hashFileSha256,
+  rebrandEvidence,
   writeExecutionEvidence,
 } = require("./execution-evidence");
 
@@ -99,4 +100,64 @@ test("dispatch execution evidence is not corrupted by a second tmp file in the r
   const written = JSON.parse(fs.readFileSync(finalPath, "utf-8"));
   assert.equal(written.head_sha, "e".repeat(40));
   assert.equal(fs.readFileSync(staleTmpPath, "utf-8"), "garbage\n");
+});
+
+test("rebrandEvidence rewrites existing evidence to the new head and preserves audit trail", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-rebrand-"));
+  const evidencePath = writeExecutionEvidence(runDir, {
+    schema_version: 1,
+    head_sha: "a".repeat(40),
+    test_command: "node --test",
+    test_result_hash: "unspecified",
+    test_result_summary: "unspecified",
+    recorded_at: "2026-04-22T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  });
+
+  const result = rebrandEvidence(runDir, {
+    newHeadSha: "b".repeat(40),
+    recordedBy: "recover-commit-rebrand",
+    reason: "recover-commit added new commit",
+  });
+  const written = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+
+  assert.deepEqual(result, {
+    rewritten: true,
+    previousSha: "a".repeat(40),
+    newHeadSha: "b".repeat(40),
+  });
+  assert.equal(written.head_sha, "b".repeat(40));
+  assert.equal(written.recorded_by, "recover-commit-rebrand");
+  assert.equal(written.rebrand.previous_head_sha, "a".repeat(40));
+  assert.equal(written.rebrand.previous_recorded_by, "dispatch-orchestrator-v1");
+  assert.equal(written.rebrand.reason, "recover-commit added new commit");
+  assert.match(written.rebrand.recorded_at, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("rebrandEvidence skips when execution evidence is absent", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-no-evidence-"));
+
+  assert.deepEqual(rebrandEvidence(runDir, { newHeadSha: "b".repeat(40) }), {
+    skipped: "no_existing_evidence",
+  });
+  assert.equal(fs.existsSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME)), false);
+});
+
+test("rebrandEvidence skips unchanged SHA without rewriting", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-unchanged-"));
+  const evidencePath = writeExecutionEvidence(runDir, {
+    schema_version: 1,
+    head_sha: "c".repeat(40),
+    test_command: "node --test",
+    test_result_hash: "unspecified",
+    test_result_summary: "unspecified",
+    recorded_at: "2026-04-22T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  });
+  const before = fs.readFileSync(evidencePath, "utf-8");
+
+  assert.deepEqual(rebrandEvidence(runDir, { newHeadSha: "c".repeat(40) }), {
+    skipped: "sha_unchanged",
+  });
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), before);
 });

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -13,9 +13,10 @@ const { parsePrNumber, formatExecError } = require("./dispatch-publish");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent } = require("./relay-events");
 const { STATES } = require("./manifest/lifecycle");
-const { getCanonicalRepoRoot, validateManifestPaths } = require("./manifest/paths");
+const { getCanonicalRepoRoot, getRunDir, validateManifestPaths } = require("./manifest/paths");
 const { summarizeError } = require("./manifest/store");
 const { stampPrNumberUnderLock } = require("./manifest/pr-number-stamp");
+const { rebrandEvidence } = require("./execution-evidence");
 const {
   findUnknownFlags,
   getArg,
@@ -315,6 +316,21 @@ function main() {
       const detail = formatExecError(error);
       appendFailureEvent(validatedPaths.repoRoot, data, "commit_failed", detail, commitSha, branch);
       throw new Error(`commit_failed: ${detail}`);
+    }
+  }
+  if (commitCreated) {
+    const rebrandResult = rebrandEvidence(getRunDir(validatedPaths.repoRoot, data.run_id), {
+      newHeadSha: commitSha,
+      recordedBy: "recover-commit-rebrand",
+      reason: `recover-commit added new commit; previous evidence bound to pre-commit SHA. Audit reason: ${reason}`,
+    });
+    if (rebrandResult.rewritten) {
+      appendRunEvent(validatedPaths.repoRoot, data.run_id, {
+        event: "execution_evidence_rebranded",
+        previous_head_sha: rebrandResult.previousSha,
+        new_head_sha: commitSha,
+        reason,
+      });
     }
   }
 

--- a/skills/relay-dispatch/scripts/recover-commit.test.js
+++ b/skills/relay-dispatch/scripts/recover-commit.test.js
@@ -15,6 +15,10 @@ const {
   writeManifest,
 } = require("./relay-manifest");
 const { readRunEvents } = require("./relay-events");
+const {
+  EXECUTION_EVIDENCE_FILENAME,
+  writeExecutionEvidence,
+} = require("./execution-evidence");
 
 const SCRIPT = path.join(__dirname, "recover-commit.js");
 
@@ -117,7 +121,7 @@ function buildManifestForState(manifest, state, repoRoot, runId) {
   throw new Error(`Unsupported test state: ${state}`);
 }
 
-function setupRepo({ dirty = false, unpushed = false, manifestState = STATES.REVIEW_PENDING } = {}) {
+function setupRepo({ dirty = false, unpushed = false, evidence = false, manifestState = STATES.REVIEW_PENDING } = {}) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-recover-commit-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
   const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-")));
@@ -151,7 +155,9 @@ function setupRepo({ dirty = false, unpushed = false, manifestState = STATES.REV
   }
 
   const runId = createRunId({ issueNumber: 281, branch, timestamp: new Date("2026-04-24T01:00:00.000Z") });
-  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  const runLayout = ensureRunLayout(repoRoot, runId);
+  const manifestPath = runLayout.manifestPath;
+  const runDir = runLayout.runDir;
   let manifest = createManifestSkeleton({
     repoRoot,
     runId,
@@ -165,6 +171,18 @@ function setupRepo({ dirty = false, unpushed = false, manifestState = STATES.REV
   });
   manifest = buildManifestForState(manifest, manifestState, repoRoot, runId);
   writeManifest(manifestPath, manifest);
+  if (evidence) {
+    const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+    writeExecutionEvidence(runDir, {
+      schema_version: 1,
+      head_sha: headSha,
+      test_command: "node --test skills/relay-*/scripts/*.test.js",
+      test_result_hash: "unspecified",
+      test_result_summary: "unspecified",
+      recorded_at: "2026-04-24T01:00:00.000Z",
+      recorded_by: "dispatch-orchestrator-v1",
+    });
+  }
 
   const ghPath = writeFakeGh(binDir, statePath, ghLogPath);
   const preloadPath = writeEventPreload(binDir, eventLogPath);
@@ -178,7 +196,7 @@ function setupRepo({ dirty = false, unpushed = false, manifestState = STATES.REV
       ? `${process.env.NODE_OPTIONS} --require ${preloadPath}`
       : `--require ${preloadPath}`,
   };
-  return { repoRoot, relayHome, runId, manifestPath, worktreePath, branch, statePath, ghLogPath, eventLogPath, env };
+  return { repoRoot, relayHome, runId, manifestPath, runDir, worktreePath, branch, statePath, ghLogPath, eventLogPath, env };
 }
 
 function runRecover(fixture, extraArgs = []) {
@@ -221,8 +239,48 @@ test("happy path commits dirty worktree, pushes, opens PR, stamps manifest, and 
   assert.equal(recoverEvent.commit_sha, parsed.commitSha);
   assert.equal(recoverEvent.pr_number, 281);
   assert.equal(events.filter((entry) => entry.event === "pr_number_stamped").length, 1);
+  assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);
   assert.ok(readJsonLines(fixture.eventLogPath).some((entry) => entry.eventData.event === "recover_commit"));
   assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 1);
+});
+
+test("dirty worktree recovery rebrands execution evidence to the created commit and emits event", () => {
+  const fixture = setupRepo({ dirty: true, evidence: true });
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  const result = runRecover(fixture, ["--reason", "executor completed before commit", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const afterEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  assert.equal(parsed.commitCreated, true);
+  assert.equal(afterEvidence.head_sha, parsed.commitSha);
+  assert.equal(afterEvidence.recorded_by, "recover-commit-rebrand");
+  assert.equal(afterEvidence.rebrand.previous_head_sha, beforeEvidence.head_sha);
+  assert.equal(afterEvidence.rebrand.previous_recorded_by, "dispatch-orchestrator-v1");
+  assert.match(afterEvidence.rebrand.reason, /Audit reason: executor completed before commit/);
+
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  const rebrandEvent = events.find((entry) => entry.event === "execution_evidence_rebranded");
+  assert.equal(rebrandEvent.previous_head_sha, beforeEvidence.head_sha);
+  assert.equal(rebrandEvent.new_head_sha, parsed.commitSha);
+  assert.equal(rebrandEvent.reason, "executor completed before commit");
+});
+
+test("already-committed recovery leaves execution evidence byte-identical", () => {
+  const fixture = setupRepo({ unpushed: true, evidence: true });
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+  const result = runRecover(fixture, ["--reason", "executor committed but did not push", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.commitCreated, false);
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(
+    readRunEvents(fixture.repoRoot, fixture.runId).filter((entry) => entry.event === "execution_evidence_rebranded").length,
+    0
+  );
 });
 
 test("clean worktree with no unpushed commits rejects as nothing to recover", () => {

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -60,6 +60,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.last_reviewed_sha !== undefined
       ? { last_reviewed_sha: normalizeEventValue(eventData.last_reviewed_sha) }
       : {}),
+    ...(eventData.previous_head_sha !== undefined
+      ? { previous_head_sha: normalizeEventValue(eventData.previous_head_sha) }
+      : {}),
+    ...(eventData.new_head_sha !== undefined
+      ? { new_head_sha: normalizeEventValue(eventData.new_head_sha) }
+      : {}),
     ...(eventData.pr_number !== undefined
       ? { pr_number: normalizeEventValue(eventData.pr_number) }
       : {}),


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-284-20260424123227660-5b267d17
- Branch: issue-284-rebrand-evidence
- Reason: codex completed-uncommitted; bootstrap PR for #284 rebrand feature
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-284-20260424123227660-5b267d17.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-04-24T12:38:51.144Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실행 증거 재식별 기능 추가
  * 변경 사유, 타임스탬프, 이전 상태 메타데이터 자동 기록
  * 커밋 복구 시 증거 자동 업데이트
  * 이벤트 로그에 이전/새로운 커밋 SHA 정보 포함

* **테스트**
  * 증거 재식별 및 이벤트 방출 동작에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->