### PR TITLE
Drop deprecated codex --full-auto from probe-executor-env (#391)

### DIFF
--- a/skills/relay-plan/scripts/probe-executor-env.js
+++ b/skills/relay-plan/scripts/probe-executor-env.js
@@ -194,7 +194,7 @@ function probeAgent(executor, timeout) {
 
   if (executor === "codex") {
     cmd = "codex";
-    cmdArgs = ["exec", "--full-auto", "--sandbox", "read-only", "--color", "never", PROBE_PROMPT];
+    cmdArgs = ["exec", "--sandbox", "read-only", "--color", "never", PROBE_PROMPT];
   } else if (executor === "claude") {
     cmd = "claude";
     cmdArgs = ["-p", "--output-format", "text", PROBE_PROMPT];


### PR DESCRIPTION
## Summary

- Removes the third surviving `--full-auto` call site at `skills/relay-plan/scripts/probe-executor-env.js:197`
- `--sandbox read-only` is already passed separately, so `--full-auto` is redundant
- Follow-up to #388/PR #390 — that AC scoped only `skills/relay-dispatch/scripts/`, missing this skill

## Verification

- `grep -rn "full-auto" skills/` → 0 matches
- `node --test tests/relay-plan/scripts/probe-executor-env.test.js` → 14/14 pass

## Test plan

- [x] Probe-executor-env tests pass
- [x] grep -rn full-auto skills/ returns zero
- [ ] CI green

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)