### PR TITLE
Add opencode advisory review lane

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -85,6 +85,7 @@ roles:
 model_hints:
   dispatch: opus                # optional per-phase advisory model preference
   review: haiku                 # optional per-phase advisory model preference
+  advisory_review: opencode-go/deepseek-v4-pro  # optional non-gating advisory reviewer model
 
 paths:
   repo_root: /Users/me/project
@@ -144,7 +145,7 @@ bootstrap_exempt:
 | Field | Purpose |
 |-------|---------|
 | `roles.*` | Immutable per-run binding. Decouples who decides, who implements, who validates |
-| `model_hints.*` | Optional advisory per-phase model preference. Current runtime consumers: `dispatch`, `review` |
+| `model_hints.*` | Optional advisory per-phase model preference. Current runtime consumers: `dispatch`, `review`, `advisory_review` |
 | `dispatch.last_model` / executor config | Dispatch records the effective model. If no explicit model hint is present, executor defaults come from the skill-bundled `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json` overrides |
 | `policy.merge` | `manual_after_lgtm` — orchestrator must explicitly merge |
 | `policy.reviewer_write` | `forbid` — review runner rejects rounds where reviewer mutated files |
@@ -178,12 +179,13 @@ Semantics:
 
 ## Event Journal
 
-Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `pr_number`, `bootstrap_exempt`, `model`, `executor_network`, `failure_class`, `before`, `after`):
+Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `pr_number`, `bootstrap_exempt`, `model`, `executor_network`, `failure_class`, `before`, `after`, `profile`, `status`, `artifact_path`, `raw_response_path`, `elapsed_ms`, `failure_reason`):
 
 ```jsonl
 {"ts":"2026-04-18T12:00:00.000Z","event":"dispatch_start","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"draft","state_to":"dispatched","head_sha":"abc123","round":null,"reason":"new_dispatch","model":"gpt-5-codex","executor_network":{"access":"enabled","mechanism":"sandbox_workspace_write.network_access","domains":null}}
 {"ts":"2026-04-18T12:05:00.000Z","event":"dispatch_result","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"dispatched","state_to":"review_pending","head_sha":"def456","round":null,"reason":"new_dispatch:completed","executor_network":{"access":"enabled","mechanism":"sandbox_workspace_write.network_access","domains":null},"failure_class":null}
 {"ts":"2026-04-18T12:10:00.000Z","event":"review_invoke","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"review_pending","head_sha":"def456","round":1,"reason":"codex","model":"haiku"}
+{"ts":"2026-04-18T12:11:00.000Z","event":"advisory_review","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"review_pending","head_sha":"def456","round":1,"reason":null,"reviewer":"opencode","model":"opencode-go/deepseek-v4-pro","profile":"blindspot","status":"success","artifact_path":"~/.relay/runs/project-abcd1234/issue-42-20260418120000000/review-round-1-advisory-opencode.json","raw_response_path":"~/.relay/runs/project-abcd1234/issue-42-20260418120000000/review-round-1-advisory-opencode-raw-response.txt","required_count":0,"advisory_count":1,"duplicate_low_confidence_count":0,"elapsed_ms":42000,"failure_reason":null}
 {"ts":"2026-04-18T12:12:00.000Z","event":"review_apply","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"changes_requested","head_sha":"def456","round":1,"reviewer":"codex","reason":"changes_requested"}
 {"ts":"2026-04-18T12:40:00.000Z","event":"review_apply","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"ready_to_merge","head_sha":"ghi789","round":2,"reviewer":"codex","reason":"pass"}
 {"ts":"2026-04-18T12:45:00.000Z","event":"merge_finalize","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"ready_to_merge","state_to":"merged","head_sha":"ghi789","round":2,"reason":"squash"}
@@ -198,6 +200,7 @@ Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/e
 | `close`, `cleanup_result` | `relay-dispatch/scripts/close-run.js`, `cleanup-worktrees.js` |
 | `state_recovery` | `relay-dispatch/scripts/recover-state.js` |
 | `review_invoke` | `relay-review/scripts/review-runner/reviewer-invoke.js` |
+| `advisory_review` | `relay-review/scripts/review-runner/advisory.js` |
 | `review_apply` | `relay-review/scripts/review-runner.js`, `reviewer-invoke.js` |
 | `pr_number_stamped`, `merge_blocked`, `skip_review`, `force_finalize`, `merge_finalize`, `cleanup_result` | `relay-merge/scripts/finalize-run.js`, `relay-reconcile-artifact.js`, `gate-check.js` |
 | `request_persisted`, `proposal_presented`, `question_asked`, `question_answered`, `proposal_accepted`, `proposal_edited`, `relay_ready_handoff_persisted` | `relay-intake/scripts/relay-request.js` |
@@ -219,6 +222,10 @@ Each round produces files under `~/.relay/runs/<repo-slug>/<run-id>/`:
 | `review-round-N-raw-response.txt` | Raw reviewer output |
 | `review-round-N-redispatch.md` | Fix prompt (when changes requested) |
 | `review-round-N-policy-violation.txt` | If reviewer mutated code |
+| `review-round-N-advisory-<reviewer>-prompt.md` | Optional non-gating advisory prompt |
+| `review-round-N-advisory-<reviewer>-raw-response.txt` | Optional advisory raw output |
+| `review-round-N-advisory-<reviewer>.json` | Optional validated advisory findings |
+| `review-round-N-advisory-<reviewer>-policy-violation.txt` | If advisory reviewer mutated code; recorded without manifest escalation in v1 |
 
 ## Module Boundaries (and what they are NOT)
 
@@ -275,9 +282,11 @@ Do not "simplify" the facade by collapsing submodules back into it or by force-m
    node invoke-reviewer-<name>.js --repo <repoPath> --prompt-file <promptPath> --json [--model <name>]
    ```
    The `<promptPath>` bundle already contains the diff, Done Criteria, and rubric — adapters read that single prompt file, not separate `--diff-file` / `--done-criteria-file` flags.
-3. It must print a JSON verdict to **stdout** matching `REVIEW_VERDICT_JSON_SCHEMA` in `skills/relay-review/scripts/review-schema.js`. `review-runner` captures stdout via `execFileSync({ stdio: "pipe" })` and writes it to `review-round-N-raw-response.txt`; adapters must not write their own output files or mutate the repo.
+3. Trusted primary adapters must print a JSON verdict to **stdout** matching `REVIEW_VERDICT_JSON_SCHEMA` in `skills/relay-review/scripts/review-schema.js`. `review-runner` captures stdout via `execFileSync({ stdio: "pipe" })` and writes it to `review-round-N-raw-response.txt`; adapters must not write their own output files or mutate the repo.
 4. `review-runner.js` auto-discovers adapters via `resolveReviewerScript()` by naming convention: `invoke-reviewer-<name>.js`. The `<name>` must match `/^[a-z0-9-]+$/`.
 5. Existing adapters share small utilities (`getArg`, `hasFlag`, `summarizeFailure`, `ensureJsonText`) but NOT full execution logic — each adapter encodes its own execution contract (e.g. Claude uses `--json-schema` + stdout recovery; Codex uses temp-file exchange + `--ephemeral` + sandbox). New adapters should extract only the small utilities.
+
+`invoke-reviewer-opencode.js` is currently advisory-only: `review-runner --advisory-reviewer opencode` invokes it with a separate blind-spot prompt and validates output through `advisory-review-schema.js`, not the trusted verdict schema. Do not use opencode as the primary `--reviewer` until a trusted verdict adapter exists for it.
 
 ### Shared utilities (cross-skill)
 
