### PR TITLE
Add symmetric flip trace coverage

### DIFF
--- a/skills/relay-review/scripts/review-runner-redispatch.test.js
+++ b/skills/relay-review/scripts/review-runner-redispatch.test.js
@@ -133,6 +133,14 @@ test("redispatch/computeFactorStatusFlips detects pass-fail-pass with normalized
   assert.deepEqual(flips, [{ factor: "BEHAVIOR", trace: ["pass", "fail", "pass"] }]);
 });
 
+test("redispatch/computeFactorStatusFlips detects fail-pass-fail (symmetric direction)", () => {
+  const runDir = tempRunDir();
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "Behavior", status: "fail" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "Behavior", status: "pass" }] }), "utf-8");
+  const flips = computeFactorStatusFlips(runDir, 3, { rubric_scores: [{ factor: "Behavior", status: "fail" }] });
+  assert.deepEqual(flips, [{ factor: "Behavior", trace: ["fail", "pass", "fail"] }]);
+});
+
 test("redispatch/computeFactorStatusFlips ignores two-round changes and not_run gaps", () => {
   const runDir = tempRunDir();
   fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: "behavior", status: "pass" }] }), "utf-8");


### PR DESCRIPTION
## Dispatch Summary

```text
구현과 검증은 완료했습니다.

- 변경: [review-runner-redispatch.test.js](/Users/sjlee/.relay/worktrees/fc4b3fd9/dev-relay/skills/relay-review/scripts/review-runner-redispatch.test.js:136)에 `fail → pass → fail` 대칭 flip trace 테스트 1개 추가
- production 변경 없음
- 커밋: `0a72bbe Add symmetric flip trace coverage`
- 브랜치: `issue-255` pushed to `origin/issue-255`
- 검증: `node --test skills/relay-*/scripts/*.test.js` 통과, `868 pass`

PR 생성만 완료하지 못했습니다. GitHub 앱의 mutating PR 생성 호출은 `user cancelled MCP tool call`로 거부됐고, CLI fallb
```

## Score Log

- Run: issue-255-20260426014009853-7a1937a4
- Executor: codex
- Branch: issue-255