### PR TITLE
Track dispatch reliability dimensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --dry-run
 # Reliability report
 node skills/relay-dispatch/scripts/reliability-report.js --repo . --json
 node skills/relay-dispatch/scripts/reliability-report.js --repo . --by-role --json
+node skills/relay-dispatch/scripts/reliability-report.js --repo . --by-dispatch --json
 
 # Review (cross-skill: review-runner lives under relay-review, not relay-dispatch)
 node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --reviewer codex --json

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -23,6 +23,7 @@ const FLAGS = [
   { flag: "--branch", aliases: ["-b"], kind: VALUE, mode: MODE_VERBATIM, valueName: "<name>", rationale: "Git branch names are operator-supplied and may legally begin with --." },
   { flag: "--by-acting-reviewer", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--by-actor", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--by-dispatch", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--by-role", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--contract-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path; keep the literal argv token." },
   { flag: "--copy", kind: VALUE, mode: MODE_VERBATIM, valueName: "<file,...>", rationale: "Operator-supplied file list; keep the literal argv token." },
@@ -159,7 +160,7 @@ const COMMAND_FLAGS = {
     "--json", "--help",
   ],
   "reliability-report": [
-    "--repo", "--stale-hours", "--json", "--by-actor", "--by-role", "--by-acting-reviewer", "--help",
+    "--repo", "--stale-hours", "--json", "--by-actor", "--by-role", "--by-acting-reviewer", "--by-dispatch", "--help",
   ],
   "review-runner": [
     "--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file",

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -16,7 +16,7 @@ const NO_GUIDANCE_DATA_TEXT = "no guidance data available";
 if (hasCliFlag(["--help", "-h"])) {
   console.log(
     "Usage: reliability-report.js [--repo <path>] [--stale-hours <hours>] " +
-    "[--json] [--by-actor] [--by-role] [--by-acting-reviewer]"
+    "[--json] [--by-actor] [--by-role] [--by-acting-reviewer] [--by-dispatch]"
   );
   console.log("\nOptions:");
   console.log(`  --repo <path>           ${modeLabel("--repo")} Repository root (default: .)`);
@@ -25,6 +25,7 @@ if (hasCliFlag(["--help", "-h"])) {
   console.log(`  --by-actor              ${modeLabel("--by-actor")} Include actor breakdown`);
   console.log(`  --by-role               ${modeLabel("--by-role")} Include role breakdown`);
   console.log(`  --by-acting-reviewer    ${modeLabel("--by-acting-reviewer")} Include acting reviewer breakdown`);
+  console.log(`  --by-dispatch           ${modeLabel("--by-dispatch")} Include executor/model/provider breakdown`);
   process.exit(0);
 }
 
@@ -64,6 +65,8 @@ function normalizeActorName(value) {
 function normalizeRoleName(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "unknown";
 }
+
+const normalizeDispatchKey = normalizeRoleName;
 
 function normalizeGuidancePacks(value) {
   if (!Array.isArray(value)) return [];
@@ -759,6 +762,16 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
     if (!updatedAt) return false;
     return updatedAt <= now - staleHours * 60 * 60 * 1000;
   });
+  const dispatchResults = events.filter((event) => event.event === EVENTS.DISPATCH_RESULT);
+  const dispatchTimeouts = dispatchResults.filter((event) => (
+    event.failure_class === "timeout" || /timeout/i.test(String(event.reason || ""))
+  ));
+  const dispatchFailures = dispatchResults.filter((event) => event.state_to === STATES.ESCALATED);
+  const recoveredRunIds = new Set(
+    events
+      .filter((event) => event.event === EVENTS.RECOVER_COMMIT && event.run_id)
+      .map((event) => event.run_id)
+  );
 
   return {
     repoRoot,
@@ -777,6 +790,9 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
       max_rounds_enforcement_rate: ratio(maxRoundsCompliant.size, reviewRuns.size),
       median_rounds_to_ready: median(readyRounds),
       stale_open_runs_72h: staleOpenRuns.length,
+      dispatch_timeout_rate: ratio(dispatchTimeouts.length, dispatchResults.length),
+      dispatch_failure_rate: ratio(dispatchFailures.length, dispatchResults.length),
+      recover_commit_rate: ratio(recoveredRunIds.size, manifests.length),
     },
     model_per_phase: buildModelPerPhase(events),
     factor_analysis: buildFactorAnalysis(events),
@@ -834,6 +850,40 @@ function buildRoleReports({ repoRoot, staleHours, now, manifests, events }) {
       })];
     }))];
   }));
