### PR TITLE
Consolidate duplicated relay utilities

### DIFF
--- a/skills/relay-dispatch/scripts/claude-app-register.js
+++ b/skills/relay-dispatch/scripts/claude-app-register.js
@@ -13,6 +13,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { execGit } = require("./exec");
+const { nowIso } = require("./manifest/paths");
 
 function generateUUIDv7() {
   const now = BigInt(Date.now());
@@ -26,10 +27,6 @@ function generateUUIDv7() {
   buf[8] = (buf[8] & 0x3f) | 0x80;
   const hex = buf.toString("hex");
   return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)].join("-");
-}
-
-function nowISO() {
-  return new Date().toISOString().replace(/\.\d{3}Z$/, ".000Z");
 }
 
 function getClaudeVersion() {
@@ -65,7 +62,7 @@ function registerClaudeApp({ wtPath, repoPath, branch, title, pin = false }) {
 
   const metadata = {
     version: "1",
-    created_at: nowISO(),
+    created_at: nowIso({ zeroMilliseconds: true }),
     session_id: sessionId,
     branch,
     title,

--- a/skills/relay-dispatch/scripts/codex-app-register.js
+++ b/skills/relay-dispatch/scripts/codex-app-register.js
@@ -13,6 +13,7 @@ const path = require("path");
 const crypto = require("crypto");
 const os = require("os");
 const { execGit } = require("./exec");
+const { nowIso } = require("./manifest/paths");
 
 const SOURCE = "vscode";
 const MODEL_PROVIDER = "openai";
@@ -46,10 +47,6 @@ function getCodexVersion() {
   }
 }
 
-function nowISO() {
-  return new Date().toISOString().replace(/\.\d{3}Z$/, ".000Z");
-}
-
 function ensureInArray(obj, key, value) {
   const arr = obj[key] || [];
   if (!arr.includes(value)) arr.push(value);
@@ -74,7 +71,7 @@ function registerCodexApp({ wtPath, repoPath, branch, title, pin = false }) {
   const SESSION_INDEX = path.join(CODEX_HOME, "session_index.jsonl");
 
   const threadId = generateUUIDv7();
-  const now = nowISO();
+  const now = nowIso({ zeroMilliseconds: true });
   const epoch = Math.floor(Date.now() / 1000);
 
   let gitSha = "", gitOrigin = "";

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -84,6 +84,7 @@ const {
   getManifestPath,
   getRunDir,
   inferIssueNumber,
+  looksLikeGitRepo,
   sameFilesystemLocation,
   validateManifestPaths,
 } = require("./manifest/paths");
@@ -372,10 +373,6 @@ function resolveBaseBranchForNewDispatch(repoDir) {
 
 function shellQuote(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
-}
-
-function looksLikeGitRepo(repoPath) {
-  return fs.existsSync(path.join(repoPath, ".git"));
 }
 
 function terminateProcessTree(pid) {

--- a/skills/relay-dispatch/scripts/manifest/attempts.js
+++ b/skills/relay-dispatch/scripts/manifest/attempts.js
@@ -3,15 +3,12 @@ const path = require("path");
 const {
   ensureRunLayout,
   getRunDir,
+  nowIso,
 } = require("./paths");
 const {
   readTextFileWithoutFollowingSymlinks,
   writeTextFileWithoutFollowingSymlinks,
 } = require("./rubric");
-
-function nowIso() {
-  return new Date().toISOString();
-}
 
 function getAttemptsPath(repoRoot, runId) {
   return path.join(getRunDir(repoRoot, runId), "previous-attempts.json");

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -2,8 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 const { execGit } = require("../exec");
-const { validateManifestPaths } = require("./paths");
-const { summarizeError } = require("./store");
+const { summarizeFailure, validateManifestPaths } = require("./paths");
 
 const CLEANUP_STATUSES = Object.freeze({
   PENDING: "pending",
@@ -71,7 +70,7 @@ function readWorktreeStatus(worktreePath) {
     const status = execGit(worktreePath, ["status", "--short", "--untracked-files=all"]);
     return { exists: true, clean: status === "", text: status };
   } catch (error) {
-    return { exists: true, clean: false, text: `unable to inspect worktree: ${summarizeError(error)}` };
+    return { exists: true, clean: false, text: `unable to inspect worktree: ${summarizeFailure(error)}` };
   }
 }
 
@@ -153,12 +152,12 @@ function runCleanup({
             }
           } catch (fallbackError) {
             errors.push(
-              `worktree remove failed: ${summarizeError(error)}; ` +
-              `rm fallback failed: ${summarizeError(fallbackError)}`
+              `worktree remove failed: ${summarizeFailure(error)}; ` +
+              `rm fallback failed: ${summarizeFailure(fallbackError)}`
             );
           }
         } else {
-          errors.push(`worktree remove failed: ${summarizeError(error)}`);
+          errors.push(`worktree remove failed: ${summarizeFailure(error)}`);
         }
       }
     }
@@ -170,7 +169,7 @@ function runCleanup({
         execGit(repoRoot, ["branch", "-D", branch]);
         branchDeleted = true;
       } catch (error) {
-        errors.push(`branch delete failed: ${summarizeError(error)}`);
+        errors.push(`branch delete failed: ${summarizeFailure(error)}`);
       }
     }
   }
@@ -181,7 +180,7 @@ function runCleanup({
         execGit(repoRoot, ["worktree", "prune"]);
         pruneRan = true;
       } catch (error) {
-        errors.push(`worktree prune failed: ${summarizeError(error)}`);
+        errors.push(`worktree prune failed: ${summarizeFailure(error)}`);
       }
     }
   }

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 const { execGit } = require("../exec");
-const { summarizeFailure, validateManifestPaths } = require("./paths");
+const { nowIso, summarizeFailure, validateManifestPaths } = require("./paths");
 
 const CLEANUP_STATUSES = Object.freeze({
   PENDING: "pending",
@@ -10,10 +10,6 @@ const CLEANUP_STATUSES = Object.freeze({
   FAILED: "failed",
   SKIPPED: "skipped",
 });
-
-function nowIso() {
-  return new Date().toISOString();
-}
 
 function createCleanupSkeleton() {
   return {

--- a/skills/relay-dispatch/scripts/manifest/environment.js
+++ b/skills/relay-dispatch/scripts/manifest/environment.js
@@ -2,10 +2,7 @@ const { execFileSync } = require("child_process");
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
-
-function nowIso() {
-  return new Date().toISOString();
-}
+const { nowIso } = require("./paths");
 
 function collectEnvironmentSnapshot(repoRoot, baseBranch) {
   let mainSha = null;

--- a/skills/relay-dispatch/scripts/manifest/lifecycle.js
+++ b/skills/relay-dispatch/scripts/manifest/lifecycle.js
@@ -1,3 +1,4 @@
+const { nowIso } = require("./paths");
 const { getRubricAnchorStatus } = require("./rubric");
 
 const STATES = Object.freeze({
@@ -21,10 +22,6 @@ const ALLOWED_TRANSITIONS = Object.freeze({
   [STATES.MERGED]: new Set(),
   [STATES.CLOSED]: new Set(),
 });
-
-function nowIso() {
-  return new Date().toISOString();
-}
 
 function validateTransition(fromState, toState) {
   if (!Object.values(STATES).includes(fromState)) {

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -80,6 +80,11 @@ function parsePositiveInt(value, label) {
   return parsed;
 }
 
+function nowIso({ zeroMilliseconds = false } = {}) {
+  const iso = new Date().toISOString();
+  return zeroMilliseconds ? iso.replace(/\.\d{3}Z$/, ".000Z") : iso;
+}
+
 function getRepoSlug(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {
     throw new Error(`getRepoSlug requires a non-empty repoRoot path, got: ${JSON.stringify(repoRoot)}`);
@@ -447,6 +452,7 @@ module.exports = {
   isPathContainedWithin,
   listManifestPaths,
   looksLikeGitRepo,
+  nowIso,
   parsePositiveInt,
   requireValidRunId,
   sameFilesystemLocation,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -71,6 +71,15 @@ function getExpectedManifestRepoRoot(repoPath, repoArg) {
   return getCanonicalRepoRoot(repoPath);
 }
 
+function parsePositiveInt(value, label) {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
 function getRepoSlug(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {
     throw new Error(`getRepoSlug requires a non-empty repoRoot path, got: ${JSON.stringify(repoRoot)}`);
@@ -438,6 +447,7 @@ module.exports = {
   isPathContainedWithin,
   listManifestPaths,
   looksLikeGitRepo,
+  parsePositiveInt,
   requireValidRunId,
   sameFilesystemLocation,
   summarizeFailure,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -71,11 +71,13 @@ function getExpectedManifestRepoRoot(repoPath, repoArg) {
   return getCanonicalRepoRoot(repoPath);
 }
 
-function parsePositiveInt(value, label) {
+function parsePositiveInt(value, label, { allowZero = false } = {}) {
   if (value === undefined) return undefined;
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${label} must be a positive integer`);
+  const minRejected = allowZero ? parsed < 0 : parsed <= 0;
+  if (!Number.isInteger(parsed) || minRejected) {
+    const requirement = allowZero ? "non-negative integer" : "positive integer";
+    throw new Error(`${label} must be a ${requirement}`);
   }
   return parsed;
 }

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -64,6 +64,13 @@ function looksLikeGitRepo(repoPath) {
   return fs.existsSync(path.join(repoPath, ".git"));
 }
 
+function getExpectedManifestRepoRoot(repoPath, repoArg) {
+  if (!repoArg && !looksLikeGitRepo(repoPath)) {
+    return undefined;
+  }
+  return getCanonicalRepoRoot(repoPath);
+}
+
 function getRepoSlug(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {
     throw new Error(`getRepoSlug requires a non-empty repoRoot path, got: ${JSON.stringify(repoRoot)}`);
@@ -418,6 +425,7 @@ module.exports = {
   ensureRunLayout,
   getCanonicalRepoRoot,
   getEventsPath,
+  getExpectedManifestRepoRoot,
   getManifestPath,
   getRelayHome,
   getRelayWorktreeBase,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -60,6 +60,10 @@ function getCanonicalRepoRoot(input) {
   }
 }
 
+function looksLikeGitRepo(repoPath) {
+  return fs.existsSync(path.join(repoPath, ".git"));
+}
+
 function getRepoSlug(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {
     throw new Error(`getRepoSlug requires a non-empty repoRoot path, got: ${JSON.stringify(repoRoot)}`);
@@ -425,6 +429,7 @@ module.exports = {
   inferIssueNumber,
   isPathContainedWithin,
   listManifestPaths,
+  looksLikeGitRepo,
   requireValidRunId,
   sameFilesystemLocation,
   validateManifestPaths,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-function summarizeError(error) {
+function summarizeFailure(error) {
   const stderr = String(error.stderr || "").trim();
   const stdout = String(error.stdout || "").trim();
   return stderr || stdout || error.message;
@@ -53,7 +53,7 @@ function getCanonicalRepoRoot(input) {
     return fs.realpathSync(path.dirname(commonDir));
   } catch (error) {
     const resolutionError = new Error(
-      `getCanonicalRepoRoot: unable to resolve main repo root from ${repoInput}: ${summarizeError(error)}`
+      `getCanonicalRepoRoot: unable to resolve main repo root from ${repoInput}: ${summarizeFailure(error)}`
     );
     resolutionError.name = "CanonicalRepoRootResolutionError";
     throw resolutionError;
@@ -440,6 +440,7 @@ module.exports = {
   looksLikeGitRepo,
   requireValidRunId,
   sameFilesystemLocation,
+  summarizeFailure,
   validateManifestPaths,
   validateRunId,
 };

--- a/skills/relay-dispatch/scripts/manifest/rubric.js
+++ b/skills/relay-dispatch/scripts/manifest/rubric.js
@@ -6,7 +6,7 @@ const {
   isPathContainedWithin,
   validateRunId,
 } = require("./paths");
-const { summarizeError } = require("./store");
+const { summarizeFailure } = require("./paths");
 
 function hasRubricPath(data) {
   return typeof data?.anchor?.rubric_path === "string" && data.anchor.rubric_path.trim() !== "";
@@ -212,7 +212,7 @@ function validateRubricPathContainment(rubricPath, runDir) {
       runDir: resolvedRunDir,
       resolvedPath,
       realPath: null,
-      reason: `Unable to resolve the real run directory for anchor.rubric_path=${JSON.stringify(normalizedPath)}: ${summarizeError(error)}`,
+      reason: `Unable to resolve the real run directory for anchor.rubric_path=${JSON.stringify(normalizedPath)}: ${summarizeFailure(error)}`,
     };
   }
 }
@@ -476,7 +476,7 @@ function getRubricAnchorStatus(data, options = {}) {
       ...baseStatus,
       ...containment,
       status: "unreadable",
-      error: `Unable to read rubric file ${containment.resolvedPath}: ${summarizeError(error)}`,
+      error: `Unable to read rubric file ${containment.resolvedPath}: ${summarizeFailure(error)}`,
     };
   }
 }

--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -5,15 +5,12 @@ const path = require("path");
 const {
   ensureRunLayout,
   listManifestPaths,
+  nowIso,
   requireValidRunId,
 } = require("./paths");
 
 const RELAY_VERSION = 2;
 const NOTES_TEMPLATE = "# Notes\n\n## Context\n\n## Review History\n";
-
-function nowIso() {
-  return new Date().toISOString();
-}
 
 function getActorName(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {

--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -257,12 +257,6 @@ function createManifestSkeleton({
   return manifest;
 }
 
-function summarizeError(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
-}
-
 module.exports = {
   NOTES_TEMPLATE,
   RELAY_VERSION,
@@ -273,6 +267,5 @@ module.exports = {
   nowIso,
   parseFrontmatter,
   readManifest,
-  summarizeError,
   writeManifest,
 };

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -12,7 +12,7 @@ const { parsePrNumber, formatExecError } = require("./dispatch-publish");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { STATES } = require("./manifest/lifecycle");
-const { getCanonicalRepoRoot, getRunDir, summarizeFailure, validateManifestPaths } = require("./manifest/paths");
+const { getCanonicalRepoRoot, getRunDir, nowIso, summarizeFailure, validateManifestPaths } = require("./manifest/paths");
 const { stampPrNumberUnderLock } = require("./manifest/pr-number-stamp");
 const { rebrandEvidence } = require("./execution-evidence");
 const {
@@ -49,10 +49,6 @@ function printHelp(exitCode) {
 
 if (!args.length || hasCliFlag(["--help", "-h"])) {
   printHelp(hasCliFlag(["--help", "-h"]) ? 0 : 1);
-}
-
-function nowIso() {
-  return new Date().toISOString();
 }
 
 function shellQuote(value) {

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -12,8 +12,7 @@ const { parsePrNumber, formatExecError } = require("./dispatch-publish");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { STATES } = require("./manifest/lifecycle");
-const { getCanonicalRepoRoot, getRunDir, validateManifestPaths } = require("./manifest/paths");
-const { summarizeError } = require("./manifest/store");
+const { getCanonicalRepoRoot, getRunDir, summarizeFailure, validateManifestPaths } = require("./manifest/paths");
 const { stampPrNumberUnderLock } = require("./manifest/pr-number-stamp");
 const { rebrandEvidence } = require("./execution-evidence");
 const {
@@ -176,7 +175,7 @@ function resolveRun({ repoArg, runId, manifestArg }) {
       runId,
     });
   } catch (error) {
-    throw new Error(`run_resolution_failed: ${summarizeError(error)}`);
+    throw new Error(`run_resolution_failed: ${summarizeFailure(error)}`);
   }
 }
 

--- a/skills/relay-dispatch/scripts/update-manifest-state.js
+++ b/skills/relay-dispatch/scripts/update-manifest-state.js
@@ -32,6 +32,7 @@ const {
   readManifest,
   writeManifest,
 } = require("./manifest/store");
+const { parsePositiveInt } = require("./manifest/paths");
 const { getArg, hasFlag, modeLabel } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
 
@@ -59,15 +60,6 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --dry-run            ${modeLabel("--dry-run")} Print result without writing`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(hasCliFlag(["--help", "-h"]) ? 0 : 1);
-}
-
-function parsePositiveInt(value, label) {
-  if (value === undefined) return undefined;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`${label} must be a non-negative integer`);
-  }
-  return parsed;
 }
 
 function defaultNextAction(state) {

--- a/skills/relay-dispatch/scripts/update-manifest-state.js
+++ b/skills/relay-dispatch/scripts/update-manifest-state.js
@@ -108,13 +108,13 @@ function main() {
   const manifestPath = resolveManifestPath();
   const { data, body } = readManifest(manifestPath);
   const nextAction = getArg(args, "--next-action", undefined, CLI_ARG_OPTIONS) || defaultNextAction(targetState);
-  const prNumber = parsePositiveInt(getArg(args, "--pr-number", undefined, CLI_ARG_OPTIONS), "--pr-number");
+  const prNumber = parsePositiveInt(getArg(args, "--pr-number", undefined, CLI_ARG_OPTIONS), "--pr-number", { allowZero: true });
   const headSha = getArg(args, "--head-sha", undefined, CLI_ARG_OPTIONS);
-  const rounds = parsePositiveInt(getArg(args, "--rounds", undefined, CLI_ARG_OPTIONS), "--rounds");
+  const rounds = parsePositiveInt(getArg(args, "--rounds", undefined, CLI_ARG_OPTIONS), "--rounds", { allowZero: true });
   const verdict = getArg(args, "--verdict", undefined, CLI_ARG_OPTIONS);
   const lastReviewedSha = getArg(args, "--last-reviewed-sha", undefined, CLI_ARG_OPTIONS);
-  const maxRounds = parsePositiveInt(getArg(args, "--max-rounds", undefined, CLI_ARG_OPTIONS), "--max-rounds");
-  const repeatedIssueCount = parsePositiveInt(getArg(args, "--repeated-issue-count", undefined, CLI_ARG_OPTIONS), "--repeated-issue-count");
+  const maxRounds = parsePositiveInt(getArg(args, "--max-rounds", undefined, CLI_ARG_OPTIONS), "--max-rounds", { allowZero: true });
+  const repeatedIssueCount = parsePositiveInt(getArg(args, "--repeated-issue-count", undefined, CLI_ARG_OPTIONS), "--repeated-issue-count", { allowZero: true });
 
   let updated = updateManifestState(data, targetState, nextAction);
 

--- a/skills/relay-intake/scripts/relay-request.js
+++ b/skills/relay-intake/scripts/relay-request.js
@@ -8,6 +8,7 @@ const {
   parseFrontmatter,
   writeManifest,
 } = require("../../relay-dispatch/scripts/relay-manifest");
+const { nowIso } = require("../../relay-dispatch/scripts/manifest/paths");
 
 const READINESS_LEVELS = {
   clarity: new Set(["high", "medium", "low"]),
@@ -26,10 +27,6 @@ const DEFAULT_NEXT_ACTIONS = {
   propose: "await_proposal_response",
   structure: "await_proposal_response",
 };
-
-function nowIso() {
-  return new Date().toISOString();
-}
 
 function createRequestId(timestamp = new Date()) {
   const iso = timestamp.toISOString().replace(/[-:TZ.]/g, "").slice(0, 17);

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -31,9 +31,8 @@
 
 const path = require("path");
 const {
-  getCanonicalRepoRoot,
+  getExpectedManifestRepoRoot,
   getRunDir,
-  looksLikeGitRepo,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
@@ -111,13 +110,6 @@ function parsePositiveInt(value, label) {
 
 function hasLegacyBootstrapReasonPrefix(reason) {
   return LEGACY_BOOTSTRAP_REASON_PREFIX.exec(String(reason || "")) !== null;
-}
-
-function getExpectedManifestRepoRoot(repoPath, repoArg) {
-  if (!repoArg && !looksLikeGitRepo(repoPath)) {
-    return undefined;
-  }
-  return getCanonicalRepoRoot(repoPath);
 }
 
 function resolveBranch(repoPath, prNumber, branchArg, manifestData) {

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -29,11 +29,11 @@
  *   --help, -h             Show usage
  */
 
-const fs = require("fs");
 const path = require("path");
 const {
   getCanonicalRepoRoot,
   getRunDir,
+  looksLikeGitRepo,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
@@ -111,10 +111,6 @@ function parsePositiveInt(value, label) {
 
 function hasLegacyBootstrapReasonPrefix(reason) {
   return LEGACY_BOOTSTRAP_REASON_PREFIX.exec(String(reason || "")) !== null;
-}
-
-function looksLikeGitRepo(repoPath) {
-  return fs.existsSync(path.join(repoPath, ".git"));
 }
 
 function getExpectedManifestRepoRoot(repoPath, repoArg) {

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -33,6 +33,7 @@ const path = require("path");
 const {
   getExpectedManifestRepoRoot,
   getRunDir,
+  parsePositiveInt,
   summarizeFailure,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
@@ -97,15 +98,6 @@ if (!args.length || helpRequested) {
   console.log("  State is 'escalated' + dispatch-level failure resolved:  --force-finalize-nonready --reason <text>");
   console.log("  State is 'ready_to_merge':                               neither - just run finalize-run");
   process.exit(helpRequested ? 0 : 1);
-}
-
-function parsePositiveInt(value, label) {
-  if (value === undefined) return undefined;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${label} must be a positive integer`);
-  }
-  return parsed;
 }
 
 function hasLegacyBootstrapReasonPrefix(reason) {

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -33,6 +33,7 @@ const path = require("path");
 const {
   getExpectedManifestRepoRoot,
   getRunDir,
+  summarizeFailure,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
@@ -42,7 +43,6 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/lifecycle");
 const {
   getActorName,
-  summarizeError,
   writeManifest,
 } = require("../../relay-dispatch/scripts/manifest/store");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
@@ -230,7 +230,7 @@ function deleteRemoteBranch(repoPath, branch) {
       remoteName,
       attempted: true,
       deleted: false,
-      warning: summarizeError(error),
+      warning: summarizeFailure(error),
     };
   }
 }
@@ -550,7 +550,7 @@ function main() {
         execGh(repoPath, ["issue", "close", String(issueNumber), "--comment", `Resolved in PR #${prNumber}`]);
         issueClosed = true;
       } catch (error) {
-        issueCloseWarning = summarizeError(error);
+        issueCloseWarning = summarizeFailure(error);
       }
     }
   }

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.js
@@ -22,9 +22,9 @@
  */
 
 const path = require("path");
-const fs = require("fs");
 const {
   getCanonicalRepoRoot,
+  looksLikeGitRepo,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
@@ -84,10 +84,6 @@ function parsePositiveInt(value, label) {
     throw new Error(`${label} must be a positive integer`);
   }
   return parsed;
-}
-
-function looksLikeGitRepo(repoPath) {
-  return fs.existsSync(path.join(repoPath, ".git"));
 }
 
 function getExpectedManifestRepoRoot(repoPath, repoArg) {

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.js
@@ -24,6 +24,7 @@
 const path = require("path");
 const {
   getExpectedManifestRepoRoot,
+  parsePositiveInt,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
@@ -74,17 +75,6 @@ function requireNonEmptyArg(flag, label) {
   return value.trim();
 }
 
-function parsePositiveInt(value, label) {
-  if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`${label} is required`);
-  }
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${label} must be a positive integer`);
-  }
-  return parsed;
-}
-
 function sameBootstrapExemption(data, { artifactPath, writerPr, reason }) {
   const existing = data?.bootstrap_exempt || {};
   return (
@@ -97,7 +87,7 @@ function sameBootstrapExemption(data, { artifactPath, writerPr, reason }) {
 
 function main() {
   const artifactPath = requireNonEmptyArg("--artifact-path", "--artifact-path <path>");
-  const writerPr = parsePositiveInt(getArg("--writer-pr"), "--writer-pr <int>");
+  const writerPr = parsePositiveInt(requireNonEmptyArg("--writer-pr", "--writer-pr <int>"), "--writer-pr <int>");
   const reason = requireNonEmptyArg("--reason", "--reason <text>");
   const skipReviewReason = getArg("--skip-review");
   if (hasFlag("--skip-review") && !String(skipReviewReason || "").trim()) {

--- a/skills/relay-merge/scripts/relay-reconcile-artifact.js
+++ b/skills/relay-merge/scripts/relay-reconcile-artifact.js
@@ -23,8 +23,7 @@
 
 const path = require("path");
 const {
-  getCanonicalRepoRoot,
-  looksLikeGitRepo,
+  getExpectedManifestRepoRoot,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
@@ -84,13 +83,6 @@ function parsePositiveInt(value, label) {
     throw new Error(`${label} must be a positive integer`);
   }
   return parsed;
-}
-
-function getExpectedManifestRepoRoot(repoPath, repoArg) {
-  if (!repoArg && !looksLikeGitRepo(repoPath)) {
-    return undefined;
-  }
-  return getCanonicalRepoRoot(repoPath);
 }
 
 function sameBootstrapExemption(data, { artifactPath, writerPr, reason }) {

--- a/skills/relay-plan/scripts/invoke-planner-claude.js
+++ b/skills/relay-plan/scripts/invoke-planner-claude.js
@@ -7,6 +7,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { summarizeFailure } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
   bindCliArgs,
   modeLabel,
@@ -34,12 +35,6 @@ if (!args.length || hasFlag(["--help", "-h"])) {
   console.log(`  --model <name>       ${modeLabel("--model")} Model override`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(hasFlag(["--help", "-h"]) ? 0 : 1);
-}
-
-function summarizeFailure(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
 }
 
 function ensurePlannerJson(text, label) {

--- a/skills/relay-plan/scripts/invoke-planner-codex.js
+++ b/skills/relay-plan/scripts/invoke-planner-codex.js
@@ -7,6 +7,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { summarizeFailure } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
   bindCliArgs,
   modeLabel,
@@ -34,12 +35,6 @@ if (!args.length || hasFlag(["--help", "-h"])) {
   console.log(`  --model <name>       ${modeLabel("--model")} Model override`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(hasFlag(["--help", "-h"]) ? 0 : 1);
-}
-
-function summarizeFailure(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
 }
 
 function readNonEmptyFile(filePath) {

--- a/skills/relay-plan/scripts/plan-runner.js
+++ b/skills/relay-plan/scripts/plan-runner.js
@@ -3,6 +3,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { summarizeFailure } = require("../../relay-dispatch/scripts/manifest/paths");
 const {
   bindCliArgs,
   modeLabel,
@@ -31,12 +32,6 @@ if (require.main === module && (!args.length || hasFlag(["--help", "-h"]))) {
   console.log(`  --out-dir <path>  ${modeLabel("--out-dir")} Directory for generated artifacts`);
   console.log(`  --json            ${modeLabel("--json")} Output JSON`);
   process.exit(hasFlag(["--help", "-h"]) ? 0 : 1);
-}
-
-function summarizeFailure(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
 }
 
 function readIssueBody(repoPath, issueNumber) {

--- a/skills/relay-review/scripts/analyze-flip-flop-pattern.js
+++ b/skills/relay-review/scripts/analyze-flip-flop-pattern.js
@@ -28,6 +28,7 @@ const path = require("path");
 
 const {
   getRunsBase,
+  parsePositiveInt,
   validateRunId,
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const { readManifest } = require("../../relay-dispatch/scripts/manifest/store");
@@ -55,14 +56,6 @@ const CLI_ARG_OPTIONS = {
   commandName: "analyze-flip-flop-pattern",
   reservedFlags: [...KNOWN_FLAGS],
 };
-
-function parsePositiveInt(value, label) {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${label} must be a positive integer`);
-  }
-  return parsed;
-}
 
 function parseArgs(argv) {
   const args = [...argv];

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -95,7 +95,8 @@ function printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, origin
 }
 
 function run() {
-  const repoPath = path.resolve(getArg("--repo") || ".");
+  const repoArg = getArg("--repo");
+  const repoPath = path.resolve(repoArg || ".");
   const manifestPathArg = getArg("--manifest");
   const runIdArg = getArg("--run-id");
   const branchArg = getArg("--branch");
@@ -112,6 +113,7 @@ function run() {
 
   const { branch, issueNumber, manifest, prNumber, reviewRepoPath, runRepoPath } = resolveContext(
     repoPath,
+    repoArg,
     manifestPathArg,
     runIdArg,
     branchArg,

--- a/skills/relay-review/scripts/review-runner/common.js
+++ b/skills/relay-review/scripts/review-runner/common.js
@@ -32,14 +32,9 @@ function writeText(filePath, text) {
   fs.writeFileSync(filePath, text, "utf-8");
 }
 
-function looksLikeGitRepo(repoPath) {
-  return fs.existsSync(path.join(repoPath, ".git"));
-}
-
 module.exports = {
   gh,
   git,
-  looksLikeGitRepo,
   parsePositiveInt,
   readText,
   RUBRIC_PASS_THROUGH_STATES,

--- a/skills/relay-review/scripts/review-runner/common.js
+++ b/skills/relay-review/scripts/review-runner/common.js
@@ -14,15 +14,6 @@ const git = (repoPath, ...gitArgs) => execGit(repoPath, gitArgs);
 
 const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded"]);
 
-function parsePositiveInt(value, label) {
-  if (value === undefined) return undefined;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${label} must be a positive integer`);
-  }
-  return parsed;
-}
-
 function readText(filePath) {
   return fs.readFileSync(filePath, "utf-8");
 }
@@ -35,7 +26,6 @@ function writeText(filePath, text) {
 module.exports = {
   gh,
   git,
-  parsePositiveInt,
   readText,
   RUBRIC_PASS_THROUGH_STATES,
   writeText,

--- a/skills/relay-review/scripts/review-runner/common.js
+++ b/skills/relay-review/scripts/review-runner/common.js
@@ -12,6 +12,8 @@ const gh = (repoPath, ...ghArgs) => {
 
 const git = (repoPath, ...gitArgs) => execGit(repoPath, gitArgs);
 
+const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded"]);
+
 function parsePositiveInt(value, label) {
   if (value === undefined) return undefined;
   const parsed = Number(value);
@@ -40,5 +42,6 @@ module.exports = {
   looksLikeGitRepo,
   parsePositiveInt,
   readText,
+  RUBRIC_PASS_THROUGH_STATES,
   writeText,
 };

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -7,9 +7,7 @@ const {
 } = require("../../../relay-dispatch/scripts/manifest/paths");
 const { resolveManifestRecord } = require("../../../relay-dispatch/scripts/relay-resolver");
 const { getRubricAnchorStatus } = require("../../../relay-dispatch/scripts/manifest/rubric");
-const { gh, looksLikeGitRepo, parsePositiveInt, readText } = require("./common");
-
-const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded"]);
+const { gh, looksLikeGitRepo, parsePositiveInt, readText, RUBRIC_PASS_THROUGH_STATES } = require("./common");
 
 // DNS hostname validation — conservative label allowlist. Rejects leading
 // dashes (which could be interpreted as flags by some CLI tools), whitespace,

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -3,11 +3,12 @@ const fs = require("fs");
 const path = require("path");
 const {
   getCanonicalRepoRoot,
+  looksLikeGitRepo,
   validateManifestPaths,
 } = require("../../../relay-dispatch/scripts/manifest/paths");
 const { resolveManifestRecord } = require("../../../relay-dispatch/scripts/relay-resolver");
 const { getRubricAnchorStatus } = require("../../../relay-dispatch/scripts/manifest/rubric");
-const { gh, looksLikeGitRepo, parsePositiveInt, readText, RUBRIC_PASS_THROUGH_STATES } = require("./common");
+const { gh, parsePositiveInt, readText, RUBRIC_PASS_THROUGH_STATES } = require("./common");
 
 // DNS hostname validation — conservative label allowlist. Rejects leading
 // dashes (which could be interpreted as flags by some CLI tools), whitespace,

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const {
   getCanonicalRepoRoot,
-  looksLikeGitRepo,
+  getExpectedManifestRepoRoot,
   validateManifestPaths,
 } = require("../../../relay-dispatch/scripts/manifest/paths");
 const { resolveManifestRecord } = require("../../../relay-dispatch/scripts/relay-resolver");
@@ -246,10 +246,6 @@ function resolveIssueNumber(repoPath, prNumber, branch, manifestData, options = 
   return resolveClosingReferenceIssue(parsed.closingIssuesReferences, prNumber);
 }
 
-function getExpectedManifestRepoRoot(repoPath) {
-  return looksLikeGitRepo(repoPath) ? getCanonicalRepoRoot(repoPath) : undefined;
-}
-
 function resolvePrForBranch(repoPath, branch) {
   const raw = gh(repoPath, "pr", "list", "--head", branch, "--json", "number");
   const parsed = JSON.parse(raw);
@@ -262,7 +258,7 @@ function resolveBranchForPr(repoPath, prNumber) {
   return JSON.parse(raw).headRefName;
 }
 
-function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg, doneCriteriaFileArg = null) {
+function resolveContext(repoPath, repoArg, manifestPathArg, runIdArg, branchArg, prArg, doneCriteriaFileArg = null) {
   let branch = branchArg;
   let prNumber = parsePositiveInt(prArg, "--pr");
 
@@ -282,7 +278,7 @@ function resolveContext(repoPath, manifestPathArg, runIdArg, branchArg, prArg, d
     prNumber,
   });
   const validatedPaths = validateManifestPaths(manifest.data?.paths, {
-    expectedRepoRoot: manifestPathArg ? undefined : getExpectedManifestRepoRoot(repoPath),
+    expectedRepoRoot: manifestPathArg ? undefined : getExpectedManifestRepoRoot(repoPath, repoArg),
     manifestPath: manifest.manifestPath,
     runId: manifest.data?.run_id,
     requireWorktree: true,

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -4,11 +4,12 @@ const path = require("path");
 const {
   getCanonicalRepoRoot,
   getExpectedManifestRepoRoot,
+  parsePositiveInt,
   validateManifestPaths,
 } = require("../../../relay-dispatch/scripts/manifest/paths");
 const { resolveManifestRecord } = require("../../../relay-dispatch/scripts/relay-resolver");
 const { getRubricAnchorStatus } = require("../../../relay-dispatch/scripts/manifest/rubric");
-const { gh, parsePositiveInt, readText, RUBRIC_PASS_THROUGH_STATES } = require("./common");
+const { gh, readText, RUBRIC_PASS_THROUGH_STATES } = require("./common");
 
 // DNS hostname validation — conservative label allowlist. Rejects leading
 // dashes (which could be interpreted as flags by some CLI tools), whitespace,

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -1,10 +1,10 @@
 const fs = require("fs");
 const path = require("path");
 const { formatIssueList, formatScopeDrift } = require("./comment");
+const { RUBRIC_PASS_THROUGH_STATES } = require("./common");
 const { formatPriorVerdictSummary } = require("./prompt");
 
 const FLIP_STATES = new Set(["pass", "fail"]);
-const RUBRIC_PASS_THROUGH_STATES = new Set(["loaded"]);
 const LINEAGE_VALUES = ["deepening", "repeat", "new", "newly_scoreable", "unknown"];
 
 function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource) {

--- a/skills/relay-review/scripts/reviewer-helpers.js
+++ b/skills/relay-review/scripts/reviewer-helpers.js
@@ -1,8 +1,4 @@
-function summarizeFailure(error) {
-  const stderr = String(error.stderr || "").trim();
-  const stdout = String(error.stdout || "").trim();
-  return stderr || stdout || error.message;
-}
+const { summarizeFailure } = require("../../relay-dispatch/scripts/manifest/paths");
 
 function ensureJsonText(text, label) {
   try {


### PR DESCRIPTION
## Summary

Sub-task B of #316: consolidate six duplicated utilities to one canonical home each.

## Consolidation Table

| Item | Utility | Canonical home | Count | Notes |
|---|---|---|---:|---|
| B1 | `looksLikeGitRepo` | `skills/relay-dispatch/scripts/manifest/paths.js` | 3x -> 1 | Removed duplicate definitions from dispatch/merge/review-runner callers. |
| B2 | `getExpectedManifestRepoRoot` | `skills/relay-dispatch/scripts/manifest/paths.js` | 3x -> 1 | Signature normalized to `(repoPath, repoArg)`; review-runner now passes `repoArg` explicitly. |
| B3 | `summarizeError` / `summarizeFailure` | `skills/relay-dispatch/scripts/manifest/paths.js` | 6x -> 1 | Canonical name is `summarizeFailure`; `summarizeError` code references removed. |
| B4 | `parsePositiveInt` | `skills/relay-dispatch/scripts/manifest/paths.js` | 5x -> 1 | Callers import the canonical parser directly. **R1 fix**: canonical gained an `allowZero` option to preserve `update-manifest-state.js`'s pre-consolidation non-negative semantics — it was actually `parseNonNegativeInt` mislabeled. |
| B5 | `nowIso` / `nowISO` | `skills/relay-dispatch/scripts/manifest/paths.js` | 9x -> 1 | Canonical name is `nowIso`; app registration preserves `.000Z` timestamps via a canonical helper option. |
| B6 | `RUBRIC_PASS_THROUGH_STATES` | `skills/relay-review/scripts/review-runner/common.js` | 2x -> 1 | Kept in review-runner common because this is a review-runner rubric state concept, not a manifest/path helper. |

## Score Log

| Factor | Target | Baseline | R1 | R2 (after correction) | Status |
|---|---|---:|---|---|---|
| F1: Tests green | exit 0; >= 979 pass | 979/0 | 979/0 | 979/0 | locked |
| F2: Multi-commit shape | >= 8/10 | 0 commits | 10/10 (6 focused commits) | 10/10 | locked |
| F3: 6-utility consolidation | >= 8/10 | 6 utilities x N duplicates | fail (B4 zero-handling regression) | 10/10 (canonical now preserves both semantics) | locked |

## R1 → R2 Orchestrator Correction

R1 codex reviewer correctly flagged that B4's import switch in `update-manifest-state.js` changed valid `--rounds 0` / `--repeated-issue-count 0` / etc. from accepted to rejected. The pre-consolidation local parser was named `parsePositiveInt` but actually allowed 0 (only `parsed < 0` rejected) — it was effectively `parseNonNegativeInt` mislabeled.

**Fix (commit `9e35510`)**: 
1. Canonical `parsePositiveInt` in `manifest/paths.js` accepts an `allowZero: boolean` option (default `false`, preserves strict positive-only behavior for all other callers).
2. The 4 callsites in `update-manifest-state.js` (`--pr-number`, `--rounds`, `--max-rounds`, `--repeated-issue-count`) now pass `{ allowZero: true }` to restore the original non-negative semantics.
3. Other callers (PR numbers, issue numbers, window-days) unchanged — they naturally want strict positive-only.

## Verification

- `node --test skills/*/scripts/*.test.js` → 979 pass / 0 fail (at HEAD `9e35510`)
- `git log main..HEAD --oneline` shows 7 commits: 6 utility consolidations + 1 R1 correction
- `rg` verification confirms single definitions for the six scoped utilities

## Run Metadata

- Run: `issue-316-20260429112510000-ccd67370`
- Branch: `issue-316-utils`
- HEAD: `9e35510` (R1 correction) over `41f2374` (R1 reviewed)
- Executor: codex `gpt-5.5` `model_reasoning_effort=high`
- Dispatch duration: 25min
- Closes: part of #316 (sub-task B)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **리팩토링**
  * 여러 스크립트에서 중복되던 유틸리티 함수들(타임스탐프 생성, 정수 파싱, 오류 요약, 저장소 감지)을 공유 모듈로 통합하여 코드 중복을 제거하고 유지보수 효율을 개선했습니다.
  * 공유 유틸리티 모듈을 통해 일관성 있는 함수 사용을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->