### PR TITLE
test: collapse cross-CLI validateManifestPaths smoke coverage from 12 to 1 unit + 4 smoke (~400 LoC) (#319)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -96,29 +96,6 @@ function setupDetachedHeadRepo({ originHeadBranch } = {}) {
   return fixture;
 }
 
-function createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, branch = "issue-42") {
-  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-foreign-"));
-  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
-  fs.mkdirSync(attackerRoot, { recursive: true });
-  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["config", "user.name", "Relay Dispatch Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["config", "user.email", "relay-dispatch-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
-  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  const relayWorktrees = path.join(relayHome, "worktrees");
-  fs.mkdirSync(relayWorktrees, { recursive: true });
-  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
-  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
-  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
-    cwd: attackerRoot,
-    encoding: "utf-8",
-    stdio: "pipe",
-  });
-  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
-  return { attackerRoot, attackerWorktree };
-}
-
 function createUnrelatedGitRepo(prefix = "relay-dispatch-manifest-cwd-") {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -1557,7 +1534,7 @@ test("dispatch resume fails when --run-id does not resolve", () => {
   assert.match(result.stderr, new RegExp(`No relay manifest found for run_id '${missingRunId}'`));
 });
 
-test("dispatch resume rejects crafted manifest repo roots before touching an unrelated repo", () => {
+test("dispatch resume validateManifestPaths wire rejects crafted manifest repo roots", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
@@ -1602,40 +1579,6 @@ test("dispatch resume rejects crafted manifest repo roots before touching an unr
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
-});
-
-test("dispatch resume rejects relay-base same-name worktrees from a different repo before reuse", () => {
-  const { repoRoot, relayHome } = setupRepo();
-  process.env.RELAY_HOME = relayHome;
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
-  writeFakeCodex(binDir);
-  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
-
-  const first = JSON.parse(runDispatch(repoRoot, [
-    "-b", "issue-160",
-    "--prompt", "first pass",
-    "--json",
-  ], env));
-  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, "issue-160");
-  const record = readManifest(first.manifestPath);
-  writeManifest(first.manifestPath, {
-    ...updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
-    paths: {
-      ...(record.data.paths || {}),
-      worktree: attackerWorktree,
-    },
-  }, record.body);
-
-  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--prompt", "resume", "--json"], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    env,
-  });
-
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /manifest paths\.worktree/);
-  assert.equal(fs.existsSync(path.join(attackerWorktree, "resume.txt")), false, "dispatch must reject before reusing the foreign relay worktree");
-  assert.equal(readManifest(first.manifestPath).data.state, STATES.CHANGES_REQUESTED);
 });
 
 test("dispatch refuses same-ms same-branch run-dir collisions for new runs", () => {

--- a/skills/relay-merge/scripts/finalize-run.test.js
+++ b/skills/relay-merge/scripts/finalize-run.test.js
@@ -165,36 +165,6 @@ function setupRepo({
   return { repoRoot, manifestPath, branch, worktreePath, headSha, runId };
 }
 
-function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
-  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-finalize-foreign-"));
-  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
-  fs.mkdirSync(attackerRoot, { recursive: true });
-  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["config", "user.name", "Relay Finalize Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["config", "user.email", "relay-finalize-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
-  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
-  fs.mkdirSync(relayWorktrees, { recursive: true });
-  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
-  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
-  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
-    cwd: attackerRoot,
-    encoding: "utf-8",
-    stdio: "pipe",
-  });
-  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
-  return { attackerRoot, attackerWorktree };
-}
-
-function createMissingRelayOwnedWorktree(repoRoot) {
-  const relayWorktrees = path.join(process.env.RELAY_HOME, "worktrees");
-  fs.mkdirSync(relayWorktrees, { recursive: true });
-  const worktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "missing-"));
-  return path.join(worktreeParent, path.basename(repoRoot));
-}
-
 function createUnrelatedGitRepo(prefix = "relay-finalize-manifest-cwd-") {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -799,50 +769,7 @@ test("finalize-run merges and cleans a ready run", () => {
   assert.match(ghLog, /issue close 42 --comment Resolved in PR #123/);
 });
 
-test("finalize-run rejects invalid manifest run_id before merge finalization", () => {
-  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
-  const logPath = path.join(repoRoot, "gh.log");
-  const fakeGh = writeFakeGh(logPath, {
-    comments: [
-      {
-        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
-        createdAt: "2026-04-03T08:00:00Z",
-      },
-    ],
-    commits: [
-      {
-        oid: headSha,
-        committedDate: "2026-04-03T08:00:00Z",
-      },
-    ],
-  });
-  const record = readManifest(manifestPath);
-  writeManifest(manifestPath, {
-    ...record.data,
-    run_id: "../victim-finalize-run",
-  }, record.body);
-
-  assert.throws(() => execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--branch", branch,
-    "--pr", "123",
-    "--json",
-  ], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    stdio: "pipe",
-    env: { ...process.env, RELAY_GH_BIN: fakeGh },
-  }), (error) => {
-    assert.match(String(error.stderr), /run_id must be a single path segment/);
-    return true;
-  });
-
-  assert.equal(fs.existsSync(worktreePath), true);
-  assert.equal(branchExists(repoRoot, branch), true);
-});
-
-test("finalize-run rejects crafted manifest repo roots before merge or cleanup side effects", () => {
+test("finalize-run validateManifestPaths wire rejects crafted manifest repo roots", () => {
   const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
   const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-finalize-attacker-"));
   const logPath = path.join(repoRoot, "gh.log");
@@ -886,108 +813,7 @@ test("finalize-run rejects crafted manifest repo roots before merge or cleanup s
     return true;
   });
 
-  assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
   assert.equal(branchExists(repoRoot, branch), true);
-  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
-  assert.equal(fs.existsSync(logPath), false);
-});
-
-test("finalize-run rejects relay-base same-name worktrees before merge or cleanup side effects", () => {
-  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
-  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot, branch);
-  const logPath = path.join(repoRoot, "gh.log");
-  const fakeGh = writeFakeGh(logPath, {
-    comments: [
-      {
-        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
-        createdAt: "2026-04-03T08:00:00Z",
-      },
-    ],
-    commits: [
-      {
-        oid: headSha,
-        committedDate: "2026-04-03T08:00:00Z",
-      },
-    ],
-  });
-  const record = readManifest(manifestPath);
-  writeManifest(manifestPath, {
-    ...record.data,
-    paths: {
-      ...(record.data.paths || {}),
-      worktree: attackerWorktree,
-    },
-  }, record.body);
-
-  assert.throws(() => execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--branch", branch,
-    "--pr", "123",
-    "--json",
-  ], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    stdio: "pipe",
-    env: { ...process.env, RELAY_GH_BIN: fakeGh },
-  }), (error) => {
-    assert.match(String(error.stderr), /manifest paths\.worktree/);
-    return true;
-  });
-
-  assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
-  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
-  assert.equal(branchExists(repoRoot, branch), true);
-  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
-  assert.equal(fs.existsSync(logPath), false);
-});
-
-test("finalize-run rejects missing relay-base same-name worktrees before merge or cleanup side effects", () => {
-  const { repoRoot, manifestPath, branch, worktreePath, headSha } = setupRepo();
-  const missingWorktree = createMissingRelayOwnedWorktree(repoRoot);
-  const logPath = path.join(repoRoot, "gh.log");
-  const fakeGh = writeFakeGh(logPath, {
-    comments: [
-      {
-        body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
-        createdAt: "2026-04-03T08:00:00Z",
-      },
-    ],
-    commits: [
-      {
-        oid: headSha,
-        committedDate: "2026-04-03T08:00:00Z",
-      },
-    ],
-  });
-  const record = readManifest(manifestPath);
-  writeManifest(manifestPath, {
-    ...record.data,
-    paths: {
-      ...(record.data.paths || {}),
-      worktree: missingWorktree,
-    },
-  }, record.body);
-
-  assert.throws(() => execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--branch", branch,
-    "--pr", "123",
-    "--json",
-  ], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    stdio: "pipe",
-    env: { ...process.env, RELAY_GH_BIN: fakeGh },
-  }), (error) => {
-    assert.match(String(error.stderr), /manifest paths\.worktree/);
-    return true;
-  });
-
-  assert.equal(fs.existsSync(worktreePath), true, "finalize-run must reject before cleaning the real worktree");
-  assert.equal(branchExists(repoRoot, branch), true);
-  assert.equal(fs.existsSync(missingWorktree), false);
   assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
   assert.equal(fs.existsSync(logPath), false);
 });

