### PR TITLE
Fix sprint close formatted issue parsing

### DIFF
--- a/skills/relay-merge/scripts/sprint-close-report.js
+++ b/skills/relay-merge/scripts/sprint-close-report.js
@@ -124,8 +124,8 @@ function parseSprintIssueNumbers(sprintText) {
     if (inPlan && /^##\s+\S/.test(line)) break;
     if (!inPlan) continue;
 
+    // Keep checkbox detection separate so formatted issue refs stay easy to match.
     if (!/^\s*-\s*\[[xX]\]\s+/.test(line)) continue;
-
     const match = line.match(/#(\d+)\b/);
     if (!match) continue;
     const issueNumber = Number(match[1]);

--- a/skills/relay-merge/scripts/sprint-close-report.js
+++ b/skills/relay-merge/scripts/sprint-close-report.js
@@ -124,7 +124,9 @@ function parseSprintIssueNumbers(sprintText) {
     if (inPlan && /^##\s+\S/.test(line)) break;
     if (!inPlan) continue;
 
-    const match = line.match(/^\s*-\s*\[[xX]\]\s*#(\d+)\b/);
+    if (!/^\s*-\s*\[[xX]\]\s+/.test(line)) continue;
+
+    const match = line.match(/#(\d+)\b/);
     if (!match) continue;
     const issueNumber = Number(match[1]);
     if (!seen.has(issueNumber)) {

--- a/tests/relay-merge/scripts/sprint-close-report.test.js
+++ b/tests/relay-merge/scripts/sprint-close-report.test.js
@@ -67,7 +67,15 @@ function createFakeGh(root) {
   return ghPath;
 }
 
-function createFixture({ runs, configText = null }) {
+function sprintLineForIssue(issue, format = "plain") {
+  if (format === "bold") return `- [x] **#${issue}** Fixture task -> PR #${issue + 100}`;
+  if (format === "link") return `- [x] [#${issue}](https://github.com/example/repo/issues/${issue}) Fixture task -> PR #${issue + 100}`;
+  if (format === "bold-link") return `- [x] **[#${issue}](https://github.com/example/repo/issues/${issue})** Fixture task -> PR #${issue + 100}`;
+  if (format === "unchecked") return `- [ ] **#${issue}** Fixture task -> PR #${issue + 100}`;
+  return `- [x] #${issue} Fixture task -> PR #${issue + 100}`;
+}
+
+function createFixture({ runs, configText = null, sprintFormats = {} }) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-sprint-close-"));
   const repoRoot = initRepo();
   const relayHome = path.join(root, "relay-home");
@@ -86,7 +94,7 @@ function createFixture({ runs, configText = null }) {
       "---",
       "",
       "## Plan",
-      ...issueNumbers.map((issue) => `- [x] #${issue} Fixture task -> PR #${issue + 100}`),
+      ...issueNumbers.map((issue) => sprintLineForIssue(issue, sprintFormats[issue])),
       "",
       "## Notes",
     ].join("\n"), "utf-8");
@@ -136,8 +144,8 @@ function createFixture({ runs, configText = null }) {
   }
 }
 
-function createFixtureAndRun({ runs, configText = null, args = [] }) {
-  const fixture = createFixture({ runs, configText });
+function createFixtureAndRun({ runs, configText = null, sprintFormats = {}, args = [] }) {
+  const fixture = createFixture({ runs, configText, sprintFormats });
   const bodiesByPr = {};
   for (const run of runs) {
     const prNumber = run.pr ?? run.issue + 100;
@@ -173,6 +181,30 @@ test("(a) factor at score >= 9/10 in >= 2 runs in same sprint -> reported as can
   assert.match(result.stdout, /Candidate patterns this sprint:/);
   assert.match(result.stdout, /Reusable CLI pattern/);
   assert.match(result.stdout, /2 runs/);
+});
+
+test("sprint issue parsing accepts formatted checked issue refs and ignores unchecked rows", () => {
+  const { result } = createFixtureAndRun({
+    runs: [
+      { issue: 201, factor: "Formatted checklist issue", score: 9 },
+      { issue: 202, factor: "Formatted checklist issue", score: 10 },
+      { issue: 203, factor: "Formatted checklist issue", score: 10 },
+      { issue: 204, factor: "Formatted checklist issue", score: 10 },
+      { issue: 205, factor: "Formatted checklist issue", score: 10 },
+    ],
+    sprintFormats: {
+      202: "bold",
+      203: "link",
+      204: "bold-link",
+      205: "unchecked",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Sprint issues: #201, #202, #203, #204/);
+  assert.doesNotMatch(result.stdout, /Sprint issues: .*#205/);
+  assert.match(result.stdout, /Formatted checklist issue/);
+  assert.match(result.stdout, /4 runs/);
 });
 
 test("(b) factor at score >= 9/10 in only 1 run -> NOT reported (min-runs gate holds)", () => {


### PR DESCRIPTION
## Summary
- fix sprint-close Plan parsing for formatted checked issue refs
- add coverage for plain, bold, link, bold-link, and unchecked rows

Closes #425

## Verification
- node --test tests/relay-merge/scripts/sprint-close-report.test.js
- node skills/relay-merge/scripts/sprint-close-report.js --repo . --sprint backlog/sprints/2026-05-execution-guidance-layer.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 스프린트 계획 체크리스트에서 이슈 번호 추출 방식을 개선하여 다양한 형식의 체크 항목(굵게, 링크 등)을 더 유연하게 처리합니다.
  * 스프린트 보고서 생성 시 형식 변환에 대한 안정성이 향상되었습니다.

* **테스트**
  * 형식화된 체크리스트 항목에 대한 테스트 커버리지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->