### PR TITLE
Add relay-plan rubric template matcher

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -48,7 +48,7 @@ Optionally ask for a deterministic starter template:
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/match-template.js --probe-file /tmp/probe.json --json
 ```
-The result is a SUGGESTION the planner accepts, modifies, or rejects. NEVER auto-apply. Templates live in `references/rubric-templates/`; signal field meanings stay in `references/signals.md`.
+The result is a SUGGESTION the planner accepts, modifies, or rejects. NEVER auto-apply. Templates are SCAFFOLDS; planners must fill placeholder fields. Templates live in `references/rubric-templates/`; signal field meanings stay in `references/signals.md`.
 
 ### 4. Recover Done Criteria
 

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -43,6 +43,13 @@ node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
 
 Use `probe_signal.test_infra`, `lint_format`, `type_check`, `ci`, and `scripts` to inform rubric design, prerequisites, and Available Tools. The signal exposes data; it does not pick. No-signal/failure cases render as `no quality infra detected`; details: `references/signals.md`. The `test_infra` field is consumed by `references/rubric-pattern-tdd-flavor.md` and `scripts/tdd-suggestion.js`.
 
+### 3.5 Match a template from probe signals (optional starting point)
+Optionally ask for a deterministic starter template:
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/match-template.js --probe-file /tmp/probe.json --json
+```
+The result is a SUGGESTION the planner accepts, modifies, or rejects. NEVER auto-apply. Templates live in `references/rubric-templates/`; signal field meanings stay in `references/signals.md`.
+
 ### 4. Recover Done Criteria
 
 Before drafting factors, identify the evaluation source model:
@@ -96,16 +103,9 @@ If the task touches relay gates, resolver selectors, recovery paths, audit stamp
 
 ### 6. Validate the rubric
 
-Quick gate before dispatch:
+Quick gate before dispatch: prerequisites hold repo-wide hygiene only; factors stay substantive; contract/quality tier minimums match task size; S-size mechanical tasks may use 1 contract factor and no quality factor; ≥ 1 automated check exists; every evaluated factor has low/mid/high `scoring_guide`; criteria and targets are concrete.
 
-- Prerequisites hold repo-wide hygiene only; factors stay substantive (tier test)
-- Contract/Quality tier minimums met for task size (S/M/L/XL)
-- S-size mechanical tasks may use 1 contract factor and no quality factor; do not invent quality factors just to fill a quota
-- ≥ 1 automated check across prerequisites + factors
-- Every evaluated factor has `scoring_guide` with low/mid/high anchors
-- Criteria are specific and reference discoverable artifacts; targets are concrete
-
-Full checklist, factor counts, grading, and risk signals: `references/rubric-validation.md`. Grade D = revise; Grade C = warn and state the tradeoff.
+Full checklist, counts, grading, and risk signals: `references/rubric-validation.md`. Grade D = revise; Grade C = warn and state the tradeoff.
 
 ### 7. Simplify the rubric
 
@@ -145,10 +145,6 @@ node ${CLAUDE_SKILL_DIR}/../relay-dispatch/scripts/dispatch.js . \
 
 ## When to use
 
-All tasks dispatched via relay. Rubric depth scales with task size (determined by orchestrator judgment on recovered Done Criteria, file scope, ambiguity, and risk, not raw issue AC count):
-- **S** (simple fix, typo, 1-liner): 1 contract factor; add a quality factor only when the task has real design judgment; skip stress-test
-- **M** (standard feature): 3-5 factors, skip stress-test
-- **L** (cross-cutting, multi-file): 4-6 factors; stress-test only when evaluated factors plus ambiguity/risk signal exist
-- **XL** (architecture change): 5-8 factors; stress-test only when evaluated factors plus ambiguity/risk signal exist; add calibration only when useful
+All tasks dispatched via relay. Rubric depth scales with orchestrator judgment on recovered Done Criteria, file scope, ambiguity, and risk, not raw issue AC count: **S** simple tasks use 1 contract factor and skip stress-test; **M** uses 3-5 factors and skips stress-test; **L** uses 4-6 factors and stress-tests only with evaluated factors plus ambiguity/risk; **XL** uses 5-8 factors and adds calibration only when useful.
 
