### PR TITLE
Persist Phase 1 done criteria anchors (#294)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -13,7 +13,7 @@
  *
  * Options:
  *   --branch, -b <name>    Branch name (required)
- *   --run-id <id>          Resume an existing relay run
+ *   --run-id <id>          Resume an existing run, or reserve id for new dispatch with --branch
  *   --manifest <path>      Resume an existing relay run from its manifest
  *   --prompt, -p <text>    Task prompt
  *   --prompt-file <path>   Read prompt from file (for large prompts)
@@ -83,6 +83,7 @@ const {
   getManifestPath,
   getRunDir,
   inferIssueNumber,
+  sameFilesystemLocation,
   validateManifestPaths,
 } = require("./manifest/paths");
 const {
@@ -119,7 +120,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log("       dispatch.js --manifest <path> --prompt-file <path> [options]");
   console.log("\nOptions:");
   console.log(`  --branch, -b       ${modeLabel("--branch")} Branch name (required)`);
-  console.log(`  --run-id           ${modeLabel("--run-id")} Resume an existing relay run`);
+  console.log(`  --run-id           ${modeLabel("--run-id")} Resume an existing run, or reserve id for new dispatch with --branch`);
   console.log(`  --manifest         ${modeLabel("--manifest")} Resume an existing relay run from its manifest`);
   console.log(`  --prompt, -p       ${modeLabel("--prompt")} Task prompt`);
   console.log(`  --prompt-file      ${modeLabel("--prompt-file")} Read prompt from file`);
@@ -223,7 +224,7 @@ const REGISTER = hasCliFlag("--register");
 const NO_CLEANUP = hasCliFlag("--no-cleanup");
 const DRY_RUN = hasCliFlag("--dry-run");
 const JSON_OUT = hasCliFlag("--json");
-const RESUME_MODE = !!RUN_ID || !!MANIFEST_INPUT;
+const RESUME_MODE = !!MANIFEST_INPUT || (!!RUN_ID && !BRANCH);
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
@@ -414,6 +415,28 @@ function failRunDirCollision(runId, manifestPath) {
     "Pass --run-id <id> to resume, or --manifest <path> to resume from an explicit manifest.",
   ].join("\n"));
   process.exit(1);
+}
+
+function isPlannerAnchorOnlyRunDir(runDir) {
+  if (!fs.existsSync(runDir)) return false;
+  const entries = fs.readdirSync(runDir).filter((entry) => entry !== ".DS_Store");
+  return entries.length === 1 && entries[0] === "done-criteria.md";
+}
+
+function isCanonicalPlannerDoneCriteriaPath(repoRoot, runId, doneCriteriaPath) {
+  if (!doneCriteriaPath) return false;
+  const canonicalPath = path.join(getRunDir(repoRoot, runId), "done-criteria.md");
+  return path.resolve(doneCriteriaPath) === canonicalPath
+    || sameFilesystemLocation(doneCriteriaPath, canonicalPath);
+}
+
+function inferDoneCriteriaSource({ repoRoot, runId, doneCriteriaPath, requestId, leafId }) {
+  if (!doneCriteriaPath) return null;
+  if (requestId || leafId) return "request_snapshot";
+  if (isCanonicalPlannerDoneCriteriaPath(repoRoot, runId, doneCriteriaPath)) {
+    return "planner_decision";
+  }
+  return "file";
 }
 
 function copyFileAtomically(sourcePath, finalPath) {
@@ -628,9 +651,10 @@ async function main() {
       });
     }
   } else {
-    runId = createRunId({ issueNumber, branch });
+    runId = runId || createRunId({ issueNumber, branch });
     manifestPath = getManifestPath(repoRoot, runId);
-    if (fs.existsSync(getRunDir(repoRoot, runId))) {
+    const runDir = getRunDir(repoRoot, runId);
+    if (fs.existsSync(manifestPath) || (fs.existsSync(runDir) && !isPlannerAnchorOnlyRunDir(runDir))) {
       failRunDirCollision(runId, manifestPath);
     }
     baseBranch = resolveBaseBranchForNewDispatch(repoRoot);
@@ -825,7 +849,13 @@ async function main() {
       requestId: REQUEST_ID || null,
       leafId: LEAF_ID || null,
       doneCriteriaPath: resolvedDoneCriteriaPath,
-      doneCriteriaSource: resolvedDoneCriteriaPath ? "request_snapshot" : null,
+      doneCriteriaSource: inferDoneCriteriaSource({
+        repoRoot,
+        runId,
+        doneCriteriaPath: resolvedDoneCriteriaPath,
+        requestId: REQUEST_ID,
+        leafId: LEAF_ID,
+      }),
       modelHints: MODEL_HINTS,
     });
     ensureRunLayout(repoRoot, runId);

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -2888,6 +2888,61 @@ test("dispatch stores request linkage and frozen done criteria anchor in manifes
   assert.equal(manifest.anchor.done_criteria_source, "request_snapshot");
 });
 
