### PR TITLE
feat: report guidance pack reliability insights

### DIFF
--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -11,6 +11,7 @@ const { extractAllFactors } = require("../../relay-plan/scripts/tdd-flavor");
 const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "reliability-report", reservedFlags: ["-h"] };
 const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
+const NO_GUIDANCE_DATA_TEXT = "no guidance data available";
 
 if (hasCliFlag(["--help", "-h"])) {
   console.log(
@@ -62,6 +63,18 @@ function normalizeActorName(value) {
 
 function normalizeRoleName(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+function normalizeGuidancePacks(value) {
+  if (!Array.isArray(value)) return [];
+  const result = [];
+  for (const entry of value) {
+    const pack = typeof entry === "string" ? entry.trim() : "";
+    if (pack && !result.includes(pack)) {
+      result.push(pack);
+    }
+  }
+  return result;
 }
 
 function hasRecordedReviewActivity(data) {
@@ -394,6 +407,159 @@ function buildFactorAnalysis(events) {
   };
 }
 
+function factorAnalysisToStuckFactors(factorAnalysis) {
+  return Object.entries(factorAnalysis?.factors || {})
+    .map(([factor, summary]) => ({
+      factor,
+      appearances: summary.appearances,
+      met_rate: summary.met_rate,
+      avg_rounds_to_met: summary.avg_rounds_to_met,
+    }))
+    .sort((left, right) => (
+      (left.met_rate ?? Number.POSITIVE_INFINITY) - (right.met_rate ?? Number.POSITIVE_INFINITY)
+      || right.appearances - left.appearances
+      || left.factor.localeCompare(right.factor)
+    ));
+}
+
+function buildGuidanceRunIndex(manifests, events) {
+  const packsByRun = new Map();
+
+  function addRunPacks(runId, guidancePacks) {
+    if (!runId) return;
+    const packs = normalizeGuidancePacks(guidancePacks);
+    if (packs.length === 0) return;
+    if (!packsByRun.has(runId)) {
+      packsByRun.set(runId, new Set());
+    }
+    const runPacks = packsByRun.get(runId);
+    for (const pack of packs) {
+      runPacks.add(pack);
+    }
+  }
+
+  for (const manifest of manifests) {
+    addRunPacks(
+      manifest?.data?.run_id,
+      manifest?.data?.advisory?.guidance?.guidance_packs
+    );
+  }
+
+  for (const event of events) {
+    if (event?.event === EVENTS.GUIDANCE_SELECTED) {
+      addRunPacks(event.run_id, event.guidance_packs);
+    }
+  }
+
+  return packsByRun;
+}
+
+function hasChangesRequestedOutcome(manifest, events) {
+  if (events.some((event) => (
+    event.event === EVENTS.REVIEW_APPLY
+    && (
+      event.state_to === STATES.CHANGES_REQUESTED
+      || event.reason === "changes_requested"
+    )
+  ))) {
+    return true;
+  }
+
+  const data = manifest?.data;
+  return (
+    data?.state === STATES.CHANGES_REQUESTED
+    || data?.review?.latest_verdict === "changes_requested"
+  );
+}
+
+function buildPackDivergenceSummary(events) {
+  const divergenceEvents = events.filter((event) => (
+    event.event === EVENTS.SCORE_DIVERGENCE
+    && Array.isArray(event.divergences)
+  ));
+  const deltas = [];
+
+  for (const event of divergenceEvents) {
+    for (const entry of event.divergences) {
+      const delta = Number(entry?.delta);
+      if (Number.isFinite(delta)) {
+        deltas.push(delta);
+      }
+    }
+  }
+
+  return {
+    occurrences: deltas.length,
+    avg_delta: average(deltas),
+    hotspots: buildDivergenceHotspots(divergenceEvents) || [],
+  };
+}
+
+function buildGuidancePackInsights(manifests, events) {
+  const packsByRun = buildGuidanceRunIndex(manifests, events);
+  if (packsByRun.size === 0) {
+    return {
+      status: NO_GUIDANCE_DATA_TEXT,
+      packs: {},
+    };
+  }
+
+  const manifestsByRun = new Map(
+    manifests
+      .filter((manifest) => manifest?.data?.run_id)
+      .map((manifest) => [manifest.data.run_id, manifest])
+  );
+  const eventsByRun = new Map();
+  for (const event of events) {
+    if (!event?.run_id) continue;
+    if (!eventsByRun.has(event.run_id)) {
+      eventsByRun.set(event.run_id, []);
+    }
+    eventsByRun.get(event.run_id).push(event);
+  }
+
+  const runIdsByPack = new Map();
+  for (const [runId, packs] of packsByRun.entries()) {
+    for (const pack of packs) {
+      if (!runIdsByPack.has(pack)) {
+        runIdsByPack.set(pack, new Set());
+      }
+      runIdsByPack.get(pack).add(runId);
+    }
+  }
+
+  const packSummaries = {};
+  for (const pack of [...runIdsByPack.keys()].sort((left, right) => left.localeCompare(right))) {
+    const runIds = runIdsByPack.get(pack);
+    const packManifests = [...runIds]
+      .map((runId) => manifestsByRun.get(runId))
+      .filter(Boolean);
+    const packEvents = events.filter((event) => runIds.has(event.run_id));
+    const reviewRounds = packManifests
+      .map((manifest) => Number(manifest.data?.review?.rounds))
+      .filter((value) => Number.isFinite(value) && value >= 0);
+    const changesRequestedRuns = [...runIds].filter((runId) => (
+      hasChangesRequestedOutcome(
+        manifestsByRun.get(runId),
+        eventsByRun.get(runId) || []
+      )
+    ));
+
+    packSummaries[pack] = {
+      usage_count: runIds.size,
+      avg_review_rounds: average(reviewRounds),
+      changes_requested_rate: ratio(changesRequestedRuns.length, runIds.size),
+      stuck_factors: factorAnalysisToStuckFactors(buildFactorAnalysis(packEvents)),
+      executor_reviewer_divergence: buildPackDivergenceSummary(packEvents),
+    };
+  }
+
+  return {
+    status: "available",
+    packs: packSummaries,
+  };
+}
+
 function resolveManifestRubricPath(manifest) {
   const rubricPath = manifest?.data?.anchor?.rubric_path;
   const runId = manifest?.data?.run_id;
@@ -616,6 +782,7 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
     factor_analysis: buildFactorAnalysis(events),
     rubric_insights: buildRubricInsights(events, manifests),
     qualitative_signals: buildQualitativeSignals(manifests, events),
+    guidance_pack_insights: buildGuidancePackInsights(manifests, events),
   };
 }
 
@@ -797,6 +964,21 @@ function main() {
     console.log(`  rubric_grades: ${gradeText}`);
     console.log(`  avg_quality_ratio: ${report.rubric_insights.avg_quality_ratio ?? "n/a"}`);
     console.log(`  top_divergence_hotspot: ${topHotspot ? `${topHotspot.factor_pattern} (${topHotspot.avg_delta})` : "n/a"}`);
+  }
+  if (report.guidance_pack_insights?.status === NO_GUIDANCE_DATA_TEXT) {
+    console.log(`  guidance_pack_insights: ${NO_GUIDANCE_DATA_TEXT}`);
+  } else {
+    console.log("  guidance_pack_insights:");
+    for (const [pack, summary] of Object.entries(report.guidance_pack_insights?.packs || {})) {
+      const topStuckFactor = summary.stuck_factors?.[0]?.factor || "n/a";
+      console.log(
+        `    ${pack}: usage_count=${summary.usage_count} ` +
+        `avg_review_rounds=${summary.avg_review_rounds ?? "n/a"} ` +
+        `changes_requested_rate=${summary.changes_requested_rate ?? "n/a"} ` +
+        `top_stuck_factor=${topStuckFactor} ` +
+        `divergence_avg_delta=${summary.executor_reviewer_divergence?.avg_delta ?? "n/a"}`
+      );
+    }
   }
   if (hasCliFlag("--by-actor")) {
     const actorEntries = Object.entries(report.by_actor || {});

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -152,6 +152,28 @@ function appendScore(repoRoot, runId, round, factor, met = true) {
   });
 }
 
+function setManifestGuidance(repoRoot, runId, guidancePacks) {
+  const { manifestPath } = ensureRunLayout(repoRoot, runId);
+  const manifest = readManifest(manifestPath).data;
+  manifest.advisory = {
+    ...(manifest.advisory || {}),
+    guidance: {
+      guidance_packs: guidancePacks,
+      task_profile_summary: {
+        size: "M",
+        change_type: "feature",
+        domains: ["relay-dispatch"],
+        risk_tags: [],
+        execution_mode: "standard",
+      },
+      artifact_path: "guidance-metadata.json",
+      source: "prompt",
+      updated_at: new Date().toISOString(),
+    },
+  };
+  writeManifest(manifestPath, manifest);
+}
+
 test("reliability-report derives the core scorecard from manifests and events", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
@@ -423,6 +445,268 @@ test("reliability-report keeps factor analysis backwards compatible without iter
     factors: {},
     most_stuck_factor: null,
   });
+});
+
+test("reliability-report derives guidance pack insights from guidance events and manifest metadata", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-guidance-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runEventPass = createRunId({ branch: "run-guidance-event-pass", timestamp: new Date("2026-04-12T02:05:00.000Z") });
+  const runEventChanges = createRunId({ branch: "run-guidance-event-changes", timestamp: new Date("2026-04-12T02:05:01.000Z") });
+  const runEventMixed = createRunId({ branch: "run-guidance-event-mixed", timestamp: new Date("2026-04-12T02:05:02.000Z") });
+  const runManifestOnly = createRunId({ branch: "run-guidance-manifest-only", timestamp: new Date("2026-04-12T02:05:03.000Z") });
+  const runLegacy = createRunId({ branch: "run-guidance-legacy", timestamp: new Date("2026-04-12T02:05:04.000Z") });
+
+  writeRun(repoRoot, {
+    runId: runEventPass,
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: runEventChanges,
+    state: STATES.CHANGES_REQUESTED,
+    rounds: 3,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: runEventMixed,
+    state: STATES.READY_TO_MERGE,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: runManifestOnly,
+    state: STATES.READY_TO_MERGE,
+    rounds: 5,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: runLegacy,
+    state: STATES.READY_TO_MERGE,
+    rounds: 4,
+    updatedAt: recentTs,
+  });
+  setManifestGuidance(repoRoot, runManifestOnly, ["surgical-change"]);
+
+  appendRunEvent(repoRoot, runEventPass, {
+    event: "guidance_selected",
+    state_from: STATES.DRAFT,
+    state_to: STATES.DISPATCHED,
+    guidance_packs: ["surgical-change", "verification-evidence"],
+    guidance_source: "prompt",
+  });
+  appendRunEvent(repoRoot, runEventChanges, {
+    event: "guidance_selected",
+    state_from: STATES.DRAFT,
+    state_to: STATES.DISPATCHED,
+    guidance_packs: ["surgical-change"],
+    guidance_source: "prompt",
+  });
+  appendRunEvent(repoRoot, runEventMixed, {
+    event: "guidance_selected",
+    state_from: STATES.DRAFT,
+    state_to: STATES.DISPATCHED,
+    guidance_packs: ["simplify-pass"],
+    guidance_source: "prompt",
+  });
+
+  appendRunEvent(repoRoot, runEventPass, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.READY_TO_MERGE,
+    round: 1,
+    reviewer: "codex",
+    reason: "pass",
+  });
+  appendRunEvent(repoRoot, runEventChanges, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 3,
+    reviewer: "codex",
+    reason: "changes_requested",
+  });
+  appendRunEvent(repoRoot, runEventMixed, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.CHANGES_REQUESTED,
+    round: 1,
+    reviewer: "codex",
+    reason: "changes_requested",
+  });
+  appendRunEvent(repoRoot, runEventMixed, {
+    event: "review_apply",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.READY_TO_MERGE,
+    round: 2,
+    reviewer: "codex",
+    reason: "pass",
+  });
+
+  appendIterationScore(repoRoot, runEventPass, {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "8", met: true, status: "pass" },
+      { factor: "Docs", target: ">= 8", observed: "8", met: true, status: "pass" },
+    ],
+  });
+  appendIterationScore(repoRoot, runEventChanges, {
+    round: 1,
+    scores: [
+      { factor: "Coverage", target: ">= 8", observed: "5", met: false, status: "fail" },
+      { factor: "Docs", target: ">= 8", observed: "5", met: false, status: "fail" },
+    ],
+  });
+  appendIterationScore(repoRoot, runEventMixed, {
+    round: 2,
+    scores: [
+      { factor: "Refactor", target: ">= 8", observed: "8", met: true, status: "pass" },
+    ],
+  });
+  appendScoreDivergence(repoRoot, runEventPass, {
+    round: 1,
+    divergences: [
+      { factor: "Coverage", executor: "9", reviewer: "7", delta: 2, tier: "contract" },
+    ],
+  });
+  appendScoreDivergence(repoRoot, runEventChanges, {
+    round: 3,
+    divergences: [
+      { factor: "Docs", executor: "5", reviewer: "6", delta: -1, tier: "quality" },
+    ],
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(report.guidance_pack_insights, {
+    status: "available",
+    packs: {
+      "simplify-pass": {
+        usage_count: 1,
+        avg_review_rounds: 2,
+        changes_requested_rate: 1,
+        stuck_factors: [
+          {
+            factor: "Refactor",
+            appearances: 1,
+            met_rate: 1,
+            avg_rounds_to_met: 2,
+          },
+        ],
+        executor_reviewer_divergence: {
+          occurrences: 0,
+          avg_delta: null,
+          hotspots: [],
+        },
+      },
+      "surgical-change": {
+        usage_count: 3,
+        avg_review_rounds: 3,
+        changes_requested_rate: 0.3333,
+        stuck_factors: [
+          {
+            factor: "Coverage",
+            appearances: 2,
+            met_rate: 0.5,
+            avg_rounds_to_met: 1,
+          },
+          {
+            factor: "Docs",
+            appearances: 2,
+            met_rate: 0.5,
+            avg_rounds_to_met: 1,
+          },
+        ],
+        executor_reviewer_divergence: {
+          occurrences: 2,
+          avg_delta: 0.5,
+          hotspots: [
+            {
+              factor_pattern: "Coverage",
+              occurrences: 1,
+              avg_delta: 2,
+              recommendation: "Executor scores trend higher than review; tighten examples or add automation.",
+            },
+            {
+              factor_pattern: "Docs",
+              occurrences: 1,
+              avg_delta: -1,
+              recommendation: "Reviewer scores trend higher than executor; check whether the factor is underspecified.",
+            },
+          ],
+        },
+      },
+      "verification-evidence": {
+        usage_count: 1,
+        avg_review_rounds: 1,
+        changes_requested_rate: 0,
+        stuck_factors: [
+          {
+            factor: "Coverage",
+            appearances: 1,
+            met_rate: 1,
+            avg_rounds_to_met: 1,
+          },
+          {
+            factor: "Docs",
+            appearances: 1,
+            met_rate: 1,
+            avg_rounds_to_met: 1,
+          },
+        ],
+        executor_reviewer_divergence: {
+          occurrences: 1,
+          avg_delta: 2,
+          hotspots: [
+            {
+              factor_pattern: "Coverage",
+              occurrences: 1,
+              avg_delta: 2,
+              recommendation: "Executor scores trend higher than review; tighten examples or add automation.",
+            },
+          ],
+        },
+      },
+    },
+  });
+});
+
+test("reliability-report renders no guidance data available for empty and legacy runs", () => {
+  const emptyRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-guidance-empty-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(emptyRepoRoot);
+
+  const emptyJson = JSON.parse(execFileSync("node", [SCRIPT, "--repo", emptyRepoRoot, "--json"], { encoding: "utf-8" }));
+  const emptyText = execFileSync("node", [SCRIPT, "--repo", emptyRepoRoot], { encoding: "utf-8" });
+
+  assert.deepEqual(emptyJson.guidance_pack_insights, {
+    status: "no guidance data available",
+    packs: {},
+  });
+  assert.match(emptyText, /guidance_pack_insights: no guidance data available/);
+
+  const legacyRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-guidance-legacy-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runLegacy = createRunId({ branch: "run-guidance-legacy-only", timestamp: new Date("2026-04-12T02:06:00.000Z") });
+
+  writeRun(legacyRepoRoot, {
+    runId: runLegacy,
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  const legacyJson = JSON.parse(execFileSync("node", [SCRIPT, "--repo", legacyRepoRoot, "--json"], { encoding: "utf-8" }));
+  const legacyText = execFileSync("node", [SCRIPT, "--repo", legacyRepoRoot], { encoding: "utf-8" });
+
+  assert.deepEqual(legacyJson.guidance_pack_insights, {
+    status: "no guidance data available",
+    packs: {},
+  });
+  assert.match(legacyText, /guidance_pack_insights: no guidance data available/);
 });
 
 test("reliability-report keeps qualitative_signals null below the minimum readable-rubric threshold", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 `issue-399` 브랜치에 커밋했습니다.

Changed artifacts:
- [reliability-report.js](/Users/sjlee/.relay/worktrees/4da0123d/dev-relay/skills/relay-dispatch/scripts/reliability-report.js)
- [reliability-report.test.js](/Users/sjlee/.relay/worktrees/4da0123d/dev-relay/tests/relay-dispatch/scripts/reliability-report.test.js)

Commits:
- `db8935e test: cover guidance pack reliability insights`
- `8c38091 feat: report guidance pack reliability insights`

Evidence:
- Baseline before changes: `node --test te
```

## Score Log

- Run: issue-399-20260502075702855-19860d9e
- Executor: codex
- Branch: issue-399