### PR TITLE
docs: move Batch Mode section to references/batch-mode.md (#325)

### DIFF
--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -141,28 +141,7 @@ Create follow-up issues if discovered during review.
 
 ## Batch Mode
 
-When multiple independent tasks are ready, dispatch them in parallel instead of sequential relay cycles.
-
-### Flow: Plan all → Dispatch all → Review as completed → Merge one-by-one
-
-1. **Plan all tasks** — follow Steps 0 through 2 (including 1.5) for each task. Write each dispatch prompt to its own temp file.
-2. **Dispatch all** — run dispatch.js for each task asynchronously (in the background). Mark all as `[~]` in sprint file.
-3. **Review as completed** — as each dispatch finishes, run Step 4 (relay-review). No need to wait for all.
-4. **Merge one-by-one** — merge each ready PR sequentially only after explicit approval. After each merge, check remaining PRs for conflicts.
-5. **Re-anchor** — after the batch completes, run Step 0 before starting the next batch.
-
-### Merge conflict recovery
-
-If a ready-to-merge PR has conflicts after an earlier merge:
-1. In the worktree: `git fetch origin && git rebase origin/main`
-2. Re-review the rebased PR (run relay-review again — Phase 1 from scratch)
-3. Merge
-
-### Principles
-
-- **When in doubt, run sequentially.** Batch mode is an optimization, not the default.
-- Merge order doesn't matter until it does — if conflict arises, rebase the rest.
-- No DAG analysis needed for 3-5 task batches. If tasks touch the same files, run them sequentially.
+When multiple independent tasks are ready, dispatch in parallel instead of running sequential relay cycles. See `references/batch-mode.md` for the full flow (plan all → dispatch all → review as completed → merge one-by-one), merge-conflict recovery, and the "when in doubt, run sequentially" principle.
 
 ## Summary Checklist
 

--- a/skills/relay/references/batch-mode.md
+++ b/skills/relay/references/batch-mode.md
@@ -1,0 +1,25 @@
+# Batch Mode
+
+Operator playbook for parallel relay dispatch. Consult only when batching multiple independent tasks; the dominant single-task path in `SKILL.md` does not need this.
+
+## Flow: Plan all → Dispatch all → Review as completed → Merge one-by-one
+
+1. **Plan all tasks** — follow Steps 0 through 2 (including 1.5) for each task. Write each dispatch prompt to its own temp file.
+2. **Dispatch all** — run dispatch.js for each task asynchronously (in the background). Mark all as `[~]` in sprint file.
+3. **Review as completed** — as each dispatch finishes, run Step 4 (relay-review). No need to wait for all.
+4. **Merge one-by-one** — merge each ready PR sequentially only after explicit approval. After each merge, check remaining PRs for conflicts.
+5. **Re-anchor** — after the batch completes, run Step 0 before starting the next batch.
+
+## Merge conflict recovery
+
+If a ready-to-merge PR has conflicts after an earlier merge:
+
+1. In the worktree: `git fetch origin && git rebase origin/main`
+2. Re-review the rebased PR (run relay-review again — Phase 1 from scratch)
+3. Merge
+
+## Principles
+
+- **When in doubt, run sequentially.** Batch mode is an optimization, not the default.
+- Merge order doesn't matter until it does — if conflict arises, rebase the rest.
+- No DAG analysis needed for 3-5 task batches. If tasks touch the same files, run them sequentially.


### PR DESCRIPTION
## Summary
- Closes #325 — Step 3 of the 5-step Phase ② SKILL.md diet sequence
- Moves Batch Mode (Flow, Merge conflict recovery, Principles) from `relay/SKILL.md` to a new `relay/references/batch-mode.md`
- `relay/SKILL.md` Batch Mode section reduced from 23 lines to a 3-line pointer paragraph
- One-way move — reference body retained verbatim, no semantically distinct content lost

## Why

Batch Mode is operator playbook content consulted only when batching multiple independent tasks (the section's own guidance pegs the sweet spot at 3-5 tasks). Loading 23 lines on every single relay invocation costs prompt budget for no benefit on the dominant single-task path. Matches the progressive-disclosure pattern already established by `relay/references/prompt-template.md` and the broader `relay-plan/references/rubric-*.md` family.

## Out of scope

These remain separate issues / PRs per the diet sequence's atomic-revertable discipline:
- **Step 4**: cross-file deduplication (Context Isolation, intake flow, etc.)
- **Step 5**: `relay-plan` flat step renumbering — must remain last because cross-file references to "Step 3.5" need a sweep first

## Test plan
- [x] `node --test skills/*/scripts/*.test.js` — **942 pass, 0 fail**
- [x] `relay/SKILL.md` line count: 174 → **153** (-21)
- [x] `awk` audit between ` ```bash ` fences confirms no inline bash block exceeds 5 lines
- [x] One-way move verified — every line of the original Batch Mode section is present in `references/batch-mode.md` (Flow, Merge conflict recovery, Principles subsections all intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)