+test("dispatch infers planner_decision for canonical run-dir done criteria anchor", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+  const runId = "issue-294-20260425020202000-cafebabe";
+  const runDir = getRunDir(repoRoot, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  const doneCriteriaFile = path.join(runDir, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Planner decision\n", "utf-8");
+  const rubricFile = path.join(repoRoot, "rubric.yaml");
+  fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: planner anchor\n      target: source planner_decision\n", "utf-8");
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", runId,
+    "-b", "issue-294",
+    "--prompt", "planner anchor test",
+    "--done-criteria-file", doneCriteriaFile,
+    "--rubric-file", rubricFile,
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.mode, "new");
+  assert.equal(result.doneCriteriaPath, doneCriteriaFile);
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.run_id, runId);
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_source, "planner_decision");
+});
+
+test("dispatch preserves file source for ad-hoc done criteria paths", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+  const doneCriteriaFile = path.join(repoRoot, "adhoc-done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Ad-hoc file\n", "utf-8");
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-294-adhoc",
+    "--prompt", "ad-hoc anchor test",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_source, "file");
+});
+
 test("dispatch dry-run includes request linkage and frozen done criteria file info", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -31,7 +31,7 @@ Before designing the rubric, read relay reliability history:
 node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/reliability-report.js --repo . --json
 ```
 
-Use `historical_signal.stuck_factors`, `historical_signal.divergence_hotspots`, and `historical_signal.avg_rounds` to tighten factor wording, calibration examples, and review guidance. The signal does not gate dispatch, alter state transitions, or modify rubric structure. Empty-history and failure cases are rendered as `no historical data available`. Full field mapping + case handling: `references/signals.md` § Historical signal.
+Use `historical_signal.stuck_factors`, `divergence_hotspots`, and `avg_rounds` to tighten factor wording and calibration. The signal does not gate dispatch or alter state. Empty/failure cases render as `no historical data available`; details: `references/signals.md`.
 
 ### 1.6 Read probe quality signals
 
@@ -41,7 +41,7 @@ Before designing the rubric, read repo-local quality signals:
 node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
 ```
 
-Use `probe_signal.test_infra`, `probe_signal.lint_format`, `probe_signal.type_check`, `probe_signal.ci`, and `probe_signal.scripts` to inform rubric design, prerequisite naming, and Available Tools context. The planner picks what fits the task — the signal exposes data, it does not pick for them. No-signal and failure cases are rendered as `no quality infra detected`. Full field mapping + case handling: `references/signals.md` § Probe signal.
+Use `probe_signal.test_infra`, `lint_format`, `type_check`, `ci`, and `scripts` to inform rubric design, prerequisites, and Available Tools. The signal exposes data; it does not pick. No-signal/failure cases render as `no quality infra detected`; details: `references/signals.md`.
 
 ### 2. Build the rubric
 
@@ -49,57 +49,34 @@ Use the guided interview (`references/rubric-design-guide.md`) to derive factors
 
 ```yaml
 rubric:
-  setup: "npm install && npm start &"              # run before checks (if needed)
-  baseline: "npm run metrics > baseline.json"      # capture before-state (if delta metrics used)
-
-  prerequisites:                                    # repo-wide hygiene; must all pass; uncounted
+  prerequisites:
     - command: "npm test"
       target: "exit 0"
-    - command: "npx tsc --noEmit"
-      target: "exit 0"
-
-  factors:                                          # substantive checks (contract + quality)
+  factors:
     - name: API returns cursor-paginated response
       tier: contract
       type: automated
       command: "curl -s localhost:3000/api/items?limit=10 | jq '.next_cursor'"
       target: "non-null cursor string"
       weight: required
-
     - name: Pagination robustness
       tier: quality
       type: evaluated
-      criteria: |
-        - Last page: returns empty array + no next cursor (not null, not error)
-        - Concurrent writes: cursor stable when items inserted/deleted mid-pagination
-        - Large result set: query plan uses index scan (EXPLAIN ANALYZE)
-        - Cursor opacity: cursor is encoded, not raw DB id exposed to client
-      scoring_guide:
-        low: "Happy path works, last page returns error or null cursor"
-        mid: "Last page handled, but cursor is raw ID, no query plan check"
-        high: "All four criteria met, cursor is opaque, query uses index"
+      criteria: "Last page works; cursor is opaque and stable under writes."
+      scoring_guide: { low: "happy path only", mid: "last page handled", high: "opaque stable cursor" }
       target: ">= 8/10"
       weight: required
 ```
 
-Tier classification (hygiene / contract / quality), `type` = `automated` vs `evaluated`, and `weight` = `required` vs `best-effort`: see `references/rubric-design-guide.md` § Guided Interview. `setup`/`baseline` run before checks; `criteria` must be specific bullets; `scoring_guide` provides three anchors (low/mid/high) that executor and reviewer share.
+Tier classification, `type`, `weight`, `setup`/`baseline`, `criteria`, and `scoring_guide`: see `references/rubric-design-guide.md`.
 
-### Domain references (for expert perspective)
+### Domain references
 
-Consult `references/rubric-*.md` for specialist thinking. Design factors from AC, informed by (not copied from) references.
-
-| Task type | Reference | Key signal |
-|-----------|-----------|-----------|
-| UI components, pages, interactions | `rubric-frontend.md` | Lighthouse, CLS, a11y, interaction fidelity |
-| API endpoints, data layer, infra | `rubric-backend.md` | Query count, response time, failure modes |
-| User input, auth, file uploads, APIs with sensitive data | `rubric-security.md` | Trust boundaries, auth coverage, injection resistance, exposure control |
-| Code restructuring, migration | `rubric-refactoring.md` | Dead code delta, concept count, dependency direction |
-| README, guides, API docs, specs | `rubric-documentation.md` | Reader testing score, zero-context completeness |
-| Design-driven features, UX flows | `rubric-design.md` | Value → Usability → Delight hierarchy |
+Consult `references/rubric-*.md` for frontend, backend, security, refactoring, documentation, and design thinking. Design factors from AC, informed by references.
 
 ### Trust-model audit factor (auth-boundary tasks)
 
-If the task crosses an auth boundary (label `phase-0-follow-up`; keywords trust root, anchor, invariant, grandfather, validate, forge, bypass, gate-check, auth-boundary; or any `validateTransition*` / `validateManifest*` / `evaluateReviewGate` callsite), follow `references/rubric-trust-model.md`. Each of the three questions (who forges? where is the gate? what verifies?) becomes a **named factor**, not a criterion bullet. Record the answers under `### Trust-model audit` in the PR body before dispatch. This reference sharpens `rubric-security.md` — use both.
+If the task crosses an auth boundary (trust root, anchor, invariant, validate, forge, bypass, gate-check, auth-boundary, or `validateTransition*` / `validateManifest*` / `evaluateReviewGate`), follow `references/rubric-trust-model.md`. Each question becomes a named factor. Record answers under `### Trust-model audit` in the PR body before dispatch.
 
 ### 3. Validate the rubric
 
@@ -111,13 +88,13 @@ Quick gate before dispatch:
 - Every evaluated factor has `scoring_guide` with low/mid/high anchors
 - Criteria are specific and reference discoverable artifacts; targets are concrete
 
-Full validation checklist, factor count rules, Rubric Quality Card examples, grading (A/B/C/D), and risk signals: `references/rubric-validation.md`. Grade D = revise before dispatch; Grade C = warn and make the tradeoff explicit.
+Full checklist, factor counts, grading, and risk signals: `references/rubric-validation.md`. Grade D = revise; Grade C = warn and state the tradeoff.
 
 ### 3.4 Simplify the rubric
 
 Before persisting the draft rubric, apply the 6 heuristics in `references/rubric-simplification.md`.
 
-This applies to all task sizes; do not gate it on S/M vs L/XL. Rewrite prescriptive HOW language into observable WHAT, merge overlapping factors, remove unsupported defensive clauses, and verify weights before dispatch.
+Apply to all task sizes: rewrite HOW into observable WHAT, merge overlaps, remove unsupported defensive clauses, and verify weights.
 
 ### 3.45 Optional isolated planner draft
 
@@ -128,24 +105,32 @@ node ${CLAUDE_SKILL_DIR}/scripts/plan-runner.js \
   --issue 42 --planner codex --repo . --out-dir /tmp/relay-plan-42 --json
 ```
 
-This writes `rubric.yaml`, `dispatch-prompt.md`, and `planner-notes.md` under the output directory. The orchestrator still reviews and may edit the draft before dispatch.
+This writes `rubric.yaml`, `dispatch-prompt.md`, and `planner-notes.md`. The orchestrator reviews and may edit before dispatch.
+
+### Persisting Phase 1 deviations as anchor
+
+Use this when operator planning rejects or narrows the issue body AC. Persist the operator-authored Phase 1 decision before dispatch so fresh-context review uses the same scope anchor.
+
+```bash
+RUN_ID=issue-42-$(date -u +%Y%m%d%H%M%S000)-deadbeef
+node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js \
+  --repo . --run-id "$RUN_ID" --file /tmp/done-criteria-42.md --json
+
+node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
+  --run-id "$RUN_ID" -b issue-42 --prompt-file /tmp/dispatch-42.md \
+  --rubric-file /tmp/rubric-42.yaml \
+  --done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md
+```
+
+The helper writes `~/.relay/runs/<repo-slug>/<run-id>/done-criteria.md` with source `planner_decision`. Dispatch picks it up via `--done-criteria-file` when the same run id is used. Canonical filename is always `done-criteria.md`; ad-hoc file paths remain source `file`.
 
 ### 3.5 Review the rubric (L/XL tasks)
 
-- **S/M (1-4 AC)**: skip
-- **L (5-6 AC)**: stress-test (max 1 round) — subagent games rubric (gaming vectors, coverage gaps, disappear test, Padding Test)
-- **XL (7+ or cross-domain)**: stress-test + calibration simulation (parallel)
-
-Skip: re-dispatches with iteration history, all-automated rubrics. Full protocol + prompt templates: `references/rubric-stress-test.md`.
+S/M skips. L does one stress-test round. XL adds calibration simulation. Skip re-dispatches with iteration history and all-automated rubrics. Protocol: `references/rubric-stress-test.md`.
 
 ### 4. Generate dispatch prompt
 
-Take the base template (`../relay/references/prompt-template.md`) and append:
-
-- **Setup** — setup commands from rubric
-- **Scoring Rubric** — automated checks table + evaluated factors table
-- **Iteration Protocol** — measure-fix-keep loop with regression check, adversarial self-review, and stuck detection
-- **Score Log** — iteration scores table appended to the PR description (reviewer re-scores independently)
+Take the base template (`../relay/references/prompt-template.md`) and append Setup, Scoring Rubric, Iteration Protocol, and Score Log sections.
 
 Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 
@@ -154,7 +139,7 @@ Full iteration-protocol text + Score Log format: `references/iteration-protocol.
 Write the rubric YAML to a temp file alongside the dispatch prompt. Every relay dispatch must pass `--rubric-file` so the rubric is persisted at `anchor.rubric_path` for review and merge gates.
 
 ```bash
-${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
+node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
   -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml --timeout 3600
 ```
 

--- a/skills/relay-plan/scripts/persist-done-criteria.js
+++ b/skills/relay-plan/scripts/persist-done-criteria.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const {
+  ensureRunLayout,
+  getRunDir,
+  requireValidRunId,
+} = require("../../relay-dispatch/scripts/manifest/paths");
+
+function usage() {
+  console.error([
+    "Usage: persist-done-criteria.js --repo <path> --run-id <id> (--text <text> | --file <path>) [--json]",
+    "",
+    "Writes operator-authored Phase 1 Done Criteria to:",
+    "  ~/.relay/runs/<repo-slug>/<run-id>/done-criteria.md",
+  ].join("\n"));
+}
+
+function getArg(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function hasFlag(args, name) {
+  return args.includes(name);
+}
+
+function readInputText({ text, file }) {
+  if (text && file) {
+    throw new Error("use either --text or --file, not both");
+  }
+  if (!text && !file) {
+    throw new Error("one of --text or --file is required");
+  }
+  if (text) return text;
+
+  const inputPath = path.resolve(file);
+  if (!fs.existsSync(inputPath)) {
+    throw new Error(`input file not found: ${inputPath}`);
+  }
+  return fs.readFileSync(inputPath, "utf-8");
+}
+
+function persistDoneCriteria({ repo, runId, text }) {
+  const repoRoot = path.resolve(repo);
+  const normalizedRunId = requireValidRunId(runId);
+  ensureRunLayout(repoRoot, normalizedRunId);
+  const outputPath = path.join(getRunDir(repoRoot, normalizedRunId), "done-criteria.md");
+  fs.writeFileSync(outputPath, `${String(text).trim()}\n`, "utf-8");
+  return { path: outputPath, source: "planner_decision" };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
+    usage();
+    return;
+  }
+
+  try {
+    const repo = getArg(args, "--repo");
+    const runId = getArg(args, "--run-id");
+    if (!repo) throw new Error("--repo is required");
+    if (!runId) throw new Error("--run-id is required");
+
+    const result = persistDoneCriteria({
+      repo,
+      runId,
+      text: readInputText({
+        text: getArg(args, "--text"),
+        file: getArg(args, "--file"),
+      }),
+    });
+
+    if (hasFlag(args, "--json")) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`Done Criteria: ${result.path}`);
+      console.log(`Source: ${result.source}`);
+    }
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    usage();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  persistDoneCriteria,
+};

