### PR TITLE
docs: flatten relay-plan/SKILL.md to monotonic 1-N numbering (#329)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -23,7 +23,7 @@ Read the normalized task source (try in order, use first that succeeds):
 
 If relay-intake already produced a handoff brief, treat that file as the source of truth instead of re-reading the raw request.
 
-### 1.5 Read historical signal
+### 2. Read historical signal
 
 Before designing the rubric, read relay reliability history:
 
@@ -33,7 +33,7 @@ node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/reliability-report.js --repo 
 
 Use `historical_signal.stuck_factors`, `divergence_hotspots`, and `avg_rounds` to tighten factor wording and calibration. The signal does not gate dispatch or alter state. Empty/failure cases render as `no historical data available`; details: `references/signals.md`.
 
-### 1.6 Read probe quality signals
+### 3. Read probe quality signals
 
 Before designing the rubric, read repo-local quality signals:
 
@@ -43,7 +43,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
 
 Use `probe_signal.test_infra`, `lint_format`, `type_check`, `ci`, and `scripts` to inform rubric design, prerequisites, and Available Tools. The signal exposes data; it does not pick. No-signal/failure cases render as `no quality infra detected`; details: `references/signals.md`. The `test_infra` field is consumed by `references/rubric-pattern-tdd-flavor.md` and `scripts/tdd-suggestion.js`.
 
-### 2. Build the rubric
+### 4. Build the rubric
 
 Use the guided interview (`references/rubric-design-guide.md`) to derive factors from AC, or convert directly:
 
@@ -78,7 +78,7 @@ Consult `references/rubric-*.md` for frontend, backend, security, refactoring, d
 
 If the task crosses an auth boundary (trust root, anchor, invariant, validate, forge, bypass, gate-check, auth-boundary, or `validateTransition*` / `validateManifest*` / `evaluateReviewGate`), follow `references/rubric-trust-model.md`. Each question becomes a named factor. Record answers under `### Trust-model audit` in the PR body before dispatch.
 
-### 3. Validate the rubric
+### 5. Validate the rubric
 
 Quick gate before dispatch:
 
@@ -90,13 +90,13 @@ Quick gate before dispatch:
 
 Full checklist, factor counts, grading, and risk signals: `references/rubric-validation.md`. Grade D = revise; Grade C = warn and state the tradeoff.
 
-### 3.4 Simplify the rubric
+### 6. Simplify the rubric
 
 Before persisting the draft rubric, apply the 6 heuristics in `references/rubric-simplification.md`.
 
 Apply to all task sizes: rewrite HOW into observable WHAT, merge overlaps, remove unsupported defensive clauses, and verify weights.
 
-### 3.45 Optional isolated planner draft
+### 7. Optional isolated planner draft
 
 For standalone opt-in planner isolation, generate draft artifacts without changing the default `/relay` flow:
 
@@ -107,27 +107,27 @@ node ${CLAUDE_SKILL_DIR}/scripts/plan-runner.js \
 
 This writes `rubric.yaml`, `dispatch-prompt.md`, and `planner-notes.md`. The orchestrator reviews and may edit before dispatch.
 
-### Persisting Phase 1 deviations as anchor
+### 8. Persisting Phase 1 deviations as anchor
 
 Use this when operator planning rejects or narrows the issue body AC. Persist the operator-authored Phase 1 decision before dispatch so fresh-context review uses the same scope anchor.
 
 1. Choose `RUN_ID` (e.g., `issue-<N>-$(date -u +%Y%m%d%H%M%S000)-<short-sha>`).
 2. Persist: `node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js --repo . --run-id "$RUN_ID" --file /tmp/done-criteria-<N>.md --json`
-3. Dispatch with the same `RUN_ID`, adding `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md` to the Step 5 invocation below.
+3. Dispatch with the same `RUN_ID`, adding `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md` to the Step 11 invocation below.
 
 The helper writes `~/.relay/runs/<repo-slug>/<run-id>/done-criteria.md` with source `planner_decision`. Dispatch picks it up via `--done-criteria-file` when the same run id is used. Canonical filename is always `done-criteria.md`; ad-hoc file paths remain source `file`.
 
-### 3.5 Review the rubric (L/XL tasks)
+### 9. Review the rubric (L/XL tasks)
 
 S/M skips. L does one stress-test round. XL adds calibration simulation. Skip re-dispatches with iteration history and all-automated rubrics. Protocol: `references/rubric-stress-test.md`.
 
-### 4. Generate dispatch prompt
+### 10. Generate dispatch prompt
 
 Take the base template (`../relay/references/prompt-template.md`) and append Setup, Scoring Rubric, Iteration Protocol, and Score Log sections. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
 
 Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 
-### 5. Dispatch
+### 11. Dispatch
 
 Write the rubric YAML to a temp file alongside the dispatch prompt. Every relay dispatch must pass `--rubric-file` so the rubric is persisted at `anchor.rubric_path` for review and merge gates.
 

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -17,7 +17,7 @@ For complex tasks (5+ AC items), stress-test the rubric before dispatch. A subag
 Insert this between "Validate the rubric" (step 3) and "Generate dispatch prompt" (step 4):
 
 ```
-Step 3 (Validate) → Step 3.5 (Rubric Review) → Step 4 (Generate dispatch prompt)
+Step 5 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)
 ```
 
 ## Stress-Test (L and XL)

--- a/skills/relay-plan/references/rubric-trust-model.md
+++ b/skills/relay-plan/references/rubric-trust-model.md
@@ -4,7 +4,7 @@ Authoring guidance for rubrics on tasks that cross an **auth boundary**. Schema-
 
 ## When to apply
 
-Trigger this checklist during rubric design (relay-plan step 2) if any of the following is true:
+Trigger this checklist during rubric design (relay-plan step 4) if any of the following is true:
 
 - The issue carries the `phase-0-follow-up` label.
 - The issue or its AC mentions any of: **trust root**, **anchor**, **invariant**, **grandfather**, **validate**, **forge/forgery**, **bypass**, **gate-check**, **auth(-boundary)**, or any `validateTransition*` / `validateManifest*` / `evaluateReviewGate` callsite.

--- a/skills/relay-plan/references/signals.md
+++ b/skills/relay-plan/references/signals.md
@@ -1,6 +1,6 @@
 # Planner Input Signals
 
-Two informational signals feed into rubric design during `relay-plan` steps 1.5 and 1.6. Both are read-only inputs; neither gates dispatch, alters state transitions, or modifies rubric structure. They inform factor wording, prerequisite naming, and Available Tools context only.
+Two informational signals feed into rubric design during `relay-plan` steps 2 and 3. Both are read-only inputs; neither gates dispatch, alters state transitions, or modifies rubric structure. They inform factor wording, prerequisite naming, and Available Tools context only.
 
 ## Historical signal — `reliability-report.js`
 

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -70,7 +70,7 @@ PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
 
 ## Step 2: Plan
 
-**Always build a rubric.** Follow relay-plan's process (Steps 1-3 only: read task → build rubric → generate prompt). Do NOT dispatch from relay-plan — Step 3 below handles dispatch. See `relay-plan` SKILL.md for rubric depth by task size (S/M/L/XL).
+**Always build a rubric.** Follow relay-plan's process (Steps 1-10 only: read task → build rubric → generate prompt). Do NOT dispatch from relay-plan — Step 3 below handles dispatch. See `relay-plan` SKILL.md for rubric depth by task size (S/M/L/XL).
 
 Write the dispatch prompt to a temp file (e.g., `/tmp/dispatch-<N>.md`).
 If intake ran, the relay-ready handoff brief becomes the task source of truth for planning.


### PR DESCRIPTION
## Summary

Final step of the Phase 2 SKILL.md diet sequence (Steps 1-4 shipped via #322, #324, #326, #328). Renumber `skills/relay-plan/SKILL.md` from a dotted insert-sequence (`### 1`, `### 1.5`, `### 1.6`, `### 2`, `### 3`, `### 3.4`, `### 3.45`, `### 3.5`, `### 4`, `### 5`) to a flat monotonic 1-11 sequence, and update every cross-reference in lockstep.

Closes #329.

## Heading mapping (relay-plan/SKILL.md)

| Old | New | Heading | Why |
|---|---|---|---|
| `### 1` | `### 1` | Read the task | unchanged anchor |
| `### 1.5` | `### 2` | Read historical signal | flatten |
| `### 1.6` | `### 3` | Read probe quality signals | flatten |
| `### 2` | `### 4` | Build the rubric | flatten |
| `### Domain references` | unchanged | (reference list under Build) | reference note, not process action |
| `### Trust-model audit factor (auth-boundary tasks)` | unchanged | (conditional reference under Build) | reference note, not process action |
| `### 3` | `### 5` | Validate the rubric | flatten |
| `### 3.4` | `### 6` | Simplify the rubric | flatten |
| `### 3.45` | `### 7` | Optional isolated planner draft | flatten |
| `### Persisting Phase 1 deviations as anchor` | `### 8` | Persisting Phase 1 deviations as anchor | numbered to fit flat sequence — has its own bash invocation, structurally between optional planner draft (7) and stress-test review (9), references step 11 for dispatch follow-on |
| `### 3.5` | `### 9` | Review the rubric (L/XL tasks) | flatten |
| `### 4` | `### 10` | Generate dispatch prompt | flatten |
| `### 5` | `### 11` | Dispatch | flatten |

\`Domain references\` and \`Trust-model audit factor\` stay unnumbered because they are reference notes attached to step 4 (Build the rubric), not separate process actions.

## Cross-references updated in lockstep

Pre-PR sweep (\`grep -rn 'Step 1\\.5\\|Step 1\\.6\\|Step 3\\.4\\|Step 3\\.45\\|Step 3\\.5'\` plus relay-plan-step glosses):

| File:line | Old | New |
|---|---|---|
| \`skills/relay-plan/SKILL.md:116\` | "the Step 5 invocation below" | "the Step 11 invocation below" |
| \`skills/relay-plan/references/rubric-stress-test.md:20\` | \`Step 3 (Validate) → Step 3.5 (Rubric Review) → Step 4 (Generate dispatch prompt)\` | \`Step 5 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)\` |
| \`skills/relay-plan/references/signals.md:3\` | "during \`relay-plan\` steps 1.5 and 1.6" | "during \`relay-plan\` steps 2 and 3" |
| \`skills/relay-plan/references/rubric-trust-model.md:7\` | "during rubric design (relay-plan step 2)" | "during rubric design (relay-plan step 4)" |
| \`skills/relay/SKILL.md:73\` | "Follow relay-plan's process (Steps 1-3 only: ...)" | "Follow relay-plan's process (Steps 1-10 only: ...)" — also corrects pre-existing drift (gloss was already inaccurate after 1.5/1.6/3.4/3.45/3.5 inserts) |

False positives ruled out:
- \`skills/relay/SKILL.md:61\` — \`## Step 1.5: Check for in-flight work\` is relay's own internal step, separate namespace
- \`skills/relay-dispatch/scripts/dispatch.js:1237\` — internal code comment for relay-dispatch
- \`Step 0a\` / \`Step 0\` / \`Step 4(a)\` references in iteration-protocol.md and tdd-flavor.* — dispatch-prompt protocol step namespace, not relay-plan SKILL.md step namespace

## Tests

\`node --test skills/*/scripts/*.test.js\` — 942 pass / 0 fail. Doc-only change; no behavioral surface touched.

## Out of scope

**none — Step 5 closes the Phase 2 diet sequence.** No subsection collapses, no prose tightening, no script changes. Renumbering and cross-ref updates only.

## Test plan

- [x] All 13 \`### \` headings in relay-plan/SKILL.md scanned: flat 1-11 + 2 named anchors, no dotted variants
- [x] Sweep confirms no \`Step 1.5/1.6/3.4/3.45/3.5\` cross-refs remain (the one remaining match is relay's own internal Step 1.5, different namespace)
- [x] \`node --test skills/*/scripts/*.test.js\` 942/0
- [x] \`git diff --stat\`: 5 files, 15+/15-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 릴레이 플랜 워크플로우의 단계 참조 업데이트
  * 검증, 검토, 디스패치 지침의 단계 번호 조정
  * 신뢰 모델 감사 요청 단계 변경
  * 신호 입력 참조 단계 정렬
  * 사용자 지침 범위 확대로 워크플로우 명확성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->