### PR TITLE
Add opencode probe-only executor adapter

### DIFF
--- a/skills/relay-dispatch/scripts/executors/README.md
+++ b/skills/relay-dispatch/scripts/executors/README.md
@@ -14,3 +14,5 @@ Each file in this directory is an executor adapter. To add a new executor:
 3. Add tests in `tests/relay-dispatch/scripts/executors.test.js`.
 
 That's it. `dispatch.js` and `probe-executor-env.js` will pick up the new executor automatically via `getExecutor(name)`.
+
+opencode is registered as a probe-only adapter pending full executor support in #377. Its buildExecCommand/register/validateExecutionMode stubs throw with a `#377` reference.

--- a/skills/relay-dispatch/scripts/executors/index.js
+++ b/skills/relay-dispatch/scripts/executors/index.js
@@ -1,7 +1,8 @@
 const codex = require("./codex");
 const claude = require("./claude");
+const opencode = require("./opencode");
 
-const EXECUTORS = { codex, claude };
+const EXECUTORS = { codex, claude, opencode };
 
 function getExecutor(name) {
   if (!Object.prototype.hasOwnProperty.call(EXECUTORS, name)) {

--- a/skills/relay-dispatch/scripts/executors/opencode.js
+++ b/skills/relay-dispatch/scripts/executors/opencode.js
@@ -39,6 +39,10 @@ function discoverConfigPath() {
   return null;
 }
 
+function helpMentionsCommand(help, name) {
+  return new RegExp(`(^|\\s)${name}(\\s|,|$)`).test(help);
+}
+
 function probe({ timeout }) {
   const cmd = "opencode";
 
@@ -48,6 +52,25 @@ function probe({ timeout }) {
     version = execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim();
   } catch {
     return { error: `${cmd} CLI not found`, raw: null };
+  }
+
+  let cliPath = null;
+  try {
+    const result = spawnSync("/bin/sh", ["-c", "command -v opencode"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+    if (result.status === 0) cliPath = (result.stdout || "").trim() || null;
+  } catch {}
+  if (!cliPath) {
+    for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+      const candidate = path.join(dir, process.platform === "win32" ? "opencode.exe" : "opencode");
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        cliPath = candidate;
+        break;
+      } catch {}
+    }
   }
 
   // 2. Try richer discovery; degrade gracefully if any sub-command is unavailable.
@@ -83,6 +106,38 @@ function probe({ timeout }) {
     if (result.status === 0) authList = (result.stdout || "").trim();
   } catch {}
 
+  const discoveryProbes = [
+    { name: "models", argv: ["models"] },
+    { name: "providers", argv: ["providers"] },
+    { name: "model", argv: ["model"] },
+    { name: "list", argv: ["list"] },
+  ];
+  const discoveryResults = {};
+  for (const { name, argv } of discoveryProbes) {
+    if (help && helpMentionsCommand(help, name)) {
+      try {
+        const result = spawnSync(cmd, argv, {
+          encoding: "utf-8",
+          stdio: "pipe",
+          timeout: Math.min(timeout, 30) * 1000,
+        });
+        if (result.status === 0) {
+          discoveryResults[`${name}_output`] = (result.stdout || "").trim();
+        } else {
+          discoveryResults[`${name}_error`] =
+            `exit ${result.status}: ${(result.stderr || "").trim().slice(0, 200)}`;
+        }
+      } catch (e) {
+        discoveryResults[`${name}_error`] = e.message;
+      }
+    }
+  }
+  if (!help || (!helpMentionsCommand(help, "models") && !helpMentionsCommand(help, "providers"))) {
+    warnings.push(
+      "opencode --help does not expose models/providers discovery; provider state inferred from auth list only",
+    );
+  }
+
   // 3. Run the actual probe prompt against opencode if it has a `run` command. Time-boxed.
   // If this fails or times out, still return the version + auth info we collected.
   let probeOutput = null;
@@ -107,8 +162,10 @@ function probe({ timeout }) {
   // Compose the raw payload as a JSON string so existing consumers reading `raw` still get text.
   const raw = JSON.stringify({
     version,
+    cli_path: cliPath,
     config_path: configPath,
     auth_list: authList,
+    ...discoveryResults,
     probe_output: probeOutput,
     probe_error: probeError,
     warnings,

--- a/skills/relay-dispatch/scripts/executors/opencode.js
+++ b/skills/relay-dispatch/scripts/executors/opencode.js
@@ -1,0 +1,128 @@
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const PROBE_PROMPT =
+  "List ALL your available tools, MCP servers, and installed skills. " +
+  "Output a JSON array of objects with {name, type, description} fields. " +
+  "type is one of: skill, mcp_tool, built_in.";
+
+const NOT_YET = "opencode executor is experimental and not yet wired up; see #377";
+
+function validateExecutionMode(/* { sandbox, networkAccess } */) {
+  return { ok: false, error: NOT_YET };
+}
+
+function buildExecCommand() {
+  throw new Error(NOT_YET);
+}
+
+function finalizeResult(/* { stdoutLog, resultFile } */) {
+  // safe no-op so dispatch.js can call this unconditionally
+}
+
+function register() {
+  throw new Error(NOT_YET);
+}
+
+function discoverConfigPath() {
+  // opencode config locations (best-effort, no hard dependency)
+  const candidates = [
+    path.join(os.homedir(), ".config", "opencode", "auth.json"),
+    path.join(os.homedir(), ".config", "opencode", "config.json"),
+    path.join(os.homedir(), ".opencode", "config.json"),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+function probe({ timeout }) {
+  const cmd = "opencode";
+
+  // 1. Fast availability check via --version
+  let version = null;
+  try {
+    version = execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  } catch {
+    return { error: `${cmd} CLI not found`, raw: null };
+  }
+
+  // 2. Try richer discovery; degrade gracefully if any sub-command is unavailable.
+  const help = (() => {
+    try {
+      return execFileSync(cmd, ["--help"], { encoding: "utf-8", stdio: "pipe" }).trim();
+    } catch {
+      return null;
+    }
+  })();
+
+  // List of commands documented in opencode README. If --help doesn't show one, surface a warning.
+  const expectedFlags = ["run", "auth"];
+  const warnings = [];
+  if (help) {
+    for (const flag of expectedFlags) {
+      if (!help.includes(flag)) {
+        warnings.push(`opencode --help does not mention '${flag}' (docs say it should)`);
+      }
+    }
+  }
+
+  const configPath = discoverConfigPath();
+
+  // Best-effort provider/model listing. opencode auth list is documented.
+  let authList = null;
+  try {
+    const result = spawnSync(cmd, ["auth", "list"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: Math.min(timeout, 30) * 1000,
+    });
+    if (result.status === 0) authList = (result.stdout || "").trim();
+  } catch {}
+
+  // 3. Run the actual probe prompt against opencode if it has a `run` command. Time-boxed.
+  // If this fails or times out, still return the version + auth info we collected.
+  let probeOutput = null;
+  let probeError = null;
+  if (help && help.includes("run")) {
+    const result = spawnSync(cmd, ["run", PROBE_PROMPT], {
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: timeout * 1000,
+    });
+    if (result.error) {
+      probeError = result.error.code === "ETIMEDOUT"
+        ? `probe timed out after ${timeout}s`
+        : result.error.message;
+    } else if (result.status !== 0) {
+      probeError = `executor exited with code ${result.status}`;
+    } else {
+      probeOutput = (result.stdout || "").trim() || null;
+    }
+  }
+
+  // Compose the raw payload as a JSON string so existing consumers reading `raw` still get text.
+  const raw = JSON.stringify({
+    version,
+    config_path: configPath,
+    auth_list: authList,
+    probe_output: probeOutput,
+    probe_error: probeError,
+    warnings,
+  });
+
+  return { error: probeError, raw };
+}
+
+module.exports = {
+  cliBinary: "opencode",
+  defaultTimeout: 1800,
+  validateExecutionMode,
+  buildExecCommand,
+  finalizeResult,
+  register,
+  probe,
+};

--- a/skills/relay-dispatch/scripts/executors/opencode.js
+++ b/skills/relay-dispatch/scripts/executors/opencode.js
@@ -171,7 +171,9 @@ function probe({ timeout }) {
     warnings,
   });
 
-  return { error: probeError, raw };
+  // Match codex/claude probe semantics: any probe-run error returns raw=null so
+  // consumers do not treat failed probe output as discovered tools.
+  return { error: probeError, raw: probeError ? null : raw };
 }
 
 module.exports = {

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -66,15 +66,20 @@ test("opencode finalizeResult is a safe no-op", () => {
   o.finalizeResult({ stdoutLog: "/nonexistent", resultFile: "/nonexistent" });
 });
 
-test("opencode probe returns {error, raw} shape when binary missing", () => {
-  const o = getExecutor("opencode");
-  // We can't reliably assume opencode is installed; assert the shape is consistent regardless.
-  const result = o.probe({ timeout: 5 });
-  assert.ok("error" in result, "probe result must have 'error' key");
-  assert.ok("raw" in result, "probe result must have 'raw' key");
-  // If binary is missing the error message should mention "opencode CLI not found"
-  if (result.raw === null && typeof result.error === "string") {
+test("opencode probe returns {error: 'opencode CLI not found', raw: null} when binary missing", () => {
+  // Isolate PATH to a directory without opencode so this test never depends on the
+  // host machine having (or not having) opencode installed.
+  const emptyBin = path.join(TMP_ROOT, "empty-bin");
+  fs.mkdirSync(emptyBin, { recursive: true });
+  const originalPath = process.env.PATH;
+  process.env.PATH = emptyBin;
+  try {
+    const o = getExecutor("opencode");
+    const result = o.probe({ timeout: 5 });
+    assert.equal(result.raw, null);
     assert.match(result.error, /opencode CLI not found/);
+  } finally {
+    process.env.PATH = originalPath;
   }
 });
 

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -30,9 +30,52 @@ after(() => {
   if (TMP_ROOT) fs.rmSync(TMP_ROOT, { recursive: true, force: true });
 });
 
-test("registry exposes codex and claude", () => {
-  assert.deepEqual(listExecutors().sort(), ["claude", "codex"]);
-  assert.throws(() => getExecutor("opencode"), /unknown executor/);
+test("registry exposes codex, claude, and opencode", () => {
+  assert.deepEqual(listExecutors().sort(), ["claude", "codex", "opencode"]);
+  assert.throws(() => getExecutor("nonexistent"), /unknown executor/);
+});
+
+test("opencode adapter exposes the same 7 fields", () => {
+  const o = getExecutor("opencode");
+  for (const k of ["cliBinary", "defaultTimeout", "validateExecutionMode", "buildExecCommand", "finalizeResult", "register", "probe"]) {
+    assert.ok(typeof o[k] !== "undefined", `missing field: ${k}`);
+  }
+  assert.equal(o.cliBinary, "opencode");
+});
+
+test("opencode buildExecCommand throws with #377 reference (probe-only adapter)", () => {
+  const o = getExecutor("opencode");
+  assert.throws(() => o.buildExecCommand({}), /#377/);
+});
+
+test("opencode register throws with #377 reference", () => {
+  const o = getExecutor("opencode");
+  assert.throws(() => o.register({}), /#377/);
+});
+
+test("opencode validateExecutionMode rejects with #377 reference", () => {
+  const o = getExecutor("opencode");
+  const result = o.validateExecutionMode({ sandbox: "workspace-write", networkAccess: "disabled" });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /#377/);
+});
+
+test("opencode finalizeResult is a safe no-op", () => {
+  const o = getExecutor("opencode");
+  // Should not throw with garbage input
+  o.finalizeResult({ stdoutLog: "/nonexistent", resultFile: "/nonexistent" });
+});
+
+test("opencode probe returns {error, raw} shape when binary missing", () => {
+  const o = getExecutor("opencode");
+  // We can't reliably assume opencode is installed; assert the shape is consistent regardless.
+  const result = o.probe({ timeout: 5 });
+  assert.ok("error" in result, "probe result must have 'error' key");
+  assert.ok("raw" in result, "probe result must have 'raw' key");
+  // If binary is missing the error message should mention "opencode CLI not found"
+  if (result.raw === null && typeof result.error === "string") {
+    assert.match(result.error, /opencode CLI not found/);
+  }
 });
 
 test("codex buildExecCommand: workspace-write + network disabled + no model - full argv lock", () => {

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -78,6 +78,43 @@ test("opencode probe returns {error, raw} shape when binary missing", () => {
   }
 });
 
+test("opencode probe payload exposes cli_path and discovery outputs", () => {
+  const fakeBin = path.join(TMP_ROOT, "fake-bin");
+  const fakeOpencode = path.join(fakeBin, "opencode");
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(fakeOpencode, `#!/bin/sh
+case "$1" in
+  --version) echo "opencode 1.2.3" ;;
+  --help) echo "Usage: opencode run auth models providers" ;;
+  auth)
+    if [ "$2" = "list" ]; then echo "github logged-in"; else exit 2; fi
+    ;;
+  models) echo "gpt-test" ;;
+  providers) echo "openai" ;;
+  run) echo '{"name":"tool","type":"built_in","description":"test"}' ;;
+  *) exit 2 ;;
+esac
+`);
+  fs.chmodSync(fakeOpencode, 0o755);
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${fakeBin}${path.delimiter}${originalPath || ""}`;
+  try {
+    const o = getExecutor("opencode");
+    const result = o.probe({ timeout: 5 });
+    assert.equal(result.error, null);
+    const parsed = JSON.parse(result.raw);
+    assert.equal(parsed.version, "opencode 1.2.3");
+    assert.equal(parsed.cli_path, fakeOpencode);
+    assert.equal(parsed.auth_list, "github logged-in");
+    assert.equal(parsed.models_output, "gpt-test");
+    assert.equal(parsed.providers_output, "openai");
+    assert.ok(Array.isArray(parsed.warnings), "raw payload must include warnings array");
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
 test("codex buildExecCommand: workspace-write + network disabled + no model - full argv lock", () => {
   const codex = getExecutor("codex");
   const result = codex.buildExecCommand({


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. `issue-378` 브랜치에 커밋도 만들었습니다.

커밋: `8a88cf6 Add opencode probe-only executor adapter`

변경 사항:
- `opencode` probe-only executor adapter 추가
- executor registry에 `opencode` 등록
- `opencode` adapter contract 및 `#377` stub behavior 테스트 추가
- executor README에 probe-only 상태 문서화

검증:
- `node --test tests/relay-dispatch/scripts/executors.test.js` 통과
- `node --test tests/relay-dispatch/scripts/*.test.js tests/relay-plan/scripts/*.test.js` 통과
- `listExecutors()` 결과: `["claude","codex","opencode"]`
- `
```

## Score Log

- Run: issue-378-20260503160409248-c3756619
- Executor: codex
- Branch: issue-378