### PR TITLE
Align relay loop around Done Criteria anchors

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -119,7 +119,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js --repo . \
 
 Dispatch with the same `RUN_ID` and `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md`. Skip this step only when the issue or intake handoff already provides the final Done Criteria without planner changes.
 
-### 9. Review the rubric (triggered L/XL tasks)
+### 9. Review the rubric (triggered by ambiguity/risk)
 
 S/M usually skips, but ambiguity or risk can opt any size into stress-test. Run stress-test for L/XL rubrics with evaluated factors and an ambiguity/risk signal, and for smaller rubrics when the recovered Done Criteria are novel, vague, or easy to game. XL adds calibration simulation only when novel or subjective evaluated factors need it. Skip re-dispatches with iteration history, all-automated rubrics, and simple tasks where recovered Done Criteria map cleanly to checks. Protocol: `references/rubric-stress-test.md`.
 

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -52,7 +52,7 @@ Before drafting factors, identify the evaluation source model:
 - Historical relay signal from stuck factors and score divergence
 - Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes
 
-If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. If planner judgment expands, rejects, or narrows issue-body AC, persist that decision in step 8 so the reviewer has the same anchor.
+If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. If the final review anchor is planner-authored or differs from the task source, persist it in step 8 so the reviewer has the same anchor.
 
 ### 5. Build the rubric
 
@@ -108,20 +108,20 @@ Before persisting the draft rubric, apply the 6 heuristics in `references/rubric
 
 Apply to all task sizes: rewrite HOW into observable WHAT, merge overlaps, remove unsupported defensive clauses, and verify weights.
 
-### 8. Persist Phase 1 deviations only when Done Criteria change
+### 8. Persist planner-authored Done Criteria
 
-If operator planning expands, rejects, or narrows issue-body AC, persist that decision before dispatch so fresh-context review uses the same anchor:
+If operator planning writes the final Done Criteria, persist that decision before dispatch so fresh-context review uses the same anchor. This includes AC-missing inputs, user-provided descriptions, and any case where planning expands, rejects, or narrows issue-body AC:
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/persist-done-criteria.js --repo . \
   --run-id "$RUN_ID" --file /tmp/done-criteria-<N>.md --json
 ```
 
-Dispatch with the same `RUN_ID` and `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md`. Skip this step when the issue or intake handoff already provides the final Done Criteria.
+Dispatch with the same `RUN_ID` and `--done-criteria-file ~/.relay/runs/<repo-slug>/$RUN_ID/done-criteria.md`. Skip this step only when the issue or intake handoff already provides the final Done Criteria without planner changes.
 
 ### 9. Review the rubric (triggered L/XL tasks)
 
-S/M skips. Run stress-test only for L/XL rubrics with evaluated factors and an ambiguity/risk signal. XL adds calibration simulation only when novel or subjective evaluated factors need it. Skip re-dispatches with iteration history, all-automated rubrics, and simple L tasks where recovered Done Criteria map cleanly to checks. Protocol: `references/rubric-stress-test.md`.
+S/M usually skips, but ambiguity or risk can opt any size into stress-test. Run stress-test for L/XL rubrics with evaluated factors and an ambiguity/risk signal, and for smaller rubrics when the recovered Done Criteria are novel, vague, or easy to game. XL adds calibration simulation only when novel or subjective evaluated factors need it. Skip re-dispatches with iteration history, all-automated rubrics, and simple tasks where recovered Done Criteria map cleanly to checks. Protocol: `references/rubric-stress-test.md`.
 
 ### 10. Generate dispatch prompt
 

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -6,13 +6,13 @@ For complex, design-bearing tasks, stress-test the rubric before dispatch. A fre
 
 | Size | Criteria | Rubric Review |
 |------|----------|---------------|
