### PR TITLE
feat(relay-review): track finding lineage escalation decisions

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -35,6 +35,7 @@ function parseScalar(value) {
   if (value === "null") return null;
   if (value === "true") return true;
   if (value === "false") return false;
+  if (value.startsWith("[") && value.endsWith("]")) return JSON.parse(value);
   if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value);
   if (value.startsWith("'") && value.endsWith("'")) {
     return value.slice(1, -1).replace(/''/g, "'");
@@ -108,6 +109,7 @@ function parseFrontmatter(text) {
 
 function formatScalar(value) {
   if (value === null) return "null";
+  if (Array.isArray(value)) return JSON.stringify(value);
   if (typeof value === "boolean" || typeof value === "number") return String(value);
   if (typeof value === "string" && value.includes("\n")) {
     return JSON.stringify(value);

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -96,6 +96,21 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.reviewer_swap_count !== undefined
       ? { reviewer_swap_count: normalizeEventValue(eventData.reviewer_swap_count) }
       : {}),
+    ...(eventData.trigger !== undefined
+      ? { trigger: normalizeEventValue(eventData.trigger) }
+      : {}),
+    ...(eventData.factors !== undefined
+      ? { factors: normalizeEventValue(eventData.factors) }
+      : {}),
+    ...(eventData.traces !== undefined
+      ? { traces: normalizeEventValue(eventData.traces) }
+      : {}),
+    ...(eventData.lineage_summary !== undefined
+      ? { lineage_summary: normalizeEventValue(eventData.lineage_summary) }
+      : {}),
+    ...(eventData.decision !== undefined
+      ? { decision: normalizeEventValue(eventData.decision) }
+      : {}),
   };
 
   appendEventLine(repoRoot, runId, record);

--- a/skills/relay-review/references/evaluate-criteria.md
+++ b/skills/relay-review/references/evaluate-criteria.md
@@ -42,3 +42,23 @@ Note: The reviewer does NOT fix code directly — all fixes go through the execu
 **Convergence model:** Loop until all rubric factors meet target AND qualitative checks pass. The rubric anchors each round to the original scope — prevents drift. Safety cap: 20 rounds.
 
 **After safety cap:** Escalate — show user the PR URL, list unresolved issues, let them decide. Hitting the cap means something is structurally wrong, not that more rounds would help.
+
+## Lineage Grammar (#270 Phase B)
+
+| Value | Meaning | `relates_to` guidance |
+|---|---|---|
+| `new` | First-time finding with no prior-round ancestor. | Omit unless a prior factor reference clarifies the finding. |
+| `deepening` | The prior issue was valid, and this round exposes a narrower or deeper edge case rather than repeating the same blocker. | Reference the prior issue title, factor, or round/factor id. |
+| `repeat` | The same semantic issue is still blocking the PR. | Reference the prior issue title, factor, or round/factor id. |
+| `newly_scoreable` | A factor was previously blocked, missing evidence, or `not_run`, and is now scoreable with a concrete finding. | Reference the prior unscoreable factor or issue. |
+| `unknown` | Relationship cannot be determined, including omitted lineage from older verdicts. | Omit unless a partial reference is known. |
+
+Flip-flop suppression is narrow: when a factor flip-flops, `repeated_issue_count` is 0, and all current issues tied to the flipped factor have `lineage=deepening`, continue the review without escalation. Otherwise escalate. Missing lineage is coerced to `unknown`, which fails closed like `repeat`.
+
+Example traces:
+- `new`: `Behavior: r1:pass -> r2:fail` when round 2 finds a first-time issue in a factor with no prior blocker.
+- `deepening`: `Behavior: r1:pass -> r2:fail -> r3:pass` when the round 3 finding is a deeper edge case tied to the same factor rather than the same issue.
+- `repeat`: `Forensics: r1:fail -> r2:pass -> r3:fail` when the current finding restates a prior blocker.
+- `newly_scoreable`: `Behavior: r1:not_run -> r2:fail -> r3:pass` when a previously unscoreable factor becomes reviewable and exposes a finding.
+
+Non-regression guard: tamgu-note#1621 (PR 1634) and finjuice#416 (PR 417) both had `repeated_issue_count >= 1`, so they still escalate regardless of lineage. Phase B only suppresses the `repeated_issue_count === 0` progressive-deepening shape.

--- a/skills/relay-review/references/reviewer-prompt.md
+++ b/skills/relay-review/references/reviewer-prompt.md
@@ -101,6 +101,18 @@ In your summary, enumerate each Done Criteria item with one of four statuses. Ba
 
 If any item is NOT_DONE or CHANGED, verdict cannot be pass. PARTIAL items require `changes_requested`.
 
+### Lineage labeling
+
+For every entry in `issues[]`, populate `lineage`; populate `relates_to` whenever a prior issue or factor exists.
+
+Use `lineage: "new"` when this is a first-time finding with no prior-round ancestor; omit `relates_to` unless a specific prior note helps.
+Use `lineage: "deepening"` when the prior issue was valid but the current finding exposes a narrower or deeper edge case; set `relates_to` to the prior issue title or stable id when known.
+Use `lineage: "repeat"` when the same issue still blocks the PR; set `relates_to` to the prior issue title or stable id when known.
+Use `lineage: "newly_scoreable"` when earlier rounds could not score the factor (`not_run`, missing evidence, or blocked prerequisite) and this round reveals a scoreable finding; set `relates_to` to the prior unscoreable factor or issue when known.
+Use `lineage: "unknown"` only when you cannot determine the relationship from prior-round context.
+
+Do not invent prior ids. `relates_to` may be a concise prior issue title, factor name, or round/factor reference, but it must be non-empty when present.
+
 ### Verdict
 
 Reply with one of:

--- a/skills/relay-review/scripts/review-runner-manifest-apply.test.js
+++ b/skills/relay-review/scripts/review-runner-manifest-apply.test.js
@@ -120,6 +120,19 @@ function normalizeUpdatedTimestamp(manifest) {
   };
 }
 
+function makeEscalationDecision(overrides = {}) {
+  return {
+    round: 1,
+    trigger: "none",
+    factors: [],
+    traces: [],
+    lineage_summary: { deepening: 0, repeat: 0, new: 0, newly_scoreable: 0, unknown: 0 },
+    decision: "continue",
+    reason: "no_trigger",
+    ...overrides,
+  };
+}
+
 function assertManifestWriteParity(actual, before, expected) {
   assert.equal(actual.timestamps.created_at, before.timestamps.created_at);
   assert.ok(Date.parse(actual.timestamps.updated_at) >= Date.parse(before.timestamps.updated_at));
@@ -155,6 +168,22 @@ test("manifest-apply/applyVerdictToManifest preserves the PASS field-write contr
       last_gate: null,
     },
   });
