### PR TITLE
Add configurable opencode executor model defaults

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -145,6 +145,7 @@ bootstrap_exempt:
 |-------|---------|
 | `roles.*` | Immutable per-run binding. Decouples who decides, who implements, who validates |
 | `model_hints.*` | Optional advisory per-phase model preference. Current runtime consumers: `dispatch`, `review` |
+| `dispatch.last_model` / executor config | Dispatch records the effective model. If no explicit model hint is present, executor defaults come from the skill-bundled `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json` overrides |
 | `policy.merge` | `manual_after_lgtm` — orchestrator must explicitly merge |
 | `policy.reviewer_write` | `forbid` — review runner rejects rounds where reviewer mutated files |
 | `anchor.*` | Immutable review scope — prevents drift across rounds |

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Use when
 
-- Delegating implementation to an executor (`codex`, `claude`) via worktree isolation
+- Delegating implementation to an executor (`codex`, `claude`, `opencode`) via worktree isolation
 - Resuming a same-run after a `changes_requested` review
 - Running background or parallel dispatches for independent tasks
 
@@ -35,6 +35,9 @@ ${CLAUDE_SKILL_DIR}/scripts/dispatch.js . -e codex -b feature-auth -p "..." --ru
 
 # Claude Code as executor (no Codex required)
 ${CLAUDE_SKILL_DIR}/scripts/dispatch.js . -e claude -b feature-auth -p "..." --rubric-file rubric.yaml
