### PR TITLE
feat: persist dispatch guidance metadata

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -99,6 +99,11 @@ const {
 } = require("./manifest/rubric");
 const { getPositionals, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { formatAttemptsForPrompt, readPreviousAttempts } = require("./manifest/attempts");
+const {
+  buildGuidanceMetadata,
+  GUIDANCE_METADATA_FILENAME,
+  persistGuidanceMetadata,
+} = require("./manifest/guidance");
 const { STATES, updateManifestState } = require("./manifest/lifecycle");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
@@ -956,6 +961,34 @@ async function main() {
       failRubricPersistence(rubricAnchor.error);
     }
     writeManifest(manifestPath, manifest);
+  }
+
+  const guidanceMetadata = buildGuidanceMetadata({
+    promptText: taskPrompt,
+    manifest,
+    promptSource: taskPromptResult.source,
+    rubricPath: manifest?.anchor?.rubric_path || null,
+  });
+  if (guidanceMetadata) {
+    const runDir = getRunDir(repoRoot, runId);
+    try {
+      manifest = persistGuidanceMetadata({ runDir, manifest, metadata: guidanceMetadata });
+      writeManifest(manifestPath, manifest);
+      appendRunEvent(repoRoot, runId, {
+        event: EVENTS.GUIDANCE_SELECTED,
+        state_from: manifest.state,
+        state_to: manifest.state,
+        head_sha: manifest.git?.head_sha || null,
+        reason: RESUME_MODE ? "same_run_resume" : "new_dispatch",
+        guidance_packs: guidanceMetadata.guidance_packs,
+        task_profile_summary: guidanceMetadata.task_profile_summary,
+        guidance_source: guidanceMetadata.source,
+        guidance_artifact_path: GUIDANCE_METADATA_FILENAME,
+      });
+    } catch (guidanceError) {
+      console.error(`Error: failed to persist guidance metadata: ${guidanceError.message}`);
+      process.exit(1);
+    }
   }
 
   // --- Step 3: Execute task ---