+});
+
+test("manifest-apply/applyVerdictToManifest writes last_escalation_decision on clean rounds", () => {
+  const manifest = createManifestInState(STATES.REVIEW_PENDING);
+  const escalationDecision = makeEscalationDecision();
+  const result = applyVerdictToManifest(
+    manifest,
+    makeVerdict("pass", "ready_to_merge"),
+    1,
+    189,
+    "abc123",
+    0,
+    { escalationDecision }
+  );
+
+  assert.deepEqual(result.review.last_escalation_decision, escalationDecision);
 });
 
 test("manifest-apply/applyVerdictToManifest fail-closes PASS with the full rubric gate payload", () => {

--- a/skills/relay-review/scripts/review-runner-redispatch.test.js
+++ b/skills/relay-review/scripts/review-runner-redispatch.test.js
@@ -10,12 +10,32 @@ const {
   buildReviewRunnerRubricGateFailure,
   computeFactorStatusFlips,
   computeRepeatedIssueCount,
+  decideFlipFlopEscalation,
   detectChurnGrowth,
   scanPriorVerdicts,
+  summarizeLineage,
 } = require("./review-runner/redispatch");
 
 function tempRunDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-redispatch-"));
+}
+
+function makeFlipIssue(overrides = {}) {
+  return {
+    title: "Behavior edge case",
+    category: "Behavior",
+    lineage: "deepening",
+    ...overrides,
+  };
+}
+
+function makeFlipDecision(overrides = {}) {
+  return decideFlipFlopEscalation({
+    verdict: { issues: [makeFlipIssue()] },
+    factorFlips: [{ factor: "Behavior", trace: ["pass", "fail", "pass"] }],
+    repeatedIssueCount: 0,
+    ...overrides,
+  });
 }
 
 test("redispatch/detectChurnGrowth preserves the diff-growth matrix", () => {
@@ -127,6 +147,47 @@ test("redispatch/computeFactorStatusFlips ignores factors that change in differe
   fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "A", status: "fail" }, { factor: "B", status: "pass" }] }), "utf-8");
   const flips = computeFactorStatusFlips(runDir, 3, { rubric_scores: [{ factor: "A", status: "fail" }, { factor: "B", status: "fail" }] });
   assert.deepEqual(flips, []);
