### PR TITLE
Implement relay-ready Q&A loop

### DIFF
--- a/skills/relay-ready/scripts/run-qa-loop.js
+++ b/skills/relay-ready/scripts/run-qa-loop.js
@@ -1,0 +1,597 @@
+"use strict";
+
+const { scoreReadiness } = require("./score-readiness");
+
+const BUDGET_MAX = 3;
+const QUESTION_PRIORITY = Object.freeze(["verifiability", "clarity", "granularity"]);
+const ACK_RE = /^(?:y|yes|yeah|yep|ok|okay|sure|accept|accepted|default|use default|looks good)$/i;
+const NO_ANSWER_RE = /^(?:|n|no|skip|pass|none|silent)$/i;
+const FILE_PATH_RE = /`?((?:\.{0,2}\/)?(?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+)(?::\d+)?`?/i;
+const TEST_PATH_RE = /`?((?:\.{0,2}\/)?(?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+(?:test|spec)\.[A-Za-z0-9]+)`?/i;
+const FUNCTION_RE = /`?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\))`?/;
+const NUMERIC_THRESHOLD_RE = /\b((?:p\d{2}|latency|duration|coverage|count|runs?|size)?\s*(?:<=|>=|<|>|=|\u2264|\u2265)\s*\d+(?:\.\d+)?\s*(?:ms|s|kb|mb|gb|%|runs?)?)\b/i;
+
+function runQaLoop(input = {}) {
+  const normalized = normalizeInput(input);
+  const answers = normalizeAnswers(input.answers);
+  const events = [];
+  const retryCounts = new Map();
+  const reentryRequested = Boolean(input.reentry ?? input.re_entry);
+  let reentryAnswered = !reentryRequested;
+  let effectiveBody = normalized.body;
+  let changedBody = false;
+  let budgetUsed = 0;
+  let score = scoreCurrent(normalized, effectiveBody, changedBody);
+  let pendingAsk = null;
+
+  for (const rawAnswer of answers) {
+    pendingAsk = pendingAsk || nextAsk({
+      score,
+      budgetUsed,
+      reentryAnswered,
+      leafId: normalized.leafId,
+      body: effectiveBody,
+    });
+
+    if (!pendingAsk) {
+      break;
+    }
+
+    events.push(questionAskedEvent(pendingAsk));
+
+    const answer = normalizeAnswer(rawAnswer, pendingAsk.dimension);
+    const classification = classifyAnswer(answer.answer, pendingAsk.default);
+
+    events.push(questionAnsweredEvent({
+      ask: pendingAsk,
+      answer: answer.answer,
+      acceptedDefault: classification.kind === "accepted_default",
+    }));
+
+    if (pendingAsk.dimension === "_reentry") {
+      reentryAnswered = true;
+      pendingAsk = null;
+      continue;
+    }
+
+    if (classification.kind === "no_answer") {
+      const retry = recordRetry(retryCounts, pendingAsk.dimension);
+      if (retry.exhausted) {
+        return escalateResult({
+          reason: "clarification_retry_exhausted",
+          score,
+          budgetUsed,
+          events,
+          leafId: normalized.leafId,
+          dimensionsLow: [pendingAsk.dimension],
+        });
+      }
+      pendingAsk = buildClarificationAsk({
+        dimension: pendingAsk.dimension,
+        body: effectiveBody,
+        score,
+        budgetUsed,
+        leafId: normalized.leafId,
+        defaultValue: pendingAsk.default,
+        answer: answer.answer,
+        reason: "Please provide a concrete answer or accept the default.",
+      });
+      continue;
+    }
+
+    if (classification.kind === "accepted_default") {
+      events.push(proposalAcceptedEvent({
+        ask: pendingAsk,
+        defaultValue: pendingAsk.default,
+      }));
+      effectiveBody = appendDimensionAnswer(effectiveBody, pendingAsk.dimension, pendingAsk.default);
+      changedBody = true;
+      budgetUsed += 1;
+      score = scoreCurrent(normalized, effectiveBody, changedBody);
+      pendingAsk = null;
+      continue;
+    }
+
+    events.push(proposalEditedEvent({
+      ask: pendingAsk,
+      override: answer.answer,
+    }));
+
+    const trialBody = appendDimensionAnswer(effectiveBody, pendingAsk.dimension, answer.answer);
+    const trialScore = scoreReadiness(trialBody);
+    if (trialScore.readiness[pendingAsk.dimension] === "high") {
+      effectiveBody = trialBody;
+      changedBody = true;
+      budgetUsed += 1;
+      score = trialScore;
+      pendingAsk = null;
+      continue;
+    }
+
+    const retry = recordRetry(retryCounts, pendingAsk.dimension);
+    if (retry.exhausted) {
+      return escalateResult({
+        reason: "clarification_retry_exhausted",
+        score: trialScore,
+        budgetUsed,
+        events,
+        leafId: normalized.leafId,
+        dimensionsLow: [pendingAsk.dimension],
+      });
+    }
+    pendingAsk = buildClarificationAsk({
+      dimension: pendingAsk.dimension,
+      body: effectiveBody,
+      score,
+      budgetUsed,
+      leafId: normalized.leafId,
+      defaultValue: pendingAsk.default,
+      answer: answer.answer,
+      reason: `Your answer "${answer.answer}" is still too vague to close ${pendingAsk.dimension}.`,
+    });
+  }
+
+  const decision = decideNext({
+    score,
+    budgetUsed,
+    reentryAnswered,
+    pendingAsk,
+    leafId: normalized.leafId,
+    body: effectiveBody,
+  });
+
+  if (decision.action === "ask") {
+    events.push(questionAskedEvent(decision));
+    return {
+      ...decision,
+      events,
+    };
+  }
+
+  return {
+    ...decision,
+    events,
+  };
+}
+
+function normalizeInput(input) {
+  const scored = input.scored || input.score || (isScoredOutput(input.body) ? input.body : null);
+  const body = typeof input.body === "string" ? input.body : normalizeString(input.text || input.request_text || "");
+  return {
+    body,
+    scored,
+    leafId: normalizeOptionalString(input.leaf_id ?? input.leafId),
+  };
+}
+
+function normalizeAnswers(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => {
+    if (typeof entry === "string") {
+      return { dimension: null, answer: entry };
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return { dimension: null, answer: "" };
+    }
+    return {
+      dimension: normalizeOptionalString(entry.dimension),
+      answer: normalizeString(entry.answer ?? entry.answer_text ?? entry.text),
+    };
+  });
+}
+
+function normalizeAnswer(answer, fallbackDimension) {
+  return {
+    dimension: answer.dimension || fallbackDimension,
+    answer: normalizeString(answer.answer),
+  };
+}
+
+function normalizeString(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeOptionalString(value) {
+  if (value === undefined || value === null) return null;
+  const normalized = normalizeString(value).trim();
+  return normalized || null;
+}
+
+function isScoredOutput(value) {
+  return Boolean(
+    value
+      && typeof value === "object"
+      && !Array.isArray(value)
+      && value.readiness
+      && typeof value.readiness === "object"
+  );
+}
+
+function scoreCurrent(normalized, body, changedBody) {
+  if (normalized.scored && !changedBody) {
+    return normalizeScoredOutput(normalized.scored);
+  }
+  return scoreReadiness(body);
+}
+
+function normalizeScoredOutput(scored) {
+  return {
+    readiness: scored.readiness || {},
+    bypass: Boolean(scored.bypass),
+    signals: Array.isArray(scored.signals) ? scored.signals : [],
+    next_action: scored.next_action || "qa_needed",
+  };
+}
+
+function decideNext({ score, budgetUsed, reentryAnswered, pendingAsk, leafId, body }) {
+  if (pendingAsk) {
+    return pendingAsk;
+  }
+  if (!reentryAnswered) {
+    return buildReentryAsk(leafId);
+  }
+  if (score.bypass || score.next_action === "proceed" || !selectQuestionDimension(score.readiness)) {
+    return proceedResult(score, budgetUsed);
+  }
+
+  const dimensionsLow = lowDimensions(score.readiness);
+  if (budgetUsed >= BUDGET_MAX) {
+    return escalateResult({
+      reason: dimensionsLow.length >= 3 ? "low_dimensions_exhausted" : "question_budget_exhausted",
+      score,
+      budgetUsed,
+      events: [],
+      leafId,
+      dimensionsLow,
+    });
+  }
+
+  return buildAsk({
+    dimension: selectQuestionDimension(score.readiness),
+    body,
+    score,
+    budgetUsed,
+    leafId,
+  });
+}
+
+function nextAsk({ score, budgetUsed, reentryAnswered, leafId, body }) {
+  const decision = decideNext({
+    score,
+    budgetUsed,
+    reentryAnswered,
+    pendingAsk: null,
+    leafId,
+    body,
+  });
+  return decision.action === "ask" ? decision : null;
+}
+
+function proceedResult(score, budgetUsed) {
+  return {
+    action: "proceed",
+    readiness_score: score.readiness,
+    signals: score.signals,
+    budget_used: budgetUsed,
+  };
+}
+
+function escalateResult({ reason, score, budgetUsed, events, leafId, dimensionsLow }) {
+  return {
+    action: "escalate",
+    reason,
+    dimensions_low: dimensionsLow || lowDimensions(score.readiness),
+    readiness_score: score.readiness,
+    signals: score.signals,
+    budget_used: budgetUsed,
+    budget_max: BUDGET_MAX,
+    leaf_id: leafId,
+    events,
+  };
+}
+
+function buildReentryAsk(leafId) {
+  return {
+    action: "ask",
+    dimension: "_reentry",
+    question: "Discard prior or update?",
+    default: null,
+    budget_used: 0,
+    budget_max: BUDGET_MAX,
+    leaf_id: leafId,
+    readiness_score: null,
+    signals: [],
+  };
+}
+
+function buildAsk({ dimension, body, score, budgetUsed, leafId }) {
+  return {
+    action: "ask",
+    dimension,
+    question: questionForDimension(dimension),
+    default: extractDefault(dimension, body, score.signals),
+    budget_used: budgetUsed,
+    budget_max: BUDGET_MAX,
+    leaf_id: leafId,
+    readiness_score: score.readiness,
+    signals: score.signals,
+  };
+}
+
+function buildClarificationAsk({
+  dimension,
+  body,
+  score,
+  budgetUsed,
+  leafId,
+  defaultValue,
+  answer,
+  reason,
+}) {
+  return {
+    action: "ask",
+    dimension,
+    question: answer.trim()
+      ? `${reason} Please provide a concrete answer for ${dimension}.`
+      : `Please provide a concrete answer for ${dimension} or accept the default.`,
+    default: defaultValue === undefined ? extractDefault(dimension, body, score.signals) : defaultValue,
+    budget_used: budgetUsed,
+    budget_max: BUDGET_MAX,
+    leaf_id: leafId,
+    readiness_score: score.readiness,
+    signals: score.signals,
+  };
+}
+
+function questionForDimension(dimension) {
+  switch (dimension) {
+    case "verifiability":
+      return "What concrete check will prove this is done?";
+    case "clarity":
+      return "What exact target file, function, or behavior should change?";
+    case "granularity":
+      return "What single leaf should this request focus on?";
+    default:
+      return "What clarification should be applied?";
+  }
+}
+
+function selectQuestionDimension(readiness = {}) {
+  for (const dimension of QUESTION_PRIORITY) {
+    if (readiness[dimension] === "low") {
+      return dimension;
+    }
+  }
+  return null;
+}
+
+function lowDimensions(readiness = {}) {
+  return QUESTION_PRIORITY.filter((dimension) => readiness[dimension] === "low");
+}
+
+function classifyAnswer(answer, defaultValue) {
+  const trimmed = answer.trim();
+  if (NO_ANSWER_RE.test(trimmed)) {
+    return { kind: "no_answer" };
+  }
+  if (defaultValue && ACK_RE.test(trimmed)) {
+    return { kind: "accepted_default" };
+  }
+  return { kind: "override" };
+}
+
+function recordRetry(retryCounts, dimension) {
+  const used = retryCounts.get(dimension) || 0;
+  retryCounts.set(dimension, used + 1);
+  return { exhausted: used >= 1 };
+}
+
+function appendDimensionAnswer(body, dimension, answer) {
+  const normalizedBody = body.trim();
+  const normalizedAnswer = answer.trim();
+  const bullet = dimension === "verifiability" ? `- ${normalizedAnswer}` : normalizedAnswer;
+  const section = `\n\nRelay-ready ${dimension} answer:\n${bullet}\n`;
+  return normalizedBody ? `${normalizedBody}${section}` : section.trim();
+}
+
+function questionAskedEvent(ask) {
+  return eventRecord("question_asked", ask.leaf_id, {
+    dimension: ask.dimension,
+    question: ask.question,
+    default: ask.default,
+    budget_used: ask.budget_used,
+  });
+}
+
+function questionAnsweredEvent({ ask, answer, acceptedDefault }) {
+  return eventRecord("question_answered", ask.leaf_id, {
+    dimension: ask.dimension,
+    question: ask.question,
+    answer,
+    accepted_default: acceptedDefault,
+  });
+}
+
+function proposalAcceptedEvent({ ask, defaultValue }) {
+  return eventRecord("proposal_accepted", ask.leaf_id, {
+    dimension: ask.dimension,
+    default: defaultValue,
+  });
+}
+
+function proposalEditedEvent({ ask, override }) {
+  return eventRecord("proposal_edited", ask.leaf_id, {
+    dimension: ask.dimension,
+    default: ask.default,
+    override,
+  });
+}
+
+function eventRecord(event, leafId, payload) {
+  return {
+    event,
+    leaf_id: leafId,
+    payload: {
+      leaf_id: leafId,
+      ...payload,
+    },
+  };
+}
+
+function emitQaEvents({ repoRoot, requestId, events, helpers } = {}) {
+  const qnaHelpers = helpers || require("./relay-request");
+  return (events || []).map((entry) => emitQaEvent({ repoRoot, requestId, entry, helpers: qnaHelpers }));
+}
+
+function emitQaEvent({ repoRoot, requestId, entry, helpers }) {
+  const payload = entry.payload || {};
+  switch (entry.event) {
+    case "question_asked":
+      return helpers.clarify(repoRoot, requestId, {
+        ...payload,
+        question_text: payload.question,
+        response_options: payload.default
+          ? [`Accept default: ${payload.default}`, "Provide another answer", "Skip"]
+          : ["Provide answer", "Skip"],
+        reason: payload.dimension,
+      });
+    case "question_answered":
+      return helpers.answerQuestion(repoRoot, requestId, {
+        ...payload,
+        question_text: payload.question || `Question for ${payload.dimension}`,
+        answer_text: payload.answer.trim() || "(no answer)",
+        answer_choice: payload.accepted_default ? "default" : undefined,
+        reason: payload.dimension,
+      });
+    case "proposal_accepted":
+      return helpers.acceptProposal(repoRoot, requestId, {
+        ...payload,
+        proposal_summary: `Use default for ${payload.dimension}`,
+        acceptance_note: payload.default || "Accepted default.",
+        accepted_with_edits: false,
+        reason: payload.dimension,
+      });
+    case "proposal_edited":
+      return helpers.editProposal(repoRoot, requestId, {
+        ...payload,
+        proposal_summary: payload.default
+          ? `Default for ${payload.dimension}: ${payload.default}`
+          : `Answer for ${payload.dimension}`,
+        edit_summary: payload.override,
+        proposal_text: payload.override,
+        reason: payload.dimension,
+      });
+    default:
+      throw new Error(`unsupported Q&A event: ${entry.event}`);
+  }
+}
+
+function extractDefault(dimension, body, signals = []) {
+  const text = normalizeString(body);
+
+  // Phase 1 D3 heuristic table, fail-open:
+  // - verifiability: existing test/spec path, numeric threshold, or target JS path
+  //   that can be mapped to a likely sibling test path.
+  // - clarity: explicit file/function target already present in the request.
+  // - granularity: first concrete subsystem from a file path or scorer signal.
+  switch (dimension) {
+    case "verifiability":
+      return extractVerifiabilityDefault(text);
+    case "clarity":
+      return extractClarityDefault(text);
+    case "granularity":
+      return extractGranularityDefault(text, signals);
+    default:
+      return null;
+  }
+}
+
+function extractVerifiabilityDefault(text) {
+  const testPath = firstMatch(text, TEST_PATH_RE);
+  if (testPath) {
+    return `\`${testPath}\` passes.`;
+  }
+
+  const threshold = firstMatch(text, NUMERIC_THRESHOLD_RE);
+  if (threshold) {
+    return `The measurable threshold is ${threshold}.`;
+  }
+
+  const targetPath = firstMatch(text, FILE_PATH_RE);
+  const inferredTestPath = targetPath ? inferTestPath(targetPath) : null;
+  if (inferredTestPath) {
+    return `\`${inferredTestPath}\` passes.`;
+  }
+
+  return null;
+}
+
+function extractClarityDefault(text) {
+  const targetPath = firstMatch(text, FILE_PATH_RE);
+  if (targetPath) {
+    return `Change \`${targetPath}\` only, preserving behavior outside that target.`;
+  }
+  const functionName = firstMatch(text, FUNCTION_RE);
+  if (functionName) {
+    return `Change \`${functionName}\` only, preserving behavior outside that target.`;
+  }
+  return null;
+}
+
+function extractGranularityDefault(text, signals) {
+  const targetPath = firstMatch(text, FILE_PATH_RE);
+  const subsystem = targetPath ? subsystemFromPath(targetPath) : subsystemFromSignals(signals);
+  if (!subsystem) {
+    return null;
+  }
+  return `Keep one relay leaf focused on ${subsystem}.`;
+}
+
+function firstMatch(text, regex) {
+  const match = text.match(regex);
+  return match ? match[1] || match[0] : null;
+}
+
+function inferTestPath(value) {
+  const clean = cleanPath(value);
+  const skillScript = clean.match(/^skills\/([^/]+)\/scripts\/(.+)\.js$/);
+  if (skillScript) {
+    return `tests/${skillScript[1]}/scripts/${skillScript[2]}.test.js`;
+  }
+
+  const srcPath = clean.match(/^src\/([^/]+)\/(.+)\.js$/);
+  if (srcPath) {
+    return `tests/${srcPath[1]}/${srcPath[2]}.test.js`;
+  }
+
+  if (clean.endsWith(".test.js") || clean.endsWith(".spec.js")) {
+    return clean;
+  }
+  return null;
+}
+
+function cleanPath(value) {
+  return value.replace(/`/g, "").replace(/^\.\//, "");
+}
+
+function subsystemFromPath(value) {
+  const parts = cleanPath(value).split("/").filter(Boolean);
+  if (!parts.length) return null;
+  if (parts[0] === "skills" && parts[1]) return parts[1];
+  if (parts[0] === "tests" && parts[1]) return parts[1];
+  if (parts[0] === "src" && parts[1]) return parts[1];
+  return parts[0];
+}
+
+function subsystemFromSignals(signals) {
+  const signal = signals.find((entry) => entry.dimension === "granularity" && /single_subsystem/.test(entry.condition));
+  return signal ? signal.evidence : null;
+}
+
+module.exports = runQaLoop;
+module.exports.BUDGET_MAX = BUDGET_MAX;
+module.exports.QUESTION_PRIORITY = QUESTION_PRIORITY;
+module.exports.emitQaEvents = emitQaEvents;
+module.exports.extractDefault = extractDefault;
+module.exports.runQaLoop = runQaLoop;
+module.exports.selectQuestionDimension = selectQuestionDimension;

--- a/skills/relay-ready/scripts/run-qa-loop.js
+++ b/skills/relay-ready/scripts/run-qa-loop.js
@@ -24,7 +24,9 @@ function runQaLoop(input = {}) {
   let score = scoreCurrent(normalized, effectiveBody, changedBody);
   let pendingAsk = null;
 
-  for (const rawAnswer of answers) {
+  for (let index = 0; index < answers.length; index += 1) {
+    const rawAnswer = answers[index];
+    const emitAnswerEvents = index === answers.length - 1;
     pendingAsk = pendingAsk || nextAsk({
       score,
       budgetUsed,
@@ -37,16 +39,16 @@ function runQaLoop(input = {}) {
       break;
     }
 
-    events.push(questionAskedEvent(pendingAsk));
-
     const answer = normalizeAnswer(rawAnswer, pendingAsk.dimension);
     const classification = classifyAnswer(answer.answer, pendingAsk.default);
 
-    events.push(questionAnsweredEvent({
-      ask: pendingAsk,
-      answer: answer.answer,
-      acceptedDefault: classification.kind === "accepted_default",
-    }));
+    if (emitAnswerEvents) {
+      events.push(questionAnsweredEvent({
+        ask: pendingAsk,
+        answer: answer.answer,
+        acceptedDefault: classification.kind === "accepted_default",
+      }));
+    }
 
     if (pendingAsk.dimension === "_reentry") {
       reentryAnswered = true;
@@ -80,10 +82,12 @@ function runQaLoop(input = {}) {
     }
 
     if (classification.kind === "accepted_default") {
-      events.push(proposalAcceptedEvent({
-        ask: pendingAsk,
-        defaultValue: pendingAsk.default,
-      }));
+      if (emitAnswerEvents) {
+        events.push(proposalAcceptedEvent({
+          ask: pendingAsk,
+          defaultValue: pendingAsk.default,
+        }));
+      }
       effectiveBody = appendDimensionAnswer(effectiveBody, pendingAsk.dimension, pendingAsk.default);
       changedBody = true;
       budgetUsed += 1;
@@ -92,10 +96,12 @@ function runQaLoop(input = {}) {
       continue;
     }
 
-    events.push(proposalEditedEvent({
-      ask: pendingAsk,
-      override: answer.answer,
-    }));
+    if (emitAnswerEvents) {
+      events.push(proposalEditedEvent({
+        ask: pendingAsk,
+        override: answer.answer,
+      }));
+    }
 
     const trialBody = appendDimensionAnswer(effectiveBody, pendingAsk.dimension, answer.answer);
     const trialScore = scoreReadiness(trialBody);
@@ -110,14 +116,12 @@ function runQaLoop(input = {}) {
 
     const retry = recordRetry(retryCounts, pendingAsk.dimension);
     if (retry.exhausted) {
-      return escalateResult({
-        reason: "clarification_retry_exhausted",
-        score: trialScore,
-        budgetUsed,
-        events,
-        leafId: normalized.leafId,
-        dimensionsLow: [pendingAsk.dimension],
-      });
+      effectiveBody = trialBody;
+      changedBody = true;
+      budgetUsed += 1;
+      score = trialScore;
+      pendingAsk = null;
+      continue;
     }
     pendingAsk = buildClarificationAsk({
       dimension: pendingAsk.dimension,

--- a/tests/relay-ready/scripts/run-qa-loop.test.js
+++ b/tests/relay-ready/scripts/run-qa-loop.test.js
@@ -1,0 +1,272 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  emitQaEvents,
+  runQaLoop,
+  selectQuestionDimension,
+} = require("../../../skills/relay-ready/scripts/run-qa-loop");
+
+const VERIFIABILITY_LOW_BODY = `Update \`skills/relay-ready/scripts/run-qa-loop.js\` so the sequential Q&A loop returns deterministic action objects for a caller that stores answers externally.
+
+The implementation should stay pure, keep caller I/O outside this module, and preserve a compact event ledger that a post-hook can replay through relay-ready request helpers.
+
+## Done Criteria
+
+- The loop returns stable actions for repeated invocations with the same answer history.
+`;
+
+const GRANULARITY_LOW_BODY = `Update parser and docs in \`src/parser/index.js\` while keeping the parse API stable for existing callers across the relay-ready parser surface.
+
+The request is deliberately long enough to avoid the short-body gate, names a concrete file target, and keeps verification objective so only the opener's top-level conjunction should remain low.
+
+## Done Criteria
+
+- \`src/parser/index.js\` keeps parse output stable.
+- \`tests/parser/index.test.js\` passes.
+`;
+
+function eventNames(result) {
+  return result.events.map((event) => event.event);
+}
+
+function askedDimensions(result) {
+  return result.events
+    .filter((event) => event.event === "question_asked")
+    .map((event) => event.payload.dimension);
+}
+
+test("all_yes accepts extracted defaults and proceeds when the default closes the low score", () => {
+  const result = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    leaf_id: "leaf-yes",
+    answers: [{ dimension: "verifiability", answer: "yes" }],
+  });
+
+  assert.equal(result.action, "proceed");
+  assert.equal(result.budget_used, 1);
+  assert.deepEqual(askedDimensions(result), ["verifiability"]);
+  assert.deepEqual(eventNames(result), [
+    "question_asked",
+    "question_answered",
+    "proposal_accepted",
+  ]);
+
+  const helperCalls = [];
+  emitQaEvents({
+    repoRoot: "/tmp/repo",
+    requestId: "req-1",
+    events: result.events,
+    helpers: {
+      clarify(_repoRoot, _requestId, data) {
+        helperCalls.push(["clarify", data.dimension, data.default]);
+      },
+      answerQuestion(_repoRoot, _requestId, data) {
+        helperCalls.push(["answerQuestion", data.dimension, data.accepted_default]);
+      },
+      acceptProposal(_repoRoot, _requestId, data) {
+        helperCalls.push(["acceptProposal", data.dimension, data.default]);
+      },
+      editProposal() {
+        helperCalls.push(["editProposal"]);
+      },
+    },
+  });
+  assert.deepEqual(helperCalls.map((call) => call[0]), [
+    "clarify",
+    "answerQuestion",
+    "acceptProposal",
+  ]);
+  assert.equal(helperCalls[0][1], "verifiability");
+  assert.match(helperCalls[0][2], /tests\/relay-ready\/scripts\/run-qa-loop\.test\.js/);
+});
+
+test("all_no_or_silent does not charge budget and escalates after one retry", () => {
+  const result = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    answers: [
+      { dimension: "verifiability", answer: "skip" },
+      { dimension: "verifiability", answer: "  " },
+    ],
+  });
+
+  assert.equal(result.action, "escalate");
+  assert.equal(result.reason, "clarification_retry_exhausted");
+  assert.equal(result.budget_used, 0);
+  assert.deepEqual(result.dimensions_low, ["verifiability"]);
+  assert.deepEqual(askedDimensions(result), ["verifiability", "verifiability"]);
+  assert.deepEqual(eventNames(result), [
+    "question_asked",
+    "question_answered",
+    "question_asked",
+    "question_answered",
+  ]);
+});
+
+test("override_with_specific_text advances to proceed when the override re-scores high", () => {
+  const result = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    answers: [{
+      dimension: "verifiability",
+      answer: "`tests/relay-ready/scripts/run-qa-loop.test.js` passes and the event ledger lists Q&A events in order.",
+    }],
+  });
+
+  assert.equal(result.action, "proceed");
+  assert.equal(result.budget_used, 1);
+  assert.deepEqual(askedDimensions(result), ["verifiability"]);
+  assert.deepEqual(eventNames(result), [
+    "question_asked",
+    "question_answered",
+    "proposal_edited",
+  ]);
+
+  const helperCalls = [];
+  emitQaEvents({
+    repoRoot: "/tmp/repo",
+    requestId: "req-override",
+    events: result.events,
+    helpers: {
+      clarify(_repoRoot, _requestId, data) {
+        helperCalls.push(["clarify", data.dimension]);
+      },
+      answerQuestion(_repoRoot, _requestId, data) {
+        helperCalls.push(["answerQuestion", data.dimension]);
+      },
+      acceptProposal() {
+        helperCalls.push(["acceptProposal"]);
+      },
+      editProposal(_repoRoot, _requestId, data) {
+        helperCalls.push(["editProposal", data.dimension, data.override]);
+      },
+    },
+  });
+  assert.deepEqual(helperCalls.map((call) => call[0]), [
+    "clarify",
+    "answerQuestion",
+    "editProposal",
+  ]);
+  assert.equal(helperCalls[2][1], "verifiability");
+  assert.match(helperCalls[2][2], /run-qa-loop\.test\.js/);
+});
+
+test("override_with_vague_text is re-asked without laundering the budget", () => {
+  const result = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    answers: [{ dimension: "verifiability", answer: "improve it" }],
+  });
+
+  assert.equal(result.action, "ask");
+  assert.equal(result.dimension, "verifiability");
+  assert.equal(result.budget_used, 0);
+  assert.match(result.question, /"improve it"/);
+  assert.deepEqual(askedDimensions(result), ["verifiability", "verifiability"]);
+  assert.deepEqual(eventNames(result), [
+    "question_asked",
+    "question_answered",
+    "proposal_edited",
+    "question_asked",
+  ]);
+});
+
+test("escalation_path triggers instead of asking a fourth budgeted question", () => {
+  const result = runQaLoop({
+    body: GRANULARITY_LOW_BODY,
+    answers: [
+      { dimension: "granularity", answer: "yes" },
+      { dimension: "granularity", answer: "yes" },
+      { dimension: "granularity", answer: "yes" },
+    ],
+  });
+
+  assert.equal(result.action, "escalate");
+  assert.equal(result.reason, "question_budget_exhausted");
+  assert.equal(result.budget_used, 3);
+  assert.deepEqual(result.dimensions_low, ["granularity"]);
+  assert.deepEqual(askedDimensions(result), ["granularity", "granularity", "granularity"]);
+});
+
+test("reentry_with_prior_escalation asks the recovery question first without charging budget", () => {
+  const first = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    reentry: true,
+    leaf_id: "leaf-reentry",
+  });
+
+  assert.equal(first.action, "ask");
+  assert.equal(first.dimension, "_reentry");
+  assert.equal(first.question, "Discard prior or update?");
+  assert.equal(first.budget_used, 0);
+  assert.deepEqual(askedDimensions(first), ["_reentry"]);
+
+  const resumed = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    reentry: true,
+    leaf_id: "leaf-reentry",
+    answers: [
+      { dimension: "_reentry", answer: "update" },
+      { dimension: "verifiability", answer: "yes" },
+    ],
+  });
+
+  assert.equal(resumed.action, "proceed");
+  assert.equal(resumed.budget_used, 1);
+  assert.deepEqual(askedDimensions(resumed), ["_reentry", "verifiability"]);
+});
+
+test("bypass_input proceeds immediately and suppresses all Q&A events", () => {
+  const result = runQaLoop({
+    scored: {
+      readiness: {
+        clarity: "high",
+        granularity: "high",
+        verifiability: "high",
+      },
+      bypass: true,
+      signals: [],
+      next_action: "proceed",
+    },
+  });
+
+  assert.equal(result.action, "proceed");
+  assert.equal(result.budget_used, 0);
+  assert.deepEqual(result.events, []);
+});
+
+test("initial call returns an ask action for the highest-priority low dimension", () => {
+  const result = runQaLoop({ body: VERIFIABILITY_LOW_BODY });
+
+  assert.equal(result.action, "ask");
+  assert.equal(result.dimension, "verifiability");
+  assert.equal(result.budget_used, 0);
+  assert.equal(result.budget_max, 3);
+});
+
+test("question priority is deterministic across score combinations", () => {
+  const cases = [
+    [{
+      verifiability: "low",
+      clarity: "low",
+      granularity: "low",
+    }, "verifiability"],
+    [{
+      verifiability: "medium",
+      clarity: "low",
+      granularity: "low",
+    }, "clarity"],
+    [{
+      verifiability: "high",
+      clarity: "medium",
+      granularity: "low",
+    }, "granularity"],
+    [{
+      verifiability: "medium",
+      clarity: "medium",
+      granularity: "medium",
+    }, null],
+  ];
+
+  for (const [readiness, expected] of cases) {
+    assert.equal(selectQuestionDimension(readiness), expected);
+  }
+});

