### PR TITLE
Render working guidance in dispatch prompts

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -126,7 +126,7 @@ S/M usually skips, but ambiguity or risk can opt any size into stress-test. Run 
 
 ### 10. Generate dispatch prompt
 
-Take the base template (`../relay/references/prompt-template.md`) and append Setup, optional `task_profile` metadata when guidance packs are selected, Scoring Rubric, Iteration Protocol, and Score Log sections. Selected pack names come from `references/guidance-packs.md`, but pack text rendering is follow-up work; keep this step limited to existing task profile metadata until Working Guidance rendering lands. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
+Take the base template (`../relay/references/prompt-template.md`) and append Setup, optional `task_profile` metadata plus Working Guidance when guidance packs are selected, Scoring Rubric, Iteration Protocol, and Score Log sections. Selected pack names and prompt-ready guidance bullets come from `references/guidance-packs.md`; the Working Guidance section is advisory and must state that it does not override Done Criteria, rubric commands, or scope boundaries. Insert the optional Step 0a block from `references/iteration-protocol.md` iff any factor has a non-empty `tdd_anchor`; when no factor has `tdd_anchor`, keep the emitted prompt identical to the pre-TDD baseline.
 
 Full iteration-protocol text + Score Log format: `references/iteration-protocol.md`.
 

--- a/skills/relay-plan/references/guidance-packs.md
+++ b/skills/relay-plan/references/guidance-packs.md
@@ -2,7 +2,7 @@
 
 Compact execution guidance packs are advisory working-style snippets selected by `task_profile.guidance_packs`. They help the executor choose useful habits for the task shape, but Done Criteria, rubric factors, rubric commands, and scope boundaries remain authoritative.
 
-This reference is the pack library. Rendering the selected packs into dispatch prompts, persisting pack metadata in run artifacts, and reporting pack analytics are separate follow-up work.
+This reference is the pack library. Relay-plan renders the selected `#### Guidance` bullets into dispatch prompts. Persisting pack metadata in run artifacts and reporting pack analytics are separate follow-up work.
 
 ## Pack Contract
 

--- a/skills/relay-plan/references/task-profile.md
+++ b/skills/relay-plan/references/task-profile.md
@@ -35,7 +35,7 @@ Build the profile from the same planning evidence used for the rubric:
 
 `task_profile` is planner metadata. It may be shown in dispatch artifacts so executors know why guidance was selected, but it is not a reviewer verdict field, manifest role binding, lifecycle state, or merge gate. Correctness still lives in Done Criteria and rubric factors.
 
-The only prompt-visible behavior in the profile step is the profile metadata block. Guidance pack text rendering, dispatch persistence/events, and reliability analytics are follow-up work.
+When `guidance_packs` is non-empty, dispatch prompts render both the profile metadata block and a Working Guidance section using the selected pack guidance bullets. Working Guidance is advisory and must not override Done Criteria, rubric commands, or scope boundaries. Dispatch persistence/events and reliability analytics are separate follow-up work.
 
 ## Selection Hints
 

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -1,8 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
 const CHANGE_TYPES = new Set(["bugfix", "feature", "refactor", "docs", "test", "infra", "visual", "prompt"]);
 const EXECUTION_MODES = new Set(["quick", "standard", "fresh-context", "batch-wave"]);
 const SIZES = new Set(["S", "M", "L", "XL"]);
 const TRUST_BOUNDARY_PATTERN = /\b(?:trust[- ]boundary|auth[- ]boundary|trust root|forge|forged|bypass|fail closed|gate-check|validate[- ]?(?:manifest|transition)|state transition|state-machine)\b/;
 const STATE_MACHINE_PATTERN = /\b(?:state transition|state-machine|validate[- ]?transition|manifest state)\b/;