+});
+
+test("redispatch/decideFlipFlopEscalation suppresses progressive deepening flip-flops", () => {
+  assert.deepEqual(makeFlipDecision(), {
+    decision: "continue",
+    reason: "progressive_deepening",
+    factors: ["Behavior"],
+    traces: [{ factor: "Behavior", trace: ["pass", "fail", "pass"] }],
+    lineage_summary: { deepening: 1, repeat: 0, new: 0, newly_scoreable: 0, unknown: 0 },
+  });
+});
+
+test("redispatch/decideFlipFlopEscalation escalates mixed lineage flip-flops", () => {
+  const decision = makeFlipDecision({
+    verdict: { issues: [makeFlipIssue(), makeFlipIssue({ title: "Behavior still broken", lineage: "repeat" })] },
+  });
+  assert.equal(decision.decision, "escalate");
+  assert.equal(decision.reason, "flip_flop_thrash");
+  assert.deepEqual(decision.lineage_summary, { deepening: 1, repeat: 1, new: 0, newly_scoreable: 0, unknown: 0 });
+});
+
+test("redispatch/decideFlipFlopEscalation escalates repeated-issue thrash even with deepening lineage", () => {
+  const decision = makeFlipDecision({ repeatedIssueCount: 1 });
+  assert.equal(decision.decision, "escalate");
+  assert.equal(decision.reason, "flip_flop_thrash");
+});
+
+test("redispatch/decideFlipFlopEscalation escalates missing lineage on flipped-factor issues", () => {
+  const decision = makeFlipDecision({ verdict: { issues: [makeFlipIssue({ lineage: undefined })] } });
+  assert.equal(decision.decision, "escalate");
+  assert.equal(decision.reason, "flip_flop_thrash");
+  assert.deepEqual(decision.lineage_summary, { deepening: 0, repeat: 0, new: 0, newly_scoreable: 0, unknown: 1 });
+});
+
+test("redispatch/summarizeLineage distinguishes unknown from repeat", () => {
+  assert.deepEqual(summarizeLineage([
+    { lineage: "repeat" },
+    { lineage: "unknown" },
+    {},
+    { lineage: "made_up" },
+  ]), { deepening: 0, repeat: 1, new: 0, newly_scoreable: 0, unknown: 3 });
 });
 
 test("redispatch/buildReviewRunnerRubricGateFailure preserves the fail-closed recovery matrix", async (t) => {

--- a/skills/relay-review/scripts/review-runner-redispatch.test.js
+++ b/skills/relay-review/scripts/review-runner-redispatch.test.js
@@ -159,6 +159,16 @@ test("redispatch/decideFlipFlopEscalation suppresses progressive deepening flip-
   });
 });
 