--- a/skills/relay-merge/scripts/gate-check.test.js
+++ b/skills/relay-merge/scripts/gate-check.test.js
@@ -304,29 +304,6 @@ function createLiveGateFixture({ manifest, rubricContent, afterManifestSetup = n
   return { ...liveManifest, repoRoot, relayHome, binDir, logPath };
 }
 
-function createUnrelatedRelayOwnedWorktree(repoRoot, relayHome, branch = "issue-40") {
-  const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-foreign-"));
-  const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
-  fs.mkdirSync(attackerRoot, { recursive: true });
-  execFileSync("git", ["init", "-b", "main"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["config", "user.name", "Relay Gate Foreign"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["config", "user.email", "relay-gate-foreign@example.com"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  fs.writeFileSync(path.join(attackerRoot, "README.md"), "foreign\n", "utf-8");
-  execFileSync("git", ["add", "README.md"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  execFileSync("git", ["commit", "-m", "init"], { cwd: attackerRoot, encoding: "utf-8", stdio: "pipe" });
-  const relayWorktrees = path.join(relayHome, "worktrees");
-  fs.mkdirSync(relayWorktrees, { recursive: true });
-  const attackerWorktreeParent = fs.mkdtempSync(path.join(relayWorktrees, "foreign-"));
-  const attackerWorktree = path.join(attackerWorktreeParent, path.basename(repoRoot));
-  execFileSync("git", ["worktree", "add", attackerWorktree, "-b", branch], {
-    cwd: attackerRoot,
-    encoding: "utf-8",
-    stdio: "pipe",
-  });
-  fs.writeFileSync(path.join(attackerWorktree, "sentinel.txt"), "foreign\n", "utf-8");
-  return { attackerRoot, attackerWorktree };
-}
-
 function buildStampLockEnv({ timeoutMs = 75, pollMs = 5 } = {}) {
   return {
     RELAY_PR_NUMBER_STAMP_LOCK_TIMEOUT_MS: String(timeoutMs),
@@ -790,28 +767,7 @@ test("gate-check --skip audit comment records rubric_status: missing", () => {
   assert.match(fs.readFileSync(result.logPath, "utf-8"), /rubric_status: missing/);
 });
 
-test("gate-check rejects manifests whose stored run_id is invalid", () => {
-  const result = runGateCheckLive({
-    manifest: {
-      anchor: {
-        rubric_path: "rubric.yaml",
-      },
-      storedRunId: "../victim-gate-run",
-    },
-    prViewPayload: {
-      comments: [],
-      commits: [],
-      headRefName: "issue-40",
-    },
-  });
-
-  assert.equal(result.status, 1);
-  assert.equal(result.json.status, "manifest_resolution_failed");
-  assert.match(result.json.reason, /run_id must be a single path segment/);
-  assert.equal(fs.existsSync(path.join(result.relayHome, "runs", "victim-gate-run")), false);
-});
-
-test("gate-check rejects crafted manifest repo roots before stamping or merge gating", () => {
+test("gate-check validateManifestPaths wire rejects crafted manifest repo roots", () => {
   const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-attacker-"));
   const result = runGateCheckLive({
     manifest: {
@@ -842,40 +798,6 @@ test("gate-check rejects crafted manifest repo roots before stamping or merge ga
   assert.equal(result.json.status, "manifest_resolution_failed");
   assert.equal(result.json.readyToMerge, false);
   assert.match(result.json.reason, /manifest paths\.repo_root/);
-});
-
-test("gate-check rejects relay-base same-name worktrees before stamping or merge gating", () => {
-  const fixture = createLiveGateFixture({
-    manifest: {
-      anchor: {
-        rubric_path: "rubric.yaml",
-      },
-      state: STATES.REVIEW_PENDING,
-    },
-  });
-  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(fixture.repoRoot, fixture.relayHome);
-  const record = readManifest(fixture.manifestPath);
-  writeManifest(fixture.manifestPath, {
-    ...record.data,
-    paths: {
-      ...(record.data.paths || {}),
-      worktree: attackerWorktree,
-    },
-  }, record.body);
-
-  const result = runGateCheckWithFixture(fixture, {
-    prViewPayload: {
-      comments: [],
-      commits: [],
-      headRefName: "issue-40",
-    },
-  });
-
-  assert.equal(result.status, 1);
-  assert.equal(result.json.status, "manifest_resolution_failed");
-  assert.equal(result.json.readyToMerge, false);
-  assert.match(result.json.reason, /manifest paths\.worktree/);
-  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
 });
 
 test("gate-check skips unauthorized and uses authorized review when both exist", () => {

--- a/skills/relay-review/scripts/review-runner.test.js
+++ b/skills/relay-review/scripts/review-runner.test.js
@@ -1198,32 +1198,6 @@ test("review-runner fail-closes reviewer PASS into changes_requested when execut
   assert.equal(reviewApplyEvent?.reason, "changes_requested");
 });
 
-test("review-runner rejects invalid manifest run_id before creating a sibling run directory", () => {
-  const { repoRoot, manifestPath, diffPath } = setupRepo();
-  const record = readManifest(manifestPath);
-  const victimRunDir = path.resolve(getRunsDir(repoRoot), "../victim-review-run");
-
-  writeManifest(manifestPath, {
-    ...record.data,
-    run_id: "../victim-review-run",
-  }, record.body);
-
-  assert.equal(fs.existsSync(victimRunDir), false);
-  assert.throws(() => execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--manifest", manifestPath,
-    "--pr", "123",
-    "--diff-file", diffPath,
-    "--prepare-only",
-    "--json",
-  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
-    assert.match(String(error.stderr), /run_id must be a single path segment/);
-    return true;
-  });
-  assert.equal(fs.existsSync(victimRunDir), false);
-});
-
 test("review-runner can prepare from --manifest when --repo points at an unrelated git repo", () => {
   const { repoRoot, manifestPath, runId, worktreePath, doneCriteriaPath, diffPath } = setupRepo();
   const selectorRepo = createUnrelatedGitRepo();
@@ -1303,37 +1277,7 @@ test("review-runner manifest-only rounds keep gh-backed reads and comments on th
   assert.equal(manifest.review.latest_verdict, "lgtm");
 });
 
-test("review-runner rejects relay-base same-name worktrees before preparing prompts in an unrelated checkout", () => {
-  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
-  const { attackerWorktree } = createUnrelatedRelayOwnedWorktree(repoRoot);
-  const record = readManifest(manifestPath);
-  writeManifest(manifestPath, {
-    ...record.data,
-    paths: {
-      ...(record.data.paths || {}),
-      worktree: attackerWorktree,
-    },
-  }, record.body);
-
-  assert.throws(() => execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--run-id", runId,
-    "--pr", "123",
-    "--done-criteria-file", doneCriteriaPath,
-    "--diff-file", diffPath,
-    "--prepare-only",
-    "--json",
-  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
-    assert.match(String(error.stderr), /manifest paths\.worktree/);
-    return true;
-  });
-
-  assert.equal(fs.existsSync(path.join(attackerWorktree, "review-round-1-prompt.md")), false);
-  assert.equal(fs.existsSync(path.join(attackerWorktree, "sentinel.txt")), true);
-});
-
-test("review-runner rejects tampered paths.repo_root before prepare-only prompt side effects", () => {
+test("review-runner validateManifestPaths wire rejects crafted manifest repo roots", () => {
   const { repoRoot, worktreePath, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
   const { attackerRoot } = createUnrelatedRelayOwnedWorktree(repoRoot);
   const record = readManifest(manifestPath);


### PR DESCRIPTION
## Summary

- Collapse duplicated cross-CLI `validateManifestPaths` perimeter smokes to one representative `paths.repo_root` wire-up smoke per CLI.
- Keep the existing unit-level validator coverage in `relay-manifest.test.js` unchanged.
- Remove now-unused same-name worktree fixture helpers from the affected test files.

Closes #319.

## Validation

- `node --test skills/*/scripts/*.test.js` -> `# tests 960`, `# pass 960`, `# fail 0`
- Test counts: `finalize=28 gate=43 dispatch=86 review=78 manifest=56`
- LoC across the 4 refactored test files: `10292 -> 9927` (365 lines reclaimed)
- `git diff main -- skills/ | grep -cE '^\\+.*//.*validateManifestPaths'` -> `0`

## Mutation Evidence

| CLI | Temporarily disabled call site | Smoke test | Broken-state result | Restored result |
| --- | --- | --- | --- | --- |
| dispatch | `skills/relay-dispatch/scripts/dispatch.js:581-586` (`dispatch resume`) | `dispatch resume validateManifestPaths wire rejects crafted manifest repo roots` | FAIL: stderr changed from `manifest paths.repo_root` to retained-worktree-missing | PASS |
| gate-check | `skills/relay-merge/scripts/gate-check.js:352-357` (`gate-check`; primary live PR path, not skip audit path at 138) | `gate-check validateManifestPaths wire rejects crafted manifest repo roots` | FAIL: reason changed from `manifest paths.repo_root` to canonical repo root resolution error | PASS |
| finalize-run | `skills/relay-merge/scripts/finalize-run.js:264-269` (first gate; not post-checkout gate at 280) | `finalize-run validateManifestPaths wire rejects crafted manifest repo roots` | FAIL: stderr changed from `manifest paths.repo_root` to canonical repo root resolution error | PASS |
| review-runner | `skills/relay-review/scripts/review-runner/context.js:280-286` | `review-runner validateManifestPaths wire rejects crafted manifest repo roots` | FAIL: command exited 0 instead of rejecting | PASS |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 여러 테스트 스위트에서 경로 검증 관련 테스트 케이스를 재구성하고 통합했습니다.
  * 테스트 커버리지는 유지하면서 검증 로직 테스트를 더 명확하게 조직화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->