@@ -292,10 +301,10 @@ Current shared helpers:
 
 | Module | Owner | Consumers |
 |--------|-------|-----------|
-| `skills/relay-dispatch/scripts/cli-args.js` | relay-dispatch | `review-runner.js`, `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `finalize-run.js`, `persist-request.js`, `probe-executor-env.js` |
-| `skills/relay-review/scripts/reviewer-helpers.js` | relay-review | `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js` |
+| `skills/relay-dispatch/scripts/cli-args.js` | relay-dispatch | `review-runner.js`, `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `invoke-reviewer-opencode.js`, `finalize-run.js`, `persist-request.js`, `probe-executor-env.js` |
+| `skills/relay-review/scripts/reviewer-helpers.js` | relay-review | `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `invoke-reviewer-opencode.js` |
 
-`reviewer-helpers.js` is scoped to `summarizeFailure` and `ensureJsonText`. The two reviewer adapters intentionally keep divergent execution contracts (Claude uses `--json-schema` + stdout recovery; Codex uses temp schema/result files + `--ephemeral` + sandbox), so a full adapter factory would hide meaningful differences and make it harder to add a third executor. See item 5 under "Adding a new reviewer adapter" above.
+`reviewer-helpers.js` is scoped to `summarizeFailure` and `ensureJsonText`. Reviewer adapters intentionally keep divergent execution contracts (Claude uses `--json-schema` + stdout recovery; Codex uses temp schema/result files + `--ephemeral` + sandbox; opencode is advisory-only with prompt-enforced read-only behavior), so a full adapter factory would hide meaningful differences. See item 5 under "Adding a new reviewer adapter" above.
 
 Call sites take a local-wrapper pattern so inline flag lists (`KNOWN_FLAGS`) keep acting as fail-closed `reservedFlags`:
 

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -18,6 +18,10 @@ const FLAGS = [
   { flag: "--all", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--allow-conflicting-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Operator override for the in-flight-run check; logs a conflicting_run_override event." },
   { flag: "--allow-same-head", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit same-HEAD recovery opt-in; no value is consumed." },
+  { flag: "--advisory-profile", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed advisory review profile selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--advisory-reviewer", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Optional advisory reviewer adapter selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--advisory-reviewer-model", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Advisory reviewer model selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--advisory-timeout", kind: VALUE, mode: MODE_PARSED, valueName: "<seconds>", rationale: "Advisory reviewer timeout; flag-like following tokens should mean the value is missing." },
   { flag: "--auto-recover-commit", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit dispatch opt-in to run recover-commit after completed-uncommitted; no value is consumed." },
   { flag: "--artifact-path", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path being reconciled; keep the literal argv token." },
   { flag: "--branch", aliases: ["-b"], kind: VALUE, mode: MODE_VERBATIM, valueName: "<name>", rationale: "Git branch names are operator-supplied and may legally begin with --." },
@@ -134,6 +138,9 @@ const COMMAND_FLAGS = {
   "invoke-reviewer-codex": [
     "--repo", "--prompt-file", "--model", "--json", "--help",
   ],
+  "invoke-reviewer-opencode": [
+    "--repo", "--prompt-file", "--model", "--json", "--help",
+  ],
   "persist-done-criteria": [
     "--repo", "--run-id", "--text", "--file", "--json", "--help",
   ],
@@ -165,7 +172,9 @@ const COMMAND_FLAGS = {
   "review-runner": [
     "--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file",
     "--diff-file", "--review-file", "--reviewer", "--reviewer-script",
-    "--reviewer-model", "--prepare-only", "--no-comment", "--json", "--help",
+    "--reviewer-model", "--advisory-reviewer", "--advisory-profile",
+    "--advisory-reviewer-model", "--advisory-timeout", "--prepare-only",
+    "--no-comment", "--json", "--help",
   ],
   "update-manifest-state": [
     "--manifest", "--repo", "--run-id", "--branch", "--state", "--next-action",

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -15,6 +15,7 @@ const {
 // absent: current producer code no longer emits them, and readRunEvents remains tolerant
 // because validation is write-only.
 const EVENTS = Object.freeze({
+  ADVISORY_REVIEW: "advisory_review",
   CLEANUP_RESULT: "cleanup_result",
   CLOSE: "close",
   CONFLICTING_RUN_OVERRIDE: "conflicting_run_override",
@@ -184,6 +185,33 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
     ...(eventData.guidance_artifact_path !== undefined
       ? { guidance_artifact_path: normalizeEventValue(eventData.guidance_artifact_path) }
+      : {}),
+    ...(eventData.profile !== undefined
+      ? { profile: normalizeEventValue(eventData.profile) }
+      : {}),
+    ...(eventData.status !== undefined
+      ? { status: normalizeEventValue(eventData.status) }
+      : {}),
+    ...(eventData.artifact_path !== undefined
+      ? { artifact_path: normalizeEventValue(eventData.artifact_path) }
+      : {}),
+    ...(eventData.raw_response_path !== undefined
+      ? { raw_response_path: normalizeEventValue(eventData.raw_response_path) }
+      : {}),
+    ...(eventData.required_count !== undefined
+      ? { required_count: normalizeEventValue(eventData.required_count) }
+      : {}),
+    ...(eventData.advisory_count !== undefined
+      ? { advisory_count: normalizeEventValue(eventData.advisory_count) }
+      : {}),
+    ...(eventData.duplicate_low_confidence_count !== undefined
+      ? { duplicate_low_confidence_count: normalizeEventValue(eventData.duplicate_low_confidence_count) }
+      : {}),
+    ...(eventData.elapsed_ms !== undefined
+      ? { elapsed_ms: normalizeEventValue(eventData.elapsed_ms) }
+      : {}),
+    ...(eventData.failure_reason !== undefined
+      ? { failure_reason: normalizeEventValue(eventData.failure_reason) }
       : {}),
   };
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -58,6 +58,20 @@ Notes:
 - Model precedence for reviewer invocation is `--reviewer-model` -> `manifest.model_hints.review` -> reviewer default.
 - When the runner invokes the reviewer itself, it records a `review_invoke` event with the effective `model` value (or `null` when unset).
 
+Optional advisory path: add an opencode-powered blind-spot lane alongside the primary reviewer:
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" \
+  --reviewer codex \
+  --advisory-reviewer opencode \
+  --advisory-profile blindspot \
+  --json
+```
+
+Advisory review is non-gating. Runner-managed advisory invocation starts concurrently with the primary reviewer and records `advisory_review` plus `review-round-N-advisory-<reviewer>-*` artifacts. Advisory findings are not merged into the trusted verdict or redispatch prompt in v1. Advisory failure, timeout, invalid JSON, or write-policy violation is recorded without changing the primary review outcome. Use `--advisory-reviewer-model` to override the model; otherwise opencode uses the same executor model defaults as dispatch (`skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json`).
+
+Current advisory profiles:
+- `blindspot`: look for likely misses from the primary review such as test gaps, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.
+
 4. Fallback path for unsupported environments or debugging:
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/review-runner.js --repo . --branch "$BRANCH" --pr "$PR_NUM" --prepare-only --json

