### PR TITLE
fix(prompt-template): commit-required wording; orchestrator handles push/PR

### DIFF
--- a/skills/relay/references/prompt-template.md
+++ b/skills/relay/references/prompt-template.md
@@ -85,6 +85,5 @@ Check for:
 Run tests. Fix failures. Repeat review-fix until solid.
 
 ## When Satisfied
-Stop after local verification and leave the branch ready for the orchestrator.
-The orchestrator handles branch publication and PR creation for review.
+Commit your final work to the branch with a clear message. The orchestrator handles `git push` + `gh pr create` after the dispatch returns (and is idempotent if you also push or open a PR yourself). Do NOT skip the commit — that is the one step the orchestrator cannot recover automatically.
 ```


### PR DESCRIPTION
## Summary
- Replace the base dispatch prompt template's "When Satisfied" section so it tells the executor to **commit** (the one step the orchestrator can't recover) and clarifies that `dispatch.js`'s `pushAndOpenPR` is idempotent.
- Fixes the long-standing footgun documented in `feedback_prompt_template_orchestrator_language.md`: codex (high reasoning effort) was reading "leave the branch ready for the orchestrator" literally and skipping commit/push/PR, requiring `recover-commit.js`. Observed live on #142 R1 and worked around per-run on #143 R1 / #309 R1.

## Context
- `pushAndOpenPR` already exists at `skills/relay-dispatch/scripts/dispatch-publish.js` (delivered 2026-04-18 via #198) and is idempotent — it `gh pr list --head <branch>` checks for an existing PR before creating, returning `createdByUs: false` if one already exists. So executor-side push/PR is safe (no duplicates) but not required.
- Only one occurrence of the misleading wording exists in the repo (`skills/relay/references/prompt-template.md` line 87-89). `skills/relay-plan/SKILL.md`, `relay-plan/references/*`, and other prompt-adjacent docs are clean.
- `docs/issue-198-orchestrator-push-and-pr-plan.md` retains historical "orchestrator handles" prose — that's a closed-issue plan doc describing delivered architecture, not user-facing prompt prose, so it's left untouched.

## Test plan
- [x] `node --test skills/relay-*/scripts/*.test.js` → 938 / 938 green (no test asserts prompt-template content; behavioral change is in dispatch prose only)
- [x] Diff is one file, one paragraph rewrite (+1 / -2 lines) — verify with `git diff origin/main`
- [ ] After merge: next `/relay` dispatch runs without per-run "When Satisfied" override and codex still commits/pushes/PRs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * "When Satisfied" 단계의 요구사항을 명확히 했습니다. 브랜치에 최종 커밋을 명시적으로 수행해야 하며, 오케스트레이터가 푸시 및 PR 생성을 처리합니다. 이미 푸시했거나 PR을 열었다면 멱등성이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->