### PR TITLE
Add completion audit to relay prompt template

### DIFF
--- a/skills/relay/references/prompt-template.md
+++ b/skills/relay/references/prompt-template.md
@@ -84,6 +84,10 @@ Check for:
 
 Run tests. Fix failures. Repeat review-fix until solid.
 
+## Completion Audit
+Before declaring done, build an objective-to-artifact checklist from the existing Done Criteria block and the rubric Score Log: for each Done Criteria item and each `weight: required` rubric factor, name the concrete artifact that proves it (file path, function name, test file, PR description section, manifest field, or equivalent).
+Treat tests, manifests, PR description text, and self-reports as proxy signals, not proof by themselves; the checklist must point to the implementation or reviewable artifact that makes each outcome independently verifiable.
+
 ## When Satisfied
 Commit your final work to the branch with a clear message. The orchestrator handles `git push` + `gh pr create` after the dispatch returns (and is idempotent if you also push or open a PR yourself). Do NOT skip the commit — that is the one step the orchestrator cannot recover automatically.
 ```

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -127,6 +127,8 @@ test("relay dispatch template and wrapper use Done Criteria outcome language", (
 
   assert.match(template, /specific Done Criteria outcome is implemented/);
   assert.match(template, /\[specific Done Criteria outcome\]/);
+  assert.match(template, /## Completion Audit/);
+  assert.match(template, /proxy signal/i);
   assert.doesNotMatch(template, /specific AC (item|implemented)/i);
 
   assert.match(relaySkill, /Task evidence/);


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 만들었습니다.

변경 사항:
- [prompt-template.md](/Users/sjlee/.relay/worktrees/a7d5df5d/dev-relay/skills/relay/references/prompt-template.md:87)에 `## Completion Audit` 섹션 추가
- [rubric-reference-contract.test.js](/Users/sjlee/.relay/worktrees/a7d5df5d/dev-relay/tests/relay-plan/scripts/rubric-reference-contract.test.js:130)에 `Completion Audit` / `proxy signal` 계약 assertion 추가

검증:
- TDD red 확인: 새 assertion 추가 후 집중 테스트가 `## Completion Audit` 미존재로 실패
- 집중 테스트: `node --test tests/relay-plan/scrip
```

## Score Log

- Run: issue-370-20260502020016945-6b9a0cae
- Executor: codex
- Branch: issue-370