-| S/M | Narrow or standard task, low ambiguity/risk, limited file scope | None (current flow) |
+| S/M | Narrow or standard task, low ambiguity/risk, limited file scope | Usually none; stress-test when ambiguity/risk signal exists |
 | L | Cross-cutting, multi-file, ambiguous, or risk-bearing task with evaluated factors and ambiguity/risk signal | Stress-test (1 fresh-context reviewer) |
 | XL | Architecture change, cross-domain work, migration, or high-risk boundary with evaluated factors and ambiguity/risk signal | Stress-test + Calibration simulation (parallel only when useful) |
 
 **Cross-domain**: task spans frontend + backend, infra + application, or multiple services.
 
-**Ambiguity/risk signal**: novel quality criteria, historical score divergence, trust/security boundary, unclear AC decomposition, or factors that could be gamed by a minimal implementation.
+**Ambiguity/risk signal**: novel quality criteria, historical score divergence, trust/security boundary, unclear Done Criteria recovery, or factors that could be gamed by a minimal implementation.
 
 ## Process: Validate → Review → Generate
 
@@ -73,7 +73,7 @@ not what's universally true of competent code.
 
 ## Summary
 - Factors that need tightening: {list}
-- Missing factors for uncovered AC: {list}
+- Missing factors for uncovered Done Criteria: {list}
 - Generic factors to reconsider: {list}
 ```
 
@@ -143,7 +143,7 @@ After receiving stress-test (and calibration) results:
 
 ## When to Skip
 
-- **S/M tasks** (narrow scope, low ambiguity/risk): Rubric is simple enough that stress-testing adds overhead without proportional value
+- **S/M tasks with no ambiguity/risk signal**: Rubric is simple enough that stress-testing adds overhead without proportional value
 - **L tasks with no ambiguity/risk signal**: A direct rubric review by the orchestrator is enough
 - **Re-dispatches with iteration history**: The rubric was already stress-tested on the first dispatch; re-dispatch focuses on addressing reviewer feedback, not rubric quality
 - **All-automated rubrics**: No evaluated factors to calibrate — stress-test adds nothing

--- a/skills/relay-plan/references/rubric-stress-test.md
+++ b/skills/relay-plan/references/rubric-stress-test.md
@@ -1,6 +1,6 @@
-# Rubric Stress-Test for L/XL Tasks
+# Rubric Stress-Test
 
-For complex, design-bearing tasks, stress-test the rubric before dispatch. A fresh-context reviewer attempts to "game" the rubric — finding minimal implementations that technically pass but a senior engineer would reject.
+For complex, ambiguous, or risk-bearing tasks, stress-test the rubric before dispatch. A fresh-context reviewer attempts to "game" the rubric — finding minimal implementations that technically pass but a senior engineer would reject.
 
 ## Task Size Classification
 
@@ -22,9 +22,9 @@ Insert this between "Validate the rubric" and "Generate dispatch prompt":
 Step 6 (Validate) → Step 9 (Rubric Review) → Step 10 (Generate dispatch prompt)
 ```
 
-## Stress-Test (L and XL when triggered)
+## Stress-Test (when triggered)
 
-Use a fresh-context reviewer (subagent when available, otherwise a separate isolated review prompt). Hand it the rubric YAML + task brief / recovered Done Criteria as a structured artifact. Do not launch this for direct all-automated rubrics or simple L tasks where the recovered Done Criteria already map cleanly to checks.
+Use a fresh-context reviewer (subagent when available, otherwise a separate isolated review prompt). Hand it the rubric YAML + task brief / recovered Done Criteria as a structured artifact. Do not launch this for direct all-automated rubrics or simple tasks where the recovered Done Criteria already map cleanly to checks.
 
 ### Prompt Template
 

--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -18,6 +18,18 @@ Before dispatch, verify:
 - [ ] Targets are concrete ("≥ 8/10", "< 200ms") not relative ("good", "fast")
 - [ ] Automated checks measure outcomes not proxies
 
