### PR TITLE
relay-merge: sprint-close candidate pattern reporting (#146)

### DIFF
--- a/skills/relay-merge/scripts/sprint-close-report.js
+++ b/skills/relay-merge/scripts/sprint-close-report.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const {
+  loadPrBody,
+  normalizeFactorKey,
+  parseNumericScore,
+  parseScoreLog,
+} = require("../../relay-review/scripts/review-runner/divergence");
+const { extractAllFactors } = require("../../relay-plan/scripts/tdd-flavor");
+const { bindCliArgs } = require("../../relay-dispatch/scripts/cli-args");
+const { listManifestRecords } = require("../../relay-dispatch/scripts/manifest/store");
+
+const DEFAULT_THRESHOLD = 9;
+const DEFAULT_MIN_RUNS = 2;
+const TERMINAL_STATES = new Set(["merged", "closed"]);
+const RESERVED_FLAGS = ["--repo", "--sprint", "--threshold", "--min-runs", "--help", "-h"];
+
+function usage() {
+  return [
+    "Usage: node skills/relay-merge/scripts/sprint-close-report.js --repo <path> --sprint <path-to-sprint-md> [--threshold N] [--min-runs N]",
+    "",
+    "Reports rubric factors that scored consistently high across completed sprint runs.",
+    "",
+    "Options:",
+    "  --repo <path>       Repository root used to resolve relay manifests.",
+    "  --sprint <path>     Sprint markdown file containing a Plan checklist.",
+    "  --threshold N       Minimum numeric Score Log value; overrides backlog/config.yml.",
+    "  --min-runs N        Minimum distinct runs for a factor; overrides backlog/config.yml.",
+    "  --help, -h          Show this help.",
+    "",
+    "Config fallback: backlog/config.yml may define sprint_close.threshold_score and sprint_close.min_runs.",
+  ].join("\n");
+}
+
+function parsePositiveNumber(value, label) {
+  if (value === undefined || value === null || String(value).trim() === "") return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive number`);
+  }
+  return parsed;
+}
+
+function parseSprintCloseConfig(configText) {
+  const result = {};
+  let inSprintClose = false;
+  let sprintCloseIndent = null;
+
+  for (const rawLine of String(configText || "").split(/\r?\n/)) {
+    if (/^\s*(#.*)?$/.test(rawLine)) continue;
+    const line = rawLine.replace(/\s+#.*$/, "");
+    const section = line.match(/^(\s*)sprint_close:\s*$/);
+    if (section) {
+      inSprintClose = true;
+      sprintCloseIndent = section[1].length;
+      continue;
+    }
+
+    if (!inSprintClose) continue;
+
+    const indent = line.match(/^\s*/)[0].length;
+    if (indent <= sprintCloseIndent) {
+      inSprintClose = false;
+      continue;
+    }
+
+    const field = line.match(/^\s*(threshold_score|min_runs):\s*([^\s#]+)\s*$/);
+    if (field) {
+      result[field[1]] = field[2].replace(/^['"]|['"]$/g, "");
+    }
+  }
+
+  return result;
+}
+
+function loadSprintCloseConfig(repoRoot) {
+  const configPath = path.join(repoRoot, "backlog", "config.yml");
+  if (!fs.existsSync(configPath)) return {};
+  return parseSprintCloseConfig(fs.readFileSync(configPath, "utf-8"));
+}
+
+function resolveOptions(args) {
+  const cli = bindCliArgs(args, { reservedFlags: RESERVED_FLAGS });
+  if (cli.hasFlag("--help") || cli.hasFlag("-h")) {
+    return { help: true };
+  }
+
+  const repoRoot = path.resolve(cli.getArg("--repo", "."));
+  const sprintArg = cli.getArg("--sprint", undefined);
+  if (!sprintArg) {
+    throw new Error("--sprint <path-to-sprint-md> is required");
+  }
+
+  const sprintPath = path.resolve(repoRoot, sprintArg);
+  const config = loadSprintCloseConfig(repoRoot);
+  const configThreshold = parsePositiveNumber(config.threshold_score, "sprint_close.threshold_score");
+  const configMinRuns = parsePositiveNumber(config.min_runs, "sprint_close.min_runs");
+  const cliThreshold = parsePositiveNumber(cli.getArg("--threshold", undefined), "--threshold");
+  const cliMinRuns = parsePositiveNumber(cli.getArg("--min-runs", undefined), "--min-runs");
+
+  return {
+    help: false,
+    repoRoot,
+    sprintPath,
+    threshold: cliThreshold ?? configThreshold ?? DEFAULT_THRESHOLD,
+    minRuns: cliMinRuns ?? configMinRuns ?? DEFAULT_MIN_RUNS,
+  };
+}
+
+function parseSprintIssueNumbers(sprintText) {
+  const issues = [];
+  const seen = new Set();
+  let inPlan = false;
+
+  for (const line of String(sprintText || "").split(/\r?\n/)) {
+    if (/^##+\s+Plan\b/i.test(line)) {
+      inPlan = true;
+      continue;
+    }
+    if (inPlan && /^##\s+\S/.test(line)) break;
+    if (!inPlan) continue;
+
+    const match = line.match(/^\s*-\s*\[[xX]\]\s*#(\d+)\b/);
+    if (!match) continue;
+    const issueNumber = Number(match[1]);
+    if (!seen.has(issueNumber)) {
+      seen.add(issueNumber);
+      issues.push(issueNumber);
+    }
+  }
+
+  return issues;
+}
+
+function issueNumberForManifest(record) {
+  const issueNumber = record?.data?.issue?.number ?? record?.data?.git?.issue_number;
+  if (Number.isInteger(issueNumber)) return issueNumber;
+  const runId = record?.data?.run_id || path.basename(record?.manifestPath || "", ".md");
+  const match = String(runId).match(/^issue-(\d+)-/);
+  return match ? Number(match[1]) : null;
+}
+
+function resolveRubricPath(record) {
+  const runId = record?.data?.run_id;
+  const rubricPath = record?.data?.anchor?.rubric_path;
+  if (!record?.manifestPath || typeof runId !== "string" || typeof rubricPath !== "string" || !rubricPath.trim()) {
+    return null;
+  }
+
+  const runDir = path.join(path.dirname(record.manifestPath), runId);
+  const resolved = path.resolve(runDir, rubricPath);
+  const relative = path.relative(runDir, resolved);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return null;
+  }
+  return resolved;
+}
+
+function readRubricFactorIndex(record) {
+  const rubricPath = resolveRubricPath(record);
+  if (!rubricPath) return new Map();
+
+  try {
+    const factors = extractAllFactors(fs.readFileSync(rubricPath, "utf-8"));
+    return new Map(
+      factors
+        .map((factor) => String(factor?.name || "").trim())
+        .filter(Boolean)
+        .map((name) => [normalizeFactorKey(name), name])
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+function matchingSprintRecords(repoRoot, issueNumbers) {
+  const issueSet = new Set(issueNumbers);
+  return listManifestRecords(repoRoot).filter((record) => {
+    const issueNumber = issueNumberForManifest(record);
+    return issueSet.has(issueNumber) && TERMINAL_STATES.has(String(record?.data?.state || "").toLowerCase());
+  });
+}
+
+function aggregateCandidatePatterns({ repoRoot, sprintPath, threshold, minRuns }) {
+  const issueNumbers = parseSprintIssueNumbers(fs.readFileSync(sprintPath, "utf-8"));
+  const records = matchingSprintRecords(repoRoot, issueNumbers);
+  const byFactor = new Map();
+  let scorableRuns = 0;
+
+  for (const record of records) {
+    const rubricFactors = readRubricFactorIndex(record);
+    if (rubricFactors.size === 0) continue;
+
+    const prNumber = record?.data?.git?.pr_number;
+    const scoreLog = parseScoreLog(loadPrBody(repoRoot, prNumber));
+    if (scoreLog.length === 0) continue;
+
+    let runHasNumericRubricScore = false;
+    const countedInRun = new Set();
+    for (const row of scoreLog) {
+      const factorKey = normalizeFactorKey(row.factor);
+      const rubricName = rubricFactors.get(factorKey);
+      if (!rubricName || countedInRun.has(factorKey)) continue;
+
+      const score = parseNumericScore(row.score);
+      if (score === null) continue;
+      runHasNumericRubricScore = true;
+      if (score < threshold) continue;
+
+      if (!byFactor.has(factorKey)) {
+        byFactor.set(factorKey, { factor: rubricName, runs: new Set(), scores: [] });
+      }
+      byFactor.get(factorKey).runs.add(record.data.run_id);
+      byFactor.get(factorKey).scores.push(score);
+      countedInRun.add(factorKey);
+    }
+
+    if (runHasNumericRubricScore) scorableRuns += 1;
+  }
+
+  const candidates = [...byFactor.values()]
+    .filter((entry) => entry.runs.size >= minRuns)
+    .sort((left, right) => right.runs.size - left.runs.size || left.factor.localeCompare(right.factor))
+    .map((entry) => ({
+      factor: entry.factor,
+      runCount: entry.runs.size,
+      runs: [...entry.runs].sort(),
+      scores: entry.scores.slice().sort((left, right) => right - left),
+    }));
+
+  return {
+    issueNumbers,
+    recordsScanned: records.length,
+    scorableRuns,
+    threshold,
+    minRuns,
+    candidates,
+  };
+}
+
+function renderReport(report) {
+  const lines = [
+    "Candidate patterns this sprint:",
+    `Threshold: >= ${report.threshold}/10 across >= ${report.minRuns} runs`,
+    `Sprint issues: ${report.issueNumbers.length ? report.issueNumbers.map((issue) => `#${issue}`).join(", ") : "(none found in Plan)"}`,
+    `Completed runs scanned: ${report.recordsScanned}`,
+    "",
+  ];
+
+  if (report.candidates.length > 0) {
+    for (const candidate of report.candidates) {
+      const scores = candidate.scores.map((score) => `${score}/10`).join(", ");
+      lines.push(`- ${candidate.factor} (${candidate.runCount} runs; scores: ${scores})`);
+    }
+  } else if (report.scorableRuns === 0) {
+    lines.push("(none — no scorable Score Log tables in sprint runs)");
+  } else {
+    lines.push("(none — no factors met threshold and min-runs gates)");
+  }
+
+  lines.push("", "Promote manually to _context.md if applicable");
+  return lines.join("\n");
+}
+
+function main(args = process.argv.slice(2)) {
+  const options = resolveOptions(args);
+  if (options.help) {
+    console.log(usage());
+    return 0;
+  }
+
+  const report = aggregateCandidatePatterns(options);
+  console.log(renderReport(report));
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  aggregateCandidatePatterns,
+  main,
+  parseSprintCloseConfig,
+  parseSprintIssueNumbers,
+  renderReport,
+  resolveOptions,
+};

--- a/skills/relay-merge/scripts/sprint-close-report.test.js
+++ b/skills/relay-merge/scripts/sprint-close-report.test.js
@@ -1,0 +1,259 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/relay-manifest");
+
+const SCRIPT = path.join(__dirname, "sprint-close-report.js");
+
+function initRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-sprint-close-repo-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Sprint Close Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "sprint-close@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "fixture\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return repoRoot;
+}
+
+function scoreLog(rows) {
+  return [
+    "## Score Log",
+    "",
+    "| Factor | Target | Baseline | Iter 1 | Final | Status |",
+    "|--------|--------|----------|--------|-------|--------|",
+    ...rows.map(({ factor, score }) => `| ${factor} | >= 8/10 | — | ${score}/10 | ${score}/10 | locked |`),
+  ].join("\n");
+}
+
+function rubricFor(factors) {
+  return [
+    "rubric:",
+    "  factors:",
+    ...factors.flatMap((factor) => [
+      `    - name: ${factor}`,
+      "      tier: contract",
+      "      type: automated",
+    ]),
+  ].join("\n");
+}
+
+function createFakeGh(root) {
+  const ghPath = path.join(root, "fake-gh.js");
+  fs.writeFileSync(ghPath, [
+    "#!/usr/bin/env node",
+    "const bodies = JSON.parse(process.env.RELAY_TEST_PR_BODIES || '{}');",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'pr' && args[1] === 'view' && args[3] === '--json' && args[4] === 'body') {",
+    "  process.stdout.write(JSON.stringify({ body: bodies[args[2]] || '' }));",
+    "  process.exit(0);",
+    "}",
+    "process.stderr.write(`Unsupported gh invocation: ${args.join(' ')}\\n`);",
+    "process.exit(1);",
+  ].join("\n"), "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return ghPath;
+}
+
+function createFixture({ runs, configText = null }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-sprint-close-"));
+  const repoRoot = initRepo();
+  const relayHome = path.join(root, "relay-home");
+  const previousRelayHome = process.env.RELAY_HOME;
+  process.env.RELAY_HOME = relayHome;
+
+  try {
+    const sprintDir = path.join(repoRoot, "backlog", "sprints");
+    fs.mkdirSync(sprintDir, { recursive: true });
+    const issueNumbers = [...new Set(runs.map((run) => run.issue))].sort((left, right) => left - right);
+    const sprintPath = path.join(sprintDir, "fixture-sprint.md");
+    fs.writeFileSync(sprintPath, [
+      "---",
+      "milestone: fixture",
+      "status: completed",
+      "---",
+      "",
+      "## Plan",
+      ...issueNumbers.map((issue) => `- [x] #${issue} Fixture task -> PR #${issue + 100}`),
+      "",
+      "## Notes",
+    ].join("\n"), "utf-8");
+
+    if (configText !== null) {
+      fs.mkdirSync(path.join(repoRoot, "backlog"), { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, "backlog", "config.yml"), configText, "utf-8");
+    }
+
+    for (const [index, run] of runs.entries()) {
+      const runId = createRunId({
+        issueNumber: run.issue,
+        timestamp: new Date(`2026-04-20T00:00:${String(index).padStart(2, "0")}.000Z`),
+      });
+      const { runDir, manifestPath } = ensureRunLayout(repoRoot, runId);
+      const rubricPath = "rubric.yaml";
+      fs.writeFileSync(path.join(runDir, rubricPath), rubricFor(run.rubricFactors || [run.factor]), "utf-8");
+      const prNumber = run.pr ?? run.issue + 100;
+
+      const manifest = createManifestSkeleton({
+        repoRoot,
+        runId,
+        branch: `issue-${run.issue}-fixture`,
+        baseBranch: "main",
+        issueNumber: run.issue,
+        worktreePath: path.join(root, "worktrees", runId),
+      });
+      manifest.state = run.state || STATES.MERGED;
+      manifest.git.pr_number = prNumber;
+      manifest.anchor.rubric_path = rubricPath;
+      writeManifest(manifestPath, manifest);
+    }
+
+    return {
+      root,
+      repoRoot,
+      sprintPath,
+      relayHome,
+      ghPath: createFakeGh(root),
+    };
+  } finally {
+    if (previousRelayHome === undefined) {
+      delete process.env.RELAY_HOME;
+    } else {
+      process.env.RELAY_HOME = previousRelayHome;
+    }
+  }
+}
+
+function createFixtureAndRun({ runs, configText = null, args = [] }) {
+  const fixture = createFixture({ runs, configText });
+  const bodiesByPr = {};
+  for (const run of runs) {
+    const prNumber = run.pr ?? run.issue + 100;
+    bodiesByPr[String(prNumber)] = run.body ?? scoreLog([{ factor: run.factor, score: run.score }]);
+  }
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--sprint", fixture.sprintPath,
+    ...args,
+  ], {
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      RELAY_HOME: fixture.relayHome,
+      RELAY_GH_BIN: fixture.ghPath,
+      RELAY_TEST_PR_BODIES: JSON.stringify(bodiesByPr),
+    },
+  });
+  return { fixture, result };
+}
+
+test("(a) factor at score >= 9/10 in >= 2 runs in same sprint -> reported as candidate", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 101, factor: "Reusable CLI pattern", score: 9 },
+      { issue: 102, factor: "Reusable CLI pattern", score: 10 },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Candidate patterns this sprint:/);
+  assert.match(result.stdout, /Reusable CLI pattern/);
+  assert.match(result.stdout, /2 runs/);
+});
+
+test("(b) factor at score >= 9/10 in only 1 run -> NOT reported (min-runs gate holds)", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 111, factor: "Single-run insight", score: 10 },
+      { issue: 112, factor: "Other factor", score: 10 },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /^- Single-run insight/m);
+  assert.match(result.stdout, /\(none — no factors met threshold and min-runs gates\)/);
+});
+
+test("(c) factor at score < 9/10 across many runs -> NOT reported (threshold gate holds)", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 121, factor: "Almost pattern", score: 8 },
+      { issue: 122, factor: "Almost pattern", score: 8 },
+      { issue: 123, factor: "Almost pattern", score: 8 },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /^- Almost pattern/m);
+  assert.match(result.stdout, /\(none — no factors met threshold and min-runs gates\)/);
+});
+
+test("(d) --threshold N CLI flag overrides default 9", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 131, factor: "Eight-point convention", score: 8 },
+      { issue: 132, factor: "Eight-point convention", score: 8 },
+    ],
+    args: ["--threshold", "8"],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^- Eight-point convention/m);
+});
+
+test("(e) --min-runs N CLI flag overrides default 2", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 141, factor: "Solo strong signal", score: 9 },
+    ],
+    args: ["--min-runs", "1"],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^- Solo strong signal/m);
+});
+
+test("(f) backlog/config.yml sprint_close.* honored when CLI silent; CLI takes precedence when both are set", () => {
+  const configText = [
+    "project_name: fixture",
+    "sprint_close:",
+    "  threshold_score: 8",
+    "  min_runs: 1",
+  ].join("\n");
+  const runs = [{ issue: 151, factor: "Configured candidate", score: 8 }];
+
+  const configOnly = createFixtureAndRun({ runs, configText });
+  assert.equal(configOnly.result.status, 0, configOnly.result.stderr);
+  assert.match(configOnly.result.stdout, /^- Configured candidate/m);
+
+  const cliOverride = createFixtureAndRun({ runs, configText, args: ["--threshold", "9"] });
+  assert.equal(cliOverride.result.status, 0, cliOverride.result.stderr);
+  assert.doesNotMatch(cliOverride.result.stdout, /^- Configured candidate/m);
+});
+
+test("empty scorable sprint still emits prescribed header, annotation, and manual-promotion instruction", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 161, factor: "Unscored factor", score: 10, body: "## Score Log\n\nNo table here." },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Candidate patterns this sprint:/);
+  assert.match(result.stdout, /\(none — no scorable Score Log tables in sprint runs\)/);
+  assert.match(result.stdout, /Promote manually to _context\.md if applicable/);
+});


