### PR TITLE
refactor(dispatch): extract executor adapter contract before opencode introduction (#419)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,5 +122,5 @@ node skills/relay-merge/scripts/finalize-run.js --run-id <id> --force-finalize-n
 - Operator utilities and recovery playbooks live in `skills/<skill>/references/`, not SKILL.md. Sunset deprecated flags within one release.
 - Test files and test fixtures live under `tests/<skill>/`, never under `skills/<skill>/`, so `npx skills add` does not install them.
 - Manifest state transitions must go through `validateTransition()` — direct state assignment is a bug
-- New executors: add entry to `EXECUTOR_CLI` + execution branch in `dispatch.js`; app registration uses `create-worktree.js --register`
+- New executors: drop a file in `skills/relay-dispatch/scripts/executors/` exporting the 6-field adapter contract, register in `executors/index.js`. See `skills/relay-dispatch/scripts/executors/README.md` for the contract and add a row to `tests/relay-dispatch/scripts/executors.test.js`.
 - New reviewers: create `invoke-reviewer-<name>.js` in `relay-review/scripts/`

--- a/README.md
+++ b/README.md
@@ -338,14 +338,13 @@ dev-relay is designed to support new agents. No framework changes needed.
 
 ### Adding a new executor
 
-1. Add an entry to `EXECUTOR_CLI` in `skills/relay-dispatch/scripts/dispatch.js`:
-   ```js
-   const EXECUTOR_CLI = { codex: "codex", claude: "claude", yourAgent: "your-agent-cli" };
-   ```
+1. Add `skills/relay-dispatch/scripts/executors/<name>.js` exporting the adapter contract documented in `skills/relay-dispatch/scripts/executors/README.md`.
 
-2. Add an execution branch in the same file to wire up CLI arguments for the new executor
+2. Register it in `skills/relay-dispatch/scripts/executors/index.js`.
 
-3. Optional: dispatch-time app registration supports both executors. Codex writes a real Codex App thread; Claude writes a relay-side registration receipt under `~/.relay/worktrees/<wt-hash>/claude-registration.json`. `create-worktree.js --register` remains Codex-only.
+3. Add behavior-matrix coverage in `tests/relay-dispatch/scripts/executors.test.js`.
+
+4. Optional: implement adapter `register(...)`. Dispatch-time app registration supports both current executors. Codex writes a real Codex App thread; Claude writes a relay-side registration receipt under `~/.relay/worktrees/<wt-hash>/claude-registration.json`. `create-worktree.js --register` remains Codex-only.
 
 ### Adding a new reviewer
 

--- a/docs/script-inventory-and-cleanup.md
+++ b/docs/script-inventory-and-cleanup.md
@@ -31,8 +31,8 @@ an operator CLI, adapter entry point, or archived measurement tool.
 | `scripts/update-manifest-state.js` | Decision needed | Public CLI in `cli-schema.js`, tests, and historical docs; not the canonical recovery path. | Either deprecate in favor of `recover-state.js` or document the remaining use case. Do not delete silently. |
 | `scripts/reliability-report.js` | Optional operator tool / planner signal producer | `/relay-plan` reads it before rubric design. | Keep. |
 | `scripts/smoke_dispatch_scenarios.py` | Archived measurement tool | Referenced from scenario-test docs only. | Move out of packaged `skills/` if it is no longer a shipped operator tool. |
-| `scripts/claude-app-register.js` | Shared helper | Imported by `dispatch.js`. | Keep while Claude executor registration parity exists. |
-| `scripts/codex-app-register.js` | Shared helper | Imported by `worktree-runtime.js`. | Keep. |
+| `scripts/claude-app-register.js` | Shared helper | Imported by the Claude executor adapter. | Keep while Claude executor registration parity exists. |
+| `scripts/codex-app-register.js` | Shared helper | Imported by the Codex executor adapter. | Keep. |
 | `scripts/worktree-runtime.js` | Shared helper | Imported by `dispatch.js` and `create-worktree.js`. | Keep. |
 | `scripts/worktreeinclude.js` | Shared helper | Imported by `worktree-runtime.js`. | Keep or inline only if the worktree include contract stays trivial. |
 | `scripts/dispatch-publish.js` | Shared helper | Imported by `dispatch.js` and `recover-commit.js`. | Keep. |

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -261,21 +261,10 @@ Do not "simplify" the facade by collapsing submodules back into it or by force-m
 
 ### Adding a new executor
 
-1. **`dispatch.js` line ~181**: Add entry to `EXECUTOR_CLI` map
-   ```js
-   const EXECUTOR_CLI = { codex: "codex", gemini: "gemini-cli" };
-   ```
-
-2. **`dispatch.js` line ~396**: Add execution branch
-   ```js
-   } else if (EXECUTOR === "gemini") {
-     cmd = "gemini-cli";
-     execArgs = ["run", "--dir", wtPath, ...];
-     // ...
-   }
-   ```
-
-3. **Optional**: App registration uses `create-worktree.js --register` (executor-agnostic)
+1. Add `skills/relay-dispatch/scripts/executors/<name>.js` exporting the 6-field adapter contract.
+2. Register it in `skills/relay-dispatch/scripts/executors/index.js`.
+3. Add behavior-matrix coverage in `tests/relay-dispatch/scripts/executors.test.js`.
+4. Optional: implement adapter `register(...)` for dispatch-time app registration.
 
 ### Adding a new reviewer adapter
 

--- a/skills/relay-dispatch/scripts/create-worktree.js
+++ b/skills/relay-dispatch/scripts/create-worktree.js
@@ -35,8 +35,8 @@ const os = require("os");
 const {
   createWorktree,
   formatPlan,
-  registerWorktree,
 } = require("./worktree-runtime");
+const { getExecutor } = require("./executors");
 const { getPositionals, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { execGit } = require("./exec");
 
@@ -93,6 +93,7 @@ const PIN = hasCliFlag("--pin");
 const REGISTER = hasCliFlag("--register") || !!WORKTREE_PATH;
 const DRY_RUN = hasCliFlag("--dry-run");
 const JSON_OUT = hasCliFlag("--json");
+const registerAdapter = getExecutor("codex");
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -219,6 +220,7 @@ function main() {
         title: TITLE,
         copyFiles: COPY_FILES,
         register: REGISTER,
+        registerFn: registerAdapter.register,
         pin: PIN,
         assertWithin,
       });
@@ -231,7 +233,7 @@ function main() {
   // --- Step 3 (optional): Register in Codex state ---
   let threadId = null;
   if (REGISTER && WORKTREE_PATH) {
-    const reg = registerWorktree({ repoRoot: REPO_PATH, worktreePath: wtPath, branch, title: TITLE, pin: PIN });
+    const reg = registerAdapter.register({ wtPath, repoPath: REPO_PATH, branch, title: TITLE, pin: PIN });
     threadId = reg.threadId;
   } else if (REGISTER) {
     threadId = createResult?.threadId || null;

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -505,10 +505,18 @@ function enforceRubricPersistence(manifest, runDir) {
 }
 
 function validateExecutorCli() {
+  let adapter;
   try {
-    getExecutor(EXECUTOR);
+    adapter = getExecutor(EXECUTOR);
   } catch (error) {
     console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+  const cli = adapter.cliBinary || EXECUTOR;
+  try {
+    execFileSync(cli, ["--version"], { encoding: "utf-8", stdio: "pipe" });
+  } catch {
+    console.error(`Error: ${cli} CLI not found.`);
     process.exit(1);
   }
 }

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -60,7 +60,6 @@ const path = require("path");
 const crypto = require("crypto");
 const os = require("os");
 const { pushAndOpenPR } = require("./dispatch-publish");
-const { registerClaudeApp } = require("./claude-app-register");
 const {
   buildExecutionEvidence,
   writeExecutionEvidence,
@@ -68,9 +67,9 @@ const {
 const {
   createWorktree,
   formatDispatchDryRun,
-  registerWorktree,
   removeWorktree,
 } = require("./worktree-runtime");
+const { getExecutor, listExecutors } = require("./executors");
 const {
   collectEnvironmentSnapshot,
   compareEnvironmentSnapshot,
@@ -141,7 +140,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --manifest         ${modeLabel("--manifest")} Resume an existing relay run from its manifest`);
   console.log(`  --prompt, -p       ${modeLabel("--prompt")} Task prompt`);
   console.log(`  --prompt-file      ${modeLabel("--prompt-file")} Read prompt from file`);
-  console.log(`  --executor, -e     ${modeLabel("--executor")} Executor: codex (default), claude`);
+  console.log(`  --executor, -e     ${modeLabel("--executor")} Executor: ${listExecutors().join(", ")} (default: codex)`);
   console.log(`  --model, -m        ${modeLabel("--model")} Model override`);
   console.log(`  --model-hints      ${modeLabel("--model-hints")} Persist per-phase model hints (phase=model,...)`);
   console.log(`  --sandbox          ${modeLabel("--sandbox")} workspace-write | read-only (default: workspace-write)`);
@@ -180,8 +179,14 @@ const MANIFEST_INPUT = readArg(args, "--manifest", undefined, CLI_ARG_OPTIONS);
 const PROMPT = readArg(args, ["--prompt", "-p"], undefined, CLI_ARG_OPTIONS);
 const PROMPT_FILE = readArg(args, "--prompt-file", undefined, CLI_ARG_OPTIONS);
 const EXECUTOR = readArg(args, ["--executor", "-e"], "codex", CLI_ARG_OPTIONS);
-const DEFAULT_TIMEOUT_BY_EXECUTOR = { codex: 2400, claude: 1800 };
-const defaultTimeout = String(DEFAULT_TIMEOUT_BY_EXECUTOR[EXECUTOR] ?? 1800);
+let adapter;
+try {
+  adapter = getExecutor(EXECUTOR);
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}
+const defaultTimeout = String(adapter.defaultTimeout ?? 1800);
 const MODEL = readArg(args, ["--model", "-m"], undefined, CLI_ARG_OPTIONS);
 const MODEL_HINTS_RAW = readArg(args, "--model-hints", undefined, CLI_ARG_OPTIONS);
 const REASONING_OVERRIDE = readArg(args, "--reasoning", undefined, CLI_ARG_OPTIONS);
@@ -203,13 +208,13 @@ if (!["disabled", "enabled"].includes(NETWORK_ACCESS)) {
   console.error("Error: --network-access must be disabled or enabled");
   process.exit(1);
 }
-if (NETWORK_ACCESS === "enabled" && EXECUTOR !== "codex") {
-  console.error("Error: --network-access enabled is only supported for codex executor");
+const modeValidation = adapter.validateExecutionMode({ sandbox: SANDBOX, networkAccess: NETWORK_ACCESS });
+if (!modeValidation.ok) {
+  console.error(`Error: ${modeValidation.error}`);
   process.exit(1);
 }
-if (NETWORK_ACCESS === "enabled" && SANDBOX !== "workspace-write") {
-  console.error("Error: --network-access enabled requires --sandbox workspace-write");
-  process.exit(1);
+for (const warn of (modeValidation.warnings || [])) {
+  console.error(`Warning: ${warn}`);
 }
 
 const executorNetworkPolicy = {
@@ -298,9 +303,6 @@ if (!MANIFEST_INPUT && !fs.existsSync(path.join(REPO_PATH, ".git"))) {
   console.error(`Error: ${msg}`);
   process.exit(1);
 }
-
-// To add a new executor: add entry here + execution branch in Step 3.
-const EXECUTOR_CLI = { codex: "codex", claude: "claude" };
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -503,15 +505,10 @@ function enforceRubricPersistence(manifest, runDir) {
 }
 
 function validateExecutorCli() {
-  const cli = EXECUTOR_CLI[EXECUTOR];
-  if (!cli) {
-    console.error(`Error: unknown executor '${EXECUTOR}'. Supported: ${Object.keys(EXECUTOR_CLI).join(", ")}`);
-    process.exit(1);
-  }
   try {
-    execFileSync(cli, ["--version"], { encoding: "utf-8", stdio: "pipe" });
-  } catch {
-    console.error(`Error: ${cli} CLI not found.`);
+    getExecutor(EXECUTOR);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
     process.exit(1);
   }
 }
@@ -580,33 +577,6 @@ function resolveEffectiveDispatchModel({ cliModel, manifestModelHints, cliModelH
     return cliModelHints.dispatch;
   }
   return null;
-}
-
-function realpathForContainment(targetPath) {
-  return fs.realpathSync.native ? fs.realpathSync.native(targetPath) : fs.realpathSync(targetPath);
-}
-
-function resolveCodexCommonGitDir(worktreePath) {
-  // Widen the codex sandbox to the common git dir (`<main-repo>/.git`), not just
-  // the per-worktree admin dir. Linked-worktree `git add` writes blob objects
-  // under `<common>/objects/`, and `git commit` updates branch refs and reflogs
-  // under `<common>/refs/...` and `<common>/logs/...` — both in the common dir,
-  // not in `<common>/worktrees/<name>/`. The worktree admin dir is a subdir of
-  // the common dir, so passing common-dir alone covers both paths.
-  const adminDirRaw = execGit(worktreePath, ["rev-parse", "--git-dir"]);
-  const commonDirRaw = execGit(worktreePath, ["rev-parse", "--git-common-dir"]);
-  const adminDir = path.resolve(worktreePath, adminDirRaw);
-  const commonDir = path.resolve(worktreePath, commonDirRaw);
-  const worktreesDir = path.join(commonDir, "worktrees");
-
-  const realAdminDir = realpathForContainment(adminDir);
-  const realWorktreesDir = realpathForContainment(worktreesDir);
-  if (!realAdminDir.startsWith(`${realWorktreesDir}${path.sep}`)) {
-    throw new Error(
-      `codex worktree git admin dir is outside ${worktreesDir}: ${adminDir}`
-    );
-  }
-  return commonDir;
 }
 
 function summarizeCommitMode({ status, gitLog, uncommitted }) {
@@ -1022,9 +992,7 @@ async function main() {
   }
 
   // --- Step 3: Execute task ---
-  // Executor-specific: build command + args + handle quirks.
-  // To add a new executor: add a branch here.
-  // execCwd: spawn cwd option — set when the executor has no CLI flag for CWD.
+  // Executor adapter builds command + args + spawn cwd.
 
   let cmd, execArgs;
   let execCwd;
@@ -1046,37 +1014,19 @@ async function main() {
     "Execute the task fully and autonomously.\n\n" +
     taskPrompt;
 
-  if (EXECUTOR === "codex") {
-    cmd = "codex";
-    execArgs = ["exec", "-C", wtPath, "--color", "never", "-o", resultFile];
-    execArgs.push("-c", `model_reasoning_effort=${resolvedReasoningEffort}`);
-    if (NETWORK_ACCESS === "enabled") {
-      execArgs.push("-c", "sandbox_workspace_write.network_access=true");
-    }
-    if (effectiveDispatchModel) execArgs.push("-m", effectiveDispatchModel);
-    execArgs.push("--sandbox", SANDBOX);
-    if (SANDBOX === "workspace-write") {
-      codexGitCommonDir = resolveCodexCommonGitDir(wtPath);
-      execArgs.push("--add-dir", codexGitCommonDir);
-    }
-    execArgs.push(execPrompt);
-  } else if (EXECUTOR === "claude") {
-    cmd = "claude";
-    execCwd = wtPath; // Claude Code has no --cwd flag; use spawn cwd instead
-    execArgs = [
-      "-p",                            // print (non-interactive) mode
-      "--dangerously-skip-permissions", // full autonomy in isolated worktree
-      "--output-format", "text",
-    ];
-    if (effectiveDispatchModel) execArgs.push("--model", effectiveDispatchModel);
-    execArgs.push(execPrompt);
-    if (SANDBOX !== "workspace-write") {
-      console.error(`Warning: --sandbox '${SANDBOX}' is not supported for Claude executor; using --dangerously-skip-permissions`);
-    }
-  } else {
-    console.error(`Error: executor '${EXECUTOR}' has no execution handler`);
-    process.exit(1);
-  }
+  const buildResult = adapter.buildExecCommand({
+    wtPath,
+    resultFile,
+    prompt: execPrompt,
+    model: effectiveDispatchModel,
+    sandbox: SANDBOX,
+    networkAccess: NETWORK_ACCESS,
+    reasoning: resolvedReasoningEffort,
+  });
+  cmd = buildResult.cmd;
+  execArgs = buildResult.args;
+  execCwd = buildResult.cwd;
+  codexGitCommonDir = buildResult.codexGitCommonDir || null;
 
   if (!JSON_OUT) {
     console.log(`Dispatching to ${EXECUTOR}...`);
@@ -1169,11 +1119,7 @@ async function main() {
   }
   const elapsed = Math.round((Date.now() - startTime) / 1000);
 
-  // For Claude executor, stdout IS the result — copy to resultFile so
-  // downstream collection logic works the same as Codex's -o flag.
-  if (EXECUTOR === "claude" && fs.existsSync(stdoutLog)) {
-    try { fs.copyFileSync(stdoutLog, resultFile); } catch {}
-  }
+  adapter.finalizeResult({ stdoutLog, resultFile });
 
   // --- Step 4: Collect results ---
   let resultText = "";
@@ -1369,11 +1315,11 @@ async function main() {
 
   // --- Step 4.5: Optional app registration ---
   let threadId = null;
-  if (REGISTER && status !== "failed" && EXECUTOR === "codex") {
+  if (REGISTER && status !== "failed") {
     try {
-      const reg = registerWorktree({
-        repoRoot,
-        worktreePath: wtPath,
+      const reg = adapter.register({
+        wtPath,
+        repoPath: repoRoot,
         branch,
         title: `Dispatch: ${branch}`,
       });
@@ -1381,19 +1327,6 @@ async function main() {
       if (!JSON_OUT) console.log(`\n  Registered in ${EXECUTOR} app.`);
     } catch (e) {
       if (!JSON_OUT) console.log(`\n  Warning: app registration failed: ${e.message.split("\n")[0]}`);
-    }
-  } else if (REGISTER && status !== "failed" && EXECUTOR === "claude") {
-    try {
-      const reg = registerClaudeApp({
-        wtPath,
-        repoPath: repoRoot,
-        branch,
-        title: `Dispatch: ${branch}`,
-      });
-      threadId = reg.sessionId;
-      if (!JSON_OUT) console.log(`\n  Registered in ${EXECUTOR} app.`);
-    } catch (e) {
-      if (!JSON_OUT) console.log(`\n  Warning: claude registration failed: ${e.message.split("\n")[0]}`);
     }
   }
 

--- a/skills/relay-dispatch/scripts/executors/README.md
+++ b/skills/relay-dispatch/scripts/executors/README.md
@@ -1,0 +1,15 @@
+# Executors
+
+Each file in this directory is an executor adapter. To add a new executor:
+
+1. Drop a file here named `<executor>.js` exporting the 6-field contract:
+   - `defaultTimeout` (number, seconds)
+   - `validateExecutionMode({sandbox, networkAccess})` -> `{ok, error?, warnings?}`
+   - `buildExecCommand({wtPath, resultFile, prompt, model, sandbox, networkAccess, reasoning})` -> `{cmd, args, cwd?, codexGitCommonDir?}`
+   - `finalizeResult({stdoutLog, resultFile})` (optional, default no-op)
+   - `register({wtPath, repoPath, branch, title, pin?})` -> `{threadId, raw}`
+   - `probe({timeout})` -> `{error, raw}`
+2. Register it in `index.js`'s `EXECUTORS` map.
+3. Add tests in `tests/relay-dispatch/scripts/executors.test.js`.
+
+That's it. `dispatch.js` and `probe-executor-env.js` will pick up the new executor automatically via `getExecutor(name)`.

--- a/skills/relay-dispatch/scripts/executors/README.md
+++ b/skills/relay-dispatch/scripts/executors/README.md
@@ -2,7 +2,8 @@
 
 Each file in this directory is an executor adapter. To add a new executor:
 
-1. Drop a file here named `<executor>.js` exporting the 6-field contract:
+1. Drop a file here named `<executor>.js` exporting the 7-field contract:
+   - `cliBinary` (string) — binary name on PATH used for `--version` preflight
    - `defaultTimeout` (number, seconds)
    - `validateExecutionMode({sandbox, networkAccess})` -> `{ok, error?, warnings?}`
    - `buildExecCommand({wtPath, resultFile, prompt, model, sandbox, networkAccess, reasoning})` -> `{cmd, args, cwd?, codexGitCommonDir?}`

--- a/skills/relay-dispatch/scripts/executors/claude.js
+++ b/skills/relay-dispatch/scripts/executors/claude.js
@@ -1,0 +1,69 @@
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const { registerClaudeApp } = require("../claude-app-register");
+
+const PROBE_PROMPT =
+  "List ALL your available tools, MCP servers, and installed skills. " +
+  "Output a JSON array of objects with {name, type, description} fields. " +
+  "type is one of: skill, mcp_tool, built_in.";
+
+function validateExecutionMode({ sandbox, networkAccess }) {
+  if (networkAccess === "enabled") {
+    return { ok: false, error: "--network-access enabled is only supported for codex executor" };
+  }
+  const warnings = [];
+  if (sandbox !== "workspace-write") {
+    warnings.push(`--sandbox '${sandbox}' is not supported for Claude executor; using --dangerously-skip-permissions`);
+  }
+  return { ok: true, warnings };
+}
+
+function buildExecCommand({ wtPath, prompt, model }) {
+  const cmd = "claude";
+  const args = ["-p", "--dangerously-skip-permissions", "--output-format", "text"];
+  if (model) args.push("--model", model);
+  args.push(prompt);
+  return { cmd, args, cwd: wtPath, codexGitCommonDir: null };
+}
+
+function finalizeResult({ stdoutLog, resultFile }) {
+  // claude writes its result to stdout; copy to resultFile so downstream collection works.
+  if (fs.existsSync(stdoutLog)) {
+    try { fs.copyFileSync(stdoutLog, resultFile); } catch {}
+  }
+}
+
+function register({ wtPath, repoPath, branch, title }) {
+  const reg = registerClaudeApp({ wtPath, repoPath, branch, title });
+  return { threadId: reg.sessionId || null, raw: reg };
+}
+
+function probe({ timeout }) {
+  const cmd = "claude";
+  const cmdArgs = ["-p", "--output-format", "text", PROBE_PROMPT];
+  try {
+    execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" });
+  } catch {
+    return { error: `${cmd} CLI not found`, raw: null };
+  }
+  const result = spawnSync(cmd, cmdArgs, {
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: timeout * 1000,
+  });
+  if (result.error) {
+    const msg = result.error.code === "ETIMEDOUT" ? `probe timed out after ${timeout}s` : result.error.message;
+    return { error: msg, raw: null };
+  }
+  if (result.status !== 0) return { error: `executor exited with code ${result.status}`, raw: null };
+  return { error: null, raw: (result.stdout || "").trim() || null };
+}
+
+module.exports = {
+  defaultTimeout: 1800,
+  validateExecutionMode,
+  buildExecCommand,
+  finalizeResult,
+  register,
+  probe,
+};

--- a/skills/relay-dispatch/scripts/executors/claude.js
+++ b/skills/relay-dispatch/scripts/executors/claude.js
@@ -60,6 +60,7 @@ function probe({ timeout }) {
 }
 
 module.exports = {
+  cliBinary: "claude",
   defaultTimeout: 1800,
   validateExecutionMode,
   buildExecCommand,

--- a/skills/relay-dispatch/scripts/executors/codex.js
+++ b/skills/relay-dispatch/scripts/executors/codex.js
@@ -1,0 +1,95 @@
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { execGit } = require("../exec");
+const { registerCodexApp } = require("../codex-app-register");
+
+const PROBE_PROMPT =
+  "List ALL your available tools, MCP servers, and installed skills. " +
+  "Output a JSON array of objects with {name, type, description} fields. " +
+  "type is one of: skill, mcp_tool, built_in.";
+
+function realpathForContainment(targetPath) {
+  try {
+    return fs.realpathSync(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+function resolveCodexCommonGitDir(worktreePath) {
+  const real = realpathForContainment(worktreePath);
+  try {
+    const out = execGit(real, ["rev-parse", "--git-common-dir"]);
+    const trimmed = out.trim();
+    if (path.isAbsolute(trimmed)) return trimmed;
+    return path.resolve(real, trimmed);
+  } catch {
+    return path.resolve(real, ".git");
+  }
+}
+
+function validateExecutionMode({ sandbox, networkAccess }) {
+  const warnings = [];
+  if (networkAccess === "enabled" && sandbox !== "workspace-write") {
+    return { ok: false, error: "--network-access enabled requires --sandbox workspace-write" };
+  }
+  return { ok: true, warnings };
+}
+
+function buildExecCommand({ wtPath, resultFile, prompt, model, sandbox, networkAccess, reasoning }) {
+  const cmd = "codex";
+  const args = ["exec", "-C", wtPath, "--color", "never", "-o", resultFile];
+  args.push("-c", `model_reasoning_effort=${reasoning}`);
+  if (networkAccess === "enabled") {
+    args.push("-c", "sandbox_workspace_write.network_access=true");
+  }
+  if (model) args.push("-m", model);
+  args.push("--sandbox", sandbox);
+  let codexGitCommonDir = null;
+  if (sandbox === "workspace-write") {
+    codexGitCommonDir = resolveCodexCommonGitDir(wtPath);
+    args.push("--add-dir", codexGitCommonDir);
+  }
+  args.push(prompt);
+  return { cmd, args, cwd: undefined, codexGitCommonDir };
+}
+
+function finalizeResult() {
+  // codex writes to resultFile via -o flag; nothing to do
+}
+
+function register({ wtPath, repoPath, branch, title, pin = false }) {
+  const reg = registerCodexApp({ wtPath, repoPath, branch, title, pin });
+  return { threadId: reg.threadId || null, raw: reg };
+}
+
+function probe({ timeout }) {
+  const cmd = "codex";
+  const cmdArgs = ["exec", "--sandbox", "read-only", "--color", "never", PROBE_PROMPT];
+  try {
+    execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" });
+  } catch {
+    return { error: `${cmd} CLI not found`, raw: null };
+  }
+  const result = spawnSync(cmd, cmdArgs, {
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: timeout * 1000,
+  });
+  if (result.error) {
+    const msg = result.error.code === "ETIMEDOUT" ? `probe timed out after ${timeout}s` : result.error.message;
+    return { error: msg, raw: null };
+  }
+  if (result.status !== 0) return { error: `executor exited with code ${result.status}`, raw: null };
+  return { error: null, raw: (result.stdout || "").trim() || null };
+}
+
+module.exports = {
+  defaultTimeout: 2400,
+  validateExecutionMode,
+  buildExecCommand,
+  finalizeResult,
+  register,
+  probe,
+};

--- a/skills/relay-dispatch/scripts/executors/codex.js
+++ b/skills/relay-dispatch/scripts/executors/codex.js
@@ -18,15 +18,20 @@ function realpathForContainment(targetPath) {
 }
 
 function resolveCodexCommonGitDir(worktreePath) {
-  const real = realpathForContainment(worktreePath);
-  try {
-    const out = execGit(real, ["rev-parse", "--git-common-dir"]);
-    const trimmed = out.trim();
-    if (path.isAbsolute(trimmed)) return trimmed;
-    return path.resolve(real, trimmed);
-  } catch {
-    return path.resolve(real, ".git");
+  const adminDirRaw = execGit(worktreePath, ["rev-parse", "--git-dir"]);
+  const commonDirRaw = execGit(worktreePath, ["rev-parse", "--git-common-dir"]);
+  const adminDir = path.resolve(worktreePath, adminDirRaw);
+  const commonDir = path.resolve(worktreePath, commonDirRaw);
+  const worktreesDir = path.join(commonDir, "worktrees");
+
+  const realAdminDir = realpathForContainment(adminDir);
+  const realWorktreesDir = realpathForContainment(worktreesDir);
+  if (!realAdminDir.startsWith(`${realWorktreesDir}${path.sep}`)) {
+    throw new Error(
+      `codex worktree git admin dir is outside ${worktreesDir}: ${adminDir}` // outside worktrees guard
+    );
   }
+  return commonDir;
 }
 
 function validateExecutionMode({ sandbox, networkAccess }) {

--- a/skills/relay-dispatch/scripts/executors/codex.js
+++ b/skills/relay-dispatch/scripts/executors/codex.js
@@ -87,6 +87,7 @@ function probe({ timeout }) {
 }
 
 module.exports = {
+  cliBinary: "codex",
   defaultTimeout: 2400,
   validateExecutionMode,
   buildExecCommand,

--- a/skills/relay-dispatch/scripts/executors/codex.js
+++ b/skills/relay-dispatch/scripts/executors/codex.js
@@ -10,11 +10,7 @@ const PROBE_PROMPT =
   "type is one of: skill, mcp_tool, built_in.";
 
 function realpathForContainment(targetPath) {
-  try {
-    return fs.realpathSync(targetPath);
-  } catch {
-    return path.resolve(targetPath);
-  }
+  return fs.realpathSync.native ? fs.realpathSync.native(targetPath) : fs.realpathSync(targetPath);
 }
 
 function resolveCodexCommonGitDir(worktreePath) {

--- a/skills/relay-dispatch/scripts/executors/index.js
+++ b/skills/relay-dispatch/scripts/executors/index.js
@@ -1,0 +1,17 @@
+const codex = require("./codex");
+const claude = require("./claude");
+
+const EXECUTORS = { codex, claude };
+
+function getExecutor(name) {
+  if (!Object.prototype.hasOwnProperty.call(EXECUTORS, name)) {
+    throw new Error(`unknown executor '${name}'. Supported: ${Object.keys(EXECUTORS).join(", ")}`);
+  }
+  return EXECUTORS[name];
+}
+
+function listExecutors() {
+  return Object.keys(EXECUTORS);
+}
+
+module.exports = { getExecutor, listExecutors };

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -2,7 +2,6 @@ const fs = require("fs");
 const path = require("path");
 
 const { copyWorktreeFiles, getWorktreeIncludeFiles } = require("./worktreeinclude");
-const { registerCodexApp } = require("./codex-app-register");
 const { execGit } = require("./exec");
 
 function formatPlan({ worktreePath, branch, title, register, pin, includeFiles }) {
@@ -81,29 +80,6 @@ function removeWorktree({ repoRoot, worktreePath, dependencies = {} }) {
   } catch {}
 }
 
-function registerWorktree({
-  repoRoot,
-  worktreePath,
-  branch,
-  title,
-  pin = false,
-  logger = null,
-  dependencies = {},
-}) {
-  const registerCodexAppImpl = dependencies.registerCodexAppImpl || registerCodexApp;
-  const registration = registerCodexAppImpl({
-    wtPath: worktreePath,
-    repoPath: repoRoot,
-    branch,
-    title,
-    pin,
-  });
-  if (typeof logger === "function") {
-    logger({ event: "register", worktreePath, branch, title, pin, threadId: registration.threadId || null });
-  }
-  return registration;
-}
-
 function createWorktree({
   repoRoot,
   worktreePath,
@@ -112,6 +88,7 @@ function createWorktree({
   includeFiles,
   copyFiles = [],
   register = false,
+  registerFn = null,
   pin = false,
   dryRun = false,
   logger = null,
@@ -121,7 +98,6 @@ function createWorktree({
   const gitRunner = dependencies.gitRunner || ((repoDir, ...gitArgs) => execGit(repoDir, gitArgs));
   const getWorktreeIncludeFilesImpl = dependencies.getWorktreeIncludeFilesImpl || getWorktreeIncludeFiles;
   const copyWorktreeFilesImpl = dependencies.copyWorktreeFilesImpl || copyWorktreeFiles;
-  const registerWorktreeImpl = dependencies.registerWorktreeImpl || registerWorktree;
   const removeWorktreeImpl = dependencies.removeWorktreeImpl || removeWorktree;
   const resolvedIncludeFiles = includeFiles || getWorktreeIncludeFilesImpl(repoRoot);
   const plan = {
@@ -169,16 +145,18 @@ function createWorktree({
       logger({ event: "copy", worktreePath, copiedFiles });
     }
 
-    if (register) {
-      const registration = registerWorktreeImpl({
-        repoRoot,
-        worktreePath,
+    if (register && registerFn) {
+      const registration = registerFn({
+        wtPath: worktreePath,
+        repoPath: repoRoot,
         branch,
         title,
         pin,
-        logger,
       });
-      threadId = registration.threadId || null;
+      threadId = registration.threadId || registration.sessionId || null;
+      if (typeof logger === "function") {
+        logger({ event: "register", worktreePath, branch, title, pin, threadId });
+      }
     }
   } catch (error) {
     if (createdWorktree) {
@@ -198,6 +176,5 @@ module.exports = {
   createWorktree,
   formatDispatchDryRun,
   formatPlan,
-  registerWorktree,
   removeWorktree,
 };

--- a/skills/relay-plan/scripts/probe-executor-env.js
+++ b/skills/relay-plan/scripts/probe-executor-env.js
@@ -4,7 +4,7 @@
  * Informs rubric design by revealing which evaluated factors can become automated.
  *
  * Usage:
- *   ./probe-executor-env.js <repo-path> --executor <codex|claude> [options]
+ *   ./probe-executor-env.js <repo-path> --executor <name> [options]
  *
  * Options:
  *   --executor, -e <name>  Executor to probe (required)
@@ -13,7 +13,6 @@
  *   --json                 Output as JSON (default: human-readable)
  */
 
-const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const {
@@ -21,6 +20,7 @@ const {
   getPositionals,
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
+const { getExecutor, listExecutors } = require("../../relay-dispatch/scripts/executors");
 
 // ---------------------------------------------------------------------------
 // CLI (only when run directly)
@@ -37,9 +37,9 @@ function parseCli(argv) {
   });
 
   if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
-    console.log("Usage: probe-executor-env.js <repo-path> --executor <codex|claude> [options]");
+    console.log(`Usage: probe-executor-env.js <repo-path> --executor <${listExecutors().join("|")}> [options]`);
     console.log("\nOptions:");
-    console.log(`  --executor, -e   ${modeLabel("--executor")} Executor to probe (codex, claude)`);
+    console.log(`  --executor, -e   ${modeLabel("--executor")} Executor to probe (${listExecutors().join(", ")})`);
     console.log(`  --timeout        ${modeLabel("--timeout")} Probe timeout in seconds (default: 30)`);
     console.log(`  --project-only   ${modeLabel("--project-only")} Skip agent probe, only scan project tools`);
     console.log(`  --json           ${modeLabel("--json")} Output as JSON`);
@@ -184,50 +184,14 @@ function deriveTestInfra(projectTools) {
 // Agent probe
 // ---------------------------------------------------------------------------
 
-const PROBE_PROMPT =
-  "List ALL your available tools, MCP servers, and installed skills. " +
-  "Output a JSON array of objects with {name, type, description} fields. " +
-  "type is one of: skill, mcp_tool, built_in.";
-
 function probeAgent(executor, timeout) {
-  let cmd, cmdArgs;
-
-  if (executor === "codex") {
-    cmd = "codex";
-    cmdArgs = ["exec", "--sandbox", "read-only", "--color", "never", PROBE_PROMPT];
-  } else if (executor === "claude") {
-    cmd = "claude";
-    cmdArgs = ["-p", "--output-format", "text", PROBE_PROMPT];
-  } else {
+  let adapter;
+  try {
+    adapter = getExecutor(executor);
+  } catch {
     return { error: `unknown executor: ${executor}`, raw: null };
   }
-
-  // Check executor is available
-  try {
-    execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" });
-  } catch {
-    return { error: `${cmd} CLI not found`, raw: null };
-  }
-
-  const result = spawnSync(cmd, cmdArgs, {
-    encoding: "utf-8",
-    stdio: "pipe",
-    timeout: timeout * 1000,
-  });
-
-  if (result.error) {
-    const msg = result.error.code === "ETIMEDOUT"
-      ? `probe timed out after ${timeout}s`
-      : result.error.message;
-    return { error: msg, raw: null };
-  }
-
-  if (result.status !== 0) {
-    return { error: `executor exited with code ${result.status}`, raw: null };
-  }
-
-  const stdout = (result.stdout || "").trim();
-  return { error: null, raw: stdout || null };
+  return adapter.probe({ timeout });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -1,0 +1,134 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { getExecutor, listExecutors } = require("../../../skills/relay-dispatch/scripts/executors");
+
+test("registry exposes codex and claude", () => {
+  assert.deepEqual(listExecutors().sort(), ["claude", "codex"]);
+  assert.throws(() => getExecutor("opencode"), /unknown executor/);
+});
+
+test("codex buildExecCommand: workspace-write + network disabled + no model", () => {
+  const codex = getExecutor("codex");
+  const { cmd, args, cwd } = codex.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/result.txt",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  assert.equal(cmd, "codex");
+  assert.equal(cwd, undefined);
+  assert.deepEqual(args.slice(0, 9), ["exec", "-C", "/tmp/wt", "--color", "never", "-o", "/tmp/result.txt", "-c", "model_reasoning_effort=high"]);
+  assert.ok(args.includes("--sandbox"));
+  assert.equal(args[args.indexOf("--sandbox") + 1], "workspace-write");
+  assert.ok(args.includes("--add-dir"));
+  assert.ok(!args.includes("-m"));
+  assert.ok(!args.some((a) => a === "sandbox_workspace_write.network_access=true"));
+  assert.equal(args[args.length - 1], "P");
+});
+
+test("codex buildExecCommand: network enabled adds network flag", () => {
+  const codex = getExecutor("codex");
+  const { args } = codex.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    networkAccess: "enabled",
+    reasoning: "medium",
+  });
+  assert.ok(args.includes("sandbox_workspace_write.network_access=true"));
+});
+
+test("codex buildExecCommand: model is appended via -m", () => {
+  const codex = getExecutor("codex");
+  const { args } = codex.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: "gpt-5",
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  const i = args.indexOf("-m");
+  assert.ok(i >= 0);
+  assert.equal(args[i + 1], "gpt-5");
+});
+
+test("codex buildExecCommand: read-only sandbox omits --add-dir", () => {
+  const codex = getExecutor("codex");
+  const { args } = codex.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: null,
+    sandbox: "read-only",
+    networkAccess: "disabled",
+    reasoning: "low",
+  });
+  assert.equal(args[args.indexOf("--sandbox") + 1], "read-only");
+  assert.ok(!args.includes("--add-dir"));
+});
+
+test("claude buildExecCommand: cwd via spawn opt, not flag", () => {
+  const claude = getExecutor("claude");
+  const { cmd, args, cwd } = claude.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  assert.equal(cmd, "claude");
+  assert.equal(cwd, "/tmp/wt");
+  assert.deepEqual(args, ["-p", "--dangerously-skip-permissions", "--output-format", "text", "P"]);
+  assert.ok(!args.includes("--cwd"));
+});
+
+test("claude buildExecCommand: model is appended via --model", () => {
+  const claude = getExecutor("claude");
+  const { args } = claude.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: "claude-opus-4-7",
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  const i = args.indexOf("--model");
+  assert.ok(i >= 0);
+  assert.equal(args[i + 1], "claude-opus-4-7");
+});
+
+test("validateExecutionMode: codex rejects network without workspace-write", () => {
+  const codex = getExecutor("codex");
+  const result = codex.validateExecutionMode({ sandbox: "read-only", networkAccess: "enabled" });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /workspace-write/);
+});
+
+test("validateExecutionMode: claude rejects networkAccess=enabled", () => {
+  const claude = getExecutor("claude");
+  const result = claude.validateExecutionMode({ sandbox: "workspace-write", networkAccess: "enabled" });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /codex/);
+});
+
+test("validateExecutionMode: claude warns on non-workspace-write sandbox", () => {
+  const claude = getExecutor("claude");
+  const result = claude.validateExecutionMode({ sandbox: "read-only", networkAccess: "disabled" });
+  assert.equal(result.ok, true);
+  assert.ok(result.warnings && result.warnings.length > 0);
+});
+
+test("default timeouts match pre-refactor values", () => {
+  assert.equal(getExecutor("codex").defaultTimeout, 2400);
+  assert.equal(getExecutor("claude").defaultTimeout, 1800);
+});

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -1,16 +1,44 @@
-const { test } = require("node:test");
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+const { execFileSync } = require("node:child_process");
+const { test, before, after } = require("node:test");
 const assert = require("node:assert/strict");
 const { getExecutor, listExecutors } = require("../../../skills/relay-dispatch/scripts/executors");
+
+let TMP_ROOT, REPO, WT, COMMON_DIR;
+
+before(() => {
+  TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "executors-test-"));
+  REPO = path.join(TMP_ROOT, "repo");
+  fs.mkdirSync(REPO);
+  execFileSync("git", ["-C", REPO, "init", "-q", "-b", "main"]);
+  execFileSync("git", ["-C", REPO, "config", "user.email", "t@example.com"]);
+  execFileSync("git", ["-C", REPO, "config", "user.name", "t"]);
+  fs.writeFileSync(path.join(REPO, "README"), "x\n");
+  execFileSync("git", ["-C", REPO, "add", "README"]);
+  execFileSync("git", ["-C", REPO, "commit", "-q", "-m", "init"]);
+  WT = path.join(TMP_ROOT, "wt");
+  execFileSync("git", ["-C", REPO, "worktree", "add", "-q", "-b", "wb", WT]);
+  const commonRaw = execFileSync("git", ["-C", WT, "rev-parse", "--git-common-dir"], {
+    encoding: "utf-8",
+  }).trim();
+  COMMON_DIR = path.resolve(WT, commonRaw);
+});
+
+after(() => {
+  if (TMP_ROOT) fs.rmSync(TMP_ROOT, { recursive: true, force: true });
+});
 
 test("registry exposes codex and claude", () => {
   assert.deepEqual(listExecutors().sort(), ["claude", "codex"]);
   assert.throws(() => getExecutor("opencode"), /unknown executor/);
 });
 
-test("codex buildExecCommand: workspace-write + network disabled + no model", () => {
+test("codex buildExecCommand: workspace-write + network disabled + no model - full argv lock", () => {
   const codex = getExecutor("codex");
-  const { cmd, args, cwd } = codex.buildExecCommand({
-    wtPath: "/tmp/wt",
+  const result = codex.buildExecCommand({
+    wtPath: WT,
     resultFile: "/tmp/result.txt",
     prompt: "P",
     model: null,
@@ -18,21 +46,22 @@ test("codex buildExecCommand: workspace-write + network disabled + no model", ()
     networkAccess: "disabled",
     reasoning: "high",
   });
-  assert.equal(cmd, "codex");
-  assert.equal(cwd, undefined);
-  assert.deepEqual(args.slice(0, 9), ["exec", "-C", "/tmp/wt", "--color", "never", "-o", "/tmp/result.txt", "-c", "model_reasoning_effort=high"]);
-  assert.ok(args.includes("--sandbox"));
-  assert.equal(args[args.indexOf("--sandbox") + 1], "workspace-write");
-  assert.ok(args.includes("--add-dir"));
-  assert.ok(!args.includes("-m"));
-  assert.ok(!args.some((a) => a === "sandbox_workspace_write.network_access=true"));
-  assert.equal(args[args.length - 1], "P");
+  assert.equal(result.cmd, "codex");
+  assert.equal(result.cwd, undefined);
+  assert.deepEqual(result.args, [
+    "exec", "-C", WT, "--color", "never", "-o", "/tmp/result.txt",
+    "-c", "model_reasoning_effort=high",
+    "--sandbox", "workspace-write",
+    "--add-dir", COMMON_DIR,
+    "P",
+  ]);
+  assert.equal(result.codexGitCommonDir, COMMON_DIR);
 });
 
-test("codex buildExecCommand: network enabled adds network flag", () => {
+test("codex buildExecCommand: network enabled inserts the network arg before --sandbox", () => {
   const codex = getExecutor("codex");
   const { args } = codex.buildExecCommand({
-    wtPath: "/tmp/wt",
+    wtPath: WT,
     resultFile: "/tmp/r",
     prompt: "P",
     model: null,
@@ -40,13 +69,20 @@ test("codex buildExecCommand: network enabled adds network flag", () => {
     networkAccess: "enabled",
     reasoning: "medium",
   });
-  assert.ok(args.includes("sandbox_workspace_write.network_access=true"));
+  assert.deepEqual(args, [
+    "exec", "-C", WT, "--color", "never", "-o", "/tmp/r",
+    "-c", "model_reasoning_effort=medium",
+    "-c", "sandbox_workspace_write.network_access=true",
+    "--sandbox", "workspace-write",
+    "--add-dir", COMMON_DIR,
+    "P",
+  ]);
 });
 
-test("codex buildExecCommand: model is appended via -m", () => {
+test("codex buildExecCommand: model adds -m before --sandbox", () => {
   const codex = getExecutor("codex");
   const { args } = codex.buildExecCommand({
-    wtPath: "/tmp/wt",
+    wtPath: WT,
     resultFile: "/tmp/r",
     prompt: "P",
     model: "gpt-5",
@@ -54,15 +90,20 @@ test("codex buildExecCommand: model is appended via -m", () => {
     networkAccess: "disabled",
     reasoning: "high",
   });
-  const i = args.indexOf("-m");
-  assert.ok(i >= 0);
-  assert.equal(args[i + 1], "gpt-5");
+  assert.deepEqual(args, [
+    "exec", "-C", WT, "--color", "never", "-o", "/tmp/r",
+    "-c", "model_reasoning_effort=high",
+    "-m", "gpt-5",
+    "--sandbox", "workspace-write",
+    "--add-dir", COMMON_DIR,
+    "P",
+  ]);
 });
 
-test("codex buildExecCommand: read-only sandbox omits --add-dir", () => {
+test("codex buildExecCommand: read-only sandbox omits --add-dir entirely", () => {
   const codex = getExecutor("codex");
-  const { args } = codex.buildExecCommand({
-    wtPath: "/tmp/wt",
+  const { args, codexGitCommonDir } = codex.buildExecCommand({
+    wtPath: WT,
     resultFile: "/tmp/r",
     prompt: "P",
     model: null,
@@ -70,8 +111,26 @@ test("codex buildExecCommand: read-only sandbox omits --add-dir", () => {
     networkAccess: "disabled",
     reasoning: "low",
   });
-  assert.equal(args[args.indexOf("--sandbox") + 1], "read-only");
-  assert.ok(!args.includes("--add-dir"));
+  assert.deepEqual(args, [
+    "exec", "-C", WT, "--color", "never", "-o", "/tmp/r",
+    "-c", "model_reasoning_effort=low",
+    "--sandbox", "read-only",
+    "P",
+  ]);
+  assert.equal(codexGitCommonDir, null);
+});
+
+test("codex buildExecCommand: workspace-write on non-worktree path throws", () => {
+  const codex = getExecutor("codex");
+  assert.throws(() => codex.buildExecCommand({
+    wtPath: "/tmp",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  }));
 });
 
 test("claude buildExecCommand: cwd via spawn opt, not flag", () => {

--- a/tests/relay-dispatch/scripts/worktree-runtime.test.js
+++ b/tests/relay-dispatch/scripts/worktree-runtime.test.js
@@ -121,7 +121,7 @@ test("createWorktree falls back to an existing branch when -b creation fails", (
   );
 });
 
-test("createWorktree forwards registration args through the shared runtime helper", () => {
+test("createWorktree forwards registration args through an adapter callback", () => {
   const { repoRoot, root } = setupRepo();
   const worktreePath = path.join(root, "worktrees", "register", "repo");
   const calls = [];
@@ -132,24 +132,21 @@ test("createWorktree forwards registration args through the shared runtime helpe
     branch: "issue-187-register",
     title: "Pinned Register",
     register: true,
+    registerFn(options) {
+      calls.push(options);
+      return { threadId: "thread-123" };
+    },
     pin: true,
     copyFiles: [],
-    dependencies: {
-      registerWorktreeImpl(options) {
-        calls.push(options);
-        return { threadId: "thread-123" };
-      },
-    },
   });
 
   assert.equal(result.threadId, "thread-123");
   assert.deepEqual(calls, [{
-    repoRoot,
-    worktreePath,
+    wtPath: worktreePath,
+    repoPath: repoRoot,
     branch: "issue-187-register",
     title: "Pinned Register",
     pin: true,
-    logger: null,
   }]);
 });
 
@@ -164,12 +161,10 @@ test("createWorktree removes the created worktree when a post-create step fails"
       branch: "issue-187-cleanup",
       title: "Cleanup Test",
       register: true,
-      copyFiles: [],
-      dependencies: {
-        registerWorktreeImpl() {
-          throw new Error("simulated register failure");
-        },
+      registerFn() {
+        throw new Error("simulated register failure");
       },
+      copyFiles: [],
     });
   }, /simulated register failure/);
 


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-419-20260503151828213-e7d9e132
- Branch: issue-419
- Reason: codex finished implementation but stopped before committing — standard sandbox/non-interactive pattern
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-419-20260503151828213-e7d9e132.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-03T15:28:36.323Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 실행자(executor) 아키텍처를 어댑터 패턴으로 재구성하여 더 나은 확장성 제공
  * 코드 베이스 전반에서 실행자별 로직을 중앙화된 인터페이스로 통합

* **Documentation**
  * 새로운 실행자 추가 방법 및 실행자 어댑터 계약 명세 문서 업데이트

* **Tests**
  * 실행자 레지스트리 및 동작에 대한 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->