### PR TITLE
recover-state: support audited same-HEAD rerun for PR-body-only fixes (#334)

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -31,6 +31,11 @@ If a PR already exists for the branch, the command no-ops the create step and st
 ${CLAUDE_SKILL_DIR}/scripts/recover-state.js --repo . --run-id <id> \
   --to review_pending --reason "external commit pushed; see <sha>"
 
+# PR body fixed with gh pr edit, code HEAD unchanged → return to review without re-dispatch
+${CLAUDE_SKILL_DIR}/scripts/recover-state.js --repo . --run-id <id> \
+  --to review_pending --allow-same-head --require-pr-body-change \
+  --reason "PR body metadata fixed with gh pr edit"
+
 # No-op re-dispatch escalated the run → bring it back for a fresh review
 ${CLAUDE_SKILL_DIR}/scripts/recover-state.js --repo . --run-id <id> \
   --to review_pending --force --reason "no-op-dispatch-recovery"
@@ -45,8 +50,19 @@ Whitelisted transitions (unlisted pairs are rejected — use the normal dispatch
 | From | To | Force | Precondition |
 |---|---|---|---|
 | `changes_requested` | `review_pending` | no | fresh commit on branch (HEAD ≠ `review.last_reviewed_sha`) |
+| `changes_requested` | `review_pending` | no | same HEAD allowed only with `--allow-same-head --require-pr-body-change`, a manifest PR number (`git.pr_number` or `github.pr_number`), a prior `review-round-N-pr-body.md` snapshot, and a current GitHub PR body that differs from the latest numbered snapshot |
 | `escalated` | `review_pending` | yes | — |
 | `escalated` | `changes_requested` | no | — |
 | `dispatched` | `changes_requested` | yes | — |
 
 The script refuses transitions `ALLOWED_TRANSITIONS` already supports — always prefer the normal flow when it applies. Terminal states (`merged`, `closed`) are not recoverable.
+
+### Recovery command boundaries
+
+Use `recover-commit.js` when the executor changed files but did not commit, push, or create/stamp a PR. It creates the missing commit/PR handoff and leaves the manifest in `review_pending`.
+
+Use normal `dispatch.js --run-id <id>` when reviewer feedback requires code changes. That path re-dispatches implementation work and must produce a fresh code handoff before review.
+
+Use `recover-state.js --to review_pending` for external events that make a new review valid without redispatch. The normal path still requires `HEAD != review.last_reviewed_sha`. The same-HEAD exception is only for PR-body-only evidence changes and emits a `state_recovery` event with `pr_body_only: true`, `head_sha`, `last_reviewed_sha`, `pr_number`, and the operator `reason`.
+
+Use `finalize-run.js --force-finalize-nonready --reason ...` only as a merge/finalization override for non-ready terminal cleanup. It is not a substitute for fresh review evidence and does not repair missing PR body metadata.

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -16,6 +16,7 @@ const VALUE = "value";
 
 const FLAGS = [
   { flag: "--all", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--allow-same-head", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit same-HEAD recovery opt-in; no value is consumed." },
   { flag: "--artifact-path", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path being reconciled; keep the literal argv token." },
   { flag: "--branch", aliases: ["-b"], kind: VALUE, mode: MODE_VERBATIM, valueName: "<name>", rationale: "Git branch names are operator-supplied and may legally begin with --." },
   { flag: "--by-acting-reviewer", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
@@ -68,6 +69,7 @@ const FLAGS = [
   { flag: "--repeated-issue-count", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Numeric review field; flag-like following tokens should mean the value is missing." },
   { flag: "--repo", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied repository path; keep the literal argv token." },
   { flag: "--request-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay-intake identifier; flag-like following tokens should mean the value is missing." },
+  { flag: "--require-pr-body-change", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Require audited PR body evidence for same-HEAD recovery; no value is consumed." },
   { flag: "--review-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied verdict path; keep the literal argv token." },
   { flag: "--reviewer", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Reviewer adapter selector; flag-like following tokens should mean the value is missing." },
   { flag: "--reviewer-model", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Reviewer model selector; flag-like following tokens should mean the value is missing." },
@@ -143,6 +145,7 @@ const COMMAND_FLAGS = {
   ],
   "recover-state": [
     "--repo", "--run-id", "--manifest", "--to", "--reason", "--force", "--dry-run", "--json", "--help",
+    "--allow-same-head", "--require-pr-body-change",
   ],
   "recover-commit": [
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -16,16 +16,20 @@
 //     independent artifact (git's object db for the branch).
 
 const path = require("path");
+const fs = require("fs");
 const { execFileSync } = require("child_process");
 const { STATES, forceTransitionState } = require("./manifest/lifecycle");
 const {
+  getRunDir,
   validateManifestPaths,
 } = require("./manifest/paths");
 const { writeManifest } = require("./manifest/store");
+const { readTextFileWithoutFollowingSymlinks } = require("./manifest/rubric");
 const { getArg, hasFlag, modeLabel } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const CLI_ARG_OPTIONS = { commandName: "recover-state", reservedFlags: ["-h"] };
+const PR_BODY_FETCH_TIMEOUT_MS = 15000;
 
 // Whitelist: recovery transitions that the normal dispatch/review/merge flow does NOT support.
 // If `ALLOWED_TRANSITIONS` in relay-manifest.js changes, this table must be reviewed — recovery
@@ -80,13 +84,17 @@ function printUsage(stream = console.log) {
     `  --to <state>      ${modeLabel("--to")} Recovery target state\n` +
     `  --reason <text>   ${modeLabel("--reason")} Audit reason\n` +
     `  --force           ${modeLabel("--force")} Confirm selected recovery transitions\n` +
+    `  --allow-same-head ${modeLabel("--allow-same-head")} Allow same-HEAD review recovery when PR-body evidence changed\n` +
+    `  --require-pr-body-change ${modeLabel("--require-pr-body-change")} Require current PR body to differ from the latest review snapshot\n` +
     `  --dry-run         ${modeLabel("--dry-run")} Print result without writing\n` +
     `  --json            ${modeLabel("--json")} Output JSON\n` +
     "\n" +
     "Whitelisted recovery transitions:\n" +
     RECOVERY_TRANSITIONS.map((t) => {
       const forceFlag = t.requireForce ? " (--force required)" : "";
-      const freshFlag = t.requireFreshCommit ? " (fresh commit required on branch)" : "";
+      const freshFlag = t.requireFreshCommit
+        ? " (fresh commit required on branch; same-HEAD PR-body-only recovery requires both same-HEAD flags)"
+        : "";
       return `  ${t.from} -> ${t.to}${forceFlag}${freshFlag}`;
     }).join("\n")
   );
@@ -107,7 +115,7 @@ function readHeadSha(repoRoot, branch) {
   return execFileSync("git", args, { encoding: "utf-8", stdio: "pipe" }).trim();
 }
 
-function requireFreshCommitOnBranch({ repoRoot, manifestData }) {
+function getBranchHeadContext({ repoRoot, manifestData }) {
   const branch = manifestData?.git?.working_branch;
   if (!branch) {
     throw new Error(
@@ -127,6 +135,12 @@ function requireFreshCommitOnBranch({ repoRoot, manifestData }) {
   }
 
   const lastReviewedSha = manifestData?.review?.last_reviewed_sha || null;
+  return { currentHead, lastReviewedSha };
+}
+
+function requireFreshCommitOnBranch({ repoRoot, manifestData }) {
+  const { currentHead, lastReviewedSha } = getBranchHeadContext({ repoRoot, manifestData });
+  const branch = manifestData?.git?.working_branch;
   if (lastReviewedSha && currentHead === lastReviewedSha) {
     throw new Error(
       `Refusing recovery: git HEAD for '${branch}' (${currentHead}) equals review.last_reviewed_sha. ` +
@@ -136,6 +150,112 @@ function requireFreshCommitOnBranch({ repoRoot, manifestData }) {
   }
 
   return { currentHead, lastReviewedSha };
+}
+
+function normalizePrBody(text) {
+  return `${String(text || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n?$/, "\n")}`;
+}
+
+function collapseWhitespace(text) {
+  return String(text || "").replace(/\s+/g, " ").trim();
+}
+
+function summarizeCommandFailure(error) {
+  const status = error?.status ?? error?.signal ?? "unknown";
+  const stderr = collapseWhitespace(error?.stderr || "");
+  const stdout = collapseWhitespace(error?.stdout || "");
+  const message = collapseWhitespace(error?.message || String(error));
+  const detail = stderr || stdout || message || "unknown error";
+  const truncated = detail.length > 500 ? `${detail.slice(0, 497)}...` : detail;
+  return `status ${status}: ${truncated}`;
+}
+
+function getManifestPrNumber(manifestData) {
+  const raw = manifestData?.git?.pr_number ?? manifestData?.github?.pr_number ?? null;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function findLatestPrBodySnapshot(runDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(runDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+
+  const snapshots = entries
+    .map((entry) => {
+      const match = entry.name.match(/^review-round-(\d+)-pr-body\.md$/);
+      if (!match) return null;
+      return {
+        name: entry.name,
+        path: path.join(runDir, entry.name),
+        round: Number(match[1]),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => (right.round - left.round) || left.name.localeCompare(right.name));
+
+  return snapshots[0] || null;
+}
+
+function fetchCurrentPrBody(repoRoot, prNumber) {
+  try {
+    const body = execFileSync(
+      "gh",
+      ["pr", "view", String(prNumber), "--json", "body", "-q", ".body"],
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+        timeout: PR_BODY_FETCH_TIMEOUT_MS,
+      }
+    );
+    return normalizePrBody(body);
+  } catch (error) {
+    throw new Error(
+      `Cannot fetch current PR body for PR #${prNumber}: ${summarizeCommandFailure(error)}`
+    );
+  }
+}
+
+function requirePrBodyOnlyEvidence({ repoRoot, manifestData, currentHead, lastReviewedSha }) {
+  const prNumber = getManifestPrNumber(manifestData);
+  if (!prNumber) {
+    throw new Error(
+      "Refusing same-HEAD PR-body-only recovery: manifest has no PR number " +
+      "(expected git.pr_number or github.pr_number)."
+    );
+  }
+
+  const runDir = getRunDir(repoRoot, manifestData.run_id);
+  const latestSnapshot = findLatestPrBodySnapshot(runDir);
+  if (!latestSnapshot) {
+    throw new Error(
+      `Refusing same-HEAD PR-body-only recovery: no prior PR body snapshot found in ${runDir}. ` +
+      "Expected review-round-N-pr-body.md from an earlier review round."
+    );
+  }
+
+  const previousBody = readTextFileWithoutFollowingSymlinks(latestSnapshot.path);
+  const currentBody = fetchCurrentPrBody(repoRoot, prNumber);
+  if (currentBody === normalizePrBody(previousBody)) {
+    throw new Error(
+      "Refusing same-HEAD PR-body-only recovery: current PR body matches latest prior " +
+      `PR body snapshot ${latestSnapshot.name}. Edit the PR body before retrying.`
+    );
+  }
+
+  return {
+    currentHead,
+    lastReviewedSha,
+    prBodyOnly: true,
+    prNumber,
+    previousSnapshotPath: latestSnapshot.path,
+    previousSnapshotRound: latestSnapshot.round,
+  };
 }
 
 function main() {
@@ -152,6 +272,8 @@ function main() {
   const toState = getArg(args, "--to", undefined, CLI_ARG_OPTIONS);
   const reason = getArg(args, "--reason", undefined, CLI_ARG_OPTIONS);
   const force = hasCliFlag("--force");
+  const allowSameHead = hasCliFlag("--allow-same-head");
+  const requirePrBodyChange = hasCliFlag("--require-pr-body-change");
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
 
@@ -163,6 +285,12 @@ function main() {
   }
   if (!reason) {
     throw new Error("--reason <text> is required (audit trail)");
+  }
+  if (allowSameHead !== requirePrBodyChange) {
+    throw new Error(
+      "--allow-same-head and --require-pr-body-change must be passed together. " +
+      "Same-HEAD recovery is only supported for audited PR-body-only evidence changes."
+    );
   }
 
   const { manifestPath, data, body } = resolveManifestRecord({
@@ -202,11 +330,26 @@ function main() {
   }
 
   let commitContext = null;
+  let prBodyOnlyContext = null;
   if (recovery.requireFreshCommit) {
-    commitContext = requireFreshCommitOnBranch({
+    const headContext = getBranchHeadContext({
       repoRoot: validatedPaths.repoRoot,
       manifestData: safeData,
     });
+    const sameReviewedHead = headContext.lastReviewedSha
+      && headContext.currentHead === headContext.lastReviewedSha;
+    if (sameReviewedHead && allowSameHead && requirePrBodyChange) {
+      prBodyOnlyContext = requirePrBodyOnlyEvidence({
+        repoRoot: validatedPaths.repoRoot,
+        manifestData: safeData,
+        ...headContext,
+      });
+    } else {
+      commitContext = requireFreshCommitOnBranch({
+        repoRoot: validatedPaths.repoRoot,
+        manifestData: safeData,
+      });
+    }
   }
 
   const updated = forceTransitionState(safeData, toState, recovery.nextAction);
@@ -221,10 +364,18 @@ function main() {
       event: EVENTS.STATE_RECOVERY,
       state_from: fromState,
       state_to: toState,
-      head_sha: commitContext?.currentHead || updated.git?.head_sha || null,
-      round: updated.review?.rounds || null,
+      head_sha: commitContext?.currentHead || prBodyOnlyContext?.currentHead || updated.git?.head_sha || null,
+      round: prBodyOnlyContext?.previousSnapshotRound || updated.review?.rounds || null,
       reason,
-      last_reviewed_sha: commitContext?.lastReviewedSha ?? (safeData.review?.last_reviewed_sha || null),
+      last_reviewed_sha: commitContext?.lastReviewedSha
+        ?? prBodyOnlyContext?.lastReviewedSha
+        ?? (safeData.review?.last_reviewed_sha || null),
+      ...(prBodyOnlyContext
+        ? {
+            pr_body_only: true,
+            pr_number: prBodyOnlyContext.prNumber,
+          }
+        : {}),
     });
   }
 
@@ -237,6 +388,7 @@ function main() {
     reason,
     force,
     freshCommit: commitContext,
+    prBodyOnly: prBodyOnlyContext,
     dryRun,
   };
 
@@ -250,6 +402,13 @@ function main() {
     if (commitContext) {
       console.log(`  HEAD sha:     ${commitContext.currentHead}`);
       console.log(`  Prev reviewed: ${commitContext.lastReviewedSha || "(none)"}`);
+    }
+    if (prBodyOnlyContext) {
+      console.log("  PR body only: true");
+      console.log(`  HEAD sha:     ${prBodyOnlyContext.currentHead}`);
+      console.log(`  Prev reviewed: ${prBodyOnlyContext.lastReviewedSha || "(none)"}`);
+      console.log(`  PR number:    ${prBodyOnlyContext.prNumber}`);
+      console.log(`  Snapshot:     ${prBodyOnlyContext.previousSnapshotPath}`);
     }
     if (dryRun) console.log("  dry-run:      no changes written");
   }

--- a/skills/relay-dispatch/scripts/recover-state.test.js
+++ b/skills/relay-dispatch/scripts/recover-state.test.js
@@ -15,13 +15,14 @@ const {
   updateManifestState,
   writeManifest,
 } = require("./relay-manifest");
+const { readRunEvents } = require("./relay-events");
 
 const SCRIPT = path.join(__dirname, "recover-state.js");
 
 // Runs the manifest through DRAFT -> DISPATCHED -> REVIEW_PENDING -> desired end state.
 // After REVIEW_PENDING the fixture records review.last_reviewed_sha = <initial HEAD on branch>
 // so tests can simulate "no fresh commits" vs "fresh commit landed" scenarios.
-function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211" } = {}) {
+function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211", prNumber = null, githubPrNumber = null } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-recover-"));
   const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   process.env.RELAY_HOME = relayHome;
@@ -38,7 +39,8 @@ function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211" } = 
   execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
 
   const runId = createRunId({ branch, timestamp: new Date("2026-04-17T13:00:00.000Z") });
-  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  const runLayout = ensureRunLayout(repoRoot, runId);
+  const manifestPath = runLayout.manifestPath;
   let manifest = createManifestSkeleton({
     repoRoot,
     runId,
@@ -50,9 +52,13 @@ function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211" } = 
     executor: "codex",
     reviewer: "codex",
   });
+  manifest.git.pr_number = prNumber;
+  if (githubPrNumber !== null) {
+    manifest.github = { pr_number: githubPrNumber };
+  }
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
   manifest.anchor.rubric_path = "rubric.yaml";
-  fs.writeFileSync(path.join(ensureRunLayout(repoRoot, runId).runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: recover-state\n", "utf-8");
+  fs.writeFileSync(path.join(runLayout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: recover-state\n", "utf-8");
   manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
 
   // Record the current HEAD as if review round 1 just completed.
@@ -71,7 +77,7 @@ function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211" } = 
 
   writeManifest(manifestPath, manifest);
 
-  return { repoRoot, manifestPath, runId, worktreePath, branch, initialHead };
+  return { repoRoot, manifestPath, runId, runDir: runLayout.runDir, worktreePath, branch, initialHead };
 }
 
 function addCommitOnBranch(worktreePath, branch, filename = "fix.txt") {
@@ -87,6 +93,31 @@ function addCommitOnBranch(worktreePath, branch, filename = "fix.txt") {
   }).trim();
   assert.notEqual(newHead, existing);
   return newHead;
+}
+
+function writeGhPrBodyScript(body) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (
+  args[0] === "pr"
+  && args[1] === "view"
+  && args.includes("--json")
+  && args.includes("body")
+  && args.includes("-q")
+  && args[args.indexOf("-q") + 1] === ".body"
+) {
+  process.stdout.write(${JSON.stringify(body)});
+  process.exit(0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return {
+    PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+  };
 }
 
 test("changes_requested -> review_pending succeeds after a fresh commit", () => {
@@ -138,6 +169,164 @@ test("changes_requested -> review_pending fails when HEAD equals last_reviewed_s
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /equals review\.last_reviewed_sha/);
   assert.match(result.stderr, /Push the fix commit first/);
+});
+
+test("changes_requested -> review_pending supports audited same-HEAD PR-body-only recovery", () => {
+  const { repoRoot, manifestPath, runId, runDir, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  fs.writeFileSync(path.join(runDir, "review-round-1-pr-body.md"), "missing metadata\n", "utf-8");
+  const env = { ...process.env, ...writeGhPrBodyScript("fixed metadata\n") };
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR body metadata fixed with gh pr edit",
+    "--allow-same-head",
+    "--require-pr-body-change",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.previousState, STATES.CHANGES_REQUESTED);
+  assert.equal(result.nextAction, "run_review");
+  assert.equal(result.freshCommit, null);
+  assert.equal(result.prBodyOnly.prBodyOnly, true);
+  assert.equal(result.prBodyOnly.currentHead, initialHead);
+  assert.equal(result.prBodyOnly.lastReviewedSha, initialHead);
+  assert.equal(result.prBodyOnly.prNumber, 334);
+  assert.equal(path.basename(result.prBodyOnly.previousSnapshotPath), "review-round-1-pr-body.md");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.next_action, "run_review");
+  assert.equal(manifest.review.last_reviewed_sha, initialHead, "recovery must NOT auto-reset last_reviewed_sha");
+
+  const event = readRunEvents(repoRoot, runId).find((entry) => entry.event === "state_recovery");
+  assert.equal(event?.head_sha, initialHead);
+  assert.equal(event?.last_reviewed_sha, initialHead);
+  assert.equal(event?.pr_body_only, true);
+  assert.equal(event?.pr_number, 334);
+  assert.equal(event?.reason, "PR body metadata fixed with gh pr edit");
+});
+
+test("same-HEAD PR-body-only recovery requires a PR number", () => {
+  const { repoRoot, runId, runDir } = setupRepo({ state: STATES.CHANGES_REQUESTED });
+  fs.writeFileSync(path.join(runDir, "review-round-1-pr-body.md"), "missing metadata\n", "utf-8");
+  const env = { ...process.env, ...writeGhPrBodyScript("fixed metadata\n") };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR body metadata fixed",
+    "--allow-same-head",
+    "--require-pr-body-change",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest has no PR number/);
+});
+
+test("same-HEAD PR-body-only recovery accepts github.pr_number fallback", () => {
+  const { repoRoot, runId, runDir } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    githubPrNumber: 335,
+  });
+  fs.writeFileSync(path.join(runDir, "review-round-1-pr-body.md"), "missing metadata\n", "utf-8");
+  const env = { ...process.env, ...writeGhPrBodyScript("fixed metadata\n") };
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR body metadata fixed",
+    "--allow-same-head",
+    "--require-pr-body-change",
+    "--dry-run",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.dryRun, true);
+  assert.equal(result.prBodyOnly.prNumber, 335);
+});
+
+test("same-HEAD PR-body-only recovery requires a prior PR body snapshot", () => {
+  const { repoRoot, runId } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  const env = { ...process.env, ...writeGhPrBodyScript("fixed metadata\n") };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR body metadata fixed",
+    "--allow-same-head",
+    "--require-pr-body-change",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /no prior PR body snapshot/);
+});
+
+test("same-HEAD PR-body-only recovery compares the latest numbered PR body snapshot", () => {
+  const { repoRoot, runId, runDir } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  fs.writeFileSync(path.join(runDir, "review-round-1-pr-body.md"), "old metadata\n", "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-pr-body.md"), "fixed metadata\n", "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-10-pr-body.md"), "latest metadata\n", "utf-8");
+  const env = { ...process.env, ...writeGhPrBodyScript("latest metadata\n") };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR body metadata fixed",
+    "--allow-same-head",
+    "--require-pr-body-change",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /matches latest prior PR body snapshot review-round-10-pr-body\.md/);
+});
+
+test("same-HEAD PR-body-only recovery requires both explicit opt-in flags", () => {
+  const { repoRoot, runId, runDir } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  fs.writeFileSync(path.join(runDir, "review-round-1-pr-body.md"), "missing metadata\n", "utf-8");
+  const env = { ...process.env, ...writeGhPrBodyScript("fixed metadata\n") };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR body metadata fixed",
+    "--allow-same-head",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must be passed together/);
 });
 
 test("escalated -> review_pending requires --force; succeeds with --force", () => {

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -114,6 +114,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.pr_number !== undefined
       ? { pr_number: normalizeEventValue(eventData.pr_number) }
       : {}),
+    ...(eventData.pr_body_only !== undefined
+      ? { pr_body_only: eventData.pr_body_only === true }
+      : {}),
     ...(eventData.commit_sha !== undefined
       ? { commit_sha: normalizeEventValue(eventData.commit_sha) }
       : {}),

--- a/skills/relay-dispatch/scripts/relay-events.test.js
+++ b/skills/relay-dispatch/scripts/relay-events.test.js
@@ -205,6 +205,23 @@ test("appendRunEvent persists pr_number when provided", () => {
   assert.equal(parsed.pr_number, 123);
 });
 
+test("appendRunEvent persists pr_body_only when provided", () => {
+  const { repoRoot, runId } = createContext();
+  const record = appendRunEvent(repoRoot, runId, {
+    event: EVENTS.STATE_RECOVERY,
+    state_from: "changes_requested",
+    state_to: "review_pending",
+    head_sha: "deadbeef",
+    reason: "PR body metadata fixed",
+    last_reviewed_sha: "deadbeef",
+    pr_body_only: true,
+  });
+
+  const [parsed] = readRunEvents(repoRoot, runId);
+  assert.equal(record.pr_body_only, true);
+  assert.equal(parsed.pr_body_only, true);
+});
+
 test("appendRunEvent persists recover commit commit_sha and branch when provided", () => {
   const { repoRoot, runId } = createContext();
   const record = appendRunEvent(repoRoot, runId, {


### PR DESCRIPTION
## Summary

- Added `recover-state.js` flags `--allow-same-head` and `--require-pr-body-change` for audited PR-body-only same-HEAD recovery.
- Same-HEAD recovery requires: manifest PR number (`git.pr_number` or `github.pr_number`), a prior `review-round-N-pr-body.md` snapshot, current GitHub PR body fetched via `gh pr view`, a body diff from the latest numbered snapshot, and both opt-in flags.
- `state_recovery` events for this path record `reason`, `head_sha`, `last_reviewed_sha`, `pr_number`, and `pr_body_only: true`.
- The fresh-commit recovery path and fresh-review gate are preserved: without the same-HEAD flags, `changes_requested -> review_pending` still requires `HEAD != review.last_reviewed_sha`.

## Tests

- `node --test skills/relay-dispatch/scripts/recover-state.test.js`
- `node --test skills/relay-dispatch/scripts/relay-events.test.js`
- `node --test skills/relay-dispatch/scripts/*.test.js` (`482` pass)
- `git diff --check`

Fixes #334