-Re-dispatches automatically prepend previous Score Log + reviewer feedback to the prompt (see `relay-dispatch` docs). Full rubric guide: `references/rubric-design-guide.md`.
+Re-dispatches automatically prepend previous Score Log + reviewer feedback. Full rubric guide: `references/rubric-design-guide.md`.

--- a/skills/relay-plan/references/rubric-templates/_index.json
+++ b/skills/relay-plan/references/rubric-templates/_index.json
@@ -1,0 +1,29 @@
+[
+  {
+    "file": "jest-tsc-strict.yaml",
+    "signals": {
+      "test_infra": ["jest"],
+      "type_check": ["typescript"],
+      "lint_format": []
+    },
+    "description": "TypeScript + Jest + tsc --noEmit"
+  },
+  {
+    "file": "pytest-mypy-strict.yaml",
+    "signals": {
+      "test_infra": ["pytest"],
+      "type_check": ["mypy"],
+      "lint_format": []
+    },
+    "description": "Python + pytest + mypy strict"
+  },
+  {
+    "file": "go-test.yaml",
+    "signals": {
+      "test_infra": [],
+      "type_check": [],
+      "lint_format": []
+    },
+    "description": "Go + go test + gofmt/go vet"
+  }
+]

--- a/skills/relay-plan/references/rubric-templates/go-test.yaml
+++ b/skills/relay-plan/references/rubric-templates/go-test.yaml
@@ -1,0 +1,33 @@
+# Template: go-test
+# Match signals: repo contains go.mod or a shallow *.go file when --repo is supplied.
+# Use when: Go repos rely on go test, gofmt, and go vet as executable checks.
+# Customize: factor names, commands, targets, criteria, and scoring guide anchors.
+# Fill in task-specific Done Criteria before dispatch.
+# NOTE: This is a STARTING POINT, not a finished rubric. Do not ship-as-is.
+size: M
+prerequisites:
+  - command: "go test ./..."
+    target: "exit 0"
+  - command: "gofmt -d ."
+    target: "no diff"
+  - command: "go vet ./..."
+    target: "exit 0"
+factors:
+  - name: "[fill in: specific Done Criteria outcome]"
+    tier: contract
+    type: automated
+    command: "[fill in: task-specific go test command]"
+    target: "[fill in: expected output or exit condition]"
+    weight: required
+  - name: "[fill in: implementation quality area]"
+    tier: quality
+    type: evaluated
+    criteria: |
+      - [fill in: specific quality criterion 1]
+      - [fill in: specific quality criterion 2]
+    scoring_guide:
+      low: "[fill in: what barely works looks like]"
+      mid: "[fill in: what partially succeeds]"
+      high: "[fill in: what genuinely meets the bar]"
+    target: ">= 8/10"
+    weight: required

--- a/skills/relay-plan/references/rubric-templates/jest-tsc-strict.yaml
+++ b/skills/relay-plan/references/rubric-templates/jest-tsc-strict.yaml
@@ -1,0 +1,31 @@
+# Template: jest-tsc-strict
+# Match signals: test_infra=jest, type_check=typescript
+# Use when: TypeScript repos already expose Jest tests and tsc --noEmit.
+# Customize: factor names, commands, targets, criteria, and scoring guide anchors.
+# Fill in task-specific Done Criteria before dispatch.
+# NOTE: This is a STARTING POINT, not a finished rubric. Do not ship-as-is.
+size: M
+prerequisites:
+  - command: "npm test"
+    target: "exit 0"
+  - command: "tsc --noEmit"
+    target: "exit 0"
+factors:
+  - name: "[fill in: specific Done Criteria outcome]"
+    tier: contract
+    type: automated
+    command: "[fill in: task-specific Jest or Node check command]"
+    target: "[fill in: expected output or exit condition]"
+    weight: required
+  - name: "[fill in: implementation quality area]"
+    tier: quality
+    type: evaluated
+    criteria: |
+      - [fill in: specific quality criterion 1]
+      - [fill in: specific quality criterion 2]
+    scoring_guide:
+      low: "[fill in: what barely works looks like]"
+      mid: "[fill in: what partially succeeds]"
+      high: "[fill in: what genuinely meets the bar]"
+    target: ">= 8/10"
+    weight: required

