### PR TITLE
Reframe relay-plan around task intent

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relay-plan
 argument-hint: "[issue-number]"
-description: Convert task acceptance criteria into a scored rubric for autonomous iteration. Always used before relay-dispatch — rubric depth scales with task size.
+description: Synthesize task intent, explicit AC when present, repo signals, and task risk into a scored rubric for autonomous iteration. Always used before relay-dispatch — rubric depth scales with task size.
 compatibility: Requires gh CLI.
 metadata:
   related-skills: "relay, relay-intake, relay-dispatch, relay-review, dev-backlog"
@@ -9,7 +9,7 @@ metadata:
 
 # Relay Plan
 
-Build a scoring rubric from task Acceptance Criteria (AC), then generate a dispatch prompt that drives autonomous iteration until convergence.
+Build a scoring rubric from the task's intended outcome: explicit Acceptance Criteria (AC) when available, inferred Done Criteria when missing or incomplete, repo quality signals, historical relay signal, and task-specific risk. Then generate a dispatch prompt that drives autonomous iteration until convergence.
 
 ## Process
 
@@ -43,9 +43,20 @@ node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
 
 Use `probe_signal.test_infra`, `lint_format`, `type_check`, `ci`, and `scripts` to inform rubric design, prerequisites, and Available Tools. The signal exposes data; it does not pick. No-signal/failure cases render as `no quality infra detected`; details: `references/signals.md`. The `test_infra` field is consumed by `references/rubric-pattern-tdd-flavor.md` and `scripts/tdd-suggestion.js`.
 
-### 4. Build the rubric
+### 4. Recover Done Criteria
 
-Use the guided interview (`references/rubric-design-guide.md`) to derive factors from AC, or convert directly:
+Before drafting factors, identify the evaluation source model:
+- Explicit AC from the task source, when present
+- Inferred Done Criteria from user intent, issue body, relay-intake handoff, and nearby repo conventions
+- Repo quality signal from probes and available commands
+- Historical relay signal from stuck factors and score divergence
+- Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes
+
+If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. If planner judgment expands, rejects, or narrows issue-body AC, persist that decision in step 8 so the reviewer has the same anchor.
+
+### 5. Build the rubric
+
+Use the guided interview (`references/rubric-design-guide.md`) to synthesize factors from the recovered Done Criteria, or convert directly:
 
 ```yaml
 rubric:
@@ -72,13 +83,13 @@ Tier classification, `type`, `weight`, `setup`/`baseline`, `criteria`, `scoring_
 
 ### Domain references
 
-Consult `references/rubric-*.md` for frontend, backend, security, refactoring, documentation, and design thinking. Design factors from AC, informed by references.
+Consult `references/rubric-*.md` for frontend, backend, security, refactoring, documentation, and design thinking. Design factors from task-specific evidence and risk, informed by references.
 
 ### Trust-model audit factor (auth-boundary tasks)
 
 If the task crosses an auth boundary (trust root, anchor, invariant, validate, forge, bypass, gate-check, auth-boundary, or `validateTransition*` / `validateManifest*` / `evaluateReviewGate`), follow `references/rubric-trust-model.md`. Each question becomes a named factor. Record answers under `### Trust-model audit` in the PR body before dispatch.
 
-### 5. Validate the rubric
+### 6. Validate the rubric
 
 Quick gate before dispatch:
 
@@ -91,15 +102,15 @@ Quick gate before dispatch:
 
 Full checklist, factor counts, grading, and risk signals: `references/rubric-validation.md`. Grade D = revise; Grade C = warn and state the tradeoff.
 
-### 6. Simplify the rubric
+### 7. Simplify the rubric
 
 Before persisting the draft rubric, apply the 6 heuristics in `references/rubric-simplification.md`.
 
 Apply to all task sizes: rewrite HOW into observable WHAT, merge overlaps, remove unsupported defensive clauses, and verify weights.
 
-### 7. Persist Phase 1 deviations only when scope changes
+### 8. Persist Phase 1 deviations only when Done Criteria change
 