+const GUIDANCE_PACK_REFERENCE_PATH = path.join(__dirname, "..", "references", "guidance-packs.md");
+const WORKING_GUIDANCE_HEADING = "## Working Guidance";
+const WORKING_GUIDANCE_BOUNDARY = "These instructions guide execution style. They do not override Done Criteria, rubric commands, or scope boundaries.";
 
 function parseJsonish(value) {
   if (!value) return {};
@@ -202,12 +208,49 @@ function renderTaskProfileBlock(taskProfile) {
   return lines.join("\n");
 }
 
-function applyTaskProfileToDispatchPrompt({ dispatchPrompt, taskProfile }) {
-  const profile = normalizeTaskProfile(taskProfile);
-  if (profile.guidance_packs.length === 0) return dispatchPrompt;
-  if (String(dispatchPrompt || "").includes("## Task Profile")) return dispatchPrompt;
-  const block = renderTaskProfileBlock(profile);
-  const prompt = String(dispatchPrompt || "");
+function extractMarkdownSubsection(sectionText, heading) {
+  const lines = String(sectionText || "").split(/\r?\n/);
+  const headingIndex = lines.findIndex((line) => line.trim() === `#### ${heading}`);
+  if (headingIndex === -1) return "";
+  const content = [];
+  for (let index = headingIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^####\s+/.test(line)) break;
+    if (content.length === 0 && line.trim() === "") continue;
+    content.push(line);
+  }
+  return content.join("\n").trim();
+}
+
+function readGuidancePackLibrary() {
+  const text = fs.readFileSync(GUIDANCE_PACK_REFERENCE_PATH, "utf-8");
+  const sections = new Map();
+  const packHeadingPattern = /^### `([^`]+)`\n([\s\S]*?)(?=^### `|(?![\s\S]))/gm;
+  for (const match of text.matchAll(packHeadingPattern)) {
+    const guidance = extractMarkdownSubsection(match[2], "Guidance");
+    if (guidance) sections.set(match[1], guidance);
+  }
+  return sections;
+}
+
+function renderWorkingGuidanceBlock(guidancePacks) {
+  const packLibrary = readGuidancePackLibrary();
+  const lines = [
+    WORKING_GUIDANCE_HEADING,
+    "",
+    WORKING_GUIDANCE_BOUNDARY,
+  ];
+  for (const pack of guidancePacks) {
+    const guidance = packLibrary.get(pack);
+    if (!guidance) continue;
+    lines.push("", `### ${pack}`, guidance);
+  }
+  return lines.length > 3 ? lines.join("\n") : "";
+}
+
+function insertBlocksBeforeRubric(prompt, blocks) {
+  const block = blocks.filter(Boolean).join("\n\n");
+  if (!block) return prompt;
   const rubricHeading = "\n## Scoring Rubric";
   if (prompt.includes(rubricHeading)) {
     return prompt.replace(rubricHeading, `\n${block}\n${rubricHeading}`);
@@ -215,8 +258,23 @@ function applyTaskProfileToDispatchPrompt({ dispatchPrompt, taskProfile }) {
   return `${prompt.replace(/\s*$/, "")}\n\n${block}\n`;
 }
 
+function applyTaskProfileToDispatchPrompt({ dispatchPrompt, taskProfile }) {
+  const profile = normalizeTaskProfile(taskProfile);
+  if (profile.guidance_packs.length === 0) return dispatchPrompt;
+  const prompt = String(dispatchPrompt || "");
+  const blocks = [];
+  if (!prompt.includes("## Task Profile")) {
+    blocks.push(renderTaskProfileBlock(profile));
+  }
+  if (!prompt.includes(WORKING_GUIDANCE_HEADING)) {
+    blocks.push(renderWorkingGuidanceBlock(profile.guidance_packs));
+  }
+  return insertBlocksBeforeRubric(prompt, blocks);
+}
+
 module.exports = {
   applyTaskProfileToDispatchPrompt,
   deriveTaskProfile,
   renderTaskProfileBlock,
+  renderWorkingGuidanceBlock,
 };

--- a/tests/relay-plan/scripts/dispatch-prompt-emit.test.js
+++ b/tests/relay-plan/scripts/dispatch-prompt-emit.test.js
@@ -1,2 +1,124 @@
-// Command-addressable entrypoint for the dispatch-prompt TDD rubric contract.
+// Command-addressable entrypoint for the dispatch-prompt emission contract.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { applyTaskProfileToDispatchPrompt } = require("../../../skills/relay-plan/scripts/task-profile");
+const { applyTddFlavorToDispatchPrompt } = require("../../../skills/relay-plan/scripts/tdd-flavor");
+
+const BASELINE_PROMPT_PATH = path.join(__dirname, "..", "fixtures", "dispatch-prompt-baseline", "non-tdd.md");
+
+const TDD_RUBRIC = [
+  "rubric:",
+  "  prerequisites:",
+  "    - command: \"node --test\"",
+  "      target: \"exit 0\"",
+  "  factors:",
+  "    - name: Parser rejects invalid input",
+  "      tier: contract",
+  "      type: automated",
+  "      command: \"node --test tests/parser.test.js\"",
+  "      target: \"exit 0\"",
+  "      weight: required",
+  "      tdd_anchor: \"tests/parser.test.js\"",
+  "      tdd_runner: \"node:test\"",
+].join("\n");
+
+function baselinePrompt() {
+  return fs.readFileSync(BASELINE_PROMPT_PATH, "utf-8");
+}
+
+test("no guidance packs leave the dispatch prompt byte-identical", () => {
+  const baseline = baselinePrompt();
+  const rendered = applyTaskProfileToDispatchPrompt({
+    dispatchPrompt: baseline,
+    taskProfile: {
+      size: "M",
+      change_type: "prompt",
+      domains: ["relay-plan"],
+      risk_tags: [],
+      execution_mode: "standard",
+      guidance_packs: [],
+    },
+  });
+
+  assert.equal(rendered, baseline);
+  assert.doesNotMatch(rendered, /## Task Profile/);
+  assert.doesNotMatch(rendered, /## Working Guidance/);
+});
+
+test("single selected guidance pack renders compact Working Guidance", () => {
+  const rendered = applyTaskProfileToDispatchPrompt({
+    dispatchPrompt: baselinePrompt(),
+    taskProfile: {
+      size: "S",
+      change_type: "docs",
+      domains: ["docs"],
+      risk_tags: [],
+      execution_mode: "quick",
+      guidance_packs: ["docs-reader-success"],
+    },
+  });
+
+  assert.match(rendered, /## Task Profile/);
+  assert.match(rendered, /## Working Guidance/);
+  assert.match(rendered, /These instructions guide execution style\. They do not override Done Criteria, rubric commands, or scope boundaries\./);
+  assert.match(rendered, /### docs-reader-success/);
+  assert.match(rendered, /- Verify referenced files, flags, commands, and issue numbers when practical\./);
+  assert.doesNotMatch(rendered, /### surgical-change/);
+  assert.ok(rendered.indexOf("## Task Profile") < rendered.indexOf("## Working Guidance"));
+  assert.ok(rendered.indexOf("## Working Guidance") < rendered.indexOf("## Scoring Rubric"));
+});
+
+test("multiple selected guidance packs render in task profile order", () => {
+  const rendered = applyTaskProfileToDispatchPrompt({
+    dispatchPrompt: baselinePrompt(),
+    taskProfile: {
+      size: "M",
+      change_type: "prompt",
+      domains: ["relay-plan", "prompt", "tests"],
+      risk_tags: ["backward-compatibility", "prompt-contract"],
+      execution_mode: "standard",
+      guidance_packs: ["surgical-change", "verification-evidence", "simplify-pass"],
+    },
+  });
+
+  assert.match(rendered, /### surgical-change/);
+  assert.match(rendered, /### verification-evidence/);
+  assert.match(rendered, /### simplify-pass/);
+  assert.match(rendered, /- Keep the diff narrow and trace each changed line/);
+  assert.match(rendered, /- Record changed artifacts, exact checks run, pass\/fail results, and known blockers before completion\./);
+  assert.match(rendered, /- After green checks, review only files changed by this task\./);
+  assert.ok(rendered.indexOf("### surgical-change") < rendered.indexOf("### verification-evidence"));
+  assert.ok(rendered.indexOf("### verification-evidence") < rendered.indexOf("### simplify-pass"));
+});
+
+test("TDD Step 0a remains factor-scoped when Working Guidance is rendered", () => {
+  const withGuidance = applyTaskProfileToDispatchPrompt({
+    dispatchPrompt: baselinePrompt(),
+    taskProfile: {
+      size: "M",
+      change_type: "prompt",
+      domains: ["relay-plan", "prompt", "tests"],
+      risk_tags: ["prompt-contract"],
+      execution_mode: "standard",
+      guidance_packs: ["surgical-change"],
+    },
+  });
+  const rendered = applyTddFlavorToDispatchPrompt({
+    dispatchPrompt: withGuidance,
+    rubricYaml: TDD_RUBRIC,
+    probeSignal: JSON.stringify({ test_infra: [{ name: "node:test" }] }),
+  });
+
+  assert.match(rendered, /## Working Guidance/);
+  assert.match(rendered, /0a\. TDD RED ANCHOR STEP/);
+  assert.match(rendered, /tests\/parser\.test\.js/);
+  assert.doesNotMatch(rendered, /tdd_mode/);
+  assert.doesNotMatch(rendered, /## TDD/i);
+  assert.ok(rendered.indexOf("## Working Guidance") < rendered.indexOf("## Scoring Rubric"));
+  assert.ok(rendered.indexOf("0a. TDD RED ANCHOR STEP") > rendered.indexOf("## Iteration Protocol"));
+});
+
 require("./tdd-flavor.test");

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -135,7 +135,7 @@ test("validate manifest wording selects trust-boundary guidance", () => {
   assert.equal(profile.execution_mode, "fresh-context");
 });
 
-test("selected task_profile is visible in dispatch prompt metadata only", () => {
+test("selected task_profile renders metadata and working guidance in dispatch prompts", () => {
   const baseline = fs.readFileSync(BASELINE_PROMPT_PATH, "utf-8");
   const profile = deriveTaskProfile({
     doneCriteria: "Add code in skills/relay-plan/scripts/task-profile.js with tests.",
@@ -154,7 +154,9 @@ test("selected task_profile is visible in dispatch prompt metadata only", () => 
   assert.match(rendered, /surgical-change/);
   assert.match(rendered, /derivation_inputs:/);
   assert.match(rendered, /advisory planner metadata/);
-  assert.doesNotMatch(rendered, /## Working Guidance/);
+  assert.match(rendered, /## Working Guidance/);
+  assert.match(rendered, /These instructions guide execution style\. They do not override Done Criteria, rubric commands, or scope boundaries\./);
+  assert.match(rendered, /### surgical-change/);
   assert.doesNotMatch(fs.readFileSync(REVIEW_SCHEMA_PATH, "utf-8"), /task_profile|guidance_packs|execution_mode/);
 });
 


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 `issue-397` 브랜치에 커밋까지 끝냈습니다.

변경 요약:
- [task-profile.js](/Users/sjlee/.relay/worktrees/ca88923c/dev-relay/skills/relay-plan/scripts/task-profile.js): `guidance_packs`가 있을 때 `## Task Profile` 뒤에 `## Working Guidance`를 렌더링하도록 확장했습니다. pack 본문은 [guidance-packs.md](/Users/sjlee/.relay/worktrees/ca88923c/dev-relay/skills/relay-plan/references/guidance-packs.md)의 `#### Guidance` bullets에서 읽습니다.
- [dispatch-prompt-emit.test.js](/Users/sjlee/.relay/worktrees/ca88923c/dev-relay/tests/relay-plan/sc
```

## Score Log

- Run: issue-397-20260502072455948-89edad42
- Executor: codex
- Branch: issue-397