--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -1,0 +1,94 @@
+const ADVISORY_PROFILES = Object.freeze(["blindspot"]);
+const ADVISORY_SEVERITIES = new Set(["P1", "P2", "P3"]);
+const ADVISORY_CATEGORIES = new Set([
+  "test-gap",
+  "bypass",
+  "edge-case",
+  "integration",
+  "docs",
+  "other",
+]);
+
+function parseJsonObject(text, context) {
+  let parsed;
+  try {
+    parsed = JSON.parse(String(text || "").trim());
+  } catch (error) {
+    throw new Error(`${context} did not return valid JSON: ${error.message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${context} must return a JSON object`);
+  }
+  return parsed;
+}
+
+function requireString(value, location) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${location} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function requireFinding(value, location) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${location} must be an object`);
+  }
+  const severity = requireString(value.severity, `${location}.severity`);
+  const category = requireString(value.category, `${location}.category`);
+  const confidence = value.confidence;
+  if (!ADVISORY_SEVERITIES.has(severity)) {
+    throw new Error(`${location}.severity must be one of: P1, P2, P3`);
+  }
+  if (!ADVISORY_CATEGORIES.has(category)) {
+    throw new Error(`${location}.category must be one of: ${[...ADVISORY_CATEGORIES].join(", ")}`);
+  }
+  if (typeof confidence !== "number" || !Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new Error(`${location}.confidence must be a number from 0 to 1`);
+  }
+  return {
+    title: requireString(value.title, `${location}.title`),
+    body: requireString(value.body, `${location}.body`),
+    file: requireString(value.file, `${location}.file`),
+    line: Number.isInteger(value.line) && value.line > 0 ? value.line : null,
+    severity,
+    category,
+    confidence,
+  };
+}
+
+function normalizeFindingArray(value, location) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${location} must be an array`);
+  }
+  return value.map((finding, index) => requireFinding(finding, `${location}[${index}]`));
+}
+
+function validateAdvisoryProfile(profile) {
+  const normalized = String(profile || "blindspot").trim();
+  if (!ADVISORY_PROFILES.includes(normalized)) {
+    throw new Error(`Unknown advisory profile '${profile}'. Supported profiles: ${ADVISORY_PROFILES.join(", ")}`);
+  }
+  return normalized;
+}
+
+function parseAdvisoryReview(text, { profile = "blindspot" } = {}) {
+  const expectedProfile = validateAdvisoryProfile(profile);
+  const parsed = parseJsonObject(text, "Advisory reviewer");
+  const actualProfile = requireString(parsed.profile, "profile");
+  if (actualProfile !== expectedProfile) {
+    throw new Error(`profile must be '${expectedProfile}', got '${actualProfile}'`);
+  }
+  return {
+    profile: actualProfile,
+    summary: requireString(parsed.summary, "summary"),
+    required_findings: normalizeFindingArray(parsed.required_findings, "required_findings"),
+    advisory_findings: normalizeFindingArray(parsed.advisory_findings, "advisory_findings"),
+    duplicate_or_low_confidence: normalizeFindingArray(parsed.duplicate_or_low_confidence, "duplicate_or_low_confidence"),
+  };
+}
+
+module.exports = {
+  ADVISORY_PROFILES,
+  parseAdvisoryReview,
+  validateAdvisoryProfile,
+};

--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -45,11 +45,18 @@ function requireFinding(value, location) {
   if (typeof confidence !== "number" || !Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
     throw new Error(`${location}.confidence must be a number from 0 to 1`);
   }
+  let line = null;
+  if (value.line !== undefined && value.line !== null) {
+    if (!Number.isInteger(value.line) || value.line <= 0) {
+      throw new Error(`${location}.line must be a positive integer or null`);
+    }
+    line = value.line;
+  }
   return {
     title: requireString(value.title, `${location}.title`),
     body: requireString(value.body, `${location}.body`),
     file: requireString(value.file, `${location}.file`),
-    line: Number.isInteger(value.line) && value.line > 0 ? value.line : null,
+    line,
     severity,
     category,
     confidence,

--- a/skills/relay-review/scripts/invoke-reviewer-opencode.js
+++ b/skills/relay-review/scripts/invoke-reviewer-opencode.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Invoke opencode as a structured advisory reviewer.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const {
+  bindCliArgs,
+  modeLabel,
+} = require("../../relay-dispatch/scripts/cli-args");
+const { summarizeFailure, ensureJsonText } = require("./reviewer-helpers");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
+const cliArgs = bindCliArgs(args, {
+  commandName: "invoke-reviewer-opencode",
+  reservedFlags: KNOWN_FLAGS,
+});
+
+if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
+  console.log("Usage: invoke-reviewer-opencode.js --repo <path> --prompt-file <path> [--model <name>] [--json]");
+  console.log("\nOptions:");
+  console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
+  console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
+  console.log(`  --model <name>       ${modeLabel("--model")} Model override`);
+  console.log(`  --json               ${modeLabel("--json")} Output JSON`);
+  process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
+}
+
+function main() {
+  const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
+  const promptFile = cliArgs.getArg("--prompt-file");
+  const model = cliArgs.getArg("--model");
+  const opencodeBin = process.env.RELAY_OPENCODE_BIN || "opencode";
+
+  if (!promptFile) {
+    throw new Error("--prompt-file is required");
+  }
+
+  const promptText = fs.readFileSync(promptFile, "utf-8").trim();
+  const fullPrompt = [
+    "[NON-INTERACTIVE ADVISORY REVIEW]",
+    "Return only JSON matching the advisory review shape in the prompt.",
+    "Do not wrap the response in markdown fences.",
+    "Do not modify files, create commits, or write comments. Treat the checkout as read-only.",
+    "",
+    promptText,
+  ].join("\n");
+
+  const execArgs = ["run"];
+  if (model) execArgs.push("-m", model);
+  execArgs.push(fullPrompt);
+
+  let result;
+  try {
+    result = execFileSync(opencodeBin, execArgs, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      stdio: "pipe",
+      maxBuffer: 10 * 1024 * 1024,
+    }).trim();
+  } catch (error) {
+    const recovered = String(error.stdout || "").trim();
+    if (!recovered) {
+      throw new Error(`opencode advisory reviewer failed: ${summarizeFailure(error)}`);
+    }
+    result = recovered;
+  }
+
+  if (!result) {
+    throw new Error("opencode advisory reviewer did not produce a structured result");
+  }
+  ensureJsonText(result, "opencode advisory reviewer");
+
+  if (cliArgs.hasFlag("--json")) {
+    console.log(result);
+  } else {
+    process.stdout.write(result);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -21,6 +21,7 @@ const {
   resolveRemoteHost,
 } = require("./review-runner/context");
 const { buildPrompt, formatPriorVerdictSummary } = require("./review-runner/prompt");
+const { buildAdvisoryPrompt } = require("./review-runner/advisory-prompt");
 const { parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
 const { buildCommentBody, formatIssueList, formatScopeDrift, postComment } = require("./review-runner/comment");
 const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog, toIterationScoreEventEntry } = require("./review-runner/divergence");
@@ -39,65 +40,26 @@ const { applyPolicyViolationToManifest, applyVerdictToManifest } = require("./re
 const { writePrBodySnapshot } = require("./review-runner/pr-body-snapshot");
 const { loadReviewText, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
+const { finishAdvisoryReview, parsePositiveSeconds, resolveAdvisoryModel, startAdvisoryReview, validateAdvisoryProfile } = require("./review-runner/advisory");
+const { printResult, printUsage } = require("./review-runner/output");
 const {
   bindCliArgs,
   findUnknownFlags,
-  modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--reviewer", "--reviewer-script", "--reviewer-model", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--reviewer", "--reviewer-script", "--reviewer-model", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
   commandName: "review-runner",
   reservedFlags: KNOWN_FLAGS,
 });
 
 if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]))) {
-  console.log("Usage: review-runner.js --repo <path> (--run-id <id> | --branch <name> | --pr <number>) [options]");
-  console.log("\nPrepare or apply a structured relay review round.");
-  console.log("\nOptions:");
-  console.log(`  --repo <path>                ${modeLabel("--repo")} Repository root (default: .)`);
-  console.log(`  --run-id <id>                ${modeLabel("--run-id")} Relay run identifier`);
-  console.log(`  --branch <name>              ${modeLabel("--branch")} Working branch`);
-  console.log(`  --pr <number>                ${modeLabel("--pr")} PR number`);
-  console.log(`  --manifest <path>            ${modeLabel("--manifest")} Explicit manifest path`);
-  console.log(`  --done-criteria-file <path>  ${modeLabel("--done-criteria-file")} Use fixture file instead of gh issue fetch`);
-  console.log(`  --diff-file <path>           ${modeLabel("--diff-file")} Use fixture file instead of gh pr diff`);
-  console.log(`  --review-file <path>         ${modeLabel("--review-file")} Structured reviewer JSON verdict to apply`);
-  console.log(`  --reviewer <name>            ${modeLabel("--reviewer")} Reviewer adapter to invoke (codex|claude|...)`);
-  console.log(`  --reviewer-script <path>     ${modeLabel("--reviewer-script")} Override adapter script path`);
-  console.log(`  --reviewer-model <name>      ${modeLabel("--reviewer-model")} Reviewer model override`);
-  console.log(`  --prepare-only               ${modeLabel("--prepare-only")} Emit prompt bundle only; do not apply verdict`);
-  console.log(`  --no-comment                 ${modeLabel("--no-comment")} Do not post a PR comment`);
-  console.log(`  --json                       ${modeLabel("--json")} Output JSON`);
+  printUsage();
   process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
 }
 
