### PR TITLE
docs: add event-shape rubric pattern

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -68,7 +68,7 @@ rubric:
       weight: required
 ```
 
-Tier classification, `type`, `weight`, `setup`/`baseline`, `criteria`, and `scoring_guide`: see `references/rubric-design-guide.md`.
+Tier classification, `type`, `weight`, `setup`/`baseline`, `criteria`, and `scoring_guide`: see `references/rubric-design-guide.md`. For event-schema evolution, use the [event-shape rubric pattern](references/rubric-pattern-event-shape.md).
 
 ### Domain references
 

--- a/skills/relay-plan/references/rubric-pattern-event-shape.md
+++ b/skills/relay-plan/references/rubric-pattern-event-shape.md
@@ -3,10 +3,10 @@
 Use this pattern when a quality factor concerns event schema evolution.
 The rubric must name the complete event tuple, not just the newly added field.
 
-## **Field presence** — new field name + literal value expected
+## Field presence
 
-Name the new marker field exactly and require the literal value that proves the
-new shape was emitted by the intended path.
+Name the new marker field exactly and require the literal value expected. The
+literal value proves the new shape was emitted by the intended path.
 
 Do not write "includes the new marker." Write the assertion:
 
@@ -14,7 +14,7 @@ Do not write "includes the new marker." Write the assertion:
 criteria: "`review_apply` event includes `origin: \"system\"`"
 ```
 
-## **Field absence** — related fields that MUST remain absent
+## Field absence
 
 Name related fields that must not appear when the event is system-generated.
 This prevents implementations from satisfying the new field while preserving
@@ -23,20 +23,20 @@ an incompatible legacy shape.
 For a system-forced review transition, the event must not invent reviewer-only
 fields that imply a human or model review round ran.
 
-## **State context** — `state_to`, `state_from`, round, or other tuple members
+## State context
 
-Pin the event to the transition that generates it. Include the state movement,
-round value, reason, or other tuple members needed to distinguish the target
-event from similar emissions.
+Pin the event to the transition that generates it. Include `state_to`,
+`state_from`, round number, or other tuple members needed to distinguish the
+target event from similar emissions.
 
 For escalation paths, require the terminal state and the policy reason rather
 than checking only the event name.
 
-## **Legacy shape tolerance** — explicit assertion that pre-change events (without the new marker) continue to be read correctly
+## Legacy shape tolerance
 
 Schema evolution rubrics must also protect old manifests and event journals.
-State that events emitted before the new marker existed still parse and retain
-their original meaning.
+State explicitly that pre-change events emitted without the new marker still
+parse and retain their original meaning.
 
 This is a compatibility assertion, not a request to backfill historical events.
 

--- a/skills/relay-plan/references/rubric-pattern-event-shape.md
+++ b/skills/relay-plan/references/rubric-pattern-event-shape.md
@@ -1,0 +1,60 @@
+# Rubric Pattern — Event Shape Changes
+
+Use this pattern when a quality factor concerns event schema evolution.
+The rubric must name the complete event tuple, not just the newly added field.
+
+## **Field presence** — new field name + literal value expected
+
+Name the new marker field exactly and require the literal value that proves the
+new shape was emitted by the intended path.
+
+Do not write "includes the new marker." Write the assertion:
+
+```yaml
+criteria: "`review_apply` event includes `origin: \"system\"`"
+```
+
+## **Field absence** — related fields that MUST remain absent
+
+Name related fields that must not appear when the event is system-generated.
+This prevents implementations from satisfying the new field while preserving
+an incompatible legacy shape.
+
+For a system-forced review transition, the event must not invent reviewer-only
+fields that imply a human or model review round ran.
+
+## **State context** — `state_to`, `state_from`, round, or other tuple members
+
+Pin the event to the transition that generates it. Include the state movement,
+round value, reason, or other tuple members needed to distinguish the target
+event from similar emissions.
+
+For escalation paths, require the terminal state and the policy reason rather
+than checking only the event name.
+
+## **Legacy shape tolerance** — explicit assertion that pre-change events (without the new marker) continue to be read correctly
+
+Schema evolution rubrics must also protect old manifests and event journals.
+State that events emitted before the new marker existed still parse and retain
+their original meaning.
+
+This is a compatibility assertion, not a request to backfill historical events.
+
+**Worked example: `max_rounds_exceeded` -> `review_apply`**
+
+For #228, the rubric factor should enumerate all four assertions:
+
+```yaml
+criteria: >
+  When the review round cap is exceeded, the emitted `review_apply` event has
+  `origin: "system"`, keeps reviewer-only fields absent, records
+  `state_to: ESCALATED`, and records `reason: "max_rounds_exceeded"`.
+  Legacy `review_apply` events emitted before `origin` existed still parse.
+```
+
+Concrete checks:
+
+- Field presence: `origin` is present with the literal value `"system"`.
+- Field absence: reviewer-only fields remain absent for the system transition.
+- State context: `state_to: ESCALATED` and `reason: "max_rounds_exceeded"`.
+- Legacy shape tolerance: older events without `origin` still parse correctly.


### PR DESCRIPTION
doc-only rubric pattern for event-shape factors. Closes #264; closes epic #260.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 이벤트 스키마 진화 관련 작성 지침을 업데이트했습니다.
  * 마커 필드 검증, 상태 컨텍스트, 하위 호환성 보장에 대한 새로운 참조 자료를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->