--- a/skills/relay-dispatch/scripts/manifest/guidance.js
+++ b/skills/relay-dispatch/scripts/manifest/guidance.js
@@ -1,0 +1,182 @@
+const path = require("path");
+
+const { nowIso } = require("./paths");
+const { writeTextFileWithoutFollowingSymlinks } = require("./rubric");
+
+const GUIDANCE_METADATA_FILENAME = "guidance-metadata.json";
+const DISPATCH_PROMPT_FILENAME = "dispatch-prompt.md";
+
+const SCALAR_FIELDS = new Set(["size", "change_type", "execution_mode"]);
+const ARRAY_FIELDS = new Set(["domains", "risk_tags", "guidance_packs", "derivation_inputs"]);
+
+function stripYamlScalar(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  if (raw === "[]") return [];
+  if (raw.startsWith("\"") && raw.endsWith("\"")) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw.slice(1, -1);
+    }
+  }
+  if (raw.startsWith("'") && raw.endsWith("'")) {
+    return raw.slice(1, -1).replace(/''/g, "'");
+  }
+  return raw;
+}
+
+function uniqueStrings(values) {
+  const result = [];
+  for (const value of values || []) {
+    const text = String(value || "").trim();
+    if (text && !result.includes(text)) result.push(text);
+  }
+  return result;
+}
+
+function parseTaskProfileYaml(blockText) {
+  const lines = String(blockText || "").replace(/\r\n/g, "\n").split("\n");
+  const startIndex = lines.findIndex((line) => line.trim() === "task_profile:");
+  if (startIndex === -1) return null;
+
+  const profile = {};
+  let currentArrayKey = null;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    const keyValue = /^ {2}([A-Za-z0-9_]+):(?:\s*(.*))?$/.exec(line);
+    if (keyValue) {
+      const key = keyValue[1];
+      const rawValue = keyValue[2] || "";
+      currentArrayKey = null;
+      if (ARRAY_FIELDS.has(key)) {
+        profile[key] = [];
+        if (rawValue.trim()) {
+          const parsed = stripYamlScalar(rawValue);
+          profile[key] = Array.isArray(parsed) ? uniqueStrings(parsed) : uniqueStrings([parsed]);
+        } else {
+          currentArrayKey = key;
+        }
+      } else if (SCALAR_FIELDS.has(key)) {
+        profile[key] = String(stripYamlScalar(rawValue) || "").trim();
+      }
+      continue;
+    }
+
+    const listItem = /^ {4}-\s*(.*)$/.exec(line);
+    if (listItem && currentArrayKey) {
+      profile[currentArrayKey].push(String(stripYamlScalar(listItem[1]) || "").trim());
+    }
+  }
+
+  for (const key of ARRAY_FIELDS) {
+    if (profile[key]) profile[key] = uniqueStrings(profile[key]);
+  }
+  return profile;
+}
+
+function extractTaskProfileBlock(promptText) {
+  const text = String(promptText || "").replace(/\r\n/g, "\n");
+  const fencePattern = /```(?:yaml|yml)?\s*\n([\s\S]*?)```/g;
+  for (const match of text.matchAll(fencePattern)) {
+    if (/^task_profile:\s*$/m.test(match[1])) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function buildTaskProfileSummary(profile) {
+  return {
+    size: profile.size || null,
+    change_type: profile.change_type || null,
+    domains: uniqueStrings(profile.domains),
+    risk_tags: uniqueStrings(profile.risk_tags),
+    execution_mode: profile.execution_mode || null,
+    ...(profile.derivation_inputs?.length
+      ? { derivation_inputs: uniqueStrings(profile.derivation_inputs) }
+      : {}),
+  };
+}
+
+function extractGuidanceFromPrompt(promptText) {
+  const block = extractTaskProfileBlock(promptText);
+  if (!block) return null;
+  const profile = parseTaskProfileYaml(block);
+  const guidancePacks = uniqueStrings(profile?.guidance_packs);
+  if (guidancePacks.length === 0) return null;
+
+  return {
+    guidance_packs: guidancePacks,
+    task_profile_summary: buildTaskProfileSummary(profile),
+    source: "prompt",
+  };
+}
+
+function readExistingGuidance(manifest) {
+  const existing = manifest?.advisory?.guidance;
+  const guidancePacks = uniqueStrings(existing?.guidance_packs);
+  if (guidancePacks.length === 0) return null;
+  return {
+    guidance_packs: guidancePacks,
+    task_profile_summary: existing.task_profile_summary || null,
+    source: "manifest-preserved",
+  };
+}
+
+function buildGuidanceMetadata({
+  promptText,
+  manifest,
+  promptSource,
+  rubricPath,
+}) {
+  const extracted = extractGuidanceFromPrompt(promptText);
+  const selected = extracted || readExistingGuidance(manifest);
+  if (!selected) return null;
+
+  return {
+    version: 1,
+    captured_at: nowIso(),
+    source: selected.source,
+    prompt_source: promptSource || null,
+    guidance_packs: selected.guidance_packs,
+    task_profile_summary: selected.task_profile_summary,
+    dispatch_prompt_path: DISPATCH_PROMPT_FILENAME,
+    rubric_path: rubricPath || null,
+  };
+}
+
+function manifestGuidanceRecord(metadata) {
+  return {
+    guidance_packs: metadata.guidance_packs,
+    task_profile_summary: metadata.task_profile_summary,
+    artifact_path: GUIDANCE_METADATA_FILENAME,
+    source: metadata.source,
+    updated_at: metadata.captured_at,
+  };
+}
+
+function persistGuidanceMetadata({ runDir, manifest, metadata }) {
+  if (!metadata) return manifest;
+  const artifactPath = path.join(runDir, GUIDANCE_METADATA_FILENAME);
+  writeTextFileWithoutFollowingSymlinks(
+    artifactPath,
+    `${JSON.stringify(metadata, null, 2)}\n`
+  );
+  return {
+    ...manifest,
+    advisory: {
+      ...(manifest.advisory || {}),
+      guidance: manifestGuidanceRecord(metadata),
+    },
+  };
+}
+
+module.exports = {
+  buildGuidanceMetadata,
+  DISPATCH_PROMPT_FILENAME,
+  extractGuidanceFromPrompt,
+  GUIDANCE_METADATA_FILENAME,
+  persistGuidanceMetadata,
+};

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -23,6 +23,7 @@ const EVENTS = Object.freeze({
   ESCALATION_DECISION: "escalation_decision",
   EXECUTION_EVIDENCE_REBRANDED: "execution_evidence_rebranded",
   FORCE_FINALIZE: "force_finalize",
+  GUIDANCE_SELECTED: "guidance_selected",
   ITERATION_SCORE: "iteration_score",
   MERGE_BLOCKED: "merge_blocked",
   MERGE_FINALIZE: "merge_finalize",
@@ -164,6 +165,18 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
     ...(eventData.decision !== undefined
       ? { decision: normalizeEventValue(eventData.decision) }
+      : {}),
+    ...(eventData.guidance_packs !== undefined
+      ? { guidance_packs: normalizeEventValue(eventData.guidance_packs) }
+      : {}),
+    ...(eventData.task_profile_summary !== undefined
+      ? { task_profile_summary: normalizeEventValue(eventData.task_profile_summary) }
+      : {}),
+    ...(eventData.guidance_source !== undefined
+      ? { guidance_source: normalizeEventValue(eventData.guidance_source) }
+      : {}),
+    ...(eventData.guidance_artifact_path !== undefined
+      ? { guidance_artifact_path: normalizeEventValue(eventData.guidance_artifact_path) }
       : {}),
   };
 

--- a/skills/relay-dispatch/scripts/relay-manifest.js
+++ b/skills/relay-dispatch/scripts/relay-manifest.js
@@ -8,6 +8,7 @@ const rubric = require("./manifest/rubric");
 const cleanup = require("./manifest/cleanup");
 const attempts = require("./manifest/attempts");
 const environment = require("./manifest/environment");
+const guidance = require("./manifest/guidance");
 
 module.exports = {
   ...paths,
@@ -17,4 +18,5 @@ module.exports = {
   ...cleanup,
   ...attempts,
   ...environment,
+  ...guidance,
 };

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -639,6 +639,51 @@ function readExecutionEvidence(runDir) {
   return JSON.parse(fs.readFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"));
 }
 
+function guidancePrompt({ task = "guidance test task" } = {}) {
+  return [
+    "# Dispatch: Guidance persistence",
+    "",
+    task,
+    "",
+    "## Task Profile",
+    "",
+    "This is advisory planner metadata for executor working style. It is not a reviewer verdict field, manifest role binding, or merge gate.",
+    "",
+    "```yaml",
+    "task_profile:",
+    "  size: M",
+    "  change_type: feature",
+    "  domains:",
+    "    - relay-dispatch",
+    "    - tests",
+    "  risk_tags:",
+    "    - trust-boundary",
+    "    - prompt-contract",
+    "  execution_mode: fresh-context",
+    "  guidance_packs:",
+    "    - surgical-change",
+    "    - verification-evidence",
+    "    - trust-boundary",
+    "  derivation_inputs:",
+    "    - github_issue_398",
+    "    - issue_394_reference_doc",
+    "```",
+    "",
+    "## Working Guidance",
+    "",
+    "These instructions guide execution style. They do not override Done Criteria, rubric commands, or scope boundaries.",
+    "",
+    "### surgical-change",
+    "- Keep the diff narrow.",
+    "",
+    "### verification-evidence",
+    "- Record changed artifacts and checks.",
+    "",
+    "### trust-boundary",
+    "- Name the trust root and protected decision.",
+  ].join("\n");
+}
+
 function setupDryRunFixtureRepo() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-dry-run-"));
   const repoRoot = path.join(root, "repo");
@@ -1938,6 +1983,101 @@ test("dispatch artifacts are persisted in the run directory", () => {
   assert.ok(fs.existsSync(path.join(result.runDir, "dispatch-result.txt")));
   const resultText = fs.readFileSync(path.join(result.runDir, "dispatch-result.txt"), "utf-8");
   assert.match(resultText, /ok/);
+});
+
+test("dispatch persists selected guidance metadata in run artifacts and events", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-398-guidance",
+    "--prompt", guidancePrompt(),
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  const manifest = readManifest(result.manifestPath).data;
+  assert.deepEqual(manifest.advisory.guidance.guidance_packs, [
+    "surgical-change",
+    "verification-evidence",
+    "trust-boundary",
+  ]);
+  assert.deepEqual(manifest.advisory.guidance.task_profile_summary, {
+    size: "M",
+    change_type: "feature",
+    domains: ["relay-dispatch", "tests"],
+    risk_tags: ["trust-boundary", "prompt-contract"],
+    execution_mode: "fresh-context",
+    derivation_inputs: ["github_issue_398", "issue_394_reference_doc"],
+  });
+  assert.equal(manifest.advisory.guidance.artifact_path, "guidance-metadata.json");
+  assert.equal(manifest.roles.executor, "codex");
+  assert.equal(manifest.review.latest_verdict, "pending");
+
+  const artifact = JSON.parse(fs.readFileSync(path.join(result.runDir, "guidance-metadata.json"), "utf-8"));
+  assert.equal(artifact.dispatch_prompt_path, "dispatch-prompt.md");
+  assert.equal(artifact.rubric_path, "rubric.yaml");
+  assert.deepEqual(artifact.guidance_packs, manifest.advisory.guidance.guidance_packs);
+  assert.deepEqual(artifact.task_profile_summary, manifest.advisory.guidance.task_profile_summary);
+
+  const events = readJsonLines(getEventsPath(repoRoot, result.runId));
+  const guidanceEvent = events.find((event) => event.event === "guidance_selected");
+  assert.ok(guidanceEvent, "guidance_selected event should be appended");
+  assert.equal(typeof guidanceEvent.ts, "string");
+  assert.equal(guidanceEvent.run_id, result.runId);
+  assert.deepEqual(guidanceEvent.guidance_packs, artifact.guidance_packs);
+  assert.deepEqual(guidanceEvent.task_profile_summary, artifact.task_profile_summary);
+});
+
+test("dispatch resume preserves guidance metadata without injecting stale Working Guidance blocks", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-398-guidance-resume",
+    "--prompt", guidancePrompt({ task: "initial guided dispatch" }),
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", first.runId,
+    "--prompt", "fix review feedback without a new task profile",
+    "--json",
+  ], env));
+
+  assert.equal(second.mode, "resume");
+  const manifest = readManifest(first.manifestPath).data;
+  assert.deepEqual(manifest.advisory.guidance.guidance_packs, [
+    "surgical-change",
+    "verification-evidence",
+    "trust-boundary",
+  ]);
+
+  const artifact = JSON.parse(fs.readFileSync(path.join(second.runDir, "guidance-metadata.json"), "utf-8"));
+  assert.equal(artifact.source, "manifest-preserved");
+  assert.deepEqual(artifact.guidance_packs, manifest.advisory.guidance.guidance_packs);
+
+  const dispatchPrompt = fs.readFileSync(path.join(second.runDir, "dispatch-prompt.md"), "utf-8");
+  assert.match(dispatchPrompt, /fix review feedback without a new task profile/);
+  assert.doesNotMatch(dispatchPrompt, /## Working Guidance/);
+
+  const guidanceEvents = readJsonLines(getEventsPath(repoRoot, first.runId))
+    .filter((event) => event.event === "guidance_selected");
+  assert.equal(guidanceEvents.length, 2);
+  assert.deepEqual(guidanceEvents[1].guidance_packs, guidanceEvents[0].guidance_packs);
+  assert.equal(guidanceEvents[1].guidance_source, "manifest-preserved");
 });
 
 test("dispatch with --executor claude supports resume", () => {

--- a/tests/relay-dispatch/scripts/relay-events-enum.test.js
+++ b/tests/relay-dispatch/scripts/relay-events-enum.test.js
@@ -160,6 +160,7 @@ test("EVENTS is a frozen object map for current run journal event names", () => 
   assert.equal(Object.values(EVENTS).includes("manual_state_override"), false);
   assert.equal(Object.values(EVENTS).includes("request_persisted"), false);
   assert.equal(Object.values(EVENTS).includes("register"), false);
+  assert.equal(EVENTS.GUIDANCE_SELECTED, "guidance_selected");
 });
 
 test("EVENTS values match the event names emitted by producer call sites under skills", () => {

--- a/tests/relay-dispatch/scripts/relay-events.test.js
+++ b/tests/relay-dispatch/scripts/relay-events.test.js
@@ -228,6 +228,37 @@ const RUN_EVENT_FIELD_CASES = [
     },
     expected: { commit_sha: "deadbeef", branch: "issue-281" },
   },
+  {
+    label: "guidance metadata",
+    fields: {
+      event: EVENTS.GUIDANCE_SELECTED,
+      state_from: "draft",
+      state_to: "draft",
+      reason: "new_dispatch",
+      guidance_packs: ["surgical-change", "verification-evidence"],
+      task_profile_summary: {
+        size: "M",
+        change_type: "feature",
+        domains: ["relay-dispatch"],
+        risk_tags: ["trust-boundary"],
+        execution_mode: "fresh-context",
+      },
+      guidance_source: "prompt",
+      guidance_artifact_path: "guidance-metadata.json",
+    },
+    expected: {
+      guidance_packs: ["surgical-change", "verification-evidence"],
+      task_profile_summary: {
+        size: "M",
+        change_type: "feature",
+        domains: ["relay-dispatch"],
+        risk_tags: ["trust-boundary"],
+        execution_mode: "fresh-context",
+      },
+      guidance_source: "prompt",
+      guidance_artifact_path: "guidance-metadata.json",
+    },
+  },
 ];
 
 test("appendRunEvent round-trips optional fields when provided", () => {
@@ -237,8 +268,8 @@ test("appendRunEvent round-trips optional fields when provided", () => {
 
     const [parsed] = readRunEvents(repoRoot, runId);
     for (const [key, value] of Object.entries(row.expected)) {
-      assert.equal(record[key], value, `${row.label} record ${key}`);
-      assert.equal(parsed[key], value, `${row.label} parsed ${key}`);
+      assert.deepEqual(record[key], value, `${row.label} record ${key}`);
+      assert.deepEqual(parsed[key], value, `${row.label} parsed ${key}`);
     }
   }
 });


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 `issue-398` 브랜치에 커밋했습니다.

변경 내용:
- `guidance-metadata.json` run artifact 추가: `guidance_packs`, `task_profile_summary`, `dispatch_prompt_path`, `rubric_path` 기록
- manifest에는 `advisory.guidance`로만 저장해서 역할 바인딩/상태/review verdict schema와 분리
- `guidance_selected` append-only event 추가: `ts`, `run_id`, pack names, task profile summary 기록
- re-dispatch에서 기존 guidance metadata는 보존하되, 새 prompt에 오래된 `## Working Guidance` 블록을 주입하지 않음

커밋:
- `22f4ab6 test: cover guidance persistence dispatch artifacts`
```

## Score Log

- Run: issue-398-20260502073638320-42327190
- Executor: codex
- Branch: issue-398