### PR TITLE
docs(relay-plan): document atomic-revert factor wording with R1-fix-commit affordance (#410)

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -63,6 +63,8 @@ The script refuses transitions `ALLOWED_TRANSITIONS` already supports — always
 
 Decision tree: if the executor finished implementation but did not commit, use `recover-commit.js`; it handles commit, push, PR publication/stamping, and evidence rebrand atomically. If the orchestrator hand-edited fixes after R1, the evidence is still bound to the dispatch SHA, and review at HEAD substantively PASSed, run `rebrand-evidence.js --run-id <id> --reason "..."`, then `finalize-run.js --run-id <id> --force-finalize-nonready --reason "stale-execution-evidence: orchestrator-correction"`. If the reviewer state machine refuses to re-trigger on the same SHA and no commit is needed, skip evidence repair and use `finalize-run.js --run-id <id> --force-finalize-nonready --reason "..."` directly.
 
+When R2 fails F2 (atomic-revert / commit count) only because the R1 fix added a +1 commit AND F3 substantive PASS AND CI is green, force-finalize-nonready is the right response — see `skills/relay-plan/references/rubric-design-guide.md` § "Atomic-revert factor wording" for the recommended factor wording (which prevents the failure entirely on new rubrics) and the four-bullet provenance template (which cites the case for force-finalize on rubrics that still use the strict wording).
+
 Use `recover-commit.js` when the executor changed files but did not commit, push, or create/stamp a PR. It creates the missing commit/PR handoff and leaves the manifest in `review_pending`.
 
 ### Codex worktree admin-dir sandbox

--- a/skills/relay-plan/references/rubric-design-guide.md
+++ b/skills/relay-plan/references/rubric-design-guide.md
@@ -170,6 +170,48 @@ Evaluated criteria must point to discoverable artifacts. If the executor would n
 | "consistent API style" | "match the response shape in `src/routes/users.ts`: `{ data, meta, errors }`" |
 | "matches component patterns" | "follow `src/components/UserCard.tsx`: props interface, named export, co-located test" |
 
+## Atomic-revert factor wording
+
+When a rubric factor scores commit count or commit-per-item structure (the "atomic-revert" check, often F2), avoid wording that prescribes an EXACT count. The orchestrator-correction flow — where R1 finds a real bug, the orchestrator hand-fixes and pushes a +1 commit, and R2 re-reviews — is a first-class flow (see `skills/relay-dispatch/references/recovery-playbook.md` § "Recovery command boundaries"). Strict "exactly N" wording forces a `--force-finalize-nonready` for every legitimate R1 catch.
+
+Anti-pattern (forces force-finalize on every R1 fix cycle):
+
+```yaml
+- name: Atomic-revert preserved
+  type: evaluated
+  criteria: "Exactly N commits, one per AC item, no fix-up commits."
+  target: ">= 8/10"
+```
+
+Recommended — allow one R1-fix commit explicitly:
+
+```yaml
+- name: Atomic-revert preserved
+  type: evaluated
+  criteria: >
+    >= N commits with one optional R1-fix-commit allowance.
+    Atomic-revert preserved in practice — `git revert <fix-sha> <original-sha>`
+    reverts <item> as a unit. Orchestrator-correction commits per
+    recovery-playbook.md are legitimate and do not violate this factor.
+  target: ">= 8/10"
+  scoring_guide:
+    low: "Single squashed commit; revert removes everything."
+    mid: "N or N+1 (with documented R1 fix) commits; multi-commit revert works."
+    high: "N commits, one per AC item, no fix-up needed; R1 was clean."
+```
+
+The N+1 affordance applies only to commits whose subject describes an R1-feedback fix. New AC scope shipped as fix-up commits is still graded down.
+
+Two dogfood data points (#316 Sub B PR #342 and #316 Sub A PR #343, same session) hit this exact pattern: R1 found a real substantive bug, orchestrator-correction added a +1 commit, R2 flagged F2 fail despite F3 PASS + green CI. Both required `--force-finalize-nonready` to merge. Below rule of three, but the pattern is intrinsic to the orchestrator-correction flow — fold this affordance into new rubrics rather than waiting for a third instance.
+
+### Force-finalize-nonready provenance template
+
+When R2 fails F2 only on commit count after a bug-fix cycle AND F3 (substantive) passes AND CI is green at HEAD, force-finalize is the right response. Cite all four:
+
+> "R2 confirmed F3 [substantive] PASS but flagged F2 [commit count] — R1 fix `<sha>` is a Nth commit. Same orchestrator-correction-becomes-extra-commit pattern as `<prior PR if any>`. CI green at HEAD `<sha>` (test pass <s>s visible in `gh pr checks <pr>`). Atomic-revert preserved in practice — `git revert <fix-sha> <original-sha>` reverts <item> as a unit."
+
+Rebase-fold to merge the fix into the original commit is technically cleaner but requires force-push and a fresh review round; cost rarely beats benefit for procedural-only blockers.
+
 ## What Lives Elsewhere
 
 - Validation checklist, quality card, grades, and risk signals: `rubric-validation.md`


### PR DESCRIPTION
## Summary

- Adds an "Atomic-revert factor wording" section to `skills/relay-plan/references/rubric-design-guide.md` covering the anti-pattern (`exactly N commits`), the recommended wording (`>= N with one R1-fix-commit allowance` + explicit `atomic-revert preserved in practice` phrasing), and the four-bullet force-finalize-nonready provenance template (verbatim from `feedback_orchestrator_fix_commit_count`).
- Cross-links `skills/relay-dispatch/references/recovery-playbook.md` § "Recovery command boundaries" to the new rubric-design subsection in both directions.

## Why

`feedback_orchestrator_fix_commit_count` documents two PRs in #316 (Sub B PR #342 and Sub A PR #343, same session) that hit identical procedural failures: rubric F2 prescribed an exact commit count, R1 found a real bug, orchestrator-correction added a +1 commit, R2 flagged F2 fail despite F3 substantive PASS + green CI. Both required `--force-finalize-nonready`.

This is below rule of three on dogfood data points, but the failure is intrinsic to the orchestrator-correction flow (memory `feedback_orchestrator_correction_evidence_chain`) — every legitimate R1 catch on a rubric with strict commit-count wording will hit it. Folding the affordance into the design guide rather than spinning a new pattern doc — that was the explicit call in the source memory's "How to apply".

## Test plan

- [x] `node --test tests/relay-{intake,plan,dispatch,review,merge}/scripts/*.test.js` → 1045/1045 pass (no test surface added)
- [x] `rubric-design-guide.md` gains a new section with anti-pattern + recommended pattern + scoring_guide example
- [x] Force-finalize-nonready four-bullet provenance template included verbatim from memory
- [x] Cross-link from `recovery-playbook.md` § force-finalize forward to the new rubric-design subsection
- [x] New rubric-design subsection cross-links back to `recovery-playbook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)