### PR TITLE
recover-commit: derive default PR title from linked issue title (#335)

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -15,10 +15,12 @@ ${CLAUDE_SKILL_DIR}/scripts/recover-commit.js --run-id <id> \
 ${CLAUDE_SKILL_DIR}/scripts/recover-commit.js --run-id <id> \
   --reason "..." --dry-run
 
-# Override PR title / body (defaults derive from branch + run-id)
+# Override PR title / body (default title prefers linked issue title, then branch + run-id)
 ${CLAUDE_SKILL_DIR}/scripts/recover-commit.js --run-id <id> \
   --reason "..." --pr-title "..." --pr-body-file /tmp/pr-body.md
 ```
+
+When `--pr-title` is omitted, the PR title defaults to the linked GitHub issue title as `<issue title> (#<N>)`, first from `manifest.issue.number`, then from an unambiguous `issue-N` branch name. If issue lookup fails or no issue is linked, it falls back to `Recover <branch> (<run-id>)`. `--pr-title` always wins exactly.
 
 If a PR already exists for the branch, the command no-ops the create step and stamps `pr_number` from the existing PR — safe to re-run after a partial failure. Use `--dry-run` first when uncertain.
 

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -74,6 +74,67 @@ function defaultPrTitle(branch, runId) {
   return `Recover ${branch} (${runId})`;
 }
 
+function normalizeIssueNumber(value) {
+  const issueNumber = Number(value);
+  return Number.isSafeInteger(issueNumber) && issueNumber > 0 ? issueNumber : null;
+}
+
+function inferIssueNumberFromBranch(branch) {
+  const matches = [...String(branch || "").matchAll(/(?:^|\/)issue-(\d+)(?=$|[-/])/g)];
+  if (matches.length !== 1) return null;
+  return normalizeIssueNumber(matches[0][1]);
+}
+
+function resolveIssueNumberForTitle(data, branch) {
+  return normalizeIssueNumber(data.issue?.number) || inferIssueNumberFromBranch(branch);
+}
+
+function fetchIssueTitle(repoPath, issueNumber) {
+  const raw = execGh(repoPath, ["issue", "view", String(issueNumber), "--json", "title,number"]);
+  const parsed = JSON.parse(raw);
+  const parsedNumber = normalizeIssueNumber(parsed.number);
+  const title = String(parsed.title || "").trim();
+  if (parsedNumber !== issueNumber || !title) {
+    throw new Error(`gh issue view returned invalid title data for issue #${issueNumber}`);
+  }
+  return title;
+}
+
+function resolvePrTitle({ explicitTitle, repoPath, branch, runId, data }) {
+  if (explicitTitle) {
+    return {
+      title: explicitTitle,
+      source: "explicit",
+      issueNumber: null,
+    };
+  }
+
+  const fallbackTitle = defaultPrTitle(branch, runId);
+  const issueNumber = resolveIssueNumberForTitle(data, branch);
+  if (!issueNumber) {
+    return {
+      title: fallbackTitle,
+      source: "fallback",
+      issueNumber: null,
+    };
+  }
+
+  try {
+    const issueTitle = fetchIssueTitle(repoPath, issueNumber);
+    return {
+      title: `${issueTitle} (#${issueNumber})`,
+      source: normalizeIssueNumber(data.issue?.number) ? "manifest_issue" : "branch_issue",
+      issueNumber,
+    };
+  } catch {
+    return {
+      title: fallbackTitle,
+      source: "fallback",
+      issueNumber,
+    };
+  }
+}
+
 function buildPrBody({ runId, reason, branch, timestamp, manifestPath, data }) {
   return [
     "## Recovery Summary",
@@ -244,18 +305,8 @@ function main() {
     manifestPath: manifestRecord.manifestPath,
     data,
   });
-  const prTitle = prTitleArg || defaultPrTitle(branch, data.run_id);
   const commitTitle = `Recover relay run ${data.run_id}`;
   const commitBody = buildCommitBody({ runId: data.run_id, reason, timestamp });
-  const plannedCommands = [
-    commandRecord(worktreePath, ["gh", "pr", "list", "--head", branch, "--json", "number", "--jq", ".[0].number"]),
-  ];
-  if (hasUncommittedChanges) {
-    plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "add", "-A"]));
-    plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "commit", "-m", commitTitle, "-m", commitBody]));
-  }
-  plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "push", "-u", "origin", branch]));
-  plannedCommands.push(commandRecord(worktreePath, ["gh", "pr", "create", "--title", prTitle, "--body", prBody]));
 
   let existingPrNumber = null;
   if (!dryRun) {
@@ -270,11 +321,31 @@ function main() {
   }
 
   if (dryRun) {
+    const prTitleResolution = resolvePrTitle({
+      explicitTitle: prTitleArg,
+      repoPath: worktreePath,
+      branch,
+      runId: data.run_id,
+      data,
+    });
+    const plannedCommands = [
+      commandRecord(worktreePath, ["gh", "pr", "list", "--head", branch, "--json", "number", "--jq", ".[0].number"]),
+    ];
+    if (hasUncommittedChanges) {
+      plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "add", "-A"]));
+      plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "commit", "-m", commitTitle, "-m", commitBody]));
+    }
+    plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "push", "-u", "origin", branch]));
+    plannedCommands.push(commandRecord(worktreePath, ["gh", "pr", "create", "--title", prTitleResolution.title, "--body", prBody]));
+
     const result = {
       status: "dry_run",
       runId: data.run_id,
       branch,
       worktree: worktreePath,
+      prTitle: prTitleResolution.title,
+      prTitleSource: prTitleResolution.source,
+      prTitleIssueNumber: prTitleResolution.issueNumber,
       hasUncommittedChanges,
       unpushedCommits,
       commands: plannedCommands,
@@ -340,7 +411,14 @@ function main() {
     }
     if (prNumber === null) {
       try {
-        const raw = execGh(worktreePath, ["pr", "create", "--title", prTitle, "--body", prBody]);
+        const prTitleResolution = resolvePrTitle({
+          explicitTitle: prTitleArg,
+          repoPath: worktreePath,
+          branch,
+          runId: data.run_id,
+          data,
+        });
+        const raw = execGh(worktreePath, ["pr", "create", "--title", prTitleResolution.title, "--body", prBody]);
         prNumber = parsePrNumber(raw);
       } catch (error) {
         const detail = formatExecError(error);

--- a/skills/relay-dispatch/scripts/recover-commit.test.js
+++ b/skills/relay-dispatch/scripts/recover-commit.test.js
@@ -23,7 +23,7 @@ const {
 
 const SCRIPT = path.join(__dirname, "recover-commit.js");
 
-function writeFakeGh(binDir, statePath, logPath) {
+function writeFakeGh(binDir, statePath, logPath, initialState = {}) {
   const ghPath = path.join(binDir, "gh");
   fs.writeFileSync(ghPath, `#!/usr/bin/env node
 const fs = require("fs");
@@ -55,11 +55,31 @@ if (args[0] === "pr" && args[1] === "create") {
   process.stdout.write("https://github.com/acme/dev-relay/pull/" + state.existingPrNumber + "\\n");
   process.exit(0);
 }
+if (args[0] === "issue" && args[1] === "view") {
+  const issueNumber = String(args[2]);
+  state.issueViewCalls = Number(state.issueViewCalls || 0) + 1;
+  save();
+  if (state.failIssueView) {
+    process.stderr.write(state.failIssueView + "\\n");
+    process.exit(1);
+  }
+  const title = state.issueTitles && state.issueTitles[issueNumber];
+  if (!title) {
+    process.stderr.write("issue not found: " + issueNumber + "\\n");
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify({ number: Number(issueNumber), title }) + "\\n");
+  process.exit(0);
+}
 process.stderr.write("unexpected fake gh invocation: " + args.join(" ") + "\\n");
 process.exit(1);
 `, "utf-8");
   fs.chmodSync(ghPath, 0o755);
-  fs.writeFileSync(statePath, JSON.stringify({ createNumber: 281 }, null, 2));
+  fs.writeFileSync(statePath, JSON.stringify({
+    createNumber: 281,
+    issueTitles: { "281": "Recover commit should use the issue title" },
+    ...initialState,
+  }, null, 2));
   fs.writeFileSync(logPath, "");
   return ghPath;
 }
@@ -122,7 +142,15 @@ function buildManifestForState(manifest, state, repoRoot, runId) {
   throw new Error(`Unsupported test state: ${state}`);
 }
 
-function setupRepo({ dirty = false, unpushed = false, evidence = false, manifestState = STATES.REVIEW_PENDING } = {}) {
+function setupRepo({
+  dirty = false,
+  unpushed = false,
+  evidence = false,
+  manifestState = STATES.REVIEW_PENDING,
+  branch = "issue-281",
+  issueNumber = 281,
+  ghState = {},
+} = {}) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-recover-commit-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
   const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-")));
@@ -142,7 +170,6 @@ function setupRepo({ dirty = false, unpushed = false, evidence = false, manifest
   execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
 
-  const branch = "issue-281";
   const worktreePath = path.join(repoRoot, "wt", branch);
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
   execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -155,7 +182,7 @@ function setupRepo({ dirty = false, unpushed = false, evidence = false, manifest
     execFileSync("git", ["-C", worktreePath, "commit", "-m", "Executor commit"], { encoding: "utf-8", stdio: "pipe" });
   }
 
-  const runId = createRunId({ issueNumber: 281, branch, timestamp: new Date("2026-04-24T01:00:00.000Z") });
+  const runId = createRunId({ issueNumber, branch, timestamp: new Date("2026-04-24T01:00:00.000Z") });
   const runLayout = ensureRunLayout(repoRoot, runId);
   const manifestPath = runLayout.manifestPath;
   const runDir = runLayout.runDir;
@@ -164,7 +191,7 @@ function setupRepo({ dirty = false, unpushed = false, evidence = false, manifest
     runId,
     branch,
     baseBranch: "main",
-    issueNumber: 281,
+    issueNumber,
     worktreePath,
     orchestrator: "codex",
     executor: "codex",
@@ -185,7 +212,7 @@ function setupRepo({ dirty = false, unpushed = false, evidence = false, manifest
     });
   }
 
-  const ghPath = writeFakeGh(binDir, statePath, ghLogPath);
+  const ghPath = writeFakeGh(binDir, statePath, ghLogPath, ghState);
   const preloadPath = writeEventPreload(binDir, eventLogPath);
   const env = {
     ...process.env,
@@ -211,6 +238,15 @@ function runRecover(fixture, extraArgs = []) {
 function readJsonLines(filePath) {
   const text = fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf-8").trim() : "";
   return text ? text.split("\n").map((line) => JSON.parse(line)) : [];
+}
+
+function findGhCall(fixture, command, subcommand) {
+  return readJsonLines(fixture.ghLogPath).find((argv) => argv[0] === command && argv[1] === subcommand);
+}
+
+function ghArg(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index === -1 ? undefined : argv[index + 1];
 }
 
 test("happy path commits dirty worktree, pushes, opens PR, stamps manifest, and emits audit event", () => {
@@ -243,6 +279,58 @@ test("happy path commits dirty worktree, pushes, opens PR, stamps manifest, and 
   assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);
   assert.ok(readJsonLines(fixture.eventLogPath).some((entry) => entry.eventData.event === "recover_commit"));
   assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 1);
+});
+
+test("default PR title uses manifest issue title when available", () => {
+  const fixture = setupRepo({ dirty: true });
+  const result = runRecover(fixture, ["--reason", "executor completed before commit", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const issueView = findGhCall(fixture, "issue", "view");
+  assert.deepEqual(issueView, ["issue", "view", "281", "--json", "title,number"]);
+  const prCreate = findGhCall(fixture, "pr", "create");
+  assert.equal(ghArg(prCreate, "--title"), "Recover commit should use the issue title (#281)");
+});
+
+test("default PR title uses branch-inferred issue title when manifest issue is absent", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    branch: "issue-282",
+    issueNumber: null,
+    ghState: { issueTitles: { "282": "Branch inferred recovery title" } },
+  });
+  const result = runRecover(fixture, ["--reason", "executor completed before commit", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const issueView = findGhCall(fixture, "issue", "view");
+  assert.deepEqual(issueView, ["issue", "view", "282", "--json", "title,number"]);
+  const prCreate = findGhCall(fixture, "pr", "create");
+  assert.equal(ghArg(prCreate, "--title"), "Branch inferred recovery title (#282)");
+});
+
+test("explicit --pr-title wins without issue title lookup", () => {
+  const fixture = setupRepo({ dirty: true });
+  const result = runRecover(fixture, [
+    "--reason", "executor completed before commit",
+    "--pr-title", "Operator supplied recovery title",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(findGhCall(fixture, "issue", "view"), undefined);
+  const prCreate = findGhCall(fixture, "pr", "create");
+  assert.equal(ghArg(prCreate, "--title"), "Operator supplied recovery title");
+});
+
+test("issue lookup failure falls back to existing recovery title", () => {
+  const fixture = setupRepo({ dirty: true, ghState: { failIssueView: "not found" } });
+  const result = runRecover(fixture, ["--reason", "executor completed before commit", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const issueView = findGhCall(fixture, "issue", "view");
+  assert.deepEqual(issueView, ["issue", "view", "281", "--json", "title,number"]);
+  const prCreate = findGhCall(fixture, "pr", "create");
+  assert.equal(ghArg(prCreate, "--title"), `Recover ${fixture.branch} (${fixture.runId})`);
 });
 
 test("dirty worktree recovery rebrands execution evidence to the created commit and emits event", () => {
@@ -309,7 +397,7 @@ test("unknown run id fails through resolveManifestRecord", () => {
   assert.match(result.stderr, /No relay manifest found/);
 });
 
-test("dry-run previews commands without committing, calling gh, or mutating manifest", () => {
+test("dry-run previews commands and computed PR title without committing or mutating manifest", () => {
   const fixture = setupRepo({ dirty: true });
   const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
   const result = runRecover(fixture, ["--reason", "preview only", "--dry-run", "--json"]);
@@ -317,13 +405,18 @@ test("dry-run previews commands without committing, calling gh, or mutating mani
   assert.equal(result.status, 0, result.stderr);
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.status, "dry_run");
+  assert.equal(parsed.prTitle, "Recover commit should use the issue title (#281)");
+  assert.equal(parsed.prTitleSource, "manifest_issue");
+  assert.equal(parsed.prTitleIssueNumber, 281);
   assert.ok(parsed.commands.some((cmd) => cmd.argv.includes("add") && cmd.argv.includes("-A")));
   assert.ok(parsed.commands.some((cmd) => cmd.argv.includes("commit")));
   assert.ok(parsed.commands.some((cmd) => cmd.argv.includes("push")));
   assert.ok(parsed.commands.some((cmd) => cmd.argv.includes("create")));
+  const prCreate = parsed.commands.find((cmd) => cmd.argv[1] === "pr" && cmd.argv[2] === "create");
+  assert.equal(ghArg(prCreate.argv, "--title"), "Recover commit should use the issue title (#281)");
   assert.equal(readManifest(fixture.manifestPath).data.git.pr_number, null);
   assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
-  assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
+  assert.deepEqual(readJsonLines(fixture.ghLogPath), [["issue", "view", "281", "--json", "title,number"]]);
   assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
 });
 
@@ -353,6 +446,23 @@ test("closed terminal state rejection matches finalize-run force-finalize shape"
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /force-finalize cannot be used from terminal state closed/);
   assert.equal(readManifest(fixture.manifestPath).data.state, STATES.CLOSED);
+});
+
+test("existing PR reuse does not create or rename a PR", () => {
+  const fixture = setupRepo({ dirty: true, ghState: { existingPrNumber: 333 } });
+  const result = runRecover(fixture, ["--reason", "recover onto existing PR", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.existingPr, true);
+  assert.equal(parsed.prCreated, false);
+  assert.equal(parsed.prNumber, 333);
+
+  const calls = readJsonLines(fixture.ghLogPath);
+  assert.equal(calls.filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 0);
+  assert.equal(calls.filter((argv) => argv[0] === "pr" && argv[1] === "edit").length, 0);
+  assert.equal(calls.filter((argv) => argv[0] === "issue" && argv[1] === "view").length, 0);
+  assert.equal(readManifest(fixture.manifestPath).data.git.pr_number, 333);
 });
 
 test("idempotent re-run reuses existing PR without restamping or creating a second PR", () => {


### PR DESCRIPTION
## Summary

- Added issue-title default PR titles for `recover-commit.js` when `--pr-title` is omitted.
- Title precedence is: explicit `--pr-title`, then `manifest.issue.number`, then unambiguous `issue-N` branch inference, then the existing `Recover <branch> (<runId>)` fallback.
- Issue titles are fetched with `gh issue view <N> --json title,number` via argv-based `execFileSync` helper flow.
- Dry-run JSON now exposes `prTitle`, `prTitleSource`, and `prTitleIssueNumber`, and the planned `gh pr create` command uses the computed title.
- Existing PRs are reused without rename, and commit message generation is unchanged.

## Tests

- `node --test skills/relay-dispatch/scripts/recover-commit.test.js`
- `node --test skills/relay-dispatch/scripts/*.test.js` (`480` pass)
- `git diff --check`

Fixes #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * GitHub 이슈를 기반으로 PR 타이틀을 자동 선택하는 기능 추가. --pr-title 옵션 생략 시 연결된 이슈 타이틀에서 파생되며, 이슈 조회 실패 시 기존 기본값으로 폴백.

* **문서**
  * PR 타이틀 설정 전략 및 우선순위를 명확히 한 플레이북 업데이트.

* **테스트**
  * PR 타이틀 선택 및 이슈 조회 동작을 검증하는 테스트 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->