--- a/skills/relay-plan/references/rubric-templates/pytest-mypy-strict.yaml
+++ b/skills/relay-plan/references/rubric-templates/pytest-mypy-strict.yaml
@@ -1,0 +1,31 @@
+# Template: pytest-mypy-strict
+# Match signals: test_infra=pytest, type_check=mypy
+# Use when: Python repos already expose pytest tests and strict mypy checks.
+# Customize: factor names, commands, targets, criteria, and scoring guide anchors.
+# Fill in task-specific Done Criteria before dispatch.
+# NOTE: This is a STARTING POINT, not a finished rubric. Do not ship-as-is.
+size: M
+prerequisites:
+  - command: "pytest"
+    target: "exit 0"
+  - command: "mypy --strict ."
+    target: "exit 0"
+factors:
+  - name: "[fill in: specific Done Criteria outcome]"
+    tier: contract
+    type: automated
+    command: "[fill in: task-specific pytest command or Python check]"
+    target: "[fill in: expected output or exit condition]"
+    weight: required
+  - name: "[fill in: implementation quality area]"
+    tier: quality
+    type: evaluated
+    criteria: |
+      - [fill in: specific quality criterion 1]
+      - [fill in: specific quality criterion 2]
+    scoring_guide:
+      low: "[fill in: what barely works looks like]"
+      mid: "[fill in: what partially succeeds]"
+      high: "[fill in: what genuinely meets the bar]"
+    target: ">= 8/10"
+    weight: required

--- a/skills/relay-plan/scripts/match-template.js
+++ b/skills/relay-plan/scripts/match-template.js
@@ -7,6 +7,27 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/rubric");
 
 const SIGNAL_KEYS = ["test_infra", "type_check", "lint_format"];
+const TEST_RUNNERS = new Set([
+  "jest",
+  "vitest",
+  "mocha",
+  "playwright",
+  "@playwright/test",
+  "cypress",
+  "pytest",
+]);
+const LINT_FORMAT_TOOLS = new Set([
+  "eslint",
+  "prettier",
+  "ruff",
+  "black",
+  "isort",
+  "pylint",
+]);
+const TYPE_CHECK_TOOLS = new Set([
+  "typescript",
+  "mypy",
+]);
 const CATALOG_DIR = path.join(__dirname, "..", "references", "rubric-templates");
 const CATALOG_PATH = path.join(CATALOG_DIR, "_index.json");
 
