### PR TITLE
Add relay-plan guidance pack references

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -51,6 +51,7 @@ Before drafting factors, identify the evaluation source model:
 - Repo quality signal from probes and available commands
 - Historical relay signal from stuck factors and score divergence
 - Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes; derive `task_profile` per `references/task-profile.md`
+- Selected guidance pack names from `task_profile.guidance_packs`, using `references/guidance-packs.md` as the compact advisory pack library
 
 If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. If the final review anchor is planner-authored or differs from the task source, persist it in step 8 so the reviewer has the same anchor.
 
@@ -125,7 +126,7 @@ S/M usually skips, but ambiguity or risk can opt any size into stress-test. Run 
 
 ### 10. Generate dispatch prompt
 
-Take the base template (`../relay/references/prompt-template.md`) and append Setup, optional `task_profile` metadata when guidance packs are selected, Scoring Rubric, Iteration Protocol, and Score Log sections. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
+Take the base template (`../relay/references/prompt-template.md`) and append Setup, optional `task_profile` metadata when guidance packs are selected, Scoring Rubric, Iteration Protocol, and Score Log sections. Selected pack names come from `references/guidance-packs.md`, but pack text rendering is follow-up work; keep this step limited to existing task profile metadata until Working Guidance rendering lands. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
 
 Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 

--- a/skills/relay-plan/references/guidance-packs.md
+++ b/skills/relay-plan/references/guidance-packs.md
@@ -1,0 +1,124 @@
+# Guidance Packs
+
+Compact execution guidance packs are advisory working-style snippets selected by `task_profile.guidance_packs`. They help the executor choose useful habits for the task shape, but Done Criteria, rubric factors, rubric commands, and scope boundaries remain authoritative.
+
+This reference is the pack library. Rendering the selected packs into dispatch prompts, persisting pack metadata in run artifacts, and reporting pack analytics are separate follow-up work.
+
+## Pack Contract
+
+- Keep pack text compact enough for future dispatch prompt rendering.
+- Write behavior guidance, not full skill instructions.
+- Use executor-agnostic wording; correctness must not depend on provider-specific skill paths, local tool names, or workflow commands.
+- Promote required outcomes into Done Criteria or rubric factors. Guidance can suggest how to work, but it cannot define pass/fail by itself.
+
+## Initial Pack Library
+
+### `surgical-change`
+
+#### Use when
+
+- Source, prompt, test, or reference changes are expected.
+- The task is S/M size and scope creep is a primary risk.
+
+#### Do not use when
+
+- The task intentionally asks for broad redesign, migration, or exploratory cleanup.
+- Correctness depends on a larger coordinated refactor already captured in Done Criteria.
+
+#### Guidance
+
+- Keep the diff narrow and trace each changed line to Done Criteria, rubric factors, or cleanup caused by this task.
+- Prefer existing local patterns before adding new abstractions.
+- Avoid adjacent refactors unless the task change made them necessary.
+
+#### Rubric still carries
+
+- Required behavior, compatibility, public surface, and scope boundaries must remain in Done Criteria or rubric factors. This pack is advisory and does not override them.
+
+### `verification-evidence`
+
+#### Use when
+
+- The executor changes files, commits work, or must leave reviewable proof.
+- The reviewer needs exact artifacts, commands, or outcomes to evaluate the run.
+
+#### Do not use when
+
+- The task is read-only analysis with no changed artifacts or runnable checks.
+- Evidence requirements are already fully specified as rubric factors and no extra completion note is useful.
+
+#### Guidance
+
+- Record changed artifacts, exact checks run, pass/fail results, and known blockers before completion.
+- Treat tests, manifests, logs, and self-reports as evidence signals, not proof by themselves.
+- If a required factor remains failing after focused attempts, stop with a concrete stuck note.
+
+#### Rubric still carries
+
+- Required commands, targets, failure thresholds, and evidence fields must remain in Done Criteria or rubric factors. This pack is advisory and cannot replace automated checks.
+
+### `simplify-pass`
+
+#### Use when
+
+- M+ code, refactor, parsing, prompt rendering, state handling, or helper extraction is involved.
+- Historical or task-specific signal suggests quality factors may take extra rounds.
+
+#### Do not use when
+
+- The task is a tiny mechanical edit where a second cleanup pass would add churn.
+- The requested change is intentionally a compatibility shim or temporary bridge.
+
+#### Guidance
+
+- After green checks, review only files changed by this task.
+- Preserve behavior exactly while removing unnecessary branching, duplication, and single-use abstractions.
+- Prefer explicit readable code over dense clever code.
+
+#### Rubric still carries
+
+- Behavior preservation, public API compatibility, performance constraints, and changed-file scope must remain in Done Criteria or rubric factors. This pack is advisory cleanup guidance only.
+
+### `docs-reader-success`
+
+#### Use when
+
+- Documentation, README, operator guide, skill text, or reference material changes are expected.
+- A reader should be able to act with no conversation context.
+
+#### Do not use when
+
+- The work is primarily implementation and docs are only incidental release notes.
+- Reader outcomes cannot be evaluated without product decisions outside the task.
+
+#### Guidance
+
+- Verify referenced files, flags, commands, and issue numbers when practical.
+- Make examples runnable or clearly mark them as illustrative.
+- Explain enough context for the intended reader to choose the next action.
+
+#### Rubric still carries
+
+- Required doc artifacts, link or command checks, terminology, and reader outcomes must remain in Done Criteria or rubric factors. This pack is advisory and not a doc acceptance test.
+
+### `trust-boundary`
+
+#### Use when
+
+- The task touches manifest validation, state transitions, review gates, auth boundaries, trust roots, or fail-closed behavior.
+- Forged, missing, stale, or mismatched inputs could change a protected decision.
+
+#### Do not use when
+
+- The task only uses generic validation language for docs, formatting, or non-security input cleanup.
+- Security posture is unaffected and trust assumptions stay unchanged.
+
+#### Guidance
+
+- Name the trust root and the protected decision.
+- Distinguish visible warnings from fail-closed enforcement.
+- Test forged, missing, stale, or mismatched inputs where practical.
+
+#### Rubric still carries
+
+- Trust root, enforcement layer, bypass cases, fail-closed behavior, and regression coverage must remain in Done Criteria or rubric factors. This pack is advisory and pairs with `references/rubric-trust-model.md`.