-function printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState, prepareOnly, prNumber, promptPath, redispatchPath, result, updatedManifest, verdictPath }) {
-  if (jsonOut) {
-    console.log(JSON.stringify(result, null, 2));
-    return;
-  }
-
-  if (prepareOnly) {
-    console.log(`Prepared relay review round ${result.round}`);
-    console.log(`  Manifest:      ${manifestPath}`);
-    console.log(`  Prompt:        ${promptPath}`);
-    console.log(`  Done criteria: ${doneCriteriaPath}`);
-    console.log(`  Diff:          ${diffPath}`);
-    return;
-  }
-
-  console.log(`Applied relay review round ${result.round}`);
-  console.log(`  Manifest: ${manifestPath}`);
-  console.log(`  State:    ${originalState} -> ${updatedManifest.state}`);
-  console.log(`  Prompt:   ${promptPath}`);
-  console.log(`  Verdict:  ${verdictPath}`);
-  if (redispatchPath) console.log(`  Re-dispatch: ${redispatchPath}`);
-  if (result.commentPosted) console.log(`  PR comment posted to #${prNumber}`);
-}
-
-function run() {
+async function run() {
   const unknownFlags = findUnknownFlags(args, "review-runner");
   if (unknownFlags.length) {
     throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
@@ -115,9 +77,18 @@ function run() {
   const reviewerArg = cliArgs.getArg("--reviewer");
   const reviewerScriptArg = cliArgs.getArg("--reviewer-script");
   const reviewerModel = cliArgs.getArg("--reviewer-model");
+  const advisoryReviewerArg = cliArgs.getArg("--advisory-reviewer");
+  const advisoryProfileArg = cliArgs.getArg("--advisory-profile");
+  const advisoryReviewerModel = cliArgs.getArg("--advisory-reviewer-model");
+  const advisoryTimeoutArg = cliArgs.getArg("--advisory-timeout");
   const prepareOnly = cliArgs.hasFlag("--prepare-only");
   const noComment = cliArgs.hasFlag("--no-comment");
   const jsonOut = cliArgs.hasFlag("--json");
+  if (!advisoryReviewerArg && (advisoryProfileArg || advisoryReviewerModel || advisoryTimeoutArg)) {
+    throw new Error("--advisory-reviewer is required when advisory options are supplied");
+  }
+  const advisoryProfile = advisoryReviewerArg ? validateAdvisoryProfile(advisoryProfileArg || "blindspot") : null;
+  const advisoryTimeoutSeconds = advisoryReviewerArg ? parsePositiveSeconds(advisoryTimeoutArg) : null;
 
   const { branch, issueNumber, manifest, prNumber, reviewRepoPath, runRepoPath } = resolveContext(
     repoPath,
@@ -226,12 +197,37 @@ function run() {
     state: data.state,
     verdictPath: null,
   };
+  let advisoryRun = null;
+  let advisoryResult = null;
+  const finishAdvisoryOnce = async () => {
+    if (!advisoryRun || advisoryResult) return advisoryResult;
+    advisoryResult = await finishAdvisoryReview({
+      advisoryRun,
+      data,
+      headSha: reviewedHeadSha,
+      profile: advisoryProfile,
+      reviewRepoPath,
+      round,
+      runDir,
+      runRepoPath,
+      timeoutSeconds: advisoryTimeoutSeconds,
+    });
+    result.advisoryReview = advisoryResult;
+    return advisoryResult;
+  };
 
   if (prepareOnly) {
     printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath: null, result, updatedManifest: null, verdictPath: null });
     return;
   }
+  if (advisoryReviewerArg) {
+    const advisoryModel = resolveAdvisoryModel(data, advisoryReviewerArg, advisoryReviewerModel);
+    const advisoryPromptText = buildAdvisoryPrompt({ branch, diffText, doneCriteria, doneCriteriaSource, issueNumber, prNumber, profile: advisoryProfile, round, rubricLoad });
+    advisoryRun = startAdvisoryReview({ promptText: advisoryPromptText, reviewerModel: advisoryModel, reviewerName: advisoryReviewerArg, reviewRepoPath, round, runDir });
+    result.advisoryReview = { profile: advisoryProfile, reviewer: advisoryReviewerArg, status: "running" };
+  }
 
+  try {
   const { rawResponsePath, reviewText } = loadReviewText({
     body,
     data,
@@ -383,16 +379,19 @@ function run() {
   result.state = updatedManifest.state;
   result.verdictPath = verdictPath;
 
+  await finishAdvisoryOnce();
   printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath, result, updatedManifest, verdictPath });
+  } catch (error) {
+    await finishAdvisoryOnce();
+    throw error;
+  }
 }
 
 if (require.main === module) {
-  try {
-    run();
-  } catch (error) {
+  Promise.resolve(run()).catch((error) => {
     console.error(`Error: ${error.message}`);
     process.exit(1);
-  }
+  });
 }
 
 module.exports = {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -206,7 +206,6 @@ async function run() {
       data,
       headSha: reviewedHeadSha,
       profile: advisoryProfile,
-      reviewRepoPath,
       round,
       runDir,
       runRepoPath,

--- a/skills/relay-review/scripts/review-runner/advisory-prompt.js
+++ b/skills/relay-review/scripts/review-runner/advisory-prompt.js
@@ -1,0 +1,87 @@
+function formatRubricSummary(rubricLoad) {
+  if (!rubricLoad || rubricLoad.state !== "loaded") {
+    return "No rubric was loaded for this review round.";
+  }
+  return [
+    `Rubric status: ${rubricLoad.status || "unknown"}`,
+    "",
+    String(rubricLoad.content || "").trim(),
+  ].join("\n");
+}
+
+function buildAdvisoryPrompt({
+  branch,
+  diffText,
+  doneCriteria,
+  doneCriteriaSource,
+  issueNumber,
+  prNumber,
+  profile,
+  round,
+  rubricLoad,
+}) {
+  return [
+    "# Relay Advisory Blind-Spot Review",
+    "",
+    "You are an advisory reviewer, not the trusted merge-gating reviewer.",
+    "Return only JSON. Do not wrap the response in markdown fences.",
+    "Do not modify files, run fix commands, create commits, or write comments.",
+    "",
+    "Your job is to find important blind spots the primary reviewer may miss while checking the same PR.",
+    "Prioritize areas that are easy to under-review during a logic-focused pass: missing tests, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.",
+    "Separate high-confidence findings from speculative or duplicate observations. Do not issue an LGTM or merge verdict.",
+    "",
+    "## Required JSON Shape",
+    "",
+    JSON.stringify({
+      profile,
+      summary: "One sentence summary of advisory risk.",
+      required_findings: [{
+        title: "Required fix title",
+        body: "Why this must be fixed before merge.",
+        file: "path/to/file",
+        line: 1,
+        severity: "P1|P2|P3",
+        category: "test-gap|bypass|edge-case|integration|docs|other",
+        confidence: 0.9,
+      }],
+      advisory_findings: [{
+        title: "Useful non-blocking observation",
+        body: "Why this is worth considering.",
+        file: "path/to/file",
+        line: 1,
+        severity: "P2|P3",
+        category: "test-gap|bypass|edge-case|integration|docs|other",
+        confidence: 0.75,
+      }],
+      duplicate_or_low_confidence: [],
+    }, null, 2),
+    "",
+    "Use empty arrays when there are no findings in a bucket.",
+    "",
+    "## Review Context",
+    "",
+    `Profile: ${profile}`,
+    `Round: ${round}`,
+    `Branch: ${branch || "(unknown)"}`,
+    `PR: ${prNumber || "(unknown)"}`,
+    `Issue: ${issueNumber || "(none)"}`,
+    `Done Criteria source: ${doneCriteriaSource || "(unknown)"}`,
+    "",
+    "## Done Criteria",
+    "",
+    doneCriteria,
+    "",
+    "## Rubric",
+    "",
+    formatRubricSummary(rubricLoad),
+    "",
+    "## Diff",
+    "",
+    diffText,
+  ].join("\n");
+}
+
+module.exports = {
+  buildAdvisoryPrompt,
+};

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -91,32 +91,32 @@ async function finishAdvisoryReview({
   data,
   headSha,
   profile,
-  reviewRepoPath,
   round,
   runDir,
   runRepoPath,
   timeoutSeconds,
 }) {
   const timeoutMs = parsePositiveSeconds(timeoutSeconds) * 1000;
-  const timeout = new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      advisoryRun.child.kill("SIGTERM");
-      resolve({ code: null, signal: "SIGTERM", timeout: true });
-    }, timeoutMs);
-    advisoryRun.completion.then(() => clearTimeout(timer));
-  });
-  const outcome = await Promise.race([advisoryRun.completion, timeout]);
-  const elapsedMs = Date.now() - advisoryRun.startedAt;
-  const stdout = advisoryRun.stdout();
-  const stderr = advisoryRun.stderr();
-  const rawResponsePath = writeRawResponse(runDir, round, advisoryRun.reviewerName, stdout, stderr);
-  const statusAfter = captureGitStatus(advisoryRun.advisoryRepoPath);
+  const elapsed = () => Date.now() - advisoryRun.startedAt;
   let artifactPath = null;
   let failureReason = null;
+  let rawResponsePath = null;
   let status = "success";
   let counts = { required_count: 0, advisory_count: 0, duplicate_low_confidence_count: 0 };
 
   try {
+    const timeout = new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        advisoryRun.child.kill("SIGTERM");
+        resolve({ code: null, signal: "SIGTERM", timeout: true });
+      }, timeoutMs);
+      advisoryRun.completion.then(() => clearTimeout(timer));
+    });
+    const outcome = await Promise.race([advisoryRun.completion, timeout]);
+    const stdout = advisoryRun.stdout();
+    const stderr = advisoryRun.stderr();
+    rawResponsePath = writeRawResponse(runDir, round, advisoryRun.reviewerName, stdout, stderr);
+    const statusAfter = captureGitStatus(advisoryRun.advisoryRepoPath);
     if (advisoryRun.statusBefore !== statusAfter) {
       status = "policy_violation";
       failureReason = "advisory_reviewer_modified_worktree";
@@ -154,25 +154,31 @@ async function finishAdvisoryReview({
     failureReason = error.message;
   }
 
-  appendRunEvent(runRepoPath, data.run_id, {
-    event: EVENTS.ADVISORY_REVIEW,
-    state_from: data.state,
-    state_to: data.state,
-    head_sha: headSha,
-    round,
-    reviewer: advisoryRun.reviewerName,
-    model: advisoryRun.reviewerModel,
-    profile,
-    status,
-    artifact_path: artifactPath,
-    raw_response_path: rawResponsePath,
-    elapsed_ms: elapsedMs,
-    failure_reason: failureReason,
-    ...counts,
-  });
-
-  cleanupAdvisoryWorktree(advisoryRun.baseRepoPath, advisoryRun.advisoryRepoPath);
-  return { artifactPath, elapsedMs, failureReason, profile, rawResponsePath, reviewer: advisoryRun.reviewerName, status, ...counts };
+  const result = { artifactPath, elapsedMs: elapsed(), failureReason, profile, rawResponsePath, reviewer: advisoryRun.reviewerName, status, ...counts };
+  try {
+    appendRunEvent(runRepoPath, data.run_id, {
+      event: EVENTS.ADVISORY_REVIEW,
+      state_from: data.state,
+      state_to: data.state,
+      head_sha: headSha,
+      round,
+      reviewer: advisoryRun.reviewerName,
+      model: advisoryRun.reviewerModel,
+      profile,
+      status,
+      artifact_path: artifactPath,
+      raw_response_path: rawResponsePath,
+      elapsed_ms: result.elapsedMs,
+      failure_reason: failureReason,
+      ...counts,
+    });
+  } catch (error) {
+    result.status = "failed";
+    result.failureReason = `advisory event write failed: ${error.message}`;
+  } finally {
+    cleanupAdvisoryWorktree(advisoryRun.baseRepoPath, advisoryRun.advisoryRepoPath);
+  }
+  return result;
 }
 
 module.exports = {

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -1,0 +1,184 @@
+const { spawn } = require("child_process");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { resolveExecutorDefaultModel } = require("../../../relay-dispatch/scripts/executor-model-config");
+const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
+const { parseAdvisoryReview, validateAdvisoryProfile } = require("../advisory-review-schema");
+const { captureGitStatus, resolveReviewerScript } = require("./reviewer-invoke");
+const { writeText } = require("./common");
+
+const DEFAULT_ADVISORY_TIMEOUT_SECONDS = 900;
+
+function parsePositiveSeconds(value, fallback = DEFAULT_ADVISORY_TIMEOUT_SECONDS) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("--advisory-timeout must be a positive integer number of seconds");
+  }
+  return parsed;
+}
+
+function resolveAdvisoryModel(data, reviewerName, explicitModel) {
+  if (explicitModel) return explicitModel;
+  const hinted = data?.model_hints?.advisory_review;
+  if (typeof hinted === "string" && hinted.trim()) return hinted.trim();
+  return resolveExecutorDefaultModel(reviewerName, { relayHome: process.env.RELAY_HOME });
+}
+
+function createAdvisoryWorktree(reviewRepoPath, runDir, reviewerName) {
+  const parent = path.join(runDir, "advisory-worktrees");
+  fs.mkdirSync(parent, { recursive: true });
+  const worktreePath = path.join(parent, `${reviewerName}-${process.pid}-${Date.now()}`);
+  execFileSync("git", ["worktree", "add", "--detach", worktreePath, "HEAD"], {
+    cwd: reviewRepoPath,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  return worktreePath;
+}
+
+function cleanupAdvisoryWorktree(baseRepoPath, worktreePath) {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+      cwd: baseRepoPath,
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+  } catch {}
+}
+
+function startAdvisoryReview({
+  promptText,
+  reviewerModel,
+  reviewerName,
+  reviewRepoPath,
+  round,
+  runDir,
+}) {
+  const promptPath = path.join(runDir, `review-round-${round}-advisory-${reviewerName}-prompt.md`);
+  writeText(promptPath, `${promptText}\n`);
+  const reviewerScript = resolveReviewerScript(reviewerName, null);
+  const advisoryRepoPath = createAdvisoryWorktree(reviewRepoPath, runDir, reviewerName);
+  const statusBefore = captureGitStatus(advisoryRepoPath);
+  const execArgs = [reviewerScript, "--repo", reviewRepoPath, "--prompt-file", promptPath, "--json"];
+  if (reviewerModel) execArgs.push("--model", reviewerModel);
+  const startedAt = Date.now();
+  execArgs[execArgs.indexOf("--repo") + 1] = advisoryRepoPath;
+  const child = spawn(process.execPath, execArgs, { cwd: advisoryRepoPath, stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
+  const completion = new Promise((resolve) => {
+    child.on("error", (error) => resolve({ code: null, error }));
+    child.on("close", (code, signal) => resolve({ code, signal }));
+  });
+  return { advisoryRepoPath, baseRepoPath: reviewRepoPath, child, completion, promptPath, reviewerModel, reviewerName, reviewerScript, startedAt, statusBefore, stderr: () => stderr, stdout: () => stdout };
+}
+
+function writeRawResponse(runDir, round, reviewerName, stdout, stderr) {
+  const rawResponsePath = path.join(runDir, `review-round-${round}-advisory-${reviewerName}-raw-response.txt`);
+  const text = stderr.trim()
+    ? [stdout.trim(), "", "stderr:", stderr.trim()].filter(Boolean).join("\n")
+    : stdout.trim();
+  writeText(rawResponsePath, `${text}\n`);
+  return rawResponsePath;
+}
+
+async function finishAdvisoryReview({
+  advisoryRun,
+  data,
+  headSha,
+  profile,
+  reviewRepoPath,
+  round,
+  runDir,
+  runRepoPath,
+  timeoutSeconds,
+}) {
+  const timeoutMs = parsePositiveSeconds(timeoutSeconds) * 1000;
+  const timeout = new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      advisoryRun.child.kill("SIGTERM");
+      resolve({ code: null, signal: "SIGTERM", timeout: true });
+    }, timeoutMs);
+    advisoryRun.completion.then(() => clearTimeout(timer));
+  });
+  const outcome = await Promise.race([advisoryRun.completion, timeout]);
+  const elapsedMs = Date.now() - advisoryRun.startedAt;
+  const stdout = advisoryRun.stdout();
+  const stderr = advisoryRun.stderr();
+  const rawResponsePath = writeRawResponse(runDir, round, advisoryRun.reviewerName, stdout, stderr);
+  const statusAfter = captureGitStatus(advisoryRun.advisoryRepoPath);
+  let artifactPath = null;
+  let failureReason = null;
+  let status = "success";
+  let counts = { required_count: 0, advisory_count: 0, duplicate_low_confidence_count: 0 };
+
+  try {
+    if (advisoryRun.statusBefore !== statusAfter) {
+      status = "policy_violation";
+      failureReason = "advisory_reviewer_modified_worktree";
+      artifactPath = path.join(runDir, `review-round-${round}-advisory-${advisoryRun.reviewerName}-policy-violation.txt`);
+      writeText(artifactPath, [
+        "Advisory reviewer write policy violation detected.",
+        "",
+        `Reviewer: ${advisoryRun.reviewerName}`,
+        `Script: ${advisoryRun.reviewerScript}`,
+        "",
+        "Status before advisory reviewer:",
+        advisoryRun.statusBefore || "(clean)",
+        "",
+        "Status after advisory reviewer:",
+        statusAfter || "(clean)",
+      ].join("\n") + "\n");
+    } else if (outcome.timeout) {
+      status = "timeout";
+      failureReason = `advisory reviewer exceeded ${timeoutMs / 1000}s timeout`;
+    } else if (outcome.error || outcome.code !== 0) {
+      status = "failed";
+      failureReason = outcome.error ? outcome.error.message : `advisory reviewer exited with code ${outcome.code}`;
+    } else {
+      const parsed = parseAdvisoryReview(stdout, { profile });
+      artifactPath = path.join(runDir, `review-round-${round}-advisory-${advisoryRun.reviewerName}.json`);
+      writeText(artifactPath, `${JSON.stringify(parsed, null, 2)}\n`);
+      counts = {
+        required_count: parsed.required_findings.length,
+        advisory_count: parsed.advisory_findings.length,
+        duplicate_low_confidence_count: parsed.duplicate_or_low_confidence.length,
+      };
+    }
+  } catch (error) {
+    status = "failed";
+    failureReason = error.message;
+  }
+
+  appendRunEvent(runRepoPath, data.run_id, {
+    event: EVENTS.ADVISORY_REVIEW,
+    state_from: data.state,
+    state_to: data.state,
+    head_sha: headSha,
+    round,
+    reviewer: advisoryRun.reviewerName,
+    model: advisoryRun.reviewerModel,
+    profile,
+    status,
+    artifact_path: artifactPath,
+    raw_response_path: rawResponsePath,
+    elapsed_ms: elapsedMs,
+    failure_reason: failureReason,
+    ...counts,
+  });
+
+  cleanupAdvisoryWorktree(advisoryRun.baseRepoPath, advisoryRun.advisoryRepoPath);
+  return { artifactPath, elapsedMs, failureReason, profile, rawResponsePath, reviewer: advisoryRun.reviewerName, status, ...counts };
+}
+
+module.exports = {
+  finishAdvisoryReview,
+  parsePositiveSeconds,
+  resolveAdvisoryModel,
+  startAdvisoryReview,
+  validateAdvisoryProfile,
+};

