### PR TITLE
Add sidecar artifact schema and lifecycle events (#372)

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -220,6 +220,38 @@ function getEventsPath(repoRoot, runId) {
   return path.join(getRunDir(repoRoot, runId), "events.jsonl");
 }
 
+function validateSidecarId(sidecarId) {
+  const normalizedSidecarId = typeof sidecarId === "string" ? sidecarId.trim() : "";
+  if (!normalizedSidecarId) {
+    throw new Error(`sidecar_id must be a non-empty path segment, got: ${JSON.stringify(sidecarId)}`);
+  }
+  if (normalizedSidecarId === "." || normalizedSidecarId === "..") {
+    throw new Error(`sidecar_id may not be "." or ".." (got ${JSON.stringify(normalizedSidecarId)}).`);
+  }
+  if (normalizedSidecarId.includes("/") || normalizedSidecarId.includes("\\")) {
+    throw new Error(`sidecar_id must be a single path segment (got ${JSON.stringify(normalizedSidecarId)}).`);
+  }
+  if (
+    path.basename(normalizedSidecarId) !== normalizedSidecarId
+    || path.win32.basename(normalizedSidecarId) !== normalizedSidecarId
+  ) {
+    throw new Error(`sidecar_id must resolve to a single path segment (got ${JSON.stringify(normalizedSidecarId)}).`);
+  }
+  return normalizedSidecarId;
+}
+
+function getSidecarsDir(repoRoot, runId) {
+  return path.join(getRunDir(repoRoot, runId), "sidecars");
+}
+
+function getSidecarsIndexPath(repoRoot, runId) {
+  return path.join(getSidecarsDir(repoRoot, runId), "index.json");
+}
+
+function getSidecarOutputDir(repoRoot, runId, sidecarId) {
+  return path.join(getSidecarsDir(repoRoot, runId), validateSidecarId(sidecarId));
+}
+
 function listManifestPaths(repoRoot) {
   const runsDir = getRunsDir(repoRoot);
   if (!fs.existsSync(runsDir)) return [];
@@ -449,6 +481,9 @@ module.exports = {
   getRunDir,
   getRunsBase,
   getRunsDir,
+  getSidecarOutputDir,
+  getSidecarsDir,
+  getSidecarsIndexPath,
   getWorktreeGitCommonDir,
   inferIssueNumber,
   isPathContainedWithin,

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -48,6 +48,9 @@ const EVENTS = Object.freeze({
   REVIEWER_SWAP: "reviewer_swap",
   RUBRIC_QUALITY: "rubric_quality",
   SCORE_DIVERGENCE: "score_divergence",
+  SIDECAR_FAILED: "sidecar_failed",
+  SIDECAR_RESULT: "sidecar_result",
+  SIDECAR_START: "sidecar_start",
   SKIP_REVIEW: "skip_review",
   STATE_RECOVERY: "state_recovery",
 });
@@ -151,6 +154,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.executor !== undefined
       ? { executor: normalizeEventValue(eventData.executor) }
       : {}),
+    ...(eventData.kind !== undefined
+      ? { kind: normalizeEventValue(eventData.kind) }
+      : {}),
     ...(eventData.model !== undefined
       ? { model: normalizeEventValue(eventData.model) }
       : {}),
@@ -214,6 +220,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.artifact_path !== undefined
       ? { artifact_path: normalizeEventValue(eventData.artifact_path) }
       : {}),
+    ...(eventData.output_path !== undefined
+      ? { output_path: normalizeEventValue(eventData.output_path) }
+      : {}),
     ...(eventData.raw_response_path !== undefined
       ? { raw_response_path: normalizeEventValue(eventData.raw_response_path) }
       : {}),
@@ -231,6 +240,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
     ...(eventData.failure_reason !== undefined
       ? { failure_reason: normalizeEventValue(eventData.failure_reason) }
+      : {}),
+    ...(eventData.sidecar_id !== undefined
+      ? { sidecar_id: normalizeEventValue(eventData.sidecar_id) }
+      : {}),
+    ...(eventData.trust_level !== undefined
+      ? { trust_level: normalizeEventValue(eventData.trust_level) }
       : {}),
   };
 