-If operator planning rejects or narrows issue-body AC, persist that decision before dispatch so fresh-context review uses the same anchor:
+If operator planning expands, rejects, or narrows issue-body AC, persist that decision before dispatch so fresh-context review uses the same anchor:
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js --repo . \
@@ -108,17 +119,17 @@ node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js --repo . \
 
 Dispatch with the same `RUN_ID` and `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md`. Skip this step when the issue or intake handoff already provides the final Done Criteria.
 
-### 8. Review the rubric (triggered L/XL tasks)
+### 9. Review the rubric (triggered L/XL tasks)
 
-S/M skips. Run stress-test only for L/XL rubrics with evaluated factors and an ambiguity/risk signal. XL adds calibration simulation only when novel or subjective evaluated factors need it. Skip re-dispatches with iteration history, all-automated rubrics, and simple L tasks where AC maps cleanly to checks. Protocol: `references/rubric-stress-test.md`.
+S/M skips. Run stress-test only for L/XL rubrics with evaluated factors and an ambiguity/risk signal. XL adds calibration simulation only when novel or subjective evaluated factors need it. Skip re-dispatches with iteration history, all-automated rubrics, and simple L tasks where recovered Done Criteria map cleanly to checks. Protocol: `references/rubric-stress-test.md`.
 
-### 9. Generate dispatch prompt
+### 10. Generate dispatch prompt
 
 Take the base template (`../relay/references/prompt-template.md`) and append Setup, Scoring Rubric, Iteration Protocol, and Score Log sections. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
 
 Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 
-### 10. Dispatch
+### 11. Dispatch
 
 Write the rubric YAML to a temp file alongside the dispatch prompt. Every relay dispatch must pass `--rubric-file` so the rubric is persisted at `anchor.rubric_path` for review and merge gates.
 
@@ -129,7 +140,7 @@ node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
 
 ## When to use
 
-All tasks dispatched via relay. Rubric depth scales with task size (determined by orchestrator judgment on normalized AC + file scope, not raw issue AC count):
+All tasks dispatched via relay. Rubric depth scales with task size (determined by orchestrator judgment on recovered Done Criteria, file scope, ambiguity, and risk, not raw issue AC count):
 - **S** (simple fix, typo, 1-liner): 1 contract factor; add a quality factor only when the task has real design judgment; skip stress-test
 - **M** (standard feature): 3-5 factors, skip stress-test
 - **L** (cross-cutting, multi-file): 4-6 factors; stress-test only when evaluated factors plus ambiguity/risk signal exist

--- a/skills/relay-plan/references/rubric-backend.md
+++ b/skills/relay-plan/references/rubric-backend.md
@@ -4,7 +4,7 @@ Backend candidate axes for production behavior, data safety, and operational fai
 
 ## Candidate Axis Library
 
-Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical backend changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real production-design judgment.
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical backend changes, one contract factor plus hygiene prerequisites is enough unless explicit AC, inferred Done Criteria, or concrete risk introduce real production-design judgment.
 
 ## Hygiene Prerequisites
 
@@ -18,7 +18,7 @@ Use only when they apply to any PR in the repo:
 
 ## Contract Axes
 
-Use when they verify a specific AC item:
+Use when they verify a specific Done Criteria item:
 
 | Axis | Example command | Target |
 |---|---|---|

--- a/skills/relay-plan/references/rubric-design-guide.md
+++ b/skills/relay-plan/references/rubric-design-guide.md
@@ -1,6 +1,6 @@
 # Rubric Design Guide
 
-How to derive a task-specific rubric from Acceptance Criteria (AC). This file is the planning guide; validation, simplification, and stress-test detail live in their own references.
+How to synthesize a task-specific evaluation rubric from the full task brief. Acceptance Criteria (AC) are high-priority evidence, not the only source. When AC are missing, vague, or incomplete, first recover observable Done Criteria from task intent, repo context, quality signals, and risk.
 
 Before dispatch, persist the finished rubric to a file and pass it through `relay-dispatch --rubric-file <path>`. This records `anchor.rubric_path` for review and merge gates.
 
