### PR TITLE
[codex] Clarify rubric reference contracts

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -118,9 +118,9 @@ Use this when operator planning rejects or narrows the issue body AC. Persist th
 
 The helper writes `~/.relay/runs/<repo-slug>/<run-id>/done-criteria.md` with source `planner_decision`. Dispatch picks it up via `--done-criteria-file` when the same run id is used. Canonical filename is always `done-criteria.md`; ad-hoc file paths remain source `file`.
 
-### 9. Review the rubric (L/XL tasks)
+### 9. Review the rubric (triggered L/XL tasks)
 
-S/M skips. L does one stress-test round. XL adds calibration simulation. Skip re-dispatches with iteration history and all-automated rubrics. Protocol: `references/rubric-stress-test.md`.
+S/M skips. Run stress-test only for L/XL rubrics with evaluated factors and an ambiguity/risk signal. XL adds calibration simulation only when novel or subjective evaluated factors need it. Skip re-dispatches with iteration history, all-automated rubrics, and simple L tasks where AC maps cleanly to checks. Protocol: `references/rubric-stress-test.md`.
 
 ### 10. Generate dispatch prompt
 
@@ -142,7 +142,7 @@ node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
 All tasks dispatched via relay. Rubric depth scales with task size (determined by orchestrator judgment on normalized AC + file scope, not raw issue AC count):
 - **S** (simple fix, typo, 1-liner): 1 contract factor; add a quality factor only when the task has real design judgment; skip stress-test
 - **M** (standard feature): 3-5 factors, skip stress-test
-- **L** (cross-cutting, multi-file): 4-6 factors + stress-test
-- **XL** (architecture change): 5-8 factors + stress-test + calibration
+- **L** (cross-cutting, multi-file): 4-6 factors; stress-test only when evaluated factors plus ambiguity/risk signal exist
+- **XL** (architecture change): 5-8 factors; stress-test only when evaluated factors plus ambiguity/risk signal exist; add calibration only when useful
 
 Re-dispatches automatically prepend previous Score Log + reviewer feedback to the prompt (see `relay-dispatch` docs). Full rubric guide: `references/rubric-design-guide.md`.

--- a/skills/relay-plan/references/rubric-backend.md
+++ b/skills/relay-plan/references/rubric-backend.md
@@ -2,6 +2,10 @@
 
 Metrics a senior backend engineer actually checks. Not "does the API return 200" but "what happens at 3 AM when the database is slow and traffic spikes."
 
+## Candidate Axis Library
+
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical backend changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real production-design judgment. Pull at most the backend axes that match the changed surface.
+
 ## Prerequisites (Hygiene)
 
 Use this section only for checks that would apply to ANY PR in this repo. They gate the run and do not count toward factor totals.

--- a/skills/relay-plan/references/rubric-design-guide.md
+++ b/skills/relay-plan/references/rubric-design-guide.md
@@ -4,6 +4,16 @@ How to derive high-quality rubrics from task acceptance criteria. Covers the gui
 
 Before dispatch, persist the finished rubric to a file and pass it through `relay-dispatch --rubric-file <path>`. This is required so the run records `anchor.rubric_path` for review and merge gating.
 
+## Reference Use Contract
+
+The domain `rubric-*.md` files are **candidate axis libraries**, not dispatch templates. Use them to sharpen task-specific judgment:
+
+- Pick only the axes earned by the Acceptance Criteria.
+- Do not copy a whole domain reference into a dispatch prompt.
+- S-size mechanical tasks may use one contract factor plus hygiene prerequisites and no quality factor.
+- Add quality factors only when the task has real design judgment or risk that a command cannot verify.
+- Treat `fix_hint` examples as optional escalation aids for historical plateaus or non-obvious score transitions, not default implementation instructions.
+
 ## Factor Fields
 
 Common factor fields are `name`, `tier`, `type`, `command`, `criteria`, `target`, `weight`, `baseline`, `setup`, `scoring_guide`, and `fix_hint`.