--- a/skills/relay-dispatch/scripts/sidecar-store.js
+++ b/skills/relay-dispatch/scripts/sidecar-store.js
@@ -1,0 +1,176 @@
+const fs = require("fs");
+const path = require("path");
+
+const {
+  ensureRunLayout,
+  getRunDir,
+  getSidecarsDir,
+  getSidecarsIndexPath,
+  isPathContainedWithin,
+} = require("./manifest/paths");
+const {
+  readTextFileWithoutFollowingSymlinks,
+  writeTextFileWithoutFollowingSymlinks,
+} = require("./manifest/rubric");
+const { appendRunEvent, EVENTS } = require("./relay-events");
+
+const SIDECAR_STATUSES = Object.freeze(["pending", "running", "completed", "failed"]);
+const SIDECAR_TRUST_LEVEL = "advisory";
+const SIDECAR_STATUS_SET = new Set(SIDECAR_STATUSES);
+
+function requireNonEmptyString(value, field) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${field} is required and must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function normalizeNullableString(value, field) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string or null`);
+  }
+  return value;
+}
+
+function validateOutputPath(repoRoot, runId, outputPath) {
+  const normalizedOutputPath = requireNonEmptyString(outputPath, "output_path");
+  const segments = normalizedOutputPath.split(/[\\/]+/).filter(Boolean);
+  if (path.isAbsolute(normalizedOutputPath) || segments.includes("..")) {
+    throw new Error(`output_path must be run-dir-relative and may not escape the run directory: ${JSON.stringify(outputPath)}`);
+  }
+
+  const runDir = getRunDir(repoRoot, runId);
+  const resolvedOutputPath = path.resolve(runDir, normalizedOutputPath);
+  if (!isPathContainedWithin(runDir, resolvedOutputPath)) {
+    throw new Error(`output_path must resolve inside the run directory: ${JSON.stringify(outputPath)}`);
+  }
+  return normalizedOutputPath;
+}
+
+function validateSidecarEntry(repoRoot, runId, entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error("sidecar entry must be an object");
+  }
+  if (!SIDECAR_STATUS_SET.has(entry.status)) {
+    throw new Error(`status must be one of: ${SIDECAR_STATUSES.join(", ")}`);
+  }
+  if (entry.trust_level !== SIDECAR_TRUST_LEVEL) {
+    throw new Error(`trust_level must be ${JSON.stringify(SIDECAR_TRUST_LEVEL)}`);
+  }
+
+  return {
+    id: requireNonEmptyString(entry.id, "id"),
+    kind: requireNonEmptyString(entry.kind, "kind"),
+    executor: requireNonEmptyString(entry.executor, "executor"),
+    model: normalizeNullableString(entry.model, "model"),
+    provider: normalizeNullableString(entry.provider, "provider"),
+    status: entry.status,
+    output_path: validateOutputPath(repoRoot, runId, entry.output_path),
+    trust_level: SIDECAR_TRUST_LEVEL,
+  };
+}
+
+function normalizeIndexShape(repoRoot, runId, parsed, indexPath) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Invalid sidecars index at ${indexPath}: expected an object`);
+  }
+  if (!Array.isArray(parsed.sidecars)) {
+    throw new Error(`Invalid sidecars index at ${indexPath}: sidecars must be an array`);
+  }
+  return {
+    sidecars: parsed.sidecars.map((entry) => validateSidecarEntry(repoRoot, runId, entry)),
+  };
+}
+
+function readSidecarIndex(repoRoot, runId) {
+  const indexPath = getSidecarsIndexPath(repoRoot, runId);
+  let rawText;
+  try {
+    rawText = readTextFileWithoutFollowingSymlinks(indexPath);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return { sidecars: [] };
+    }
+    if (error.code === "ELOOP") {
+      throw new Error(`Refusing to read symlinked sidecars index at ${indexPath}: ${error.message}`);
+    }
+    throw error;
+  }
+  return normalizeIndexShape(repoRoot, runId, JSON.parse(rawText), indexPath);
+}
+
+function writeSidecarIndex(repoRoot, runId, index) {
+  ensureRunLayout(repoRoot, runId);
+  const sidecarsDir = getSidecarsDir(repoRoot, runId);
+  const indexPath = getSidecarsIndexPath(repoRoot, runId);
+  fs.mkdirSync(sidecarsDir, { recursive: true });
+  try {
+    writeTextFileWithoutFollowingSymlinks(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+  } catch (error) {
+    if (error.code === "ELOOP") {
+      throw new Error(`Refusing to write symlinked sidecars index at ${indexPath}: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+function upsertSidecarEntry(repoRoot, runId, entry) {
+  const normalizedEntry = validateSidecarEntry(repoRoot, runId, entry);
+  const index = readSidecarIndex(repoRoot, runId);
+  const existingIndex = index.sidecars.findIndex((candidate) => candidate?.id === normalizedEntry.id);
+  const nextSidecars = [...index.sidecars];
+  if (existingIndex === -1) {
+    nextSidecars.push(normalizedEntry);
+  } else {
+    nextSidecars[existingIndex] = normalizedEntry;
+  }
+
+  const nextIndex = { sidecars: nextSidecars };
+  writeSidecarIndex(repoRoot, runId, nextIndex);
+  return normalizedEntry;
+}
+
+function appendSidecarStart(repoRoot, runId, { id, kind, executor, model, provider } = {}) {
+  const eventData = {
+    event: EVENTS.SIDECAR_START,
+    sidecar_id: requireNonEmptyString(id, "id"),
+    kind: requireNonEmptyString(kind, "kind"),
+    executor: requireNonEmptyString(executor, "executor"),
+    ...(model !== undefined ? { model: normalizeNullableString(model, "model") } : {}),
+    ...(provider !== undefined ? { provider: normalizeNullableString(provider, "provider") } : {}),
+  };
+  return appendRunEvent(repoRoot, runId, eventData);
+}
+
+function appendSidecarResult(repoRoot, runId, { id, kind, output_path, elapsed_ms } = {}) {
+  return appendRunEvent(repoRoot, runId, {
+    event: EVENTS.SIDECAR_RESULT,
+    sidecar_id: requireNonEmptyString(id, "id"),
+    kind: requireNonEmptyString(kind, "kind"),
+    output_path: validateOutputPath(repoRoot, runId, output_path),
+    trust_level: SIDECAR_TRUST_LEVEL,
+    ...(elapsed_ms !== undefined ? { elapsed_ms } : {}),
+  });
+}
+
+function appendSidecarFailed(repoRoot, runId, { id, kind, failure_reason } = {}) {
+  return appendRunEvent(repoRoot, runId, {
+    event: EVENTS.SIDECAR_FAILED,
+    sidecar_id: requireNonEmptyString(id, "id"),
+    kind: requireNonEmptyString(kind, "kind"),
+    failure_reason: requireNonEmptyString(failure_reason, "failure_reason"),
+  });
+}
+
+module.exports = {
+  appendSidecarFailed,
+  appendSidecarResult,
+  appendSidecarStart,
+  readSidecarIndex,
+  SIDECAR_STATUSES,
+  SIDECAR_TRUST_LEVEL,
+  upsertSidecarEntry,
+};

--- a/skills/relay-dispatch/scripts/sidecar-store.js
+++ b/skills/relay-dispatch/scripts/sidecar-store.js
@@ -4,6 +4,7 @@ const path = require("path");
 const {
   ensureRunLayout,
   getRunDir,
+  getSidecarOutputDir,
   getSidecarsDir,
   getSidecarsIndexPath,
   isPathContainedWithin,
@@ -35,7 +36,7 @@ function normalizeNullableString(value, field) {
   return value;
 }
 
-function validateOutputPath(repoRoot, runId, outputPath) {
+function validateOutputPath(repoRoot, runId, sidecarId, outputPath) {
   const normalizedOutputPath = requireNonEmptyString(outputPath, "output_path");
   const segments = normalizedOutputPath.split(/[\\/]+/).filter(Boolean);
   if (path.isAbsolute(normalizedOutputPath) || segments.includes("..")) {
@@ -46,6 +47,13 @@ function validateOutputPath(repoRoot, runId, outputPath) {
   const resolvedOutputPath = path.resolve(runDir, normalizedOutputPath);
   if (!isPathContainedWithin(runDir, resolvedOutputPath)) {
     throw new Error(`output_path must resolve inside the run directory: ${JSON.stringify(outputPath)}`);
+  }
+
+  const sidecarOutputDir = getSidecarOutputDir(repoRoot, runId, sidecarId);
+  if (!isPathContainedWithin(sidecarOutputDir, resolvedOutputPath)) {
+    throw new Error(
+      `output_path must be under sidecars/${sidecarId}/ for the matching sidecar id: ${JSON.stringify(outputPath)}`
+    );
   }
   return normalizedOutputPath;
 }
@@ -61,14 +69,16 @@ function validateSidecarEntry(repoRoot, runId, entry) {
     throw new Error(`trust_level must be ${JSON.stringify(SIDECAR_TRUST_LEVEL)}`);
   }
 
+  const id = requireNonEmptyString(entry.id, "id");
+
   return {
-    id: requireNonEmptyString(entry.id, "id"),
+    id,
     kind: requireNonEmptyString(entry.kind, "kind"),
     executor: requireNonEmptyString(entry.executor, "executor"),
     model: normalizeNullableString(entry.model, "model"),
     provider: normalizeNullableString(entry.provider, "provider"),
     status: entry.status,
-    output_path: validateOutputPath(repoRoot, runId, entry.output_path),
+    output_path: validateOutputPath(repoRoot, runId, id, entry.output_path),
     trust_level: SIDECAR_TRUST_LEVEL,
   };
 }
@@ -146,11 +156,12 @@ function appendSidecarStart(repoRoot, runId, { id, kind, executor, model, provid
 }
 
 function appendSidecarResult(repoRoot, runId, { id, kind, output_path, elapsed_ms } = {}) {
+  const sidecarId = requireNonEmptyString(id, "id");
   return appendRunEvent(repoRoot, runId, {
     event: EVENTS.SIDECAR_RESULT,
-    sidecar_id: requireNonEmptyString(id, "id"),
+    sidecar_id: sidecarId,
     kind: requireNonEmptyString(kind, "kind"),
-    output_path: validateOutputPath(repoRoot, runId, output_path),
+    output_path: validateOutputPath(repoRoot, runId, sidecarId, output_path),
     trust_level: SIDECAR_TRUST_LEVEL,
     ...(elapsed_ms !== undefined ? { elapsed_ms } : {}),
   });

--- a/tests/relay-dispatch/scripts/sidecar-store.test.js
+++ b/tests/relay-dispatch/scripts/sidecar-store.test.js
@@ -1,0 +1,203 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  ensureRunLayout,
+  getSidecarOutputDir,
+  getSidecarsDir,
+  getSidecarsIndexPath,
+} = require("../../../skills/relay-dispatch/scripts/manifest/paths");
+const {
+  appendRunEvent,
+  EVENTS,
+  readRunEvents,
+} = require("../../../skills/relay-dispatch/scripts/relay-events");
+const {
+  appendSidecarFailed,
+  appendSidecarResult,
+  appendSidecarStart,
+  readSidecarIndex,
+  SIDECAR_TRUST_LEVEL,
+  upsertSidecarEntry,
+} = require("../../../skills/relay-dispatch/scripts/sidecar-store");
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Sidecar Test"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function createContext() {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-sidecar-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-sidecar-repo-"));
+  initGitRepo(repoRoot);
+  const runId = "issue-372-20260508010101000-a1b2c3d4";
+  ensureRunLayout(repoRoot, runId);
+  return { repoRoot, runId };
+}
+
+function createEntry(overrides = {}) {
+  return {
+    id: "lint-report",
+    kind: "static-analysis",
+    executor: "codex",
+    model: "gpt-5",
+    provider: "openai",
+    status: "pending",
+    output_path: "sidecars/lint-report",
+    trust_level: SIDECAR_TRUST_LEVEL,
+    ...overrides,
+  };
+}
+
+test("readSidecarIndex returns an empty index without creating storage", () => {
+  const { repoRoot, runId } = createContext();
+  const sidecarsDir = getSidecarsDir(repoRoot, runId);
+  const indexPath = getSidecarsIndexPath(repoRoot, runId);
+
+  assert.deepEqual(readSidecarIndex(repoRoot, runId), { sidecars: [] });
+  assert.equal(fs.existsSync(sidecarsDir), false);
+  assert.equal(fs.existsSync(indexPath), false);
+});
+
+test("upsertSidecarEntry lazily creates index.json and replaces entries by id", () => {
+  const { repoRoot, runId } = createContext();
+  const first = upsertSidecarEntry(repoRoot, runId, createEntry({ model: undefined, provider: undefined }));
+  const second = upsertSidecarEntry(repoRoot, runId, createEntry({
+    status: "completed",
+    output_path: "sidecars/lint-report/result.json",
+  }));
+
+  assert.deepEqual(first, {
+    id: "lint-report",
+    kind: "static-analysis",
+    executor: "codex",
+    model: null,
+    provider: null,
+    status: "pending",
+    output_path: "sidecars/lint-report",
+    trust_level: SIDECAR_TRUST_LEVEL,
+  });
+  assert.equal(fs.existsSync(getSidecarsIndexPath(repoRoot, runId)), true);
+  assert.deepEqual(readSidecarIndex(repoRoot, runId), { sidecars: [second] });
+  assert.equal(readSidecarIndex(repoRoot, runId).sidecars.length, 1);
+});
+
+test("upsertSidecarEntry validates status, trust level, and run-relative output paths", () => {
+  const { repoRoot, runId } = createContext();
+
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ status: "partial" })),
+    /status must be one of: pending, running, completed, failed/
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ trust_level: "evidence" })),
+    /trust_level must be "advisory"/
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ output_path: "../escape" })),
+    /output_path must be run-dir-relative/
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ output_path: path.join(os.tmpdir(), "escape") })),
+    /output_path must be run-dir-relative/
+  );
+});
+
+test("readSidecarIndex refuses symlinked index.json", () => {
+  const { repoRoot, runId } = createContext();
+  const sidecarsDir = getSidecarsDir(repoRoot, runId);
+  const indexPath = getSidecarsIndexPath(repoRoot, runId);
+  const targetPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "relay-sidecar-target-")), "index.json");
+  fs.mkdirSync(sidecarsDir, { recursive: true });
+  fs.writeFileSync(targetPath, JSON.stringify({ sidecars: [] }), "utf-8");
+  fs.symlinkSync(targetPath, indexPath);
+
+  assert.throws(
+    () => readSidecarIndex(repoRoot, runId),
+    /Refusing to read symlinked sidecars index/
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry()),
+    /Refusing to read symlinked sidecars index/
+  );
+});
+
+test("getSidecarOutputDir exposes but does not create per-sidecar output directories", () => {
+  const { repoRoot, runId } = createContext();
+  const outputDir = getSidecarOutputDir(repoRoot, runId, "lint-report");
+
+  assert.equal(outputDir, path.join(getSidecarsDir(repoRoot, runId), "lint-report"));
+  assert.equal(fs.existsSync(outputDir), false);
+  assert.throws(
+    () => getSidecarOutputDir(repoRoot, runId, "../escape"),
+    /sidecar_id must be a single path segment|sidecar_id may not be/
+  );
+});
+
+test("sidecar lifecycle helpers append advisory events without manifest state transitions", () => {
+  const { repoRoot, runId } = createContext();
+  const started = appendSidecarStart(repoRoot, runId, {
+    id: "lint-report",
+    kind: "static-analysis",
+    executor: "codex",
+    model: "gpt-5",
+    provider: "openai",
+  });
+  const completed = appendSidecarResult(repoRoot, runId, {
+    id: "lint-report",
+    kind: "static-analysis",
+    output_path: "sidecars/lint-report/result.json",
+    elapsed_ms: 123,
+  });
+  const failed = appendSidecarFailed(repoRoot, runId, {
+    id: "coverage-report",
+    kind: "coverage",
+    failure_reason: "tool exited 1",
+  });
+
+  assert.equal(started.event, EVENTS.SIDECAR_START);
+  assert.equal(started.sidecar_id, "lint-report");
+  assert.equal(started.executor, "codex");
+  assert.equal(started.model, "gpt-5");
+  assert.equal(started.provider, "openai");
+  assert.equal(completed.event, EVENTS.SIDECAR_RESULT);
+  assert.equal(completed.output_path, "sidecars/lint-report/result.json");
+  assert.equal(completed.trust_level, SIDECAR_TRUST_LEVEL);
+  assert.equal(completed.elapsed_ms, 123);
+  assert.equal(failed.event, EVENTS.SIDECAR_FAILED);
+  assert.equal(failed.failure_reason, "tool exited 1");
+
+  const events = readRunEvents(repoRoot, runId);
+  assert.deepEqual(events, [started, completed, failed]);
+  for (const event of events) {
+    assert.equal(event.state_from, null);
+    assert.equal(event.state_to, null);
+  }
+});
+
+test("sidecar events coexist with legacy-shaped non-sidecar events", () => {
+  const { repoRoot, runId } = createContext();
+  const dispatchStart = appendRunEvent(repoRoot, runId, {
+    event: EVENTS.DISPATCH_START,
+    state_from: "draft",
+    state_to: "dispatched",
+    reason: "start",
+  });
+  const sidecarResult = appendSidecarResult(repoRoot, runId, {
+    id: "lint-report",
+    kind: "static-analysis",
+    output_path: "sidecars/lint-report/result.json",
+  });
+
+  const events = readRunEvents(repoRoot, runId);
+  assert.deepEqual(events, [dispatchStart, sidecarResult]);
+  for (const key of ["sidecar_id", "kind", "output_path", "trust_level"]) {
+    assert.equal(Object.prototype.hasOwnProperty.call(events[0], key), false);
+  }
+  assert.equal(events[1].trust_level, SIDECAR_TRUST_LEVEL);
+});

--- a/tests/relay-dispatch/scripts/sidecar-store.test.js
+++ b/tests/relay-dispatch/scripts/sidecar-store.test.js
@@ -48,7 +48,7 @@ function createEntry(overrides = {}) {
     model: "gpt-5",
     provider: "openai",
     status: "pending",
-    output_path: "sidecars/lint-report",
+    output_path: "sidecars/lint-report/result.json",
     trust_level: SIDECAR_TRUST_LEVEL,
     ...overrides,
   };
@@ -79,7 +79,7 @@ test("upsertSidecarEntry lazily creates index.json and replaces entries by id", 
     model: null,
     provider: null,
     status: "pending",
-    output_path: "sidecars/lint-report",
+    output_path: "sidecars/lint-report/result.json",
     trust_level: SIDECAR_TRUST_LEVEL,
   });
   assert.equal(fs.existsSync(getSidecarsIndexPath(repoRoot, runId)), true);
@@ -87,7 +87,7 @@ test("upsertSidecarEntry lazily creates index.json and replaces entries by id", 
   assert.equal(readSidecarIndex(repoRoot, runId).sidecars.length, 1);
 });
 
-test("upsertSidecarEntry validates status, trust level, and run-relative output paths", () => {
+test("upsertSidecarEntry validates status, trust level, and id-scoped output paths", () => {
   const { repoRoot, runId } = createContext();
 
   assert.throws(
@@ -105,6 +105,25 @@ test("upsertSidecarEntry validates status, trust level, and run-relative output 
   assert.throws(
     () => upsertSidecarEntry(repoRoot, runId, createEntry({ output_path: path.join(os.tmpdir(), "escape") })),
     /output_path must be run-dir-relative/
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ output_path: "rubric.json" })),
+    /output_path must be under sidecars\/lint-report\//
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ output_path: "sidecars/other/result.json" })),
+    /output_path must be under sidecars\/lint-report\//
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({ output_path: "sidecars/lint-report" })),
+    /output_path must be under sidecars\/lint-report\//
+  );
+  assert.throws(
+    () => upsertSidecarEntry(repoRoot, runId, createEntry({
+      id: "other",
+      output_path: "sidecars/lint-report/result.json",
+    })),
+    /output_path must be under sidecars\/other\//
   );
 });
 
@@ -200,4 +219,17 @@ test("sidecar events coexist with legacy-shaped non-sidecar events", () => {
     assert.equal(Object.prototype.hasOwnProperty.call(events[0], key), false);
   }
   assert.equal(events[1].trust_level, SIDECAR_TRUST_LEVEL);
+});
+
+test("appendSidecarResult rejects output paths outside the matching sidecar directory", () => {
+  const { repoRoot, runId } = createContext();
+
+  assert.throws(
+    () => appendSidecarResult(repoRoot, runId, {
+      id: "lint-report",
+      kind: "static-analysis",
+      output_path: "sidecars/other/result.json",
+    }),
+    /output_path must be under sidecars\/lint-report\//
+  );
 });


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-372-20260508034916908-dcc00bc6
- Branch: issue-372
- Reason: codex finished work but did not commit/push/PR (standard completed-uncommitted recovery)
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-372-20260508034916908-dcc00bc6.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-08T03:59:10.037Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실행 디렉토리 아래에서 Sidecar 출력 지원 추가
  * 새로운 이벤트 타입 추가: `sidecar_failed`, `sidecar_result`
  * Sidecar 인덱스 및 이벤트 기록 기능 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->