### PR DESCRIPTION
## Summary

Add `skills/relay-merge/scripts/sprint-close-report.js` (+ test) — an operator-facing CLI that scans the sprint file's Plan section, resolves matching terminal manifests under `~/.relay/runs/<repo-slug>/`, reads each run's rubric (via `extractAllFactors`) and PR body Score Log (via `parseScoreLog` + `parseNumericScore`), and prints rubric factors that scored at or above a threshold across at least the minimum number of runs. Spec-only — no file mutation. Closes the #143 qualitative_signals work loop (Phase 3.1 of `docs/agentic-patterns-adoption.md`).

Closes #146.

## Validation

- `node --test skills/*/scripts/*.test.js` → `# tests 967`, `# pass 967`, `# fail 0` (baseline 960 + 7 new tests in `sprint-close-report.test.js`)
- F1 smoke: `node skills/relay-merge/scripts/sprint-close-report.js --repo . --sprint backlog/sprints/2026-04-W17-pr276-followups.md` → exit 0; stdout contains `Candidate patterns this sprint:`
- F3 AC-literal output (live W17 sprint, no scorable Score Logs in real runs):

  ```
  Candidate patterns this sprint:
  Threshold: >= 9/10 across >= 2 runs
  Sprint issues: #277, #281, #279, #278, #280
  Completed runs scanned: 5

  (none — no scorable Score Log tables in sprint runs)

  Promote manually to _context.md if applicable
  ```
