### PR TITLE
relay-events: introduce EVENTS enum + write-time validation gate (#313)

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -30,7 +30,7 @@ const {
   writeManifest,
 } = require("./manifest/store");
 const { getArg, hasFlag, modeLabel } = require("./cli-args");
-const { appendRunEvent } = require("./relay-events");
+const { appendRunEvent, EVENTS } = require("./relay-events");
 const { safeFormatRunId } = require("./relay-resolver");
 
 const args = process.argv.slice(2);
@@ -223,7 +223,7 @@ function run() {
     if (!dryRun) {
       writeManifest(manifestPath, cleanupResult.updatedData, body);
       appendRunEvent(repoRoot, cleanupResult.updatedData.run_id, {
-        event: "cleanup_result",
+        event: EVENTS.CLEANUP_RESULT,
         state_from: cleanupResult.updatedData.state,
         state_to: cleanupResult.updatedData.state,
         head_sha: cleanupResult.updatedData.git?.head_sha || null,

--- a/skills/relay-dispatch/scripts/close-run.js
+++ b/skills/relay-dispatch/scripts/close-run.js
@@ -11,7 +11,7 @@ const {
 const { writeManifest } = require("./manifest/store");
 const { getArg, hasFlag, modeLabel } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
-const { appendRunEvent } = require("./relay-events");
+const { appendRunEvent, EVENTS } = require("./relay-events");
 
 const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "close-run", reservedFlags: ["-h"] };
@@ -105,7 +105,7 @@ function main() {
   if (!dryRun) {
     writeManifest(manifestPath, updated, body);
     appendRunEvent(repoRoot, updated.run_id, {
-      event: "close",
+      event: EVENTS.CLOSE,
       state_from: safeData.state,
       state_to: STATES.CLOSED,
       head_sha: updated.git?.head_sha || null,
@@ -113,7 +113,7 @@ function main() {
       reason,
     });
     appendRunEvent(repoRoot, updated.run_id, {
-      event: "cleanup_result",
+      event: EVENTS.CLEANUP_RESULT,
       state_from: updated.state,
       state_to: updated.state,
       head_sha: updated.git?.head_sha || null,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -97,7 +97,7 @@ const { getArg, getPositionals, hasFlag, modeLabel } = require("./cli-args");
 const { formatAttemptsForPrompt, readPreviousAttempts } = require("./manifest/attempts");
 const { STATES, updateManifestState } = require("./manifest/lifecycle");
 const { resolveManifestRecord } = require("./relay-resolver");
-const { appendRunEvent } = require("./relay-events");
+const { appendRunEvent, EVENTS } = require("./relay-events");
 
 // ---------------------------------------------------------------------------
 // Args
@@ -680,7 +680,7 @@ async function main() {
         console.error(`[WARN] Environment drift detected since initial dispatch: ${driftMsg}`);
       }
       appendRunEvent(repoRoot, runId, {
-        event: "environment_drift",
+        event: EVENTS.ENVIRONMENT_DRIFT,
         state_from: manifest.state,
         state_to: manifest.state,
         reason: driftMsg,
@@ -737,7 +737,7 @@ async function main() {
     if (!DRY_RUN) {
       writeManifest(manifestPath, manifest);
       appendRunEvent(repoRoot, runId, {
-        event: "model_hints_updated",
+        event: EVENTS.MODEL_HINTS_UPDATED,
         state_from: manifest.state,
         state_to: manifest.state,
         head_sha: manifest.git?.head_sha || null,
@@ -1021,7 +1021,7 @@ async function main() {
   };
   writeManifest(manifestPath, manifest);
   appendRunEvent(repoRoot, runId, {
-    event: "dispatch_start",
+    event: EVENTS.DISPATCH_START,
     state_from: dispatchFromState,
     state_to: STATES.DISPATCHED,
     head_sha: startHead || null,
@@ -1223,7 +1223,7 @@ async function main() {
   };
   writeManifest(manifestPath, manifest);
   appendRunEvent(repoRoot, runId, {
-    event: "dispatch_result",
+    event: EVENTS.DISPATCH_RESULT,
     state_from: STATES.DISPATCHED,
     state_to: manifest.state,
     head_sha: currentHead || startHead || null,

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("child_process");

--- a/skills/relay-dispatch/scripts/manifest/pr-number-stamp.js
+++ b/skills/relay-dispatch/scripts/manifest/pr-number-stamp.js
@@ -10,7 +10,7 @@ const {
   validateManifestPaths,
 } = require("./paths");
 const { readManifest, writeManifest } = require("./store");
-const { appendRunEvent, readRunEvents } = require("../relay-events");
+const { appendRunEvent, EVENTS, readRunEvents } = require("../relay-events");
 
 function parsePositiveIntEnv(name, fallback) {
   const raw = process.env[name];
@@ -136,11 +136,11 @@ function stampPrNumberUnderLock(manifestRecord, numericPrNumber, options = {}) {
     // Rule 1 layer B (#166): dedupe against the committed journal so even a future lock
     // regression cannot emit duplicate first-resolution pr_number_stamped events.
     const alreadyStamped = readRunEvents(repoRoot, updatedData.run_id)
-      .some((entry) => entry.event === "pr_number_stamped");
+      .some((entry) => entry.event === EVENTS.PR_NUMBER_STAMPED);
 
     if (!alreadyStamped) {
       appendRunEvent(repoRoot, updatedData.run_id, {
-        event: "pr_number_stamped",
+        event: EVENTS.PR_NUMBER_STAMPED,
         state_from: updatedData.state,
         state_to: updatedData.state,
         head_sha: updatedData.git?.head_sha || null,

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -11,7 +11,7 @@ const { execFileSync } = require("child_process");
 
 const { parsePrNumber, formatExecError } = require("./dispatch-publish");
 const { resolveManifestRecord } = require("./relay-resolver");
-const { appendRunEvent } = require("./relay-events");
+const { appendRunEvent, EVENTS } = require("./relay-events");
 const { STATES } = require("./manifest/lifecycle");
 const { getCanonicalRepoRoot, getRunDir, validateManifestPaths } = require("./manifest/paths");
 const { summarizeError } = require("./manifest/store");
@@ -184,7 +184,7 @@ function appendRecoveryEvent(repoRoot, data, event, reason, commitSha, prNumber,
 
 function appendFailureEvent(repoRoot, data, status, detail, commitSha, branch) {
   try {
-    appendRecoveryEvent(repoRoot, data, "recover_commit_failed", `${status}: ${detail}`, commitSha, null, branch);
+    appendRecoveryEvent(repoRoot, data, EVENTS.RECOVER_COMMIT_FAILED, `${status}: ${detail}`, commitSha, null, branch);
   } catch {}
 }
 
@@ -326,7 +326,7 @@ function main() {
     });
     if (rebrandResult.rewritten) {
       appendRunEvent(validatedPaths.repoRoot, data.run_id, {
-        event: "execution_evidence_rebranded",
+        event: EVENTS.EXECUTION_EVIDENCE_REBRANDED,
         previous_head_sha: rebrandResult.previousSha,
         new_head_sha: commitSha,
         reason,
@@ -382,7 +382,7 @@ function main() {
     });
   }
 
-  appendRecoveryEvent(validatedPaths.repoRoot, stampedRecord.data || data, "recover_commit", reason, commitSha, prNumber, branch);
+  appendRecoveryEvent(validatedPaths.repoRoot, stampedRecord.data || data, EVENTS.RECOVER_COMMIT, reason, commitSha, prNumber, branch);
 
   const result = {
     status: "recovered",

--- a/skills/relay-dispatch/scripts/recover-commit.test.js
+++ b/skills/relay-dispatch/scripts/recover-commit.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("child_process");

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -24,7 +24,7 @@ const {
 const { writeManifest } = require("./manifest/store");
 const { getArg, hasFlag, modeLabel } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
-const { appendRunEvent } = require("./relay-events");
+const { appendRunEvent, EVENTS } = require("./relay-events");
 const CLI_ARG_OPTIONS = { commandName: "recover-state", reservedFlags: ["-h"] };
 
 // Whitelist: recovery transitions that the normal dispatch/review/merge flow does NOT support.
@@ -218,7 +218,7 @@ function main() {
   if (!dryRun) {
     writeManifest(manifestPath, updated, body);
     appendRunEvent(repoRoot, updated.run_id, {
-      event: "state_recovery",
+      event: EVENTS.STATE_RECOVERY,
       state_from: fromState,
       state_to: toState,
       head_sha: commitContext?.currentHead || updated.git?.head_sha || null,

--- a/skills/relay-dispatch/scripts/relay-events-enum.test.js
+++ b/skills/relay-dispatch/scripts/relay-events-enum.test.js
@@ -1,0 +1,179 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { EVENTS } = require("./relay-events");
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SKILLS_DIR = path.join(REPO_ROOT, "skills");
+const OUT_OF_SCOPE_EVENT_SINKS = new Set([
+  "skills/relay-intake/scripts/relay-request.js",
+  "skills/relay-dispatch/scripts/worktree-runtime.js",
+]);
+
+function toRepoRelative(filePath) {
+  return path.relative(REPO_ROOT, filePath).split(path.sep).join("/");
+}
+
+function listProductionJsFiles(rootDir) {
+  const files = [];
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listProductionJsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".js") && !entry.name.endsWith(".test.js")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function readInScopeSources() {
+  return listProductionJsFiles(SKILLS_DIR)
+    .map((filePath) => ({
+      filePath,
+      relativePath: toRepoRelative(filePath),
+      source: fs.readFileSync(filePath, "utf-8"),
+    }))
+    .filter(({ relativePath }) => !OUT_OF_SCOPE_EVENT_SINKS.has(relativePath));
+}
+
+function stripEventsObjectLiteral(relativePath, source) {
+  if (relativePath !== "skills/relay-dispatch/scripts/relay-events.js") {
+    return source;
+  }
+  return source.replace(
+    /const EVENTS = Object\.freeze\(\{[\s\S]*?\n\}\);/,
+    "const EVENTS = Object.freeze({});"
+  );
+}
+
+function collectProducerEventKeys(sources) {
+  const keys = new Set();
+
+  for (const { source } of sources) {
+    for (const match of source.matchAll(/\bevent\s*:\s*EVENTS\.([A-Z0-9_]+)/g)) {
+      keys.add(match[1]);
+    }
+    for (const match of findAppendRecoveryEventCalls(source)) {
+      const eventArg = splitTopLevelArguments(match.args)[2]?.trim() || "";
+      const eventKey = eventArg.match(/^EVENTS\.([A-Z0-9_]+)$/);
+      if (eventKey) {
+        keys.add(eventKey[1]);
+      }
+    }
+  }
+
+  return keys;
+}
+
+function findAppendRecoveryEventCalls(source) {
+  const calls = [];
+  for (const match of source.matchAll(/\bappendRecoveryEvent\s*\(([\s\S]*?)\);/g)) {
+    const prefix = source.slice(Math.max(0, match.index - "function ".length), match.index);
+    if (prefix === "function ") {
+      continue;
+    }
+    calls.push({ index: match.index, text: match[0], args: match[1] });
+  }
+  return calls;
+}
+
+function splitTopLevelArguments(argsText) {
+  const args = [];
+  let current = "";
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (const char of argsText) {
+    if (quote) {
+      current += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === "(" || char === "[" || char === "{") {
+      depth += 1;
+    } else if (char === ")" || char === "]" || char === "}") {
+      depth -= 1;
+    } else if (char === "," && depth === 0) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) {
+    args.push(current.trim());
+  }
+  return args;
+}
+
+function findBareEventLiterals(sources) {
+  const matches = [];
+
+  for (const { relativePath, source } of sources) {
+    const scanSource = stripEventsObjectLiteral(relativePath, source);
+    for (const match of scanSource.matchAll(/\bevent\s*:\s*["'][a-z_]+["']/g)) {
+      matches.push(`${relativePath}:${lineNumberForIndex(scanSource, match.index)}: ${match[0]}`);
+    }
+    for (const match of findAppendRecoveryEventCalls(scanSource)) {
+      const eventArg = splitTopLevelArguments(match.args)[2]?.trim() || "";
+      if (!/^EVENTS\.[A-Z0-9_]+$/.test(eventArg)) {
+        matches.push(`${relativePath}:${lineNumberForIndex(scanSource, match.index)}: appendRecoveryEvent event arg ${eventArg || "(missing)"}`);
+      }
+    }
+  }
+
+  return matches;
+}
+
+function lineNumberForIndex(source, index) {
+  return source.slice(0, index).split("\n").length;
+}
+
+function sorted(values) {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+test("EVENTS is a frozen object map for current run journal event names", () => {
+  assert.equal(Object.isFrozen(EVENTS), true);
+  assert.equal(Object.values(EVENTS).every((eventName) => typeof eventName === "string"), true);
+  assert.equal(Object.values(EVENTS).includes("manual_recovery"), false);
+  assert.equal(Object.values(EVENTS).includes("manual_state_correction"), false);
+  assert.equal(Object.values(EVENTS).includes("manual_state_override"), false);
+  assert.equal(Object.values(EVENTS).includes("request_persisted"), false);
+  assert.equal(Object.values(EVENTS).includes("register"), false);
+});
+
+test("EVENTS values match the event names emitted by producer call sites under skills", () => {
+  const sources = readInScopeSources();
+  const producerKeys = collectProducerEventKeys(sources);
+  const unknownKeys = sorted([...producerKeys].filter((key) => !Object.hasOwn(EVENTS, key)));
+  assert.deepEqual(unknownKeys, []);
+
+  const emittedEventNames = sorted([...producerKeys].map((key) => EVENTS[key]));
+  const enumEventNames = sorted(Object.values(EVENTS));
+  assert.deepEqual(emittedEventNames, enumEventNames);
+});
+
+test("journal producer call sites do not use bare string event names", () => {
+  const bareEventLiterals = findBareEventLiterals(readInScopeSources());
+  assert.deepEqual(bareEventLiterals, []);
+});

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -6,7 +6,52 @@ const {
   readTextFileWithoutFollowingSymlinks,
 } = require("./manifest/rubric");
 
+// EVENTS covers write-time names that land in ~/.relay/runs/<slug>/<run-id>/events.jsonl
+// through appendRunEvent, recover-commit's appendRecoveryEvent wrapper, or the three
+// helper writers in this module. Out of scope: relay-intake/scripts/relay-request.js
+// writes a separate ~/.relay/requests/ artifact log, and worktree-runtime.js emits
+// pluggable logger metadata rather than journal entries. Historical-only journal names
+// (manual_recovery, manual_state_correction, manual_state_override) are intentionally
+// absent: current producer code no longer emits them, and readRunEvents remains tolerant
+// because validation is write-only.
+const EVENTS = Object.freeze({
+  CLEANUP_RESULT: "cleanup_result",
+  CLOSE: "close",
+  DISPATCH_RESULT: "dispatch_result",
+  DISPATCH_START: "dispatch_start",
+  ENVIRONMENT_DRIFT: "environment_drift",
+  ESCALATION_DECISION: "escalation_decision",
+  EXECUTION_EVIDENCE_REBRANDED: "execution_evidence_rebranded",
+  FORCE_FINALIZE: "force_finalize",
+  ITERATION_SCORE: "iteration_score",
+  MERGE_BLOCKED: "merge_blocked",
+  MERGE_FINALIZE: "merge_finalize",
+  MODEL_HINTS_UPDATED: "model_hints_updated",
+  PR_BODY_SNAPSHOT_FAILED: "pr_body_snapshot_failed",
+  PR_NUMBER_STAMPED: "pr_number_stamped",
+  RECOVER_COMMIT: "recover_commit",
+  RECOVER_COMMIT_FAILED: "recover_commit_failed",
+  REVIEW_APPLY: "review_apply",
+  REVIEW_INVOKE: "review_invoke",
+  REVIEWER_SWAP: "reviewer_swap",
+  RUBRIC_QUALITY: "rubric_quality",
+  SCORE_DIVERGENCE: "score_divergence",
+  SKIP_REVIEW: "skip_review",
+  STATE_RECOVERY: "state_recovery",
+});
+
+const EVENT_VALUES = Object.freeze(Object.values(EVENTS));
+
+function validateKnownEventName(eventName) {
+  if (!EVENT_VALUES.includes(eventName)) {
+    throw new Error(
+      `Unknown relay event name "${String(eventName)}"; expected one of: ${EVENT_VALUES.join(", ")}`
+    );
+  }
+}
+
 function appendEventLine(repoRoot, runId, record) {
+  validateKnownEventName(record?.event);
   const eventsPath = getEventsPath(repoRoot, runId);
   try {
     appendTextFileWithoutFollowingSymlinks(eventsPath, `${JSON.stringify(record)}\n`);
@@ -153,7 +198,7 @@ function appendIterationScore(repoRoot, runId, { round, scores } = {}) {
   ensureRunLayout(repoRoot, runId);
   const record = {
     ts: new Date().toISOString(),
-    event: "iteration_score",
+    event: EVENTS.ITERATION_SCORE,
     actor: getActorName(repoRoot),
     run_id: runId,
     round,
@@ -203,7 +248,7 @@ function appendRubricQuality(repoRoot, runId, data = {}) {
   ensureRunLayout(repoRoot, runId);
   const record = {
     ts: new Date().toISOString(),
-    event: "rubric_quality",
+    event: EVENTS.RUBRIC_QUALITY,
     actor: getActorName(repoRoot),
     run_id: runId,
     grade: data.grade,
@@ -251,7 +296,7 @@ function appendScoreDivergence(repoRoot, runId, { round, divergences } = {}) {
   ensureRunLayout(repoRoot, runId);
   const record = {
     ts: new Date().toISOString(),
-    event: "score_divergence",
+    event: EVENTS.SCORE_DIVERGENCE,
     actor: getActorName(repoRoot),
     run_id: runId,
     round,
@@ -308,6 +353,7 @@ module.exports = {
   appendRubricQuality,
   appendRunEvent,
   appendScoreDivergence,
+  EVENTS,
   readAllRunEvents,
   readRunEvents,
 };

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -11,6 +11,7 @@ const {
   appendRubricQuality,
   appendRunEvent,
   appendScoreDivergence,
+  EVENTS,
   readRunEvents,
 } = require("./relay-events");
 
@@ -132,7 +133,7 @@ test("appendIterationScore writes an iteration_score record to events.jsonl", ()
 test("appendRunEvent writes actor from git config user.name", () => {
   const { repoRoot, runId } = createContext("Relay Operator");
   const record = appendRunEvent(repoRoot, runId, {
-    event: "dispatch_start",
+    event: EVENTS.DISPATCH_START,
     state_from: "draft",
     state_to: "dispatched",
   });
@@ -145,7 +146,7 @@ test("appendRunEvent writes actor from git config user.name", () => {
 test("appendRunEvent persists rubric_status when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {
-    event: "skip_review",
+    event: EVENTS.SKIP_REVIEW,
     state_from: "ready_to_merge",
     state_to: "ready_to_merge",
     reason: "hotfix",
@@ -160,7 +161,7 @@ test("appendRunEvent persists rubric_status when provided", () => {
 test("appendRunEvent persists origin when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {
-    event: "review_apply",
+    event: EVENTS.REVIEW_APPLY,
     state_from: "review_pending",
     state_to: "escalated",
     reason: "max_rounds_exceeded",
@@ -175,7 +176,7 @@ test("appendRunEvent persists origin when provided", () => {
 test("appendRunEvent persists last_reviewed_sha when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {
-    event: "state_recovery",
+    event: EVENTS.STATE_RECOVERY,
     state_from: "changes_requested",
     state_to: "review_pending",
     head_sha: "deadbeef",
@@ -191,7 +192,7 @@ test("appendRunEvent persists last_reviewed_sha when provided", () => {
 test("appendRunEvent persists pr_number when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {
-    event: "force_finalize",
+    event: EVENTS.FORCE_FINALIZE,
     state_from: "escalated",
     state_to: "merged",
     head_sha: "deadbeef",
@@ -207,7 +208,7 @@ test("appendRunEvent persists pr_number when provided", () => {
 test("appendRunEvent persists recover commit commit_sha and branch when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {
-    event: "recover_commit",
+    event: EVENTS.RECOVER_COMMIT,
     state_from: "review_pending",
     state_to: "review_pending",
     head_sha: "deadbeef",
@@ -227,13 +228,38 @@ test("appendRunEvent persists recover commit commit_sha and branch when provided
 test("appendRunEvent omits last_reviewed_sha when absent", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {
-    event: "dispatch",
+    event: EVENTS.DISPATCH_START,
     state_from: "draft",
     state_to: "dispatched",
     reason: "start",
   });
 
   assert.equal(Object.prototype.hasOwnProperty.call(record, "last_reviewed_sha"), false);
+});
+
+// Test-side bare event strings below are intentional canaries: one proves write-time
+// rejection of unknown current names, and one proves read-time tolerance for legacy
+// historical journal names.
+test("appendRunEvent throws on event name not in EVENTS", () => {
+  const { repoRoot, runId } = createContext();
+  assert.throws(
+    () => appendRunEvent(repoRoot, runId, {
+      event: "not_a_relay_event",
+      state_from: "draft",
+      state_to: "draft",
+    }),
+    /Unknown relay event name "not_a_relay_event"/
+  );
+});
+
+test("readRunEvents tolerates historical-only event names", () => {
+  const { repoRoot, runId } = createContext();
+  const eventsPath = getEventsPath(repoRoot, runId);
+  fs.mkdirSync(path.dirname(eventsPath), { recursive: true });
+  const historicalEvent = { event: "manual_state_override", run_id: runId };
+  fs.writeFileSync(eventsPath, `${JSON.stringify(historicalEvent)}\n`, "utf-8");
+
+  assert.deepEqual(readRunEvents(repoRoot, runId), [historicalEvent]);
 });
 
 test("appendIterationScore requires run_id", () => {
@@ -417,7 +443,7 @@ test("appendScoreDivergence rejects a missing factor", () => {
 test("appendRunEvent refuses when events.jsonl is replaced with a symlink", () => {
   const { repoRoot, runId } = createContext();
   // Seed the run layout with a legit first event.
-  appendRunEvent(repoRoot, runId, { event: "plan" });
+  appendRunEvent(repoRoot, runId, { event: EVENTS.DISPATCH_START });
 
   const eventsPath = getEventsPath(repoRoot, runId);
   const victim = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-victim-")), "victim.jsonl");
@@ -427,7 +453,7 @@ test("appendRunEvent refuses when events.jsonl is replaced with a symlink", () =
   fs.symlinkSync(victim, eventsPath);
 
   assert.throws(
-    () => appendRunEvent(repoRoot, runId, { event: "dispatch" }),
+    () => appendRunEvent(repoRoot, runId, { event: EVENTS.DISPATCH_RESULT }),
     /Refusing to (append to|open) symlinked/i
   );
   // Victim file must not have been mutated.
@@ -436,7 +462,7 @@ test("appendRunEvent refuses when events.jsonl is replaced with a symlink", () =
 
 test("readRunEvents refuses when events.jsonl is a symlink", () => {
   const { repoRoot, runId } = createContext();
-  appendRunEvent(repoRoot, runId, { event: "plan" });
+  appendRunEvent(repoRoot, runId, { event: EVENTS.DISPATCH_START });
 
   const eventsPath = getEventsPath(repoRoot, runId);
   const foreignDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-events-foreign-"));
@@ -456,7 +482,7 @@ test("readRunEvents refuses dangling symlinks instead of silently returning []",
   // #197 fail-closed: a dangling symlink at events.jsonl must NOT be treated
   // as "file missing" (existsSync follows links and would say "missing").
   const { repoRoot, runId } = createContext();
-  appendRunEvent(repoRoot, runId, { event: "plan" });
+  appendRunEvent(repoRoot, runId, { event: EVENTS.DISPATCH_START });
 
   const eventsPath = getEventsPath(repoRoot, runId);
   fs.rmSync(eventsPath);
@@ -476,7 +502,7 @@ test("appendRunEvent refuses dangling symlinks (no silent create-through)", () =
   // fallback in openForWriteWithoutFollowingSymlinks refuses dangling links.
   const { repoRoot, runId } = createContext();
   // Seed layout (without an events.jsonl yet).
-  appendRunEvent(repoRoot, runId, { event: "plan" });
+  appendRunEvent(repoRoot, runId, { event: EVENTS.DISPATCH_START });
 
   const eventsPath = getEventsPath(repoRoot, runId);
   fs.rmSync(eventsPath);
@@ -486,7 +512,7 @@ test("appendRunEvent refuses dangling symlinks (no silent create-through)", () =
   fs.symlinkSync(victimTarget, eventsPath);
 
   assert.throws(
-    () => appendRunEvent(repoRoot, runId, { event: "dispatch" }),
+    () => appendRunEvent(repoRoot, runId, { event: EVENTS.DISPATCH_RESULT }),
     /Refusing to (append to|open) symlinked/i
   );
   assert.equal(fs.existsSync(victimTarget), false, "victim target must not have been created through the symlink");

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -5,7 +5,7 @@ const path = require("path");
 const { STATES } = require("./manifest/lifecycle");
 const { listManifestRecords } = require("./manifest/store");
 const { getArg, hasFlag, modeLabel } = require("./cli-args");
-const { readAllRunEvents } = require("./relay-events");
+const { EVENTS, readAllRunEvents } = require("./relay-events");
 const { extractAllFactors } = require("../../relay-plan/scripts/tdd-flavor");
 
 const args = process.argv.slice(2);
@@ -73,12 +73,12 @@ function hasRecordedReviewActivity(data) {
 }
 
 function isSystemReviewApplyEvent(event) {
-  return event?.event === "review_apply" && event?.origin === "system";
+  return event?.event === EVENTS.REVIEW_APPLY && event?.origin === "system";
 }
 
 function isLegacyReviewerlessReviewApplyEvent(event) {
   return (
-    event?.event === "review_apply"
+    event?.event === EVENTS.REVIEW_APPLY
     && (event?.reviewer === undefined || event?.reviewer === null)
   );
 }
@@ -113,7 +113,7 @@ function buildTierEffectiveness(events) {
   const runFactors = new Map();
 
   for (const event of events) {
-    if (event.event !== "iteration_score" || !event.run_id || !Array.isArray(event.scores)) continue;
+    if (event.event !== EVENTS.ITERATION_SCORE || !event.run_id || !Array.isArray(event.scores)) continue;
     const round = Number(event.round);
     const roundNumber = Number.isFinite(round) ? round : null;
 
@@ -180,7 +180,7 @@ function buildTierEffectiveness(events) {
 }
 
 function buildDivergenceHotspots(events) {
-  const divergenceEvents = events.filter((event) => event.event === "score_divergence" && Array.isArray(event.divergences));
+  const divergenceEvents = events.filter((event) => event.event === EVENTS.SCORE_DIVERGENCE && Array.isArray(event.divergences));
   if (divergenceEvents.length === 0) return null;
 
   const grouped = new Map();
@@ -283,7 +283,7 @@ function buildAutoVsEvalCorrelation(rubricQualityEvents, manifests) {
 
 function buildRubricInsights(events, manifests) {
   const insights = buildEmptyRubricInsights();
-  const rubricQualityEvents = events.filter((event) => event.event === "rubric_quality");
+  const rubricQualityEvents = events.filter((event) => event.event === EVENTS.RUBRIC_QUALITY);
 
   if (rubricQualityEvents.length > 0) {
     insights.quality_grade_distribution = { A: 0, B: 0, C: 0, D: 0 };
@@ -316,7 +316,7 @@ function buildFactorAnalysis(events) {
   const factorsByRun = new Map();
 
   for (const event of events) {
-    if (event.event !== "iteration_score" || !event.run_id) continue;
+    if (event.event !== EVENTS.ITERATION_SCORE || !event.run_id) continue;
     if (!Array.isArray(event.scores) || event.scores.length === 0) continue;
 
     const round = Number(event.round);
@@ -430,7 +430,7 @@ function buildIterationScoreIndex(events) {
   const scoresByRun = new Map();
 
   for (const event of events) {
-    if (event?.event !== "iteration_score" || !event.run_id || !Array.isArray(event.scores)) continue;
+    if (event?.event !== EVENTS.ITERATION_SCORE || !event.run_id || !Array.isArray(event.scores)) continue;
     if (!scoresByRun.has(event.run_id)) {
       scoresByRun.set(event.run_id, new Map());
     }
@@ -532,9 +532,9 @@ function buildModelPerPhase(events) {
 
   for (const event of events) {
     let phase = null;
-    if (event.event === "dispatch_start") {
+    if (event.event === EVENTS.DISPATCH_START) {
       phase = "dispatch";
-    } else if (event.event === "review_invoke") {
+    } else if (event.event === EVENTS.REVIEW_INVOKE) {
       phase = "review";
     }
     if (!phase || !Object.prototype.hasOwnProperty.call(event, "model")) continue;
@@ -556,18 +556,18 @@ function buildModelPerPhase(events) {
 
 function buildReport({ repoRoot, staleHours, now, manifests, events }) {
   const resumeStarts = events.filter((event) => (
-    event.event === "dispatch_start" && event.state_from === STATES.CHANGES_REQUESTED
+    event.event === EVENTS.DISPATCH_START && event.state_from === STATES.CHANGES_REQUESTED
   ));
   const resumeSuccesses = events.filter((event) => (
-    event.event === "dispatch_result" &&
+    event.event === EVENTS.DISPATCH_RESULT &&
     event.state_to === STATES.REVIEW_PENDING &&
     String(event.reason || "").startsWith("same_run_resume:")
   ));
 
   const mergeGateOutcomes = events.filter((event) => (
-    event.event === "merge_blocked" || event.event === "merge_finalize"
+    event.event === EVENTS.MERGE_BLOCKED || event.event === EVENTS.MERGE_FINALIZE
   ));
-  const mergeBlocks = mergeGateOutcomes.filter((event) => event.event === "merge_blocked");
+  const mergeBlocks = mergeGateOutcomes.filter((event) => event.event === EVENTS.MERGE_BLOCKED);
 
   const reviewRuns = new Map();
   for (const manifest of manifests) {
@@ -575,7 +575,7 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
   }
   const maxRoundsCompliant = new Set();
   for (const [runId, maxRounds] of reviewRuns.entries()) {
-    const runEvents = events.filter((event) => event.run_id === runId && event.event === "review_apply");
+    const runEvents = events.filter((event) => event.run_id === runId && event.event === EVENTS.REVIEW_APPLY);
     const overflow = runEvents.some((event) => Number(event.round || 0) > maxRounds);
     if (!overflow) {
       maxRoundsCompliant.add(runId);
@@ -681,7 +681,7 @@ function buildRoleReports({ repoRoot, staleHours, now, manifests, events }) {
 // cases stay visible.
 function buildActingReviewerReports({ repoRoot, staleHours, now, manifests, events }) {
   const reviewApplyEvents = events.filter((event) => (
-    event.event === "review_apply"
+    event.event === EVENTS.REVIEW_APPLY
     && event.run_id
     && !isSystemReviewApplyEvent(event)
     && !isLegacyReviewerlessReviewApplyEvent(event)

--- a/skills/relay-dispatch/scripts/reliability-report.test.js
+++ b/skills/relay-dispatch/scripts/reliability-report.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event: "..."` fixture literals AND reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync } = require("child_process");

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -48,7 +48,7 @@ const {
   writeManifest,
 } = require("../../relay-dispatch/scripts/manifest/store");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
-const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
+const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 const { runCleanup } = require("../../relay-dispatch/scripts/manifest/cleanup");
 const {
   getArg: sharedGetArg,
@@ -398,7 +398,7 @@ function main() {
       if (skipReviewFailure) {
         if (!dryRun) {
           appendRunEvent(repoPath, safeData.run_id, {
-            event: "merge_blocked",
+            event: EVENTS.MERGE_BLOCKED,
             state_from: safeData.state,
             state_to: safeData.state,
             head_sha: currentHeadSha,
@@ -418,7 +418,7 @@ function main() {
       if (!dryRun) {
         const skipComment = buildSkipComment(skipReviewReason, skipReviewRubricAudit);
         appendRunEvent(repoPath, safeData.run_id, {
-          event: "skip_review",
+          event: EVENTS.SKIP_REVIEW,
           state_from: safeData.state,
           state_to: safeData.state,
           head_sha: currentHeadSha,
@@ -441,7 +441,7 @@ function main() {
       if (!reviewGate.readyToMerge) {
         if (!dryRun) {
           appendRunEvent(repoPath, safeData.run_id, {
-            event: "merge_blocked",
+            event: EVENTS.MERGE_BLOCKED,
             state_from: safeData.state,
             state_to: safeData.state,
             head_sha: reviewGate.latestCommit || currentHeadSha,
@@ -461,7 +461,7 @@ function main() {
   if (mergeAllowed) {
     if (forceFinalizeNonready && !dryRun) {
       appendRunEvent(repoPath, safeData.run_id, {
-        event: "force_finalize",
+        event: EVENTS.FORCE_FINALIZE,
         state_from: safeData.state,
         state_to: STATES.MERGED,
         head_sha: currentHeadSha,
@@ -511,7 +511,7 @@ function main() {
         if (prMergeState.state === "MERGED") break;
         if (prMergeState.state === "OPEN") {
           appendRunEvent(repoPath, safeData.run_id, {
-            event: "merge_blocked",
+            event: EVENTS.MERGE_BLOCKED,
             state_from: safeData.state,
             state_to: safeData.state,
             head_sha: reviewGate?.latestCommit || currentHeadSha,
@@ -525,7 +525,7 @@ function main() {
       }
       if (prMergeState.state !== "MERGED") {
         appendRunEvent(repoPath, safeData.run_id, {
-          event: "merge_blocked",
+          event: EVENTS.MERGE_BLOCKED,
           state_from: safeData.state,
           state_to: safeData.state,
           head_sha: reviewGate?.latestCommit || currentHeadSha,
@@ -562,7 +562,7 @@ function main() {
     };
     if (!dryRun) {
       appendRunEvent(repoPath, safeData.run_id, {
-        event: "merge_finalize",
+        event: EVENTS.MERGE_FINALIZE,
         state_from: safeData.state,
         state_to: STATES.MERGED,
         head_sha: updated.git?.head_sha || null,
@@ -596,7 +596,7 @@ function main() {
   updated = cleanupResult.updatedData;
   if (!dryRun) {
     appendRunEvent(repoPath, updated.run_id, {
-      event: "cleanup_result",
+      event: EVENTS.CLEANUP_RESULT,
       state_from: updated.state,
       state_to: updated.state,
       head_sha: updated.git?.head_sha || null,

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("child_process");

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawn, spawnSync } = require("child_process");

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.js
@@ -36,7 +36,7 @@ const {
   writeManifest,
 } = require("../../relay-dispatch/scripts/manifest/store");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
-const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
+const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 const { getArg: sharedGetArg, hasFlag: sharedHasFlag } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
@@ -215,7 +215,7 @@ function main() {
 
   if (skipReviewReason) {
     appendRunEvent(repoPath, safeData.run_id, {
-      event: "skip_review",
+      event: EVENTS.SKIP_REVIEW,
       state_from: safeData.state,
       state_to: safeData.state,
       head_sha: safeData.git?.head_sha || null,
@@ -225,7 +225,7 @@ function main() {
     });
   }
   appendRunEvent(repoPath, safeData.run_id, {
-    event: "force_finalize",
+    event: EVENTS.FORCE_FINALIZE,
     state_from: safeData.state,
     state_to: STATES.MERGED,
     head_sha: safeData.git?.head_sha || null,

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.test.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("child_process");

--- a/skills/relay-plan/scripts/tdd-flavor.test.js
+++ b/skills/relay-plan/scripts/tdd-flavor.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("child_process");

--- a/skills/relay-review/scripts/review-runner-reviewer-swap.test.js
+++ b/skills/relay-review/scripts/review-runner-reviewer-swap.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync } = require("child_process");

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -4,7 +4,7 @@ const path = require("path");
 const { STATES } = require("../../relay-dispatch/scripts/manifest/lifecycle");
 const { ensureRunLayout, getRunDir } = require("../../relay-dispatch/scripts/manifest/paths");
 const { writeManifest } = require("../../relay-dispatch/scripts/manifest/store");
-const { appendIterationScore, appendRunEvent, appendScoreDivergence } = require("../../relay-dispatch/scripts/relay-events");
+const { appendIterationScore, appendRunEvent, appendScoreDivergence, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 const { git, writeText } = require("./review-runner/common");
 const {
   applyReviewerIdentity,
@@ -145,9 +145,9 @@ function run() {
     };
     const escalatedManifest = applyPolicyViolationToManifest(data, Number(data.review?.rounds || 0), prNumber, reviewedHeadSha, "max_rounds_exceeded", { escalationDecision });
     writeManifest(manifestPath, escalatedManifest, body);
-    appendRunEvent(runRepoPath, data.run_id, { event: "escalation_decision", state_from: data.state, state_to: STATES.ESCALATED, head_sha: reviewedHeadSha, ...escalationDecision });
+    appendRunEvent(runRepoPath, data.run_id, { event: EVENTS.ESCALATION_DECISION, state_from: data.state, state_to: STATES.ESCALATED, head_sha: reviewedHeadSha, ...escalationDecision });
     appendRunEvent(runRepoPath, data.run_id, {
-      event: "review_apply",
+      event: EVENTS.REVIEW_APPLY,
       state_from: data.state,
       state_to: STATES.ESCALATED,
       head_sha: reviewedHeadSha,
@@ -332,9 +332,9 @@ function run() {
   };
   updatedManifest = applyReviewerIdentity(updatedManifest, noComment, runRepoPath);
   writeManifest(manifestPath, updatedManifest, body);
-  appendRunEvent(runRepoPath, data.run_id, { event: "escalation_decision", state_from: data.state, state_to: updatedManifest.state, head_sha: reviewedHeadSha, ...escalationDecision });
+  appendRunEvent(runRepoPath, data.run_id, { event: EVENTS.ESCALATION_DECISION, state_from: data.state, state_to: updatedManifest.state, head_sha: reviewedHeadSha, ...escalationDecision });
   appendRunEvent(runRepoPath, data.run_id, {
-    event: "review_apply",
+    event: EVENTS.REVIEW_APPLY,
     state_from: data.state,
     state_to: updatedManifest.state,
     head_sha: reviewedHeadSha,

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1,3 +1,4 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("child_process");

--- a/skills/relay-review/scripts/review-runner/pr-body-snapshot.js
+++ b/skills/relay-review/scripts/review-runner/pr-body-snapshot.js
@@ -1,4 +1,4 @@
-const { appendRunEvent } = require("../../../relay-dispatch/scripts/relay-events");
+const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { gh, writeText } = require("./common");
 
 const PR_BODY_SNAPSHOT_TIMEOUT_MS = 15000;
@@ -39,7 +39,7 @@ function writePrBodySnapshot({ repoPath, runId, round, prNumber, prBodyPath }) {
     const reason = "PR number is unavailable; cannot fetch PR body";
     writeText(prBodyPath, `${buildFailureSentinel({ runId, round, prNumber, reason })}\n`);
     appendRunEvent(repoPath, runId, {
-      event: "pr_body_snapshot_failed",
+      event: EVENTS.PR_BODY_SNAPSHOT_FAILED,
       round,
       pr_number: prNumber ?? null,
       reason,
@@ -59,7 +59,7 @@ function writePrBodySnapshot({ repoPath, runId, round, prNumber, prBodyPath }) {
     const reason = summarizeGhFailure(error);
     writeText(prBodyPath, `${buildFailureSentinel({ runId, round, prNumber, reason })}\n`);
     appendRunEvent(repoPath, runId, {
-      event: "pr_body_snapshot_failed",
+      event: EVENTS.PR_BODY_SNAPSHOT_FAILED,
       round,
       pr_number: prNumber,
       reason,

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { STATES } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
 const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
-const { appendRunEvent } = require("../../../relay-dispatch/scripts/relay-events");
+const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { applyPolicyViolationToManifest } = require("./manifest-apply");
 const { git, readText, writeText } = require("./common");
 
@@ -81,7 +81,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
 
   const effectiveReviewerModel = resolveReviewerModel(data, reviewerModel);
   appendRunEvent(runRepoPath, data.run_id, {
-    event: "review_invoke",
+    event: EVENTS.REVIEW_INVOKE,
     state_from: data.state,
     state_to: data.state,
     head_sha: reviewedHeadSha || null,
@@ -131,7 +131,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
     };
     writeManifest(manifestPath, reviewerStampedManifest, body);
     appendRunEvent(runRepoPath, data.run_id, {
-      event: "review_apply",
+      event: EVENTS.REVIEW_APPLY,
       state_from: data.state,
       state_to: STATES.ESCALATED,
       head_sha: reviewedHeadSha,

--- a/skills/relay-review/scripts/review-runner/reviewer-swap.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-swap.js
@@ -1,6 +1,6 @@
 const { STATES, forceTransitionState } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
 const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
-const { appendRunEvent } = require("../../../relay-dispatch/scripts/relay-events");
+const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { resolveReviewerName } = require("./reviewer-invoke");
 
 function maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath) {
@@ -23,7 +23,7 @@ function maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath) {
   };
   writeManifest(manifestPath, swappedManifest, body);
   appendRunEvent(runRepoPath, data.run_id, {
-    event: "reviewer_swap",
+    event: EVENTS.REVIEWER_SWAP,
     state_from: STATES.ESCALATED,
     state_to: STATES.REVIEW_PENDING,
     from_reviewer: lastReviewer,


### PR DESCRIPTION
Closes #313.

## Summary

Introduces a frozen \`EVENTS\` enum in \`skills/relay-dispatch/scripts/relay-events.js\` covering every event name currently emitted at the run-events.jsonl sink (23 names). Adds a write-time validation gate at \`appendEventLine\` — the single chokepoint all four public writers funnel through — that throws when \`record.event\` is not in \`Object.values(EVENTS)\`. Routes every producer call site through \`EVENTS.X\`; production reader-side comparisons follow suit. Test-side reader assertions and fixtures stay bare-string and are marked as deliberate canaries with file-level inline comments.

## Scope Boundary

(a) **IN scope** — every event landing in \`~/.relay/runs/<slug>/<id>/events.jsonl\`:
- \`appendRunEvent\` (external callers across relay-review, relay-merge, relay-dispatch)
- \`appendRecoveryEvent\` in \`recover-commit.js\` (delegates to \`appendRunEvent\`; both call sites now pass \`EVENTS.RECOVER_COMMIT\` / \`EVENTS.RECOVER_COMMIT_FAILED\`)
- The three internal helpers in \`relay-events.js\` (\`appendIterationScore\` → \`EVENTS.ITERATION_SCORE\`, \`appendRubricQuality\` → \`EVENTS.RUBRIC_QUALITY\`, \`appendScoreDivergence\` → \`EVENTS.SCORE_DIVERGENCE\`)

(b) **OUT of scope** — different sinks; intentionally untouched:
- \`skills/relay-intake/scripts/relay-request.js\` — separate request-artifact log under \`~/.relay/requests/\` with its own event names
- \`skills/relay-dispatch/scripts/worktree-runtime.js\` — pluggable logger callback whose \`event:\` field is log-structure metadata, not a journal write

The structural test enforces this boundary explicitly via \`OUT_OF_SCOPE_EVENT_SINKS\` in \`relay-events-enum.test.js:10-13\`.

(c) **Historical-only journal names NOT in EVENTS** — \`manual_recovery\`, \`manual_state_correction\`, \`manual_state_override\`. Current producer code does not emit them. Readers (\`readRunEvents\`, aggregator code, signals) remain tolerant — validation is **write-only**, never on read. Asserted by \`readRunEvents tolerates historical-only event names\` in \`relay-events.test.js:255-263\`.

## Implementation notes

- **Validation chokepoint**: chose \`appendEventLine\` (single function; all four public writers route through it) over duplicating the gate. Single point of enforcement; no drift risk.
- **Throw message**: includes the offending event string + the full allowed-names list so a future typo surfaces with actionable detail.
- **Scope-boundary comment**: lives at \`relay-events.js:9-16\` so the EVENTS export is self-documenting at the point of definition.

## Test count delta

Baseline: 942/0 → After: 947/0 (+5 net new tests). No regressions.

New tests:
- \`appendRunEvent throws on event name not in EVENTS\` — write-time rejection
- \`readRunEvents tolerates historical-only event names\` — read-side tolerance for legacy journals
- \`EVENTS is a frozen object map for current run journal event names\` — frozen + excludes historical/out-of-scope
- \`EVENTS values match the event names emitted by producer call sites under skills\` — exhaustiveness via source scan
- \`journal producer call sites do not use bare string event names\` — bare-string regression gate

## Test-side bare-string canaries (intentional, exhaustive)

Test files MAY keep bare strings as canaries against schema drift; they are excluded from the structural regression gate. **All 10 affected test files now carry a file-level \`// canary: ...\` comment** (one-liner at top of file), so the rationale lives next to the code:

- \`skills/relay-dispatch/scripts/relay-events.test.js\` — two canaries documented inline at lines 240-242: unknown-name rejection (\`"not_a_relay_event"\`), historical-only read tolerance (\`"manual_state_override"\`)
- \`skills/relay-dispatch/scripts/dispatch.test.js\` — \`model_hints_updated\`, \`dispatch_start\` reader assertions
- \`skills/relay-dispatch/scripts/recover-commit.test.js\` — \`recover_commit\`, \`pr_number_stamped\`, \`execution_evidence_rebranded\` reader assertions
- \`skills/relay-dispatch/scripts/reliability-report.test.js\` — bare-string \`event: "..."\` FIXTURE LITERALS (test-data setup) for many event names; reader assertions on the same; deliberately not ported to EVENTS.X to keep the fixtures readable as test data
- \`skills/relay-merge/scripts/finalize-run.test.js\` — \`force_finalize\`, \`merge_finalize\`, \`skip_review\`, \`merge_blocked\` reader assertions
- \`skills/relay-merge/scripts/gate-check.test.js\` — \`pr_number_stamped\` reader filters
- \`skills/relay-merge/scripts/relay-reconcile-artifact.test.js\` — \`force_finalize\`, \`skip_review\` reader assertions
- \`skills/relay-plan/scripts/tdd-flavor.test.js\` — \`iteration_score\` reader assertion
- \`skills/relay-review/scripts/review-runner.test.js\` — \`pr_body_snapshot_failed\`, \`iteration_score\`, \`review_apply\`, \`escalation_decision\` reader assertions
- \`skills/relay-review/scripts/review-runner-reviewer-swap.test.js\` — \`reviewer_swap\` reader assertion

Verified via final sweep: \`grep -rEln 'event\.event\s*===|entry\.event\s*===|\.event\s*===\s*"|^\\s*event:\\s*"[a-z_]+"' skills/ --include='*.test.js'\` — all 10 hits have file-level canary comments.

Reasoning: porting these to \`EVENTS.X\` would couple the tests to the EVENTS export and weaken their value as schema-drift canaries. If a future refactor renames an EVENTS value but forgets to update test assertions, the bare-string match would fail loudly — exactly the canary signal we want.

## Score Log

| Factor | Target | Round 1 | Round 2 | Round 3 (expected) | Status |
|--------|--------|---------|---------|--------------------|--------|
| EVENTS enum exhaustiveness                                  | structural test passes | pass | pass | pass | locked |
| appendRunEvent throws on unknown event name                 | test passes            | pass | pass | pass | locked |
| All producer call sites use EVENTS.X (no bare strings)      | structural test passes | pass | pass | pass | locked |
| Scope boundary documented                                   | >= 8/10                | pass | pass | pass | locked |
| Reader-side audit                                           | >= 8/10                | fail (PR body snapshot stale) | fail (canary list missed 2 files: tdd-flavor.test.js, reliability-report.test.js) | pass (file-level canary comments on all 10 files; PR body list now exhaustive) | — |

## Test plan

- [x] \`node --test skills/*/scripts/*.test.js\` — 947/0 in worktree
- [x] \`relay-events-enum.test.js\` — exhaustiveness + bare-string regression both pass
- [x] \`relay-events.test.js\` — unknown-name throw + historical read tolerance both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 이벤트 이름을 중앙화된 상수로 통합하여 코드 일관성을 개선했습니다.
  * 여러 스크립트의 하드코딩된 이벤트 문자열을 공유 상수로 대체했습니다.
  * 이벤트 유효성 검증 메커니즘을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->