### PR TITLE
docs: cross-file dedup — S/M/L/XL table + Phase 1/2 framing (#327)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -138,4 +138,10 @@ node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
 
 ## When to use
 
-All tasks dispatched via relay. S/M = lightweight rubric (1-5 factors), skip stress-test. L/XL = detailed rubric with stress-test and calibration. Re-dispatches automatically prepend previous Score Log + reviewer feedback to the prompt (see `relay-dispatch` docs). Full rubric guide: `references/rubric-design-guide.md`.
+All tasks dispatched via relay. Rubric depth scales with task size (determined by orchestrator judgment on normalized AC + file scope, not raw issue AC count):
+- **S** (simple fix, typo, 1-liner): 1-2 factors, skip stress-test
+- **M** (standard feature): 3-5 factors, skip stress-test
+- **L** (cross-cutting, multi-file): 4-6 factors + stress-test
+- **XL** (architecture change): 5-8 factors + stress-test + calibration
+
+Re-dispatches automatically prepend previous Score Log + reviewer feedback to the prompt (see `relay-dispatch` docs). Full rubric guide: `references/rubric-design-guide.md`.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -70,13 +70,7 @@ PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
 
 ## Step 2: Plan
 
-**Always build a rubric.** Follow relay-plan's process (Steps 1-3 only: read task → build rubric → generate prompt). Do NOT dispatch from relay-plan — Step 3 below handles dispatch.
-
-Rubric depth scales with task size (determined by orchestrator judgment on normalized AC + file scope, not raw issue AC count):
-- **S** (simple fix, typo, 1-liner): 1-2 factors, skip stress-test
-- **M** (standard feature): 3-5 factors, skip stress-test
-- **L** (cross-cutting, multi-file): 4-6 factors + stress-test
-- **XL** (architecture change): 5-8 factors + stress-test + calibration
+**Always build a rubric.** Follow relay-plan's process (Steps 1-3 only: read task → build rubric → generate prompt). Do NOT dispatch from relay-plan — Step 3 below handles dispatch. See `relay-plan` SKILL.md for rubric depth by task size (S/M/L/XL).
 
 Write the dispatch prompt to a temp file (e.g., `/tmp/dispatch-<N>.md`).
 If intake ran, the relay-ready handoff brief becomes the task source of truth for planning.
@@ -123,11 +117,7 @@ If sprint file exists, mark Plan item as in-flight: `[~] #42 OAuth2 flow → PR 
 
 Verify PR exists: `gh pr list --head issue-<N>`
 
-Invoke **relay-review** in an isolated context (no planning bias). The review runner manages rounds, PR comments, and manifest updates. See relay-review's **Context Isolation** section for per-platform mechanisms — adapter scripts handle this automatically when using `--reviewer`.
-
-- **Phase 1 — Spec Compliance:** Done Criteria faithfulness, stubs, security, integration, rubric re-verification. Must pass before Phase 2.
-- **Phase 2 — Code Quality:** Code review + simplification on changed files. Issues re-dispatch back to Phase 1.
-- **Runner:** `scripts/review-runner.js` invokes an isolated reviewer via adapter (built-in: `codex`, `claude`), rejects reviewer-written diffs, posts the PR comment, and updates manifest state
+Invoke **relay-review** in an isolated context (no planning bias). It runs two phases (Spec Compliance → Code Quality), re-dispatches on issues, and updates manifest state. See `relay-review` SKILL.md for the Phase 1/2 procedure, Context Isolation per platform, and runner details.
 
 The rubric from relay-plan anchors each iteration — prevents context drift across rounds. Safety cap: 20 rounds (most PRs converge in 1-3).
 


### PR DESCRIPTION
Closes #327. Step 4 of the Phase ② SKILL.md diet sequence.

## Summary

- Move S/M/L/XL factor-count table from `relay/SKILL.md` Step 2 → `relay-plan/SKILL.md` `## When to use` (canonical owner). Replace source with 1-line pointer.
- Collapse 3-bullet Phase 1 / Phase 2 / Runner block in `relay/SKILL.md` Step 4 → 1-paragraph pointer at `relay-review`. The full Phase 1/2 procedure (steps 5-11 + drift detection) already lives in `relay-review/SKILL.md` and stays untouched.

## Why these owners

| Section | Canonical owner | Reason |
|---|---|---|
| S/M/L/XL sizing rubric | `relay-plan/SKILL.md` | Rubric design is what relay-plan exists for. The orchestrator routes operators there with *"Always build a rubric. Follow relay-plan's process."* Factor-count rule is a planning concern, not orchestration. |
| Phase 1/2 review framing | `relay-review/SKILL.md` | Operator running `/relay` does NOT do Phase 1/2 manually — `review-runner.js` handles it. The 3 bullets in `relay/` were informational only; the runner script and `relay-review/SKILL.md` carry the contract. |

The dropped table (Candidate 1) was moved byte-identical to its new location. Candidate 2's 3 bullets were paraphrased into a single pointer paragraph; `relay-review/SKILL.md` is unmodified.

## Line count impact

| File | Before | After | Δ |
|---|---|---|---|
| `skills/relay/SKILL.md` | 153 | 143 | −10 |
| `skills/relay-plan/SKILL.md` | 141 | 147 | +6 (hosts moved table) |
| `skills/relay-review/SKILL.md` | 142 | 142 | 0 |

Net −4 lines across 3 SKILLs while consolidating canonical content into one owner per topic.

## Out of scope (atomic-revertable per Steps 1-3 pattern)

- **Step 5** — cross-reference renumbering sweep (`Step 1.5/1.6/3.45/3.5` inside `relay-plan/SKILL.md` plus any external citations). Stays as a separate PR. Step 5 is last because the renumbering touches reference shapes and any external citation must be swept first.
- `relay-dispatch/SKILL.md`, `relay-merge/SKILL.md`, `relay-intake/SKILL.md` — already minimal; no dedup target there.
- Backlog triage artifacts — landed separately on `main` as `294b57e`.

## Test plan

- [x] `node --test skills/*/scripts/*.test.js` → **942 pass / 0 fail** (matches main pre-PR)
- [x] Diff is doc-only — no script changes; CI smoke-test parity expected
- [x] Spot-checked moved table: byte-identical to original 5 bullet lines in `relay/SKILL.md`
- [x] Spot-checked pointer wording: includes "S/M/L/XL" and "Phase 1/2 procedure, Context Isolation per platform" so operators searching from `relay/` find the canonical sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)