@@ -8,7 +8,7 @@ Before dispatch, persist the finished rubric to a file and pass it through `rela
 
 The domain `rubric-*.md` files are **candidate axis libraries**, not dispatch templates. Use them to sharpen task-specific judgment:
 
-- Pick only the axes earned by the Acceptance Criteria.
+- Pick only the axes earned by task-specific evidence: explicit AC, inferred Done Criteria, repo conventions, historical signal, probe signal, or concrete risk.
 - Do not copy a whole domain reference into a dispatch prompt.
 - S-size mechanical tasks may use one contract factor plus hygiene prerequisites and no quality factor.
 - Add quality factors only when the task has real design judgment or risk that a command cannot verify.
@@ -52,21 +52,33 @@ Use `tdd_anchor` only when red-first testing fits the factor's contract: crisp b
 
 ## Guided Interview
 
-Walk through these questions to design a task-specific rubric. Stop when the rubric covers the AC without adding generic quality wishes.
+Walk through these questions to design a task-specific rubric. Stop when the rubric covers the recovered Done Criteria without adding generic quality wishes.
 
-### Q1: What actually matters for this task?
+### Q1: What is the evaluation source model?
 
-Read the AC and rank the outcomes that would hurt most if they shipped wrong. Each kept concern must pass the tier test:
+List the evidence that defines success for this task:
+
+- Explicit AC, if present
+- Inferred Done Criteria from the user request, issue body, relay-intake handoff, and nearby repo conventions
+- Repo quality signals from available tests, lint, typecheck, CI, and scripts
+- Historical relay signals such as stuck factors, score divergence, and average rounds
+- Task risk such as trust boundaries, data loss, migrations, user-visible flows, performance, or operational failure modes
+
+If explicit AC and inferred Done Criteria disagree, resolve the conflict before drafting factors. Persist planner-authored Done Criteria when the final anchor differs from the issue body or intake handoff.
+
+### Q2: What actually matters for this task?
+
+Rank the outcomes that would hurt most if they shipped wrong. Each kept concern must pass the tier test:
 
 | Tier | Question | Placement | Examples |
 |---|---|---|---|
 | Hygiene | Would this apply to any PR in this repo? | `prerequisites` | `npm test`, `tsc --noEmit`, repo lint |
-| Contract | Does this verify a specific AC item exists? | `factors` | endpoint returns pagination metadata, config accepts a new field |
+| Contract | Does this verify a specific Done Criteria outcome exists? | `factors` | endpoint returns pagination metadata, config accepts a new field |
 | Quality | Does this judge how well the implementation is designed? | `factors` | failure-mode strategy, abstraction boundary, reader success |
 
 Contract is "is it there?" Quality is "is it good?" Move repo-wide checks to `prerequisites`; do not count them as substantive factors.
 
-### Q2: What can be measured with a command?
+### Q3: What can be measured with a command?
 
 Inventory project tools before deciding what is measurable:
 
@@ -74,14 +86,14 @@ Inventory project tools before deciding what is measurable:
 ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js <repo-path> --project-only --json
 ```
 
-For each AC item, ask whether a shell command can verify the outcome with available tools.
+For each Done Criteria item, ask whether a shell command can verify the outcome with available tools.
 
 - Yes: make it an automated factor with an immutable `command` and concrete `target`.
-- No: make it an evaluated factor and continue to Q3.
+- No: make it an evaluated factor and continue to Q4.
 
 Examples:
 
-| AC item | Measurable command | Factor type |
+| Done Criteria item | Measurable command | Factor type |
 |---|---|---|
 | API responds within 200ms | `curl -w '%{time_total}'` | automated |
 | links in one doc work | `npx markdown-link-check <file>` | automated |
@@ -90,7 +102,7 @@ Examples:
 
 Automated does not automatically mean substantive. `npm test` is hygiene unless the command directly targets this task's changed behavior.
 
-### Q3: What would a specialist check?
+### Q4: What would a specialist check?
 
 For each evaluated factor, write criteria specific to this task. A useful evaluated factor names what to inspect, not a vague standard.
 
