### PR TITLE
feat(relay-plan): add task profile guidance model

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -50,7 +50,7 @@ Before drafting factors, identify the evaluation source model:
 - Inferred Done Criteria from user intent, issue body, relay-intake handoff, and nearby repo conventions
 - Repo quality signal from probes and available commands
 - Historical relay signal from stuck factors and score divergence
-- Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes
+- Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes; derive `task_profile` per `references/task-profile.md`
 
 If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. If the final review anchor is planner-authored or differs from the task source, persist it in step 8 so the reviewer has the same anchor.
 
@@ -125,7 +125,7 @@ S/M usually skips, but ambiguity or risk can opt any size into stress-test. Run 
 
 ### 10. Generate dispatch prompt
 
-Take the base template (`../relay/references/prompt-template.md`) and append Setup, Scoring Rubric, Iteration Protocol, and Score Log sections. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
+Take the base template (`../relay/references/prompt-template.md`) and append Setup, optional `task_profile` metadata when guidance packs are selected, Scoring Rubric, Iteration Protocol, and Score Log sections. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
 
 Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 

--- a/skills/relay-plan/references/task-profile.md
+++ b/skills/relay-plan/references/task-profile.md
@@ -1,0 +1,45 @@
+# Task Profile
+
+`task_profile` is relay-plan metadata that makes guidance selection explicit and auditable before dispatch.
+
+```yaml
+task_profile:
+  size: S | M | L | XL
+  change_type: bugfix | feature | refactor | docs | test | infra | visual | prompt
+  domains:
+    - relay-plan
+    - docs
+    - tests
+  risk_tags:
+    - trust-boundary
+    - public-api
+    - backward-compatibility
+  execution_mode: quick | standard | fresh-context | batch-wave
+  guidance_packs:
+    - surgical-change
+    - verification-evidence
+```
+
+## Derivation Inputs
+
+Build the profile from the same planning evidence used for the rubric:
+
+- Done Criteria: infer the work shape, touched domains, and scope boundary.
+- probe signal: use available tests, CI, scripts, and detected project tools as evidence for domains and runnable verification, not as automatic commands.
+- historical signal: use stuck factors, divergence hotspots, and average rounds to choose stronger working-style guidance when quality convergence has historically taken more rounds.
+- task risk: surface trust boundaries, state machines, public APIs, migrations, data loss, prompt contracts, or backward-compatibility concerns as `risk_tags`.
+
+## Planner Boundary
+
+`task_profile` is planner metadata. It may be shown in dispatch artifacts so executors know why guidance was selected, but it is not a reviewer verdict field, manifest role binding, lifecycle state, or merge gate. Correctness still lives in Done Criteria and rubric factors.
+
+The only prompt-visible behavior in this issue is the profile metadata block. Compact guidance pack text, dispatch persistence/events, and reliability analytics are follow-up work.
+
+## Selection Hints
+
+- Code tasks normally select `surgical-change` and `verification-evidence`.
+- Documentation tasks select `docs-reader-success`.
+- Refactors and quality-risk M+ code tasks select `simplify-pass`.
+- Trust-boundary tasks select `trust-boundary` and usually use `execution_mode: fresh-context`.
+
+When `guidance_packs` is empty, relay-plan must leave non-guidance dispatch prompt behavior unchanged.

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -1,6 +1,8 @@
 const CHANGE_TYPES = new Set(["bugfix", "feature", "refactor", "docs", "test", "infra", "visual", "prompt"]);
 const EXECUTION_MODES = new Set(["quick", "standard", "fresh-context", "batch-wave"]);
 const SIZES = new Set(["S", "M", "L", "XL"]);
