### PR TITLE
fix(relay-review): resolve Done Criteria issue anchors conservatively (#333)

### DIFF
--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -28,12 +28,12 @@ Standard path: run `review-runner.js --reviewer codex` or `--reviewer claude`. I
 
 ## Setup: Establish the anchor
 
-1. Get the PR diff and Done Criteria (this runs in a fresh context — fetch everything needed). The resolver tries `closingIssuesReferences`, then PR-body keyword grep, then branch-name regex; exits 1 if all three fail.
+1. Get the PR diff and Done Criteria (this runs in a fresh context — fetch everything needed). `review-runner.js` keeps file-backed Done Criteria strongest: `--done-criteria-file`, then `anchor.done_criteria_path`, then issue loading. When it must infer a GitHub issue, it tries `manifest.issue.number`, explicit PR-body closing keywords (`Fix/Fixes`, `Close/Closes`, `Resolve/Resolves`), branch `issue-N`, then a single `closingIssuesReferences` entry. It ignores `Refs`, `Related`, and incidental issue prose; multiple inferred closing refs fail instead of silently selecting one.
 ```bash
 PR_NUM=$(gh pr list --head <branch> --json number -q '.[0].number')
 BRANCH=$(gh pr view $PR_NUM --json headRefName -q '.headRefName')
 gh pr diff $PR_NUM > /tmp/pr-diff.txt
-ISSUE_NUM=$(${CLAUDE_SKILL_DIR}/scripts/resolve-issue-number.sh "$PR_NUM" "$BRANCH")
+ISSUE_NUM=$(${CLAUDE_SKILL_DIR}/scripts/resolve-issue-number.sh "$PR_NUM" "$BRANCH")  # legacy manual helper; runner resolution is canonical
 gh issue view $ISSUE_NUM  # Done Criteria / Acceptance Criteria source
 ```
 

--- a/skills/relay-review/scripts/resolve-issue-number.sh
+++ b/skills/relay-review/scripts/resolve-issue-number.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# Resolve the GitHub issue number associated with a PR.
+# Resolve the GitHub issue number associated with a PR for legacy manual review.
 #
-# Tries three fallbacks in order, prints the first match to stdout:
-#   1. PR's `closingIssuesReferences` API field (gh-linked issue)
-#   2. PR body grep for `(closes|fixes|resolves|refs|related to) #N`
-#   3. Branch name — `issue-N` first, then any trailing number
+# `review-runner/context.js` is the canonical resolver. This helper mirrors its
+# conservative fallback order where manual shell review still uses it:
+#   1. PR body explicit closing keywords: Fix/Fixes, Close/Closes, Resolve/Resolves
+#   2. Branch name — `issue-N`
+#   3. A single PR `closingIssuesReferences` API entry
+#
+# Manifest issue anchors and file-backed Done Criteria anchors are runner-only;
+# pass those to review-runner instead of this helper.
 #
 # Usage:  resolve-issue-number.sh <PR_NUMBER> [<BRANCH>]
 # Stdout: the resolved issue number
@@ -15,28 +19,46 @@ set -euo pipefail
 PR_NUM="${1:?usage: resolve-issue-number.sh <PR_NUMBER> [<BRANCH>]}"
 BRANCH="${2:-}"
 
-# Method 1: PR-linked issue via gh API
-ISSUE_NUM=$(gh pr view "$PR_NUM" --json closingIssuesReferences \
-  -q '.closingIssuesReferences[0].number' 2>/dev/null || true)
-[ "$ISSUE_NUM" = "null" ] && ISSUE_NUM=""
+PR_JSON=$(gh pr view "$PR_NUM" --json closingIssuesReferences,body,headRefName 2>/dev/null || true)
 
-# Method 2: PR body keyword grep
-if [ -z "$ISSUE_NUM" ]; then
-  ISSUE_NUM=$(gh pr view "$PR_NUM" --json body -q '.body' 2>/dev/null \
-    | grep -oiE '(closes|fixes|resolves|refs|related to) #[0-9]+' \
-    | grep -oE '[0-9]+' \
-    | head -1 || true)
-fi
+set +e
+ISSUE_NUM=$(PR_JSON="$PR_JSON" BRANCH="$BRANCH" PR_NUM="$PR_NUM" node <<'NODE'
+const parsed = process.env.PR_JSON ? JSON.parse(process.env.PR_JSON) : {};
+const unique = (values) => [...new Set(values.map(Number).filter((number) => Number.isInteger(number) && number > 0))];
 
-# Method 3: branch name (issue-N preferred, else trailing digits)
-if [ -z "$ISSUE_NUM" ]; then
-  if [ -z "$BRANCH" ]; then
-    BRANCH=$(gh pr view "$PR_NUM" --json headRefName -q '.headRefName' 2>/dev/null || true)
-  fi
-  ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+' || true)
-  if [ -z "$ISSUE_NUM" ]; then
-    ISSUE_NUM=$(echo "$BRANCH" | grep -oE '[0-9]+' | tail -1 || true)
-  fi
+const bodyMatches = String(parsed.body || "").matchAll(/\b(?:close|closes|fix|fixes|resolve|resolves)\s+#(\d+)\b/gi);
+const bodyNumbers = unique([...bodyMatches].map((match) => match[1]));
+if (bodyNumbers.length > 1) {
+  console.error(`ERROR: Ambiguous PR body closing keywords reference multiple issues: ${bodyNumbers.map((number) => `#${number}`).join(", ")}.`);
+  process.exit(2);
+}
+if (bodyNumbers.length === 1) {
+  console.log(bodyNumbers[0]);
+  process.exit(0);
+}
+
+const branch = process.env.BRANCH || parsed.headRefName || "";
+const branchMatch = String(branch).match(/issue-(\d+)/i);
+if (branchMatch) {
+  console.log(branchMatch[1]);
+  process.exit(0);
+}
+
+const closingNumbers = unique((Array.isArray(parsed.closingIssuesReferences) ? parsed.closingIssuesReferences : []).map((reference) => reference && reference.number));
+if (closingNumbers.length > 1) {
+  console.error(`ERROR: Ambiguous GitHub closing issue references for PR #${process.env.PR_NUM}: ${closingNumbers.map((number) => `#${number}`).join(", ")}. Provide an explicit Done Criteria anchor.`);
+  process.exit(2);
+}
+if (closingNumbers.length === 1) {
+  console.log(closingNumbers[0]);
+}
+NODE
+)
+STATUS=$?
+set -e
+
+if [ "$STATUS" -ne 0 ]; then
+  exit "$STATUS"
 fi
 
 if [ -z "$ISSUE_NUM" ]; then

--- a/skills/relay-review/scripts/review-runner-context.test.js
+++ b/skills/relay-review/scripts/review-runner-context.test.js
@@ -14,6 +14,7 @@ const {
   loadProjectConventions,
   loadRubricFromRunDir,
   parseRemoteHost,
+  resolveIssueNumber,
 } = require("./review-runner/context");
 const { buildPrompt } = require("./review-runner/prompt");
 
@@ -30,6 +31,127 @@ function createRunFixture() {
   const { runDir } = ensureRunLayout(repoRoot, runId);
   return { repoRoot, runDir, runId };
 }
+
+function withFakeGh(fixture, callback) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-repo-"));
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-bin-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const fixture = JSON.parse(process.env.RELAY_REVIEW_FAKE_GH_FIXTURE || "{}");
+const args = process.argv.slice(2);
+
+if (fixture.failOnCall) {
+  process.stderr.write("gh should not have been called");
+  process.exit(91);
+}
+
+if (args[0] === "pr" && args[1] === "view") {
+  const jsonIndex = args.indexOf("--json");
+  const fields = jsonIndex === -1 ? "" : args[jsonIndex + 1];
+  if (fields === "closingIssuesReferences,body,headRefName") {
+    process.stdout.write(JSON.stringify({
+      closingIssuesReferences: fixture.closingIssuesReferences || [],
+      body: fixture.body || "",
+      headRefName: fixture.headRefName || "",
+    }));
+    process.exit(0);
+  }
+}
+
+process.stderr.write("Unsupported gh invocation: " + args.join(" "));
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+
+  const originalPath = process.env.PATH;
+  const originalFixture = process.env.RELAY_REVIEW_FAKE_GH_FIXTURE;
+  process.env.PATH = `${binDir}:${originalPath}`;
+  process.env.RELAY_REVIEW_FAKE_GH_FIXTURE = JSON.stringify(fixture);
+  try {
+    return callback(repoRoot);
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalFixture === undefined) {
+      delete process.env.RELAY_REVIEW_FAKE_GH_FIXTURE;
+    } else {
+      process.env.RELAY_REVIEW_FAKE_GH_FIXTURE = originalFixture;
+    }
+  }
+}
+
+test("context/resolveIssueNumber prefers manifest issue before GitHub fallbacks", () => {
+  withFakeGh({ failOnCall: true }, (repoRoot) => {
+    const issueNumber = resolveIssueNumber(repoRoot, 123, "issue-42", {
+      issue: { number: 77 },
+    });
+
+    assert.equal(issueNumber, 77);
+  });
+});
+
+test("context/resolveIssueNumber accepts explicit PR body closing keywords", async (t) => {
+  const cases = [
+    ["fixes", "Fixes #51", 51],
+    ["closes", "Closes #52", 52],
+    ["resolves", "Resolves #53", 53],
+    ["fix", "Fix #54", 54],
+    ["close", "Close #55", 55],
+    ["resolve", "Resolve #56", 56],
+  ];
+
+  for (const [label, body, expected] of cases) {
+    await t.test(label, () => {
+      withFakeGh({
+        body,
+        closingIssuesReferences: [{ number: 99 }],
+        headRefName: "issue-12",
+      }, (repoRoot) => {
+        assert.equal(resolveIssueNumber(repoRoot, 123, null, {}), expected);
+      });
+    });
+  }
+});
+
+test("context/resolveIssueNumber ignores Refs, Related, and incidental issue prose", () => {
+  withFakeGh({
+    body: "Refs #31\nRelated to #32\nSprint 3, #33 should stay incidental.",
+    closingIssuesReferences: [],
+    headRefName: "feature/issue-44-review-anchor",
+  }, (repoRoot) => {
+    assert.equal(resolveIssueNumber(repoRoot, 123, null, {}), 44);
+  });
+});
+
+test("context/resolveIssueNumber treats closingIssuesReferences as the weakest fallback", () => {
+  withFakeGh({
+    body: "",
+    closingIssuesReferences: [{ number: 99 }],
+    headRefName: "feature/issue-44-review-anchor",
+  }, (repoRoot) => {
+    assert.equal(resolveIssueNumber(repoRoot, 123, null, {}), 44);
+  });
+
+  withFakeGh({
+    body: "",
+    closingIssuesReferences: [{ number: 99 }],
+    headRefName: "feature/no-issue-anchor",
+  }, (repoRoot) => {
+    assert.equal(resolveIssueNumber(repoRoot, 123, null, {}), 99);
+  });
+});
+
+test("context/resolveIssueNumber rejects multiple inferred closing refs without a stronger anchor", () => {
+  withFakeGh({
+    body: "Refs #31\nRelated to #32",
+    closingIssuesReferences: [{ number: 99 }, { number: 100 }],
+    headRefName: "feature/no-issue-anchor",
+  }, (repoRoot) => {
+    assert.throws(
+      () => resolveIssueNumber(repoRoot, 123, null, {}),
+      /Ambiguous GitHub closing issue references for PR #123: #99, #100.*manifest\.issue\.number.*anchor\.done_criteria_path/s
+    );
+  });
+});
 
 test("context/loadRubricFromRunDir preserves the rubric state matrix", async (t) => {
   const cases = [

--- a/skills/relay-review/scripts/review-runner-context.test.js
+++ b/skills/relay-review/scripts/review-runner-context.test.js
@@ -89,6 +89,26 @@ test("context/resolveIssueNumber prefers manifest issue before GitHub fallbacks"
   });
 });
 
+test("context/resolveIssueNumber skips inference when explicit Done Criteria file is present", () => {
+  withFakeGh({ failOnCall: true }, (repoRoot) => {
+    assert.equal(
+      resolveIssueNumber(repoRoot, 123, "issue-42", {}, { doneCriteriaFile: "/tmp/done-criteria.md" }),
+      null
+    );
+  });
+});
+
+test("context/resolveIssueNumber skips inference when manifest Done Criteria anchor is present", () => {
+  withFakeGh({ failOnCall: true }, (repoRoot) => {
+    assert.equal(
+      resolveIssueNumber(repoRoot, 123, "issue-42", {
+        anchor: { done_criteria_path: "/tmp/frozen-done-criteria.md" },
+      }),
+      null
+    );
+  });
+});
+
 test("context/resolveIssueNumber accepts explicit PR body closing keywords", async (t) => {
   const cases = [
     ["fixes", "Fixes #51", 51],

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -115,7 +115,8 @@ function run() {
     manifestPathArg,
     runIdArg,
     branchArg,
-    prArg
+    prArg,
+    doneCriteriaFile
   );
   const { body, manifestPath } = manifest;
   let { data } = manifest;

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -316,6 +316,34 @@ process.exit(1);
   return filePath;
 }
 
+function writeIssueInferenceGuardGhScript(binDir) {
+  const filePath = path.join(binDir, "gh");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "view") {
+  const jsonIndex = args.indexOf("--json");
+  const fields = jsonIndex === -1 ? "" : args[jsonIndex + 1];
+  if (fields === "closingIssuesReferences,body,headRefName") {
+    process.stderr.write("issue inference should be skipped when Done Criteria are file-backed");
+    process.exit(91);
+  }
+  if (fields === "body") {
+    const body = "Refs #999\\nRelated to #1000\\nSprint 3, #1001";
+    if (args.includes("-q") && args[args.indexOf("-q") + 1] === ".body") {
+      process.stdout.write(body);
+    } else {
+      process.stdout.write(JSON.stringify({ body }));
+    }
+    process.exit(0);
+  }
+}
+process.stderr.write("Unsupported gh invocation: " + args.join(" "));
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
 function writeFailingPrBodyGhScript(repoRoot, message = "simulated pr body fetch failure") {
   const filePath = path.join(repoRoot, "gh");
   fs.writeFileSync(filePath, `#!/usr/bin/env node
@@ -659,6 +687,36 @@ test("review-runner facade stays within orchestrator caps and preserves CLI help
   assert.match(help.stdout, /--reviewer-script <path>/);
 });
 
+test("prepare-only with explicit Done Criteria file skips issue inference ambiguity", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  updateManifestRecord(manifestPath, (data) => {
+    const next = { ...data };
+    delete next.issue;
+    return next;
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-bin-"));
+  writeIssueInferenceGuardGhScript(binDir);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+  });
+
+  const result = JSON.parse(stdout);
+  const promptText = fs.readFileSync(result.promptPath, "utf-8");
+  assert.match(promptText, /Issue: unknown/);
+  assert.match(fs.readFileSync(result.doneCriteriaPath, "utf-8"), /Add smoke\.txt/);
+});
+
 test("prepare-only loads frozen Done Criteria from manifest anchor before GitHub fallbacks", () => {
   const { repoRoot, manifestPath, runId, diffPath } = setupRepo();
   const anchoredDoneCriteriaPath = path.join(repoRoot, "frozen-done-criteria.md");
@@ -673,7 +731,10 @@ test("prepare-only loads frozen Done Criteria from manifest anchor before GitHub
       done_criteria_source: "request_snapshot",
     },
   };
+  delete updated.issue;
   writeManifest(manifestPath, updated, record.body);
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-bin-"));
+  writeIssueInferenceGuardGhScript(binDir);
 
   const stdout = execFileSync("node", [
     SCRIPT,
@@ -683,11 +744,15 @@ test("prepare-only loads frozen Done Criteria from manifest anchor before GitHub
     "--diff-file", diffPath,
     "--prepare-only",
     "--json",
-  ], { encoding: "utf-8" });
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+  });
 
   const result = JSON.parse(stdout);
   const promptText = fs.readFileSync(result.promptPath, "utf-8");
   const doneCriteriaText = fs.readFileSync(result.doneCriteriaPath, "utf-8");
+  assert.match(promptText, /Issue: unknown/);
   assert.match(promptText, /source="request_snapshot"/);
   assert.match(doneCriteriaText, /Use the persisted intake snapshot/);
 });

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -195,7 +195,7 @@ function resolvePrBodyClosingIssue(body) {
   if (numbers.length > 1) {
     throw new Error(
       `Ambiguous PR body closing keywords reference multiple issues: ${numbers.map((number) => `#${number}`).join(", ")}. ` +
-      "Provide manifest.issue.number or anchor.done_criteria_path to select the Done Criteria source explicitly."
+      "Provide --done-criteria-file, manifest.issue.number, or anchor.done_criteria_path to select the Done Criteria source explicitly."
     );
   }
   return numbers[0] || null;
@@ -215,16 +215,22 @@ function resolveClosingReferenceIssue(closingIssuesReferences, prNumber) {
     throw new Error(
       `Ambiguous GitHub closing issue references for PR #${prNumber}: ${numbers.map((number) => `#${number}`).join(", ")}. ` +
       "Add manifest.issue.number, use one explicit PR body closing keyword (Fixes #N, Closes #N, or Resolves #N), " +
-      "rename the branch to issue-N, or provide anchor.done_criteria_path."
+      "rename the branch to issue-N, or provide --done-criteria-file or anchor.done_criteria_path."
     );
   }
   return numbers[0] || null;
 }
 
-function resolveIssueNumber(repoPath, prNumber, branch, manifestData) {
+function hasFileBackedDoneCriteria(manifestData, options = {}) {
+  return Boolean(options.doneCriteriaFile || options.skipIssueInference || manifestData?.anchor?.done_criteria_path);
+}
+
+function resolveIssueNumber(repoPath, prNumber, branch, manifestData, options = {}) {
   if (manifestData?.issue?.number) {
     return Number(manifestData.issue.number);
   }
+
+  if (hasFileBackedDoneCriteria(manifestData, options)) return null;
 
   if (!prNumber) return resolveBranchIssueNumber(branch);
 
@@ -257,7 +263,7 @@ function resolveBranchForPr(repoPath, prNumber) {
   return JSON.parse(raw).headRefName;
 }
 
-function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg) {
+function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg, doneCriteriaFileArg = null) {
   let branch = branchArg;
   let prNumber = parsePositiveInt(prArg, "--pr");
 
@@ -290,7 +296,9 @@ function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg) {
   if (!prNumber && branch) {
     prNumber = resolvePrForBranch(runRepoPath, branch);
   }
-  const issueNumber = resolveIssueNumber(runRepoPath, prNumber, branch, manifest.data);
+  const issueNumber = resolveIssueNumber(runRepoPath, prNumber, branch, manifest.data, {
+    doneCriteriaFile: doneCriteriaFileArg,
+  });
   const normalizedManifest = {
     ...manifest,
     data: {

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -176,24 +176,69 @@ function getGhLogin(repoPath) {
   }
 }
 
+const PR_BODY_CLOSING_KEYWORD_RE = /\b(?:close|closes|fix|fixes|resolve|resolves)\s+#(\d+)\b/gi;
+
+function uniquePositiveIssueNumbers(values) {
+  const numbers = new Set();
+  for (const value of values) {
+    const number = Number(value);
+    if (Number.isInteger(number) && number > 0) {
+      numbers.add(number);
+    }
+  }
+  return [...numbers];
+}
+
+function resolvePrBodyClosingIssue(body) {
+  const matches = String(body || "").matchAll(PR_BODY_CLOSING_KEYWORD_RE);
+  const numbers = uniquePositiveIssueNumbers([...matches].map((match) => match[1]));
+  if (numbers.length > 1) {
+    throw new Error(
+      `Ambiguous PR body closing keywords reference multiple issues: ${numbers.map((number) => `#${number}`).join(", ")}. ` +
+      "Provide manifest.issue.number or anchor.done_criteria_path to select the Done Criteria source explicitly."
+    );
+  }
+  return numbers[0] || null;
+}
+
+function resolveBranchIssueNumber(branch) {
+  const issueMatch = String(branch || "").match(/issue-(\d+)/i);
+  return issueMatch ? Number(issueMatch[1]) : null;
+}
+
+function resolveClosingReferenceIssue(closingIssuesReferences, prNumber) {
+  const numbers = uniquePositiveIssueNumbers(
+    (Array.isArray(closingIssuesReferences) ? closingIssuesReferences : [])
+      .map((reference) => reference?.number)
+  );
+  if (numbers.length > 1) {
+    throw new Error(
+      `Ambiguous GitHub closing issue references for PR #${prNumber}: ${numbers.map((number) => `#${number}`).join(", ")}. ` +
+      "Add manifest.issue.number, use one explicit PR body closing keyword (Fixes #N, Closes #N, or Resolves #N), " +
+      "rename the branch to issue-N, or provide anchor.done_criteria_path."
+    );
+  }
+  return numbers[0] || null;
+}
+
 function resolveIssueNumber(repoPath, prNumber, branch, manifestData) {
   if (manifestData?.issue?.number) {
     return Number(manifestData.issue.number);
   }
 
-  if (!prNumber) return null;
+  if (!prNumber) return resolveBranchIssueNumber(branch);
 
   const raw = gh(repoPath, "pr", "view", String(prNumber), "--json", "closingIssuesReferences,body,headRefName");
   const parsed = JSON.parse(raw);
-  const closingIssue = (parsed.closingIssuesReferences || [])[0];
-  if (closingIssue?.number) return Number(closingIssue.number);
 
-  const bodyMatch = String(parsed.body || "").match(/(?:closes|fixes|resolves|refs|related to)\s+#(\d+)/i);
-  if (bodyMatch) return Number(bodyMatch[1]);
+  const bodyIssue = resolvePrBodyClosingIssue(parsed.body);
+  if (bodyIssue) return bodyIssue;
 
   const branchSource = branch || parsed.headRefName || "";
-  const issueMatch = branchSource.match(/issue-(\d+)/);
-  return issueMatch ? Number(issueMatch[1]) : null;
+  const branchIssue = resolveBranchIssueNumber(branchSource);
+  if (branchIssue) return branchIssue;
+
+  return resolveClosingReferenceIssue(parsed.closingIssuesReferences, prNumber);
 }
 
 function getExpectedManifestRepoRoot(repoPath) {


### PR DESCRIPTION
## Summary

Fixes relay-review Done Criteria issue anchor resolution to be conservative.

Final resolver precedence:
1. File-backed Done Criteria remains strongest via `--done-criteria-file`.
2. Manifest `anchor.done_criteria_path` remains the next strongest Done Criteria source.
3. When an issue must be inferred, `manifest.issue.number` wins.
4. PR body parsing only accepts explicit closing intent: `Fix/Fixes #N`, `Close/Closes #N`, or `Resolve/Resolves #N`.
5. Branch `issue-N` is used only when stronger anchors are absent.
6. `closingIssuesReferences` is the weakest fallback; multiple inferred refs now fail loudly instead of silently selecting the first one.

`Refs #N`, `Related to #N`, and incidental prose are ignored for Done Criteria selection.

## Tests

- `node --test skills/relay-review/scripts/review-runner-context.test.js`
- `node --test skills/relay-review/scripts/review-runner-context.test.js skills/relay-review/scripts/review-runner.test.js`
- `node --test skills/relay-review/scripts/*.test.js`
- `git diff --check`
- `bash -n skills/relay-review/scripts/resolve-issue-number.sh`

## Notes

`anchor.done_criteria_path` semantics are unchanged. Review and merge gates are unchanged.

Fixes #333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 이슈 참조 해석 우선순위 및 동작에 대한 설명서 업데이트

* **개선사항**
  * 풀 리퀘스트 본문의 명시적 닫힘 키워드 우선 처리로 이슈 링크 신뢰성 향상
  * 모호한 참조 감지 시 명확한 오류 메시지 제공
  * 여러 이슈가 참조될 때 더 견고한 오류 처리 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->