@@ -89,6 +110,10 @@ function loadCatalog(catalogPath = CATALOG_PATH) {
 }
 
 function normalizeSignalValues(values) {
+  if (typeof values === "string") {
+    if (values === "no quality infra detected") return [];
+    return values.split(",").map((value) => value.trim()).filter(Boolean);
+  }
   if (!Array.isArray(values)) {
     return [];
   }
@@ -101,10 +126,69 @@ function normalizeSignalValues(values) {
     .filter(Boolean);
 }
 
-function scoreTemplate(probe, entry, repoDir) {
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function normalizeScriptEntries(scripts) {
+  if (!Array.isArray(scripts)) return [];
+  return scripts.filter((entry) => entry && typeof entry === "object");
+}
+
+function addScriptToolSignals(signals, scripts) {
+  for (const script of normalizeScriptEntries(scripts)) {
+    const command = typeof script.command === "string" ? script.command : "";
+    const name = typeof script.name === "string" ? script.name : "";
+    const searchable = `${name}\n${command}`;
+
+    for (const runner of TEST_RUNNERS) {
+      if (new RegExp(`(^|\\b)${runner.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\b|$)`).test(searchable)) {
+        signals.test_infra.push(runner);
+      }
+    }
+    for (const tool of LINT_FORMAT_TOOLS) {
+      if (new RegExp(`(^|\\b)${tool.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\b|$)`).test(searchable)) {
+        signals.lint_format.push(tool);
+      }
+    }
+    if (/tsc\s+--noEmit/.test(searchable)) {
+      signals.type_check.push("typescript", "tsc --noEmit");
+    }
+    if (/\bmypy\b/.test(searchable)) {
+      signals.type_check.push("mypy");
+    }
+  }
+}
+
+function normalizeProbeSignals(probe) {
+  const signals = {
+    test_infra: [],
+    type_check: [],
+    lint_format: [],
+  };
+
+  for (const key of SIGNAL_KEYS) {
+    signals[key].push(...normalizeSignalValues(probe?.[key]));
+    signals[key].push(...normalizeSignalValues(probe?.probe_signal?.[key]));
+  }
+
+  const frameworkNames = normalizeSignalValues(probe?.project_tools?.frameworks);
+  signals.test_infra.push(...frameworkNames.filter((name) => TEST_RUNNERS.has(name)));
+  signals.lint_format.push(...frameworkNames.filter((name) => LINT_FORMAT_TOOLS.has(name)));
+  signals.type_check.push(...frameworkNames.filter((name) => TYPE_CHECK_TOOLS.has(name)));
+  addScriptToolSignals(signals, probe?.project_tools?.scripts);
+
+  return {
+    test_infra: unique(signals.test_infra),
+    type_check: unique(signals.type_check),
+    lint_format: unique(signals.lint_format),
+  };
+}
+
+function scoreTemplate(probeSignals, entry, repoDir) {
   let score = 0;
   for (const key of SIGNAL_KEYS) {
-    const probeValues = new Set(normalizeSignalValues(probe?.[key]));
+    const probeValues = new Set(probeSignals[key] || []);
     const expectedValues = normalizeSignalValues(entry?.signals?.[key]);
     for (const expected of expectedValues) {
       if (probeValues.has(expected)) {
@@ -161,8 +245,9 @@ function hasGoFiles(repoDir, maxDepth = 3) {
 }
 
 function bestMatch(probe, catalog, repoDir = null) {
+  const probeSignals = normalizeProbeSignals(probe);
   const allMatches = catalog.map((entry) => {
-    const score = scoreTemplate(probe, entry, repoDir);
+    const score = scoreTemplate(probeSignals, entry, repoDir);
     return {
       file: entry.file,
       score,
@@ -181,7 +266,7 @@ function bestMatch(probe, catalog, repoDir = null) {
       matched_template: null,
       score: 0,
       all_matches: allMatches,
-      reason: "no template scored above 0",
+      reason: "no clear match",
     };
   }
 
@@ -223,6 +308,7 @@ module.exports = {
   parseArgs,
   readProbe,
   loadCatalog,
+  normalizeProbeSignals,
   scoreTemplate,
   bestMatch,
   hasGoFiles,

--- a/skills/relay-plan/scripts/match-template.js
+++ b/skills/relay-plan/scripts/match-template.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const {
+  readTextFileWithoutFollowingSymlinks,
+} = require("../../relay-dispatch/scripts/manifest/rubric");
+
+const SIGNAL_KEYS = ["test_infra", "type_check", "lint_format"];
+const CATALOG_DIR = path.join(__dirname, "..", "references", "rubric-templates");
+const CATALOG_PATH = path.join(CATALOG_DIR, "_index.json");
+
+function usage() {
+  return [
+    "Usage: match-template.js [--probe-file <path> | --probe-json <json>] [--repo <path>] [--json]",
+    "",
+    "Options:",
+    "  --probe-file <path>  Read probe JSON from a file",
+    "  --probe-json <json>  Read probe JSON from an inline argument",
+    "  --repo <path>        Optional repo root for Go file detection",
+    "  --json               Emit JSON output",
+    "  --help, -h           Show this help",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const opts = {
+    probeFile: null,
+    probeJson: null,
+    repo: null,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      opts.help = true;
+    } else if (arg === "--json") {
+      opts.json = true;
+    } else if (arg === "--probe-file") {
+      index += 1;
+      if (index >= argv.length) throw new Error("--probe-file requires a path");
+      opts.probeFile = argv[index];
+    } else if (arg === "--probe-json") {
+      index += 1;
+      if (index >= argv.length) throw new Error("--probe-json requires JSON");
+      opts.probeJson = argv[index];
+    } else if (arg === "--repo") {
+      index += 1;
+      if (index >= argv.length) throw new Error("--repo requires a path");
+      opts.repo = argv[index];
+    } else {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+  }
+
+  if (opts.probeFile && opts.probeJson) {
+    throw new Error("Use only one of --probe-file or --probe-json");
+  }
+
+  return opts;
+}
+
+function parseProbeJson(text) {
+  if (!text || !text.trim()) {
+    return {};
+  }
+  return JSON.parse(text);
+}
+
+function readProbe({ probeFile, probeJson }) {
+  if (probeJson) {
+    return parseProbeJson(probeJson);
+  }
+  if (probeFile) {
+    return parseProbeJson(readTextFileWithoutFollowingSymlinks(path.resolve(probeFile)));
+  }
+  return parseProbeJson(fs.readFileSync(0, "utf-8"));
+}
+
+function loadCatalog(catalogPath = CATALOG_PATH) {
+  const raw = readTextFileWithoutFollowingSymlinks(catalogPath);
+  const catalog = JSON.parse(raw);
+  if (!Array.isArray(catalog)) {
+    throw new Error("_index.json must be an array");
+  }
+  return catalog;
+}
+
+function normalizeSignalValues(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .map((value) => {
+      if (typeof value === "string") return value;
+      if (value && typeof value.name === "string") return value.name;
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function scoreTemplate(probe, entry, repoDir) {
+  let score = 0;
+  for (const key of SIGNAL_KEYS) {
+    const probeValues = new Set(normalizeSignalValues(probe?.[key]));
+    const expectedValues = normalizeSignalValues(entry?.signals?.[key]);
+    for (const expected of expectedValues) {
+      if (probeValues.has(expected)) {
+        score += 1;
+      }
+    }
+  }
+
+  if (entry?.file === "go-test.yaml" && repoDir && hasGoFiles(path.resolve(repoDir))) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function hasGoFiles(repoDir, maxDepth = 3) {
+  if (!fs.existsSync(repoDir)) {
+    return false;
+  }
+  const rootGoMod = path.join(repoDir, "go.mod");
+  if (fs.existsSync(rootGoMod) && fs.statSync(rootGoMod).isFile()) {
+    return true;
+  }
+
+  function visit(dir, depth) {
+    if (depth > maxDepth) {
+      return false;
+    }
+
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === ".git") {
+        continue;
+      }
+      const childPath = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name.endsWith(".go")) {
+        return true;
+      }
+      if (entry.isDirectory() && visit(childPath, depth + 1)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  return visit(repoDir, 0);
+}
+
+function bestMatch(probe, catalog, repoDir = null) {
+  const allMatches = catalog.map((entry) => {
+    const score = scoreTemplate(probe, entry, repoDir);
+    return {
+      file: entry.file,
+      score,
+      reason: score > 0 ? "signal overlap" : "no signal overlap",
+    };
+  });
+  const best = allMatches.reduce((current, candidate) => {
+    if (!current || candidate.score > current.score) {
+      return candidate;
+    }
+    return current;
+  }, null);
+
+  if (!best || best.score <= 0) {
+    return {
+      matched_template: null,
+      score: 0,
+      all_matches: allMatches,
+      reason: "no template scored above 0",
+    };
+  }
+
+  return {
+    matched_template: best.file,
+    score: best.score,
+    all_matches: allMatches,
+    reason: "matched on signal overlap",
+  };
+}
+
+function main() {
+  try {
+    const opts = parseArgs(process.argv);
+    if (opts.help) {
+      console.log(usage());
+      return;
+    }
+
+    const probe = readProbe(opts);
+    const result = bestMatch(probe, loadCatalog(), opts.repo);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    console.log(JSON.stringify({
+      matched_template: null,
+      score: 0,
+      all_matches: [],
+      reason: error.message,
+    }, null, 2));
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  parseArgs,
+  readProbe,
+  loadCatalog,
+  scoreTemplate,
+  bestMatch,
+  hasGoFiles,
+};

--- a/tests/relay-plan/scripts/match-template.test.js
+++ b/tests/relay-plan/scripts/match-template.test.js
@@ -56,6 +56,33 @@ test("matches jest-tsc-strict from synthesized probe signals", () => {
   assert.ok(result.score > 0);
 });
 
+test("matches raw project-only probe file shape", () => {
+  const probeFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-raw-probe-")), "probe.json");
+  fs.writeFileSync(probeFile, JSON.stringify({
+    executor: null,
+    repo: "/tmp/example",
+    agent_tools_raw: null,
+    agent_probe_error: null,
+    test_infra: [{ name: "jest", source: "package.json" }],
+    project_tools: {
+      frameworks: [
+        { name: "typescript", source: "package.json" },
+        { name: "eslint", source: "package.json" },
+      ],
+      scripts: [
+        { name: "npm run test", command: "jest", source: "package.json" },
+        { name: "npm run typecheck", command: "tsc --noEmit", source: "package.json" },
+      ],
+      ci: [],
+    },
+  }), "utf-8");
+
+  const result = parseMatcher(["--probe-file", probeFile, "--json"]);
+
+  assert.equal(result.matched_template, "jest-tsc-strict.yaml");
+  assert.ok(result.score > 0);
+});
+
 test("matches pytest-mypy-strict from synthesized probe signals", () => {
   const result = bestMatch({
     test_infra: ["pytest"],
@@ -85,13 +112,14 @@ test("matches go-test from empty probe when repo contains go.mod", () => {
 
 test("returns null when no template has a positive score", () => {
   const result = bestMatch({
-    test_infra: ["vitest"],
-    type_check: ["flow"],
-    lint_format: ["biome"],
+    test_infra: ["junit"],
+    type_check: [],
+    lint_format: [],
   }, loadCatalog());
 
   assert.equal(result.matched_template, null);
   assert.equal(result.score, 0);
+  assert.equal(result.reason, "no clear match");
 });
 
 test("uses _index.json order to break tied scores deterministically", () => {

--- a/tests/relay-plan/scripts/match-template.test.js
+++ b/tests/relay-plan/scripts/match-template.test.js
@@ -1,0 +1,153 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const {
+  bestMatch,
+  loadCatalog,
+} = require("../../../skills/relay-plan/scripts/match-template");
+
+const MATCHER_SCRIPT = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "skills",
+  "relay-plan",
+  "scripts",
+  "match-template.js"
+);
+const TEMPLATE_DIR = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "skills",
+  "relay-plan",
+  "references",
+  "rubric-templates"
+);
+
+function runMatcher(args, input) {
+  return spawnSync(process.execPath, [MATCHER_SCRIPT, ...args], {
+    encoding: "utf-8",
+    input,
+    stdio: "pipe",
+  });
+}
+
+function parseMatcher(args, input) {
+  const result = runMatcher(args, input);
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("matches jest-tsc-strict from synthesized probe signals", () => {
+  const result = bestMatch({
+    test_infra: ["jest"],
+    type_check: ["typescript"],
+    lint_format: [],
+  }, loadCatalog());
+
+  assert.equal(result.matched_template, "jest-tsc-strict.yaml");
+  assert.ok(result.score > 0);
+});
+
+test("matches pytest-mypy-strict from synthesized probe signals", () => {
+  const result = bestMatch({
+    test_infra: ["pytest"],
+    type_check: ["mypy"],
+    lint_format: [],
+  }, loadCatalog());
+
+  assert.equal(result.matched_template, "pytest-mypy-strict.yaml");
+  assert.ok(result.score > 0);
+});
+
+test("matches go-test from empty probe when repo contains go.mod", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-go-template-"));
+  fs.writeFileSync(path.join(repoRoot, "go.mod"), "module example.test/repo\n", "utf-8");
+
+  const result = parseMatcher([
+    "--probe-json",
+    JSON.stringify({ test_infra: [], type_check: [], lint_format: [] }),
+    "--repo",
+    repoRoot,
+    "--json",
+  ]);
+
+  assert.equal(result.matched_template, "go-test.yaml");
+  assert.ok(result.score > 0);
+});
+
+test("returns null when no template has a positive score", () => {
+  const result = bestMatch({
+    test_infra: ["vitest"],
+    type_check: ["flow"],
+    lint_format: ["biome"],
+  }, loadCatalog());
+
+  assert.equal(result.matched_template, null);
+  assert.equal(result.score, 0);
+});
+
+test("uses _index.json order to break tied scores deterministically", () => {
+  const result = bestMatch({
+    test_infra: ["jest", "pytest"],
+    type_check: [],
+    lint_format: [],
+  }, loadCatalog());
+
+  assert.equal(result.matched_template, "jest-tsc-strict.yaml");
+  assert.equal(result.score, 1);
+});
+
+test("template files exist and carry scaffold sentinels", () => {
+  for (const file of ["jest-tsc-strict.yaml", "pytest-mypy-strict.yaml", "go-test.yaml"]) {
+    const body = fs.readFileSync(path.join(TEMPLATE_DIR, file), "utf-8");
+    assert.match(body, /prerequisites:/);
+    assert.match(body, /factors:/);
+    assert.ok((body.match(/\[fill in:/g) || []).length >= 3, `${file} needs fill-in sentinels`);
+  }
+});
+
+test("_index.json parses and names existing template files", () => {
+  const catalog = loadCatalog();
+  assert.ok(catalog.length >= 3);
+
+  for (const entry of catalog) {
+    assert.equal(typeof entry.file, "string");
+    assert.equal(typeof entry.description, "string");
+    assert.equal(typeof entry.signals, "object");
+    assert.ok(fs.existsSync(path.join(TEMPLATE_DIR, entry.file)), `${entry.file} should exist`);
+  }
+});
+
+test("--help exits 0 and prints every supported flag", () => {
+  const result = runMatcher(["--help"]);
+  assert.equal(result.status, 0, result.stderr);
+
+  for (const flag of ["--probe-file", "--probe-json", "--repo", "--help", "-h", "--json"]) {
+    assert.match(result.stdout, new RegExp(flag.replace("-", "\\-")));
+  }
+});
+
+test("stdin input mode returns the same result as --probe-json", () => {
+  const probeJson = JSON.stringify({
+    test_infra: ["jest"],
+    type_check: ["typescript"],
+    lint_format: [],
+  });
+  const probeFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "relay-plan-probe-file-")), "probe.json");
+  fs.writeFileSync(probeFile, probeJson, "utf-8");
+
+  const fromArg = parseMatcher(["--probe-json", probeJson, "--json"]);
+  const fromFile = parseMatcher(["--probe-file", probeFile, "--json"]);
+  const fromStdin = parseMatcher(["--json"], probeJson);
+
+  assert.deepEqual(fromFile, fromArg);
+  assert.deepEqual(fromStdin, fromArg);
+});


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 끝냈습니다.

커밋: `3ffc32e Add relay-plan rubric template matcher`

주요 변경:
- `skills/relay-plan/references/rubric-templates/` 카탈로그 추가
  - `_index.json`
  - `jest-tsc-strict.yaml`
  - `pytest-mypy-strict.yaml`
  - `go-test.yaml`
- `skills/relay-plan/scripts/match-template.js` 추가
  - `--probe-file`, `--probe-json`, stdin 입력 지원
  - `--repo` 기반 Go 감지
  - 동점 시 `_index.json` 순서 유지
  - symlink-safe `_index.json` / probe file 읽기
  - read-only, no write, no network, no child_process
- `skills/rela
```

## Score Log

- Run: issue-144-20260508132718365-15660bf5
- Executor: codex
- Branch: issue-144