@@ -99,11 +111,11 @@ Good criteria:
 - name concrete files, functions, commands, user flows, or data shapes
 - use 3-5 bullets
 - distinguish required outcomes from nice-to-have polish
-- avoid helper names, exact line counts, or internal control flow unless the AC explicitly requires them
+- avoid helper names, exact line counts, or internal control flow unless the Done Criteria explicitly requires them
 
-Consult domain references only after drafting from AC. Borrow the thinking, not the whole checklist.
+Consult domain references only after drafting from task-specific evidence. Borrow the thinking, not the whole checklist.
 
-### Q4: What does each score level mean?
+### Q5: What does each score level mean?
 
 Every evaluated factor needs a `scoring_guide` with low/mid/high anchors.
 
@@ -124,7 +136,7 @@ fix_hint:
   mid_to_high: "Add exponential backoff with jitter and structured caller-actionable errors"
 ```
 
-### Q5: Is there a baseline?
+### Q6: Is there a baseline?
 
 For delta metrics such as performance, bundle size, complexity, or dead code, target the current state instead of an arbitrary number.
 

--- a/skills/relay-plan/references/rubric-design.md
+++ b/skills/relay-plan/references/rubric-design.md
@@ -4,7 +4,7 @@ Design candidate axes for product value, usability, visual hierarchy, and polish
 
 ## Candidate Axis Library
 
-Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical design changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real product or UX judgment.
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical design changes, one contract factor plus hygiene prerequisites is enough unless explicit AC, inferred Done Criteria, or concrete risk introduce real product or UX judgment.
 
 ## Hygiene Prerequisites
 
@@ -18,7 +18,7 @@ Use only when they apply to any PR in the repo:
 
 ## Contract Axes
 
-Use when they verify a specific AC item:
+Use when they verify a specific Done Criteria item:
 
 | Axis | Example check | Target |
 |---|---|---|

--- a/skills/relay-plan/references/rubric-documentation.md
+++ b/skills/relay-plan/references/rubric-documentation.md
@@ -4,7 +4,7 @@ Documentation candidate axes for reader success, maintainability, and executable
 
 ## Candidate Axis Library
 
-Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical docs changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real reader-success judgment.
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical docs changes, one contract factor plus hygiene prerequisites is enough unless explicit AC, inferred Done Criteria, or concrete risk introduce real reader-success judgment.
 
 ## Hygiene Prerequisites
 

--- a/skills/relay-plan/references/rubric-frontend.md
+++ b/skills/relay-plan/references/rubric-frontend.md
@@ -4,7 +4,7 @@ Frontend candidate axes for user-visible behavior, accessibility, responsiveness
 
 ## Candidate Axis Library
 
-Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical frontend changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real UX or state-management judgment.
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical frontend changes, one contract factor plus hygiene prerequisites is enough unless explicit AC, inferred Done Criteria, or concrete risk introduce real UX or state-management judgment.
 
 ## Hygiene Prerequisites
 
@@ -18,7 +18,7 @@ Use only when they apply to any PR in the repo:
 
 ## Contract Axes
 
-Use when they verify a specific AC item:
+Use when they verify a specific Done Criteria item:
 
 | Axis | Example command | Target |
 |---|---|---|

--- a/skills/relay-plan/references/rubric-refactoring.md
+++ b/skills/relay-plan/references/rubric-refactoring.md
@@ -4,7 +4,7 @@ Refactoring candidate axes for behavior preservation, concept reduction, and mai
 
 ## Candidate Axis Library
 
-Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical refactors, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real design judgment.
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical refactors, one contract factor plus hygiene prerequisites is enough unless explicit AC, inferred Done Criteria, or concrete risk introduce real design judgment.
 
 ## Hygiene Prerequisites
 

--- a/skills/relay-plan/references/rubric-security.md
+++ b/skills/relay-plan/references/rubric-security.md
@@ -6,7 +6,7 @@ Security candidate axes for trust boundaries, secrets, inputs, files, dependenci
 
 ## Candidate Axis Library
 
-Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical security-adjacent changes, one contract factor plus hygiene prerequisites is enough unless the Acceptance Criteria introduce real trust-boundary judgment.
+Use this file to choose task-relevant rubric axes, not as a template to paste wholesale. For S-size mechanical security-adjacent changes, one contract factor plus hygiene prerequisites is enough unless explicit AC, inferred Done Criteria, or concrete risk introduce real trust-boundary judgment.
 
 ## Hygiene Prerequisites
 
@@ -20,7 +20,7 @@ Use only when they apply to any PR in the repo:
 
 ## Contract Axes
 
-Use when they verify a specific AC item:
+Use when they verify a specific Done Criteria item:
 
 | Axis | Example command | Target |
 |---|---|---|

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -6,9 +6,9 @@ For complex, design-bearing tasks, stress-test the rubric before dispatch. A fre
 
 | Size | Criteria | Rubric Review |
 |------|----------|---------------|
-| S/M | 1-4 AC items | None (current flow) |
-| L | 5-6 AC items plus evaluated factors and ambiguity/risk signal | Stress-test (1 fresh-context reviewer) |
-| XL | 7+ AC items or cross-domain plus evaluated factors and ambiguity/risk signal | Stress-test + Calibration simulation (parallel only when useful) |
+| S/M | Narrow or standard task, low ambiguity/risk, limited file scope | None (current flow) |
+| L | Cross-cutting, multi-file, ambiguous, or risk-bearing task with evaluated factors and ambiguity/risk signal | Stress-test (1 fresh-context reviewer) |
+| XL | Architecture change, cross-domain work, migration, or high-risk boundary with evaluated factors and ambiguity/risk signal | Stress-test + Calibration simulation (parallel only when useful) |
 
 **Cross-domain**: task spans frontend + backend, infra + application, or multiple services.
 
@@ -16,7 +16,7 @@ For complex, design-bearing tasks, stress-test the rubric before dispatch. A fre
 
 ## Process: Validate → Review → Generate
 
-Insert this between "Validate the rubric" (step 3) and "Generate dispatch prompt" (step 4):
+Insert this between "Validate the rubric" and "Generate dispatch prompt":
 
 ```
 Step 5 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)
