### PR TITLE
Reject unknown flags in 7 destructive relay CLIs (#407)

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -29,7 +29,7 @@ const {
   readManifest,
   writeManifest,
 } = require("./manifest/store");
-const { modeLabel, readArg, schemaHasFlag } = require("./cli-args");
+const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { safeFormatRunId } = require("./relay-resolver");
 
@@ -112,6 +112,11 @@ if (hasCliFlag(["--help", "-h"])) {
 }
 
 function run() {
+  const unknownFlags = findUnknownFlags(args, "cleanup-worktrees");
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+
   const repoRoot = path.resolve(readArg(args, "--repo", ".", CLI_ARG_OPTIONS));
   const dryRun = hasCliFlag("--dry-run");
   const all = hasCliFlag("--all");

--- a/skills/relay-dispatch/scripts/close-run.js
+++ b/skills/relay-dispatch/scripts/close-run.js
@@ -9,7 +9,7 @@ const {
   validateManifestPaths,
 } = require("./manifest/paths");
 const { writeManifest } = require("./manifest/store");
-const { modeLabel, readArg, schemaHasFlag } = require("./cli-args");
+const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 
@@ -50,6 +50,11 @@ function buildSkippedCleanupSummary(data, dryRun) {
 }
 
 function main() {
+  const unknownFlags = findUnknownFlags(args, "close-run");
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+
   const repoRoot = path.resolve(readArg(args, "--repo", undefined, CLI_ARG_OPTIONS) || ".");
   const runId = readArg(args, "--run-id", undefined, CLI_ARG_OPTIONS);
   const reason = readArg(args, "--reason", undefined, CLI_ARG_OPTIONS);

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -97,7 +97,7 @@ const {
   rejectLegacyGrandfatherField,
   validateRubricPathContainment,
 } = require("./manifest/rubric");
-const { getPositionals, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
+const { findUnknownFlags, getPositionals, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { formatAttemptsForPrompt, readPreviousAttempts } = require("./manifest/attempts");
 const {
   buildGuidanceMetadata,
@@ -156,6 +156,12 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --dry-run          ${modeLabel("--dry-run")} Show plan without executing`);
   console.log(`  --json             ${modeLabel("--json")} Output as JSON`);
   process.exit(hasCliFlag(["--help", "-h"]) ? 0 : 1);
+}
+
+const UNKNOWN_FLAGS = findUnknownFlags(args, "dispatch");
+if (UNKNOWN_FLAGS.length) {
+  console.error(`Error: unknown flags: ${UNKNOWN_FLAGS.join(", ")}`);
+  process.exit(1);
 }
 
 // Positional arg: first arg that isn't a flag and isn't consumed as a flag's value.

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -25,7 +25,7 @@ const {
 } = require("./manifest/paths");
 const { writeManifest } = require("./manifest/store");
 const { readTextFileWithoutFollowingSymlinks } = require("./manifest/rubric");
-const { modeLabel, readArg, schemaHasFlag } = require("./cli-args");
+const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const CLI_ARG_OPTIONS = { commandName: "recover-state", reservedFlags: ["-h"] };
@@ -264,6 +264,11 @@ function main() {
   if (!args.length || hasCliFlag("--help") || hasCliFlag("-h")) {
     printUsage(console.log);
     process.exit(hasCliFlag("--help") || hasCliFlag("-h") ? 0 : 1);
+  }
+
+  const unknownFlags = findUnknownFlags(args, "recover-state");
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
   }
 
   const repoRoot = path.resolve(readArg(args, "--repo", undefined, CLI_ARG_OPTIONS) || ".");

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -52,6 +52,7 @@ const { runCleanup } = require("../../relay-dispatch/scripts/manifest/cleanup");
 const { execGit, execGh } = require("../../relay-dispatch/scripts/exec");
 const {
   bindCliArgs,
+  findUnknownFlags,
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 const {
@@ -223,6 +224,11 @@ function deleteRemoteBranch(repoPath, branch) {
 }
 
 function main() {
+  const unknownFlags = findUnknownFlags(args, "finalize-run");
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+
   const repoArg = cliArgs.getArg("--repo");
   let repoPath = path.resolve(repoArg || ".");
   const manifestArg = cliArgs.getArg("--manifest");

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -45,6 +45,7 @@ const { appendRunEvent } = require("../../relay-dispatch/scripts/relay-events");
 const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-resolver");
 const { stampPrNumberUnderLock } = require("../../relay-dispatch/scripts/manifest/pr-number-stamp");
 const {
+  findUnknownFlags,
   getPositionals,
   modeLabel,
   readArg,
@@ -72,6 +73,12 @@ if (!args.length || hasCliFlag("--help") || hasCliFlag("-h")) {
   console.log(`  --dry-run         ${modeLabel("--dry-run")} Read comment JSON from stdin instead of gh CLI`);
   console.log(`  --json            ${modeLabel("--json")} Output as JSON`);
   process.exit(hasCliFlag("--help") || hasCliFlag("-h") ? 0 : 1);
+}
+
+const UNKNOWN_FLAGS = findUnknownFlags(args, "gate-check");
+if (UNKNOWN_FLAGS.length) {
+  console.error(`Error: unknown flags: ${UNKNOWN_FLAGS.join(", ")}`);
+  process.exit(1);
 }
 
 const PR_NUM = getPositionals(args, "gate-check")[0];

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -41,6 +41,7 @@ const { loadReviewText, resolveReviewerName, resolveReviewerScript } = require("
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const {
   bindCliArgs,
+  findUnknownFlags,
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 
@@ -97,6 +98,11 @@ function printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, origin
 }
 
 function run() {
+  const unknownFlags = findUnknownFlags(args, "review-runner");
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+
   const repoArg = cliArgs.getArg("--repo");
   const repoPath = path.resolve(repoArg || ".");
   const manifestPathArg = cliArgs.getArg("--manifest");

--- a/tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
+++ b/tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
@@ -1,0 +1,45 @@
+// Regression: every destructive relay CLI must reject unknown flags via
+// findUnknownFlags. Without this, silently-accepted typos like
+// `finalize-run.js --no-merge` (real flag: --skip-merge) can drive
+// unauthorized side effects — see #407 and the 2026-05-02 PR #392 incident.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const REPO_ROOT = path.join(__dirname, "..", "..", "..");
+
+const CLI_TARGETS = [
+  // [skill, script-relative-path, args-that-include-an-unknown-flag, unknown-flag-token]
+  ["relay-merge", "skills/relay-merge/scripts/finalize-run.js",
+    ["--run-id", "fake", "--no-merge"], "--no-merge"],
+  ["relay-merge", "skills/relay-merge/scripts/gate-check.js",
+    ["123", "--no-merge"], "--no-merge"],
+  ["relay-dispatch", "skills/relay-dispatch/scripts/dispatch.js",
+    [".", "--branch", "fake", "--prompt", "x", "--no-merge"], "--no-merge"],
+  ["relay-dispatch", "skills/relay-dispatch/scripts/close-run.js",
+    ["--repo", ".", "--run-id", "fake", "--reason", "test", "--no-merge"], "--no-merge"],
+  ["relay-dispatch", "skills/relay-dispatch/scripts/cleanup-worktrees.js",
+    ["--repo", ".", "--no-merge"], "--no-merge"],
+  ["relay-dispatch", "skills/relay-dispatch/scripts/recover-state.js",
+    ["--repo", ".", "--run-id", "fake", "--to", "review_pending",
+     "--reason", "test", "--no-merge"], "--no-merge"],
+  ["relay-review", "skills/relay-review/scripts/review-runner.js",
+    ["--repo", ".", "--run-id", "fake", "--no-merge"], "--no-merge"],
+];
+
+for (const [skill, scriptRel, args, unknownFlag] of CLI_TARGETS) {
+  test(`${skill}: ${path.basename(scriptRel)} rejects unknown flag ${unknownFlag}`, () => {
+    const scriptPath = path.join(REPO_ROOT, scriptRel);
+    const result = spawnSync(process.execPath, [scriptPath, ...args], {
+      encoding: "utf-8",
+    });
+    const combined = `${result.stdout}\n${result.stderr}`;
+    assert.notStrictEqual(result.status, 0,
+      `expected non-zero exit; got ${result.status}\n${combined}`);
+    assert.ok(/unknown flag/i.test(combined),
+      `expected stderr to mention "unknown flag"; got:\n${combined}`);
+    assert.ok(combined.includes(unknownFlag),
+      `expected stderr to name the flag ${unknownFlag}; got:\n${combined}`);
+  });
+}


### PR DESCRIPTION
## Summary
- Wire `findUnknownFlags` into the 7 destructive relay CLIs that were silently accepting typos (closes #407)
- Add a regression test that spawns each CLI with `--no-merge` and asserts non-zero exit + flag name in stderr
- Backstops the 2026-05-02 PR #392 incident where `finalize-run.js --no-merge` (real flag: `--skip-merge`) plus `--force-finalize-nonready` produced an unauthorized merge

## Wired CLIs
| CLI | Placement |
|---|---|
| `skills/relay-merge/scripts/finalize-run.js` | top of `main()`, throws under existing try/catch |
| `skills/relay-merge/scripts/gate-check.js` | module-level after help block (no try/catch wrapper) |
| `skills/relay-dispatch/scripts/dispatch.js` | module-level after help block (top-level reads) |
| `skills/relay-dispatch/scripts/close-run.js` | top of `main()` |
| `skills/relay-dispatch/scripts/cleanup-worktrees.js` | top of `run()` |
| `skills/relay-dispatch/scripts/recover-state.js` | inside `main()` after help check |
| `skills/relay-review/scripts/review-runner.js` | top of `run()` |

All 7 use `findUnknownFlags(args, "<command-name>")` keyed off the `cli-schema.js` `COMMAND_FLAGS` source of truth, so adding a new flag automatically gets schema coverage.

## Note on the 8th target
The issue body listed `skills/relay-merge/scripts/review-gate.js` as the 8th CLI, but it exports library functions only — no `process.argv` / `require.main` / `main()` entry point. Nothing to wire there. Calling this out so the issue can be closed cleanly.

## Test plan
- [x] `node --test tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js` — 7/7 pass
- [x] `node --test tests/relay-{intake,plan,dispatch,review,merge}/scripts/*.test.js` — 1014/1014 pass
- [x] Smoke: `node skills/relay-merge/scripts/finalize-run.js --run-id fake --no-merge 2>&1 | grep -q 'unknown flag'` exits 0
- [x] `--help` still works on all 7 CLIs (verified manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * relay CLI 스크립트의 미알려진 플래그 검증 기능을 추가했습니다. 사용자가 잘못된 플래그를 입력하면 명확한 오류 메시지로 즉시 실패합니다.

* **테스트**
  * CLI 플래그 검증 동작의 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->