### PR TITLE
refactor: consolidate git()/gh() execFile wrappers into shared exec helpers (#314)

### DIFF
--- a/skills/relay-dispatch/scripts/claude-app-register.js
+++ b/skills/relay-dispatch/scripts/claude-app-register.js
@@ -12,6 +12,7 @@ const crypto = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { execGit } = require("./exec");
 
 function generateUUIDv7() {
   const now = BigInt(Date.now());
@@ -25,10 +26,6 @@ function generateUUIDv7() {
   buf[8] = (buf[8] & 0x3f) | 0x80;
   const hex = buf.toString("hex");
   return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)].join("-");
-}
-
-function git(repoDir, ...gitArgs) {
-  return execFileSync("git", ["-C", repoDir, ...gitArgs], { encoding: "utf-8" }).trim();
 }
 
 function nowISO() {
@@ -63,8 +60,8 @@ function registerClaudeApp({ wtPath, repoPath, branch, title, pin = false }) {
 
   let commitHash = "";
   let repositoryUrl = "";
-  try { commitHash = git(wtPath, "rev-parse", "HEAD"); } catch {}
-  try { repositoryUrl = git(repoPath, "remote", "get-url", "origin"); } catch {}
+  try { commitHash = execGit(wtPath, ["rev-parse", "HEAD"]); } catch {}
+  try { repositoryUrl = execGit(repoPath, ["remote", "get-url", "origin"]); } catch {}
 
   const metadata = {
     version: "1",

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -116,7 +116,6 @@ function run() {
   const dryRun = hasCliFlag("--dry-run");
   const all = hasCliFlag("--all");
   const jsonOut = hasCliFlag("--json");
-  const gitBin = process.env.RELAY_GIT_BIN || "git";
   const olderThanHours = all ? 0 : parseHours(getArg(args, "--older-than", "24", CLI_ARG_OPTIONS), "--older-than");
   const now = Date.now();
   const cutoff = now - olderThanHours * 60 * 60 * 1000;
@@ -204,7 +203,6 @@ function run() {
     const cleanupResult = runCleanup({
       repoRoot,
       data: normalizedData,
-      gitBin,
       dryRun,
       deleteMergedBranch: normalizedData.state === "merged",
       acceptPrunedRelayOwned: true,

--- a/skills/relay-dispatch/scripts/close-run.js
+++ b/skills/relay-dispatch/scripts/close-run.js
@@ -55,7 +55,6 @@ function main() {
   const reason = getArg(args, "--reason", undefined, CLI_ARG_OPTIONS);
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
-  const gitBin = process.env.RELAY_GIT_BIN || "git";
 
   if (!runId) {
     throw new Error("--run-id is required");
@@ -89,7 +88,6 @@ function main() {
     cleanupResult = runCleanup({
       repoRoot,
       data: updated,
-      gitBin,
       dryRun,
       deleteMergedBranch: false,
     });

--- a/skills/relay-dispatch/scripts/codex-app-register.js
+++ b/skills/relay-dispatch/scripts/codex-app-register.js
@@ -12,6 +12,7 @@ const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
 const os = require("os");
+const { execGit } = require("./exec");
 
 const SOURCE = "vscode";
 const MODEL_PROVIDER = "openai";
@@ -31,10 +32,6 @@ function generateUUIDv7() {
   buf[8] = (buf[8] & 0x3f) | 0x80;
   const hex = buf.toString("hex");
   return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)].join("-");
-}
-
-function git(repoDir, ...gitArgs) {
-  return execFileSync("git", ["-C", repoDir, ...gitArgs], { encoding: "utf-8" }).trim();
 }
 
 function sql(db, query) {
@@ -81,8 +78,8 @@ function registerCodexApp({ wtPath, repoPath, branch, title, pin = false }) {
   const epoch = Math.floor(Date.now() / 1000);
 
   let gitSha = "", gitOrigin = "";
-  try { gitSha = git(wtPath, "rev-parse", "HEAD"); } catch {}
-  try { gitOrigin = git(repoPath, "remote", "get-url", "origin"); } catch {}
+  try { gitSha = execGit(wtPath, ["rev-parse", "HEAD"]); } catch {}
+  try { gitOrigin = execGit(repoPath, ["remote", "get-url", "origin"]); } catch {}
 
   // Rollout file
   const cliVersion = getCodexVersion();

--- a/skills/relay-dispatch/scripts/create-worktree.js
+++ b/skills/relay-dispatch/scripts/create-worktree.js
@@ -38,6 +38,7 @@ const {
   registerWorktree,
 } = require("./worktree-runtime");
 const { getArg, getPositionals, hasFlag, modeLabel } = require("./cli-args");
+const { execGit } = require("./exec");
 
 // ---------------------------------------------------------------------------
 // Args
@@ -136,10 +137,6 @@ if (REGISTER) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function git(repoDir, ...gitArgs) {
-  return execFileSync("git", ["-C", repoDir, ...gitArgs], { encoding: "utf-8" }).trim();
-}
-
 function assertWithin(base, resolved, label) {
   const norm = path.resolve(resolved);
   if (!norm.startsWith(base + path.sep) && norm !== base) {
@@ -171,7 +168,7 @@ function main() {
     branch = BRANCH;
     if (!branch) {
       try {
-        branch = git(wtPath, "rev-parse", "--abbrev-ref", "HEAD");
+        branch = execGit(wtPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
       } catch {
         console.error("Error: --branch required (could not detect from worktree)");
         process.exit(1);

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -98,6 +98,7 @@ const { formatAttemptsForPrompt, readPreviousAttempts } = require("./manifest/at
 const { STATES, updateManifestState } = require("./manifest/lifecycle");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
+const { execGit } = require("./exec");
 
 // ---------------------------------------------------------------------------
 // Args
@@ -327,16 +328,12 @@ function assertWithin(base, resolved, label) {
   }
 }
 
-function git(repoDir, ...gitArgs) {
-  return execFileSync("git", ["-C", repoDir, ...gitArgs], { encoding: "utf-8" }).trim();
-}
-
 function isValidBaseBranchName(branch) {
   return typeof branch === "string" && branch.trim() !== "" && branch.trim() !== "HEAD";
 }
 
 function resolveOriginDefaultBranch(repoDir) {
-  const remoteHeadRef = git(repoDir, "symbolic-ref", "refs/remotes/origin/HEAD");
+  const remoteHeadRef = execGit(repoDir, ["symbolic-ref", "refs/remotes/origin/HEAD"]);
   const prefix = "refs/remotes/origin/";
   if (!remoteHeadRef.startsWith(prefix)) {
     throw new Error(`origin/HEAD resolved to unexpected ref '${remoteHeadRef}'`);
@@ -352,7 +349,7 @@ function resolveOriginDefaultBranch(repoDir) {
 function resolveBaseBranchForNewDispatch(repoDir) {
   let detectedBranch = "";
   try {
-    detectedBranch = git(repoDir, "rev-parse", "--abbrev-ref", "HEAD");
+    detectedBranch = execGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   } catch {}
 
   if (isValidBaseBranchName(detectedBranch)) {
@@ -661,7 +658,7 @@ async function main() {
       process.exit(1);
     }
     try {
-      const currentBranch = git(wtPath, "rev-parse", "--abbrev-ref", "HEAD");
+      const currentBranch = execGit(wtPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
       if (currentBranch !== branch) {
         console.error(`Error: retained worktree HEAD is '${currentBranch}', expected '${branch}'`);
         process.exit(1);
@@ -850,7 +847,7 @@ async function main() {
     // On merge conflict, the worktree is cleaned up and dispatch aborts.
     let fetchSucceeded = false;
     try {
-      git(wtPath, "fetch", "origin", baseBranch);
+      execGit(wtPath, ["fetch", "origin", baseBranch]);
       fetchSucceeded = true;
     } catch (fetchErr) {
       const msg = (fetchErr.stderr || fetchErr.message || String(fetchErr)).split("\n")[0];
@@ -860,9 +857,9 @@ async function main() {
     }
     if (fetchSucceeded) {
       try {
-        git(wtPath, "merge", `origin/${baseBranch}`, "--no-edit");
+        execGit(wtPath, ["merge", `origin/${baseBranch}`, "--no-edit"]);
       } catch (mergeErr) {
-        try { git(wtPath, "merge", "--abort"); } catch {}
+        try { execGit(wtPath, ["merge", "--abort"]); } catch {}
         removeWorktree({ repoRoot, worktreePath: wtPath });
         const reason = (mergeErr.stderr || mergeErr.message || String(mergeErr)).split("\n")[0];
         console.error(`Error: failed to merge origin/${baseBranch} into worktree: ${reason}`);
@@ -1007,7 +1004,7 @@ async function main() {
   // Record HEAD before execution so we can measure only new work.
   let startHead = "";
   try {
-    startHead = git(wtPath, "rev-parse", "HEAD");
+    startHead = execGit(wtPath, ["rev-parse", "HEAD"]);
   } catch {}
 
   const dispatchFromState = manifest.state;
@@ -1099,31 +1096,31 @@ async function main() {
   let gitLog = "";
   let currentHead = startHead;
   try {
-    currentHead = git(wtPath, "rev-parse", "HEAD");
+    currentHead = execGit(wtPath, ["rev-parse", "HEAD"]);
     if (startHead && currentHead !== startHead) {
-      gitLog = git(wtPath, "log", "--oneline", `${startHead}..HEAD`);
+      gitLog = execGit(wtPath, ["log", "--oneline", `${startHead}..HEAD`]);
     }
   } catch {}
 
   let diffStat = "";
   try {
     if (startHead && gitLog) {
-      diffStat = git(wtPath, "diff", "--stat", `${startHead}..HEAD`);
+      diffStat = execGit(wtPath, ["diff", "--stat", `${startHead}..HEAD`]);
     }
   } catch {}
 
   // Also capture uncommitted diff for partial runs (timeout, interrupted).
   let uncommittedDiff = "";
   try {
-    const wd = git(wtPath, "diff", "--stat");
-    const staged = git(wtPath, "diff", "--stat", "--cached");
+    const wd = execGit(wtPath, ["diff", "--stat"]);
+    const staged = execGit(wtPath, ["diff", "--stat", "--cached"]);
     uncommittedDiff = [wd, staged].filter(Boolean).join("\n");
   } catch {}
 
   // Check for uncommitted work (executor may have worked but not committed)
   let uncommitted = "";
   try {
-    uncommitted = git(wtPath, "status", "--porcelain");
+    uncommitted = execGit(wtPath, ["status", "--porcelain"]);
   } catch {}
 
   const hasResult = resultText !== "";

--- a/skills/relay-dispatch/scripts/exec.js
+++ b/skills/relay-dispatch/scripts/exec.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const { execFileSync } = require("child_process");
+
+function outputOrRaw(output, raw) {
+  return raw ? output : output.trim();
+}
+
+function execGit(repoPath, args, opts = {}) {
+  const { raw = false, cwd, encoding, stdio, ...execOpts } = opts;
+  const gitBin = process.env.RELAY_GIT_BIN || "git";
+  const output = execFileSync(gitBin, ["-C", repoPath, ...args], {
+    ...execOpts,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  return outputOrRaw(output, raw);
+}
+
+function execGh(repoPath, args, opts = {}) {
+  const { raw = false, cwd, encoding, stdio, ...execOpts } = opts;
+  const ghBin = process.env.RELAY_GH_BIN || "gh";
+  const options = {
+    ...execOpts,
+    encoding: "utf-8",
+    stdio: "pipe",
+  };
+  if (repoPath != null) {
+    options.cwd = repoPath;
+  }
+  const output = execFileSync(ghBin, args, options);
+  return outputOrRaw(output, raw);
+}
+
+module.exports = {
+  execGit,
+  execGh,
+};

--- a/skills/relay-dispatch/scripts/exec.test.js
+++ b/skills/relay-dispatch/scripts/exec.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const test = require("node:test");
+
+const { execGit, execGh } = require("./exec");
+
+function withEnv(name, value, fn) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
+
+function writeStub(dir, sentinel) {
+  const stubPath = path.join(dir, `${sentinel}-stub.js`);
+  fs.writeFileSync(
+    stubPath,
+    [
+      "#!/usr/bin/env node",
+      `process.stdout.write(${JSON.stringify(`${sentinel}\n`)});`,
+    ].join("\n"),
+    "utf-8"
+  );
+  fs.chmodSync(stubPath, 0o755);
+  return stubPath;
+}
+
+test("execGit honors RELAY_GIT_BIN override", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-exec-git-"));
+  const stub = writeStub(dir, "git-sentinel");
+
+  const output = withEnv("RELAY_GIT_BIN", stub, () => execGit(dir, ["status"]));
+
+  assert.strictEqual(output, "git-sentinel");
+});
+
+test("execGh honors RELAY_GH_BIN override", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-exec-gh-"));
+  const stub = writeStub(dir, "gh-sentinel");
+
+  const output = withEnv("RELAY_GH_BIN", stub, () => execGh(dir, ["status"]));
+
+  assert.strictEqual(output, "gh-sentinel");
+});

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -1,7 +1,7 @@
-const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
+const { execGit } = require("../exec");
 const { validateManifestPaths } = require("./paths");
 const { summarizeError } = require("./store");
 
@@ -53,32 +53,22 @@ function updateManifestCleanup(data, cleanupPatch = {}, nextAction = data.next_a
   };
 }
 
-function gitExec(gitBin, repoPath, ...gitArgs) {
-  return execFileSync(gitBin, ["-C", repoPath, ...gitArgs], {
-    encoding: "utf-8",
-    stdio: "pipe",
-  }).trim();
-}
-
-function localBranchExists(gitBin, repoRoot, branch) {
+function localBranchExists(repoRoot, branch) {
   if (!branch) return false;
   try {
-    gitExec(gitBin, repoRoot, "rev-parse", "--verify", `refs/heads/${branch}`);
+    execGit(repoRoot, ["rev-parse", "--verify", `refs/heads/${branch}`]);
     return true;
   } catch {
     return false;
   }
 }
 
-function readWorktreeStatus(gitBin, worktreePath) {
+function readWorktreeStatus(worktreePath) {
   if (!worktreePath || !fs.existsSync(worktreePath)) {
     return { exists: false, clean: true, text: "" };
   }
   try {
-    const status = execFileSync(gitBin, ["-C", worktreePath, "status", "--short", "--untracked-files=all"], {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    const status = execGit(worktreePath, ["status", "--short", "--untracked-files=all"]);
     return { exists: true, clean: status === "", text: status };
   } catch (error) {
     return { exists: true, clean: false, text: `unable to inspect worktree: ${summarizeError(error)}` };
@@ -113,7 +103,6 @@ function removePrunedRelayWorktreeDirectory(worktreePath, relayWorktreeBase) {
 function runCleanup({
   repoRoot,
   data,
-  gitBin = "git",
   dryRun = false,
   deleteMergedBranch = false,
   acceptPrunedRelayOwned = false,
@@ -135,11 +124,11 @@ function runCleanup({
   const attemptedAt = nowIso();
   const worktreePath = normalizedData.paths?.worktree || null;
   const branch = normalizedData.git?.working_branch || null;
-  const worktreeStatus = readWorktreeStatus(gitBin, worktreePath);
+  const worktreeStatus = readWorktreeStatus(worktreePath);
   const allowPrunedRelayWorktreeRemoval = acceptPrunedRelayOwned
     && validatedPaths.prunedRelayOwnedForCleanup
     && validatedPaths.worktreeLocation === "relay_worktree";
-  const branchExistsBefore = localBranchExists(gitBin, repoRoot, branch);
+  const branchExistsBefore = localBranchExists(repoRoot, branch);
   const errors = [];
 
   let worktreeRemoved = !worktreeStatus.exists;
@@ -153,7 +142,7 @@ function runCleanup({
   if (errors.length === 0 && worktreeStatus.exists) {
     if (!dryRun) {
       try {
-        gitExec(gitBin, repoRoot, "worktree", "remove", "--force", worktreePath);
+        execGit(repoRoot, ["worktree", "remove", "--force", worktreePath]);
         worktreeRemoved = true;
       } catch (error) {
         if (allowPrunedRelayWorktreeRemoval) {
@@ -178,7 +167,7 @@ function runCleanup({
   if (errors.length === 0 && deleteMergedBranch && branch && branchExistsBefore) {
     if (!dryRun) {
       try {
-        gitExec(gitBin, repoRoot, "branch", "-D", branch);
+        execGit(repoRoot, ["branch", "-D", branch]);
         branchDeleted = true;
       } catch (error) {
         errors.push(`branch delete failed: ${summarizeError(error)}`);
@@ -189,7 +178,7 @@ function runCleanup({
   if (errors.length === 0) {
     if (!dryRun) {
       try {
-        gitExec(gitBin, repoRoot, "worktree", "prune");
+        execGit(repoRoot, ["worktree", "prune"]);
         pruneRan = true;
       } catch (error) {
         errors.push(`worktree prune failed: ${summarizeError(error)}`);

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -7,7 +7,6 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execFileSync } = require("child_process");
 
 const { parsePrNumber, formatExecError } = require("./dispatch-publish");
 const { resolveManifestRecord } = require("./relay-resolver");
@@ -23,6 +22,7 @@ const {
   hasFlag,
   modeLabel,
 } = require("./cli-args");
+const { execGit, execGh } = require("./exec");
 
 const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "recover-commit", reservedFlags: ["-h"] };
@@ -54,21 +54,6 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
 
 function nowIso() {
   return new Date().toISOString();
-}
-
-function git(gitBin, repoPath, ...gitArgs) {
-  return execFileSync(gitBin, ["-C", repoPath, ...gitArgs], {
-    encoding: "utf-8",
-    stdio: "pipe",
-  }).trim();
-}
-
-function gh(ghBin, repoPath, ...ghArgs) {
-  return execFileSync(ghBin, ghArgs, {
-    cwd: repoPath,
-    encoding: "utf-8",
-    stdio: "pipe",
-  }).trim();
 }
 
 function shellQuote(value) {
@@ -139,16 +124,16 @@ function expectedRepoRootForValidation(repoArg, manifestArg) {
   return getCanonicalRepoRoot(path.resolve(repoArg || "."));
 }
 
-function countRange(gitBin, worktreePath, range) {
-  const raw = git(gitBin, worktreePath, "rev-list", "--count", range);
+function countRange(worktreePath, range) {
+  const raw = execGit(worktreePath, ["rev-list", "--count", range]);
   const count = Number(raw);
   return Number.isInteger(count) && count > 0 ? count : 0;
 }
 
-function countUnpushedCommits(gitBin, worktreePath, branch, baseBranch) {
+function countUnpushedCommits(worktreePath, branch, baseBranch) {
   try {
-    const upstream = git(gitBin, worktreePath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}");
-    if (upstream) return countRange(gitBin, worktreePath, `${upstream}..HEAD`);
+    const upstream = execGit(worktreePath, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]);
+    if (upstream) return countRange(worktreePath, `${upstream}..HEAD`);
   } catch {}
 
   for (const ref of [
@@ -156,15 +141,15 @@ function countUnpushedCommits(gitBin, worktreePath, branch, baseBranch) {
     ...(baseBranch ? [`refs/remotes/origin/${baseBranch}`, baseBranch] : []),
   ]) {
     try {
-      git(gitBin, worktreePath, "rev-parse", "--verify", ref);
-      return countRange(gitBin, worktreePath, `${ref}..HEAD`);
+      execGit(worktreePath, ["rev-parse", "--verify", ref]);
+      return countRange(worktreePath, `${ref}..HEAD`);
     } catch {}
   }
   return 0;
 }
 
-function findExistingPr(ghBin, worktreePath, branch) {
-  const raw = gh(ghBin, worktreePath, "pr", "list", "--head", branch, "--json", "number", "--jq", ".[0].number");
+function findExistingPr(worktreePath, branch) {
+  const raw = execGh(worktreePath, ["pr", "list", "--head", branch, "--json", "number", "--jq", ".[0].number"]);
   return parsePrNumber(raw);
 }
 
@@ -202,8 +187,6 @@ function main() {
   const prBodyFile = getCliArg("--pr-body-file");
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
-  const gitBin = process.env.RELAY_GIT_BIN || "git";
-  const ghBin = process.env.RELAY_GH_BIN || "gh";
   const timestamp = nowIso();
 
   if (!runId && !manifestArg) {
@@ -245,14 +228,14 @@ function main() {
     throw new Error("manifest is missing git.working_branch");
   }
 
-  const currentBranch = git(gitBin, worktreePath, "rev-parse", "--abbrev-ref", "HEAD");
+  const currentBranch = execGit(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (currentBranch !== branch) {
     throw new Error(`manifest worktree is on branch ${currentBranch}, expected ${branch}`);
   }
 
-  const statusText = git(gitBin, worktreePath, "status", "--porcelain");
+  const statusText = execGit(worktreePath, ["status", "--porcelain"]);
   const hasUncommittedChanges = statusText.trim() !== "";
-  const unpushedCommits = countUnpushedCommits(gitBin, worktreePath, branch, data.git?.base_branch);
+  const unpushedCommits = countUnpushedCommits(worktreePath, branch, data.git?.base_branch);
   const prBody = readPrBodyFile(prBodyFile) || buildPrBody({
     runId: data.run_id,
     reason,
@@ -265,19 +248,19 @@ function main() {
   const commitTitle = `Recover relay run ${data.run_id}`;
   const commitBody = buildCommitBody({ runId: data.run_id, reason, timestamp });
   const plannedCommands = [
-    commandRecord(worktreePath, [ghBin, "pr", "list", "--head", branch, "--json", "number", "--jq", ".[0].number"]),
+    commandRecord(worktreePath, ["gh", "pr", "list", "--head", branch, "--json", "number", "--jq", ".[0].number"]),
   ];
   if (hasUncommittedChanges) {
-    plannedCommands.push(commandRecord(worktreePath, [gitBin, "-C", worktreePath, "add", "-A"]));
-    plannedCommands.push(commandRecord(worktreePath, [gitBin, "-C", worktreePath, "commit", "-m", commitTitle, "-m", commitBody]));
+    plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "add", "-A"]));
+    plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "commit", "-m", commitTitle, "-m", commitBody]));
   }
-  plannedCommands.push(commandRecord(worktreePath, [gitBin, "-C", worktreePath, "push", "-u", "origin", branch]));
-  plannedCommands.push(commandRecord(worktreePath, [ghBin, "pr", "create", "--title", prTitle, "--body", prBody]));
+  plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "push", "-u", "origin", branch]));
+  plannedCommands.push(commandRecord(worktreePath, ["gh", "pr", "create", "--title", prTitle, "--body", prBody]));
 
   let existingPrNumber = null;
   if (!dryRun) {
     try {
-      existingPrNumber = findExistingPr(ghBin, worktreePath, branch);
+      existingPrNumber = findExistingPr(worktreePath, branch);
     } catch (error) {
       throw new Error(`pr_list_failed: ${formatExecError(error)}`);
     }
@@ -304,13 +287,13 @@ function main() {
     return;
   }
 
-  let commitSha = git(gitBin, worktreePath, "rev-parse", "HEAD");
+  let commitSha = execGit(worktreePath, ["rev-parse", "HEAD"]);
   let commitCreated = false;
   if (hasUncommittedChanges) {
     try {
-      git(gitBin, worktreePath, "add", "-A");
-      git(gitBin, worktreePath, "commit", "-m", commitTitle, "-m", commitBody);
-      commitSha = git(gitBin, worktreePath, "rev-parse", "HEAD");
+      execGit(worktreePath, ["add", "-A"]);
+      execGit(worktreePath, ["commit", "-m", commitTitle, "-m", commitBody]);
+      commitSha = execGit(worktreePath, ["rev-parse", "HEAD"]);
       commitCreated = true;
     } catch (error) {
       const detail = formatExecError(error);
@@ -339,7 +322,7 @@ function main() {
   const shouldPush = prNumber === null || hasUncommittedChanges || unpushedCommits > 0;
   if (shouldPush) {
     try {
-      git(gitBin, worktreePath, "push", "-u", "origin", branch);
+      execGit(worktreePath, ["push", "-u", "origin", branch]);
     } catch (error) {
       const detail = formatExecError(error);
       appendFailureEvent(validatedPaths.repoRoot, data, "push_failed", detail, commitSha, branch);
@@ -349,7 +332,7 @@ function main() {
 
   if (prNumber === null) {
     try {
-      prNumber = findExistingPr(ghBin, worktreePath, branch);
+      prNumber = findExistingPr(worktreePath, branch);
     } catch (error) {
       const detail = formatExecError(error);
       appendFailureEvent(validatedPaths.repoRoot, data, "pr_create_failed", detail, commitSha, branch);
@@ -357,7 +340,7 @@ function main() {
     }
     if (prNumber === null) {
       try {
-        const raw = gh(ghBin, worktreePath, "pr", "create", "--title", prTitle, "--body", prBody);
+        const raw = execGh(worktreePath, ["pr", "create", "--title", prTitle, "--body", prBody]);
         prNumber = parsePrNumber(raw);
       } catch (error) {
         const detail = formatExecError(error);

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -1,13 +1,9 @@
-const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
 const { copyWorktreeFiles, getWorktreeIncludeFiles } = require("./worktreeinclude");
 const { registerCodexApp } = require("./codex-app-register");
-
-function git(repoDir, ...gitArgs) {
-  return execFileSync("git", ["-C", repoDir, ...gitArgs], { encoding: "utf-8" }).trim();
-}
+const { execGit } = require("./exec");
 
 function formatPlan({ worktreePath, branch, title, register, pin, includeFiles }) {
   const lines = [
@@ -79,7 +75,7 @@ function formatDispatchDryRun({
 }
 
 function removeWorktree({ repoRoot, worktreePath, dependencies = {} }) {
-  const gitRunner = dependencies.gitRunner || git;
+  const gitRunner = dependencies.gitRunner || ((repoDir, ...gitArgs) => execGit(repoDir, gitArgs));
   try {
     gitRunner(repoRoot, "worktree", "remove", "--force", worktreePath);
   } catch {}
@@ -122,7 +118,7 @@ function createWorktree({
   assertWithin = null,
   dependencies = {},
 }) {
-  const gitRunner = dependencies.gitRunner || git;
+  const gitRunner = dependencies.gitRunner || ((repoDir, ...gitArgs) => execGit(repoDir, gitArgs));
   const getWorktreeIncludeFilesImpl = dependencies.getWorktreeIncludeFilesImpl || getWorktreeIncludeFiles;
   const copyWorktreeFilesImpl = dependencies.copyWorktreeFilesImpl || copyWorktreeFiles;
   const registerWorktreeImpl = dependencies.registerWorktreeImpl || registerWorktree;

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -29,7 +29,6 @@
  *   --help, -h             Show usage
  */
 
-const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const {
@@ -50,6 +49,7 @@ const {
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 const { runCleanup } = require("../../relay-dispatch/scripts/manifest/cleanup");
+const { execGit, execGh } = require("../../relay-dispatch/scripts/exec");
 const {
   bindCliArgs,
   modeLabel,
@@ -113,22 +113,6 @@ function hasLegacyBootstrapReasonPrefix(reason) {
   return LEGACY_BOOTSTRAP_REASON_PREFIX.exec(String(reason || "")) !== null;
 }
 
-function gh(ghBin, repoPath, ...ghArgs) {
-  return execFileSync(ghBin, ghArgs, {
-    cwd: repoPath,
-    encoding: "utf-8",
-    stdio: "pipe",
-  }).trim();
-}
-
-function git(gitBin, repoPath, ...gitArgs) {
-  return execFileSync(gitBin, ["-C", repoPath, ...gitArgs], {
-    cwd: repoPath,
-    encoding: "utf-8",
-    stdio: "pipe",
-  }).trim();
-}
-
 function looksLikeGitRepo(repoPath) {
   return fs.existsSync(path.join(repoPath, ".git"));
 }
@@ -140,11 +124,11 @@ function getExpectedManifestRepoRoot(repoPath, repoArg) {
   return getCanonicalRepoRoot(repoPath);
 }
 
-function resolveBranch(ghBin, repoPath, prNumber, branchArg, manifestData) {
+function resolveBranch(repoPath, prNumber, branchArg, manifestData) {
   if (branchArg) return branchArg;
   if (manifestData?.git?.working_branch) return manifestData.git.working_branch;
   if (!prNumber) return null;
-  const raw = gh(ghBin, repoPath, "pr", "view", String(prNumber), "--json", "headRefName");
+  const raw = execGh(repoPath, ["pr", "view", String(prNumber), "--json", "headRefName"]);
   return JSON.parse(raw).headRefName;
 }
 
@@ -161,9 +145,9 @@ function mergeFlag(method) {
   }
 }
 
-function fetchPreMergeContext(ghBin, repoPath, prNumber) {
-  const raw = gh(ghBin, repoPath, "pr", "view", String(prNumber),
-    "--json", "comments,commits,mergeable,statusCheckRollup");
+function fetchPreMergeContext(repoPath, prNumber) {
+  const raw = execGh(repoPath, ["pr", "view", String(prNumber),
+    "--json", "comments,commits,mergeable,statusCheckRollup"]);
   const parsed = JSON.parse(raw);
   const checks = parsed.statusCheckRollup || [];
   return {
@@ -175,8 +159,8 @@ function fetchPreMergeContext(ghBin, repoPath, prNumber) {
   };
 }
 
-function fetchPrMergeState(ghBin, repoPath, prNumber) {
-  const raw = gh(ghBin, repoPath, "pr", "view", String(prNumber), "--json", "state,mergeCommit");
+function fetchPrMergeState(repoPath, prNumber) {
+  const raw = execGh(repoPath, ["pr", "view", String(prNumber), "--json", "state,mergeCommit"]);
   const parsed = JSON.parse(raw);
   return {
     state: parsed.state || null,
@@ -198,38 +182,38 @@ function assertPreMergeSafety(preMerge, prNumber) {
   }
 }
 
-function resolveRemoteName(gitBin, repoPath, branch) {
+function resolveRemoteName(repoPath, branch) {
   if (!branch) return null;
   try {
-    return git(gitBin, repoPath, "config", `branch.${branch}.remote`) || "origin";
+    return execGit(repoPath, ["config", `branch.${branch}.remote`]) || "origin";
   } catch {
     return "origin";
   }
 }
 
-function hasRemote(gitBin, repoPath, remoteName) {
+function hasRemote(repoPath, remoteName) {
   if (!remoteName) return false;
   try {
-    git(gitBin, repoPath, "remote", "get-url", remoteName);
+    execGit(repoPath, ["remote", "get-url", remoteName]);
     return true;
   } catch {
     return false;
   }
 }
 
-function remoteBranchExists(gitBin, repoPath, remoteName, branch) {
+function remoteBranchExists(repoPath, remoteName, branch) {
   if (!remoteName || !branch) return false;
   try {
-    git(gitBin, repoPath, "ls-remote", "--exit-code", "--heads", remoteName, branch);
+    execGit(repoPath, ["ls-remote", "--exit-code", "--heads", remoteName, branch]);
     return true;
   } catch {
     return false;
   }
 }
 
-function deleteRemoteBranch(gitBin, repoPath, branch) {
-  const remoteName = resolveRemoteName(gitBin, repoPath, branch);
-  if (!remoteName || !hasRemote(gitBin, repoPath, remoteName)) {
+function deleteRemoteBranch(repoPath, branch) {
+  const remoteName = resolveRemoteName(repoPath, branch);
+  if (!remoteName || !hasRemote(repoPath, remoteName)) {
     return {
       remoteName,
       attempted: false,
@@ -237,7 +221,7 @@ function deleteRemoteBranch(gitBin, repoPath, branch) {
       warning: null,
     };
   }
-  if (!remoteBranchExists(gitBin, repoPath, remoteName, branch)) {
+  if (!remoteBranchExists(repoPath, remoteName, branch)) {
     return {
       remoteName,
       attempted: false,
@@ -246,7 +230,7 @@ function deleteRemoteBranch(gitBin, repoPath, branch) {
     };
   }
   try {
-    git(gitBin, repoPath, "push", remoteName, "--delete", branch);
+    execGit(repoPath, ["push", remoteName, "--delete", branch]);
     return {
       remoteName,
       attempted: true,
@@ -286,8 +270,6 @@ function main() {
   const skipMerge = hasFlag("--skip-merge");
   const skipIssueClose = hasFlag("--no-issue-close");
   const jsonOut = hasFlag("--json");
-  const ghBin = process.env.RELAY_GH_BIN || "gh";
-  const gitBin = process.env.RELAY_GIT_BIN || "git";
   if (forceFinalizeNonready && !String(forceFinalizeReason || "").trim()) {
     throw new Error("--force-finalize-nonready requires --reason <non-empty-text>");
   }
@@ -352,7 +334,7 @@ function main() {
     STATES.READY_TO_MERGE,
   ]);
   prNumber = prNumber || safeData.git?.pr_number || null;
-  branch = resolveBranch(ghBin, repoPath, prNumber, branch, safeData);
+  branch = resolveBranch(repoPath, prNumber, branch, safeData);
   if (!skipMerge && !prNumber) {
     throw new Error("PR number is required for merge finalization");
   }
@@ -391,7 +373,7 @@ function main() {
   const skipReviewRubricStatus = skipReviewRubricAudit.rubricStatus;
 
   if (mergeAllowed) {
-    currentHeadSha = git(gitBin, validatedPaths.worktree, "rev-parse", "HEAD");
+    currentHeadSha = execGit(validatedPaths.worktree, ["rev-parse", "HEAD"]);
     if (skipReviewReason) {
       const skipReviewFailure = buildSkipReviewGateFailure(prNumber, skipReviewRubricAudit);
       if (skipReviewFailure) {
@@ -425,10 +407,10 @@ function main() {
           reason: skipReviewReason,
           rubric_status: skipReviewRubricStatus,
         });
-        gh(ghBin, repoPath, "pr", "comment", String(prNumber), "--body", skipComment);
+        execGh(repoPath, ["pr", "comment", String(prNumber), "--body", skipComment]);
       }
     } else if (safeData.state === STATES.READY_TO_MERGE) {
-      const preMerge = fetchPreMergeContext(ghBin, repoPath, prNumber);
+      const preMerge = fetchPreMergeContext(repoPath, prNumber);
       reviewGate = evaluateReviewGate({
         prNumber,
         comments: preMerge.comments,
@@ -452,7 +434,7 @@ function main() {
       }
       assertPreMergeSafety(preMerge, prNumber);
     } else if (forceFinalizeNonready) {
-      const preMerge = fetchPreMergeContext(ghBin, repoPath, prNumber);
+      const preMerge = fetchPreMergeContext(repoPath, prNumber);
       assertPreMergeSafety(preMerge, prNumber);
     }
   }
@@ -471,14 +453,14 @@ function main() {
       });
     }
 
-    prMergeState = dryRun ? prMergeState : fetchPrMergeState(ghBin, repoPath, prNumber);
+    prMergeState = dryRun ? prMergeState : fetchPrMergeState(repoPath, prNumber);
     if (!dryRun && prMergeState.state !== "MERGED") {
       try {
-        gh(ghBin, repoPath, "pr", "merge", String(prNumber), mergeFlag(mergeMethod));
+        execGh(repoPath, ["pr", "merge", String(prNumber), mergeFlag(mergeMethod)]);
         mergePerformed = true;
-        prMergeState = fetchPrMergeState(ghBin, repoPath, prNumber);
+        prMergeState = fetchPrMergeState(repoPath, prNumber);
       } catch (error) {
-        prMergeState = fetchPrMergeState(ghBin, repoPath, prNumber);
+        prMergeState = fetchPrMergeState(repoPath, prNumber);
         if (prMergeState.state !== "MERGED") {
           throw error;
         }
@@ -506,7 +488,7 @@ function main() {
       }
       for (let i = 0; i < MERGE_QUEUE_MAX_POLLS; i++) {
         Atomics.wait(sleepBuf, 0, 0, MERGE_QUEUE_POLL_INTERVAL_MS);
-        prMergeState = fetchPrMergeState(ghBin, repoPath, prNumber);
+        prMergeState = fetchPrMergeState(repoPath, prNumber);
         if (prMergeState.state === "MERGED") break;
         if (prMergeState.state === "OPEN") {
           appendRunEvent(repoPath, safeData.run_id, {
@@ -538,7 +520,7 @@ function main() {
       }
     }
     if (!dryRun) {
-      const remoteDelete = deleteRemoteBranch(gitBin, repoPath, branch);
+      const remoteDelete = deleteRemoteBranch(repoPath, branch);
       remoteName = remoteDelete.remoteName;
       remoteBranchDeleteAttempted = remoteDelete.attempted;
       remoteBranchDeleted = remoteDelete.deleted;
@@ -577,7 +559,7 @@ function main() {
   if (!skipIssueClose && issueNumber) {
     if (!dryRun) {
       try {
-        gh(ghBin, repoPath, "issue", "close", String(issueNumber), "--comment", `Resolved in PR #${prNumber}`);
+        execGh(repoPath, ["issue", "close", String(issueNumber), "--comment", `Resolved in PR #${prNumber}`]);
         issueClosed = true;
       } catch (error) {
         issueCloseWarning = summarizeError(error);
@@ -588,7 +570,6 @@ function main() {
   const cleanupResult = runCleanup({
     repoRoot: repoPath,
     data: updated,
-    gitBin,
     dryRun,
     deleteMergedBranch: updated.state === STATES.MERGED,
   });

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -26,7 +26,6 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execFileSync } = require("child_process");
 const {
   buildSkipReviewGateFailure,
   buildSkipComment,
@@ -49,6 +48,7 @@ const {
   hasFlag,
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
+const { execGh } = require("../../relay-dispatch/scripts/exec");
 
 function getGateCheckRepoRoot() {
   return getCanonicalRepoRoot(process.cwd());
@@ -93,14 +93,6 @@ if (SKIP && !SKIP_REASON) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function gh(...ghArgs) {
-  const ghBin = process.env.RELAY_GH_BIN || "gh";
-  return execFileSync(ghBin, ghArgs, {
-    encoding: "utf-8",
-    stdio: "pipe",
-  });
-}
-
 function tryResolveManifestForPr(prNumber, headRefName) {
   try {
     // gate-check runs before merge finalization, so it must never resolve merged/closed manifests.
@@ -129,7 +121,7 @@ function tryResolveManifestForPr(prNumber, headRefName) {
 
 function resolveSkipAuditContext(prNumber) {
   try {
-    const raw = gh("pr", "view", String(prNumber), "--json", "headRefName");
+    const raw = execGh(null, ["pr", "view", String(prNumber), "--json", "headRefName"]);
     const parsed = JSON.parse(raw);
     const manifestRecord = tryResolveManifestForPr(prNumber, parsed.headRefName || null);
     if (manifestRecord.error || !manifestRecord.data) {
@@ -285,7 +277,7 @@ function main() {
         readyToMerge: true,
       });
     } else {
-      gh("pr", "comment", PR_NUM, "--body", skipComment);
+      execGh(null, ["pr", "comment", PR_NUM, "--body", skipComment]);
       output({
         status: "skipped",
         pr: PR_NUM,
@@ -318,7 +310,7 @@ function main() {
       commits = [];
     }
   } else {
-    const raw = gh("pr", "view", PR_NUM, "--json", "comments,commits,headRefName");
+    const raw = execGh(null, ["pr", "view", PR_NUM, "--json", "comments,commits,headRefName"]);
     const parsed = JSON.parse(raw);
     comments = parsed.comments || [];
     commits = parsed.commits || [];

--- a/skills/relay-review/scripts/review-runner/common.js
+++ b/skills/relay-review/scripts/review-runner/common.js
@@ -1,27 +1,16 @@
-const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const { execGit, execGh } = require("../../../relay-dispatch/scripts/exec");
 
-function gh(repoPath, ...ghArgs) {
+const gh = (repoPath, ...ghArgs) => {
   const lastArg = ghArgs.at(-1);
   const options = lastArg && typeof lastArg === "object" && !Array.isArray(lastArg)
     ? ghArgs.pop()
     : {};
-  return execFileSync("gh", ghArgs, {
-    cwd: repoPath,
-    encoding: "utf-8",
-    stdio: "pipe",
-    ...(options.timeout ? { timeout: options.timeout } : {}),
-  });
-}
+  return execGh(repoPath, ghArgs, options);
+};
 
-function git(repoPath, ...gitArgs) {
-  return execFileSync("git", gitArgs, {
-    cwd: repoPath,
-    encoding: "utf-8",
-    stdio: "pipe",
-  });
-}
+const git = (repoPath, ...gitArgs) => execGit(repoPath, gitArgs);
 
 function parsePositiveInt(value, label) {
   if (value === undefined) return undefined;

--- a/skills/relay-review/scripts/review-runner/pr-body-snapshot.js
+++ b/skills/relay-review/scripts/review-runner/pr-body-snapshot.js
@@ -51,7 +51,7 @@ function writePrBodySnapshot({ repoPath, runId, round, prNumber, prBodyPath }) {
     const body = gh(
       repoPath,
       "pr", "view", String(prNumber), "--json", "body", "-q", ".body",
-      { timeout: PR_BODY_SNAPSHOT_TIMEOUT_MS }
+      { timeout: PR_BODY_SNAPSHOT_TIMEOUT_MS, raw: true }
     );
     writeText(prBodyPath, `${String(body).replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n?$/, "\n")}`);
     return { status: "loaded", reason: null };


### PR DESCRIPTION

## Summary
- Added `skills/relay-dispatch/scripts/exec.js` with `execGit` and `execGh`, including centralized `RELAY_GIT_BIN` / `RELAY_GH_BIN` resolution.
- Migrated the 12 in-scope `git()` / `gh()` wrapper sites across dispatch, merge, and review code to route through the shared helpers.
- Removed the `runCleanup({ gitBin })` pass-through and now use `execGit` inside cleanup internals.

## Reconciliation Decisions
1. Git uses `git -C <repo>` and gh uses `cwd: repoPath`, matching the acceptance criteria. `gate-check.js` passes `null` for repo-agnostic gh calls.
2. Output trims by default, with `opts.raw = true` for callers that need exact output. The review-runner callsites tolerate trimming for JSON, status, and diff parsing; `pr-body-snapshot.js` uses `raw: true` to preserve PR body text before its existing newline normalization.
3. `stdio: "pipe"` is enforced in `exec.js` for both helpers, so child output remains consistently suppressed.
4. `execGh(null, args)` omits `cwd` and inherits the process cwd. `exec.js` also strips caller-provided `cwd`, `encoding`, and `stdio` from opts so these defaults stay centralized.
5. `runCleanup` no longer accepts `gitBin`; `readWorktreeStatus`, `localBranchExists`, and cleanup git operations call `execGit` directly. `close-run.js`, `cleanup-worktrees.js`, and `finalize-run.js` no longer pass git binaries through cleanup.

## Scope Boundary
The direct inline `execFileSync("gh", ...)` calls remain intentionally untouched because they are not wrapped helper callsites and are deferred to a follow-up:
- `skills/relay-review/scripts/review-runner/context.js:113` (`gh auth status`)
- `skills/relay-review/scripts/review-runner/context.js:131` (login lookup)
- `skills/relay-review/scripts/review-runner/context.js:159` (`gh api user`)
- `skills/relay-review/scripts/analyze-flip-flop-pattern.js:660` (`gh issue comment`)
- `skills/relay-plan/scripts/plan-runner.js:43` (`gh issue view`)

## Tests
- `node --test skills/*/scripts/*.test.js` -> 952 pass / 0 fail
- `node --test skills/relay-dispatch/scripts/exec.test.js` -> 2 pass / 0 fail
- wrapper sweep -> 0
- env-var read sweep -> 0

Closes #314.

## Score Log

| Factor | Target | Baseline | R1 | Status |
|---|---|---|---|---|
| exec.js API surface + env-override test | exits 0 / prints "ok" | FAIL (didn't exist) | TBD | — |
| Wrapper-definition sweep | 0 hits | 12 | TBD | — |
| Env-var read sweep | 0 hits | 7 | TBD | — |
| Reconciliation decisions documented | ≥ 8/10 | 0 | TBD | — |
| Behavior + scope discipline | ≥ 8/10 | 0 | TBD | — |

- Run: `issue-314-20260428135622513-60985525`
- Executor: codex (gpt-5.5, reasoning=high, 885s elapsed)
- Branch: `issue-314`