### PR TITLE
Fix cleanup-worktrees pruned binding cleanup (#295)

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -98,6 +98,7 @@ function run() {
         expectedRepoRoot: repoRoot,
         manifestPath,
         runId: data.run_id,
+        acceptPrunedRelayOwned: true,
         caller: "cleanup-worktrees",
       });
       normalizedData = {
@@ -144,6 +145,7 @@ function run() {
       gitBin,
       dryRun,
       deleteMergedBranch: normalizedData.state === "merged",
+      acceptPrunedRelayOwned: true,
     });
 
     const item = {

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -10,6 +10,7 @@ const {
   createManifestSkeleton,
   createRunId,
   ensureRunLayout,
+  getRelayWorktreeBase,
   readManifest,
   updateManifestState,
   writeManifest,
@@ -53,11 +54,37 @@ function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   return { attackerRoot, attackerWorktree };
 }
 
-function createMissingRelayOwnedWorktree(repoRoot) {
-  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
-  fs.mkdirSync(relayWorktrees, { recursive: true });
-  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "missing-"));
-  return path.join(worktreeParent, path.basename(repoRoot));
+function writeStaleMissingRelayRun(repoRoot, { branch, updatedAt }) {
+  const runId = createRunId({
+    branch,
+    timestamp: new Date(updatedAt),
+  });
+  const worktreePath = path.join(getRelayWorktreeBase(), `stale-${branch}`, path.basename(repoRoot));
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+
+  const layout = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 295,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: stale-cleanup\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  manifest = updateManifestState(manifest, STATES.MERGED, "manual_cleanup_required");
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  writeManifest(layout.manifestPath, manifest);
+  assert.equal(fs.existsSync(worktreePath), false, "fixture must model a pruned missing worktree");
+  return { manifestPath: layout.manifestPath, runId, worktreePath };
 }
 
 function writeRun(repoRoot, { branch, state, updatedAt }) {
@@ -254,40 +281,61 @@ test("cleanup-worktrees rejects relay-base same-name worktrees before deleting u
   assert.equal(manifest.cleanup.status, "pending");
 });
 