+}
+
+function buildDispatchDimensionReport({ repoRoot, staleHours, now, manifests, events }, dimension) {
+  const fieldName = `last_${dimension}`;
+  const names = [...new Set(
+    manifests.map(({ data }) => normalizeDispatchKey(data?.dispatch?.[fieldName]))
+  )].sort((left, right) => left.localeCompare(right));
+
+  return Object.fromEntries(names.map((name) => {
+    const groupManifests = manifests.filter(
+      ({ data }) => normalizeDispatchKey(data?.dispatch?.[fieldName]) === name
+    );
+    const groupRunIds = new Set(
+      groupManifests
+        .map(({ data }) => data?.run_id)
+        .filter(Boolean)
+    );
+    const groupEvents = events.filter((event) => groupRunIds.has(event.run_id));
+    return [name, buildReport({
+      repoRoot,
+      staleHours,
+      now,
+      manifests: groupManifests,
+      events: groupEvents,
+    })];
+  }));
+}
+
+function buildDispatchReports(opts) {
+  return {
+    executor: buildDispatchDimensionReport(opts, "executor"),
+    model: buildDispatchDimensionReport(opts, "model"),
+    provider: buildDispatchDimensionReport(opts, "provider"),
+  };
 }
 
 // `review_apply` can be emitted for a system-forced escalation before any
@@ -939,6 +989,9 @@ function main() {
   if (hasCliFlag("--by-acting-reviewer")) {
     report.by_acting_reviewer = buildActingReviewerReports({ repoRoot, staleHours, now, manifests, events });
   }
+  if (hasCliFlag("--by-dispatch")) {
+    report.by_dispatch = buildDispatchReports({ repoRoot, staleHours, now, manifests, events });
+  }
 
   if (hasCliFlag("--json")) {
     console.log(JSON.stringify(report, null, 2));
@@ -951,6 +1004,9 @@ function main() {
   console.log(`  max_rounds_enforcement_rate: ${report.metrics.max_rounds_enforcement_rate ?? "n/a"}`);
   console.log(`  median_rounds_to_ready: ${report.metrics.median_rounds_to_ready ?? "n/a"}`);
   console.log(`  stale_open_runs_72h: ${report.metrics.stale_open_runs_72h}`);
+  console.log(`  dispatch_timeout_rate: ${report.metrics.dispatch_timeout_rate ?? "n/a"}`);
+  console.log(`  dispatch_failure_rate: ${report.metrics.dispatch_failure_rate ?? "n/a"}`);
+  console.log(`  recover_commit_rate: ${report.metrics.recover_commit_rate ?? "n/a"}`);
   if (report.model_per_phase) {
     console.log(`  model_per_phase: ${JSON.stringify(report.model_per_phase)}`);
   }
@@ -1009,6 +1065,29 @@ function main() {
         console.log(
           `    ${roleKey}.${roleName}: manifests=${scopedReport.totals.manifests} events=${scopedReport.totals.events} ` +
           `most_stuck_factor=${scopedReport.factor_analysis.most_stuck_factor ?? "n/a"}`
+        );
+      }
+    }
+  }
+  if (hasCliFlag("--by-dispatch")) {
+    const dispatchEntries = Object.entries(report.by_dispatch || {});
+    console.log("  by_dispatch:");
+    if (dispatchEntries.length === 0) {
+      console.log("    n/a");
+    }
+    for (const [dimensionKey, dimensionReport] of dispatchEntries) {
+      const names = Object.entries(dimensionReport || {});
+      if (names.length === 0) {
+        console.log(`    ${dimensionKey}: n/a`);
+        continue;
+      }
+      for (const [name, scopedReport] of names) {
+        console.log(
+          `    ${dimensionKey}.${name}: manifests=${scopedReport.totals.manifests} events=${scopedReport.totals.events} ` +
+          `pass_rate=${scopedReport.metrics.median_rounds_to_ready ?? "n/a"} ` +
+          `timeout_rate=${scopedReport.metrics.dispatch_timeout_rate ?? "n/a"} ` +
+          `failure_rate=${scopedReport.metrics.dispatch_failure_rate ?? "n/a"} ` +
+          `recover_commit_rate=${scopedReport.metrics.recover_commit_rate ?? "n/a"}`
         );
       }
     }

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -751,8 +751,9 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
     }
   }
 
