### PR TITLE
Refuse to dispatch when an in-flight run owns the issue (#408)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -16,6 +16,7 @@ const VALUE = "value";
 
 const FLAGS = [
   { flag: "--all", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--allow-conflicting-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Operator override for the in-flight-run check; logs a conflicting_run_override event." },
   { flag: "--allow-same-head", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit same-HEAD recovery opt-in; no value is consumed." },
   { flag: "--auto-recover-commit", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit dispatch opt-in to run recover-commit after completed-uncommitted; no value is consumed." },
   { flag: "--artifact-path", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path being reconciled; keep the literal argv token." },
@@ -115,7 +116,8 @@ const COMMAND_FLAGS = {
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
     "--model", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
     "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
-    "--done-criteria-file", "--register", "--no-cleanup", "--auto-recover-commit", "--dry-run", "--json", "--help",
+    "--done-criteria-file", "--register", "--no-cleanup", "--auto-recover-commit",
+    "--allow-conflicting-run", "--dry-run", "--json", "--help",
   ],
   "finalize-run": [
     "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method",

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -92,6 +92,11 @@ const {
   validateManifestPaths,
 } = require("./manifest/paths");
 const {
+  findInflightRunsForIssue,
+  formatInflightCollisionError,
+  inferIssueFromPromptOrBranch,
+} = require("./manifest/inflight-runs");
+const {
   getRubricAnchorStatus,
   hasRubricPath,
   rejectLegacyGrandfatherField,
@@ -120,7 +125,7 @@ const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
   "--model", "-m", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
   "--request-id", "--leaf-id", "--done-criteria-file",
-  "--register", "--no-cleanup", "--auto-recover-commit", "--dry-run", "--json", "--help", "-h",
+  "--register", "--no-cleanup", "--auto-recover-commit", "--allow-conflicting-run", "--dry-run", "--json", "--help", "-h",
 ];
 const CLI_ARG_OPTIONS = { commandName: "dispatch", reservedFlags: KNOWN_FLAGS };
 const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
@@ -153,6 +158,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --register         ${modeLabel("--register")} Register session in executor's app (keeps worktree)`);
   console.log(`  --no-cleanup       ${modeLabel("--no-cleanup")} Compatibility alias; worktree is retained by default`);
   console.log(`  --auto-recover-commit  ${modeLabel("--auto-recover-commit")} Opt-in: run recover-commit after completed-uncommitted (default: off)`);
+  console.log(`  --allow-conflicting-run  ${modeLabel("--allow-conflicting-run")} Bypass the in-flight run check (logs conflicting_run_override event)`);
   console.log(`  --dry-run          ${modeLabel("--dry-run")} Show plan without executing`);
   console.log(`  --json             ${modeLabel("--json")} Output as JSON`);
   process.exit(hasCliFlag(["--help", "-h"]) ? 0 : 1);
@@ -238,6 +244,7 @@ try {
 const REGISTER = hasCliFlag("--register");
 const NO_CLEANUP = hasCliFlag("--no-cleanup");
 const AUTO_RECOVER_COMMIT = hasCliFlag("--auto-recover-commit");
+const ALLOW_CONFLICTING_RUN = hasCliFlag("--allow-conflicting-run");
 const DRY_RUN = hasCliFlag("--dry-run");
 const JSON_OUT = hasCliFlag("--json");
 const RESUME_MODE = !!MANIFEST_INPUT || (!!RUN_ID && !BRANCH);
@@ -716,6 +723,15 @@ async function main() {
       });
     }
   } else {
+    const issueForCollisionCheck = issueNumber
+      || inferIssueFromPromptOrBranch(branch, PROMPT);
+    const inflightRuns = issueForCollisionCheck
+      ? findInflightRunsForIssue(repoRoot, issueForCollisionCheck)
+      : [];
+    if (inflightRuns.length > 0 && !ALLOW_CONFLICTING_RUN) {
+      console.error("Error: " + formatInflightCollisionError(inflightRuns, { issueNumber: issueForCollisionCheck }));
+      process.exit(1);
+    }
     runId = runId || createRunId({ issueNumber, branch });
     manifestPath = getManifestPath(repoRoot, runId);
     const runDir = getRunDir(repoRoot, runId);
@@ -726,6 +742,14 @@ async function main() {
     if (fs.existsSync(wtPath)) {
       console.error(`Error: worktree path already exists: ${wtPath}`);
       process.exit(1);
+    }
+    if (inflightRuns.length > 0 && ALLOW_CONFLICTING_RUN) {
+      appendRunEvent(repoRoot, runId, {
+        event: EVENTS.CONFLICTING_RUN_OVERRIDE,
+        state_from: STATES.DRAFT,
+        state_to: STATES.DRAFT,
+        reason: `bypassed ${inflightRuns.length} non-terminal run(s) for issue-${issueForCollisionCheck}: ${inflightRuns.map((run) => run.runId).join(", ")}`,
+      });
     }
   }
 

--- a/skills/relay-dispatch/scripts/manifest/inflight-runs.js
+++ b/skills/relay-dispatch/scripts/manifest/inflight-runs.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { getRunDir, listManifestPaths } = require("./paths");
+const { readManifest } = require("./store");
+const { isTerminalState } = require("./lifecycle");
+
+const ISSUE_PATTERN = /\bissue-(\d+)\b/;
+
+function inferIssueFromPromptOrBranch(branch, prompt) {
+  for (const source of [branch, prompt]) {
+    if (!source) continue;
+    const match = String(source).match(ISSUE_PATTERN);
+    if (match) return Number(match[1]);
+  }
+  return null;
+}
+
+function readLastEventTimestamp(repoRoot, runId) {
+  try {
+    const eventsPath = path.join(getRunDir(repoRoot, runId), "events.jsonl");
+    if (!fs.existsSync(eventsPath)) return null;
+    const content = fs.readFileSync(eventsPath, "utf-8").trim();
+    if (!content) return null;
+    const lines = content.split("\n");
+    const parsed = JSON.parse(lines[lines.length - 1]);
+    return parsed.ts || null;
+  } catch {
+    return null;
+  }
+}
+
+function findInflightRunsForIssue(repoRoot, issueNumber) {
+  if (!issueNumber || !Number.isInteger(Number(issueNumber))) return [];
+  const prefix = `issue-${issueNumber}-`;
+  const inflight = [];
+  for (const manifestPath of listManifestPaths(repoRoot)) {
+    if (!path.basename(manifestPath).startsWith(prefix)) continue;
+    let data;
+    try {
+      ({ data } = readManifest(manifestPath));
+    } catch {
+      continue;
+    }
+    if (!data || isTerminalState(data.state)) continue;
+    const runId = data.run_id || path.basename(manifestPath, ".md");
+    inflight.push({
+      runId,
+      state: data.state,
+      manifestPath,
+      worktreePath: data.paths?.worktree || null,
+      lastEventAt: readLastEventTimestamp(repoRoot, runId),
+    });
+  }
+  return inflight;
+}
+
+function formatInflightCollisionError(inflightRuns, { issueNumber } = {}) {
+  const header = issueNumber
+    ? `Refusing to dispatch: ${inflightRuns.length} non-terminal run(s) already own issue-${issueNumber}.`
+    : `Refusing to dispatch: ${inflightRuns.length} non-terminal run(s) already own this issue.`;
+  const lines = [
+    header,
+    "Pass --allow-conflicting-run to override (e.g., orchestrator-initiated cleanup).",
+    "",
+  ];
+  for (const run of inflightRuns) {
+    lines.push(`  run_id:     ${run.runId}`);
+    lines.push(`  state:      ${run.state}`);
+    lines.push(`  worktree:   ${run.worktreePath || "(unset)"}`);
+    lines.push(`  last_event: ${run.lastEventAt || "(none)"}`);
+    lines.push(`  manifest:   ${run.manifestPath}`);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+module.exports = {
+  findInflightRunsForIssue,
+  formatInflightCollisionError,
+  inferIssueFromPromptOrBranch,
+};

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -17,6 +17,7 @@ const {
 const EVENTS = Object.freeze({
   CLEANUP_RESULT: "cleanup_result",
   CLOSE: "close",
+  CONFLICTING_RUN_OVERRIDE: "conflicting_run_override",
   DISPATCH_RESULT: "dispatch_result",
   DISPATCH_START: "dispatch_start",
   ENVIRONMENT_DRIFT: "environment_drift",

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1886,9 +1886,11 @@ crypto.randomBytes = function randomBytes(size) {
   });
 
   assert.notEqual(second.status, 0);
-  assert.match(second.stderr, /Refusing to overwrite existing run dir:/);
+  // #408 in-flight check fires before the runDir-collision check when the branch carries
+  // an issue-N pattern; the runDir guard remains as a defense for non-issue branches.
+  assert.match(second.stderr, /Refusing to dispatch: 1 non-terminal run\(s\) already own issue-158/);
   assert.match(second.stderr, new RegExp(first.runId));
-  assert.match(second.stderr, /Pass --run-id <id> to resume, or --manifest <path> to resume from an explicit manifest\./);
+  assert.match(second.stderr, /--allow-conflicting-run/);
 });
 
 test("dispatch cleans up tmp rubric files when atomic rubric persistence fails", () => {

--- a/tests/relay-dispatch/scripts/inflight-runs.test.js
+++ b/tests/relay-dispatch/scripts/inflight-runs.test.js
@@ -1,0 +1,163 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  STATES,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { appendRunEvent, EVENTS } = require("../../../skills/relay-dispatch/scripts/relay-events");
+const {
+  findInflightRunsForIssue,
+  formatInflightCollisionError,
+  inferIssueFromPromptOrBranch,
+} = require("../../../skills/relay-dispatch/scripts/manifest/inflight-runs");
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-inflight-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Inflight Test"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "inflight@example.com"], { cwd: repoRoot, stdio: "pipe" });
+  return repoRoot;
+}
+
+function newRunRelayHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+}
+
+function writeRunWithState({
+  repoRoot,
+  issueNumber,
+  state,
+  timestamp = new Date(),
+  worktreePath = "/tmp/fake-worktree",
+}) {
+  const runId = createRunId({ issueNumber, branch: `issue-${issueNumber}`, timestamp });
+  const layout = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: `issue-${issueNumber}`,
+    baseBranch: "main",
+    issueNumber,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  if (state && state !== STATES.DRAFT) {
+    manifest = { ...manifest, state, next_action: "test_fixture" };
+  }
+  writeManifest(layout.manifestPath, manifest);
+  return { runId, manifestPath: layout.manifestPath };
+}
+
+test("inferIssueFromPromptOrBranch: matches issue-N in branch", () => {
+  assert.equal(inferIssueFromPromptOrBranch("issue-408", null), 408);
+  assert.equal(inferIssueFromPromptOrBranch("feature/issue-99", null), 99);
+});
+
+test("inferIssueFromPromptOrBranch: falls back to prompt when branch lacks issue", () => {
+  assert.equal(inferIssueFromPromptOrBranch("feature-x", "implement issue-42 fixes"), 42);
+});
+
+test("inferIssueFromPromptOrBranch: returns null when neither matches", () => {
+  assert.equal(inferIssueFromPromptOrBranch("feature-x", "some prompt"), null);
+  assert.equal(inferIssueFromPromptOrBranch(null, null), null);
+  assert.equal(inferIssueFromPromptOrBranch("", ""), null);
+});
+
+test("findInflightRunsForIssue: returns empty when no manifests exist", () => {
+  process.env.RELAY_HOME = newRunRelayHome();
+  const repoRoot = setupRepo();
+  assert.deepEqual(findInflightRunsForIssue(repoRoot, 408), []);
+});
+
+test("findInflightRunsForIssue: returns non-terminal runs for the matching issue", () => {
+  process.env.RELAY_HOME = newRunRelayHome();
+  const repoRoot = setupRepo();
+  const { runId } = writeRunWithState({ repoRoot, issueNumber: 408, state: STATES.DISPATCHED });
+  const result = findInflightRunsForIssue(repoRoot, 408);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].runId, runId);
+  assert.equal(result[0].state, STATES.DISPATCHED);
+  assert.equal(result[0].worktreePath, "/tmp/fake-worktree");
+});
+
+test("findInflightRunsForIssue: skips terminal runs (merged/closed)", () => {
+  process.env.RELAY_HOME = newRunRelayHome();
+  const repoRoot = setupRepo();
+  writeRunWithState({ repoRoot, issueNumber: 408, state: STATES.MERGED });
+  writeRunWithState({ repoRoot, issueNumber: 408, state: STATES.CLOSED });
+  assert.deepEqual(findInflightRunsForIssue(repoRoot, 408), []);
+});
+
+test("findInflightRunsForIssue: only matches the specific issue prefix", () => {
+  process.env.RELAY_HOME = newRunRelayHome();
+  const repoRoot = setupRepo();
+  writeRunWithState({ repoRoot, issueNumber: 408, state: STATES.DISPATCHED });
+  writeRunWithState({ repoRoot, issueNumber: 4080, state: STATES.DISPATCHED });
+  writeRunWithState({ repoRoot, issueNumber: 99, state: STATES.DISPATCHED });
+  const result = findInflightRunsForIssue(repoRoot, 408);
+  assert.equal(result.length, 1);
+  assert.ok(result[0].runId.startsWith("issue-408-"));
+});
+
+test("findInflightRunsForIssue: populates lastEventAt from events.jsonl tail", () => {
+  process.env.RELAY_HOME = newRunRelayHome();
+  const repoRoot = setupRepo();
+  const { runId } = writeRunWithState({ repoRoot, issueNumber: 408, state: STATES.DISPATCHED });
+  appendRunEvent(repoRoot, runId, {
+    event: EVENTS.DISPATCH_START,
+    state_from: STATES.DRAFT,
+    state_to: STATES.DISPATCHED,
+    ts: "2026-05-02T13:00:00.000Z",
+  });
+  const result = findInflightRunsForIssue(repoRoot, 408);
+  assert.equal(result[0].lastEventAt, "2026-05-02T13:00:00.000Z");
+});
+
+test("findInflightRunsForIssue: returns empty for falsy/non-numeric issueNumber", () => {
+  process.env.RELAY_HOME = newRunRelayHome();
+  const repoRoot = setupRepo();
+  writeRunWithState({ repoRoot, issueNumber: 408, state: STATES.DISPATCHED });
+  assert.deepEqual(findInflightRunsForIssue(repoRoot, null), []);
+  assert.deepEqual(findInflightRunsForIssue(repoRoot, "bad"), []);
+  assert.deepEqual(findInflightRunsForIssue(repoRoot, 0), []);
+});
+
+test("formatInflightCollisionError: includes runId, state, worktree, manifest in output", () => {
+  const inflightRuns = [{
+    runId: "issue-408-20260502130000000-deadbeef",
+    state: "dispatched",
+    manifestPath: "/relay/runs/slug/issue-408-20260502130000000-deadbeef.md",
+    worktreePath: "/tmp/wt/foo",
+    lastEventAt: "2026-05-02T13:00:00.000Z",
+  }];
+  const message = formatInflightCollisionError(inflightRuns, { issueNumber: 408 });
+  assert.match(message, /issue-408/);
+  assert.match(message, /issue-408-20260502130000000-deadbeef/);
+  assert.match(message, /dispatched/);
+  assert.match(message, /\/tmp\/wt\/foo/);
+  assert.match(message, /\/relay\/runs\/slug\/issue-408-/);
+  assert.match(message, /--allow-conflicting-run/);
+});
+
+test("formatInflightCollisionError: handles missing optional fields", () => {
+  const inflightRuns = [{
+    runId: "issue-99-x",
+    state: "dispatched",
+    manifestPath: "/m",
+    worktreePath: null,
+    lastEventAt: null,
+  }];
+  const message = formatInflightCollisionError(inflightRuns, { issueNumber: 99 });
+  assert.match(message, /worktree:\s+\(unset\)/);
+  assert.match(message, /last_event:\s+\(none\)/);
+});


### PR DESCRIPTION
## Summary
- New helper `manifest/inflight-runs.js` scans for non-terminal manifests by issue number
- `dispatch.js` setup phase refuses fresh dispatches when an in-flight run already owns `issue-<N>` (closes #408)
- Opt-in `--allow-conflicting-run` bypasses the check and emits a new `conflicting_run_override` audit event
- Backstops the silent-collision pattern recorded in `feedback_dispatch_inflight_run_check` (#315 dogfood, 2026-04-28)

## Mechanism
| Layer | Behavior |
|---|---|
| **Helper** (`manifest/inflight-runs.js`) | `findInflightRunsForIssue(repoRoot, N)` returns `{runId, state, worktreePath, lastEventAt, manifestPath}` for non-terminal manifests prefixed `issue-<N>-`. `inferIssueFromPromptOrBranch(branch, prompt)` matches `\bissue-(\d+)\b` in either source. |
| **dispatch.js setup** | Fresh-dispatch branch (line 718+) infers issue from branch first, prompt second. If any in-flight runs found and `--allow-conflicting-run` not set → exit 1 with structured error. If override flag set → emit `CONFLICTING_RUN_OVERRIDE` event after `runId` is created and continue. |
| **EVENTS enum** | `CONFLICTING_RUN_OVERRIDE: "conflicting_run_override"` added in alphabetical position; structural-exhaustiveness test in `relay-events-enum.test.js` already covers the new producer site in `dispatch.js`. |
| **CLI schema** | `--allow-conflicting-run` registered as boolean in `FLAGS` and added to `dispatch` `COMMAND_FLAGS`. |

The runDir-collision check at the same layer remains as a defense for branches that don't carry an issue marker.

## Test plan
- [x] `node --test tests/relay-dispatch/scripts/inflight-runs.test.js` — 11 unit tests pass
- [x] `node --test tests/relay-{intake,plan,dispatch,review,merge}/scripts/*.test.js` — **1045/1045 pass**
- [x] Smoke (block): fixture manifest in `dispatched` state → `dispatch.js -b issue-99999 -p task --dry-run` exits 1 with `Refusing to dispatch:` + run-id named in stderr
- [x] Smoke (override): same fixture + `--allow-conflicting-run` → proceeds past the in-flight check and emits `conflicting_run_override` event to events.jsonl before the downstream `--rubric-file` validation fires
- [x] Existing #158 anti-theater test (`dispatch refuses same-ms same-branch run-dir collisions`) updated to assert on the new (more informative) error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)