+const TRUST_BOUNDARY_PATTERN = /\b(?:trust[- ]boundary|auth[- ]boundary|trust root|forge|forged|bypass|fail closed|gate-check|validate[- ]?(?:manifest|transition)|state transition|state-machine)\b/;
+const STATE_MACHINE_PATTERN = /\b(?:state transition|state-machine|validate[- ]?transition|manifest state)\b/;
 
 function parseJsonish(value) {
   if (!value) return {};
@@ -75,10 +77,10 @@ function inferRiskTags(text, taskRisk) {
   const tags = [];
   addMany(tags, asStringArray(taskRisk?.risk_tags));
   addMany(tags, asStringArray(taskRisk?.riskTags));
-  if (/\btrust[- ]boundary|auth[- ]boundary|trust root|forg(e|ed)|bypass|fail closed|gate-check|validatemanifest|validatetransition|state transition|state-machine\b/.test(text)) {
+  if (TRUST_BOUNDARY_PATTERN.test(text)) {
     addUnique(tags, "trust-boundary");
   }
-  if (/\bstate transition|state-machine|validatetransition|manifest state\b/.test(text)) addUnique(tags, "state-machine");
+  if (STATE_MACHINE_PATTERN.test(text)) addUnique(tags, "state-machine");
   if (/\bpublic api|exported|schema|contract|cli flag|command line|user-facing\b/.test(text)) addUnique(tags, "public-api");
   if (/\bbackward|compat|byte-identical|unchanged|stable|existing behavior\b/.test(text)) addUnique(tags, "backward-compatibility");
   if (/\bprompt|rubric|skill\.md|dispatch prompt|reviewer prompt|done criteria|content boundary\b/.test(text)) addUnique(tags, "prompt-contract");

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -1,0 +1,220 @@
+const CHANGE_TYPES = new Set(["bugfix", "feature", "refactor", "docs", "test", "infra", "visual", "prompt"]);
+const EXECUTION_MODES = new Set(["quick", "standard", "fresh-context", "batch-wave"]);
+const SIZES = new Set(["S", "M", "L", "XL"]);
+
+function parseJsonish(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function stringifySignal(value) {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeText(...parts) {
+  return parts.map(stringifySignal).join("\n").toLowerCase();
+}
+
+function normalizeSize(size) {
+  const normalized = String(size || "M").toUpperCase();
+  return SIZES.has(normalized) ? normalized : "M";
+}
+
+function addUnique(values, value) {
+  if (value && !values.includes(value)) values.push(value);
+}
+
+function addMany(values, candidates) {
+  for (const candidate of candidates || []) addUnique(values, candidate);
+}
+
+function asStringArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.map(String).filter(Boolean);
+  return [String(value)].filter(Boolean);
+}
+
+function inferChangeType(text) {
+  if (/\b(readme|docs?|documentation|operator guide|reference doc|\.md)\b/.test(text)) return "docs";
+  if (/\b(refactor|decompose|split|cleanup|simplify|no behavior change|without behavior changes)\b/.test(text)) return "refactor";
+  if (/\b(prompt|rubric|skill\.md|dispatch prompt|reviewer prompt|done criteria)\b/.test(text)) return "prompt";
+  if (/\b(test|fixture|coverage|regression)\b/.test(text) && !/\b(add|implement|feature|script|api)\b/.test(text)) return "test";
+  if (/\b(ci|workflow|github actions|build|deploy|infra|configuration)\b/.test(text)) return "infra";
+  if (/\b(ui|ux|visual|css|layout|screen|component)\b/.test(text)) return "visual";
+  if (/\b(fix|bug|regression|broken|failure|fail(ing|s)?|error)\b/.test(text)) return "bugfix";
+  return "feature";
+}
+
+function inferDomains(text, probe) {
+  const domains = [];
+  if (/\brelay-plan\b|skills\/relay-plan|tests\/relay-plan/.test(text)) addUnique(domains, "relay-plan");
+  if (/\brelay-dispatch\b|skills\/relay-dispatch|manifest|worktree|dispatch\.js/.test(text)) addUnique(domains, "relay-dispatch");
+  if (/\brelay-review\b|skills\/relay-review|reviewer|verdict|review schema/.test(text)) addUnique(domains, "relay-review");
+  if (/\brelay-merge\b|skills\/relay-merge|merge gate|finalize/.test(text)) addUnique(domains, "relay-merge");
+  if (/\bdocs?\b|documentation|readme|\.md\b/.test(text)) addUnique(domains, "docs");
+  if (/\bprompt|rubric|skill\.md|working guidance|done criteria/.test(text)) addUnique(domains, "prompt");
+  if (/\btests?\b|fixtures?|node --test|regression/.test(text)) addUnique(domains, "tests");
+  if (/\bcli|command|flag|argv|stdio/.test(text)) addUnique(domains, "cli");
+  if (Array.isArray(probe?.project_tools?.ci) && probe.project_tools.ci.length > 0) addUnique(domains, "ci");
+  if (domains.length === 0) addUnique(domains, "code");
+  return domains;
+}
+
+function inferRiskTags(text, taskRisk) {
+  const tags = [];
+  addMany(tags, asStringArray(taskRisk?.risk_tags));
+  addMany(tags, asStringArray(taskRisk?.riskTags));
+  if (/\btrust[- ]boundary|auth[- ]boundary|trust root|forg(e|ed)|bypass|fail closed|gate-check|validate(manifest|transition)?|state transition|state-machine\b/.test(text)) {
+    addUnique(tags, "trust-boundary");
+  }
+  if (/\bstate transition|state-machine|validateTransition|manifest state\b/.test(text)) addUnique(tags, "state-machine");
+  if (/\bpublic api|exported|schema|contract|cli flag|command line|user-facing\b/.test(text)) addUnique(tags, "public-api");
+  if (/\bbackward|compat|byte-identical|unchanged|stable|existing behavior\b/.test(text)) addUnique(tags, "backward-compatibility");
+  if (/\bprompt|rubric|skill\.md|dispatch prompt|reviewer prompt|done criteria|content boundary\b/.test(text)) addUnique(tags, "prompt-contract");
+  if (/\bmigration|data loss|destructive|delete|cleanup worktree\b/.test(text)) addUnique(tags, "migration");
+  return tags;
+}
+
+function historicalQualityNeedsTightening(historical) {
+  const tiers = historical?.rubric_insights?.tier_effectiveness || {};
+  const contractRounds = Number(tiers.contract?.avg_rounds_to_met);
+  const qualityRounds = Number(tiers.quality?.avg_rounds_to_met);
+  if (!Number.isFinite(contractRounds) || !Number.isFinite(qualityRounds)) return false;
+  return qualityRounds > contractRounds;
+}
+
+function inferExecutionMode({ size, risk_tags, text }) {
+  if (risk_tags.includes("trust-boundary")) return "fresh-context";
+  if (/\bbatch|wave|parallel dispatch|multiple independent\b/.test(text)) return "batch-wave";
+  if (size === "S" && risk_tags.length === 0) return "quick";
+  return "standard";
+}
+
+function selectGuidancePacks({ change_type, risk_tags, size, historical }) {
+  const packs = [];
+  if (change_type === "docs") {
+    addUnique(packs, "docs-reader-success");
+  } else {
+    addUnique(packs, "surgical-change");
+    addUnique(packs, "verification-evidence");
+  }
+  if (change_type !== "docs" && (change_type === "refactor" || (["M", "L", "XL"].includes(size) && historicalQualityNeedsTightening(historical)))) {
+    addUnique(packs, "simplify-pass");
+  }
+  if (risk_tags.includes("trust-boundary")) addUnique(packs, "trust-boundary");
+  return packs;
+}
+
+function normalizeTaskProfile(profile) {
+  const change_type = CHANGE_TYPES.has(profile?.change_type) ? profile.change_type : "feature";
+  const execution_mode = EXECUTION_MODES.has(profile?.execution_mode) ? profile.execution_mode : "standard";
+  return {
+    size: normalizeSize(profile?.size),
+    change_type,
+    domains: asStringArray(profile?.domains),
+    risk_tags: asStringArray(profile?.risk_tags),
+    execution_mode,
+    guidance_packs: asStringArray(profile?.guidance_packs),
+    derivation_inputs: asStringArray(profile?.derivation_inputs),
+  };
+}
+
+function deriveTaskProfile({
+  doneCriteria = "",
+  probeSignal = "",
+  historicalSignal = "",
+  taskRisk = {},
+  size = "M",
+} = {}) {
+  const probe = parseJsonish(probeSignal);
+  const historical = parseJsonish(historicalSignal);
+  const risk = parseJsonish(taskRisk);
+  const normalizedSize = normalizeSize(size);
+  const intentText = normalizeText(doneCriteria, taskRisk);
+  const signalText = normalizeText(doneCriteria, probeSignal, historicalSignal, taskRisk);
+  const change_type = inferChangeType(intentText);
+  const domains = inferDomains(signalText, probe);
+  const risk_tags = inferRiskTags(intentText, risk);
+  const execution_mode = inferExecutionMode({ size: normalizedSize, risk_tags, text: signalText });
+  const guidance_packs = selectGuidancePacks({
+    change_type,
+    risk_tags,
+    size: normalizedSize,
+    historical,
+  });
+
+  return {
+    size: normalizedSize,
+    change_type,
+    domains,
+    risk_tags,
+    execution_mode,
+    guidance_packs,
+    derivation_inputs: ["done_criteria", "probe_signal", "historical_signal", "task_risk"],
+  };
+}
+
+function yamlScalar(value) {
+  const scalar = String(value);
+  if (/^[A-Za-z0-9_.\/-]+$/.test(scalar)) return scalar;
+  return JSON.stringify(scalar);
+}
+
+function renderYamlArray(key, values, indent) {
+  const prefix = " ".repeat(indent);
+  if (!values || values.length === 0) return `${prefix}${key}: []`;
+  return [`${prefix}${key}:`, ...values.map((value) => `${prefix}  - ${yamlScalar(value)}`)].join("\n");
+}
+
+function renderTaskProfileBlock(taskProfile) {
+  const profile = normalizeTaskProfile(taskProfile);
+  const lines = [
+    "## Task Profile",
+    "",
+    "This is advisory planner metadata for executor working style. It is not a reviewer verdict field, manifest role binding, or merge gate.",
+    "",
+    "```yaml",
+    "task_profile:",
+    `  size: ${yamlScalar(profile.size)}`,
+    `  change_type: ${yamlScalar(profile.change_type)}`,
+    renderYamlArray("domains", profile.domains, 2),
+    renderYamlArray("risk_tags", profile.risk_tags, 2),
+    `  execution_mode: ${yamlScalar(profile.execution_mode)}`,
+    renderYamlArray("guidance_packs", profile.guidance_packs, 2),
+  ];
+  if (profile.derivation_inputs.length > 0) {
+    lines.push(renderYamlArray("derivation_inputs", profile.derivation_inputs, 2));
+  }
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function applyTaskProfileToDispatchPrompt({ dispatchPrompt, taskProfile }) {
+  const profile = normalizeTaskProfile(taskProfile);
+  if (profile.guidance_packs.length === 0) return dispatchPrompt;
+  if (String(dispatchPrompt || "").includes("## Task Profile")) return dispatchPrompt;
+  const block = renderTaskProfileBlock(profile);
+  const prompt = String(dispatchPrompt || "");
+  const rubricHeading = "\n## Scoring Rubric";
+  if (prompt.includes(rubricHeading)) {
+    return prompt.replace(rubricHeading, `\n${block}\n${rubricHeading}`);
+  }
+  return `${prompt.replace(/\s*$/, "")}\n\n${block}\n`;
+}
+
+module.exports = {
+  applyTaskProfileToDispatchPrompt,
+  deriveTaskProfile,
+  renderTaskProfileBlock,
+};

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -75,10 +75,10 @@ function inferRiskTags(text, taskRisk) {
   const tags = [];
   addMany(tags, asStringArray(taskRisk?.risk_tags));
   addMany(tags, asStringArray(taskRisk?.riskTags));
-  if (/\btrust[- ]boundary|auth[- ]boundary|trust root|forg(e|ed)|bypass|fail closed|gate-check|validate(manifest|transition)?|state transition|state-machine\b/.test(text)) {
+  if (/\btrust[- ]boundary|auth[- ]boundary|trust root|forg(e|ed)|bypass|fail closed|gate-check|validatemanifest|validatetransition|state transition|state-machine\b/.test(text)) {
     addUnique(tags, "trust-boundary");
   }
-  if (/\bstate transition|state-machine|validateTransition|manifest state\b/.test(text)) addUnique(tags, "state-machine");
+  if (/\bstate transition|state-machine|validatetransition|manifest state\b/.test(text)) addUnique(tags, "state-machine");
   if (/\bpublic api|exported|schema|contract|cli flag|command line|user-facing\b/.test(text)) addUnique(tags, "public-api");
   if (/\bbackward|compat|byte-identical|unchanged|stable|existing behavior\b/.test(text)) addUnique(tags, "backward-compatibility");
   if (/\bprompt|rubric|skill\.md|dispatch prompt|reviewer prompt|done criteria|content boundary\b/.test(text)) addUnique(tags, "prompt-contract");

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -1,0 +1,165 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const {
+  applyTaskProfileToDispatchPrompt,
+  deriveTaskProfile,
+} = require("../../../skills/relay-plan/scripts/task-profile");
+
+const BASELINE_PROMPT_PATH = path.join(__dirname, "..", "fixtures", "dispatch-prompt-baseline", "non-tdd.md");
+const SKILL_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "SKILL.md");
+const PROFILE_REFERENCE_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "references", "task-profile.md");
+const REVIEW_SCHEMA_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-schema.js");
+
+const PROBE_SIGNAL = JSON.stringify({
+  test_infra: [{ name: "node:test" }],
+  project_tools: {
+    ci: [{ path: ".github/workflows/test.yml" }],
+    scripts: [{ name: "test", command: "node --test tests/relay-plan/scripts/*.test.js" }],
+  },
+});
+
+const HISTORICAL_SIGNAL = JSON.stringify({
+  metrics: { median_rounds_to_ready: 2 },
+  rubric_insights: {
+    tier_effectiveness: {
+      contract: { avg_rounds_to_met: 1.4 },
+      quality: { avg_rounds_to_met: 2.8 },
+    },
+  },
+});
+
+test("code task profile selects source-code guidance and records derivation inputs", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: [
+      "Add a relay-plan script API for generated dispatch artifacts.",
+      "Cover the behavior with tests under tests/relay-plan/scripts/.",
+    ].join("\n"),
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: { risk_tags: ["public-api", "backward-compatibility"] },
+    size: "M",
+  });
+
+  assert.equal(profile.change_type, "feature");
+  assert.equal(profile.execution_mode, "standard");
+  assert.ok(profile.domains.includes("relay-plan"));
+  assert.ok(profile.domains.includes("tests"));
+  assert.ok(profile.domains.includes("ci"));
+  assert.ok(profile.risk_tags.includes("public-api"));
+  assert.ok(profile.risk_tags.includes("backward-compatibility"));
+  assert.ok(profile.guidance_packs.includes("surgical-change"));
+  assert.ok(profile.guidance_packs.includes("verification-evidence"));
+  assert.ok(profile.guidance_packs.includes("simplify-pass"));
+  assert.deepEqual(profile.derivation_inputs, [
+    "done_criteria",
+    "probe_signal",
+    "historical_signal",
+    "task_risk",
+  ]);
+});
+
+test("docs task profile selects docs reader-success guidance", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Update docs/operator-guide.md and README examples so a reader can run the command.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: {},
+    size: "S",
+  });
+
+  assert.equal(profile.change_type, "docs");
+  assert.ok(profile.domains.includes("docs"));
+  assert.ok(profile.guidance_packs.includes("docs-reader-success"));
+});
+
+test("refactor task profile selects simplify guidance", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Refactor skills/relay-plan/scripts/probe-executor-env.js without behavior changes.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: {},
+    size: "M",
+  });
+
+  assert.equal(profile.change_type, "refactor");
+  assert.ok(profile.guidance_packs.includes("simplify-pass"));
+});
+
+test("trust-boundary task profile selects trust-boundary guidance", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: [
+      "Harden validateManifest before gate-check reads a run manifest.",
+      "Forged state-transition metadata must fail closed.",
+    ].join("\n"),
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: { risk_tags: ["state-machine"] },
+    size: "L",
+  });
+
+  assert.ok(profile.risk_tags.includes("trust-boundary"));
+  assert.ok(profile.risk_tags.includes("state-machine"));
+  assert.equal(profile.execution_mode, "fresh-context");
+  assert.ok(profile.guidance_packs.includes("trust-boundary"));
+});
+
+test("selected task_profile is visible in dispatch prompt metadata only", () => {
+  const baseline = fs.readFileSync(BASELINE_PROMPT_PATH, "utf-8");
+  const profile = deriveTaskProfile({
+    doneCriteria: "Add code in skills/relay-plan/scripts/task-profile.js with tests.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: {},
+    size: "M",
+  });
+
+  const rendered = applyTaskProfileToDispatchPrompt({ dispatchPrompt: baseline, taskProfile: profile });
+
+  assert.match(rendered, /## Task Profile/);
+  assert.match(rendered, /task_profile:/);
+  assert.match(rendered, /change_type: feature/);
+  assert.match(rendered, /guidance_packs:/);
+  assert.match(rendered, /surgical-change/);
+  assert.match(rendered, /derivation_inputs:/);
+  assert.match(rendered, /advisory planner metadata/);
+  assert.doesNotMatch(rendered, /## Working Guidance/);
+  assert.doesNotMatch(fs.readFileSync(REVIEW_SCHEMA_PATH, "utf-8"), /task_profile|guidance_packs|execution_mode/);
+});
+
+test("empty guidance_packs leaves existing non-guidance prompt byte-identical", () => {
+  const baseline = fs.readFileSync(BASELINE_PROMPT_PATH, "utf-8");
+  const rendered = applyTaskProfileToDispatchPrompt({
+    dispatchPrompt: baseline,
+    taskProfile: {
+      change_type: "feature",
+      domains: ["relay-plan"],
+      risk_tags: [],
+      execution_mode: "standard",
+      guidance_packs: [],
+    },
+  });
+
+  assert.equal(rendered, baseline);
+});
+
+test("relay-plan documents task_profile shape, derivation, and planner-only boundary", () => {
+  const skill = fs.readFileSync(SKILL_PATH, "utf-8");
+  const reference = fs.readFileSync(PROFILE_REFERENCE_PATH, "utf-8");
+
+  assert.match(skill, /task_profile/);
+  assert.match(skill, /references\/task-profile\.md/);
+  assert.match(reference, /change_type/);
+  assert.match(reference, /domains/);
+  assert.match(reference, /risk_tags/);
+  assert.match(reference, /execution_mode/);
+  assert.match(reference, /guidance_packs/);
+  assert.match(reference, /Done Criteria/);
+  assert.match(reference, /probe signal/);
+  assert.match(reference, /historical signal/);
+  assert.match(reference, /task risk/);
+  assert.match(reference, /planner metadata/);
+  assert.match(reference, /not a reviewer verdict field/);
+});

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -75,6 +75,21 @@ test("docs task profile selects docs reader-success guidance", () => {
   assert.ok(profile.guidance_packs.includes("docs-reader-success"));
 });
 
+test("generic validate wording does not imply trust-boundary guidance", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Validate docs/operator-guide.md examples so a reader can run the command.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: {},
+    size: "S",
+  });
+
+  assert.equal(profile.change_type, "docs");
+  assert.equal(profile.execution_mode, "quick");
+  assert.ok(!profile.risk_tags.includes("trust-boundary"));
+  assert.ok(!profile.guidance_packs.includes("trust-boundary"));
+});
+
 test("refactor task profile selects simplify guidance", () => {
   const profile = deriveTaskProfile({
     doneCriteria: "Refactor skills/relay-plan/scripts/probe-executor-env.js without behavior changes.",

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -121,6 +121,20 @@ test("trust-boundary task profile selects trust-boundary guidance", () => {
   assert.ok(profile.guidance_packs.includes("trust-boundary"));
 });
 
+test("validate manifest wording selects trust-boundary guidance", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Validate manifest state before applying review gate decisions.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: {},
+    size: "M",
+  });
+
+  assert.ok(profile.risk_tags.includes("trust-boundary"));
+  assert.ok(profile.risk_tags.includes("state-machine"));
+  assert.equal(profile.execution_mode, "fresh-context");
+});
+
 test("selected task_profile is visible in dispatch prompt metadata only", () => {
   const baseline = fs.readFileSync(BASELINE_PROMPT_PATH, "utf-8");
   const profile = deriveTaskProfile({


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 끝냈습니다.

커밋: `f9bf9f9 feat(relay-plan): add task profile guidance model`

변경 사항:
- `skills/relay-plan/scripts/task-profile.js`: `deriveTaskProfile`, `applyTaskProfileToDispatchPrompt` 추가
- `skills/relay-plan/references/task-profile.md`: schema, derivation inputs, planner-only boundary 문서화
- `skills/relay-plan/SKILL.md`: task_profile 생성/dispatch artifact 위치 연결
- `tests/relay-plan/scripts/task-profile.test.js`: code/docs/refactor/trust-boundary, prompt visibility, no-guidance byte-stab
```

## Score Log

- Run: issue-395-20260502063958182-55bdbb59
- Executor: codex
- Branch: issue-395