--- a/skills/relay-plan/references/task-profile.md
+++ b/skills/relay-plan/references/task-profile.md
@@ -2,6 +2,8 @@
 
 `task_profile` is relay-plan metadata that makes guidance selection explicit and auditable before dispatch.
 
+Guidance pack names refer to the compact advisory library in `references/guidance-packs.md`.
+
 ```yaml
 task_profile:
   size: S | M | L | XL
@@ -33,7 +35,7 @@ Build the profile from the same planning evidence used for the rubric:
 
 `task_profile` is planner metadata. It may be shown in dispatch artifacts so executors know why guidance was selected, but it is not a reviewer verdict field, manifest role binding, lifecycle state, or merge gate. Correctness still lives in Done Criteria and rubric factors.
 
-The only prompt-visible behavior in this issue is the profile metadata block. Compact guidance pack text, dispatch persistence/events, and reliability analytics are follow-up work.
+The only prompt-visible behavior in the profile step is the profile metadata block. Guidance pack text rendering, dispatch persistence/events, and reliability analytics are follow-up work.
 
 ## Selection Hints
 

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -7,6 +7,14 @@ const REFERENCES_DIR = path.join(__dirname, "..", "..", "..", "skills", "relay-p
 const SKILL_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "SKILL.md");
 const RELAY_SKILL_PATH = path.join(__dirname, "..", "..", "..", "skills", "relay", "SKILL.md");
 const RELAY_REFERENCES_DIR = path.join(__dirname, "..", "..", "..", "skills", "relay", "references");
+const GUIDANCE_PACK_REFERENCE = "guidance-packs.md";
+const REQUIRED_GUIDANCE_PACKS = [
+  "surgical-change",
+  "verification-evidence",
+  "simplify-pass",
+  "docs-reader-success",
+  "trust-boundary",
+];
 
 function readReference(name) {
   return fs.readFileSync(path.join(REFERENCES_DIR, name), "utf-8");
@@ -22,6 +30,15 @@ function readRelaySkill() {
 
 function readRelayReference(name) {
   return fs.readFileSync(path.join(RELAY_REFERENCES_DIR, name), "utf-8");
+}
+
+function extractGuidancePackSections(text) {
+  const sections = new Map();
+  const packHeadingPattern = /^### `([^`]+)`\n([\s\S]*?)(?=^### `|(?![\s\S]))/gm;
+  for (const match of text.matchAll(packHeadingPattern)) {
+    sections.set(match[1], match[2].trim());
+  }
+  return sections;
 }
 
 test("domain rubric references declare candidate-axis usage", () => {
@@ -136,4 +153,58 @@ test("relay dispatch template and wrapper use Done Criteria outcome language", (
   assert.match(relaySkill, /Done Criteria fully implemented/);
   assert.doesNotMatch(relaySkill, /Steps 1-10 only/);
   assert.doesNotMatch(relaySkill, /Issue AC fully implemented/);
+});
+
+test("guidance pack reference declares exactly the initial five packs", () => {
+  const text = readReference(GUIDANCE_PACK_REFERENCE);
+  const skill = readSkill();
+  const taskProfile = readReference("task-profile.md");
+  const sections = extractGuidancePackSections(text);
+
+  assert.deepEqual([...sections.keys()], REQUIRED_GUIDANCE_PACKS);
+  assert.match(skill, /references\/guidance-packs\.md/);
+  assert.match(taskProfile, /references\/guidance-packs\.md/);
+});
+
+test("each guidance pack states use, non-use, and rubric boundary", () => {
+  const text = readReference(GUIDANCE_PACK_REFERENCE);
+  const sections = extractGuidancePackSections(text);
+
+  for (const pack of REQUIRED_GUIDANCE_PACKS) {
+    const section = sections.get(pack);
+    assert.ok(section, pack);
+    assert.match(section, /^#### Use when$/m, pack);
+    assert.match(section, /^#### Do not use when$/m, pack);
+    assert.match(section, /^#### Guidance$/m, pack);
+    assert.match(section, /^#### Rubric still carries$/m, pack);
+    assert.match(section, /advisory|does not override|must remain/i, pack);
+    assert.match(section, /Done Criteria|rubric factor|rubric factors/i, pack);
+  }
+});
+
+test("guidance packs stay compact and executor-agnostic", () => {
+  const text = readReference(GUIDANCE_PACK_REFERENCE);
+  const sections = extractGuidancePackSections(text);
+  const forbiddenProviderTerms = [
+    /\bCodex\b/,
+    /\bClaude\b/,
+    /\bGPT\b/,
+    /\bOpenAI\b/,
+    /\bAnthropic\b/,
+    /\bCLAUDE_SKILL_DIR\b/,
+    /\bgh\s+/,
+    /\bnpm\s+/,
+    /\bnode --test\b/,
+    /\bapply_patch\b/,
+  ];
+
+  for (const pack of REQUIRED_GUIDANCE_PACKS) {
+    const section = sections.get(pack);
+    const words = section.split(/\s+/).filter(Boolean);
+    assert.ok(words.length <= 170, `${pack} has ${words.length} words`);
+    assert.ok(section.split("\n").length <= 24, `${pack} is too long`);
+    for (const pattern of forbiddenProviderTerms) {
+      assert.doesNotMatch(section, pattern, pack);
+    }
+  }
 });


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료하고 커밋했습니다.

Commit: `c445c97 Add relay-plan guidance pack references`

변경 요약:
- [guidance-packs.md](/Users/sjlee/.relay/worktrees/400f7016/dev-relay/skills/relay-plan/references/guidance-packs.md:1) 추가: `surgical-change`, `verification-evidence`, `simplify-pass`, `docs-reader-success`, `trust-boundary` 5개 pack 정의
- [SKILL.md](/Users/sjlee/.relay/worktrees/400f7016/dev-relay/skills/relay-plan/SKILL.md:51), [task-profile.md](/Users/sjlee/.relay/worktrees/400f7016/dev-relay/skills/relay-plan/r
```

## Score Log

- Run: issue-396-20260502071247068-add95c75
- Executor: codex
- Branch: issue-396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 릴레이 플랜 스킬 문서를 업데이트하여 가이던스 팩 선택 프로세스 및 관련 참조 라이브러리를 통합했습니다.
  * 새로운 가이던스 팩 참조 문서를 추가하여 선택 가능한 팩의 라이브러리를 정의했습니다.

* **Tests**
  * 가이던스 팩 검증 테스트를 추가하여 요구 사항 준수를 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->