-test("cleanup-worktrees rejects missing relay-base same-name worktrees before cleanup side effects", () => {
+test("cleanup-worktrees cleans stale missing relay-owned manifests and is idempotent", () => {
   const repoRoot = setupRepo();
   const updatedAt = "2026-04-01T00:00:00.000Z";
-  const { manifestPath, worktreePath } = writeRun(repoRoot, {
-    branch: "issue-160b",
-    state: STATES.MERGED,
+  const first = writeStaleMissingRelayRun(repoRoot, {
+    branch: "issue-295-a",
     updatedAt,
   });
-  const missingWorktree = createMissingRelayOwnedWorktree(repoRoot);
+  const second = writeStaleMissingRelayRun(repoRoot, {
+    branch: "issue-295-b",
+    updatedAt,
+  });
 
-  const record = readManifest(manifestPath);
-  writeManifest(manifestPath, {
-    ...record.data,
-    paths: {
-      ...(record.data.paths || {}),
-      worktree: missingWorktree,
-    },
-  }, record.body);
+  const dryRunStdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--dry-run",
+    "--json",
+  ], { encoding: "utf-8" });
 
-  const stdout = execFileSync("node", [
+  const dryRunResult = JSON.parse(dryRunStdout);
+  const dryRunCleanedIds = new Set(dryRunResult.cleaned.map((entry) => entry.runId));
+  assert.equal(dryRunResult.failed.length, 0);
+  assert.equal(dryRunCleanedIds.has(first.runId), true);
+  assert.equal(dryRunCleanedIds.has(second.runId), true);
+  assert.equal(readManifest(first.manifestPath).data.cleanup.status, "pending", "dry-run must not persist cleanup state");
+
+  const firstRunStdout = execFileSync("node", [
     SCRIPT,
     "--repo", repoRoot,
     "--all",
     "--json",
   ], { encoding: "utf-8" });
 
-  const result = JSON.parse(stdout);
-  assert.equal(result.cleaned.length, 0);
-  assert.equal(result.failed.length, 1);
-  assert.match(result.failed[0].error, /manifest paths\.worktree/);
-  assert.equal(fs.existsSync(worktreePath), true, "cleanup-worktrees must fail closed before removing the real worktree");
-  assert.equal(branchExists(repoRoot, "issue-160b"), true);
-  assert.equal(fs.existsSync(missingWorktree), false);
-  assert.equal(readManifest(manifestPath).data.cleanup.status, "pending");
+  const firstRunResult = JSON.parse(firstRunStdout);
+  const cleanedIds = new Set(firstRunResult.cleaned.map((entry) => entry.runId));
+  assert.equal(firstRunResult.failed.length, 0);
+  assert.equal(cleanedIds.has(first.runId), true);
+  assert.equal(cleanedIds.has(second.runId), true);
+  assert.equal(readManifest(first.manifestPath).data.cleanup.status, "succeeded");
+  assert.equal(readManifest(second.manifestPath).data.cleanup.status, "succeeded");
+
+  const secondRunStdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const secondRunResult = JSON.parse(secondRunStdout);
+  const skippedById = new Map(secondRunResult.skipped.map((entry) => [entry.runId, entry.reason]));
+  assert.equal(secondRunResult.failed.length, 0);
+  assert.equal(secondRunResult.cleaned.length, 0);
+  assert.equal(skippedById.get(first.runId), "already_cleaned");
+  assert.equal(skippedById.get(second.runId), "already_cleaned");
 });
 
 test("cleanup-worktrees rejects tampered paths.repo_root before cleanup side effects", () => {

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -87,6 +87,40 @@ function writeStaleMissingRelayRun(repoRoot, { branch, updatedAt }) {
   return { manifestPath: layout.manifestPath, runId, worktreePath };
 }
 
+function writeStalePrunedRelayRun(repoRoot, { branch, updatedAt }) {
+  const runId = createRunId({
+    branch,
+    timestamp: new Date(updatedAt),
+  });
+  const worktreePath = path.join(getRelayWorktreeBase(), `pruned-${branch}`, path.basename(repoRoot));
+  fs.mkdirSync(worktreePath, { recursive: true });
+  fs.writeFileSync(path.join(worktreePath, ".git"), `gitdir: ${path.join(path.dirname(worktreePath), "missing-admin")}\n`, "utf-8");
+  fs.writeFileSync(path.join(worktreePath, "sentinel.txt"), "stale\n", "utf-8");
+
+  const layout = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 295,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: stale-cleanup\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  manifest = updateManifestState(manifest, STATES.MERGED, "manual_cleanup_required");
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  writeManifest(layout.manifestPath, manifest);
+  return { manifestPath: layout.manifestPath, runId, worktreePath };
+}
+
 function writeRun(repoRoot, { branch, state, updatedAt }) {
   const worktreePath = path.join(repoRoot, "wt", branch);
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
@@ -336,6 +370,45 @@ test("cleanup-worktrees cleans stale missing relay-owned manifests and is idempo
   assert.equal(secondRunResult.cleaned.length, 0);
   assert.equal(skippedById.get(first.runId), "already_cleaned");
   assert.equal(skippedById.get(second.runId), "already_cleaned");
+});
+
+test("cleanup-worktrees removes existing relay-owned directories with pruned git bindings", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const stale = writeStalePrunedRelayRun(repoRoot, {
+    branch: "issue-295-pruned",
+    updatedAt,
+  });
+
+  const dryRunStdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--dry-run",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const dryRunResult = JSON.parse(dryRunStdout);
+  assert.equal(dryRunResult.failed.length, 0);
+  assert.equal(dryRunResult.cleaned.some((entry) => entry.runId === stale.runId), true);
+  assert.equal(fs.existsSync(stale.worktreePath), true, "dry-run must not remove the pruned directory");
+  assert.equal(readManifest(stale.manifestPath).data.cleanup.status, "pending", "dry-run must not persist cleanup state");
+
+  const cleanupStdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const cleanupResult = JSON.parse(cleanupStdout);
+  const cleaned = cleanupResult.cleaned.find((entry) => entry.runId === stale.runId);
+  assert.ok(cleaned);
+  assert.equal(cleanupResult.failed.length, 0);
+  assert.equal(cleaned.worktreeRemoved, true);
+  assert.equal(cleaned.error, null);
+  assert.equal(fs.existsSync(stale.worktreePath), false);
+  assert.equal(readManifest(stale.manifestPath).data.cleanup.status, "succeeded");
 });
 
 test("cleanup-worktrees rejects tampered paths.repo_root before cleanup side effects", () => {

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -84,10 +84,18 @@ function readWorktreeStatus(gitBin, worktreePath) {
   }
 }
 
-function runCleanup({ repoRoot, data, gitBin = "git", dryRun = false, deleteMergedBranch = false }) {
+function runCleanup({
+  repoRoot,
+  data,
+  gitBin = "git",
+  dryRun = false,
+  deleteMergedBranch = false,
+  acceptPrunedRelayOwned = false,
+}) {
   const validatedPaths = validateManifestPaths(data?.paths, {
     expectedRepoRoot: repoRoot,
     runId: data?.run_id,
+    acceptPrunedRelayOwned,
     caller: "runCleanup",
   });
   const normalizedData = {

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -1,5 +1,6 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
+const path = require("path");
 
 const { validateManifestPaths } = require("./paths");
 const { summarizeError } = require("./store");
@@ -84,6 +85,31 @@ function readWorktreeStatus(gitBin, worktreePath) {
   }
 }
 
+function isRealpathContainedWithin(basePath, candidatePath) {
+  try {
+    const realBase = fs.realpathSync.native(basePath);
+    const realCandidate = fs.realpathSync.native(candidatePath);
+    const relative = path.relative(realBase, realCandidate);
+    return relative !== ""
+      && relative !== ".."
+      && !relative.startsWith(`..${path.sep}`)
+      && !path.isAbsolute(relative);
+  } catch {
+    return false;
+  }
+}
+
+function removePrunedRelayWorktreeDirectory(worktreePath, relayWorktreeBase) {
+  if (!fs.existsSync(worktreePath)) {
+    return true;
+  }
+  if (!isRealpathContainedWithin(relayWorktreeBase, worktreePath)) {
+    throw new Error(`refusing rm fallback outside relay worktree base: ${worktreePath}`);
+  }
+  fs.rmSync(worktreePath, { recursive: true, force: true });
+  return !fs.existsSync(worktreePath);
+}
+
 function runCleanup({
   repoRoot,
   data,
@@ -110,6 +136,9 @@ function runCleanup({
   const worktreePath = normalizedData.paths?.worktree || null;
   const branch = normalizedData.git?.working_branch || null;
   const worktreeStatus = readWorktreeStatus(gitBin, worktreePath);
+  const allowPrunedRelayWorktreeRemoval = acceptPrunedRelayOwned
+    && validatedPaths.prunedRelayOwnedForCleanup
+    && validatedPaths.worktreeLocation === "relay_worktree";
   const branchExistsBefore = localBranchExists(gitBin, repoRoot, branch);
   const errors = [];
 
@@ -117,7 +146,7 @@ function runCleanup({
   let branchDeleted = !deleteMergedBranch || !branch || !branchExistsBefore;
   let pruneRan = false;
 
-  if (worktreeStatus.exists && !worktreeStatus.clean) {
+  if (worktreeStatus.exists && !worktreeStatus.clean && !allowPrunedRelayWorktreeRemoval) {
     errors.push(`dirty worktree: ${worktreeStatus.text}`);
   }
 
@@ -127,7 +156,21 @@ function runCleanup({
         gitExec(gitBin, repoRoot, "worktree", "remove", "--force", worktreePath);
         worktreeRemoved = true;
       } catch (error) {
-        errors.push(`worktree remove failed: ${summarizeError(error)}`);
+        if (allowPrunedRelayWorktreeRemoval) {
+          try {
+            worktreeRemoved = removePrunedRelayWorktreeDirectory(worktreePath, validatedPaths.relayWorktreeBase);
+            if (!worktreeRemoved) {
+              errors.push(`worktree remove fallback failed: ${worktreePath} still exists`);
+            }
+          } catch (fallbackError) {
+            errors.push(
+              `worktree remove failed: ${summarizeError(error)}; ` +
+              `rm fallback failed: ${summarizeError(fallbackError)}`
+            );
+          }
+        } else {
+          errors.push(`worktree remove failed: ${summarizeError(error)}`);
+        }
       }
     }
   }
@@ -185,7 +228,7 @@ function runCleanup({
       worktreePath,
       worktreeExistsBefore: worktreeStatus.exists,
       worktreeRemoved,
-      worktreeDirty: worktreeStatus.exists && !worktreeStatus.clean,
+      worktreeDirty: worktreeStatus.exists && !worktreeStatus.clean && !allowPrunedRelayWorktreeRemoval,
       worktreeStatus: worktreeStatus.text || null,
       branch,
       branchExistedBefore: branchExistsBefore,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -238,6 +238,36 @@ function sameFilesystemLocation(leftPath, rightPath) {
   }
 }
 
+function isRealpathContainedWithin(basePath, candidatePath, { allowEqual = false } = {}) {
+  if (!basePath || !candidatePath) return false;
+  try {
+    const realBase = fs.realpathSync.native(basePath);
+    const realCandidate = fs.realpathSync.native(candidatePath);
+    return isPathContainedWithin(realBase, realCandidate, { allowEqual });
+  } catch {
+    return false;
+  }
+}
+
+function isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot }) {
+  const structurallyRelayOwned = isPathContainedWithin(relayWorktreeBase, worktree)
+    && path.basename(worktree) === path.basename(repoRoot);
+  if (!structurallyRelayOwned) {
+    return false;
+  }
+
+  if (fs.existsSync(worktree)) {
+    return isRealpathContainedWithin(relayWorktreeBase, worktree);
+  }
+
+  // A missing stale worktree cannot be realpath-resolved. In cleanup mode this
+  // structural recorded-path check is sufficient because cleanup consumes only
+  // the recorded path (git worktree remove --force when present; absent paths
+  // have no target to dereference). Malicious manifest write paths are a
+  // separate manifest-authoring trust boundary.
+  return true;
+}
+
 function getWorktreeGitCommonDir(worktreePath) {
   if (!worktreePath || !fs.existsSync(worktreePath)) {
     return null;
@@ -274,6 +304,7 @@ function validateManifestPaths(paths, {
   manifestPath,
   runId,
   requireWorktree = false,
+  acceptPrunedRelayOwned = false,
   caller = "relay manifest consumer",
 } = {}) {
   if (!paths || typeof paths !== "object" || Array.isArray(paths)) {
@@ -356,8 +387,12 @@ function validateManifestPaths(paths, {
           );
       })()
     );
+  const prunedRelayOwnedWorktreeForCleanup = acceptPrunedRelayOwned
+    && !relayOwnedWorktree
+    && (!fs.existsSync(worktree) || !getWorktreeGitCommonDir(worktree))
+    && isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot });
 
-  if (!repoContainedWorktree && !relayOwnedWorktree) {
+  if (!repoContainedWorktree && !relayOwnedWorktree && !prunedRelayOwnedWorktreeForCleanup) {
     throw new Error(
       `${caller}: manifest paths.worktree ${JSON.stringify(worktree)} is not contained under the expected repo root ` +
       `${JSON.stringify(repoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -375,21 +375,21 @@ function validateManifestPaths(paths, {
   const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
     && path.basename(worktree) === path.basename(repoRoot);
   const expectedGitCommonDir = getWorktreeGitCommonDir(repoRoot) || path.join(repoRoot, ".git");
+  const worktreeGitCommonDir = fs.existsSync(worktree)
+    ? getWorktreeGitCommonDir(worktree)
+    : null;
   const relayOwnedWorktree = relayOwnedWorktreeCandidate
     && (
       fs.existsSync(worktree)
-      && (() => {
-        const worktreeGitCommonDir = getWorktreeGitCommonDir(worktree);
-        return worktreeGitCommonDir
-          && (
-            worktreeGitCommonDir === expectedGitCommonDir
-            || sameFilesystemLocation(worktreeGitCommonDir, expectedGitCommonDir)
-          );
-      })()
+      && worktreeGitCommonDir
+      && (
+        worktreeGitCommonDir === expectedGitCommonDir
+        || sameFilesystemLocation(worktreeGitCommonDir, expectedGitCommonDir)
+      )
     );
   const prunedRelayOwnedWorktreeForCleanup = acceptPrunedRelayOwned
     && !relayOwnedWorktree
-    && (!fs.existsSync(worktree) || !getWorktreeGitCommonDir(worktree))
+    && (!worktreeGitCommonDir || !fs.existsSync(worktreeGitCommonDir))
     && isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot });
 
   if (!repoContainedWorktree && !relayOwnedWorktree && !prunedRelayOwnedWorktreeForCleanup) {
@@ -404,6 +404,7 @@ function validateManifestPaths(paths, {
     repoRoot,
     worktree,
     worktreeLocation: repoContainedWorktree ? "repo_root" : "relay_worktree",
+    prunedRelayOwnedForCleanup: prunedRelayOwnedWorktreeForCleanup,
     relayWorktreeBase,
   };
 }

--- a/skills/relay-dispatch/scripts/manifest/paths.test.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.test.js
@@ -59,6 +59,11 @@ test("manifest/paths cleanup mode accepts pruned and missing relay-owned worktre
 
   const prunedWorktree = path.join(relayWorktreeBase, "pruned-binding", repoBasename);
   fs.mkdirSync(prunedWorktree, { recursive: true });
+  fs.writeFileSync(
+    path.join(prunedWorktree, ".git"),
+    `gitdir: ${path.join(relayWorktreeBase, "pruned-binding-admin")}\n`,
+    "utf-8"
+  );
   const prunedResult = validateManifestPaths({
     repo_root: repoRoot,
     worktree: prunedWorktree,
@@ -71,6 +76,7 @@ test("manifest/paths cleanup mode accepts pruned and missing relay-owned worktre
   });
   assert.equal(prunedResult.worktree, prunedWorktree);
   assert.equal(prunedResult.worktreeLocation, "relay_worktree");
+  assert.equal(prunedResult.prunedRelayOwnedForCleanup, true);
 
   const missingWorktree = path.join(relayWorktreeBase, "missing-directory", repoBasename);
   fs.mkdirSync(path.dirname(missingWorktree), { recursive: true });

--- a/skills/relay-dispatch/scripts/manifest/paths.test.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.test.js
@@ -47,3 +47,104 @@ test("manifest/paths validateManifestPaths rejects manifest-path mismatches", ()
   );
   assert.match(getManifestPath(repoRoot, runId), /issue-188-20260418091011123-a1b2c3d4\.md$/);
 });
+
+test("manifest/paths cleanup mode accepts pruned and missing relay-owned worktrees", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-cleanup-repo-"));
+  initGitRepo(repoRoot);
+  const runId = "issue-295-20260425010101000-a1b2c3d4";
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const relayWorktreeBase = path.join(process.env.RELAY_HOME, "worktrees");
+  const repoBasename = path.basename(repoRoot);
+
+  const prunedWorktree = path.join(relayWorktreeBase, "pruned-binding", repoBasename);
+  fs.mkdirSync(prunedWorktree, { recursive: true });
+  const prunedResult = validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: prunedWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    acceptPrunedRelayOwned: true,
+    caller: "manifest/paths.test cleanup pruned",
+  });
+  assert.equal(prunedResult.worktree, prunedWorktree);
+  assert.equal(prunedResult.worktreeLocation, "relay_worktree");
+
+  const missingWorktree = path.join(relayWorktreeBase, "missing-directory", repoBasename);
+  fs.mkdirSync(path.dirname(missingWorktree), { recursive: true });
+  const missingResult = validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: missingWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    acceptPrunedRelayOwned: true,
+    caller: "manifest/paths.test cleanup missing",
+  });
+  assert.equal(missingResult.worktree, missingWorktree);
+  assert.equal(missingResult.worktreeLocation, "relay_worktree");
+  assert.equal(fs.existsSync(missingWorktree), false, "fixture must exercise the no-realpath missing-directory branch");
+});
+
+test("manifest/paths cleanup mode rejects relay-owned symlink escapes", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-symlink-repo-"));
+  initGitRepo(repoRoot);
+  const runId = "issue-295-20260425010102000-a1b2c3d4";
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const relayWorktreeBase = path.join(process.env.RELAY_HOME, "worktrees");
+  const repoBasename = path.basename(repoRoot);
+  const symlinkParent = path.join(relayWorktreeBase, "symlink-escape");
+  const symlinkWorktree = path.join(symlinkParent, repoBasename);
+  const escapedTarget = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-escaped-target-"));
+
+  fs.mkdirSync(symlinkParent, { recursive: true });
+  fs.symlinkSync(escapedTarget, symlinkWorktree, "dir");
+
+  assert.throws(
+    () => validateManifestPaths({
+      repo_root: repoRoot,
+      worktree: symlinkWorktree,
+    }, {
+      expectedRepoRoot: repoRoot,
+      manifestPath,
+      runId,
+      acceptPrunedRelayOwned: true,
+      caller: "manifest/paths.test cleanup symlink escape",
+    }),
+    /is not contained under the expected repo root/
+  );
+});
+
+test("manifest/paths default mode still rejects pruned relay-owned worktrees", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-strict-repo-"));
+  initGitRepo(repoRoot);
+  const runId = "issue-295-20260425010103000-a1b2c3d4";
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const relayWorktreeBase = path.join(process.env.RELAY_HOME, "worktrees");
+  const repoBasename = path.basename(repoRoot);
+  const prunedWorktree = path.join(relayWorktreeBase, "pruned-binding", repoBasename);
+  const missingWorktree = path.join(relayWorktreeBase, "missing-directory", repoBasename);
+
+  fs.mkdirSync(prunedWorktree, { recursive: true });
+  fs.mkdirSync(path.dirname(missingWorktree), { recursive: true });
+
+  for (const worktree of [prunedWorktree, missingWorktree]) {
+    assert.throws(
+      () => validateManifestPaths({
+        repo_root: repoRoot,
+        worktree,
+      }, {
+        expectedRepoRoot: repoRoot,
+        manifestPath,
+        runId,
+        caller: "manifest/paths.test strict pruned",
+      }),
+      /is not contained under the expected repo root/
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add cleanup-only opt-in validation for pruned relay-owned worktrees
- preserve symlink escape rejection with realpath containment for existing paths
- cover pruned, missing, strict default, symlink escape, and idempotent cleanup fixtures

## Tests
- node --test skills/relay-*/scripts/*.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 누락되었거나 제거된 릴레이 소유 작업 트리에 대한 정리 프로세스 개선
  * 정리 작업의 멱등성 강화 - 반복 실행 시 이미 정리된 항목 자동 건너뛰기

* **테스트**
  * 정리 작업의 상태 전환 및 검증 로직 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->