### PR TITLE
fix(relay-review): schema strict-mode required + nullable relates_to (#301)

### DIFF
--- a/skills/relay-review/scripts/review-runner-verdict.test.js
+++ b/skills/relay-review/scripts/review-runner-verdict.test.js
@@ -8,6 +8,7 @@ const {
   validateRubricScore,
   validateScopeDrift,
 } = require("./review-runner/verdict");
+const { REVIEW_VERDICT_JSON_SCHEMA, REVIEWER_VERDICT_JSON_SCHEMA } = require("./review-schema");
 
 function makeIssue(overrides = {}) {
   return {
@@ -99,9 +100,10 @@ test("verdict/validateReviewVerdict rejects unrecognized lineage values", () => 
 
 test("verdict/validateReviewVerdict validates relates_to when present", () => {
   assert.equal(validateReviewVerdict(makeChangesRequestedVerdict({ relates_to: "prior finding" })).issues[0].relates_to, "prior finding");
+  assert.equal(validateReviewVerdict(makeChangesRequestedVerdict({ relates_to: null })).issues[0].relates_to, null);
   assert.throws(
     () => validateReviewVerdict(makeChangesRequestedVerdict({ relates_to: "" })),
-    /issues\[0\]\.relates_to must be a non-empty string when present/
+    /issues\[0\]\.relates_to must be a non-empty string or null when present/
   );
 });
 
@@ -320,4 +322,34 @@ test("verdict/validateScopeDrift preserves legacy malformed nested-entry behavio
       assert.throws(() => validateScopeDrift(scopeDrift), expected);
     });
   }
+});
+
+test("schema/strict-mode invariant: every additionalProperties:false object lists every property in required (OpenAI strict-mode)", () => {
+  function findStrictModeViolations(node, pathParts, violations) {
+    if (!node || typeof node !== "object") return;
+    if (node.type === "object" && node.additionalProperties === false) {
+      const propKeys = Object.keys(node.properties || {});
+      const required = new Set(node.required || []);
+      const missing = propKeys.filter((key) => !required.has(key));
+      if (missing.length) {
+        violations.push({ path: pathParts.join(".") || "<root>", missing });
+      }
+    }
+    for (const [key, value] of Object.entries(node)) {
+      findStrictModeViolations(value, [...pathParts, key], violations);
+    }
+  }
+
+  for (const [label, schema] of [
+    ["REVIEW_VERDICT_JSON_SCHEMA", REVIEW_VERDICT_JSON_SCHEMA],
+    ["REVIEWER_VERDICT_JSON_SCHEMA", REVIEWER_VERDICT_JSON_SCHEMA],
+  ]) {
+    const violations = [];
+    findStrictModeViolations(schema, [label], violations);
+    assert.deepEqual(violations, [], `${label} has properties missing from required: ${JSON.stringify(violations)}`);
+  }
+});
+
+test("verdict/validateIssue accepts relates_to=null (codex strict-mode emits null when no relation)", () => {
+  assert.doesNotThrow(() => validateIssue(makeIssue({ lineage: "new", relates_to: null }), 0));
 });

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -36,8 +36,8 @@ function validateIssue(issue, index) {
   if (issue.lineage !== undefined && !ALLOWED_LINEAGE_VALUES.has(issue.lineage)) {
     throw new Error(`${location}.lineage must be one of: ${Array.from(ALLOWED_LINEAGE_VALUES).join(", ")}`);
   }
-  if (issue.relates_to !== undefined && (typeof issue.relates_to !== "string" || !issue.relates_to.trim())) {
-    throw new Error(`${location}.relates_to must be a non-empty string when present`);
+  if (issue.relates_to !== undefined && issue.relates_to !== null && (typeof issue.relates_to !== "string" || !issue.relates_to.trim())) {
+    throw new Error(`${location}.relates_to must be a non-empty string or null when present`);
   }
 }
 

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -28,7 +28,7 @@ const REVIEW_VERDICT_PROPERTIES = {
     items: {
       type: "object",
       additionalProperties: false,
-      required: ["title", "body", "file", "line", "category", "severity"],
+      required: ["title", "body", "file", "line", "category", "severity", "lineage", "relates_to"],
       properties: {
         title: { type: "string", minLength: 1 },
         body: { type: "string", minLength: 1 },
@@ -40,7 +40,7 @@ const REVIEW_VERDICT_PROPERTIES = {
           type: "string",
           enum: ["new", "deepening", "repeat", "newly_scoreable", "unknown"],
         },
-        relates_to: { type: "string", minLength: 1 },
+        relates_to: { type: ["string", "null"] },
       },
     },
   },


### PR DESCRIPTION
## Summary

Hotfix for issue #301. PR #298 added \`lineage\` and \`relates_to\` to \`issues[].items.properties\` without listing them in \`items.required\`. OpenAI structured-output strict mode rejects this — every codex review post-#298 fails before generating a verdict.

Bootstrap paradox: PR #298's own review ran on the OLD installed schema before the rsync, so the bug only surfaced on the post-#298 batch (#264, #255, #299). Same class as #267 (epic #268).

## Changes

- \`review-schema.js\`: \`lineage\` and \`relates_to\` now in \`issues.items.required\`. \`relates_to\` type is \`[\"string\", \"null\"]\` so reviewers can return \`null\` when no prior issue applies. \`lineage\` stays plain string with enum (always populated per prompt).
- \`verdict.js\`: \`validateIssue\` treats \`relates_to=null\` same as undefined.
- \`review-runner-verdict.test.js\`: structural regression test asserts every \`additionalProperties:false\` object lists every property in \`required\` — locks the OpenAI strict-mode invariant. Plus a positive test for \`relates_to=null\`.

## Test plan

- [x] \`node --test skills/relay-*/scripts/*.test.js\` — 869 pass, 0 fail (was 866 + 3 new)
- [x] Schema invariant test catches violations across both \`REVIEW_VERDICT_JSON_SCHEMA\` and \`REVIEWER_VERDICT_JSON_SCHEMA\`
- [ ] Post-merge: rsync to \`~/.agents/skills/\`, retry blocked reviews on PRs #300 (#264), #255, #299

## Bypassing relay

This is the unblock-via-narrow-infra-PR pattern (per dev-relay memory): the relay review path is itself broken until this lands, so the fix is committed directly rather than dispatched through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)