### PR TITLE
fix(relay-review): nullable+required rejection metadata for OpenAI strict mode

### DIFF
--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -41,8 +41,8 @@ function validateIssue(issue, index) {
     throw new Error(`${location}.line must be a positive integer`);
   }
   for (const key of OPTIONAL_ISSUE_REJECTION_METADATA) {
-    if (issue[key] !== undefined && !String(issue[key] || "").trim()) {
-      throw new Error(`${location}.${key} must be a non-empty string when present`);
+    if (issue[key] !== undefined && issue[key] !== null && !String(issue[key] || "").trim()) {
+      throw new Error(`${location}.${key} must be a non-empty string, null, or absent`);
     }
   }
   if (issue.lineage !== undefined && !ALLOWED_LINEAGE_VALUES.has(issue.lineage)) {

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -1,7 +1,7 @@
 const REJECTION_METADATA_PROPERTIES = {
-  factor: { type: "string", minLength: 1 },
-  attempted_approach: { type: "string", minLength: 1 },
-  fix_direction: { type: "string", minLength: 1 },
+  factor: { type: ["string", "null"], minLength: 1 },
+  attempted_approach: { type: ["string", "null"], minLength: 1 },
+  fix_direction: { type: ["string", "null"], minLength: 1 },
 };
 
 const REVIEW_VERDICT_PROPERTIES = {
@@ -34,7 +34,19 @@ const REVIEW_VERDICT_PROPERTIES = {
     items: {
       type: "object",
       additionalProperties: false,
-      required: ["title", "body", "file", "line", "category", "severity", "lineage", "relates_to"],
+      required: [
+        "title",
+        "body",
+        "file",
+        "line",
+        "category",
+        "severity",
+        "factor",
+        "attempted_approach",
+        "fix_direction",
+        "lineage",
+        "relates_to",
+      ],
       properties: {
         title: { type: "string", minLength: 1 },
         body: { type: "string", minLength: 1 },

--- a/tests/relay-review/scripts/review-runner-verdict.test.js
+++ b/tests/relay-review/scripts/review-runner-verdict.test.js
@@ -122,7 +122,7 @@ test("verdict/validateReviewVerdict accepts optional rejection metadata", () => 
 test("verdict/validateReviewVerdict rejects blank rejection metadata", () => {
   assert.throws(
     () => validateReviewVerdict(makeChangesRequestedVerdict({ attempted_approach: " " })),
-    /issues\[0\]\.attempted_approach must be a non-empty string when present/
+    /issues\[0\]\.attempted_approach must be a non-empty string, null, or absent/
   );
 });
 
@@ -414,19 +414,17 @@ test("verdict/validateScopeDrift preserves legacy malformed nested-entry behavio
   }
 });
 
-test("schema/strict-mode invariant: every additionalProperties:false object lists every non-optional property in required", () => {
-  const OPTIONAL_REQUIRED_EXCEPTIONS = new Map([
-    ["REVIEW_VERDICT_JSON_SCHEMA.properties.issues.items", new Set(["factor", "attempted_approach", "fix_direction"])],
-    ["REVIEWER_VERDICT_JSON_SCHEMA.properties.issues.items", new Set(["factor", "attempted_approach", "fix_direction"])],
-  ]);
-
+test("schema/strict-mode invariant: every additionalProperties:false object lists every property in required (OpenAI strict-mode forbids genuinely-optional)", () => {
+  // OpenAI structured-output strict mode requires every key in `properties` to also be in
+  // `required`. There are no genuinely-optional properties — make optional ones nullable
+  // (`type: ["string", "null"]`) and still list them in `required`.
+  // Regression history: PR #304 (relates_to), #441 (factor/attempted_approach/fix_direction).
   function findStrictModeViolations(node, pathParts, violations) {
     if (!node || typeof node !== "object") return;
     if (node.type === "object" && node.additionalProperties === false) {
       const propKeys = Object.keys(node.properties || {});
       const required = new Set(node.required || []);
-      const optional = OPTIONAL_REQUIRED_EXCEPTIONS.get(pathParts.join(".")) || new Set();
-      const missing = propKeys.filter((key) => !required.has(key) && !optional.has(key));
+      const missing = propKeys.filter((key) => !required.has(key));
       if (missing.length) {
         violations.push({ path: pathParts.join(".") || "<root>", missing });
       }
@@ -448,4 +446,11 @@ test("schema/strict-mode invariant: every additionalProperties:false object list
 
 test("verdict/validateIssue accepts relates_to=null (codex strict-mode emits null when no relation)", () => {
   assert.doesNotThrow(() => validateIssue(makeIssue({ lineage: "new", relates_to: null }), 0));
+});
+
+test("verdict/validateIssue accepts factor/attempted_approach/fix_direction = null (codex strict-mode emits null when not applicable)", () => {
+  assert.doesNotThrow(() => validateIssue(
+    makeIssue({ lineage: "new", relates_to: null, factor: null, attempted_approach: null, fix_direction: null }),
+    0,
+  ));
 });

--- a/tests/relay-review/scripts/review-schema.test.js
+++ b/tests/relay-review/scripts/review-schema.test.js
@@ -12,7 +12,10 @@ function issueSchema(schema) {
   return schema.properties.issues.items;
 }
 
-test("schema/verdict issues allow optional rejection metadata while staying strict", async (t) => {
+test("schema/verdict issues mark rejection metadata as nullable+required (OpenAI strict-mode)", async (t) => {
+  // OpenAI strict mode forbids genuinely-optional properties: every key in `properties` must
+  // appear in `required`. Optional fields are expressed as nullable types instead.
+  // Regression history: PR #304 (relates_to), #441 (factor/attempted_approach/fix_direction).
   for (const [label, schema] of [
     ["runner", REVIEW_VERDICT_JSON_SCHEMA],
     ["reviewer", REVIEWER_VERDICT_JSON_SCHEMA],
@@ -22,15 +25,15 @@ test("schema/verdict issues allow optional rejection metadata while staying stri
 
       assert.equal(issue.additionalProperties, false);
       for (const field of REJECTION_METADATA_FIELDS) {
-        assert.deepEqual(issue.properties[field], { type: "string", minLength: 1 });
-        assert.equal(issue.required.includes(field), false);
+        assert.deepEqual(issue.properties[field], { type: ["string", "null"], minLength: 1 });
+        assert.equal(issue.required.includes(field), true, `${field} must be in required`);
       }
       assert.equal(Object.hasOwn(issue.properties, "unknown_rejection_note"), false);
     });
   }
 });
 
-test("schema/verdict issue historical required fields do not gain rejection metadata", async (t) => {
+test("schema/verdict issue required matrix lists all 11 properties (strict-mode complete)", async (t) => {
   for (const [label, schema] of [
     ["runner", REVIEW_VERDICT_JSON_SCHEMA],
     ["reviewer", REVIEWER_VERDICT_JSON_SCHEMA],
@@ -45,6 +48,9 @@ test("schema/verdict issue historical required fields do not gain rejection meta
         "line",
         "category",
         "severity",
+        "factor",
+        "attempted_approach",
+        "fix_direction",
         "lineage",
         "relates_to",
       ]);


### PR DESCRIPTION
## Summary

- `issues[].items` schema spread `factor` / `attempted_approach` / `fix_direction` into `properties` but did not list them in `required`. OpenAI structured-output strict mode rejects this — every key in `properties` must appear in `required`.
- Mirror PR #304's `relates_to` fix: types become `["string", "null"]`, all three are added to `required`.
- Tighten the schema strict-mode invariant test (drop `OPTIONAL_REQUIRED_EXCEPTIONS`) so a future regression fails at test-time rather than at first reviewer run.
- `validateIssue` now treats `null` as "not applicable" alongside `undefined`, matching how codex strict-mode emits absent values.

Closes #441.

## Why now

Codex reviewer has been silently broken — `model_per_phase.review` shows null × 98 in the reliability report, suggesting recent reviews ran on Claude. Surfaced 2026-05-07 when Epic #431 (relay-ready) kicked off and the dogfood loop tried to review PR #440 with codex, exactly as the user-preferred codex-heavy workflow expects.

## Test plan

- [x] `node --test tests/relay-review/scripts/*.test.js` — 318 / 318 pass (was 312 / 318 mid-fix; old tests asserted the broken invariant; updated to assert strict-mode-correct shape)
- [x] `node --test tests/relay-{intake,plan,dispatch,merge}/scripts/*.test.js` — 800 / 800 pass (1 skipped pre-existing)
- [ ] Smoke: re-run codex reviewer on PR #440 after merge — that's the live regression repro this PR unblocks

## Trust-model audit

| Question | Answer |
|---|---|
| Trust root | The structural strict-mode invariant test in `tests/relay-review/scripts/review-runner-verdict.test.js` |
| What slipped past last time | The previous test allowed an `OPTIONAL_REQUIRED_EXCEPTIONS` map; this PR removes it so the test fails on any genuinely-optional property. Same regression class as PR #304. |
| Forge variants | None — pure schema shape change |

🤖 Generated with [Claude Code](https://claude.com/claude-code)