--- a/skills/relay-plan/references/rubric-design.md
+++ b/skills/relay-plan/references/rubric-design.md
@@ -4,6 +4,10 @@ Metrics a design-minded product engineer checks. Not "does it look nice" but "do
 
 Follows the feedback hierarchy from product leaders: **Value → Usability → Delight.** Each layer is a gate — don't polish the animation on a feature that solves the wrong problem.
 
+## Candidate Axis Library
+
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical UI changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real product, usability, or visual hierarchy judgment. Pull only the design layers that match the user's changed workflow.
+
 ## Prerequisites (Hygiene)
 
 Use this section only for checks that would apply to ANY PR in this repo. They gate the run and do not count toward factor totals.

--- a/skills/relay-plan/references/rubric-documentation.md
+++ b/skills/relay-plan/references/rubric-documentation.md
@@ -2,6 +2,10 @@
 
 Metrics a documentation specialist actually checks. Not "is the grammar correct" but "can someone with zero context complete a real task using only this document."
 
+## Candidate Axis Library
+
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical docs changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real reader-success judgment. Pull at most the documentation axes that match the changed document or workflow.
+
 ## Prerequisites (Hygiene)
 
 Use this section only for checks that would apply to ANY PR in this repo. They gate the run and do not count toward factor totals.

--- a/skills/relay-plan/references/rubric-frontend.md
+++ b/skills/relay-plan/references/rubric-frontend.md
@@ -2,6 +2,10 @@
 
 Metrics a senior frontend engineer actually checks. Not "does it render" but "does it respect the user's time, device, and attention."
 
+## Candidate Axis Library
+
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical frontend changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real UX or state-management judgment. Pull at most the frontend axes that match the changed surface.
+
 ## Prerequisites (Hygiene)
 
 Use this section only for checks that would apply to ANY PR in this repo. They gate the run and do not count toward factor totals.

--- a/skills/relay-plan/references/rubric-refactoring.md
+++ b/skills/relay-plan/references/rubric-refactoring.md
@@ -2,6 +2,10 @@
 
 Metrics a senior engineer actually checks when refactoring. Not "does it still work" but "is the codebase genuinely simpler, or did you just move the mess around."
 
+## Candidate Axis Library
+
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical cleanup, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real simplification, boundary, or migration judgment. Pull at most the refactoring axes that match the changed code path.
+
 ## Prerequisites (Hygiene)
 
 Use this section only for checks that would apply to ANY PR in this repo. They gate the run and do not count toward factor totals.

--- a/skills/relay-plan/references/rubric-security.md
+++ b/skills/relay-plan/references/rubric-security.md
@@ -6,6 +6,10 @@ Use this alongside the primary domain rubric when a task touches user input, aut
 
 > **See also**: `rubric-trust-model.md` for **auth-boundary** tasks in the relay runtime itself (manifest anchors, trust roots, gate callsites). That reference adds a distinct enforcement-layer / authentication-factor check on top of this file. The two are complementary: this file covers the broad security surface; `rubric-trust-model.md` covers the narrower case where a schema change can preserve a vulnerability under a new shape.
 
+## Candidate Axis Library
+
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical changes, add security factors only when the Acceptance Criteria touch a trust boundary, sensitive data, dependency risk, or attacker-controlled input. Pull at most the security axes that sharpen the primary domain rubric.
+
 ## Prerequisites (Hygiene)
 
 Use this section only for checks that would apply to ANY PR in this repo. They gate the run and do not count toward factor totals.

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -1,16 +1,18 @@
 # Rubric Stress-Test for L/XL Tasks
 
-For complex tasks (5+ AC items), stress-test the rubric before dispatch. A subagent with fresh context attempts to "game" the rubric — finding minimal implementations that technically pass but a senior engineer would reject.
+For complex, design-bearing tasks, stress-test the rubric before dispatch. A fresh-context reviewer attempts to "game" the rubric — finding minimal implementations that technically pass but a senior engineer would reject.
 
 ## Task Size Classification
 
 | Size | Criteria | Rubric Review |
 |------|----------|---------------|
 | S/M | 1-4 AC items | None (current flow) |
