### PR TITLE
Report sidecar value in reliability-report (#376)

### DIFF
--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -3,6 +3,8 @@
 const fs = require("fs");
 const path = require("path");
 const { STATES } = require("./manifest/lifecycle");
+const { getRunDir, getSidecarOutputDir } = require("./manifest/paths");
+const { readTextFileWithoutFollowingSymlinks } = require("./manifest/rubric");
 const { listManifestRecords } = require("./manifest/store");
 const { modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { EVENTS, readAllRunEvents } = require("./relay-events");
@@ -563,6 +565,187 @@ function buildGuidancePackInsights(manifests, events) {
   };
 }
 
+function normalizeBucketValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+function sidecarEventKey(event) {
+  const runId = normalizeBucketValue(event?.run_id);
+  const sidecarId = normalizeBucketValue(event?.sidecar_id);
+  return `${runId}\u0000${sidecarId}`;
+}
+
+function incrementInvocationBucket(buckets, key) {
+  if (!buckets.has(key)) {
+    buckets.set(key, { invocations: 0, successes: 0, failures: 0 });
+  }
+  buckets.get(key).invocations += 1;
+}
+
+function incrementOutcomeBucket(buckets, key, outcome) {
+  if (!buckets.has(key)) {
+    buckets.set(key, { invocations: 0, successes: 0, failures: 0 });
+  }
+  buckets.get(key)[outcome] += 1;
+}
+
+function sortSummaryObject(entries) {
+  return Object.fromEntries([...entries].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function buildSidecarOutcomeBuckets(starts, results, failures, fieldName) {
+  const buckets = new Map();
+  const startBucketsBySidecar = new Map();
+
+  for (const event of starts) {
+    const bucketKey = normalizeBucketValue(event?.[fieldName]);
+    startBucketsBySidecar.set(sidecarEventKey(event), bucketKey);
+    incrementInvocationBucket(buckets, bucketKey);
+  }
+
+  for (const event of results) {
+    const bucketKey = startBucketsBySidecar.get(sidecarEventKey(event)) || normalizeBucketValue(event?.[fieldName]);
+    incrementOutcomeBucket(buckets, bucketKey, "successes");
+  }
+
+  for (const event of failures) {
+    const bucketKey = startBucketsBySidecar.get(sidecarEventKey(event)) || normalizeBucketValue(event?.[fieldName]);
+    incrementOutcomeBucket(buckets, bucketKey, "failures");
+  }
+
+  return sortSummaryObject(buckets.entries());
+}
+
+function buildSidecarCountBuckets(starts, fieldName) {
+  const buckets = new Map();
+  for (const event of starts) {
+    const bucketKey = normalizeBucketValue(event?.[fieldName]);
+    if (!buckets.has(bucketKey)) {
+      buckets.set(bucketKey, { invocations: 0 });
+    }
+    buckets.get(bucketKey).invocations += 1;
+  }
+  return sortSummaryObject(buckets.entries());
+}
+
+function readReviewIssueTitles(runDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(runDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const titles = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !/^review-round-\d+-verdict\.json$/.test(entry.name)) continue;
+    try {
+      const verdictText = readTextFileWithoutFollowingSymlinks(path.join(runDir, entry.name));
+      const verdict = JSON.parse(verdictText);
+      if (!Array.isArray(verdict?.issues) || verdict.issues.length === 0) continue;
+      for (const issue of verdict.issues) {
+        const title = typeof issue?.title === "string" ? issue.title.trim() : "";
+        if (title) titles.push(title);
+      }
+    } catch {
+      // Best-effort analytics must not block the rest of the report.
+    }
+  }
+  return titles;
+}
+
+function readSidecarOutput(repoRoot, runId, sidecarId) {
+  const outputPath = path.join(getSidecarOutputDir(repoRoot, runId, sidecarId), "output.md");
+  const output = readTextFileWithoutFollowingSymlinks(outputPath);
+  if (!output || /\u0000/.test(output)) {
+    return null;
+  }
+  return output;
+}
+
+function computeSidecarPredictionRate({ events, repoRoot }) {
+  const resultEventsByRun = new Map();
+  for (const event of events) {
+    if (event?.event !== EVENTS.SIDECAR_RESULT || !event.run_id || !event.sidecar_id) continue;
+    if (!resultEventsByRun.has(event.run_id)) {
+      resultEventsByRun.set(event.run_id, []);
+    }
+    resultEventsByRun.get(event.run_id).push(event);
+  }
+
+  let predicted = 0;
+  let missed = 0;
+  let runsExamined = 0;
+
+  for (const [runId, resultEvents] of resultEventsByRun.entries()) {
+    let runDir;
+    try {
+      runDir = getRunDir(repoRoot, runId);
+    } catch {
+      continue;
+    }
+
+    const issueTitles = readReviewIssueTitles(runDir);
+    if (issueTitles.length === 0) continue;
+
+    const outputTexts = [];
+    for (const event of resultEvents) {
+      try {
+        const outputText = readSidecarOutput(repoRoot, runId, event.sidecar_id);
+        if (outputText !== null) {
+          outputTexts.push(outputText.toLowerCase());
+        }
+      } catch {
+        // Missing, symlinked, directory, or otherwise unreadable output is skipped.
+      }
+    }
+    if (outputTexts.length === 0) continue;
+
+    runsExamined += 1;
+    const combinedOutput = outputTexts.join("\n");
+    for (const title of issueTitles) {
+      if (combinedOutput.includes(title.toLowerCase())) {
+        predicted += 1;
+      } else {
+        missed += 1;
+      }
+    }
+  }
+
+  return {
+    predicted_findings_match_rate: ratio(predicted, predicted + missed),
+    predicted_findings_runs_examined: runsExamined,
+  };
+}
+
+function buildSidecarInsights({ events, repoRoot }) {
+  const starts = events.filter((event) => event.event === EVENTS.SIDECAR_START);
+  const results = events.filter((event) => event.event === EVENTS.SIDECAR_RESULT);
+  const failures = events.filter((event) => event.event === EVENTS.SIDECAR_FAILED);
+  const prediction = computeSidecarPredictionRate({ events, repoRoot });
+
+  return {
+    total_invocations: starts.length,
+    by_kind: buildSidecarOutcomeBuckets(starts, results, failures, "kind"),
+    by_executor: buildSidecarOutcomeBuckets(starts, results, failures, "executor"),
+    by_model: buildSidecarCountBuckets(starts, "model"),
+    by_provider: buildSidecarCountBuckets(starts, "provider"),
+    failure_rate: starts.length > 0 ? ratio(failures.length, starts.length) : null,
+    predicted_findings_match_rate: prediction.predicted_findings_match_rate,
+    predicted_findings_runs_examined: prediction.predicted_findings_runs_examined,
+  };
+}
+
+function formatSidecarCountSummary(buckets) {
+  return Object.entries(buckets || {})
+    .sort(([leftKey, left], [rightKey, right]) => (
+      (right.invocations || 0) - (left.invocations || 0)
+      || leftKey.localeCompare(rightKey)
+    ))
+    .map(([key, summary]) => `${key}=${summary.invocations || 0}`)
+    .join(", ");
+}
+
 function resolveManifestRubricPath(manifest) {
   const rubricPath = manifest?.data?.anchor?.rubric_path;
   const runId = manifest?.data?.run_id;
@@ -723,7 +906,7 @@ function buildModelPerPhase(events) {
   );
 }
 
-function buildReport({ repoRoot, staleHours, now, manifests, events }) {
+function buildReport({ repoRoot, staleHours, now, manifests, events, includeSidecarInsights = false }) {
   const resumeStarts = events.filter((event) => (
     event.event === EVENTS.DISPATCH_START && event.state_from === STATES.CHANGES_REQUESTED
   ));
@@ -774,7 +957,7 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
       .map((event) => event.run_id)
   );
 
-  return {
+  const report = {
     repoRoot,
     staleHours,
     bootstrap_exempt_runs: manifests.filter(({ data }) => data?.bootstrap_exempt?.enabled === true).length,
@@ -802,6 +985,12 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
     qualitative_signals: buildQualitativeSignals(manifests, events),
     guidance_pack_insights: buildGuidancePackInsights(manifests, events),
   };
+
+  if (includeSidecarInsights) {
+    report.sidecar_insights = buildSidecarInsights({ events, repoRoot });
+  }
+
+  return report;
 }
 
 function buildActorReports({ repoRoot, staleHours, now, manifests, events }) {
@@ -980,7 +1169,7 @@ function main() {
   const now = Date.now();
   const manifests = listManifestRecords(repoRoot);
   const events = readAllRunEvents(repoRoot);
-  const report = buildReport({ repoRoot, staleHours, now, manifests, events });
+  const report = buildReport({ repoRoot, staleHours, now, manifests, events, includeSidecarInsights: true });
 
   if (hasCliFlag("--by-actor")) {
     report.by_actor = buildActorReports({ repoRoot, staleHours, now, manifests, events });
@@ -1037,6 +1226,19 @@ function main() {
         `top_stuck_factor=${topStuckFactor} ` +
         `divergence_avg_delta=${summary.executor_reviewer_divergence?.avg_delta ?? "n/a"}`
       );
+    }
+  }
+  if (report.sidecar_insights?.total_invocations === 0) {
+    console.log("  sidecar_insights: no sidecar runs available");
+  } else {
+    console.log("  sidecar_insights:");
+    console.log(`    total_invocations: ${report.sidecar_insights.total_invocations}`);
+    console.log(`    failure_rate: ${report.sidecar_insights.failure_rate ?? "n/a"}`);
+    console.log(`    by_kind: ${formatSidecarCountSummary(report.sidecar_insights.by_kind) || "n/a"}`);
+    console.log(`    by_executor: ${formatSidecarCountSummary(report.sidecar_insights.by_executor) || "n/a"}`);
+    if (report.sidecar_insights.predicted_findings_match_rate !== null) {
+      console.log(`    predicted_findings_match_rate: ${report.sidecar_insights.predicted_findings_match_rate}`);
+      console.log(`    predicted_findings_runs_examined: ${report.sidecar_insights.predicted_findings_runs_examined}`);
     }
   }
   if (hasCliFlag("--by-actor")) {

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -663,6 +663,33 @@ function readSidecarOutput(repoRoot, runId, sidecarId) {
   return output;
 }
 
+const SIDECAR_TITLE_TOKEN_STOPWORDS = new Set([
+  "about",
+  "after",
+  "before",
+  "from",
+  "into",
+  "missing",
+  "should",
+  "that",
+  "then",
+  "this",
+  "with",
+]);
+
+function issueTitleMatchesSidecarOutput(combinedOutput, title) {
+  const normalizedTitle = title.toLowerCase().trim();
+  if (!normalizedTitle) return false;
+  if (combinedOutput.includes(normalizedTitle)) return true;
+
+  const tokens = normalizedTitle.match(/[a-z0-9_][a-z0-9_.:/-]{2,}/g) || [];
+  return tokens.some((token) => (
+    !SIDECAR_TITLE_TOKEN_STOPWORDS.has(token)
+    && (token.length >= 4 || token.includes("_"))
+    && combinedOutput.includes(token)
+  ));
+}
+
 function computeSidecarPredictionRate({ events, repoRoot }) {
   const resultEventsByRun = new Map();
   for (const event of events) {
@@ -704,7 +731,7 @@ function computeSidecarPredictionRate({ events, repoRoot }) {
     runsExamined += 1;
     const combinedOutput = outputTexts.join("\n");
     for (const title of issueTitles) {
-      if (combinedOutput.includes(title.toLowerCase())) {
+      if (issueTitleMatchesSidecarOutput(combinedOutput, title)) {
         predicted += 1;
       } else {
         missed += 1;

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -185,6 +185,65 @@ function setManifestDispatch(repoRoot, runId, dispatch) {
   writeManifest(manifestPath, manifest);
 }
 
+function appendSidecarStart(repoRoot, runId, {
+  sidecarId,
+  kind = "context-recap",
+  executor = "codex",
+  model = undefined,
+  provider = undefined,
+} = {}) {
+  const event = {
+    event: "sidecar_start",
+    sidecar_id: sidecarId,
+    kind,
+    executor,
+  };
+  if (model !== undefined) event.model = model;
+  if (provider !== undefined) event.provider = provider;
+  appendRunEvent(repoRoot, runId, event);
+}
+
+function appendSidecarResult(repoRoot, runId, {
+  sidecarId,
+  kind = "context-recap",
+} = {}) {
+  appendRunEvent(repoRoot, runId, {
+    event: "sidecar_result",
+    sidecar_id: sidecarId,
+    kind,
+    output_path: `sidecars/${sidecarId}/output.md`,
+    trust_level: "advisory",
+  });
+}
+
+function appendSidecarFailed(repoRoot, runId, {
+  sidecarId,
+  kind = "context-recap",
+} = {}) {
+  appendRunEvent(repoRoot, runId, {
+    event: "sidecar_failed",
+    sidecar_id: sidecarId,
+    kind,
+    failure_reason: "sidecar exited non-zero",
+  });
+}
+
+function writeSidecarOutput(repoRoot, runId, sidecarId, content) {
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  const outputDir = path.join(runDir, "sidecars", sidecarId);
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, "output.md"), content, "utf-8");
+}
+
+function writeReviewVerdict(repoRoot, runId, round, issues) {
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  fs.writeFileSync(
+    path.join(runDir, `review-round-${round}-verdict.json`),
+    JSON.stringify({ verdict: "changes_requested", issues }, null, 2),
+    "utf-8"
+  );
+}
+
 test("reliability-report derives the core scorecard from manifests and events", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
@@ -718,6 +777,195 @@ test("reliability-report renders no guidance data available for empty and legacy
     packs: {},
   });
   assert.match(legacyText, /guidance_pack_insights: no guidance data available/);
+});
+
+test("reliability-report emits canonical empty sidecar insights for legacy repos", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-empty-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  initGitRepo(repoRoot);
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+  const text = execFileSync("node", [SCRIPT, "--repo", repoRoot], { encoding: "utf-8" });
+
+  assert.deepEqual(report.sidecar_insights, {
+    total_invocations: 0,
+    by_kind: {},
+    by_executor: {},
+    by_model: {},
+    by_provider: {},
+    failure_rate: null,
+    predicted_findings_match_rate: null,
+    predicted_findings_runs_examined: 0,
+  });
+  assert.match(text, /sidecar_insights: no sidecar runs available/);
+});
+
+test("reliability-report counts sidecar usage and outcomes by kind and executor", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-counts-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runA = createRunId({ branch: "run-sidecar-a", timestamp: new Date("2026-04-12T02:07:00.000Z") });
+  const runB = createRunId({ branch: "run-sidecar-b", timestamp: new Date("2026-04-12T02:07:01.000Z") });
+
+  writeRun(repoRoot, { runId: runA, state: STATES.REVIEW_PENDING, rounds: 1, updatedAt: recentTs });
+  writeRun(repoRoot, { runId: runB, state: STATES.REVIEW_PENDING, rounds: 1, updatedAt: recentTs });
+
+  appendSidecarStart(repoRoot, runA, { sidecarId: "sc-1", kind: "context-recap", executor: "codex", model: "gpt-5", provider: "openai" });
+  appendSidecarResult(repoRoot, runA, { sidecarId: "sc-1", kind: "context-recap" });
+  appendSidecarStart(repoRoot, runA, { sidecarId: "sc-2", kind: "context-recap", executor: "codex", model: "gpt-5", provider: "openai" });
+  appendSidecarFailed(repoRoot, runA, { sidecarId: "sc-2", kind: "context-recap" });
+  appendSidecarStart(repoRoot, runB, { sidecarId: "sc-3", kind: "review-hints", executor: "claude", model: "sonnet", provider: "anthropic" });
+  appendSidecarResult(repoRoot, runB, { sidecarId: "sc-3", kind: "review-hints" });
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+  const text = execFileSync("node", [SCRIPT, "--repo", repoRoot], { encoding: "utf-8" });
+
+  assert.equal(report.sidecar_insights.total_invocations, 3);
+  assert.deepEqual(report.sidecar_insights.by_kind, {
+    "context-recap": { invocations: 2, successes: 1, failures: 1 },
+    "review-hints": { invocations: 1, successes: 1, failures: 0 },
+  });
+  assert.deepEqual(report.sidecar_insights.by_executor, {
+    claude: { invocations: 1, successes: 1, failures: 0 },
+    codex: { invocations: 2, successes: 1, failures: 1 },
+  });
+  assert.deepEqual(report.sidecar_insights.by_model, {
+    "gpt-5": { invocations: 2 },
+    sonnet: { invocations: 1 },
+  });
+  assert.deepEqual(report.sidecar_insights.by_provider, {
+    anthropic: { invocations: 1 },
+    openai: { invocations: 2 },
+  });
+  assert.equal(report.sidecar_insights.failure_rate, 0.3333);
+  assert.match(text, /sidecar_insights:/);
+  assert.match(text, /total_invocations: 3/);
+  assert.match(text, /by_kind: context-recap=2/);
+  assert.doesNotMatch(text, /predicted_findings_match_rate:/);
+});
+
+test("reliability-report keeps sidecar insights only on the top-level report", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-top-level-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runId = createRunId({ branch: "run-sidecar-top-level", timestamp: new Date("2026-04-12T02:07:30.000Z") });
+
+  writeRun(repoRoot, { runId, state: STATES.REVIEW_PENDING, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runId, { sidecarId: "sc-top", kind: "context-recap", executor: "codex" });
+
+  const report = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo",
+    repoRoot,
+    "--json",
+    "--by-actor",
+    "--by-role",
+    "--by-dispatch",
+    "--by-acting-reviewer",
+  ], { encoding: "utf-8" }));
+
+  assert.equal(report.sidecar_insights.total_invocations, 1);
+  for (const scopedReport of Object.values(report.by_actor)) {
+    assert.equal("sidecar_insights" in scopedReport, false);
+  }
+  for (const roleReport of Object.values(report.by_role)) {
+    for (const scopedReport of Object.values(roleReport)) {
+      assert.equal("sidecar_insights" in scopedReport, false);
+    }
+  }
+  for (const dimensionReport of Object.values(report.by_dispatch)) {
+    for (const scopedReport of Object.values(dimensionReport)) {
+      assert.equal("sidecar_insights" in scopedReport, false);
+    }
+  }
+});
+
+test("reliability-report buckets sidecar starts without model or provider as unknown", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-unknown-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runId = createRunId({ branch: "run-sidecar-unknown", timestamp: new Date("2026-04-12T02:08:00.000Z") });
+
+  writeRun(repoRoot, { runId, state: STATES.REVIEW_PENDING, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runId, {
+    sidecarId: "sc-unknown",
+    kind: "context-recap",
+    executor: "codex",
+    model: undefined,
+    provider: undefined,
+  });
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+
+  assert.deepEqual(report.sidecar_insights.by_model, { unknown: { invocations: 1 } });
+  assert.deepEqual(report.sidecar_insights.by_provider, { unknown: { invocations: 1 } });
+});
+
+test("reliability-report estimates sidecar prediction matches from output and review verdict titles", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-prediction-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runId = createRunId({ branch: "run-sidecar-prediction", timestamp: new Date("2026-04-12T02:09:00.000Z") });
+
+  writeRun(repoRoot, { runId, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runId, { sidecarId: "sc-predict", kind: "context-recap", executor: "codex" });
+  appendSidecarResult(repoRoot, runId, { sidecarId: "sc-predict", kind: "context-recap" });
+  writeSidecarOutput(repoRoot, runId, "sc-predict", "The recap warned about missing retry budget coverage before review.");
+  writeReviewVerdict(repoRoot, runId, 1, [
+    { title: "Missing retry budget coverage", body: "Add tests.", file: "test.js", line: 12, category: "contract", severity: "high" },
+    { title: "Document timeout behavior", body: "Document it.", file: "README.md", line: 4, category: "contract", severity: "medium" },
+  ]);
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+
+  assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 1);
+  assert.ok(report.sidecar_insights.predicted_findings_match_rate >= 0.5);
+});
+
+test("reliability-report keeps sidecar prediction null when results have no review verdicts", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-prediction-null-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runId = createRunId({ branch: "run-sidecar-prediction-null", timestamp: new Date("2026-04-12T02:10:00.000Z") });
+
+  writeRun(repoRoot, { runId, state: STATES.REVIEW_PENDING, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runId, { sidecarId: "sc-result", kind: "context-recap", executor: "codex" });
+  appendSidecarResult(repoRoot, runId, { sidecarId: "sc-result", kind: "context-recap" });
+  writeSidecarOutput(repoRoot, runId, "sc-result", "This output has no verdict to compare against.");
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+
+  assert.equal(report.sidecar_insights.predicted_findings_match_rate, null);
+  assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 0);
+});
+
+test("reliability-report skips unreadable or corrupted sidecar outputs during prediction", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-corrupt-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runDirOutput = createRunId({ branch: "run-sidecar-dir-output", timestamp: new Date("2026-04-12T02:11:00.000Z") });
+  const runNullOutput = createRunId({ branch: "run-sidecar-null-output", timestamp: new Date("2026-04-12T02:11:01.000Z") });
+
+  writeRun(repoRoot, { runId: runDirOutput, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runDirOutput, { sidecarId: "sc-dir", kind: "context-recap", executor: "codex" });
+  appendSidecarResult(repoRoot, runDirOutput, { sidecarId: "sc-dir", kind: "context-recap" });
+  fs.mkdirSync(path.join(ensureRunLayout(repoRoot, runDirOutput).runDir, "sidecars", "sc-dir", "output.md"), { recursive: true });
+  writeReviewVerdict(repoRoot, runDirOutput, 1, [
+    { title: "Directory output skipped", body: "Skip.", file: "x.js", line: 1, category: "contract", severity: "high" },
+  ]);
+
+  writeRun(repoRoot, { runId: runNullOutput, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runNullOutput, { sidecarId: "sc-null", kind: "context-recap", executor: "codex" });
+  appendSidecarResult(repoRoot, runNullOutput, { sidecarId: "sc-null", kind: "context-recap" });
+  writeSidecarOutput(repoRoot, runNullOutput, "sc-null", "\u0000\u0000\u0000");
+  writeReviewVerdict(repoRoot, runNullOutput, 1, [
+    { title: "Null output skipped", body: "Skip.", file: "x.js", line: 1, category: "contract", severity: "high" },
+  ]);
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+
+  assert.equal(report.sidecar_insights.predicted_findings_match_rate, null);
+  assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 0);
 });
 
 test("reliability-report keeps qualitative_signals null below the minimum readable-rubric threshold", () => {

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -840,6 +840,7 @@ test("reliability-report counts sidecar usage and outcomes by kind and executor"
   assert.equal(report.sidecar_insights.failure_rate, 0.3333);
   assert.match(text, /sidecar_insights:/);
   assert.match(text, /total_invocations: 3/);
+  assert.match(text, /failure_rate: 0\.3333/);
   assert.match(text, /by_kind: context-recap=2/);
   assert.doesNotMatch(text, /predicted_findings_match_rate:/);
 });
@@ -922,6 +923,27 @@ test("reliability-report estimates sidecar prediction matches from output and re
   assert.ok(report.sidecar_insights.predicted_findings_match_rate >= 0.5);
 });
 
