### PR TITLE
fix rubric size parsing for dispatch reasoning

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -101,6 +101,7 @@ const { STATES, updateManifestState } = require("./manifest/lifecycle");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { execGit } = require("./exec");
+const { resolveReasoningEffort } = require("./rubric-size");
 
 // ---------------------------------------------------------------------------
 // Args
@@ -526,21 +527,6 @@ function resolveEffectiveDispatchModel({ cliModel, manifestModelHints, cliModelH
     return cliModelHints.dispatch;
   }
   return null;
-}
-
-function extractRubricSize(rubricPath) {
-  if (!rubricPath || !fs.existsSync(rubricPath)) return null;
-  const rubricText = fs.readFileSync(rubricPath, "utf-8");
-  const match = rubricText.match(/^size:\s*["']?([A-Za-z]+)["']?\s*$/m);
-  return match ? match[1].toUpperCase() : null;
-}
-
-function resolveReasoningEffort({ override, rubricPath }) {
-  if (override) return override;
-  // Defensive-only: enforceRubricPersistence() guarantees new dispatch runs have
-  // a rubric before argv construction, but keep the resolver safe standalone.
-  const rubricSize = extractRubricSize(rubricPath);
-  return DEFAULT_REASONING_BY_SIZE[rubricSize] || "xhigh";
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/relay-dispatch/scripts/dispatch.test.js
+++ b/skills/relay-dispatch/scripts/dispatch.test.js
@@ -21,6 +21,12 @@ const {
 const { buildPrBody, pushAndOpenPR, resolveBranchRemote } = require("./dispatch-publish");
 const { EXECUTION_EVIDENCE_FILENAME } = require("./execution-evidence");
 const { parseModelHints } = require("./model-hints");
+const {
+  extractRubricSize,
+  resolveReasoningEffort,
+  RUBRIC_SIZE_MISSING,
+  RUBRIC_SIZE_UNPARSEABLE,
+} = require("./rubric-size");
 const { evaluateReviewGate } = require("../../relay-merge/scripts/review-gate");
 const { createEnforcementFixture } = require("./test-support");
 
@@ -3409,4 +3415,94 @@ test("dispatch pre-flight applies the legacy-grandfather retirement matrix", asy
       }
     });
   }
+});
+
+function writeRubricFixture(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-rubric-size-"));
+  const rubricPath = path.join(dir, "rubric.yaml");
+  fs.writeFileSync(rubricPath, contents, "utf-8");
+  return rubricPath;
+}
+
+test("extractRubricSize accepts size and size_class at top-level and nested indentation", async (t) => {
+  const cases = [
+    { name: "top-level size:", input: "size: M\n", expected: "M" },
+    { name: "top-level size_class:", input: "size_class: M\n", expected: "M" },
+    { name: "nested rubric size:", input: "rubric:\n  size: M\n", expected: "M" },
+    { name: "nested rubric size_class:", input: "rubric:\n  size_class: M\n", expected: "M" },
+  ];
+
+  for (const entry of cases) {
+    await t.test(entry.name, () => {
+      const rubricPath = writeRubricFixture(entry.input);
+      assert.equal(extractRubricSize(rubricPath), entry.expected);
+    });
+  }
+});
+
+test("extractRubricSize returns exported sentinels for missing and unparseable size fields", () => {
+  const missingPath = writeRubricFixture("rubric:\n  criteria: []\n");
+  const unparseablePath = writeRubricFixture("rubric:\n  size: garbage\n");
+
+  assert.equal(extractRubricSize(missingPath), RUBRIC_SIZE_MISSING);
+  assert.equal(extractRubricSize(unparseablePath), RUBRIC_SIZE_UNPARSEABLE);
+  assert.notEqual(RUBRIC_SIZE_MISSING, RUBRIC_SIZE_UNPARSEABLE);
+});
+
+test("resolveReasoningEffort maps valid rubric size without stderr", () => {
+  const rubricPath = writeRubricFixture("rubric:\n  size_class: M\n");
+  const writes = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    writes.push(String(chunk));
+    return true;
+  };
+  try {
+    assert.equal(resolveReasoningEffort({ rubricPath }), "high");
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  assert.equal(writes.join(""), "");
+});
+
+test("resolveReasoningEffort falls back for missing rubric size without requiring a warning", () => {
+  const rubricPath = writeRubricFixture("rubric:\n  criteria: []\n");
+  assert.equal(resolveReasoningEffort({ rubricPath }), "xhigh");
+});
+
+test("resolveReasoningEffort warns and falls back for unparseable rubric size", () => {
+  const rubricPath = writeRubricFixture("rubric:\n  size: 42\n");
+  const writes = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    writes.push(String(chunk));
+    return true;
+  };
+  try {
+    assert.equal(resolveReasoningEffort({ rubricPath }), "xhigh");
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  const stderr = writes.join("");
+  assert.match(stderr, /unparseable|invalid/i);
+  assert.match(stderr, new RegExp(rubricPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("resolveReasoningEffort override returns directly and silences unparseable warnings", () => {
+  const rubricPath = writeRubricFixture("rubric:\n  size: garbage\n");
+  const writes = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    writes.push(String(chunk));
+    return true;
+  };
+  try {
+    assert.equal(resolveReasoningEffort({ override: "medium", rubricPath }), "medium");
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  assert.equal(writes.join(""), "");
 });

--- a/skills/relay-dispatch/scripts/rubric-size.js
+++ b/skills/relay-dispatch/scripts/rubric-size.js
@@ -1,0 +1,36 @@
+const fs = require("fs");
+
+const RUBRIC_SIZE_MISSING = "__rubric_size_missing__";
+const RUBRIC_SIZE_UNPARSEABLE = "__rubric_size_unparseable__";
+const DEFAULT_REASONING_BY_SIZE = { S: "medium", M: "high", L: "xhigh", XL: "xhigh" };
+const VALID_RUBRIC_SIZES = new Set(Object.keys(DEFAULT_REASONING_BY_SIZE));
+
+function extractRubricSize(rubricPath) {
+  if (!rubricPath || !fs.existsSync(rubricPath)) return RUBRIC_SIZE_MISSING;
+  const rubricText = fs.readFileSync(rubricPath, "utf-8");
+  const match = rubricText.match(/^[ \t]*(size_class|size)\s*:\s*(.*?)\s*$/m);
+  if (!match) return RUBRIC_SIZE_MISSING;
+
+  const rawValue = match[2].trim();
+  const quoted = rawValue.match(/^["']([A-Za-z]+)["']$/);
+  const unquoted = rawValue.match(/^([A-Za-z]+)$/);
+  const size = (quoted ? quoted[1] : unquoted ? unquoted[1] : "").toUpperCase();
+  return VALID_RUBRIC_SIZES.has(size) ? size : RUBRIC_SIZE_UNPARSEABLE;
+}
+
+function resolveReasoningEffort({ override, rubricPath }) {
+  if (override) return override;
+  const rubricSize = extractRubricSize(rubricPath);
+  if (rubricSize === RUBRIC_SIZE_UNPARSEABLE) {
+    process.stderr.write(`Warning: rubric size is unparseable in ${rubricPath}; falling back to xhigh reasoning.\n`);
+    return "xhigh";
+  }
+  return DEFAULT_REASONING_BY_SIZE[rubricSize] || "xhigh";
+}
+
+module.exports = {
+  extractRubricSize,
+  resolveReasoningEffort,
+  RUBRIC_SIZE_MISSING,
+  RUBRIC_SIZE_UNPARSEABLE,
+};


### PR DESCRIPTION
## Summary

- Fixes silent xhigh fallback in `resolveReasoningEffort` when rubric uses `size_class:` (alternate field name) or nests `size:` / `size_class:` under a `rubric:` block. Both forms previously failed the column-0 `^size:` regex and degraded to `xhigh` (the root cause of #316's 60-min timeout, memorized in `feedback_dispatch_size_regex_bug.md`).
- Splits the formerly-`null` return into two named sentinels (`RUBRIC_SIZE_MISSING` / `RUBRIC_SIZE_UNPARSEABLE`) so the resolver can distinguish "field absent" (silent fallback, current behavior preserved) from "field present but value is not S/M/L/XL" (warns to stderr with rubric path + `unparseable` token, then falls back).
- Closes #346.

## Validation

- `node --test skills/relay-dispatch/scripts/dispatch.test.js` → exit 0
- Test count: **90 → 100** (10 new test names; previous tests untouched)
- 4 positive-form parser cases (top-level `size:`, top-level `size_class:`, nested `size:`, nested `size_class:`) + sentinel surface (MISSING + UNPARSEABLE distinct + asserted via `assert.equal`) + resolver behaviors (SIZE_OK no-warn, MISSING silent fallback, UNPARSEABLE warn + path + token, override-silences-warn) all pass.

## Layout choice

**Layout B — extracted to `skills/relay-dispatch/scripts/rubric-size.js` (36 LoC).** Cleaner than guarding `main()` with `require.main === module`; no module side-effects on test import; new file is small enough to be a leaf utility module.

## Helper reuse audit

| Helper | New / Reused | Source | Used at |
| --- | --- | --- | --- |
| `extractRubricSize` | New (replaces inlined version) | `skills/relay-dispatch/scripts/rubric-size.js:8` | `rubric-size.js:25` (resolver), `dispatch.test.js:3424` (4 cases), `dispatch.test.js:3441` (sentinels) |
| `resolveReasoningEffort` | Relocated (was inlined in dispatch.js:538) | `skills/relay-dispatch/scripts/rubric-size.js:22` | `dispatch.js:102` (require), `dispatch.js:907` (call site, signature unchanged), `dispatch.test.js:3450` / `3471` / `3475` / `3489` (4 behavior tests) |
| `RUBRIC_SIZE_MISSING` | New named export (string sentinel) | `rubric-size.js:3` | `rubric-size.js:9,12` (returns), `dispatch.test.js:3445` (assert) |
| `RUBRIC_SIZE_UNPARSEABLE` | New named export (string sentinel) | `rubric-size.js:4` | `rubric-size.js:20` (return), `dispatch.test.js:3446` (assert) |

## Score Log

| Factor | Status | Final |
| --- | --- | --- |
| extractRubricSize accepts all 4 positive forms | PASS | 4-case parameterized test all green |
| extractRubricSize negative + sentinel surface | PASS | MISSING + UNPARSEABLE exported + asserted distinct |
| resolveReasoningEffort warn-on-unparseable behavior | PASS | stderr captured, matches `unparseable\|invalid` AND rubric path; override silences |
| Backwards-compat preserved (no signature break) | PASS | 9/10 — existing 90 tests unmodified, signatures stable, table preserved |
| Scope discipline (no YAML dep, no parallel test file, no class refactor) | PASS | 9/10 — package.json untouched, tests appended to existing file, Layout B (≤ 80 LoC new module) |

## Scope drift checklist

- [x] No `js-yaml` or other YAML parser dep added (verified: `git diff b9eceb9..HEAD -- package.json` empty)
- [x] No new test FILE created (only `dispatch.test.js` extended)
- [x] `dispatch.js` not restructured into a class (only one require line added + two function bodies removed)
- [x] `feedback_dispatch_size_regex_bug.md` memory file untouched
- [x] No edits to existing rubric YAMLs in `skills/**/references/`

## Closes

#346