--- a/skills/relay-plan/scripts/persist-done-criteria.test.js
+++ b/skills/relay-plan/scripts/persist-done-criteria.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { getRunDir } = require("../../relay-dispatch/scripts/manifest/paths");
+
+const SCRIPT = path.join(__dirname, "persist-done-criteria.js");
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-dc-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Plan Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-plan@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return { repoRoot, relayHome };
+}
+
+test("persist-done-criteria writes canonical planner decision anchor and returns JSON", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  const runId = "issue-294-20260425010101000-deadbeef";
+  const env = { ...process.env, RELAY_HOME: relayHome };
+  const previousRelayHome = process.env.RELAY_HOME;
+  process.env.RELAY_HOME = relayHome;
+
+  try {
+    const stdout = execFileSync(process.execPath, [
+      SCRIPT,
+      "--repo", repoRoot,
+      "--run-id", runId,
+      "--text", "# Done Criteria\n\n- Follow Phase 1 planner decision",
+      "--json",
+    ], { encoding: "utf-8", stdio: "pipe", env });
+
+    const result = JSON.parse(stdout);
+    const expectedPath = path.join(getRunDir(repoRoot, runId), "done-criteria.md");
+    assert.deepEqual(result, { path: expectedPath, source: "planner_decision" });
+    assert.equal(
+      fs.readFileSync(expectedPath, "utf-8"),
+      "# Done Criteria\n\n- Follow Phase 1 planner decision\n"
+    );
+  } finally {
+    if (previousRelayHome === undefined) {
+      delete process.env.RELAY_HOME;
+    } else {
+      process.env.RELAY_HOME = previousRelayHome;
+    }
+  }
+});

