### PR TITLE
Expose rebrandEvidence as standalone CLI for orchestrator-side correction commits (#332)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --revie
 
 # Recovery (when codex finishes but does not commit/push/PR)
 node skills/relay-dispatch/scripts/recover-commit.js --run-id <id> --reason "..."
+node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id <id> --reason "..."
 
 # Finalize / merge (cross-skill: finalize-run lives under relay-merge, not relay-dispatch)
 node skills/relay-merge/scripts/finalize-run.js --run-id <id> --merge-method squash --json

--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -61,6 +61,8 @@ The script refuses transitions `ALLOWED_TRANSITIONS` already supports — always
 
 ### Recovery command boundaries
 
+Use `rebrand-evidence` when the orchestrator already made a correction commit on the run branch and the only stale artifact is `execution-evidence.json`. It rebinds the existing evidence to the current branch HEAD and appends an `execution_evidence_rebranded` event; it does not commit, push, open a PR, or change manifest state. Use `recover-commit` when executor work still needs the missing commit/push/PR handoff. Use `finalize-run --force-finalize-nonready` only when an operator intentionally finalizes a non-ready run despite the review gate; it is not an evidence repair tool.
+
 Use `recover-commit.js` when the executor changed files but did not commit, push, or create/stamp a PR. It creates the missing commit/PR handoff and leaves the manifest in `review_pending`.
 
 Use normal `dispatch.js --run-id <id>` when reviewer feedback requires code changes. That path re-dispatches implementation work and must produce a fresh code handoff before review.

--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -61,7 +61,7 @@ The script refuses transitions `ALLOWED_TRANSITIONS` already supports — always
 
 ### Recovery command boundaries
 
-Use `rebrand-evidence` when the orchestrator already made a correction commit on the run branch and the only stale artifact is `execution-evidence.json`. It rebinds the existing evidence to the current branch HEAD and appends an `execution_evidence_rebranded` event; it does not commit, push, open a PR, or change manifest state. Use `recover-commit` when executor work still needs the missing commit/push/PR handoff. Use `finalize-run --force-finalize-nonready` only when an operator intentionally finalizes a non-ready run despite the review gate; it is not an evidence repair tool.
+Decision tree: if the executor finished implementation but did not commit, use `recover-commit.js`; it handles commit, push, PR publication/stamping, and evidence rebrand atomically. If the orchestrator hand-edited fixes after R1, the evidence is still bound to the dispatch SHA, and review at HEAD substantively PASSed, run `rebrand-evidence.js --run-id <id> --reason "..."`, then `finalize-run.js --run-id <id> --force-finalize-nonready --reason "stale-execution-evidence: orchestrator-correction"`. If the reviewer state machine refuses to re-trigger on the same SHA and no commit is needed, skip evidence repair and use `finalize-run.js --run-id <id> --force-finalize-nonready --reason "..."` directly.
 
 Use `recover-commit.js` when the executor changed files but did not commit, push, or create/stamp a PR. It creates the missing commit/PR handoff and leaves the manifest in `review_pending`.
 

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -147,6 +147,9 @@ const COMMAND_FLAGS = {
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",
     "--dry-run", "--json", "--help",
   ],
+  "rebrand-evidence": [
+    "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",
+  ],
   "relay-reconcile-artifact": [
     "--repo", "--run-id", "--manifest", "--branch", "--pr",
     "--artifact-path", "--writer-pr", "--reason", "--skip-review",

--- a/skills/relay-dispatch/scripts/rebrand-evidence.js
+++ b/skills/relay-dispatch/scripts/rebrand-evidence.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * relay-rebrand-evidence: update execution evidence after orchestrator-side
+ * correction commits without committing, pushing, opening PRs, or changing state.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { resolveManifestRecord } = require("./relay-resolver");
+const { appendRunEvent, EVENTS } = require("./relay-events");
+const {
+  EXECUTION_EVIDENCE_FILENAME,
+  rebrandEvidence,
+} = require("./execution-evidence");
+const { getCanonicalRepoRoot, getRunDir, summarizeFailure, validateManifestPaths } = require("./manifest/paths");
+const {
+  findUnknownFlags,
+  modeLabel,
+  readArg,
+  schemaHasFlag,
+} = require("./cli-args");
+const { execGit } = require("./exec");
+
+const args = process.argv.slice(2);
+const CLI_ARG_OPTIONS = { commandName: "rebrand-evidence", reservedFlags: ["-h"] };
+const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
+const getCliArg = (flag, fallback) => readArg(args, flag, fallback, CLI_ARG_OPTIONS);
+const RECORDED_BY = "orchestrator-correction-rebrand";
+
+class UsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
+function printHelp(exitCode) {
+  console.log("Usage: rebrand-evidence.js (--repo <path> --run-id <id> | --manifest <path>) --reason <text> [--dry-run] [--json]");
+  console.log("\nRebind an existing execution-evidence.json artifact to the current correction commit without publishing git changes.");
+  console.log("\nOptions:");
+  console.log(`  --repo <path>       ${modeLabel("--repo")} Repository root used with --run-id (default: .)`);
+  console.log(`  --run-id <id>       ${modeLabel("--run-id")} Relay run identifier`);
+  console.log(`  --manifest <path>   ${modeLabel("--manifest")} Explicit manifest path`);
+  console.log(`  --reason <text>     ${modeLabel("--reason")} Required audit reason; preserved verbatim`);
+  console.log(`  --dry-run           ${modeLabel("--dry-run")} Print the planned evidence mutation only`);
+  console.log(`  --json              ${modeLabel("--json")} Output JSON`);
+  console.log(`  --help              ${modeLabel("--help")} Show this help`);
+  console.log("\nDecision tree:");
+  console.log("  Use rebrand-evidence after the orchestrator already made a correction commit and only execution-evidence.json is stale.");
+  console.log("  Use recover-commit when the executor left recoverable work that still needs commit, push, or PR publication.");
+  console.log("  Use finalize-run --force-finalize-nonready only when an operator intentionally finalizes a non-ready run despite the review gate.");
+  process.exit(exitCode);
+}
+
+if (hasCliFlag(["--help", "-h"])) {
+  printHelp(0);
+}
+
+function usageError(message) {
+  throw new UsageError(`${message}. See --help.`);
+}
+
+function resolveRun({ repoArg, runId, manifestArg }) {
+  const repoRoot = path.resolve(repoArg || ".");
+  try {
+    return resolveManifestRecord({
+      repoRoot,
+      manifestPath: manifestArg,
+      runId,
+    });
+  } catch (error) {
+    throw new Error(`run_resolution_failed: ${summarizeFailure(error)}`);
+  }
+}
+
+function expectedRepoRootForValidation(repoArg, manifestArg) {
+  if (manifestArg && !repoArg) return undefined;
+  return getCanonicalRepoRoot(path.resolve(repoArg || "."));
+}
+
+function readCurrentHeadSha(data, validatedPaths) {
+  const branch = data.git?.working_branch;
+  if (!branch) {
+    throw new Error("manifest is missing git.working_branch");
+  }
+
+  if (data.cleanup?.worktree_removed === false) {
+    if (!validatedPaths.worktree) {
+      throw new Error("manifest paths.worktree is required when cleanup.worktree_removed is false");
+    }
+    const currentBranch = execGit(validatedPaths.worktree, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (currentBranch !== branch) {
+      throw new Error(`manifest worktree is on branch ${currentBranch}, expected ${branch}`);
+    }
+    return {
+      branch,
+      newHeadSha: execGit(validatedPaths.worktree, ["rev-parse", "HEAD"]),
+      headSource: "worktree",
+    };
+  }
+
+  return {
+    branch,
+    newHeadSha: execGit(validatedPaths.repoRoot, ["rev-parse", `refs/heads/${branch}`]),
+    headSource: "repo_ref",
+  };
+}
+
+function previewRebrand(runDir, { newHeadSha, reason }) {
+  const evidencePath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
+  if (!fs.existsSync(evidencePath)) {
+    return { skipped: "no_existing_evidence" };
+  }
+  if (!/^[0-9a-f]{40}$/.test(newHeadSha || "")) {
+    return { skipped: "rejected_bad_sha", reason: "newHeadSha must be a 40-character lowercase hex SHA" };
+  }
+
+  const existing = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  if (existing.head_sha === newHeadSha) {
+    return { skipped: "sha_unchanged" };
+  }
+  return {
+    rewritten: true,
+    previousSha: existing.head_sha,
+    newHeadSha,
+    plannedMutation: {
+      file: evidencePath,
+      previousHeadSha: existing.head_sha,
+      newHeadSha,
+      recordedBy: RECORDED_BY,
+      reason,
+    },
+  };
+}
+
+function buildResult({ status, manifestPath, data, branch, headSource, newHeadSha, dryRun, rebrandResult }) {
+  return {
+    status,
+    manifestPath,
+    runId: data.run_id,
+    branch,
+    headSource,
+    newHeadSha,
+    dryRun,
+    ...rebrandResult,
+  };
+}
+
+function printResult(result, jsonOut) {
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (result.status === "dry_run") {
+    if (result.skipped) {
+      console.log(`Dry-run skipped rebrand: ${result.skipped}`);
+      return;
+    }
+    console.log(`Dry-run would rebrand execution evidence for ${result.runId}`);
+    console.log(`  Previous HEAD: ${result.plannedMutation.previousHeadSha}`);
+    console.log(`  New HEAD:      ${result.plannedMutation.newHeadSha}`);
+    console.log(`  Recorded by:   ${result.plannedMutation.recordedBy}`);
+    return;
+  }
+
+  if (result.skipped) {
+    console.log(`Skipped rebrand: ${result.skipped}`);
+    return;
+  }
+  console.log(`Rebranded execution evidence for ${result.runId}`);
+  console.log(`  Previous HEAD: ${result.previousSha}`);
+  console.log(`  New HEAD:      ${result.newHeadSha}`);
+}
+
+function main() {
+  const unknownFlags = findUnknownFlags(args, "rebrand-evidence");
+  if (unknownFlags.length > 0) {
+    usageError(`Unknown flag(s): ${unknownFlags.join(", ")}`);
+  }
+
+  const repoArg = getCliArg("--repo");
+  const runId = getCliArg("--run-id");
+  const manifestArg = getCliArg("--manifest");
+  const reason = getCliArg("--reason");
+  const dryRun = hasCliFlag("--dry-run");
+  const jsonOut = hasCliFlag("--json");
+
+  if (!runId && !manifestArg) {
+    usageError("Either --run-id or --manifest is required");
+  }
+  if (runId && manifestArg) {
+    usageError("Use either --run-id or --manifest, not both");
+  }
+  if (!reason) {
+    usageError("--reason <text> is required");
+  }
+
+  const manifestRecord = resolveRun({ repoArg, runId, manifestArg });
+  const expectedRepoRoot = expectedRepoRootForValidation(repoArg, manifestArg);
+  const validatedPaths = validateManifestPaths(manifestRecord.data?.paths, {
+    expectedRepoRoot,
+    manifestPath: manifestRecord.manifestPath,
+    runId: manifestRecord.data?.run_id,
+    caller: "rebrand-evidence",
+  });
+  const data = {
+    ...manifestRecord.data,
+    paths: {
+      ...(manifestRecord.data?.paths || {}),
+      repo_root: validatedPaths.repoRoot,
+      worktree: validatedPaths.worktree,
+    },
+  };
+  const { branch, newHeadSha, headSource } = readCurrentHeadSha(data, validatedPaths);
+  const runDir = getRunDir(validatedPaths.repoRoot, data.run_id);
+
+  if (dryRun) {
+    const rebrandResult = previewRebrand(runDir, { newHeadSha, reason });
+    printResult(buildResult({
+      status: "dry_run",
+      manifestPath: manifestRecord.manifestPath,
+      data,
+      branch,
+      headSource,
+      newHeadSha,
+      dryRun: true,
+      rebrandResult,
+    }), jsonOut);
+    return;
+  }
+
+  const rebrandResult = rebrandEvidence(runDir, {
+    newHeadSha,
+    recordedBy: RECORDED_BY,
+    reason,
+  });
+  if (rebrandResult.rewritten === true) {
+    appendRunEvent(validatedPaths.repoRoot, data.run_id, {
+      event: EVENTS.EXECUTION_EVIDENCE_REBRANDED,
+      previous_head_sha: rebrandResult.previousSha,
+      new_head_sha: newHeadSha,
+      reason,
+    });
+  }
+
+  printResult(buildResult({
+    status: rebrandResult.skipped ? "skipped" : "rebranded",
+    manifestPath: manifestRecord.manifestPath,
+    data,
+    branch,
+    headSource,
+    newHeadSha,
+    dryRun: false,
+    rebrandResult,
+  }), jsonOut);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof UsageError ? error.message : `Error: ${error.message}`);
+  process.exit(1);
+}

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -155,6 +155,7 @@ const HELP_COMMANDS = [
   ["persist-request", path.join(__dirname, "..", "..", "..", "skills", "relay-intake", "scripts", "persist-request.js")],
   ["probe-executor-env", path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "scripts", "probe-executor-env.js")],
   ["recover-commit", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-commit.js")],
+  ["rebrand-evidence", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "rebrand-evidence.js")],
   ["recover-state", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-state.js")],
   ["reliability-report", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "reliability-report.js")],
   ["review-runner", path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js")],

--- a/tests/relay-dispatch/scripts/rebrand-evidence.test.js
+++ b/tests/relay-dispatch/scripts/rebrand-evidence.test.js
@@ -1,0 +1,196 @@
+// canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
+const {
+  COMMAND_FLAGS,
+} = require("../../../skills/relay-dispatch/scripts/cli-schema");
+const {
+  EXECUTION_EVIDENCE_FILENAME,
+  writeExecutionEvidence,
+} = require("../../../skills/relay-dispatch/scripts/execution-evidence");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "rebrand-evidence.js");
+
+function setupRepo({ evidence = true, advanceHead = false } = {}) {
+  const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-rebrand-evidence-")));
+  const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
+  process.env.RELAY_HOME = relayHome;
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Rebrand Evidence Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-rebrand@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const branch = "issue-332";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  const originalSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+
+  if (advanceHead) {
+    fs.writeFileSync(path.join(worktreePath, "correction.txt"), "orchestrator correction\n", "utf-8");
+    execFileSync("git", ["-C", worktreePath, "add", "correction.txt"], { encoding: "utf-8", stdio: "pipe" });
+    execFileSync("git", ["-C", worktreePath, "commit", "-m", "Orchestrator correction"], { encoding: "utf-8", stdio: "pipe" });
+  }
+  const currentSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+
+  const runId = createRunId({
+    issueNumber: 332,
+    branch,
+    timestamp: new Date("2026-04-24T01:00:00.000Z"),
+  });
+  const layout = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 332,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: rebrand-evidence\n", "utf-8");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(layout.manifestPath, manifest);
+
+  if (evidence) {
+    writeExecutionEvidence(layout.runDir, {
+      schema_version: 1,
+      head_sha: originalSha,
+      test_command: "node --test tests/relay-dispatch/scripts/*.test.js",
+      test_result_hash: "unspecified",
+      test_result_summary: "unspecified",
+      recorded_at: "2026-04-24T01:00:00.000Z",
+      recorded_by: "dispatch-orchestrator-v1",
+    });
+  }
+
+  const env = {
+    ...process.env,
+    RELAY_HOME: relayHome,
+  };
+  return { repoRoot, relayHome, runId, manifestPath: layout.manifestPath, runDir: layout.runDir, worktreePath, branch, originalSha, currentSha, env };
+}
+
+function runRebrand(fixture, extraArgs = []) {
+  return spawnSync(process.execPath, [SCRIPT, "--repo", fixture.repoRoot, "--run-id", fixture.runId, ...extraArgs], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    env: fixture.env,
+  });
+}
+
+function readEvidence(fixture) {
+  return JSON.parse(fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"));
+}
+
+test("rebrand-evidence flags are registered with the CLI schema", () => {
+  assert.deepEqual(COMMAND_FLAGS["rebrand-evidence"], [
+    "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",
+  ]);
+});
+
+test("happy path rewrites stale evidence to current HEAD and emits one audit event", () => {
+  const fixture = setupRepo({ evidence: true, advanceHead: true });
+  const result = runRebrand(fixture, ["--reason", "orchestrator fixed typo", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.rewritten, true);
+  assert.equal(parsed.previousSha, fixture.originalSha);
+  assert.equal(parsed.newHeadSha, fixture.currentSha);
+
+  const evidence = readEvidence(fixture);
+  assert.equal(evidence.head_sha, fixture.currentSha);
+  assert.equal(evidence.recorded_by, "orchestrator-correction-rebrand");
+  assert.equal(evidence.rebrand.previous_head_sha, fixture.originalSha);
+  assert.equal(evidence.rebrand.reason, "orchestrator fixed typo");
+
+  const rebrandEvents = readRunEvents(fixture.repoRoot, fixture.runId)
+    .filter((entry) => entry.event === "execution_evidence_rebranded");
+  assert.equal(rebrandEvents.length, 1);
+  assert.equal(rebrandEvents[0].previous_head_sha, fixture.originalSha);
+  assert.equal(rebrandEvents[0].new_head_sha, fixture.currentSha);
+  assert.equal(rebrandEvents[0].reason, "orchestrator fixed typo");
+});
+
+test("sha_unchanged exits zero and does not append an event", () => {
+  const fixture = setupRepo({ evidence: true, advanceHead: false });
+  const beforeEvidence = fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8");
+  const result = runRebrand(fixture, ["--reason", "already current", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.skipped, "sha_unchanged");
+  assert.equal(fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"), beforeEvidence);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("no_existing_evidence exits zero without creating evidence", () => {
+  const fixture = setupRepo({ evidence: false, advanceHead: true });
+  const result = runRebrand(fixture, ["--reason", "missing historical evidence", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.skipped, "no_existing_evidence");
+  assert.equal(fs.existsSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME)), false);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("missing --reason exits non-zero with a usage hint", () => {
+  const fixture = setupRepo({ evidence: true, advanceHead: true });
+  const result = runRebrand(fixture, ["--json"]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--reason <text> is required/);
+  assert.match(result.stderr, /--help/);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("missing both --run-id and --manifest exits non-zero", () => {
+  const fixture = setupRepo({ evidence: true, advanceHead: true });
+  const result = spawnSync(process.execPath, [SCRIPT, "--repo", fixture.repoRoot, "--reason", "missing selector", "--json"], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    env: fixture.env,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Either --run-id or --manifest is required/);
+  assert.match(result.stderr, /--help/);
+});
+
+test("dry-run previews the rebrand without writing evidence or appending an event", () => {
+  const fixture = setupRepo({ evidence: true, advanceHead: true });
+  const beforeEvidence = fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8");
+  const result = runRebrand(fixture, ["--reason", "preview only", "--dry-run", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, "dry_run");
+  assert.equal(parsed.plannedMutation.previousHeadSha, fixture.originalSha);
+  assert.equal(parsed.plannedMutation.newHeadSha, fixture.currentSha);
+  assert.equal(parsed.plannedMutation.recordedBy, "orchestrator-correction-rebrand");
+  assert.equal(fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"), beforeEvidence);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-332-20260502021035010-6affaed2
- Branch: issue-332
- Reason: codex finished implementation but sandbox blocked git add/commit step
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-332-20260502021035010-6affaed2.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-02T02:19:00.275Z