+## Validate Done Criteria (full checklist)
+
+Before validating factor counts, verify the Done Criteria anchor itself:
+
+- [ ] Observable outcomes: each item describes a result a reviewer can inspect, run, or experience
+- [ ] Scope boundary: the anchor names what should change and, when useful, what should not change
+- [ ] Reviewability: each item maps to a file, command, user flow, API shape, event, or explicit inspection path
+- [ ] Risk coverage: trust boundaries, data loss, migrations, performance, UX failure states, and operational failure modes are either covered or explicitly out of scope
+- [ ] Verification path: at least one automated check or evaluated inspection path exists for the task
+
+If any Done Criteria check fails, revise or persist clearer planner-authored Done Criteria before dispatch.
+
 ## Factor count rules
 
 Prerequisites (hygiene): as many as needed, uncounted. Factors (contract + quality): no hard cap, warning at 8+.
@@ -156,5 +168,6 @@ Grade D means stop and revise the rubric first. Grade C means warn before dispat
 | `proxy_metric` | Automated checks measure effort or process instead of outcome |
 | `high_factor_count` | 8+ substantive factors |
 | `all_contract` | Zero quality coverage on a design-bearing task |
+| `weak_done_criteria` | Done Criteria are not observable, bounded, reviewable, risk-aware, or verifiable |
 
 Any check fails → revise. See `rubric-design-guide.md` for fix patterns.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -34,7 +34,7 @@ No sprint file? Just do the `git fetch`. Takes <5 seconds; never skip this step.
 ## Step 1: Route and Read Context
 
 Gather task details and sprint context:
-1. **Task AC** (try in order, use first that succeeds):
+1. **Task evidence** (try in order, use first that succeeds):
    - Local task file: `backlog/tasks/{PREFIX}-{N} - {Title}.md`
    - GitHub: `gh issue view <N>`
    - User-provided description (from argument or conversation)
@@ -70,7 +70,7 @@ PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
 
 ## Step 2: Plan
 
-**Always build a rubric.** Follow relay-plan's process (Steps 1-10 only: read task → build rubric → generate prompt). Do NOT dispatch from relay-plan — Step 3 below handles dispatch. See `relay-plan` SKILL.md for rubric depth by task size (S/M/L/XL).
+**Always build a rubric.** Follow relay-plan's planning process (read task → recover Done Criteria → build rubric → generate prompt). Do NOT dispatch from relay-plan — Step 3 below handles dispatch. See `relay-plan` SKILL.md for rubric depth by task size (S/M/L/XL).
 
 Write the dispatch prompt to a temp file (e.g., `/tmp/dispatch-<N>.md`).
 If intake ran, the relay-ready handoff brief becomes the task source of truth for planning.
@@ -136,7 +136,7 @@ When multiple independent tasks are ready, dispatch in parallel instead of runni
 ## Summary Checklist
 
 After completing the relay cycle, verify:
-- [ ] Issue AC fully implemented (relay-review confirmed)
+- [ ] Done Criteria fully implemented (relay-review confirmed)
 - [ ] PR has `<!-- relay-review -->` LGTM comment (or `<!-- relay-review-skip -->` with reason)
 - [ ] PR marked `ready_to_merge`, or merged and closed if relay-merge was explicitly requested
 - [ ] Sprint file updated — if exists (Plan `[x]`, Progress entry with review round count)

--- a/skills/relay/references/prompt-template.md
+++ b/skills/relay/references/prompt-template.md
@@ -35,7 +35,7 @@ Use the same tier judgment questions everywhere:
 | Tier | Question | Placement | Examples |
 |------|----------|-----------|----------|
 | **Hygiene** | "Would this check apply to ANY PR in this repo?" | `prerequisites` | `npm test`, `tsc --noEmit`, `eslint` |
-| **Contract** | "Does this verify a SPECIFIC AC item is implemented?" | `factors` | endpoint returns paginated response, config includes new field |
+| **Contract** | "Does this verify a specific Done Criteria outcome is implemented?" | `factors` | endpoint returns paginated response, config includes new field |
 | **Quality** | "Does this probe HOW well it was designed/implemented?" | `factors` | error recovery strategy, abstraction boundaries, failure mode differentiation |
 
 **Contract = "is it there?"**  