--- a/skills/relay-review/scripts/review-runner/output.js
+++ b/skills/relay-review/scripts/review-runner/output.js
@@ -1,0 +1,67 @@
+const { modeLabel } = require("../../../relay-dispatch/scripts/cli-args");
+
+function printUsage() {
+  console.log("Usage: review-runner.js --repo <path> (--run-id <id> | --branch <name> | --pr <number>) [options]");
+  console.log("\nPrepare or apply a structured relay review round.");
+  console.log("\nOptions:");
+  console.log(`  --repo <path>                ${modeLabel("--repo")} Repository root (default: .)`);
+  console.log(`  --run-id <id>                ${modeLabel("--run-id")} Relay run identifier`);
+  console.log(`  --branch <name>              ${modeLabel("--branch")} Working branch`);
+  console.log(`  --pr <number>                ${modeLabel("--pr")} PR number`);
+  console.log(`  --manifest <path>            ${modeLabel("--manifest")} Explicit manifest path`);
+  console.log(`  --done-criteria-file <path>  ${modeLabel("--done-criteria-file")} Use fixture file instead of gh issue fetch`);
+  console.log(`  --diff-file <path>           ${modeLabel("--diff-file")} Use fixture file instead of gh pr diff`);
+  console.log(`  --review-file <path>         ${modeLabel("--review-file")} Structured reviewer JSON verdict to apply`);
+  console.log(`  --reviewer <name>            ${modeLabel("--reviewer")} Reviewer adapter to invoke (codex|claude|...)`);
+  console.log(`  --reviewer-script <path>     ${modeLabel("--reviewer-script")} Override adapter script path`);
+  console.log(`  --reviewer-model <name>      ${modeLabel("--reviewer-model")} Reviewer model override`);
+  console.log(`  --advisory-reviewer <name>   ${modeLabel("--advisory-reviewer")} Optional non-gating reviewer adapter`);
+  console.log(`  --advisory-profile <name>    ${modeLabel("--advisory-profile")} Advisory focus profile (default: blindspot)`);
+  console.log(`  --advisory-reviewer-model <name> ${modeLabel("--advisory-reviewer-model")} Advisory model override`);
+  console.log(`  --advisory-timeout <seconds> ${modeLabel("--advisory-timeout")} Advisory timeout`);
+  console.log(`  --prepare-only               ${modeLabel("--prepare-only")} Emit prompt bundle only; do not apply verdict`);
+  console.log(`  --no-comment                 ${modeLabel("--no-comment")} Do not post a PR comment`);
+  console.log(`  --json                       ${modeLabel("--json")} Output JSON`);
+}
+
+function printResult({
+  doneCriteriaPath,
+  diffPath,
+  jsonOut,
+  manifestPath,
+  originalState,
+  prepareOnly,
+  prNumber,
+  promptPath,
+  redispatchPath,
+  result,
+  updatedManifest,
+  verdictPath,
+}) {
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (prepareOnly) {
+    console.log(`Prepared relay review round ${result.round}`);
+    console.log(`  Manifest:      ${manifestPath}`);
+    console.log(`  Prompt:        ${promptPath}`);
+    console.log(`  Done criteria: ${doneCriteriaPath}`);
+    console.log(`  Diff:          ${diffPath}`);
+    return;
+  }
+
+  console.log(`Applied relay review round ${result.round}`);
+  console.log(`  Manifest: ${manifestPath}`);
+  console.log(`  State:    ${originalState} -> ${updatedManifest.state}`);
+  console.log(`  Prompt:   ${promptPath}`);
+  console.log(`  Verdict:  ${verdictPath}`);
+  if (redispatchPath) console.log(`  Re-dispatch: ${redispatchPath}`);
+  if (result.commentPosted) console.log(`  PR comment posted to #${prNumber}`);
+}
+
+module.exports = {
+  printUsage,
+  printResult,
+};