--- a/tests/relay-ready/scripts/run-qa-loop.test.js
+++ b/tests/relay-ready/scripts/run-qa-loop.test.js
@@ -30,23 +30,63 @@ function eventNames(result) {
   return result.events.map((event) => event.event);
 }
 
+function eventNamesFor(events) {
+  return events.map((event) => event.event);
+}
+
 function askedDimensions(result) {
   return result.events
     .filter((event) => event.event === "question_asked")
     .map((event) => event.payload.dimension);
 }
 
+function runScript(input, scriptedAnswers) {
+  const history = [];
+  const events = [];
+  const results = [];
+  const asked = [];
+  let result = runQaLoop({ ...input, answers: history });
+
+  results.push(result);
+  events.push(...result.events);
+  if (result.action === "ask") asked.push(result.dimension);
+
+  for (const scriptedAnswer of scriptedAnswers) {
+    if (result.action !== "ask") break;
+    const answer = typeof scriptedAnswer === "function"
+      ? scriptedAnswer(result)
+      : scriptedAnswer;
+    history.push({
+      dimension: result.dimension,
+      answer,
+    });
+
+    result = runQaLoop({ ...input, answers: history });
+    results.push(result);
+    events.push(...result.events);
+    if (result.action === "ask") asked.push(result.dimension);
+  }
+
+  return {
+    final: result,
+    results,
+    events,
+    askedDimensions: asked,
+    history,
+  };
+}
+
 test("all_yes accepts extracted defaults and proceeds when the default closes the low score", () => {
-  const result = runQaLoop({
+  const script = runScript({
     body: VERIFIABILITY_LOW_BODY,
     leaf_id: "leaf-yes",
-    answers: [{ dimension: "verifiability", answer: "yes" }],
-  });
+  }, ["yes"]);
 
+  const result = script.final;
   assert.equal(result.action, "proceed");
   assert.equal(result.budget_used, 1);
-  assert.deepEqual(askedDimensions(result), ["verifiability"]);
-  assert.deepEqual(eventNames(result), [
+  assert.deepEqual(script.askedDimensions, ["verifiability"]);
+  assert.deepEqual(eventNamesFor(script.events), [
     "question_asked",
     "question_answered",
     "proposal_accepted",
@@ -56,7 +96,7 @@ test("all_yes accepts extracted defaults and proceeds when the default closes th
   emitQaEvents({
     repoRoot: "/tmp/repo",
     requestId: "req-1",
-    events: result.events,
+    events: script.events,
     helpers: {
       clarify(_repoRoot, _requestId, data) {
         helperCalls.push(["clarify", data.dimension, data.default]);
@@ -82,20 +122,17 @@ test("all_yes accepts extracted defaults and proceeds when the default closes th
 });
 
 test("all_no_or_silent does not charge budget and escalates after one retry", () => {
-  const result = runQaLoop({
+  const script = runScript({
     body: VERIFIABILITY_LOW_BODY,
-    answers: [
-      { dimension: "verifiability", answer: "skip" },
-      { dimension: "verifiability", answer: "  " },
-    ],
-  });
+  }, ["skip", "  "]);
 
+  const result = script.final;
   assert.equal(result.action, "escalate");
   assert.equal(result.reason, "clarification_retry_exhausted");
   assert.equal(result.budget_used, 0);
   assert.deepEqual(result.dimensions_low, ["verifiability"]);
-  assert.deepEqual(askedDimensions(result), ["verifiability", "verifiability"]);
-  assert.deepEqual(eventNames(result), [
+  assert.deepEqual(script.askedDimensions, ["verifiability", "verifiability"]);
+  assert.deepEqual(eventNamesFor(script.events), [
     "question_asked",
     "question_answered",
     "question_asked",
@@ -104,18 +141,15 @@ test("all_no_or_silent does not charge budget and escalates after one retry", ()
 });
 
 test("override_with_specific_text advances to proceed when the override re-scores high", () => {
-  const result = runQaLoop({
+  const script = runScript({
     body: VERIFIABILITY_LOW_BODY,
-    answers: [{
-      dimension: "verifiability",
-      answer: "`tests/relay-ready/scripts/run-qa-loop.test.js` passes and the event ledger lists Q&A events in order.",
-    }],
-  });
+  }, ["`tests/relay-ready/scripts/run-qa-loop.test.js` passes and the event ledger lists Q&A events in order."]);
 
+  const result = script.final;
   assert.equal(result.action, "proceed");
   assert.equal(result.budget_used, 1);
-  assert.deepEqual(askedDimensions(result), ["verifiability"]);
-  assert.deepEqual(eventNames(result), [
+  assert.deepEqual(script.askedDimensions, ["verifiability"]);
+  assert.deepEqual(eventNamesFor(script.events), [
     "question_asked",
     "question_answered",
     "proposal_edited",
@@ -125,7 +159,7 @@ test("override_with_specific_text advances to proceed when the override re-score
   emitQaEvents({
     repoRoot: "/tmp/repo",
     requestId: "req-override",
-    events: result.events,
+    events: script.events,
     helpers: {
       clarify(_repoRoot, _requestId, data) {
         helperCalls.push(["clarify", data.dimension]);
@@ -151,17 +185,18 @@ test("override_with_specific_text advances to proceed when the override re-score
 });
 
 test("override_with_vague_text is re-asked without laundering the budget", () => {
-  const result = runQaLoop({
+  const script = runScript({
     body: VERIFIABILITY_LOW_BODY,
-    answers: [{ dimension: "verifiability", answer: "improve it" }],
-  });
+  }, ["improve it"]);
 
+  const result = script.final;
   assert.equal(result.action, "ask");
   assert.equal(result.dimension, "verifiability");
   assert.equal(result.budget_used, 0);
+  assert.notEqual(result.readiness_score.verifiability, "high");
   assert.match(result.question, /"improve it"/);
-  assert.deepEqual(askedDimensions(result), ["verifiability", "verifiability"]);
-  assert.deepEqual(eventNames(result), [
+  assert.deepEqual(script.askedDimensions, ["verifiability", "verifiability"]);
+  assert.deepEqual(eventNamesFor(script.events), [
     "question_asked",
     "question_answered",
     "proposal_edited",
@@ -169,49 +204,96 @@ test("override_with_vague_text is re-asked without laundering the budget", () =>
   ]);
 });
 
-test("escalation_path triggers instead of asking a fourth budgeted question", () => {
-  const result = runQaLoop({
-    body: GRANULARITY_LOW_BODY,
-    answers: [
-      { dimension: "granularity", answer: "yes" },
-      { dimension: "granularity", answer: "yes" },
-      { dimension: "granularity", answer: "yes" },
-    ],
+test("second vague override consumes budget instead of immediate retry exhaustion", () => {
+  const script = runScript({
+    body: VERIFIABILITY_LOW_BODY,
+  }, ["improve it", "make it better"]);
+
+  const result = script.final;
+  assert.equal(result.action, "ask");
+  assert.equal(result.dimension, "verifiability");
+  assert.equal(result.budget_used, 1);
+  assert.notEqual(result.readiness_score.verifiability, "high");
+  assert.deepEqual(script.askedDimensions, ["verifiability", "verifiability", "verifiability"]);
+  assert.deepEqual(eventNamesFor(script.events), [
+    "question_asked",
+    "question_answered",
+    "proposal_edited",
+    "question_asked",
+    "question_answered",
+    "proposal_edited",
+    "question_asked",
+  ]);
+});
+
+test("answered-history calls do not replay prior question_asked events", () => {
+  const first = runQaLoop({ body: VERIFIABILITY_LOW_BODY });
+  assert.equal(first.action, "ask");
+  assert.deepEqual(eventNames(first), ["question_asked"]);
+
+  const resumed = runQaLoop({
+    body: VERIFIABILITY_LOW_BODY,
+    answers: [{ dimension: "verifiability", answer: "yes" }],
   });
 
+  assert.equal(resumed.action, "proceed");
+  assert.deepEqual(eventNames(resumed), [
+    "question_answered",
+    "proposal_accepted",
+  ]);
+  assert.deepEqual(askedDimensions(resumed), []);
+});
+
+test("normal sequential use can emit all four Q&A event types", () => {
+  const accepted = runScript({
+    body: VERIFIABILITY_LOW_BODY,
+  }, ["yes"]);
+  const edited = runScript({
+    body: VERIFIABILITY_LOW_BODY,
+  }, ["`tests/relay-ready/scripts/run-qa-loop.test.js` passes after the override is applied."]);
+  const eventTypes = new Set([
+    ...eventNamesFor(accepted.events),
+    ...eventNamesFor(edited.events),
+  ]);
+
+  assert.deepEqual([...eventTypes].sort(), [
+    "proposal_accepted",
+    "proposal_edited",
+    "question_answered",
+    "question_asked",
+  ]);
+});
+
+test("escalation_path triggers instead of asking a fourth budgeted question", () => {
+  const script = runScript({
+    body: GRANULARITY_LOW_BODY,
+  }, ["yes", "yes", "yes"]);
+
+  const result = script.final;
   assert.equal(result.action, "escalate");
   assert.equal(result.reason, "question_budget_exhausted");
   assert.equal(result.budget_used, 3);
   assert.deepEqual(result.dimensions_low, ["granularity"]);
-  assert.deepEqual(askedDimensions(result), ["granularity", "granularity", "granularity"]);
+  assert.deepEqual(script.askedDimensions, ["granularity", "granularity", "granularity"]);
 });
 
 test("reentry_with_prior_escalation asks the recovery question first without charging budget", () => {
-  const first = runQaLoop({
+  const script = runScript({
     body: VERIFIABILITY_LOW_BODY,
     reentry: true,
     leaf_id: "leaf-reentry",
-  });
+  }, ["update", "yes"]);
 
+  const first = script.results[0];
   assert.equal(first.action, "ask");
   assert.equal(first.dimension, "_reentry");
   assert.equal(first.question, "Discard prior or update?");
   assert.equal(first.budget_used, 0);
   assert.deepEqual(askedDimensions(first), ["_reentry"]);
 
-  const resumed = runQaLoop({
-    body: VERIFIABILITY_LOW_BODY,
-    reentry: true,
-    leaf_id: "leaf-reentry",
-    answers: [
-      { dimension: "_reentry", answer: "update" },
-      { dimension: "verifiability", answer: "yes" },
-    ],
-  });
-
-  assert.equal(resumed.action, "proceed");
-  assert.equal(resumed.budget_used, 1);
-  assert.deepEqual(askedDimensions(resumed), ["_reentry", "verifiability"]);
+  assert.equal(script.final.action, "proceed");
+  assert.equal(script.final.budget_used, 1);
+  assert.deepEqual(script.askedDimensions, ["_reentry", "verifiability"]);
 });
 
 test("bypass_input proceeds immediately and suppresses all Q&A events", () => {
@@ -243,30 +325,25 @@ test("initial call returns an ask action for the highest-priority low dimension"
 });
 
 test("question priority is deterministic across score combinations", () => {
-  const cases = [
-    [{
-      verifiability: "low",
-      clarity: "low",
-      granularity: "low",
-    }, "verifiability"],
-    [{
-      verifiability: "medium",
-      clarity: "low",
-      granularity: "low",
-    }, "clarity"],
-    [{
-      verifiability: "high",
-      clarity: "medium",
-      granularity: "low",
-    }, "granularity"],
-    [{
-      verifiability: "medium",
-      clarity: "medium",
-      granularity: "medium",
-    }, null],
-  ];
+  const levels = ["low", "medium", "high"];
+  let lowCombinationCount = 0;
 
-  for (const [readiness, expected] of cases) {
-    assert.equal(selectQuestionDimension(readiness), expected);
+  for (const verifiability of levels) {
+    for (const clarity of levels) {
+      for (const granularity of levels) {
+        const readiness = { verifiability, clarity, granularity };
+        const expected = ["verifiability", "clarity", "granularity"]
+          .find((dimension) => readiness[dimension] === "low") || null;
+        if (expected) lowCombinationCount += 1;
+
+        assert.equal(
+          selectQuestionDimension(readiness),
+          expected,
+          JSON.stringify(readiness)
+        );
+      }
+    }
   }
+
+  assert.equal(lowCombinationCount, 19);
 });


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했습니다. 커밋 `a63b13e Implement relay-ready Q&A loop`을 만들고 `origin/issue-436`에 push했습니다.

변경 범위:
- [run-qa-loop.js](/Users/sjlee/.relay/worktrees/60d28ef4/dev-relay/skills/relay-ready/scripts/run-qa-loop.js): 순수 Q&A 결정 함수, 기본값 추출, reentry, budget/escalation, 이벤트 ledger + 기존 `relay-request.js` 헬퍼 post-hook
- [run-qa-loop.test.js](/Users/sjlee/.relay/worktrees/60d28ef4/dev-relay/tests/relay-ready/scripts/run-qa-loop.test.js): 7개 named fixture 포함, 이벤트 순서, 세 action shape, priority 조합 테스트

검증:
- `no
```

## Score Log

- Run: issue-436-20260507235415003-02a53b5f
- Executor: codex
- Branch: issue-436