### PR TITLE
Add experimental opencode executor dispatch

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -788,6 +788,9 @@ async function main() {
     manifestModelHints: manifest?.model_hints,
     cliModelHints: MODEL_HINTS,
   });
+  const provider = typeof adapter.parseProvider === "function"
+    ? (adapter.parseProvider(effectiveDispatchModel) ?? adapter.providerDefault ?? null)
+    : (adapter.providerDefault || null);
 
   // --- Dry run ---
   if (DRY_RUN) {
@@ -1036,6 +1039,10 @@ async function main() {
   execCwd = buildResult.cwd;
   codexGitCommonDir = buildResult.codexGitCommonDir || null;
 
+  if (EXECUTOR === "opencode") {
+    console.error("Warning: opencode executor is experimental; see docs/reviewer-policy-opencode.md for trust boundary and reviewer policy.");
+  }
+
   if (!JSON_OUT) {
     console.log(`Dispatching to ${EXECUTOR}...`);
     console.log(`  Run:      ${runId}`);
@@ -1066,6 +1073,12 @@ async function main() {
       ...(manifest.git || {}),
       head_sha: startHead || null,
     },
+    dispatch: {
+      ...(manifest.dispatch || {}),
+      last_executor: EXECUTOR,
+      last_model: effectiveDispatchModel,
+      last_provider: provider,
+    },
   };
   writeManifest(manifestPath, manifest);
   appendRunEvent(repoRoot, runId, {
@@ -1074,7 +1087,9 @@ async function main() {
     state_to: STATES.DISPATCHED,
     head_sha: startHead || null,
     reason: RESUME_MODE ? "same_run_resume" : "new_dispatch",
+    executor: EXECUTOR,
     model: effectiveDispatchModel,
+    provider,
     executor_network: executorNetworkPolicy,
   });
 

--- a/skills/relay-dispatch/scripts/executors/README.md
+++ b/skills/relay-dispatch/scripts/executors/README.md
@@ -15,4 +15,4 @@ Each file in this directory is an executor adapter. To add a new executor:
 
 That's it. `dispatch.js` and `probe-executor-env.js` will pick up the new executor automatically via `getExecutor(name)`.
 
-opencode is registered as a probe-only adapter pending full executor support in #377. Its buildExecCommand/register/validateExecutionMode stubs throw with a `#377` reference.
+opencode is an experimental dispatch executor. Reviewer policy is defined in `docs/reviewer-policy-opencode.md`. opencode does not provide native sandbox enforcement; warnings surface this fact at dispatch time.

--- a/skills/relay-dispatch/scripts/executors/claude.js
+++ b/skills/relay-dispatch/scripts/executors/claude.js
@@ -61,6 +61,7 @@ function probe({ timeout }) {
 
 module.exports = {
   cliBinary: "claude",
+  providerDefault: "anthropic",
   defaultTimeout: 1800,
   validateExecutionMode,
   buildExecCommand,

--- a/skills/relay-dispatch/scripts/executors/codex.js
+++ b/skills/relay-dispatch/scripts/executors/codex.js
@@ -88,6 +88,7 @@ function probe({ timeout }) {
 
 module.exports = {
   cliBinary: "codex",
+  providerDefault: "openai",
   defaultTimeout: 2400,
   validateExecutionMode,
   buildExecCommand,

--- a/skills/relay-dispatch/scripts/executors/opencode.js
+++ b/skills/relay-dispatch/scripts/executors/opencode.js
@@ -8,22 +8,46 @@ const PROBE_PROMPT =
   "Output a JSON array of objects with {name, type, description} fields. " +
   "type is one of: skill, mcp_tool, built_in.";
 
-const NOT_YET = "opencode executor is experimental and not yet wired up; see #377";
-
-function validateExecutionMode(/* { sandbox, networkAccess } */) {
-  return { ok: false, error: NOT_YET };
+function parseProvider(model) {
+  if (typeof model !== "string" || !model) return null;
+  const idx = model.indexOf("/");
+  if (idx <= 0) return null;
+  return model.slice(0, idx);
 }
 
-function buildExecCommand() {
-  throw new Error(NOT_YET);
+function validateExecutionMode({ sandbox, networkAccess }) {
+  const warnings = [];
+  if (sandbox !== "workspace-write") {
+    warnings.push(
+      `opencode executor: --sandbox '${sandbox}' is not enforced by opencode (no native sandboxing); proceeding with workspace-write semantics.`
+    );
+  }
+  if (networkAccess === "enabled") {
+    warnings.push(
+      "opencode executor: --network-access 'enabled' is informational only; opencode does not gate network access at the executor level."
+    );
+  }
+  warnings.push("opencode executor is experimental; review boundary defined in docs/reviewer-policy-opencode.md.");
+  return { ok: true, warnings };
 }
 
-function finalizeResult(/* { stdoutLog, resultFile } */) {
-  // safe no-op so dispatch.js can call this unconditionally
+function buildExecCommand({ wtPath, prompt, model }) {
+  const cmd = "opencode";
+  const args = ["run"];
+  if (model) args.push("-m", model);
+  args.push(prompt);
+  return { cmd, args, cwd: wtPath, codexGitCommonDir: null };
+}
+
+function finalizeResult({ stdoutLog, resultFile }) {
+  // opencode writes its result to stdout; copy to resultFile so downstream collection works.
+  if (fs.existsSync(stdoutLog)) {
+    try { fs.copyFileSync(stdoutLog, resultFile); } catch {}
+  }
 }
 
 function register() {
-  throw new Error(NOT_YET);
+  return { threadId: null, raw: { provider: "opencode", note: "no app registration surface" } };
 }
 
 function discoverConfigPath() {
@@ -184,4 +208,5 @@ module.exports = {
   finalizeResult,
   register,
   probe,
+  parseProvider,
 };

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -128,8 +128,14 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.bootstrap_exempt !== undefined
       ? { bootstrap_exempt: eventData.bootstrap_exempt === true }
       : {}),
+    ...(eventData.executor !== undefined
+      ? { executor: normalizeEventValue(eventData.executor) }
+      : {}),
     ...(eventData.model !== undefined
       ? { model: normalizeEventValue(eventData.model) }
+      : {}),
+    ...(eventData.provider !== undefined
+      ? { provider: normalizeEventValue(eventData.provider) }
       : {}),
     ...(eventData.executor_network !== undefined
       ? { executor_network: normalizeEventValue(eventData.executor_network) }

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -222,6 +222,27 @@ process.stdout.write("ok\\n");
   return claudePath;
 }
 
+function writeArgCaptureOpencode(binDir, capturePath) {
+  ensureDefaultFakeGh(binDir);
+  const oc = path.join(binDir, "opencode");
+  fs.writeFileSync(oc, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("opencode-fake\\n"); process.exit(0); }
+if (args[0] !== "run") { process.stderr.write("unsupported fake opencode invocation"); process.exit(1); }
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(args), "utf-8");
+const cwd = process.cwd();
+const fileName = "captured-opencode.txt";
+fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
+process.stdout.write("ok\\n");
+`, "utf-8");
+  fs.chmodSync(oc, 0o755);
+  return oc;
+}
+
 function writeNoOpCodex(binDir) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -1408,6 +1429,56 @@ function writeTempRubric(contents) {
   fs.writeFileSync(rubricFile, contents, "utf-8");
   return rubricFile;
 }
+
+test("dispatch opencode executor records provider metadata", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "test prompt";
+  const rubricFile = writeTempRubric("size: \"S\"\nrubric:\n  factors: []\n");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-test",
+    "-p", taskPrompt,
+    "-e", "opencode",
+    "-m", "openai/gpt-5",
+    "--rubric-file", rubricFile,
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  assert.match(proc.stderr, /opencode executor is experimental/);
+  assert.match(proc.stderr, /reviewer-policy-opencode\.md/);
+  const result = JSON.parse(proc.stdout);
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "run",
+    "-m", "openai/gpt-5",
+    buildDispatchExecPrompt(taskPrompt),
+  ]);
+
+  const events = readJsonLines(path.join(result.runDir, "events.jsonl"));
+  const dispatchStart = events.find((event) => event.event === "dispatch_start");
+  assert.equal(dispatchStart.executor, "opencode");
+  assert.equal(dispatchStart.model, "openai/gpt-5");
+  assert.equal(dispatchStart.provider, "openai");
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.dispatch.last_executor, "opencode");
+  assert.equal(manifest.dispatch.last_model, "openai/gpt-5");
+  assert.equal(manifest.dispatch.last_provider, "openai");
+});
 
 function reasoningArgValue(args) {
   const index = args.indexOf("-c");

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -43,21 +43,74 @@ test("opencode adapter exposes the same 7 fields", () => {
   assert.equal(o.cliBinary, "opencode");
 });
 
-test("opencode buildExecCommand throws with #377 reference (probe-only adapter)", () => {
+test("opencode validateExecutionMode accepts workspace-write+disabled with experimental warning", () => {
   const o = getExecutor("opencode");
-  assert.throws(() => o.buildExecCommand({}), /#377/);
+  const r = o.validateExecutionMode({ sandbox: "workspace-write", networkAccess: "disabled" });
+  assert.equal(r.ok, true);
+  assert.ok(Array.isArray(r.warnings));
+  assert.ok(r.warnings.some((w) => /experimental/i.test(w)));
 });
 
-test("opencode register throws with #377 reference", () => {
+test("opencode validateExecutionMode warns on non-workspace-write sandbox", () => {
   const o = getExecutor("opencode");
-  assert.throws(() => o.register({}), /#377/);
+  const r = o.validateExecutionMode({ sandbox: "read-only", networkAccess: "disabled" });
+  assert.equal(r.ok, true);
+  assert.ok(r.warnings.some((w) => /not enforced/i.test(w)));
 });
 
-test("opencode validateExecutionMode rejects with #377 reference", () => {
+test("opencode buildExecCommand: happy path", () => {
   const o = getExecutor("opencode");
-  const result = o.validateExecutionMode({ sandbox: "workspace-write", networkAccess: "disabled" });
-  assert.equal(result.ok, false);
-  assert.match(result.error, /#377/);
+  const r = o.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  assert.equal(r.cmd, "opencode");
+  assert.deepEqual(r.args, ["run", "P"]);
+  assert.equal(r.cwd, "/tmp/wt");
+  assert.equal(r.codexGitCommonDir, null);
+});
+
+test("opencode buildExecCommand: model passthrough via -m", () => {
+  const o = getExecutor("opencode");
+  const r = o.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: "openai/gpt-5",
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  assert.deepEqual(r.args, ["run", "-m", "openai/gpt-5", "P"]);
+});
+
+test("opencode register stub returns null thread id", () => {
+  const o = getExecutor("opencode");
+  const r = o.register({ wtPath: "/tmp/wt", repoPath: "/repo", branch: "b", title: "T" });
+  assert.equal(r.threadId, null);
+});
+
+test("opencode parseProvider extracts provider from model", () => {
+  const o = getExecutor("opencode");
+  assert.equal(o.parseProvider("openai/gpt-5"), "openai");
+  assert.equal(o.parseProvider("anthropic/claude-opus-4-7"), "anthropic");
+  assert.equal(o.parseProvider("gpt-5"), null);
+  assert.equal(o.parseProvider(""), null);
+  assert.equal(o.parseProvider(null), null);
+  assert.equal(o.parseProvider(undefined), null);
+});
+
+test("codex providerDefault is openai", () => {
+  assert.equal(getExecutor("codex").providerDefault, "openai");
+});
+
+test("claude providerDefault is anthropic", () => {
+  assert.equal(getExecutor("claude").providerDefault, "anthropic");
 });
 
 test("opencode finalizeResult is a safe no-op", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. `issue-377` 브랜치에 커밋까지 했습니다.

커밋: `a7eb098 Add experimental opencode executor dispatch`

주요 변경:
- `opencode` executor 스텁을 실제 `opencode run [-m model] <prompt>` dispatch 경로로 교체
- `parseProvider()` 추가 및 `codex/claude`에 `providerDefault` 추가
- `dispatch_start` 이벤트와 manifest `dispatch.last_*`에 `executor/model/provider` 기록
- `opencode` 실행 시 stderr experimental 경고 출력
- `appendRunEvent()`가 `executor/provider` 필드를 보존하도록 확장
- probe-only README 문구 제거
- fake opencode 기반 end-to-end dispatch 테스트 추가

검증
```

## Score Log

- Run: issue-377-20260503230543969-82bfadcd
- Executor: codex
- Branch: issue-377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * Opencode 실행 엔진이 실험적 기능으로 활성화되었습니다.
  * 디스패치 매니페스트 및 이벤트에 공급자(Provider) 추적 기능이 추가되었습니다.
  * Opencode 실행 시 경고 메시지가 표시됩니다.

* **문서**
  * Opencode 실행 엔진 설명이 업데이트되었습니다.

* **테스트**
  * 실행 엔진 및 디스패치 기능에 대한 테스트 커버리지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->