--- a/tests/relay-review/scripts/advisory-review-schema.test.js
+++ b/tests/relay-review/scripts/advisory-review-schema.test.js
@@ -1,0 +1,47 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { parseAdvisoryReview, validateAdvisoryProfile } = require("../../../skills/relay-review/scripts/advisory-review-schema");
+
+function advisoryPayload(overrides = {}) {
+  return {
+    profile: "blindspot",
+    summary: "No blocking blind spots found.",
+    required_findings: [],
+    advisory_findings: [{
+      title: "Exercise timeout path",
+      body: "The new optional path should have a timeout regression test.",
+      file: "skills/relay-review/scripts/review-runner.js",
+      line: 42,
+      severity: "P3",
+      category: "test-gap",
+      confidence: 0.8,
+    }],
+    duplicate_or_low_confidence: [],
+    ...overrides,
+  };
+}
+
+test("advisory schema accepts normalized blindspot payloads", () => {
+  const parsed = parseAdvisoryReview(JSON.stringify(advisoryPayload()), { profile: "blindspot" });
+  assert.equal(parsed.profile, "blindspot");
+  assert.equal(parsed.required_findings.length, 0);
+  assert.equal(parsed.advisory_findings[0].category, "test-gap");
+});
+
+test("advisory schema rejects unsupported profiles and invalid confidences", () => {
+  assert.throws(() => validateAdvisoryProfile("cost"), /Unknown advisory profile/);
+  assert.throws(
+    () => parseAdvisoryReview(JSON.stringify(advisoryPayload({
+      advisory_findings: [{
+        title: "Bad confidence",
+        body: "Confidence must be bounded.",
+        file: "README.md",
+        line: 1,
+        severity: "P3",
+        category: "other",
+        confidence: 2,
+      }],
+    }))),
+    /confidence must be a number from 0 to 1/
+  );
+});

