### PR TITLE
fix(cleanup): reap orphaned worktree shells

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -13,12 +13,18 @@
  */
 
 const path = require("path");
+const fs = require("fs");
 const { isTerminalState } = require("./manifest/lifecycle");
 const {
   CLEANUP_STATUSES,
   runCleanup,
 } = require("./manifest/cleanup");
-const { listManifestPaths, validateManifestPaths } = require("./manifest/paths");
+const {
+  getRelayWorktreeBase,
+  isPathContainedWithin,
+  listManifestPaths,
+  validateManifestPaths,
+} = require("./manifest/paths");
 const {
   readManifest,
   writeManifest,
@@ -30,6 +36,7 @@ const { safeFormatRunId } = require("./relay-resolver");
 const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "cleanup-worktrees" };
 const hasCliFlag = (flag) => hasFlag(args, flag, CLI_ARG_OPTIONS);
+const OS_DETRITUS = new Set([".DS_Store", "Thumbs.db"]);
 
 function parseHours(value, label) {
   const parsed = Number(value);
@@ -37,6 +44,59 @@ function parseHours(value, label) {
     throw new Error(`${label} must be a non-negative number`);
   }
   return parsed;
+}
+
+function relayWorktreeChildPath(base, name) {
+  const candidate = path.join(base, name);
+  if (!isPathContainedWithin(base, candidate)) {
+    throw new Error(`refusing to sweep outside relay worktree base: ${candidate}`);
+  }
+  return candidate;
+}
+
+function inspectShellContents(shellPath) {
+  return fs.readdirSync(shellPath).map((name) => {
+    const childPath = path.join(shellPath, name);
+    const stat = fs.lstatSync(childPath);
+    return { name, childPath, removable: OS_DETRITUS.has(name) && stat.isFile() };
+  });
+}
+
+function reapShell(shellPath, removableEntries, { dryRun }) {
+  if (dryRun) {
+    console.warn(`cleanup-worktrees: dry-run would reap orphaned worktree shell ${shellPath}`);
+    return true;
+  }
+  for (const entry of removableEntries) {
+    fs.unlinkSync(entry.childPath);
+  }
+  fs.rmdirSync(shellPath);
+  return !fs.existsSync(shellPath);
+}
+
+function sweepOrphanedWorktreeShells({ dryRun }) {
+  const relayWorktreeBase = getRelayWorktreeBase();
+  const result = { reaped: [], skipped: [] };
+  if (!fs.existsSync(relayWorktreeBase)) return result;
+
+  for (const name of fs.readdirSync(relayWorktreeBase)) {
+    const shellPath = relayWorktreeChildPath(relayWorktreeBase, name);
+    const shellStat = fs.lstatSync(shellPath);
+    if (!shellStat.isDirectory()) continue;
+
+    const contents = inspectShellContents(shellPath);
+    const stray = contents.filter((entry) => !entry.removable);
+    if (stray.length) {
+      console.warn(`cleanup-worktrees: preserving ${shellPath}; contains ${stray.map((entry) => entry.name).join(", ")}`);
+      result.skipped.push({ path: shellPath, reason: "non_detritus", entries: stray.map((entry) => entry.name) });
+      continue;
+    }
+
+    if (reapShell(shellPath, contents, { dryRun })) {
+      result.reaped.push({ path: shellPath, dryRun });
+    }
+  }
+  return result;
 }
 
 if (hasCliFlag(["--help", "-h"])) {
@@ -70,6 +130,8 @@ function run() {
     failed: [],
     staleOpen: [],
     skipped: [],
+    reapedShells: [],
+    skippedShells: [],
   };
 
   const manifestPaths = listManifestPaths(repoRoot);
@@ -178,6 +240,10 @@ function run() {
       result.failed.push(item);
     }
   }
+
+  const shellSweep = sweepOrphanedWorktreeShells({ dryRun });
+  result.reapedShells = shellSweep.reaped;
+  result.skippedShells = shellSweep.skipped;
 
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -411,6 +411,63 @@ test("cleanup-worktrees removes existing relay-owned directories with pruned git
   assert.equal(readManifest(stale.manifestPath).data.cleanup.status, "succeeded");
 });
 
+test("cleanup-worktrees reaps empty relay worktree parent shells", () => {
+  const repoRoot = setupRepo();
+  const shellPath = path.join(getRelayWorktreeBase(), "empty-shell");
+  fs.mkdirSync(shellPath, { recursive: true });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(fs.existsSync(shellPath), false);
+  assert.equal(result.reapedShells.some((entry) => entry.path === shellPath), true);
+});
+
+test("cleanup-worktrees reaps relay worktree parent shells containing only .DS_Store", () => {
+  const repoRoot = setupRepo();
+  const shellPath = path.join(getRelayWorktreeBase(), "detritus-shell");
+  fs.mkdirSync(shellPath, { recursive: true });
+  fs.writeFileSync(path.join(shellPath, ".DS_Store"), "detritus\n", "utf-8");
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(fs.existsSync(shellPath), false);
+  assert.equal(result.reapedShells.some((entry) => entry.path === shellPath), true);
+});
+
+test("cleanup-worktrees preserves relay worktree parent shells with stray content and warns", () => {
+  const repoRoot = setupRepo();
+  const shellPath = path.join(getRelayWorktreeBase(), "stray-shell");
+  const strayPath = path.join(shellPath, "notes.txt");
+  fs.mkdirSync(shellPath, { recursive: true });
+  fs.writeFileSync(strayPath, "manual artifact\n", "utf-8");
+
+  const run = spawnSync(process.execPath, [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--all",
+    "--json",
+  ], { cwd: PROJECT_ROOT, encoding: "utf-8" });
+
+  assert.equal(run.status, 0, run.stderr);
+  const result = JSON.parse(run.stdout);
+  assert.equal(fs.existsSync(shellPath), true);
+  assert.equal(fs.existsSync(strayPath), true);
+  assert.match(run.stderr, /preserving .*stray-shell.*notes\.txt/);
+  assert.equal(result.skippedShells.some((entry) => entry.path === shellPath), true);
+});
+
 test("cleanup-worktrees rejects tampered paths.repo_root before cleanup side effects", () => {
   const repoRoot = setupRepo();
   const updatedAt = "2026-04-01T00:00:00.000Z";


### PR DESCRIPTION
## Dispatch Summary

```text
구현과 검증은 완료했습니다.

변경 사항:
- [cleanup-worktrees.js](/Users/sjlee/.relay/worktrees/36baa4f3/dev-relay/skills/relay-dispatch/scripts/cleanup-worktrees.js)에 inner worktree cleanup 이후 실행되는 shell reaper 추가
- empty shell, `.DS_Store`/`Thumbs.db` only shell 제거
- stray content가 있으면 보존하고 `console.warn`으로 경고
- dry-run에서는 삭제 없이 “would reap” 경고
- [cleanup-worktrees.test.js](/Users/sjlee/.relay/worktrees/36baa4f3/dev-relay/skills/relay-dispatch/scripts/cleanup-worktrees.test.js)에 3개 fixture 테스트 추가

검증:
- `node 
```

## Score Log

- Run: issue-299-20260426014012872-773d9531
- Executor: codex
- Branch: issue-299