+test("redispatch/decideFlipFlopEscalation preserves clean pass verdicts on flip-flop with zero repeats", () => {
+  assert.deepEqual(makeFlipDecision({ verdict: { verdict: "pass", issues: [] } }), {
+    decision: "continue",
+    reason: "progressive_deepening",
+    factors: ["Behavior"],
+    traces: [{ factor: "Behavior", trace: ["pass", "fail", "pass"] }],
+    lineage_summary: { deepening: 0, repeat: 0, new: 0, newly_scoreable: 0, unknown: 0 },
+  });
+});
+
 test("redispatch/decideFlipFlopEscalation escalates mixed lineage flip-flops", () => {
   const decision = makeFlipDecision({
     verdict: { issues: [makeFlipIssue(), makeFlipIssue({ title: "Behavior still broken", lineage: "repeat" })] },

--- a/skills/relay-review/scripts/review-runner-verdict.test.js
+++ b/skills/relay-review/scripts/review-runner-verdict.test.js
@@ -48,6 +48,17 @@ function makePassVerdict(overrides = {}) {
   };
 }
 
+function makeChangesRequestedVerdict(issueOverrides = {}) {
+  return makePassVerdict({
+    verdict: "changes_requested",
+    summary: "Fix the blocking issue.",
+    contract_status: "fail",
+    quality_review_status: "not_run",
+    next_action: "changes_requested",
+    issues: [makeIssue(issueOverrides)],
+  });
+}
+
 test("verdict/parseReviewVerdict preserves a valid payload shape", () => {
   const payload = makePassVerdict();
   const encoded = JSON.stringify(payload);
@@ -63,6 +74,35 @@ test("verdict/validateReviewVerdict allows reviewer payloads to omit quality_exe
 
   const validated = validateReviewVerdict(reviewerPayload, { requireExecutionStatus: false });
   assert.equal(validated.quality_execution_status, undefined);
+});
+
+test("verdict/validateReviewVerdict accepts every lineage enum value", async (t) => {
+  for (const lineage of ["new", "deepening", "repeat", "newly_scoreable", "unknown"]) {
+    await t.test(lineage, () => {
+      const verdict = validateReviewVerdict(makeChangesRequestedVerdict({ lineage, relates_to: "round-1 issue" }));
+      assert.equal(verdict.issues[0].lineage, lineage);
+    });
+  }
+});
+
+test("verdict/validateReviewVerdict accepts missing lineage for back-compat", () => {
+  const verdict = validateReviewVerdict(makeChangesRequestedVerdict());
+  assert.equal(verdict.issues[0].lineage, undefined);
+});
+
+test("verdict/validateReviewVerdict rejects unrecognized lineage values", () => {
+  assert.throws(
+    () => validateReviewVerdict(makeChangesRequestedVerdict({ lineage: "made_up" })),
+    /issues\[0\]\.lineage must be one of: new, deepening, repeat, newly_scoreable, unknown/
+  );
+});
+
+test("verdict/validateReviewVerdict validates relates_to when present", () => {
+  assert.equal(validateReviewVerdict(makeChangesRequestedVerdict({ relates_to: "prior finding" })).issues[0].relates_to, "prior finding");
+  assert.throws(
+    () => validateReviewVerdict(makeChangesRequestedVerdict({ relates_to: "" })),
+    /issues\[0\]\.relates_to must be a non-empty string when present/
+  );
 });
 
 test("verdict/parseReviewVerdict rejects invalid JSON", () => {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -21,19 +21,16 @@ const { buildPrompt, formatPriorVerdictSummary } = require("./review-runner/prom
 const { ALLOWED_SCORE_TIERS, parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
 const { buildCommentBody, formatIssueList, formatScopeDrift, postComment } = require("./review-runner/comment");
 const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog } = require("./review-runner/divergence");
-const {
-  applyQualityExecutionStatus,
-  buildExecutionEvidenceFailureVerdict,
-  buildMissingExecutionEvidenceVerdict,
-  computeQualityExecutionStatus,
-} = require("./review-runner/execution-evidence");
+const { applyQualityExecutionStatus, buildExecutionEvidenceFailureVerdict, buildMissingExecutionEvidenceVerdict, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
 const {
   buildRedispatchPrompt,
   buildReviewRunnerRubricGateFailure,
   buildRubricGateRedispatchPrompt,
   computeFactorStatusFlips,
   computeRepeatedIssueCount,
+  decideFlipFlopEscalation,
   detectChurnGrowth,
+  summarizeLineage,
   toEscalatedVerdict,
 } = require("./review-runner/redispatch");
 const { applyPolicyViolationToManifest, applyVerdictToManifest } = require("./review-runner/manifest-apply");
@@ -142,14 +139,13 @@ function run() {
   } catch {}
 
   if (round > maxRounds) {
-    const escalatedManifest = applyPolicyViolationToManifest(
-      data,
-      Number(data.review?.rounds || 0),
-      prNumber,
-      reviewedHeadSha,
-      "max_rounds_exceeded"
-    );
+    const escalationDecision = {
+      round: Number(data.review?.rounds || 0), trigger: "max_rounds", factors: [], traces: [],
+      lineage_summary: summarizeLineage([]), decision: "escalate", reason: "max_rounds_exceeded",
+    };
+    const escalatedManifest = applyPolicyViolationToManifest(data, Number(data.review?.rounds || 0), prNumber, reviewedHeadSha, "max_rounds_exceeded", { escalationDecision });
     writeManifest(manifestPath, escalatedManifest, body);
+    appendRunEvent(runRepoPath, data.run_id, { event: "escalation_decision", state_from: data.state, state_to: STATES.ESCALATED, head_sha: reviewedHeadSha, ...escalationDecision });
     appendRunEvent(runRepoPath, data.run_id, {
       event: "review_apply",
       state_from: data.state,
@@ -262,14 +258,19 @@ function run() {
   const repeatedIssueCount = verdict.verdict === "changes_requested"
     ? computeRepeatedIssueCount(runDir, round, verdict.issues)
     : 0;
+  let escalationDecision = { round, trigger: "none", factors: [], traces: [], lineage_summary: summarizeLineage(verdict.issues), decision: "continue", reason: "no_trigger" };
   if (verdict.verdict === "changes_requested" && repeatedIssueCount >= 3) {
     verdict = toEscalatedVerdict(
       verdict,
       `Repeated identical review issues hit ${repeatedIssueCount} consecutive rounds.`
     );
+    escalationDecision = { ...escalationDecision, trigger: "repeated_issues", decision: "escalate", reason: "repeated_issues" };
   }
   const factorFlips = computeFactorStatusFlips(runDir, round, verdict);
-  if (factorFlips.length) {
+  if (factorFlips.length && escalationDecision.trigger !== "repeated_issues") {
+    escalationDecision = { round, trigger: "flip_flop", ...decideFlipFlopEscalation({ verdict, factorFlips, repeatedIssueCount }) };
+  }
+  if (escalationDecision.decision === "escalate" && escalationDecision.trigger === "flip_flop") {
     verdict = toEscalatedVerdict(
       verdict,
       factorFlips.map(({ factor, trace }) => `Rubric factor '${factor}' status flipped across 3 rounds (trace: ${trace.join("→")}). Owner decision required — reviewer cannot converge autonomously.`).join("; ")
@@ -321,15 +322,7 @@ function run() {
     result.commentPosted = true;
   }
 
-  let updatedManifest = applyVerdictToManifest(
-    data,
-    verdict,
-    round,
-    prNumber,
-    reviewedHeadSha,
-    repeatedIssueCount,
-    { rubricGateFailure }
-  );
+  let updatedManifest = applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha, repeatedIssueCount, { rubricGateFailure, escalationDecision });
   updatedManifest = {
     ...updatedManifest,
     review: {
@@ -339,6 +332,7 @@ function run() {
   };
   updatedManifest = applyReviewerIdentity(updatedManifest, noComment, runRepoPath);
   writeManifest(manifestPath, updatedManifest, body);
+  appendRunEvent(runRepoPath, data.run_id, { event: "escalation_decision", state_from: data.state, state_to: updatedManifest.state, head_sha: reviewedHeadSha, ...escalationDecision });
   appendRunEvent(runRepoPath, data.run_id, {
     event: "review_apply",
     state_from: data.state,

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -2023,7 +2023,7 @@ test("repeated identical issues escalate on the third consecutive round", () => 
   assert.equal(manifest.review.repeated_issue_count, 0);
 });
 
-test("rubric factor flip-flops escalate even when the reviewer returns pass", () => {
+test("rubric factor flip-flops preserve pass verdicts when there are zero repeated issues", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
   const runDir = ensureRunLayout(repoRoot, runId).runDir;
   fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "Behavior", status: "pass" }] }), "utf-8");
@@ -2037,9 +2037,11 @@ test("rubric factor flip-flops escalate even when the reviewer returns pass", ()
   });
   const result = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123", "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath, "--review-file", reviewFile, "--no-comment", "--json"], { encoding: "utf-8" }));
   const verdict = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
-  assert.equal(result.state, STATES.ESCALATED);
-  assert.equal(verdict.verdict, "escalated");
-  assert.equal(verdict.summary, "Rubric factor 'BEHAVIOR' status flipped across 3 rounds (trace: pass→fail→pass). Owner decision required — reviewer cannot converge autonomously.");
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(verdict.verdict, "pass");
+  assert.equal(manifest.review.last_escalation_decision.decision, "continue");
+  assert.equal(manifest.review.last_escalation_decision.reason, "progressive_deepening");
 });
 
 test("formatPriorVerdictSummary produces correct round numbers and rubric summaries", () => {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -792,6 +792,41 @@ test("pass verdict preserves assigned reviewer role and records the acting revie
   assert.equal(reviewApplyEvent?.reviewer, "codex");
 });
 
+test("review-runner appends escalation_decision event on a clean no-trigger round", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewFile = writePassVerdict(repoRoot);
+
+  execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--reviewer", "codex",
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const manifest = readManifest(manifestPath).data;
+  const events = readRunEvents(repoRoot, runId);
+  const escalationEvent = events.find((event) => event.event === "escalation_decision");
+  assert.deepEqual(manifest.review.last_escalation_decision, {
+    round: 1,
+    trigger: "none",
+    factors: [],
+    traces: [],
+    lineage_summary: { deepening: 0, repeat: 0, new: 0, newly_scoreable: 0, unknown: 0 },
+    decision: "continue",
+    reason: "no_trigger",
+  });
+  assert.equal(escalationEvent?.head_sha, manifest.git.head_sha);
+  assert.equal(escalationEvent?.state_from, STATES.REVIEW_PENDING);
+  assert.equal(escalationEvent?.state_to, STATES.READY_TO_MERGE);
+  assert.equal(escalationEvent?.reason, "no_trigger");
+});
+
 test("pass verdict rejects quality_review_status=not_run", () => {
   const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
   const reviewFile = writeVerdict(repoRoot, "phase1-pass.json", {
@@ -1509,6 +1544,7 @@ test("review-runner keeps event journals on the manifest repo slug when --repo i
 
   assert.ok(result.verdictPath.startsWith(canonicalRunDir));
   assert.deepEqual(events.map((event) => event.event), [
+    "escalation_decision",
     "review_apply",
     "iteration_score",
     "score_divergence",

--- a/skills/relay-review/scripts/review-runner/manifest-apply.js
+++ b/skills/relay-review/scripts/review-runner/manifest-apply.js
@@ -30,6 +30,7 @@ function buildReviewStatusFields(verdict) {
 
 function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha, repeatedIssueCount, options = {}) {
   const rubricGateFailure = options.rubricGateFailure || null;
+  const escalationDecision = options.escalationDecision || null;
   let nextState;
   let nextAction;
   let latestVerdict;
@@ -71,6 +72,7 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
       repeated_issue_count: verdict.verdict === "changes_requested" ? repeatedIssueCount : 0,
       last_reviewed_sha: reviewedHeadSha || null,
       ...buildReviewStatusFields(verdict),
+      ...(escalationDecision ? { last_escalation_decision: escalationDecision } : {}),
       last_gate: rubricGateFailure ? {
         status: rubricGateFailure.status,
         layer: rubricGateFailure.layer,
@@ -84,7 +86,7 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
   };
 }
 
-function applyPolicyViolationToManifest(data, round, prNumber, reviewedHeadSha, reason) {
+function applyPolicyViolationToManifest(data, round, prNumber, reviewedHeadSha, reason, options = {}) {
   const updated = updateManifestState(data, STATES.ESCALATED, "inspect_review_failure");
   return {
     ...updated,
@@ -99,6 +101,7 @@ function applyPolicyViolationToManifest(data, round, prNumber, reviewedHeadSha, 
       latest_verdict: reason || "policy_violation",
       repeated_issue_count: 0,
       last_reviewed_sha: reviewedHeadSha || null,
+      ...(options.escalationDecision ? { last_escalation_decision: options.escalationDecision } : {}),
     },
   };
 }

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -5,6 +5,7 @@ const { formatPriorVerdictSummary } = require("./prompt");
 
 const FLIP_STATES = new Set(["pass", "fail"]);
 const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded"]);
+const LINEAGE_VALUES = ["deepening", "repeat", "new", "newly_scoreable", "unknown"];
 
 function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource) {
   const sections = [
@@ -167,6 +168,37 @@ function computeFactorStatusFlips(runDir, round, currentVerdict) {
   return priorVerdicts.length < 2 ? [] : collectFactorStatusFlips([priorVerdicts[1], priorVerdicts[0], currentVerdict]);
 }
 
+function summarizeLineage(issues = []) {
+  const summary = Object.fromEntries(LINEAGE_VALUES.map((value) => [value, 0]));
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    const lineage = LINEAGE_VALUES.includes(issue?.lineage) ? issue.lineage : "unknown";
+    summary[lineage] += 1;
+  }
+  return summary;
+}
+
+function issueMatchesFactor(issue, factor) {
+  const needle = normalizeFingerprintPart(factor);
+  return Boolean(needle) && ["category", "title"].some((key) => normalizeFingerprintPart(issue?.[key]).includes(needle));
+}
+
+function allFlippedFactorIssuesDeepen(issues, factorFlips) {
+  if (!Array.isArray(issues) || issues.length === 0) return false;
+  const tiedIssues = issues.filter((issue) => factorFlips.some(({ factor }) => issueMatchesFactor(issue, factor)));
+  return tiedIssues.length > 0 && tiedIssues.every((issue) => issue.lineage === "deepening");
+}
+
+function decideFlipFlopEscalation({ verdict, factorFlips, repeatedIssueCount }) {
+  const factors = factorFlips.map(({ factor }) => factor);
+  const traces = factorFlips.map(({ factor, trace }) => ({ factor, trace }));
+  const lineage_summary = summarizeLineage(verdict?.issues || []);
+  if (!factorFlips.length) return { decision: "continue", reason: "no_trigger", factors: [], traces: [], lineage_summary };
+  if (repeatedIssueCount === 0 && allFlippedFactorIssuesDeepen(verdict?.issues, factorFlips)) {
+    return { decision: "continue", reason: "progressive_deepening", factors, traces, lineage_summary };
+  }
+  return { decision: "escalate", reason: "flip_flop_thrash", factors, traces, lineage_summary };
+}
+
 function hasConsecutiveRounds(entries, index) {
   return index >= 2
     && entries[index - 2].round + 1 === entries[index - 1].round
@@ -274,10 +306,12 @@ module.exports = {
   buildRubricRecoveryCommand,
   computeFactorStatusFlips,
   computeRepeatedIssueCount,
+  decideFlipFlopEscalation,
   detectChurnGrowth,
   fingerprintIssue,
   normalizeFingerprintPart,
   readPriorVerdicts,
   scanPriorVerdicts,
+  summarizeLineage,
   toEscalatedVerdict,
 };

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -188,12 +188,16 @@ function allFlippedFactorIssuesDeepen(issues, factorFlips) {
   return tiedIssues.length > 0 && tiedIssues.every((issue) => issue.lineage === "deepening");
 }
 
+function isCleanPassVerdict(verdict) {
+  return verdict?.verdict === "pass" && (!Array.isArray(verdict.issues) || verdict.issues.length === 0);
+}
+
 function decideFlipFlopEscalation({ verdict, factorFlips, repeatedIssueCount }) {
   const factors = factorFlips.map(({ factor }) => factor);
   const traces = factorFlips.map(({ factor, trace }) => ({ factor, trace }));
   const lineage_summary = summarizeLineage(verdict?.issues || []);
   if (!factorFlips.length) return { decision: "continue", reason: "no_trigger", factors: [], traces: [], lineage_summary };
-  if (repeatedIssueCount === 0 && allFlippedFactorIssuesDeepen(verdict?.issues, factorFlips)) {
+  if (repeatedIssueCount === 0 && (isCleanPassVerdict(verdict) || allFlippedFactorIssuesDeepen(verdict?.issues, factorFlips))) {
     return { decision: "continue", reason: "progressive_deepening", factors, traces, lineage_summary };
   }
   return { decision: "escalate", reason: "flip_flop_thrash", factors, traces, lineage_summary };

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -5,6 +5,7 @@ const ALLOWED_NEXT_ACTIONS = new Set(["ready_to_merge", "changes_requested", "es
 const ALLOWED_REVIEW_STATUSES = new Set(["pass", "fail", "not_run"]);
 const ALLOWED_EXECUTION_STATUSES = new Set(["pass", "fail", "not_run", "missing"]);
 const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
+const ALLOWED_LINEAGE_VALUES = new Set(["new", "deepening", "repeat", "newly_scoreable", "unknown"]);
 const ALLOWED_DRIFT_STATUSES = new Set(
   REVIEW_VERDICT_JSON_SCHEMA.properties.scope_drift.properties.missing.items.properties.status.enum
 );
@@ -31,6 +32,12 @@ function validateIssue(issue, index) {
   }
   if (!Number.isInteger(issue.line) || issue.line <= 0) {
     throw new Error(`${location}.line must be a positive integer`);
+  }
+  if (issue.lineage !== undefined && !ALLOWED_LINEAGE_VALUES.has(issue.lineage)) {
+    throw new Error(`${location}.lineage must be one of: ${Array.from(ALLOWED_LINEAGE_VALUES).join(", ")}`);
+  }
+  if (issue.relates_to !== undefined && (typeof issue.relates_to !== "string" || !issue.relates_to.trim())) {
+    throw new Error(`${location}.relates_to must be a non-empty string when present`);
   }
 }
 
@@ -174,6 +181,7 @@ function validateReviewVerdict(data, options = {}) {
 
 module.exports = {
   ALLOWED_EXECUTION_STATUSES,
+  ALLOWED_LINEAGE_VALUES,
   ALLOWED_SCORE_TIERS,
   ALLOWED_REVIEW_STATUSES,
   parseReviewVerdict,

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -36,6 +36,11 @@ const REVIEW_VERDICT_PROPERTIES = {
         line: { type: "integer", minimum: 1 },
         category: { type: "string", minLength: 1 },
         severity: { type: "string", minLength: 1 },
+        lineage: {
+          type: "string",
+          enum: ["new", "deepening", "repeat", "newly_scoreable", "unknown"],
+        },
+        relates_to: { type: "string", minLength: 1 },
       },
     },
   },


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했습니다.

커밋:
`bc9f9a7 feat(relay-review): track finding lineage escalation decisions`

원격 브랜치:
`origin/issue-270`

검증:
`node --test skills/relay-*/scripts/*.test.js`
결과: `866 pass / 0 fail`

반영 내용:
- `issues[].lineage`, `issues[].relates_to` schema/validator 추가
- lineage-aware flip-flop decider 추가
- `escalation_decision` manifest + events 기록
- max-round/no-trigger/repeated/flip-flop decision 기록
- reviewer prompt와 evaluate criteria 문서 갱신
- Phase B 회귀 테스트 추가

로컬 작업 트리는 clean입니다.

PR 생성은 완료하지 못했
```

## Score Log

- Run: issue-270-20260425123838436-bdb4993e
- Executor: codex
- Branch: issue-270