--- a/tests/relay-review/scripts/advisory-review-schema.test.js
+++ b/tests/relay-review/scripts/advisory-review-schema.test.js
@@ -45,3 +45,20 @@ test("advisory schema rejects unsupported profiles and invalid confidences", () 
     /confidence must be a number from 0 to 1/
   );
 });
+
+test("advisory schema rejects malformed finding line values", () => {
+  assert.throws(
+    () => parseAdvisoryReview(JSON.stringify(advisoryPayload({
+      advisory_findings: [{
+        title: "Bad line",
+        body: "Line values must not be silently coerced.",
+        file: "README.md",
+        line: 0,
+        severity: "P3",
+        category: "other",
+        confidence: 0.6,
+      }],
+    }))),
+    /line must be a positive integer or null/
+  );
+});

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const CODEX_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-codex.js");
 const CLAUDE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-claude.js");
+const OPENCODE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-opencode.js");
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-adapter-"));
@@ -206,4 +207,42 @@ process.exit(1);
   assert.match(stderr, /not authenticated/i);
   assert.match(stderr, /ANTHROPIC_API_KEY|claude login --api-key/);
   assert.doesNotMatch(stderr, /did not return valid JSON/);
+});
+
+test("opencode adapter forwards model and preserves advisory prompt as one run argument", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-"));
+  const logPath = path.join(fakeDir, "opencode-args.log");
+  const fakeOpencode = writeExecutable(fakeDir, "fake-opencode.js", `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(logPath)}, args.join("\\n") + "\\n", "utf-8");
+process.stdout.write(JSON.stringify({
+  profile: "blindspot",
+  summary: "No blocking blind spots.",
+  required_findings: [],
+  advisory_findings: [],
+  duplicate_or_low_confidence: [],
+}));
+`);
+
+  const stdout = execFileSync("node", [
+    OPENCODE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--model", "opencode-go/deepseek-v4-pro",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode },
+  });
+
+  const result = JSON.parse(stdout);
+  const loggedArgs = fs.readFileSync(logPath, "utf-8");
+  assert.equal(result.profile, "blindspot");
+  assert.match(loggedArgs, /^run\n-m\nopencode-go\/deepseek-v4-pro\n/);
+  assert.match(loggedArgs, /NON-INTERACTIVE ADVISORY REVIEW/);
+  assert.match(loggedArgs, /Return a passing review\./);
 });

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -1,0 +1,265 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+  readManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
+const {
+  DEFAULT_ENFORCEMENT_RUBRIC,
+  createEnforcementFixture,
+} = require("../../../skills/relay-dispatch/scripts/test-support");
+const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+
+function defaultRubricScores() {
+  return [{
+    factor: "Default enforcement rubric",
+    target: ">= 1/1",
+    observed: "1/1",
+    status: "pass",
+    tier: "contract",
+    notes: "The enforcement fixture rubric remained satisfied.",
+  }];
+}
+
+function passVerdict() {
+  return {
+    verdict: "pass",
+    summary: "All done criteria are satisfied.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "ready_to_merge",
+    issues: [],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  };
+}
+
+function changesRequestedVerdict() {
+  return {
+    ...passVerdict(),
+    verdict: "changes_requested",
+    summary: "One required fix remains.",
+    contract_status: "fail",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Primary required fix",
+      body: "Primary reviewer requested this change.",
+      file: "README.md",
+      line: 1,
+      category: "contract",
+      severity: "high",
+    }],
+  };
+}
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-"));
+  const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-origin-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["init", "--bare", remoteRoot], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Review Advisory Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-review@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", remoteRoot], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const runId = "issue-429-20260505010000000";
+  const worktreePath = path.join(repoRoot, "wt", "issue-429");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", "issue-429"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-429",
+    baseBranch: "main",
+    issueNumber: 429,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+    rubricContent: DEFAULT_ENFORCEMENT_RUBRIC,
+  }).anchor;
+  manifest = { ...manifest, git: { ...(manifest.git || {}), pr_number: 429, head_sha: headSha } };
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(manifestPath, manifest);
+  fs.writeFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), `${JSON.stringify({
+    schema_version: 1,
+    head_sha: headSha,
+    test_command: "node --test",
+    test_result_hash: "unspecified",
+    test_result_summary: "pass",
+    recorded_at: "2026-05-05T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  }, null, 2)}\n`, "utf-8");
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const diffPath = path.join(repoRoot, "pr.diff");
+  fs.writeFileSync(doneCriteriaPath, "# Done Criteria\n\n- Add advisory lane\n", "utf-8");
+  fs.writeFileSync(diffPath, "diff --git a/README.md b/README.md\n+advisory\n", "utf-8");
+  return { repoRoot, manifestPath, runDir, runId, doneCriteriaPath, diffPath };
+}
+
+function writePrimaryReviewer(repoRoot, verdict, { logPath = null, delayMs = 0 } = {}) {
+  const filePath = path.join(repoRoot, "primary-reviewer.js");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+if (logPath) fs.appendFileSync(logPath, "primary-start " + Date.now() + "\\n");
+setTimeout(() => {
+  if (logPath) fs.appendFileSync(logPath, "primary-end " + Date.now() + "\\n");
+  process.stdout.write(${JSON.stringify(JSON.stringify(verdict))});
+}, ${Number(delayMs)});
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function writeFakeOpencode(repoRoot, { logPath = null, invalidJson = false, mutate = false } = {}) {
+  const filePath = path.join(repoRoot, "fake-opencode.js");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const logPath = ${JSON.stringify(logPath)};
+if (logPath) fs.appendFileSync(logPath, "advisory-start " + Date.now() + "\\n");
+if (${mutate ? "true" : "false"}) fs.writeFileSync(path.join(process.cwd(), "advisory-mutated.txt"), "bad\\n", "utf-8");
+if (${invalidJson ? "true" : "false"}) {
+  process.stdout.write("not json");
+} else {
+  process.stdout.write(JSON.stringify({
+    profile: "blindspot",
+    summary: "One advisory blind spot.",
+    required_findings: [],
+    advisory_findings: [{
+      title: "Advisory-only test gap",
+      body: "This should be recorded but not merged into primary redispatch.",
+      file: "README.md",
+      line: 1,
+      severity: "P3",
+      category: "test-gap",
+      confidence: 0.8
+    }],
+    duplicate_or_low_confidence: []
+  }));
+}
+if (logPath) fs.appendFileSync(logPath, "advisory-end " + Date.now() + "\\n");
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript, extraArgs = [] }) {
+  return JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "429",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer", "codex",
+    "--reviewer-script", primaryScript,
+    "--advisory-reviewer", "opencode",
+    "--no-comment",
+    "--json",
+    ...extraArgs,
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_OPENCODE_BIN: opencodeScript },
+  }));
+}
+
+test("review-runner records successful opencode advisory review without gating primary pass", () => {
+  const { repoRoot, manifestPath, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot);
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });
+  const manifest = readManifest(manifestPath).data;
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === "advisory_review");
+
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(result.advisoryReview.status, "success");
+  assert.equal(result.advisoryReview.advisory_count, 1);
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.ok(fs.existsSync(path.join(runDir, "review-round-1-advisory-opencode.json")));
+  assert.equal(event.status, "success");
+  assert.equal(event.profile, "blindspot");
+});
+
+test("advisory review starts before the primary reviewer completes", () => {
+  const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const logPath = path.join(repoRoot, "review-order.log");
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { logPath, delayMs: 300 });
+  const opencodeScript = writeFakeOpencode(repoRoot, { logPath });
+
+  runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });
+  const lines = fs.readFileSync(logPath, "utf-8").trim().split(/\n/).map((line) => line.split(" ")[0]);
+
+  assert.ok(lines.indexOf("advisory-start") !== -1);
+  assert.ok(lines.indexOf("primary-end") !== -1);
+  assert.ok(lines.indexOf("advisory-start") < lines.indexOf("primary-end"));
+});
+
+test("invalid advisory JSON is recorded as advisory failure while primary pass still applies", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot, { invalidJson: true });
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === "advisory_review");
+
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.equal(result.advisoryReview.status, "failed");
+  assert.match(result.advisoryReview.failureReason, /valid JSON|exited with code 1/);
+  assert.equal(event.status, "failed");
+});
+
+test("advisory worktree mutation is captured without escalating the manifest", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot, { mutate: true });
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === "advisory_review");
+
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.equal(result.advisoryReview.status, "policy_violation");
+  assert.match(event.artifact_path, /policy-violation\.txt$/);
+});
+
+test("advisory findings do not alter primary redispatch output", () => {
+  const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, changesRequestedVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot);
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });
+  const redispatch = fs.readFileSync(result.redispatchPath, "utf-8");
+
+  assert.equal(result.nextState, STATES.CHANGES_REQUESTED);
+  assert.match(redispatch, /Primary required fix/);
+  assert.doesNotMatch(redispatch, /Advisory-only test gap/);
+});

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -208,10 +208,35 @@ test("review-runner records successful opencode advisory review without gating p
   assert.equal(event.profile, "blindspot");
 });
 