-| L | 5-6 AC items | Stress-test (1 subagent) |
-| XL | 7+ AC items or cross-domain | Stress-test + Calibration simulation (parallel) |
+| L | 5-6 AC items plus evaluated factors and ambiguity/risk signal | Stress-test (1 fresh-context reviewer) |
+| XL | 7+ AC items or cross-domain plus evaluated factors and ambiguity/risk signal | Stress-test + Calibration simulation (parallel only when useful) |
 
 **Cross-domain**: task spans frontend + backend, infra + application, or multiple services.
+
+**Ambiguity/risk signal**: novel quality criteria, historical score divergence, trust/security boundary, unclear AC decomposition, or factors that could be gamed by a minimal implementation.
 
 ## Process: Validate → Review → Generate
 
@@ -20,9 +22,9 @@ Insert this between "Validate the rubric" (step 3) and "Generate dispatch prompt
 Step 5 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)
 ```
 
-## Stress-Test (L and XL)
+## Stress-Test (L and XL when triggered)
 
-Launch a subagent with **fresh context** (no planning conversation). Hand it the rubric YAML + original AC as a structured artifact.
+Use a fresh-context reviewer (subagent when available, otherwise a separate isolated review prompt). Hand it the rubric YAML + original AC as a structured artifact. Do not launch this for direct all-automated rubrics or simple L tasks where the AC already maps cleanly to checks.
 
 ### Prompt Template
 
@@ -77,7 +79,7 @@ not what's universally true of competent code.
 
 ## Calibration Simulation (XL only)
 
-Run **parallel** with stress-test. A second subagent imagines three implementations and scores each against evaluated factors.
+Run **parallel** with stress-test only when the XL rubric has novel or subjective evaluated factors. A second fresh-context reviewer imagines three implementations and scores each against evaluated factors.
 
 ### Prompt Template
 
@@ -142,6 +144,7 @@ After receiving stress-test (and calibration) results:
 ## When to Skip
 
 - **S/M tasks** (1-4 AC): Rubric is simple enough that stress-testing adds overhead without proportional value
+- **L tasks with no ambiguity/risk signal**: A direct rubric review by the orchestrator is enough
 - **Re-dispatches with iteration history**: The rubric was already stress-tested on the first dispatch; re-dispatch focuses on addressing reviewer feedback, not rubric quality
 - **All-automated rubrics**: No evaluated factors to calibrate — stress-test adds nothing
 - **Time-critical hotfixes**: Skip to dispatch immediately; accept rubric risk
@@ -150,7 +153,7 @@ After receiving stress-test (and calibration) results:
 
 | Size | Overhead | Mechanism |
 |------|----------|-----------|
-| L | ~2-3K tokens | 1 subagent (stress-test) |
-| XL | ~5-6K tokens | 2 subagents parallel (stress-test + calibration) |
+| L | ~2-3K tokens | 1 fresh-context reviewer (stress-test) |
+| XL | ~5-6K tokens | 1-2 fresh-context reviewers when calibration is useful |
 
 Compared to a failed dispatch + re-dispatch cycle (~50-100K tokens), the overhead is negligible for tasks where rubric quality is the primary risk.

--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -37,6 +37,28 @@ Summarize the rubric before dispatch so weak calibration is visible.
 The `Probe signal` lines below are rendered from `probe-executor-env.js --project-only --json` and stay informational only (see `signals.md`).
 
 ```text
+S mechanical example
+--------------------
+Prerequisites count: 1
+Contract factors: 1
+Quality factors: 0
+Substantive total: 1
+Quality ratio: N/A (mechanical S-size task)
+Auto coverage: 2 / 2 checks automated across prerequisites + factors
+Calibration status: skipped (S task)
+Risk signals: none
+Rationale: Acceptance Criteria only require one observable behavior change; no design-bearing quality judgment was introduced.
+Historical signal: no historical data available
+Probe signal:
+probe_signal.test_infra: node:test
+TDD suggestion: decline (S-size mechanical task)
+probe_signal.lint_format: no quality infra detected
+probe_signal.type_check: no quality infra detected
+probe_signal.ci: GitHub Actions (test.yml)
+probe_signal.scripts: no quality infra detected
+Grade: B
+Action: dispatch allowed
+
 Synthetic populated signal example
 ---------------------------------
 Prerequisites count: 2

