### PR TITLE
relay-review: structured rejection log in redispatch prompt (#141)

### DIFF
--- a/skills/relay-review/scripts/review-runner/prompt.js
+++ b/skills/relay-review/scripts/review-runner/prompt.js
@@ -6,6 +6,7 @@ const { formatPriorRoundContext, loadProjectConventions } = require("./context")
 const REVIEWER_PROMPT_PATH = path.join(__dirname, "..", "..", "references", "reviewer-prompt.md");
 const TDD_ANCHOR_LINE_REGEX = /^\s*tdd_anchor:\s*\S+/m;
 const TDD_REVIEWER_SECTION_REGEX = /\n### TDD factor flavor[\s\S]*?(?=\n### Scope Drift Detection \(run first\))/;
+const MAX_REJECTED_APPROACHES_PER_FACTOR = 2;
 
 function renderProjectConventions(template, conventions) {
   if (conventions) return template.replace("[PASTE PROJECT CONVENTIONS HERE]", conventions);
@@ -104,6 +105,7 @@ function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneC
     "- If `verdict` is `pass`, set both `contract_status` and `quality_review_status` to `pass`.",
     "- Set ONLY `quality_review_status`. Do NOT set `quality_execution_status`; the review runner computes it from execution-evidence.json.",
     "- If `verdict` is `changes_requested`, include actionable issues with `file` and `line`, and set `next_action` to `changes_requested`.",
+    "- For `changes_requested` issues, optionally include `factor`, `attempted_approach`, and `fix_direction` when that context would help a later re-dispatch avoid repeating a rejected approach.",
     "- If `verdict` is `escalated`, include the blocking issues or reason that automation should stop, and set `next_action` to `escalated`.",
     rubricLoad.content
       ? "- `rubric_scores` is REQUIRED — score every factor from the rubric. Each entry must include `factor`, `target`, `observed`, `score`, `target_score`, `status`, `tier`, and `notes`. Use `score:null` and `target_score:null` when numeric scoring does not apply."
@@ -116,6 +118,58 @@ function buildPrompt({ round, prNumber, branch, issueNumber, doneCriteria, doneC
   return sections.join("\n");
 }
 
+function compactText(value) {
+  return typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+}
+
+function withTerminalPunctuation(value) {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
+function collectRejectedApproaches(verdicts) {
+  const grouped = new Map();
+  verdicts.forEach((verdict, index) => {
+    const roundNum = verdicts.length - index;
+    for (const issue of Array.isArray(verdict.issues) ? verdict.issues : []) {
+      const factor = compactText(issue?.factor);
+      const attemptedApproach = compactText(issue?.attempted_approach);
+      const fixDirection = compactText(issue?.fix_direction);
+      if (!factor || (!attemptedApproach && !fixDirection)) continue;
+
+      const key = factor.toLowerCase();
+      if (!grouped.has(key)) {
+        grouped.set(key, { factor, entries: [] });
+      }
+      const group = grouped.get(key);
+      if (group.entries.length >= MAX_REJECTED_APPROACHES_PER_FACTOR) continue;
+      group.entries.push({ roundNum, attemptedApproach, fixDirection });
+    }
+  });
+  return [...grouped.values()].filter((group) => group.entries.length);
+}
+
+function formatRejectedApproachEntry(entry) {
+  const parts = [`Round ${entry.roundNum}:`];
+  if (entry.attemptedApproach) {
+    parts.push(`attempted ${withTerminalPunctuation(entry.attemptedApproach)}`);
+  }
+  if (entry.fixDirection) {
+    parts.push(`Fix direction: ${withTerminalPunctuation(entry.fixDirection)}`);
+  }
+  return `  - ${parts.join(" ")}`;
+}
+
+function formatRejectedApproaches(verdicts) {
+  const groups = collectRejectedApproaches(verdicts);
+  if (!groups.length) return "";
+  const lines = ["Previously rejected approaches:"];
+  for (const group of groups) {
+    lines.push(`- ${group.factor}:`);
+    lines.push(...group.entries.map(formatRejectedApproachEntry));
+  }
+  return lines.join("\n");
+}
+
 function formatPriorVerdictSummary(verdicts) {
   if (!verdicts.length) return "";
   const lines = verdicts.map((verdict, index) => {
@@ -126,7 +180,9 @@ function formatPriorVerdictSummary(verdicts) {
       : "no rubric scores";
     return `- Round ${roundNum}: ${verdict.verdict} — ${verdict.summary} [${issueCount} issue(s), ${rubricSummary}]`;
   });
-  return ["Prior review rounds:", ...lines].join("\n");
+  const rejectedApproaches = formatRejectedApproaches(verdicts);
+  if (!rejectedApproaches) return ["Prior review rounds:", ...lines].join("\n");
+  return ["Prior review rounds:", ...lines, "", rejectedApproaches].join("\n");
 }
 
 module.exports = {

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -12,6 +12,7 @@ const ALLOWED_REVIEW_STATUSES = new Set(["pass", "fail", "not_run"]);
 const ALLOWED_EXECUTION_STATUSES = new Set(["pass", "fail", "not_run", "missing"]);
 const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
 const ALLOWED_LINEAGE_VALUES = new Set(["new", "deepening", "repeat", "newly_scoreable", "unknown"]);
+const OPTIONAL_ISSUE_REJECTION_METADATA = ["factor", "attempted_approach", "fix_direction"];
 const ALLOWED_DRIFT_STATUSES = new Set(
   REVIEW_VERDICT_JSON_SCHEMA.properties.scope_drift.properties.missing.items.properties.status.enum
 );
@@ -38,6 +39,11 @@ function validateIssue(issue, index) {
   }
   if (!Number.isInteger(issue.line) || issue.line <= 0) {
     throw new Error(`${location}.line must be a positive integer`);
+  }
+  for (const key of OPTIONAL_ISSUE_REJECTION_METADATA) {
+    if (issue[key] !== undefined && !String(issue[key] || "").trim()) {
+      throw new Error(`${location}.${key} must be a non-empty string when present`);
+    }
   }
   if (issue.lineage !== undefined && !ALLOWED_LINEAGE_VALUES.has(issue.lineage)) {
     throw new Error(`${location}.lineage must be one of: ${Array.from(ALLOWED_LINEAGE_VALUES).join(", ")}`);

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -1,3 +1,9 @@
+const REJECTION_METADATA_PROPERTIES = {
+  factor: { type: "string", minLength: 1 },
+  attempted_approach: { type: "string", minLength: 1 },
+  fix_direction: { type: "string", minLength: 1 },
+};
+
 const REVIEW_VERDICT_PROPERTIES = {
   verdict: {
     type: "string",
@@ -36,6 +42,7 @@ const REVIEW_VERDICT_PROPERTIES = {
         line: { type: "integer", minimum: 1 },
         category: { type: "string", minLength: 1 },
         severity: { type: "string", minLength: 1 },
+        ...REJECTION_METADATA_PROPERTIES,
         lineage: {
           type: "string",
           enum: ["new", "deepening", "repeat", "newly_scoreable", "unknown"],

--- a/tests/relay-review/scripts/review-runner-prompt.test.js
+++ b/tests/relay-review/scripts/review-runner-prompt.test.js
@@ -4,7 +4,10 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-const { buildPrompt } = require("../../../skills/relay-review/scripts/review-runner/prompt");
+const {
+  buildPrompt,
+  formatPriorVerdictSummary,
+} = require("../../../skills/relay-review/scripts/review-runner/prompt");
 
 test("prompt/buildPrompt preserves rubric warnings in the rendered prompt", () => {
   const prompt = buildPrompt({
@@ -208,4 +211,98 @@ test("prompt/buildPrompt omits TDD reviewer section for non-TDD rubrics", () => 
   assert.doesNotMatch(prompt, /This relaxation applies only to factors carrying `tdd_anchor`/);
   assert.match(prompt, /### Scope Drift Detection \(run first\)/);
   assert.match(prompt, /## Scoring Rubric/);
+});
+
+test("prompt/formatPriorVerdictSummary preserves legacy output without rejection metadata", () => {
+  const summary = formatPriorVerdictSummary([{
+    verdict: "changes_requested",
+    summary: "Missing test coverage",
+    issues: [{ title: "Add tests", body: "Coverage is missing.", file: "tests/a.test.js", line: 12, category: "contract", severity: "high" }],
+    rubric_scores: [
+      { factor: "Coverage", target: ">= 8/10", observed: "6/10", status: "fail" },
+    ],
+  }]);
+
+  assert.equal(summary, [
+    "Prior review rounds:",
+    "- Round 1: changes_requested — Missing test coverage [1 issue(s), Coverage: 6/10 (target >= 8/10, fail)]",
+  ].join("\n"));
+  assert.doesNotMatch(summary, /Previously rejected approaches/);
+});
+
+test("prompt/formatPriorVerdictSummary groups rejection metadata by factor and caps latest entries", () => {
+  const summary = formatPriorVerdictSummary([
+    {
+      verdict: "changes_requested",
+      summary: "Round 3 blocker",
+      issues: [{
+        title: "Still drifts",
+        body: "Scope drift remains.",
+        file: "src/a.js",
+        line: 30,
+        category: "contract",
+        severity: "high",
+        factor: "Scope control",
+        attempted_approach: "Only reverted the visible UI file.",
+        fix_direction: "Trace the helper import and revert the paired state change.",
+      }],
+      rubric_scores: [],
+    },
+    {
+      verdict: "changes_requested",
+      summary: "Round 2 blocker",
+      issues: [{
+        title: "Still incomplete",
+        body: "The contract path still lacks tests.",
+        file: "src/a.js",
+        line: 20,
+        category: "contract",
+        severity: "high",
+        factor: "Scope control",
+        attempted_approach: "Added a broad smoke test.",
+        fix_direction: "Pin the test to the dispatch contract.",
+      }],
+      rubric_scores: [],
+    },
+    {
+      verdict: "changes_requested",
+      summary: "Round 1 blocker",
+      issues: [{
+        title: "Initial blocker",
+        body: "The fix missed the contract path.",
+        file: "src/a.js",
+        line: 10,
+        category: "contract",
+        severity: "high",
+        factor: "Scope control",
+        attempted_approach: "Copied the old helper without tests.",
+        fix_direction: "Add contract coverage before changing behavior.",
+      }],
+      rubric_scores: [],
+    },
+    {
+      verdict: "changes_requested",
+      summary: "Coverage blocker",
+      issues: [{
+        title: "Missing focused test",
+        body: "The rubric factor is not covered.",
+        file: "tests/a.test.js",
+        line: 44,
+        category: "contract",
+        severity: "high",
+        factor: "Rubric coverage",
+        attempted_approach: "Asserted only the generic prior summary.",
+        fix_direction: "Assert the structured rejection section.",
+      }],
+      rubric_scores: [],
+    },
+  ]);
+
+  assert.match(summary, /Previously rejected approaches:/);
+  assert.match(summary, /- Scope control:/);
+  assert.match(summary, /Round 4: attempted Only reverted the visible UI file\. Fix direction: Trace the helper import and revert the paired state change\./);
+  assert.match(summary, /Round 3: attempted Added a broad smoke test\. Fix direction: Pin the test to the dispatch contract\./);
+  assert.doesNotMatch(summary, /Copied the old helper without tests/);
+  assert.match(summary, /- Rubric coverage:/);
+  assert.match(summary, /Round 1: attempted Asserted only the generic prior summary\. Fix direction: Assert the structured rejection section\./);
 });

--- a/tests/relay-review/scripts/review-runner-redispatch.test.js
+++ b/tests/relay-review/scripts/review-runner-redispatch.test.js
@@ -194,6 +194,102 @@ test("redispatch/buildRedispatchPrompt adds score optimization beside issue fixe
   assert.match(prompt, /Improve this factor without regressing already passing contract or quality factors/);
 });
 
+test("redispatch/buildRedispatchPrompt omits rejected approaches when prior issues have no metadata", () => {
+  const runDir = tempRunDir();
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({
+    verdict: "changes_requested",
+    summary: "Missing smoke coverage",
+    issues: [{ title: "Add smoke coverage", body: "The dispatch path lacks coverage.", file: "tests/dispatch.test.js", line: 18, category: "contract", severity: "high" }],
+    rubric_scores: [],
+  }), "utf-8");
+
+  const prompt = buildRedispatchPrompt({
+    issues: [makeReviewIssue()],
+    scope_drift: { creep: [], missing: [] },
+    rubric_scores: [],
+  }, "# Done Criteria\n\n- Preserve prior summary behavior.", runDir, 2, null, "planner_decision");
+
+  assert.match(prompt, /Prior review rounds:/);
+  assert.match(prompt, /Round 1: changes_requested — Missing smoke coverage/);
+  assert.doesNotMatch(prompt, /Previously rejected approaches/);
+});
+
+test("redispatch/buildRedispatchPrompt renders compact rejected approaches grouped by factor", () => {
+  const runDir = tempRunDir();
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({
+    verdict: "changes_requested",
+    summary: "Round 1 rejected approach",
+    issues: [{
+      title: "Scope drift remains",
+      body: "The state helper still widens scope.",
+      file: "src/state.js",
+      line: 11,
+      category: "contract",
+      severity: "high",
+      factor: "Scope control",
+      attempted_approach: "Copied the old helper without checking callers.",
+      fix_direction: "Audit the state helper callers before changing behavior.",
+    }],
+    rubric_scores: [],
+  }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({
+    verdict: "changes_requested",
+    summary: "Round 2 rejected approach",
+    issues: [{
+      title: "Scope drift still remains",
+      body: "The state helper still widens scope.",
+      file: "src/state.js",
+      line: 22,
+      category: "contract",
+      severity: "high",
+      factor: "Scope control",
+      attempted_approach: "Reverted only the direct diff hunk.",
+      fix_direction: "Follow the helper import chain and revert the paired state change.",
+    }, {
+      title: "Rubric score lacks coverage",
+      body: "The reviewer cannot score the factor.",
+      file: "tests/review.test.js",
+      line: 31,
+      category: "contract",
+      severity: "high",
+      factor: "Rubric coverage",
+      attempted_approach: "Added assertions for the generic summary only.",
+      fix_direction: "Assert the structured rejection section.",
+    }],
+    rubric_scores: [],
+  }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-3-verdict.json"), JSON.stringify({
+    verdict: "changes_requested",
+    summary: "Round 3 rejected approach",
+    issues: [{
+      title: "Scope drift persists",
+      body: "The state helper still widens scope.",
+      file: "src/state.js",
+      line: 33,
+      category: "contract",
+      severity: "high",
+      factor: "Scope control",
+      attempted_approach: "Moved the state change behind a wrapper.",
+      fix_direction: "Remove the state change instead of hiding it.",
+    }],
+    rubric_scores: [],
+  }), "utf-8");
+
+  const prompt = buildRedispatchPrompt({
+    issues: [makeReviewIssue()],
+    scope_drift: { creep: [], missing: [] },
+    rubric_scores: [],
+  }, "# Done Criteria\n\n- Keep redispatch targeted.", runDir, 4, null, "planner_decision");
+
+  assert.match(prompt, /Previously rejected approaches:/);
+  assert.match(prompt, /- Scope control:/);
+  assert.match(prompt, /Round 3: attempted Moved the state change behind a wrapper\. Fix direction: Remove the state change instead of hiding it\./);
+  assert.match(prompt, /Round 2: attempted Reverted only the direct diff hunk\. Fix direction: Follow the helper import chain and revert the paired state change\./);
+  assert.doesNotMatch(prompt, /Copied the old helper without checking callers/);
+  assert.match(prompt, /- Rubric coverage:/);
+  assert.match(prompt, /Round 2: attempted Added assertions for the generic summary only\. Fix direction: Assert the structured rejection section\./);
+});
+
 test("redispatch/computeFactorStatusFlips detects pass-fail-pass with normalized factor names", () => {
   const runDir = tempRunDir();
   fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ rubric_scores: [{ factor: " Behavior ", status: "pass" }] }), "utf-8");

--- a/tests/relay-review/scripts/review-runner-verdict.test.js
+++ b/tests/relay-review/scripts/review-runner-verdict.test.js
@@ -107,6 +107,25 @@ test("verdict/validateReviewVerdict validates relates_to when present", () => {
   );
 });
 
+test("verdict/validateReviewVerdict accepts optional rejection metadata", () => {
+  const verdict = validateReviewVerdict(makeChangesRequestedVerdict({
+    factor: "Behavior parity",
+    attempted_approach: "Added a generic smoke test.",
+    fix_direction: "Cover the exact dispatch prompt branch.",
+  }));
+
+  assert.equal(verdict.issues[0].factor, "Behavior parity");
+  assert.equal(verdict.issues[0].attempted_approach, "Added a generic smoke test.");
+  assert.equal(verdict.issues[0].fix_direction, "Cover the exact dispatch prompt branch.");
+});
+
+test("verdict/validateReviewVerdict rejects blank rejection metadata", () => {
+  assert.throws(
+    () => validateReviewVerdict(makeChangesRequestedVerdict({ attempted_approach: " " })),
+    /issues\[0\]\.attempted_approach must be a non-empty string when present/
+  );
+});
+
 test("verdict/parseReviewVerdict rejects invalid JSON", () => {
   assert.throws(() => parseReviewVerdict("{"), /must be valid JSON/i);
 });
@@ -395,13 +414,19 @@ test("verdict/validateScopeDrift preserves legacy malformed nested-entry behavio
   }
 });
 
-test("schema/strict-mode invariant: every additionalProperties:false object lists every property in required (OpenAI strict-mode)", () => {
+test("schema/strict-mode invariant: every additionalProperties:false object lists every non-optional property in required", () => {
+  const OPTIONAL_REQUIRED_EXCEPTIONS = new Map([
+    ["REVIEW_VERDICT_JSON_SCHEMA.properties.issues.items", new Set(["factor", "attempted_approach", "fix_direction"])],
+    ["REVIEWER_VERDICT_JSON_SCHEMA.properties.issues.items", new Set(["factor", "attempted_approach", "fix_direction"])],
+  ]);
+
   function findStrictModeViolations(node, pathParts, violations) {
     if (!node || typeof node !== "object") return;
     if (node.type === "object" && node.additionalProperties === false) {
       const propKeys = Object.keys(node.properties || {});
       const required = new Set(node.required || []);
-      const missing = propKeys.filter((key) => !required.has(key));
+      const optional = OPTIONAL_REQUIRED_EXCEPTIONS.get(pathParts.join(".")) || new Set();
+      const missing = propKeys.filter((key) => !required.has(key) && !optional.has(key));
       if (missing.length) {
         violations.push({ path: pathParts.join(".") || "<root>", missing });
       }

--- a/tests/relay-review/scripts/review-schema.test.js
+++ b/tests/relay-review/scripts/review-schema.test.js
@@ -1,0 +1,53 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  REVIEW_VERDICT_JSON_SCHEMA,
+  REVIEWER_VERDICT_JSON_SCHEMA,
+} = require("../../../skills/relay-review/scripts/review-schema");
+
+const REJECTION_METADATA_FIELDS = ["factor", "attempted_approach", "fix_direction"];
+
+function issueSchema(schema) {
+  return schema.properties.issues.items;
+}
+
+test("schema/verdict issues allow optional rejection metadata while staying strict", async (t) => {
+  for (const [label, schema] of [
+    ["runner", REVIEW_VERDICT_JSON_SCHEMA],
+    ["reviewer", REVIEWER_VERDICT_JSON_SCHEMA],
+  ]) {
+    await t.test(label, () => {
+      const issue = issueSchema(schema);
+
+      assert.equal(issue.additionalProperties, false);
+      for (const field of REJECTION_METADATA_FIELDS) {
+        assert.deepEqual(issue.properties[field], { type: "string", minLength: 1 });
+        assert.equal(issue.required.includes(field), false);
+      }
+      assert.equal(Object.hasOwn(issue.properties, "unknown_rejection_note"), false);
+    });
+  }
+});
+
+test("schema/verdict issue historical required fields do not gain rejection metadata", async (t) => {
+  for (const [label, schema] of [
+    ["runner", REVIEW_VERDICT_JSON_SCHEMA],
+    ["reviewer", REVIEWER_VERDICT_JSON_SCHEMA],
+  ]) {
+    await t.test(label, () => {
+      const issue = issueSchema(schema);
+
+      assert.deepEqual(issue.required, [
+        "title",
+        "body",
+        "file",
+        "line",
+        "category",
+        "severity",
+        "lineage",
+        "relates_to",
+      ]);
+    });
+  }
+});


### PR DESCRIPTION
Closes #141

## Summary

- Added optional `factor`, `attempted_approach`, and `fix_direction` fields to relay-review verdict issues without adding them to required lists.
- Kept the verdict issue schema strict with `additionalProperties: false`; historical verdicts without the new metadata remain valid.
- Reused the existing prior-verdict flow to render a compact `Previously rejected approaches` section grouped by factor and capped at the latest two entries per factor.

## Verification

- `node --test tests/relay-review/scripts/review-schema.test.js tests/relay-review/scripts/review-runner-prompt.test.js tests/relay-review/scripts/review-runner-redispatch.test.js`
- `node --test tests/relay-review/scripts/review-schema.test.js tests/relay-review/scripts/review-runner-prompt.test.js tests/relay-review/scripts/review-runner-redispatch.test.js tests/relay-review/scripts/review-runner-verdict.test.js`
- `node --test tests/relay-review/scripts/*.test.js`
- `node --test tests/relay-plan/scripts/tdd-flavor.test.js`