+test("prepare-only with advisory flags writes only the primary prompt bundle", () => {
+  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "429",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--advisory-reviewer", "opencode",
+    "--prepare-only",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_OPENCODE_BIN: path.join(repoRoot, "missing-opencode") },
+  }));
+
+  assert.equal(result.prepareOnly, true);
+  assert.equal(result.advisoryReview, undefined);
+  assert.equal(fs.existsSync(path.join(runDir, "review-round-1-advisory-opencode-prompt.md")), false);
+  assert.equal(fs.existsSync(path.join(runDir, "advisory-worktrees")), false);
+  assert.equal(readRunEvents(repoRoot, runId).some((record) => record.event === "advisory_review"), false);
+});
+
 test("advisory review starts before the primary reviewer completes", () => {
   const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
   const logPath = path.join(repoRoot, "review-order.log");
-  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { logPath, delayMs: 300 });
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { logPath, delayMs: 1500 });
   const opencodeScript = writeFakeOpencode(repoRoot, { logPath });
 
   runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });


### PR DESCRIPTION
## Summary
- add optional non-gating opencode advisory blind-spot reviews to review-runner
- run advisory in an isolated temporary worktree and record advisory artifacts/events
- document advisory flags/model precedence and add coverage for concurrency, failures, mutation, and redispatch isolation

Fixes #429

## Tests
- node --test tests/relay-review/scripts/*.test.js
- node --test tests/relay-dispatch/scripts/*.test.js
- node --test tests/relay-intake/scripts/*.test.js
- node --test tests/relay-plan/scripts/*.test.js
- node --test tests/relay-merge/scripts/*.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자문 리뷰 기능 추가 - 주요 검토와 동시에 실행되는 선택적 보조 리뷰 레인
  * CLI에서 자문 리뷰어 설정 및 제어 옵션 추가 (`--advisory-reviewer`, `--advisory-profile`, `--advisory-model` 등)

* **문서**
  * 아키텍처 및 자문 리뷰 사용 가이드 업데이트
  * 리뷰 러너 명령어 및 옵션 문서 확충

* **테스트**
  * 자문 리뷰 검증 및 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->