@@ -48,7 +48,7 @@ rubric:
     - command: "[repo-wide hygiene check]"
       target: "exit 0"
   factors:
-    - name: "[specific AC implemented]"
+    - name: "[specific Done Criteria outcome]"
       tier: contract
       type: automated
       command: "[task-specific check]"

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -66,9 +66,10 @@ test("rubric stress-test is gated by ambiguity or risk signal", () => {
   const text = readReference("rubric-stress-test.md");
   const skill = readSkill();
 
-  assert.match(text, /complex, design-bearing tasks/);
+  assert.match(text, /complex, ambiguous, or risk-bearing tasks/);
   assert.match(text, /ambiguity\/risk signal/);
-  assert.match(text, /Do not launch this for direct all-automated rubrics or simple L tasks/);
+  assert.match(text, /## Stress-Test \(when triggered\)/);
+  assert.match(text, /Do not launch this for direct all-automated rubrics or simple tasks/);
   assert.match(text, /S\/M tasks with no ambiguity\/risk signal/);
   assert.match(text, /Task Brief \/ Done Criteria/);
   assert.match(text, /stress-test when ambiguity\/risk signal exists/);
@@ -77,6 +78,9 @@ test("rubric stress-test is gated by ambiguity or risk signal", () => {
   assert.match(text, /low ambiguity\/risk/);
   assert.match(skill, /ambiguity or risk can opt any size into stress-test/);
   assert.doesNotMatch(text, /uncovered AC/);
+  assert.doesNotMatch(text, /L and XL when triggered/);
+  assert.doesNotMatch(text, /simple L tasks/);
+  assert.doesNotMatch(skill, /triggered L\/XL tasks/);
   assert.doesNotMatch(skill, /L does one stress-test round/);
 });
 

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -5,6 +5,8 @@ const path = require("path");
 
 const REFERENCES_DIR = path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "references");
 const SKILL_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "SKILL.md");
+const RELAY_SKILL_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay", "SKILL.md");
+const RELAY_REFERENCES_DIR = path.join(__dirname, "..", "..", "..", "skills", "relay", "references");
 
 function readReference(name) {
   return fs.readFileSync(path.join(REFERENCES_DIR, name), "utf-8");
@@ -12,6 +14,14 @@ function readReference(name) {
 
 function readSkill() {
   return fs.readFileSync(SKILL_PATH, "utf-8");
+}
+
+function readRelaySkill() {
+  return fs.readFileSync(RELAY_SKILL_PATH, "utf-8");
+}
+
+function readRelayReference(name) {
+  return fs.readFileSync(path.join(RELAY_REFERENCES_DIR, name), "utf-8");
 }
 
 test("domain rubric references declare candidate-axis usage", () => {
@@ -59,11 +69,14 @@ test("rubric stress-test is gated by ambiguity or risk signal", () => {
   assert.match(text, /complex, design-bearing tasks/);
   assert.match(text, /ambiguity\/risk signal/);
   assert.match(text, /Do not launch this for direct all-automated rubrics or simple L tasks/);
-  assert.match(text, /L tasks with no ambiguity\/risk signal/);
+  assert.match(text, /S\/M tasks with no ambiguity\/risk signal/);
   assert.match(text, /Task Brief \/ Done Criteria/);
+  assert.match(text, /stress-test when ambiguity\/risk signal exists/);
+  assert.match(text, /uncovered Done Criteria/);
   assert.match(text, /Step 6 \(Validate\) → Step 9 \(Rubric Review\) → Step 10 \(Generate dispatch prompt\)/);
-  assert.match(text, /narrow scope, low ambiguity\/risk/);
-  assert.match(skill, /Run stress-test only for L\/XL rubrics with evaluated factors and an ambiguity\/risk signal/);
+  assert.match(text, /low ambiguity\/risk/);
+  assert.match(skill, /ambiguity or risk can opt any size into stress-test/);
+  assert.doesNotMatch(text, /uncovered AC/);
   assert.doesNotMatch(skill, /L does one stress-test round/);
 });
 
@@ -73,7 +86,37 @@ test("relay-plan frames AC as one input signal, not the whole rubric source", ()
   assert.match(skill, /Synthesize task intent, explicit AC when present, repo signals, and task risk/);
   assert.match(skill, /### 4\. Recover Done Criteria/);
   assert.match(skill, /explicit AC as high-priority evidence, not the only source/);
+  assert.match(skill, /If the final review anchor is planner-authored or differs from the task source, persist it/);
+  assert.match(skill, /AC-missing inputs, user-provided descriptions/);
   assert.match(skill, /not raw issue AC count/);
   assert.doesNotMatch(skill, /Convert task acceptance criteria into a scored rubric/);
   assert.doesNotMatch(skill, /Build a scoring rubric from task Acceptance Criteria/);
+});
+
+test("rubric validation gates Done Criteria quality before dispatch", () => {
+  const text = readReference("rubric-validation.md");
+
+  assert.match(text, /## Validate Done Criteria \(full checklist\)/);
+  assert.match(text, /Observable outcomes/);
+  assert.match(text, /Scope boundary/);
+  assert.match(text, /Reviewability/);
+  assert.match(text, /Risk coverage/);
+  assert.match(text, /Verification path/);
+  assert.match(text, /weak_done_criteria/);
+});
+
+test("relay dispatch template and wrapper use Done Criteria outcome language", () => {
+  const template = readRelayReference("prompt-template.md");
+  const relaySkill = readRelaySkill();
+
+  assert.match(template, /specific Done Criteria outcome is implemented/);
+  assert.match(template, /\[specific Done Criteria outcome\]/);
+  assert.doesNotMatch(template, /SPECIFIC AC item/);
+  assert.doesNotMatch(template, /specific AC implemented/);
+
+  assert.match(relaySkill, /Task evidence/);
+  assert.match(relaySkill, /recover Done Criteria/);
+  assert.match(relaySkill, /Done Criteria fully implemented/);
+  assert.doesNotMatch(relaySkill, /Steps 1-10 only/);
+  assert.doesNotMatch(relaySkill, /Issue AC fully implemented/);
 });

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -115,8 +115,7 @@ test("relay dispatch template and wrapper use Done Criteria outcome language", (
 
   assert.match(template, /specific Done Criteria outcome is implemented/);
   assert.match(template, /\[specific Done Criteria outcome\]/);
-  assert.doesNotMatch(template, /SPECIFIC AC item/);
-  assert.doesNotMatch(template, /specific AC implemented/);
+  assert.doesNotMatch(template, /specific AC (item|implemented)/i);
 
   assert.match(relaySkill, /Task evidence/);
   assert.match(relaySkill, /recover Done Criteria/);


### PR DESCRIPTION
## Summary
- Align relay wrapper and dispatch prompt template around Done Criteria outcome language instead of AC item language
- Clarify that planner-authored Done Criteria must be persisted whenever they become the final review anchor
- Add a Done Criteria quality gate and allow ambiguity/risk to opt any task size into rubric stress-test
- Expand contract tests to prevent AC-only wording and stale relay-plan step references from returning

Closes #362

## Tests
- node --test tests/relay-plan/scripts/rubric-reference-contract.test.js
- node --test tests/relay-plan/scripts/*.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**문서**
- 완료 기준 검증 프로세스가 강화되었습니다. 이제 결과 관찰 가능성, 명확한 범위, 검증 경로, 위험 커버리지를 포함하여 더욱 포괄적으로 검증합니다.
- 스트레스 테스트 트리거 로직이 업데이트되었습니다. 작업 규모 기반에서 모호성 및 위험 신호 기반으로 변경되어 모든 규모의 작업에 적용됩니다.
- 계획 수립 프로세스에서 완료 기준 복구 단계가 명시적으로 강조됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->