--- a/skills/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/skills/relay-plan/scripts/rubric-reference-contract.test.js
@@ -4,9 +4,14 @@ const fs = require("fs");
 const path = require("path");
 
 const REFERENCES_DIR = path.join(__dirname, "..", "references");
+const SKILL_PATH = path.join(__dirname, "..", "SKILL.md");
 
 function readReference(name) {
   return fs.readFileSync(path.join(REFERENCES_DIR, name), "utf-8");
+}
+
+function readSkill() {
+  return fs.readFileSync(SKILL_PATH, "utf-8");
 }
 
 test("domain rubric references declare candidate-axis usage", () => {
@@ -47,9 +52,12 @@ test("rubric validation preserves the S mechanical quality-card example", () => 
 
 test("rubric stress-test is gated by ambiguity or risk signal", () => {
   const text = readReference("rubric-stress-test.md");
+  const skill = readSkill();
 
   assert.match(text, /complex, design-bearing tasks/);
   assert.match(text, /ambiguity\/risk signal/);
   assert.match(text, /Do not launch this for direct all-automated rubrics or simple L tasks/);
   assert.match(text, /L tasks with no ambiguity\/risk signal/);
+  assert.match(skill, /Run stress-test only for L\/XL rubrics with evaluated factors and an ambiguity\/risk signal/);
+  assert.doesNotMatch(skill, /L does one stress-test round/);
 });

--- a/skills/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/skills/relay-plan/scripts/rubric-reference-contract.test.js
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const REFERENCES_DIR = path.join(__dirname, "..", "references");
+
+function readReference(name) {
+  return fs.readFileSync(path.join(REFERENCES_DIR, name), "utf-8");
+}
+
+test("domain rubric references declare candidate-axis usage", () => {
+  const domainFiles = [
+    "rubric-backend.md",
+    "rubric-design.md",
+    "rubric-documentation.md",
+    "rubric-frontend.md",
+    "rubric-refactoring.md",
+    "rubric-security.md",
+  ];
+
+  for (const file of domainFiles) {
+    const text = readReference(file);
+    assert.match(text, /## Candidate Axis Library/, file);
+    assert.match(text, /not as a template to paste wholesale/i, file);
+    assert.match(text, /S-size mechanical/i, file);
+  }
+});
+
+test("rubric design guide states the reference use contract", () => {
+  const text = readReference("rubric-design-guide.md");
+
+  assert.match(text, /## Reference Use Contract/);
+  assert.match(text, /candidate axis libraries/);
+  assert.match(text, /Do not copy a whole domain reference into a dispatch prompt/);
+  assert.match(text, /fix_hint.*historical plateaus or non-obvious score transitions/);
+});
+
+test("rubric validation preserves the S mechanical quality-card example", () => {
+  const text = readReference("rubric-validation.md");
+
+  assert.match(text, /S mechanical example/);
+  assert.match(text, /Quality factors: 0/);
+  assert.match(text, /Quality ratio: N\/A \(mechanical S-size task\)/);
+  assert.match(text, /Rationale: Acceptance Criteria only require one observable behavior change/);
+});
+
+test("rubric stress-test is gated by ambiguity or risk signal", () => {
+  const text = readReference("rubric-stress-test.md");
+
+  assert.match(text, /complex, design-bearing tasks/);
+  assert.match(text, /ambiguity\/risk signal/);
+  assert.match(text, /Do not launch this for direct all-automated rubrics or simple L tasks/);
+  assert.match(text, /L tasks with no ambiguity\/risk signal/);
+});


### PR DESCRIPTION
## Summary

- Clarifies that domain rubric references are candidate-axis libraries, not wholesale templates.
- Adds a reference-use contract for S-size mechanical rubrics, quality-factor boundaries, and `fix_hint` usage.
- Narrows stress-test / fresh-context reviewer guidance to ambiguity or risk signals instead of size alone.
- Adds regression tests that keep the reference contract explicit.

## Validation

- `node --test skills/relay-plan/scripts/*.test.js` (84 pass)
- `git diff --check`