### PR TITLE
chore(dispatch): drop dead DEFAULT_REASONING_BY_SIZE (#351)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -161,7 +161,6 @@ const PROMPT = readArg(args, ["--prompt", "-p"], undefined, CLI_ARG_OPTIONS);
 const PROMPT_FILE = readArg(args, "--prompt-file", undefined, CLI_ARG_OPTIONS);
 const EXECUTOR = readArg(args, ["--executor", "-e"], "codex", CLI_ARG_OPTIONS);
 const DEFAULT_TIMEOUT_BY_EXECUTOR = { codex: 2400, claude: 1800 };
-const DEFAULT_REASONING_BY_SIZE = { S: "medium", M: "high", L: "xhigh", XL: "xhigh" };
 const defaultTimeout = String(DEFAULT_TIMEOUT_BY_EXECUTOR[EXECUTOR] ?? 1800);
 const MODEL = readArg(args, ["--model", "-m"], undefined, CLI_ARG_OPTIONS);
 const MODEL_HINTS_RAW = readArg(args, "--model-hints", undefined, CLI_ARG_OPTIONS);


### PR DESCRIPTION
## Summary
- Remove the `DEFAULT_REASONING_BY_SIZE` constant declaration from `skills/relay-dispatch/scripts/dispatch.js:164`. The only consumer moved to `rubric-size.js:5` in PR #350; the dispatch.js copy was orphaned.

## Verification
- `grep -n "DEFAULT_REASONING_BY_SIZE" skills/relay-dispatch/scripts/dispatch.js` → 0 matches.
- `node --test tests/relay-dispatch/scripts/dispatch.test.js` → 100/100 pass (no count change vs. issue body's expectation).
- Live copy in `rubric-size.js` untouched: `extractRubricSize` + `resolveReasoningEffort` still drive size→effort mapping.

## Test plan
- [x] dispatch.test.js (100 tests) green.
- [x] cli-args.test.js green together (117 combined).

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Refactor**
  * 추론 노력 결정 로직을 중앙 집중식 헬퍼 함수로 통합하여 코드 유지보수성을 개선했습니다. 추론 노력 설정이 더욱 효율적으로 관리되며, 설정 값 재정의 기능도 정상 작동합니다. 내부 구조가 개선되어 향후 유지보수가 용이합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->