--- a/skills/relay-review/scripts/review-runner-prompt.test.js
+++ b/skills/relay-review/scripts/review-runner-prompt.test.js
@@ -73,6 +73,29 @@ test("prompt/buildPrompt frames PR body snapshot path before Done Criteria", () 
   assert.ok(prompt.indexOf("## PR Description Snapshot") < prompt.indexOf("<task-content source="));
 });
 
+test("prompt/buildPrompt labels planner_decision Done Criteria source", () => {
+  const prompt = buildPrompt({
+    round: 1,
+    prNumber: 294,
+    branch: "issue-294",
+    issueNumber: 294,
+    doneCriteria: "# Done Criteria\n\n- Follow the Phase 1 deviation\n",
+    doneCriteriaSource: "planner_decision",
+    diffText: "diff --git a/a.js b/a.js\n",
+    runDir: null,
+    rubricLoad: {
+      warning: null,
+      content: null,
+    },
+  });
+
+  assert.match(
+    prompt,
+    /Done Criteria source: planner_decision \(operator-authored Phase 1 decision; supersedes issue body\)/
+  );
+  assert.match(prompt, /<task-content source="planner_decision">/);
+});
+
 test("prompt/buildPrompt makes failed PR body snapshots explicit", () => {
   const prompt = buildPrompt({
     round: 1,

--- a/skills/relay-review/scripts/review-runner/prompt.js
+++ b/skills/relay-review/scripts/review-runner/prompt.js
@@ -32,6 +32,13 @@ function formatPrBodySnapshotSection(prBodyPath, prBodySnapshot) {
   ].join("\n");
 }
 
+function formatDoneCriteriaSource(doneCriteriaSource) {
+  if (doneCriteriaSource === "planner_decision") {
+    return "planner_decision (operator-authored Phase 1 decision; supersedes issue body)";
+  }
+  return doneCriteriaSource || "done-criteria";
+}
+
 function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneCriteriaSource, diffText, reviewRepoPath, runDir, rubricLoad, prBodyPath, prBodySnapshot }) {
   const template = renderProjectConventions(readText(REVIEWER_PROMPT_PATH)
     .replace("source=\"done-criteria\"", `source="${doneCriteriaSource || "done-criteria"}"`)
@@ -44,6 +51,7 @@ function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneC
     `PR: #${prNumber || "unknown"}`,
     `Branch: ${branch || "unknown"}`,
     `Issue: ${issueNumber || "unknown"}`,
+    `Done Criteria source: ${formatDoneCriteriaSource(doneCriteriaSource)}`,
   ];
   const prBodySnapshotSection = formatPrBodySnapshotSection(prBodyPath, prBodySnapshot);
   if (prBodySnapshotSection) sections.push("", prBodySnapshotSection);
@@ -113,4 +121,5 @@ module.exports = {
   buildPrompt,
   formatPrBodySnapshotSection,
   formatPriorVerdictSummary,
+  formatDoneCriteriaSource,
 };


### PR DESCRIPTION
## Summary
- Add relay-plan helper to persist operator-authored Phase 1 Done Criteria at the canonical run-dir anchor path.
- Infer planner_decision for canonical done-criteria.md dispatch anchors while preserving request_snapshot and ad-hoc file sources.
- Surface Done Criteria source in reviewer prompts and document the workflow.

## Verification
- node --test skills/relay-*/scripts/*.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * Phase 1 Done Criteria 결정을 저장하고 추적할 수 있는 기능 추가
  * Done Criteria 출처 명확성 강화 (플래너 결정, 요청 스냅샷, 파일 등)
  * Run-ID 할당 및 재개 동작 개선

* **테스트**
  * Done Criteria 앵커링 및 출처 추적에 대한 테스트 케이스 추가

* **문서**
  * 간소화된 루브릭 예제 및 Phase 1 결정 저장 절차로 가이드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->