- F4 immutability: `! grep -nE '(writeFileSync|appendFileSync|writeFile\b|appendFile\b|copyFileSync|mkdirSync|rmSync|rmdirSync|unlinkSync)' skills/relay-merge/scripts/sprint-close-report.js` → exit 0 (zero matches in production script)

## Helper reuse audit

The new script reuses every cross-skill helper named in F5; no duplicate parsing, numeric-coercion, manifest-walk, or argv logic was added. All five helper categories are imported by named `require()` from their canonical modules:

| Helper | Source (definition) | Used in `sprint-close-report.js` |
| --- | --- | --- |
| `parseScoreLog` | `skills/relay-review/scripts/review-runner/divergence.js:21` | `:199` (parses each run's PR body) |
| `parseNumericScore` | `skills/relay-review/scripts/review-runner/divergence.js:77` | `:209` (coerces `9/10` → `9`) |
| `loadPrBody` | `skills/relay-review/scripts/review-runner/divergence.js:85` | `:199` (loads PR body for each terminal run) |
| `normalizeFactorKey` | `skills/relay-review/scripts/review-runner/divergence.js:73` | `:173`, `:205` (normalizes factor name across runs) |
| `extractAllFactors` | `skills/relay-plan/scripts/tdd-flavor.js:39` | `:168` (reads each run's persisted rubric) |
| `listManifestRecords` | `skills/relay-dispatch/scripts/manifest/store.js:153` | `:182` (enumerates manifests under `~/.relay/runs/<slug>/`) |
| `bindCliArgs` | `skills/relay-dispatch/scripts/cli-args.js:122` | `:87` (parses `--repo`/`--sprint`/`--threshold`/`--min-runs`/`--help`) |

No hand-rolled markdown-table parser, regex outside `parseNumericScore`, direct `fs.readdirSync` walk of `~/.relay/runs/`, or byte-level `process.argv` parsing was added.

## Score Log

| Factor | Target | Final | Status |
| --- | --- | --- | --- |
| F1 entry point + sprint scan (contract, automated) | exit 0 + `Candidate patterns this sprint:` substring | pass | locked |
| F2 threshold + cohort + tunability (contract, automated) | `node --test` exit 0; 6 named axes covered | pass (7 tests) | locked |
| F3 AC-literal output (contract, automated) | both literal phrases in stdout, empty-state annotated | pass | locked |
| F4 no shared-file writes (contract, automated) | grep exit 0 (no matches) | pass | locked |
| F5 DRY helper reuse (quality, evaluated) | ≥ 8/10; all 5 helper categories imported + audit section in PR body | 9/10 | locked |

- Run: `issue-146-20260501010012088-d864489e`
- Executor: codex (gpt-5.5, reasoning medium)
- Branch: `issue-146`
- Iterations: 1 (single dispatch, no rework needed)

## Scope drift checklist

- ✓ Did NOT modify `backlog/sprints/_context.md` or any sprint file
- ✓ Did NOT add a writer to dev-backlog or any shared file
- ✓ Did NOT modify `~/.relay/runs/` contents
- ✓ Did NOT change the public API of `reliability-report.js`, `dispatch.js`, `finalize-run.js`, or `review-runner.js` (read-only consumer of their exported helpers)
- ✓ Did NOT introduce a top-level dev-backlog config schema field that dev-backlog itself must consume; new keys live under `sprint_close.*` and are read-only-from-dev-relay (with sensible CLI-defaulted fallback when absent)
