### PR TITLE
Drop --full-auto and auto-discover redispatch prompts (#387 #388)

### DIFF
--- a/skills/relay-dispatch/scripts/create-worktree.js
+++ b/skills/relay-dispatch/scripts/create-worktree.js
@@ -260,7 +260,7 @@ function main() {
       console.log(`  Resume: codex resume ${threadId}`);
     } else {
       console.log(`\n  Run:    dispatch.js ${shellQuote(REPO_PATH)} -b ${branch} --prompt "your task"`);
-      console.log(`  Or manually: codex exec -C ${shellQuote(wtPath)} --full-auto "your task"`);
+      console.log(`  Or manually: codex exec -C ${shellQuote(wtPath)} --sandbox workspace-write "your task"`);
     }
     if (PIN) console.log("  Pinned: yes (won't be auto-cleaned).");
   }

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -494,22 +494,54 @@ function validateExecutorCli() {
   }
 }
 
-function readTaskPrompt() {
-  if (!PROMPT && !PROMPT_FILE) {
+function findLatestRedispatchPrompt(runDir) {
+  if (!runDir || !fs.existsSync(runDir)) return null;
+  let latest = null;
+  for (const entry of fs.readdirSync(runDir)) {
+    const match = /^review-round-(\d+)-redispatch\.md$/.exec(entry);
+    if (!match) continue;
+    const round = parseInt(match[1], 10);
+    if (!Number.isFinite(round)) continue;
+    if (!latest || round > latest.round) {
+      latest = { round, path: path.join(runDir, entry) };
+    }
+  }
+  return latest;
+}
+
+function readTaskPrompt({ runDir, resumeMode } = {}) {
+  if (PROMPT_FILE) {
+    const promptPath = path.resolve(PROMPT_FILE);
+    if (!fs.existsSync(promptPath)) {
+      console.error(`Error: prompt file not found: ${promptPath}`);
+      process.exit(1);
+    }
+    return { prompt: fs.readFileSync(promptPath, "utf-8").trim(), source: "explicit-file", path: promptPath };
+  }
+
+  if (PROMPT) {
+    return { prompt: PROMPT, source: "explicit-arg", path: null };
+  }
+
+  if (resumeMode) {
+    const auto = findLatestRedispatchPrompt(runDir);
+    if (auto) {
+      return {
+        prompt: fs.readFileSync(auto.path, "utf-8").trim(),
+        source: "auto-discovered-redispatch",
+        path: auto.path,
+        round: auto.round,
+      };
+    }
     console.error("Error: --prompt or --prompt-file is required");
+    console.error(
+      `  Auto-discovery looked for review-round-<N>-redispatch.md in ${runDir} but found none.`
+    );
     process.exit(1);
   }
 
-  if (!PROMPT_FILE) {
-    return PROMPT;
-  }
-
-  const promptPath = path.resolve(PROMPT_FILE);
-  if (!fs.existsSync(promptPath)) {
-    console.error(`Error: prompt file not found: ${promptPath}`);
-    process.exit(1);
-  }
-  return fs.readFileSync(promptPath, "utf-8").trim();
+  console.error("Error: --prompt or --prompt-file is required");
+  process.exit(1);
 }
 
 function resolveRoleBinding(envName, fallback) {
@@ -699,7 +731,11 @@ async function main() {
   enforceRubricPersistence(manifest, manifestRunDir);
 
   validateExecutorCli();
-  let taskPrompt = readTaskPrompt();
+  const taskPromptResult = readTaskPrompt({ runDir: manifestRunDir, resumeMode: RESUME_MODE });
+  let taskPrompt = taskPromptResult.prompt;
+  if (taskPromptResult.source === "auto-discovered-redispatch" && !JSON_OUT) {
+    console.log(`Auto-discovered redispatch prompt (round ${taskPromptResult.round}): ${taskPromptResult.path}`);
+  }
 
   // --- Prepend iteration history on re-dispatch ---
   if (RESUME_MODE) {
@@ -945,7 +981,7 @@ async function main() {
 
   if (EXECUTOR === "codex") {
     cmd = "codex";
-    execArgs = ["exec", "-C", wtPath, "--full-auto", "--color", "never", "-o", resultFile];
+    execArgs = ["exec", "-C", wtPath, "--color", "never", "-o", resultFile];
     execArgs.push("-c", `model_reasoning_effort=${resolvedReasoningEffort}`);
     if (NETWORK_ACCESS === "enabled") {
       execArgs.push("-c", "sandbox_workspace_write.network_access=true");

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -776,6 +776,140 @@ test("dispatch reuses the same run and worktree on resume", () => {
   assert.match(events, /"reason":"same_run_resume:completed"/);
 });
 
+function writeResumeCaptureCodex(binDir, capturePath) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(args), "utf-8");
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+const fileName = fs.existsSync(cwd + "/first.txt") ? "resume.txt" : "first.txt";
+fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
+fs.writeFileSync(output, "ok\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
+test("dispatch resume auto-discovers latest review-round-N-redispatch.md when no prompt is given (#387)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-auto.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-387-auto",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), "ROUND ONE BODY\n", "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-redispatch.md"), "ROUND TWO BODY\n", "utf-8");
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", first.runId,
+    "--json",
+  ], env));
+  assert.equal(second.mode, "resume");
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  const finalPrompt = captured[captured.length - 1];
+  assert.match(finalPrompt, /ROUND TWO BODY/);
+  assert.doesNotMatch(finalPrompt, /ROUND ONE BODY/);
+});
+
+test("dispatch resume --prompt-file wins over redispatch auto-discovery (#387)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-explicit.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-387-explicit",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), "AUTO_DISCOVERED_BODY\n", "utf-8");
+
+  const explicitPath = path.join(os.tmpdir(), `relay-dispatch-explicit-${Date.now()}.md`);
+  fs.writeFileSync(explicitPath, "EXPLICIT_BODY\n", "utf-8");
+
+  runDispatch(repoRoot, [
+    "--run-id", first.runId,
+    "--prompt-file", explicitPath,
+    "--json",
+  ], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  const finalPrompt = captured[captured.length - 1];
+  assert.match(finalPrompt, /EXPLICIT_BODY/);
+  assert.doesNotMatch(finalPrompt, /AUTO_DISCOVERED_BODY/);
+});
+
+test("dispatch resume without redispatch artifact still errors with auto-discovery hint (#387)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-387-missing",
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--prompt or --prompt-file is required/);
+  assert.match(result.stderr, /Auto-discovery looked for review-round-<N>-redispatch\.md/);
+});
+
 test("dispatch stores model_hints for all four phases verbatim", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
@@ -946,7 +1080,6 @@ test("dispatch precedence D1 regression: CLI override beats manifest hint in exe
   assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
     "exec",
     "-C", result.worktree,
-    "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
     "-c", "model_reasoning_effort=xhigh",
@@ -981,7 +1114,6 @@ test("dispatch precedence D2 regression: CLI override works when manifest hint i
   assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
     "exec",
     "-C", result.worktree,
-    "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
     "-c", "model_reasoning_effort=xhigh",
@@ -1017,7 +1149,6 @@ test("dispatch precedence D3 regression: manifest hint supplies the effective mo
   assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
     "exec",
     "-C", result.worktree,
-    "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
     "-c", "model_reasoning_effort=xhigh",
@@ -1056,7 +1187,6 @@ test("dispatch precedence D4 regression: executor argv stays byte-identical when
   assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
     "exec",
     "-C", result.worktree,
-    "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
     "-c", "model_reasoning_effort=xhigh",
@@ -1093,10 +1223,9 @@ test("dispatch network-access enabled adds codex workspace-write network overrid
 
   const capturedArgs = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
   const commonGitDir = worktreeCommonGitDir(result.worktree);
-  assert.deepEqual(capturedArgs.slice(0, 10), [
+  assert.deepEqual(capturedArgs.slice(0, 9), [
     "exec",
     "-C", result.worktree,
-    "--full-auto",
     "--color", "never",
     "-o", result.resultFile,
     "-c", "model_reasoning_effort=xhigh",


### PR DESCRIPTION
## Summary

- **#388** Remove deprecated `--full-auto` from `dispatch.js` execArgs and `create-worktree.js` operator hint — `--sandbox workspace-write` is already pushed separately at `dispatch.js:913` so the flag is redundant and emits a deprecation warning on every codex 0.128.0+ dispatch
- **#387** Auto-discover the highest-N `review-round-<N>-redispatch.md` in the run-dir when `dispatch.js --run-id <id>` is invoked with no `--prompt`/`--prompt-file`; the redispatch artifact is already written by `review-runner.js:285` so dispatch just needs to read it. Explicit `--prompt-file` still wins; missing-artifact case keeps the existing error and adds a hint pointing to where auto-discovery looked.

`grep -n "full-auto" skills/relay-dispatch/scripts/` returns zero after this PR.

Bundled in one PR per the issue authors' suggestion (#388 is XS and lives in the same file).

## Out of scope (deferred)

- `skills/relay-plan/scripts/probe-executor-env.js:197` also passes `--full-auto`. The `#388` AC scoped the grep check to `skills/relay-dispatch/scripts/`, so this third call site is left for a follow-up issue. Worth filing if you want full deprecation cleanup before codex actually drops the flag.
- Several markdown docs (`docs/codex-app-server-analysis.md`, `docs/direct-read-relay-operator-note.md`, `docs/codex-orchestrator-e2e-validation-2026-04-03.md`, `README.md`) reference `--full-auto` historically. Code change only here.

## Test plan

- [x] `node --test tests/relay-dispatch/scripts/dispatch.test.js` — 100/100 pass (5 byte-equality argv regressions updated to drop `--full-auto`; 3 new `#387` tests added)
- [x] `node --test tests/relay-dispatch/scripts/*.test.js tests/relay-dispatch/scripts/manifest/*.test.js` — 534/534 pass
- [x] `node --test tests/relay-{intake,plan,review,merge}/scripts/*.test.js` — 504/504 pass
- [x] `grep -n "full-auto" skills/relay-dispatch/scripts/` returns zero
- [x] Verified `dispatch.js --run-id <id>` with no `--prompt` resumes when a `review-round-N-redispatch.md` exists (covered by happy-path test); explicit `--prompt-file` still wins (override test); missing-artifact still errors with the existing message plus auto-discovery hint (fallback test).

Closes #387, #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 재개(resume) 모드에서 이전 작업 프롬프트를 자동으로 찾아 사용하도록 추가
  * 사용자가 제공한 프롬프트 파일로 자동 검색을 덮어쓰기 가능
  * 수동 실행 안내 메시지의 실행 형식 표시가 `--full-auto`에서 `--sandbox workspace-write` 형태로 변경

* **테스트**
  * 자동 프롬프트 검색, 덮어쓰기 동작 및 프롬프트 미지정 시 오류 처리를 검증하는 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->