### PR TITLE
docs: extract long bash blocks from 3 SKILL.md files (#323)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -111,16 +111,9 @@ This writes `rubric.yaml`, `dispatch-prompt.md`, and `planner-notes.md`. The orc
 
 Use this when operator planning rejects or narrows the issue body AC. Persist the operator-authored Phase 1 decision before dispatch so fresh-context review uses the same scope anchor.
 
-```bash
-RUN_ID=issue-42-$(date -u +%Y%m%d%H%M%S000)-deadbeef
-node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js \
-  --repo . --run-id "$RUN_ID" --file /tmp/done-criteria-42.md --json
-
-node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
-  --run-id "$RUN_ID" -b issue-42 --prompt-file /tmp/dispatch-42.md \
-  --rubric-file /tmp/rubric-42.yaml \
-  --done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md
-```
+1. Choose `RUN_ID` (e.g., `issue-<N>-$(date -u +%Y%m%d%H%M%S000)-<short-sha>`).
+2. Persist: `node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js --repo . --run-id "$RUN_ID" --file /tmp/done-criteria-<N>.md --json`
+3. Dispatch with the same `RUN_ID`, adding `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md` to the Step 5 invocation below.
 
 The helper writes `~/.relay/runs/<repo-slug>/<run-id>/done-criteria.md` with source `planner_decision`. Dispatch picks it up via `--done-criteria-file` when the same run id is used. Canonical filename is always `done-criteria.md`; ad-hoc file paths remain source `file`.
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -28,23 +28,12 @@ Standard path: run `review-runner.js --reviewer codex` or `--reviewer claude`. I
 
 ## Setup: Establish the anchor
 
-1. Get the PR diff and Done Criteria (this runs in a fresh context — fetch everything needed):
+1. Get the PR diff and Done Criteria (this runs in a fresh context — fetch everything needed). The resolver tries `closingIssuesReferences`, then PR-body keyword grep, then branch-name regex; exits 1 if all three fail.
 ```bash
 PR_NUM=$(gh pr list --head <branch> --json number -q '.[0].number')
 BRANCH=$(gh pr view $PR_NUM --json headRefName -q '.headRefName')
 gh pr diff $PR_NUM > /tmp/pr-diff.txt
-
-# Issue number extraction — try each method until one succeeds:
-ISSUE_NUM=$(gh pr view $PR_NUM --json closingIssuesReferences -q '.[0].number')
-# Fallback 1: grep PR body for issue keywords
-[ -z "$ISSUE_NUM" ] && ISSUE_NUM=$(gh pr view $PR_NUM --json body -q '.body' | grep -oiE '(closes|fixes|resolves|refs|related to) #[0-9]+' | grep -oE '[0-9]+' | head -1)
-# Fallback 2: extract from branch name (try issue-<N> first, then any number)
-if [ -z "$ISSUE_NUM" ]; then
-  ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-  [ -z "$ISSUE_NUM" ] && ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | tail -1)
-fi
-# If all fail: escalate — cannot review without Done Criteria
-[ -z "$ISSUE_NUM" ] && echo "ERROR: Cannot determine issue number. Provide it manually." && exit 1
+ISSUE_NUM=$(${CLAUDE_SKILL_DIR}/scripts/resolve-issue-number.sh "$PR_NUM" "$BRANCH")
 gh issue view $ISSUE_NUM  # Done Criteria / Acceptance Criteria source
 ```
 

--- a/skills/relay-review/scripts/resolve-issue-number.sh
+++ b/skills/relay-review/scripts/resolve-issue-number.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Resolve the GitHub issue number associated with a PR.
+#
+# Tries three fallbacks in order, prints the first match to stdout:
+#   1. PR's `closingIssuesReferences` API field (gh-linked issue)
+#   2. PR body grep for `(closes|fixes|resolves|refs|related to) #N`
+#   3. Branch name — `issue-N` first, then any trailing number
+#
+# Usage:  resolve-issue-number.sh <PR_NUMBER> [<BRANCH>]
+# Stdout: the resolved issue number
+# Exit:   0 on success, 1 if all fallbacks fail (with stderr error)
+
+set -euo pipefail
+
+PR_NUM="${1:?usage: resolve-issue-number.sh <PR_NUMBER> [<BRANCH>]}"
+BRANCH="${2:-}"
+
+# Method 1: PR-linked issue via gh API
+ISSUE_NUM=$(gh pr view "$PR_NUM" --json closingIssuesReferences \
+  -q '.closingIssuesReferences[0].number' 2>/dev/null || true)
+[ "$ISSUE_NUM" = "null" ] && ISSUE_NUM=""
+
+# Method 2: PR body keyword grep
+if [ -z "$ISSUE_NUM" ]; then
+  ISSUE_NUM=$(gh pr view "$PR_NUM" --json body -q '.body' 2>/dev/null \
+    | grep -oiE '(closes|fixes|resolves|refs|related to) #[0-9]+' \
+    | grep -oE '[0-9]+' \
+    | head -1 || true)
+fi
+
+# Method 3: branch name (issue-N preferred, else trailing digits)
+if [ -z "$ISSUE_NUM" ]; then
+  if [ -z "$BRANCH" ]; then
+    BRANCH=$(gh pr view "$PR_NUM" --json headRefName -q '.headRefName' 2>/dev/null || true)
+  fi
+  ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+' || true)
+  if [ -z "$ISSUE_NUM" ]; then
+    ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | tail -1 || true)
+  fi
+fi
+
+if [ -z "$ISSUE_NUM" ]; then
+  echo "ERROR: Cannot determine issue number for PR #$PR_NUM. Provide it manually." >&2
+  exit 1
+fi
+
+echo "$ISSUE_NUM"

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -87,12 +87,7 @@ Write the rubric YAML to a temp file (e.g., `/tmp/rubric-<N>.yaml`).
 ```bash
 ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
   -b issue-<N> --prompt-file /tmp/dispatch-<N>.md --rubric-file /tmp/rubric-<N>.yaml --timeout 3600
-```
-
-If intake ran, also pass:
-
-```bash
-  --request-id <request-id> --leaf-id <leaf-id> --done-criteria-file <done-criteria-path>
+# If intake ran, append: --request-id <id> --leaf-id <id> --done-criteria-file <done-criteria-path>
 ```
 
 While dispatch runs in the background, optionally monitor progress:


### PR DESCRIPTION
## Summary
- Closes #323 — Step 2 of the 5-step Phase ② SKILL.md diet sequence
- Extracts the 18-line issue-number resolver from `relay-review/SKILL.md` into `scripts/resolve-issue-number.sh`; collapses 10-line persist-anchor bash in `relay-plan/SKILL.md` to numbered prose; merges `relay/SKILL.md` Step 3's intake conditional into a single bash block with an inline comment
- Atomic-revertable; no behavior change beyond a latent-bug fix in the resolver (see Why)

## Why

Long bash blocks inside SKILL.md cost loader-time tokens on every invocation, drown out the surrounding intent prose, and tend to drift from their callers. Extraction to `scripts/` makes the helper testable and revertable. Pure prose for the persist-anchor sequence avoids inventing a new wrapper when the two existing scripts already handle the work.

While extracting the resolver, I noticed the original block's first method was silently broken — `gh pr view --json closingIssuesReferences -q '.[0].number'` errors with `expected an array but got: object`, and the fallbacks were doing all the work. The new script uses the correct `.closingIssuesReferences[0].number` query, restoring Method 1.

## Out of scope

These remain separate issues / PRs per the diet sequence's atomic-revertable discipline:
- **Step 3**: Batch Mode reference move (extract from `relay/SKILL.md`)
- **Step 4**: cross-file deduplication (Context Isolation, intake flow, etc.)
- **Step 5**: `relay-plan` flat step renumbering (cross-file references to "Step 3.5" need a sweep first; must be last)

## Test plan
- [x] Resolver smoke-tested across all 4 paths: Method 1 (PR #322 → 321), Method 3 with `issue-321` branch hint, Method 3 with `feat/foo-99` trailing-digits, failure case (no signals → exit 1)
- [x] `node --test skills/*/scripts/*.test.js` — **942 pass, 0 fail**
- [x] `awk` audit between ` ```bash ` fences confirms no inline bash block in the 3 modified files exceeds 5 lines
- [x] Line counts: `relay-review/SKILL.md` 153→142 (under the 150 budget); `relay-plan/SKILL.md` 148→141; `relay/SKILL.md` 180→174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 이슈 번호 자동 해석 기능 추가

* **문서**
  * Phase 1 편차 지속 워크플로우 문서 업데이트
  * 이슈 검토 워크플로우 문서 개선
  * 디스패치 명령 지침 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->