+
+# Experimental opencode executor (uses bundled/default model config unless --model is set)
+${CLAUDE_SKILL_DIR}/scripts/dispatch.js . -e opencode -b feature-auth -p "..." --rubric-file rubric.yaml
 ```
 
 For background and parallel dispatch, see `../relay/SKILL.md` § Batch Mode (single source of truth for the parallel-fork flow).
@@ -50,8 +53,8 @@ All CLI flags are registered with an explicit `parsed` or `verbatim` read mode. 
 | `--manifest` | Resume an existing retained relay run by manifest path |
 | `--prompt, -p` | Task prompt (include Context + Done Criteria + self-review) |
 | `--prompt-file` | Read prompt from file (for large prompts) |
-| `--executor, -e` | Executor: `codex` (default), `claude` |
-| `--model, -m` | Model override |
+| `--executor, -e` | Executor: `codex` (default), `claude`, `opencode` |
+| `--model, -m` | Model override; for `opencode`, falls back to bundled `references/executor-models.json`, then optional `~/.relay/executors.json` override |
 | `--model-hints` | Persist per-phase model hints as `phase=model[,phase=model...]` |
 | `--sandbox` | `workspace-write` (default) or `read-only` |
 | `--copy <files>` | Additional files to copy |
@@ -66,6 +69,23 @@ All CLI flags are registered with an explicit `parsed` or `verbatim` read mode. 
 | `--json` | Structured JSON output (for background dispatch) |
 
 Manifest layout (`~/.relay/runs/<repo-slug>/<run-id>.md` + `events.jsonl`), `model_hints` precedence, and intake-source linkage (`source.request_id`, `source.leaf_id`, `anchor.done_criteria_path`) are documented in `../../references/architecture.md`.
+
+### Executor model config
+
+Bundled executor model recommendations live in `references/executor-models.json` so skill installs carry a usable default. Operators can override without editing the skill by writing `~/.relay/executors.json`:
+
+```json
+{
+  "executors": {
+    "opencode": {
+      "default_model": "opencode-go/deepseek-v4-pro",
+      "candidate_models": ["opencode-go/deepseek-v4-pro"]
+    }
+  }
+}
+```
+
+Precedence for dispatch model selection is: `--model` → manifest `model_hints.dispatch` → `--model-hints dispatch=...` → executor model config.
 
 ### Timeout guidance
 

--- a/skills/relay-dispatch/references/executor-models.json
+++ b/skills/relay-dispatch/references/executor-models.json
@@ -1,0 +1,15 @@
+{
+  "executors": {
+    "opencode": {
+      "default_model": "opencode-go/deepseek-v4-pro",
+      "candidate_models": [
+        "opencode-go/deepseek-v4-pro",
+        "opencode-go/deepseek-v4-flash",
+        "opencode-go/qwen3.6-plus",
+        "opencode-go/qwen3.5-plus",
+        "opencode-go/kimi-k2.6",
+        "opencode-go/glm-5.1"
+      ]
+    }
+  }
+}

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -80,6 +80,7 @@ const {
   writeManifest,
 } = require("./manifest/store");
 const { parseModelHints } = require("./model-hints");
+const { resolveExecutorDefaultModel } = require("./executor-model-config");
 const {
   createRunId,
   ensureRunLayout,
@@ -576,7 +577,7 @@ function resolveRoleBinding(envName, fallback) {
   return typeof explicit === "string" && explicit.trim() ? explicit.trim() : fallback;
 }
 
-function resolveEffectiveDispatchModel({ cliModel, manifestModelHints, cliModelHints }) {
+function resolveEffectiveDispatchModel({ cliModel, manifestModelHints, cliModelHints, executorDefaultModel }) {
   if (cliModel) return cliModel;
   if (manifestModelHints && typeof manifestModelHints.dispatch === "string" && manifestModelHints.dispatch.trim()) {
     return manifestModelHints.dispatch;
@@ -584,6 +585,10 @@ function resolveEffectiveDispatchModel({ cliModel, manifestModelHints, cliModelH
   if (cliModelHints && typeof cliModelHints.dispatch === "string" && cliModelHints.dispatch.trim()) {
     return cliModelHints.dispatch;
   }
+  const defaultModel = typeof executorDefaultModel === "function"
+    ? executorDefaultModel()
+    : executorDefaultModel;
+  if (defaultModel) return defaultModel;
   return null;
 }
 
@@ -787,6 +792,7 @@ async function main() {
     cliModel: MODEL,
     manifestModelHints: manifest?.model_hints,
     cliModelHints: MODEL_HINTS,
+    executorDefaultModel: () => resolveExecutorDefaultModel(EXECUTOR, { relayHome: RELAY_HOME }),
   });
   const provider = typeof adapter.parseProvider === "function"
     ? (adapter.parseProvider(effectiveDispatchModel) ?? adapter.providerDefault ?? null)

--- a/skills/relay-dispatch/scripts/executor-model-config.js
+++ b/skills/relay-dispatch/scripts/executor-model-config.js
@@ -1,0 +1,128 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const BUNDLED_EXECUTOR_MODEL_CONFIG = path.join(__dirname, "..", "references", "executor-models.json");
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readJsonConfig(filePath, { optional = false } = {}) {
+  if (optional && !fs.existsSync(filePath)) return {};
+
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (error) {
+    if (optional) {
+      console.error(`Warning: ignoring optional executor model config at ${filePath}: ${error.message}`);
+      return {};
+    }
+    throw new Error(`failed to read executor model config at ${filePath}: ${error.message}`);
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    if (optional) {
+      console.error(`Warning: ignoring optional executor model config at ${filePath}: ${error.message}`);
+      return {};
+    }
+    throw new Error(`failed to parse executor model config at ${filePath}: ${error.message}`);
+  }
+}
+
+function validateExecutorModelConfig(config, filePath) {
+  if (!isPlainObject(config)) {
+    throw new Error(`invalid executor model config at ${filePath}: expected object`);
+  }
+  if (config.executors === undefined) return config;
+  if (!isPlainObject(config.executors)) {
+    throw new Error(`invalid executor model config at ${filePath}: executors must be an object`);
+  }
+
+  for (const [executor, executorConfig] of Object.entries(config.executors)) {
+    if (!isPlainObject(executorConfig)) {
+      throw new Error(`invalid executor model config at ${filePath}: executors.${executor} must be an object`);
+    }
+    if (
+      executorConfig.default_model !== undefined &&
+      (typeof executorConfig.default_model !== "string" || !executorConfig.default_model.trim())
+    ) {
+      throw new Error(`invalid executor model config at ${filePath}: executors.${executor}.default_model must be a non-empty string`);
+    }
+    if (executorConfig.candidate_models !== undefined) {
+      if (!Array.isArray(executorConfig.candidate_models)) {
+        throw new Error(`invalid executor model config at ${filePath}: executors.${executor}.candidate_models must be an array`);
+      }
+      for (const [index, model] of executorConfig.candidate_models.entries()) {
+        if (typeof model !== "string" || !model.trim()) {
+          throw new Error(
+            `invalid executor model config at ${filePath}: executors.${executor}.candidate_models[${index}] must be a non-empty string`
+          );
+        }
+      }
+    }
+  }
+
+  return config;
+}
+
+function readOptionalExecutorModelConfig(filePath) {
+  try {
+    return validateExecutorModelConfig(readJsonConfig(filePath, { optional: true }), filePath);
+  } catch (error) {
+    console.error(`Warning: ignoring optional executor model config at ${filePath}: ${error.message}`);
+    return {};
+  }
+}
+
+function mergeExecutorModelConfigs(base, override) {
+  const merged = {
+    ...base,
+    executors: {
+      ...(base.executors || {}),
+    },
+  };
+
+  for (const [executor, executorConfig] of Object.entries(override.executors || {})) {
+    merged.executors[executor] = {
+      ...(merged.executors[executor] || {}),
+      ...executorConfig,
+    };
+  }
+
+  return merged;
+}
+
+function resolveLocalExecutorModelConfigPath(relayHome) {
+  const home = relayHome || process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
+  return path.join(home, "executors.json");
+}
+
+function loadExecutorModelConfig({ relayHome, bundledPath = BUNDLED_EXECUTOR_MODEL_CONFIG, localPath } = {}) {
+  const bundled = validateExecutorModelConfig(readJsonConfig(bundledPath), bundledPath);
+  const resolvedLocalPath = localPath || resolveLocalExecutorModelConfigPath(relayHome);
+  const local = readOptionalExecutorModelConfig(resolvedLocalPath);
+  return mergeExecutorModelConfigs(bundled, local);
+}
+
+function resolveExecutorDefaultModel(executor, options = {}) {
+  const bundledPath = options.bundledPath || BUNDLED_EXECUTOR_MODEL_CONFIG;
+  const bundled = validateExecutorModelConfig(readJsonConfig(bundledPath), bundledPath);
+  const resolvedLocalPath = options.localPath || resolveLocalExecutorModelConfigPath(options.relayHome);
+  const local = readOptionalExecutorModelConfig(resolvedLocalPath);
+  const config = mergeExecutorModelConfigs(bundled, local);
+  const value = config.executors?.[executor]?.default_model;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+module.exports = {
+  BUNDLED_EXECUTOR_MODEL_CONFIG,
+  loadExecutorModelConfig,
+  mergeExecutorModelConfigs,
+  resolveExecutorDefaultModel,
+  resolveLocalExecutorModelConfigPath,
+  validateExecutorModelConfig,
+};

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1480,6 +1480,237 @@ test("dispatch opencode executor records provider metadata", () => {
   assert.equal(manifest.dispatch.last_provider, "openai");
 });
 
+test("dispatch opencode executor uses bundled default model when no override is supplied", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-bundled-default.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "test bundled opencode default";
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-opencode-bundled-default",
+    "-p", taskPrompt,
+    "-e", "opencode",
+    "--json",
+  ], env));
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "run",
+    "-m", "opencode-go/deepseek-v4-pro",
+    buildDispatchExecPrompt(taskPrompt),
+  ]);
+
+  const dispatchStart = readJsonLines(path.join(result.runDir, "events.jsonl"))
+    .find((event) => event.event === "dispatch_start");
+  assert.equal(dispatchStart.model, "opencode-go/deepseek-v4-pro");
+  assert.equal(dispatchStart.provider, "opencode-go");
+});
+
+test("dispatch opencode executor lets RELAY_HOME executors config override bundled model", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  fs.writeFileSync(path.join(relayHome, "executors.json"), JSON.stringify({
+    executors: {
+      opencode: {
+        default_model: "opencode-go/qwen3.6-plus",
+        candidate_models: ["opencode-go/qwen3.6-plus"],
+      },
+    },
+  }, null, 2), "utf-8");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-local-default.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "test local opencode default";
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-opencode-local-default",
+    "-p", taskPrompt,
+    "-e", "opencode",
+    "--json",
+  ], env));
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "run",
+    "-m", "opencode-go/qwen3.6-plus",
+    buildDispatchExecPrompt(taskPrompt),
+  ]);
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.dispatch.last_model, "opencode-go/qwen3.6-plus");
+  assert.equal(manifest.dispatch.last_provider, "opencode-go");
+});
+
+test("dispatch lets local executor config define defaults for executors absent from bundled config", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  fs.writeFileSync(path.join(relayHome, "executors.json"), JSON.stringify({
+    executors: {
+      codex: {
+        default_model: "gpt-5.5",
+      },
+    },
+  }, null, 2), "utf-8");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-codex-local-default.json`);
+  writeArgCaptureCodex(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-codex-local-default",
+    "-p", "codex local default model",
+    "--json",
+  ], env));
+  const args = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+
+  assert.equal(result.status, "completed");
+  assert.equal(args[args.indexOf("-m") + 1], "gpt-5.5");
+});
+
+test("dispatch codex executor ignores malformed local executor model config", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  fs.writeFileSync(path.join(relayHome, "executors.json"), "{not-json", "utf-8");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-codex-malformed-local-model-config.json`);
+  writeArgCaptureCodex(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "codex should ignore unrelated malformed executor config";
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-codex-ignore-malformed-model-config",
+    "-p", taskPrompt,
+    "--json",
+  ], env));
+  const args = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+
+  assert.equal(result.status, "completed");
+  assert.equal(args.includes("-m"), false);
+});
+
+test("dispatch opencode default model falls back to bundled config when local config schema is invalid", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  fs.writeFileSync(path.join(relayHome, "executors.json"), JSON.stringify({
+    executors: {
+      opencode: {
+        default_model: 123,
+      },
+    },
+  }), "utf-8");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-invalid-local-default.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "invalid local config should fall back to bundled opencode default";
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-opencode-invalid-local-default",
+    "-p", taskPrompt,
+    "-e", "opencode",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  assert.match(proc.stderr, /Warning: ignoring optional executor model config/);
+  assert.match(proc.stderr, /default_model must be a non-empty string/);
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "run",
+    "-m", "opencode-go/deepseek-v4-pro",
+    buildDispatchExecPrompt(taskPrompt),
+  ]);
+});
+
+test("dispatch opencode explicit --model skips malformed local executor model config", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  fs.writeFileSync(path.join(relayHome, "executors.json"), "{not-json", "utf-8");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-explicit-malformed-local.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "explicit opencode model should ignore malformed default config";
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-opencode-explicit-ignore-malformed-model-config",
+    "-p", taskPrompt,
+    "-e", "opencode",
+    "-m", "opencode-go/qwen3.6-plus",
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "run",
+    "-m", "opencode-go/qwen3.6-plus",
+    buildDispatchExecPrompt(taskPrompt),
+  ]);
+});
+
+test("dispatch opencode default model falls back to bundled config when local config is malformed", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  fs.writeFileSync(path.join(relayHome, "executors.json"), "{not-json", "utf-8");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-malformed-local-default.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+  const taskPrompt = "malformed local config should fall back to bundled opencode default";
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-opencode-malformed-local-default",
+    "-p", taskPrompt,
+    "-e", "opencode",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  assert.match(proc.stderr, /Warning: ignoring optional executor model config/);
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "run",
+    "-m", "opencode-go/deepseek-v4-pro",
+    buildDispatchExecPrompt(taskPrompt),
+  ]);
+});
+
 function reasoningArgValue(args) {
   const index = args.indexOf("-c");
   return index === -1 ? null : args[index + 1];

--- a/tests/relay-dispatch/scripts/executor-model-config.test.js
+++ b/tests/relay-dispatch/scripts/executor-model-config.test.js
@@ -1,0 +1,112 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  loadExecutorModelConfig,
+  resolveExecutorDefaultModel,
+  validateExecutorModelConfig,
+} = require("../../../skills/relay-dispatch/scripts/executor-model-config");
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+  return filePath;
+}
+
+function withCapturedStderr(fn) {
+  const original = console.error;
+  const messages = [];
+  console.error = (message) => messages.push(String(message));
+  try {
+    return { result: fn(), messages };
+  } finally {
+    console.error = original;
+  }
+}
+
+test("validateExecutorModelConfig rejects invalid schema shapes", () => {
+  assert.throws(
+    () => validateExecutorModelConfig([], "bad.json"),
+    /expected object/
+  );
+  assert.throws(
+    () => validateExecutorModelConfig({ executors: [] }, "bad.json"),
+    /executors must be an object/
+  );
+  assert.throws(
+    () => validateExecutorModelConfig({ executors: { opencode: [] } }, "bad.json"),
+    /executors\.opencode must be an object/
+  );
+  assert.throws(
+    () => validateExecutorModelConfig({ executors: { opencode: { default_model: " " } } }, "bad.json"),
+    /default_model must be a non-empty string/
+  );
+  assert.throws(
+    () => validateExecutorModelConfig({ executors: { opencode: { candidate_models: "model" } } }, "bad.json"),
+    /candidate_models must be an array/
+  );
+  assert.throws(
+    () => validateExecutorModelConfig({ executors: { opencode: { candidate_models: ["ok", ""] } } }, "bad.json"),
+    /candidate_models\[1\] must be a non-empty string/
+  );
+});
+
+test("optional local schema errors are ignored with bundled fallback", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-executor-model-config-"));
+  const localPath = writeJson(path.join(dir, "executors.json"), {
+    executors: {
+      opencode: {
+        default_model: 123,
+      },
+    },
+  });
+
+  const { result, messages } = withCapturedStderr(() => resolveExecutorDefaultModel("opencode", { localPath }));
+
+  assert.equal(result, "opencode-go/deepseek-v4-pro");
+  assert.equal(messages.length, 1);
+  assert.match(messages[0], /Warning: ignoring optional executor model config/);
+  assert.match(messages[0], /default_model must be a non-empty string/);
+});
+
+test("local config can introduce defaults for executors absent from the bundled config", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-executor-model-config-"));
+  const localPath = writeJson(path.join(dir, "executors.json"), {
+    executors: {
+      codex: {
+        default_model: "gpt-5.5",
+      },
+    },
+  });
+
+  assert.equal(resolveExecutorDefaultModel("codex", { localPath }), "gpt-5.5");
+});
+
+test("loadExecutorModelConfig merges bundled and local executor entries", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-executor-model-config-"));
+  const localPath = writeJson(path.join(dir, "executors.json"), {
+    executors: {
+      opencode: {
+        default_model: "opencode-go/qwen3.6-plus",
+      },
+      codex: {
+        default_model: "gpt-5.5",
+      },
+    },
+  });
+
+  const config = loadExecutorModelConfig({ localPath });
+
+  assert.equal(config.executors.opencode.default_model, "opencode-go/qwen3.6-plus");
+  assert.deepEqual(config.executors.opencode.candidate_models, [
+    "opencode-go/deepseek-v4-pro",
+    "opencode-go/deepseek-v4-flash",
+    "opencode-go/qwen3.6-plus",
+    "opencode-go/qwen3.5-plus",
+    "opencode-go/kimi-k2.6",
+    "opencode-go/glm-5.1",
+  ]);
+  assert.equal(config.executors.codex.default_model, "gpt-5.5");
+});

--- a/tests/relay-dispatch/scripts/opencode-live.test.js
+++ b/tests/relay-dispatch/scripts/opencode-live.test.js
@@ -1,0 +1,35 @@
+const { spawnSync } = require("child_process");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const ENABLED = process.env.OPENCODE_INTEGRATION === "1";
+const MODEL = process.env.OPENCODE_MODEL || "opencode-go/deepseek-v4-pro";
+
+function runOpencode(args, options = {}) {
+  return spawnSync("opencode", args, {
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: options.timeout || 120000,
+  });
+}
+
+test("opencode live smoke runs the configured model", { skip: ENABLED ? false : "set OPENCODE_INTEGRATION=1 to run live opencode smoke" }, () => {
+  const version = runOpencode(["--version"], { timeout: 10000 });
+  assert.equal(version.status, 0, version.stderr || version.error?.message);
+
+  const provider = MODEL.split("/")[0];
+  assert.ok(provider, "OPENCODE_MODEL must use provider/model format");
+
+  const models = runOpencode(["models", provider], { timeout: 30000 });
+  assert.equal(models.status, 0, models.stderr || models.error?.message);
+  assert.match(models.stdout, new RegExp(`(^|\\n)${MODEL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\n|$)`));
+
+  const result = runOpencode([
+    "run",
+    "-m",
+    MODEL,
+    "Do not edit files. Reply exactly OPENCODE_LIVE_OK and nothing else.",
+  ]);
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+  assert.match(result.stdout, /OPENCODE_LIVE_OK/);
+});


### PR DESCRIPTION
## Summary
- add bundled opencode executor model defaults under relay-dispatch references
- add optional ~/.relay/executors.json override loading for executor defaults
- lazy-load executor model config only when fallback defaults are needed
- add opt-in live opencode smoke coverage

## Tests
- node --check skills/relay-dispatch/scripts/executor-model-config.js && node --check skills/relay-dispatch/scripts/dispatch.js && node --check tests/relay-dispatch/scripts/opencode-live.test.js
- node --test tests/relay-dispatch/scripts/executors.test.js tests/relay-dispatch/scripts/dispatch.test.js tests/relay-dispatch/scripts/opencode-live.test.js
- OPENCODE_INTEGRATION=1 OPENCODE_MODEL=opencode-go/deepseek-v4-pro node --test tests/relay-dispatch/scripts/opencode-live.test.js