### PR TITLE
docs: prune compatibility frontmatter to runtime-only (#321)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -2,7 +2,7 @@
 name: relay-plan
 argument-hint: "[issue-number]"
 description: Convert task acceptance criteria into a scored rubric for autonomous iteration. Always used before relay-dispatch — rubric depth scales with task size.
-compatibility: Requires gh CLI. Task AC reading falls back to local files or user input.
+compatibility: Requires gh CLI.
 metadata:
   related-skills: "relay, relay-intake, relay-dispatch, relay-review, dev-backlog"
 ---

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -3,7 +3,7 @@ name: relay-review
 argument-hint: "[run-id or branch-name or PR-number]"
 description: Independent PR review against Done Criteria in a fresh context, free from planning bias. Use after dispatch completes and a PR exists.
 context: fork
-compatibility: "Requires gh CLI. Context isolation is enforced per-platform (see Context Isolation section)."
+compatibility: Requires gh CLI.
 metadata:
   related-skills: "relay, relay-intake, relay-plan, relay-dispatch, relay-merge"
 ---

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -2,7 +2,7 @@
 name: relay
 argument-hint: "[issue-number or task description]"
 description: Execute the full relay cycle — plan, dispatch, review, merge. Use when implementing a GitHub issue or task through autonomous executor dispatch. Integrates with dev-backlog sprint files.
-compatibility: Requires Claude Code or Codex, gh CLI, git, and Node.js 18+. Task AC reading falls back to local files or user input.
+compatibility: Requires Claude Code or Codex, gh CLI, git, Node.js 18+.
 metadata:
   related-skills: "relay-intake, relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog"
 ---


### PR DESCRIPTION
## Summary
- Closes #321 — Step 1 of the 5-step Phase ② SKILL.md diet sequence
- Strips runtime fallback semantics from `compatibility:` frontmatter in 3 skills (`relay`, `relay-plan`, `relay-review`); the other 3 are already minimal
- 3 lines net, atomic revertable, no behavior change

## Why

`compatibility:` is skill-loader metadata — its job is constraining *when to invoke*, not documenting fallback behavior. The `relay-review` line in particular read like a README support matrix ("Context isolation is enforced per-platform"); that content already lives in the SKILL body's Context Isolation section.

Frontmatter-as-docs is a one-way trap: future readers treat it as canonical contract and edit the SKILL body to "match," silently losing real fallback paths.

## Test plan
- [ ] All 6 SKILL.md files load (no YAML parse errors)
- [ ] `grep -n '^compatibility:' skills/*/SKILL.md` shows only runtime requirements, no prose about behavior
- [ ] No semantically distinct content was deleted (everything trimmed already lives in the SKILL body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 3개 스킬의 호환성 설명이 업데이트되었습니다. 로컬 파일 폴백 및 플랫폼별 컨텍스트 격리에 대한 기술 세부사항이 제거되고, 필수 도구 요구사항만 명확히 남겨졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->