+test("reliability-report counts sidecar output substrings of review titles as predictions", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-title-substring-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runId = createRunId({ branch: "run-sidecar-title-substring", timestamp: new Date("2026-04-12T02:09:30.000Z") });
+
+  writeRun(repoRoot, { runId, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runId, { sidecarId: "sc-substring", kind: "context-recap", executor: "codex" });
+  appendSidecarResult(repoRoot, runId, { sidecarId: "sc-substring", kind: "context-recap" });
+  writeSidecarOutput(repoRoot, runId, "sc-substring", "The sidecar flagged output_path before review.");
+  writeReviewVerdict(repoRoot, runId, 1, [
+    { title: "Review verdict omits output_path validation", body: "Track output_path.", file: "report.js", line: 7, category: "contract", severity: "high" },
+    { title: "Require branch cleanup audit", body: "Audit cleanup.", file: "cleanup.js", line: 3, category: "quality", severity: "medium" },
+  ]);
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+
+  assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 1);
+  assert.equal(report.sidecar_insights.predicted_findings_match_rate, 0.5);
+});
+
 test("reliability-report keeps sidecar prediction null when results have no review verdicts", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-prediction-null-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
@@ -943,8 +965,16 @@ test("reliability-report skips unreadable or corrupted sidecar outputs during pr
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-corrupt-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runMissingOutput = createRunId({ branch: "run-sidecar-missing-output", timestamp: new Date("2026-04-12T02:10:59.000Z") });
   const runDirOutput = createRunId({ branch: "run-sidecar-dir-output", timestamp: new Date("2026-04-12T02:11:00.000Z") });
   const runNullOutput = createRunId({ branch: "run-sidecar-null-output", timestamp: new Date("2026-04-12T02:11:01.000Z") });
+
+  writeRun(repoRoot, { runId: runMissingOutput, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runMissingOutput, { sidecarId: "sc-missing", kind: "context-recap", executor: "codex" });
+  appendSidecarResult(repoRoot, runMissingOutput, { sidecarId: "sc-missing", kind: "context-recap" });
+  writeReviewVerdict(repoRoot, runMissingOutput, 1, [
+    { title: "Missing output is skipped", body: "Skip.", file: "x.js", line: 1, category: "contract", severity: "high" },
+  ]);
 
   writeRun(repoRoot, { runId: runDirOutput, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
   appendSidecarStart(repoRoot, runDirOutput, { sidecarId: "sc-dir", kind: "context-recap", executor: "codex" });
@@ -964,6 +994,7 @@ test("reliability-report skips unreadable or corrupted sidecar outputs during pr
 
   const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
 
+  assert.equal(report.sidecar_insights.total_invocations, 3);
   assert.equal(report.sidecar_insights.predicted_findings_match_rate, null);
   assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 0);
 });


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-376-20260508073928407-ce0aefd9
- Branch: issue-376
- Reason: completed-uncommitted recovery
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-376-20260508073928407-ce0aefd9.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-08T07:49:08.013Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Sidecar 통찰력 분석 기능 추가: 호출, 실패율, 종류/실행자/제공자별 분류, 예측 일치율 메트릭 포함
  * CLI 출력에서 Sidecar 통찰력 요약 표시

* **Tests**
  * Sidecar 통찰력 분석 기능에 대한 포괄적인 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->