@@ -24,16 +24,16 @@ Step 5 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prom
 
 ## Stress-Test (L and XL when triggered)
 
-Use a fresh-context reviewer (subagent when available, otherwise a separate isolated review prompt). Hand it the rubric YAML + original AC as a structured artifact. Do not launch this for direct all-automated rubrics or simple L tasks where the AC already maps cleanly to checks.
+Use a fresh-context reviewer (subagent when available, otherwise a separate isolated review prompt). Hand it the rubric YAML + task brief / recovered Done Criteria as a structured artifact. Do not launch this for direct all-automated rubrics or simple L tasks where the recovered Done Criteria already map cleanly to checks.
 
 ### Prompt Template
 
 ```
 You are reviewing a scoring rubric for quality before it goes to an executor.
-You have NOT seen the planning conversation — only the rubric and the AC.
+You have NOT seen the planning conversation — only the rubric and the task brief / recovered Done Criteria.
 
-## Task AC
-{paste original acceptance criteria}
+## Task Brief / Done Criteria
+{paste task brief and recovered Done Criteria}
 
 ## Rubric
 {paste rubric YAML}
@@ -48,12 +48,12 @@ but a senior engineer would reject. Be concrete — name the shortcut,
 not "could be gamed."
 
 ### 2. Coverage Gap
-What does this factor fail to catch that the AC implies should be checked?
-Look for AC items with no corresponding factor, or factor criteria that
-miss an AC dimension.
+What does this factor fail to catch that the task brief or Done Criteria implies should be checked?
+Look for Done Criteria items with no corresponding factor, or factor criteria that
+miss a task-specific dimension.
 
 ### 3. Disappear Test
-If this specific AC item disappeared from the task, would this factor
+If this specific Done Criteria item disappeared from the task, would this factor
 still be a worthwhile quality check? If yes → the factor may be generic
 filler rather than task-specific.
 
@@ -143,7 +143,7 @@ After receiving stress-test (and calibration) results:
 
 ## When to Skip
 
-- **S/M tasks** (1-4 AC): Rubric is simple enough that stress-testing adds overhead without proportional value
+- **S/M tasks** (narrow scope, low ambiguity/risk): Rubric is simple enough that stress-testing adds overhead without proportional value
 - **L tasks with no ambiguity/risk signal**: A direct rubric review by the orchestrator is enough
 - **Re-dispatches with iteration history**: The rubric was already stress-tested on the first dispatch; re-dispatch focuses on addressing reviewer feedback, not rubric quality
 - **All-automated rubrics**: No evaluated factors to calibrate — stress-test adds nothing

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -19,7 +19,7 @@ For complex, design-bearing tasks, stress-test the rubric before dispatch. A fre
 Insert this between "Validate the rubric" and "Generate dispatch prompt":
 
 ```