-  const readyRounds = manifests
-    .filter(({ data }) => [STATES.READY_TO_MERGE, STATES.MERGED].includes(data.state))
+  const passedRuns = manifests
+    .filter(({ data }) => [STATES.READY_TO_MERGE, STATES.MERGED].includes(data.state));
+  const readyRounds = passedRuns
     .map(({ data }) => Number(data.review?.rounds || 0))
     .filter((value) => value > 0);
 
@@ -790,6 +791,7 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
       max_rounds_enforcement_rate: ratio(maxRoundsCompliant.size, reviewRuns.size),
       median_rounds_to_ready: median(readyRounds),
       stale_open_runs_72h: staleOpenRuns.length,
+      pass_rate: ratio(passedRuns.length, manifests.length),
       dispatch_timeout_rate: ratio(dispatchTimeouts.length, dispatchResults.length),
       dispatch_failure_rate: ratio(dispatchFailures.length, dispatchResults.length),
       recover_commit_rate: ratio(recoveredRunIds.size, manifests.length),
@@ -1004,6 +1006,7 @@ function main() {
   console.log(`  max_rounds_enforcement_rate: ${report.metrics.max_rounds_enforcement_rate ?? "n/a"}`);
   console.log(`  median_rounds_to_ready: ${report.metrics.median_rounds_to_ready ?? "n/a"}`);
   console.log(`  stale_open_runs_72h: ${report.metrics.stale_open_runs_72h}`);
+  console.log(`  pass_rate: ${report.metrics.pass_rate ?? "n/a"}`);
   console.log(`  dispatch_timeout_rate: ${report.metrics.dispatch_timeout_rate ?? "n/a"}`);
   console.log(`  dispatch_failure_rate: ${report.metrics.dispatch_failure_rate ?? "n/a"}`);
   console.log(`  recover_commit_rate: ${report.metrics.recover_commit_rate ?? "n/a"}`);
@@ -1084,7 +1087,8 @@ function main() {
       for (const [name, scopedReport] of names) {
         console.log(
           `    ${dimensionKey}.${name}: manifests=${scopedReport.totals.manifests} events=${scopedReport.totals.events} ` +
-          `pass_rate=${scopedReport.metrics.median_rounds_to_ready ?? "n/a"} ` +
+          `pass_rate=${scopedReport.metrics.pass_rate ?? "n/a"} ` +
+          `median_rounds_to_ready=${scopedReport.metrics.median_rounds_to_ready ?? "n/a"} ` +
           `timeout_rate=${scopedReport.metrics.dispatch_timeout_rate ?? "n/a"} ` +
           `failure_rate=${scopedReport.metrics.dispatch_failure_rate ?? "n/a"} ` +
           `recover_commit_rate=${scopedReport.metrics.recover_commit_rate ?? "n/a"}`

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -1639,6 +1639,7 @@ test("reliability-report includes dispatch reliability metrics in the top-level 
   assert.equal(report.metrics.dispatch_timeout_rate, 0.25);
   assert.equal(report.metrics.dispatch_failure_rate, 0.25);
   assert.equal(report.metrics.recover_commit_rate, 0.5);
+  assert.equal(report.metrics.pass_rate, 0);
 });
 
 test("reliability-report keeps dispatch reliability metrics null when denominators are empty", () => {
@@ -1652,6 +1653,26 @@ test("reliability-report keeps dispatch reliability metrics null when denominato
   assert.equal(report.metrics.dispatch_timeout_rate, null);
   assert.equal(report.metrics.dispatch_failure_rate, null);
   assert.equal(report.metrics.recover_commit_rate, null);
+  assert.equal(report.metrics.pass_rate, null);
+});
+
+test("reliability-report computes non-zero pass_rate when runs reach merged/ready_to_merge", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-pass-rate-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runMerged = createRunId({ branch: "run-merged", timestamp: new Date("2026-04-12T10:10:00.000Z") });
+  const runReady = createRunId({ branch: "run-ready", timestamp: new Date("2026-04-12T10:10:01.000Z") });
+  const runOpen = createRunId({ branch: "run-open", timestamp: new Date("2026-04-12T10:10:02.000Z") });
+
+  writeRun(repoRoot, { runId: runMerged, state: STATES.MERGED, rounds: 2, updatedAt: recentTs });
+  writeRun(repoRoot, { runId: runReady, state: STATES.READY_TO_MERGE, rounds: 1, updatedAt: recentTs });
+  writeRun(repoRoot, { runId: runOpen, state: STATES.REVIEW_PENDING, rounds: 1, updatedAt: recentTs });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.metrics.pass_rate, Number((2 / 3).toFixed(4)));
 });
 
 test("reliability-report --by-dispatch groups by executor, model, and provider", () => {

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -1,7 +1,7 @@
 // canary: bare-string `event: "..."` fixture literals AND reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -171,6 +171,17 @@ function setManifestGuidance(repoRoot, runId, guidancePacks) {
       updated_at: new Date().toISOString(),
     },
   };
+  writeManifest(manifestPath, manifest);
+}
+
+function setManifestDispatch(repoRoot, runId, dispatch) {
+  const { manifestPath } = ensureRunLayout(repoRoot, runId);
+  const manifest = readManifest(manifestPath).data;
+  if (dispatch === undefined) {
+    delete manifest.dispatch;
+  } else {
+    manifest.dispatch = dispatch;
+  }
   writeManifest(manifestPath, manifest);
 }
 
@@ -1567,4 +1578,171 @@ test("reliability-report --by-acting-reviewer still routes explicit-but-empty re
   assert.deepEqual(Object.keys(report.by_acting_reviewer.reviewers), ["unknown"]);
   assert.equal(report.by_acting_reviewer.reviewers.unknown.acting_review.review_apply_events, 1);
   assert.equal(report.by_acting_reviewer.summary.missing_review_apply_runs, 0);
+});
+
+test("reliability-report includes dispatch reliability metrics in the top-level report", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-dispatch-metrics-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runRecovered = createRunId({ branch: "run-recovered", timestamp: new Date("2026-04-12T10:00:00.000Z") });
+  const runPlain = createRunId({ branch: "run-plain", timestamp: new Date("2026-04-12T10:00:01.000Z") });
+
+  writeRun(repoRoot, {
+    runId: runRecovered,
+    state: STATES.REVIEW_PENDING,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: runPlain,
+    state: STATES.REVIEW_PENDING,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  appendRunEvent(repoRoot, runRecovered, {
+    event: "dispatch_result",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    reason: "new_dispatch:completed",
+    failure_class: "timeout",
+  });
+  appendRunEvent(repoRoot, runRecovered, {
+    event: "dispatch_result",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.ESCALATED,
+    reason: "new_dispatch:dispatch_failed",
+  });
+  appendRunEvent(repoRoot, runPlain, {
+    event: "dispatch_result",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    reason: "new_dispatch:completed",
+  });
+  appendRunEvent(repoRoot, runPlain, {
+    event: "dispatch_result",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    reason: "new_dispatch:completed",
+  });
+  appendRunEvent(repoRoot, runRecovered, {
+    event: "recover_commit",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.REVIEW_PENDING,
+    reason: "completed-uncommitted recovery",
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.metrics.dispatch_timeout_rate, 0.25);
+  assert.equal(report.metrics.dispatch_failure_rate, 0.25);
+  assert.equal(report.metrics.recover_commit_rate, 0.5);
+});
+
+test("reliability-report keeps dispatch reliability metrics null when denominators are empty", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-dispatch-empty-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.metrics.dispatch_timeout_rate, null);
+  assert.equal(report.metrics.dispatch_failure_rate, null);
+  assert.equal(report.metrics.recover_commit_rate, null);
+});
+
+test("reliability-report --by-dispatch groups by executor, model, and provider", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-by-dispatch-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-a", timestamp: new Date("2026-04-12T10:05:00.000Z") });
+  const runB = createRunId({ branch: "run-b", timestamp: new Date("2026-04-12T10:05:01.000Z") });
+  const runC = createRunId({ branch: "run-c", timestamp: new Date("2026-04-12T10:05:02.000Z") });
+
+  for (const runId of [runA, runB, runC]) {
+    writeRun(repoRoot, {
+      runId,
+      state: STATES.REVIEW_PENDING,
+      rounds: 1,
+      updatedAt: recentTs,
+    });
+  }
+
+  setManifestDispatch(repoRoot, runA, {
+    last_executor: "codex",
+    last_model: "gpt-5",
+    last_provider: "openai",
+  });
+  setManifestDispatch(repoRoot, runB, {
+    last_executor: "claude",
+    last_model: "claude-sonnet-4",
+    last_provider: "anthropic",
+  });
+  setManifestDispatch(repoRoot, runC, {
+    last_executor: "opencode",
+    last_model: "openai/gpt-5",
+    last_provider: "openai",
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json", "--by-dispatch"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.deepEqual(Object.keys(report.by_dispatch.executor).sort(), ["claude", "codex", "opencode"]);
+  assert.equal(report.by_dispatch.executor.codex.totals.manifests, 1);
+  assert.equal(report.by_dispatch.provider.openai.totals.manifests, 2);
+  assert.equal(report.by_dispatch.provider.anthropic.totals.manifests, 1);
+  assert.equal(report.by_dispatch.model["openai/gpt-5"].totals.manifests, 1);
+});
+
+test("reliability-report --by-dispatch buckets missing dispatch fields as unknown", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-by-dispatch-unknown-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot, "Relay Test");
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runLegacy = createRunId({ branch: "run-legacy", timestamp: new Date("2026-04-12T10:10:00.000Z") });
+  const runNullDispatch = createRunId({ branch: "run-null-dispatch", timestamp: new Date("2026-04-12T10:10:01.000Z") });
+
+  writeRun(repoRoot, {
+    runId: runLegacy,
+    state: STATES.REVIEW_PENDING,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: runNullDispatch,
+    state: STATES.REVIEW_PENDING,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+  setManifestDispatch(repoRoot, runLegacy, undefined);
+  setManifestDispatch(repoRoot, runNullDispatch, {
+    last_executor: null,
+    last_model: null,
+    last_provider: "",
+  });
+
+  const stdout = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json", "--by-dispatch"], { encoding: "utf-8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.by_dispatch.executor.unknown.totals.manifests, 2);
+  assert.equal(report.by_dispatch.model.unknown.totals.manifests, 2);
+  assert.equal(report.by_dispatch.provider.unknown.totals.manifests, 2);
+  assert.equal(report.by_dispatch.executor.unknown.metrics.dispatch_timeout_rate, null);
+  assert.equal(report.by_dispatch.executor.unknown.metrics.dispatch_failure_rate, null);
+  assert.equal(report.by_dispatch.executor.unknown.metrics.recover_commit_rate, 0);
+});
+
+test("reliability-report --help mentions --by-dispatch", () => {
+  const result = spawnSync(process.execPath, [SCRIPT, "--help"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--by-dispatch/);
+  assert.match(result.stdout, /executor\/model\/provider/);
 });


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. `issue-379` 브랜치에 커밋까지 남겼습니다.

커밋: `8506ba8 Track dispatch reliability dimensions`

변경 내용:
- `reliability-report.js`에 `dispatch_timeout_rate`, `dispatch_failure_rate`, `recover_commit_rate` 추가
- `--by-dispatch` 플래그 추가
- `by_dispatch.executor / model / provider` breakdown 구현
- legacy manifest의 missing/empty dispatch fields를 `unknown`으로 bucket 처리
- `cli-schema.js` 플래그 등록
- `CLAUDE.md` command 예시 추가
- 관련 테스트 5개 추가

검증:
- `node --test tests/relay-dispatch/scripts/reliability-report.test.js` 통
```

## Score Log

- Run: issue-379-20260505005916873-41d0b5ce
- Executor: codex
- Branch: issue-379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `--by-dispatch` 옵션으로 디스패치 기반 신뢰성 분석 추가
  * 신뢰성 보고서에 새로운 디스패치 메트릭 추가: 타임아웃율, 실패율, 복구 커밋율
  * 실행기, 모델, 제공자별 신뢰성 메트릭 분석 및 그룹화 기능 제공

* **문서화**
  * 신뢰성 보고서 명령어 사용 예제 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->