-Step 5 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)
+Step 6 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)
 ```
 
 ## Stress-Test (L and XL when triggered)

--- a/skills/relay-plan/references/rubric-trust-model.md
+++ b/skills/relay-plan/references/rubric-trust-model.md
@@ -4,7 +4,7 @@ Authoring guidance for rubrics on tasks that cross an **auth boundary**. Schema-
 
 ## When to apply
 
-Trigger this checklist during rubric design (relay-plan step 4) if any of the following is true:
+Trigger this checklist during rubric design (relay-plan step 5) if any of the following is true:
 
 - The issue carries the `phase-0-follow-up` label.
 - The issue or its AC mentions any of: **trust root**, **anchor**, **invariant**, **grandfather**, **validate**, **forge/forgery**, **bypass**, **gate-check**, **auth(-boundary)**, or any `validateTransition*` / `validateManifest*` / `evaluateReviewGate` callsite.

--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -1,6 +1,6 @@
 # Rubric Validation, Grading, and Quality Card
 
-This reference holds the step-3 validation detail that used to live inline in `SKILL.md`. Apply it between `## 2. Build the rubric` and `## 4. Generate dispatch prompt`.
+This reference holds the validation detail that used to live inline in `SKILL.md`. Apply it after building the rubric and before simplification.
 
 ## Validate the rubric (full checklist)
 
@@ -24,11 +24,11 @@ Prerequisites (hygiene): as many as needed, uncounted. Factors (contract + quali
 
 | Size | Contract min | Quality min | Substantive total | Recommended |
 |------|--------------|-------------|-------------------|-------------|
-| S (1-2 AC, mechanical) | ≥ 1 | 0 | 1+ | 1-2 |
-| S (1-2 AC, design-bearing) | ≥ 1 | ≥ 1 | 2+ | ~2 |
-| M (3-4 AC) | ≥ 2 | ≥ 1 | 3+ | ~5 |
-| L (5-6 AC) | ≥ 2 | ≥ 2 | 4+ | ~6 |
-| XL (7+ AC) | ≥ 3 | ≥ 2 | 5+ | ~8 |
+| S (narrow mechanical outcome, low ambiguity/risk) | ≥ 1 | 0 | 1+ | 1-2 |
+| S (narrow design-bearing outcome) | ≥ 1 | ≥ 1 | 2+ | ~2 |
+| M (standard feature or fix with moderate file scope) | ≥ 2 | ≥ 1 | 3+ | ~5 |
+| L (cross-cutting, multi-file, ambiguous, or risk-bearing) | ≥ 2 | ≥ 2 | 4+ | ~6 |
+| XL (architecture change, cross-domain, migration, or high-risk boundary) | ≥ 3 | ≥ 2 | 5+ | ~8 |
 
 ## Rubric Quality Card
 
@@ -47,7 +47,7 @@ Quality ratio: N/A (mechanical S-size task)
 Auto coverage: 2 / 2 checks automated across prerequisites + factors
 Calibration status: skipped (S task)
 Risk signals: none
-Rationale: Acceptance Criteria only require one observable behavior change; no design-bearing quality judgment was introduced.
+Rationale: Recovered Done Criteria require one observable behavior change; no design-bearing quality judgment was introduced.
 Historical signal: no historical data available
 Probe signal:
 probe_signal.test_infra: node:test

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -38,6 +38,8 @@ test("rubric design guide states the reference use contract", () => {
   assert.match(text, /## Reference Use Contract/);
   assert.match(text, /candidate axis libraries/);
   assert.match(text, /Do not copy a whole domain reference into a dispatch prompt/);
+  assert.match(text, /Acceptance Criteria \(AC\) are high-priority evidence, not the only source/);
+  assert.match(text, /inferred Done Criteria/);
   assert.match(text, /fix_hint.*historical plateaus or non-obvious score transitions/);
 });
 
@@ -47,7 +49,7 @@ test("rubric validation preserves the S mechanical quality-card example", () => 
   assert.match(text, /S mechanical example/);
   assert.match(text, /Quality factors: 0/);
   assert.match(text, /Quality ratio: N\/A \(mechanical S-size task\)/);
-  assert.match(text, /Rationale: Acceptance Criteria only require one observable behavior change/);
+  assert.match(text, /Rationale: Recovered Done Criteria require one observable behavior change/);
 });
 
 test("rubric stress-test is gated by ambiguity or risk signal", () => {
@@ -58,6 +60,19 @@ test("rubric stress-test is gated by ambiguity or risk signal", () => {
   assert.match(text, /ambiguity\/risk signal/);
   assert.match(text, /Do not launch this for direct all-automated rubrics or simple L tasks/);
   assert.match(text, /L tasks with no ambiguity\/risk signal/);
+  assert.match(text, /Task Brief \/ Done Criteria/);
+  assert.match(text, /narrow scope, low ambiguity\/risk/);
   assert.match(skill, /Run stress-test only for L\/XL rubrics with evaluated factors and an ambiguity\/risk signal/);
   assert.doesNotMatch(skill, /L does one stress-test round/);
+});
+
+test("relay-plan frames AC as one input signal, not the whole rubric source", () => {
+  const skill = readSkill();
+
+  assert.match(skill, /Synthesize task intent, explicit AC when present, repo signals, and task risk/);
+  assert.match(skill, /### 4\. Recover Done Criteria/);
+  assert.match(skill, /explicit AC as high-priority evidence, not the only source/);
+  assert.match(skill, /not raw issue AC count/);
+  assert.doesNotMatch(skill, /Convert task acceptance criteria into a scored rubric/);
+  assert.doesNotMatch(skill, /Build a scoring rubric from task Acceptance Criteria/);
 });

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -61,6 +61,7 @@ test("rubric stress-test is gated by ambiguity or risk signal", () => {
   assert.match(text, /Do not launch this for direct all-automated rubrics or simple L tasks/);
   assert.match(text, /L tasks with no ambiguity\/risk signal/);
   assert.match(text, /Task Brief \/ Done Criteria/);
+  assert.match(text, /Step 6 \(Validate\) → Step 9 \(Rubric Review\) → Step 10 \(Generate dispatch prompt\)/);
   assert.match(text, /narrow scope, low ambiguity\/risk/);
   assert.match(skill, /Run stress-test only for L\/XL rubrics with evaluated factors and an ambiguity\/risk signal/);
   assert.doesNotMatch(skill, /L does one stress-test round/);


### PR DESCRIPTION
## Summary
- Reframe relay-plan from AC-only conversion to task intent / Done Criteria / signal-based rubric synthesis
- Add a Recover Done Criteria step before rubric authoring and update rubric design, validation, stress-test, trust-model, and domain references accordingly
- Add contract tests that prevent regressing to AC-only framing and lock the updated stress-test step sequence

## Review notes
- craft-critique lens: verified the skill's real job is now eval rubric synthesis, with AC treated as high-priority evidence rather than the only source
- simplify lens: kept this as documentation/contract changes only, with no new runtime abstraction or manifest schema change
- fixed one review finding before PR: stress-test reference still pointed at stale Step 5 for Validate after the new Recover Done Criteria step; now locked to Step 6 in tests

## Tests
- node --test tests/relay-plan/scripts/*.test.js