### PR TITLE
Add pre-flight DC ambiguity audit reference doc (retro stack-rank #2)

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -60,7 +60,7 @@ Before drafting factors, identify the evaluation source model:
 - Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes; derive `task_profile` per `references/task-profile.md`
 - Selected guidance pack names from `task_profile.guidance_packs`, using `references/guidance-packs.md` as the compact advisory pack library
 
-If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. If the final review anchor is planner-authored or differs from the task source, persist it in step 8 so the reviewer has the same anchor.
+If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. Before freezing, run the [pre-flight ambiguity audit](references/dc-preflight-audit.md) — it catches the spec-precision wording issues responsible for nearly every R1 changes_requested round. If the final review anchor is planner-authored or differs from the task source, persist it in step 8 so the reviewer has the same anchor.
 
 ### 5. Build the rubric
 

--- a/skills/relay-plan/references/dc-preflight-audit.md
+++ b/skills/relay-plan/references/dc-preflight-audit.md
@@ -1,0 +1,95 @@
+# Pre-Flight DC Ambiguity Audit
+
+Run this checklist after recovering Done Criteria (step 4 of `SKILL.md`) and before freezing the anchor for dispatch. It is narrower than `rubric-validation.md` § "Validate Done Criteria": that checklist asks whether each item is observable, bounded, reviewable, risk-aware, and verifiable. This one asks whether the wording leaves room for codex to ship a correct-looking implementation that still fails review on spec-precision.
+
+The two checks compose: structural validation gates on the SHAPE of the DC; this audit gates on the WORDING.
+
+## Failure mode
+
+Across the 2026-05-08 marathon (8 PRs, 7 first-round changes_requested verdicts), every single R1 catch was a DC-precision/wording issue, not a logic bug. Codex implementations were correct; the implementation simply did not match the FULLY-INTENDED spec because the DC was ambiguous on one edge of meaning.
+
+Each round of unintended ambiguity costs ~12 minutes (one dispatch + one review). #374 hit 4 rounds because the wording problem compounded with a frozen-scope helper (see § "Item 1" below).
+
+Pre-flight DC review for hidden ambiguity has higher leverage than improving codex's correctness. The investment is in the planning step, not the execution step.
+
+## Dogfood evidence (n=7, 2026-05-08)
+
+| PR | Issue | R1 catch | Audit item |
+|---|---|---|---|
+| #448 | #372 | `output_path` scope under `sidecars/<id>/` (DC implied, didn't state) | 3 (implicit scope) |
+| #449 | #381 | runner `--json` coupled to sidecar output filename (DC said independent) | 4 (coupling default) |
+| #450 | #373 | repeat-finding detector matched only `title` (AC said "title or body") | 2 (AND/OR boundary) |
+| #451 | #376 | prediction heuristic full-title vs shared-substring (DC ambiguous) | 5 (heuristic precision) |
+| #452 | #374 | `sidecar_start trust_level` on frozen helper (AC6 over-spec) | 1 (frozen-helper field) |
+| #453 | #375 | basename matching (AC test (a) used basename, codex full-path-only) | 5 (heuristic precision) |
+| #454 | #144 | shipped `"no template scored above 0"` instead of literal `"no clear match"` | 6 (literal sentinels) |
+
+#374 stretched to 4 rounds because AC6 also tripped item 1 (frozen helper). #375 applied item 1 explicitly in the DC and resolved clean in 2 rounds.
+
+## The audit
+
+### Item 1 — Event-field-on-frozen-helper
+
+For each "Event X must include field Y" claim, verify X's producer helper is in this PR's allowed-edit zone. If the helper is in a forbidden zone (frozen contract from a prior PR), either drop the field requirement, OR specify a runner-side bypass path (e.g., "runner may call `appendRunEvent` directly with the field"), OR file the helper extension as a separate follow-up issue. The reviewer anchors to the FROZEN DC and will keep flagging the gap each round even when the orchestrator's redispatch addendum says "drop the assertion." Detail: `~/.claude/projects/<repo-slug>/memory/feedback_dc_overspec_frozen_helper.md`.
+
+Worked: #374 AC6 said `sidecar_start` includes `trust_level`. `appendSidecarStart` was frozen by #372. R1+R2+R3 all flagged the gap. R4 landed via runner-side `appendRunEvent` bypass. Total cost: 2 extra cycles. #375 explicitly stated "DO NOT specify trust_level on sidecar_start" — clean R2 PASS.
+
+### Item 2 — AND/OR boundary tightness
+
+For each conjunction in an AC ("X and Y", "X or Y", "X / Y"), write the literal boolean. If the criterion is "match on title OR body", say so verbatim and add the failing-on-title-only test case to the AC. Codex tends to ship the narrower AND interpretation when "or" is implicit.
+
+Worked: #373 AC said the repeat-finding detector should match "title or body" but the DC bullet hierarchy nested matching under "title-keyed dedup", which read AND-shaped. Codex shipped title-only. R1 catch.
+
+### Item 3 — Implicit scope vs literal statement
+
+For each scope claim implied by file paths or storage locations, write the literal directory/path. If outputs go under `sidecars/<run-id>/`, say so verbatim. If a generated artifact goes in `docs/`, name the directory. Codex defaults to top-level locations when scope is implicit.
+
+Worked: #372 DC said "sidecar lifecycle events store outputs at `output_path`" and showed the schema field, but did not literally say "all outputs MUST land under `sidecars/<run-id>/`". Codex picked a plausible top-level path. R1 catch.
+
+### Item 4 — Coupling default
+
+For each "independent vs coupled" axis (CLI flag + side effect, function arg + state mutation, schema field + invariant), state the default literally. Codex defaults to COUPLED when coupling reduces parameter count or simplifies the call shape. If the AC requires independence, say "X must remain independent of Y" and add the test that fails when they're coupled.
+
+Worked: #381 AC said "runner `--json` flag controls report format only" and showed the sidecar output filename as a separate field. Codex coupled them: `--json` switched both the report and the output filename. R1 catch.
+
+### Item 5 — Heuristic precision
+
+For each "match" or "detect" verb, name the exact comparison axis: full-string vs substring vs basename vs full-path vs prefix vs case-insensitive. Codex picks a reasonable axis but rarely the same one the DC author had in mind. Two examples in the same marathon (#376 and #375) confirms this is recurrent.
+
+Worked: #376 prediction heuristic: DC said "title match"; codex shipped full-title equality, DC author meant shared-substring. #375 docs-sync: AC test (a) compared by basename, codex compared full-path. Both R1 catches.
+
+### Item 6 — Literal sentinel strings
+
+For forbidden phrases, empty-state output literals, and reviewer-anchor strings, prescribe verbatim text in the DC and put the string in quotes. Codex paraphrases reasonable English when given semantic instructions; reviewers anchor to literals.
+
+Worked: #144 DC said the matcher should emit "no clear match" reason when no template scored. Codex shipped `"no template scored above 0"`. Same fail mode as #144's other catches around scaffold-guidance phrasing. R1 catch.
+
+This pattern is also visible in #318/#319/#330's empty-state JSON shapes (`{ total_invocations: 0, ... }` spelled out verbatim) and in the forbidden-phrase enumeration used by #316 / #346 / sidecar PRs (`"ready to merge"`, `"complete"`, `"all clear"`, `"LGTM"`, `"passed"`).
+
+## Worked example — applying the audit pre-freeze
+
+For #375 docs-sync, the planner ran items 1+5+6 explicitly during DC drafting:
+
+- **Item 1**: `sidecar_start` trust_level was dropped from the AC entirely (frozen helper from #372 → no extension). Result: no R3+ rounds.
+- **Item 5**: AC test (a) and (b) both spelled out the comparison axis ("test (a) compares by `path.basename`; test (b) compares by full path"). Result: no heuristic-precision R1.
+- **Item 6**: Empty-state output spelled `"No likely stale docs detected."` verbatim with the period.
+
+R1 still caught one issue (an unrelated full-path comparison in a different code path). R2 PASS clean. 2 rounds total — bull's-eye outcome. Compare #374's 4 rounds without the audit applied.
+
+## When to skip
+
+For S-size mechanical tasks with one observable outcome (rename a function, add a single literal to an enum, fix one regex), the audit is overkill — the AC has nowhere to be ambiguous. Skip when:
+
+- Single-file edit, single observable change, no event/schema additions.
+- All AC items map to one verbatim string the reviewer can grep for.
+- No conjunctions, no scope claims, no heuristic verbs.
+
+For everything else (M+, anything that adds events/schemas/kinds, anything that extends a frozen contract, anything with conjunctions or comparison verbs), the cost of one item-by-item walk is far below the cost of one extra round.
+
+## See also
+
+- `rubric-design-guide.md` — overall rubric design guidance; this audit precedes step Q1's source-model recovery.
+- `rubric-validation.md` § "Validate Done Criteria" — structural DC checks (observable, bounded, reviewable). Composes with this audit.
+- `rubric-pattern-forbidden-zones.md` — for enumerating read-only paths, sibling pattern to item 1.
+- `rubric-pattern-grep-token-precision.md` — for path/test-name/grep-token literals, sibling pattern to item 6.
+- `~/.claude/projects/<repo-slug>/memory/feedback_dc_overspec_frozen_helper.md` — origin memory for item 1.

--- a/skills/relay-plan/references/rubric-design-guide.md
+++ b/skills/relay-plan/references/rubric-design-guide.md
@@ -66,7 +66,7 @@ List the evidence that defines success for this task:
 - Historical relay signals such as stuck factors, score divergence, and average rounds
 - Task risk such as trust boundaries, data loss, migrations, user-visible flows, performance, or operational failure modes
 
-If explicit AC and inferred Done Criteria disagree, resolve the conflict before drafting factors. Persist planner-authored Done Criteria when the final anchor differs from the issue body or intake handoff.
+If explicit AC and inferred Done Criteria disagree, resolve the conflict before drafting factors. Run the [pre-flight ambiguity audit](dc-preflight-audit.md) before freezing the Done Criteria, then persist planner-authored Done Criteria when the final anchor differs from the issue body or intake handoff.
 
 ### Q2: What actually matters for this task?
 


### PR DESCRIPTION
## Summary

Adds a new reference doc at `skills/relay-plan/references/dc-preflight-audit.md` distilling the recurrent DC-wording ambiguity patterns that drove every R1 changes_requested round across the 2026-05-08 marathon (n=7).

Retro stack-rank item #2 (item #1 was the `forbidden_zones` promotion shipped in #455). All 7 R1 catches in that marathon were spec-precision issues, not logic bugs — the highest-leverage planning lever is tighter DC wording, not better executor correctness.

## Changes

- **New**: `skills/relay-plan/references/dc-preflight-audit.md` (95 lines) — 6-item audit covering frozen-helper field-on-event, AND/OR boundary tightness, implicit-scope vs literal statement, coupling default, heuristic precision, and literal sentinel strings.
- **Forward links**: `SKILL.md` step 4 "Recover Done Criteria" paragraph + `rubric-design-guide.md` Q1 conflict-resolution sentence. Both edits are 1-line replacements (matching PR #455's per-file 2+- shape).
- **Composition**: doc explicitly distinguishes itself from `rubric-validation.md` § "Validate Done Criteria" — the existing checklist gates on SHAPE, this one gates on WORDING.

## Dogfood evidence (n=7)

| PR | Issue | R1 catch | Audit item |
|---|---|---|---|
| #448 | #372 | `output_path` scope under `sidecars/<id>/` (DC implied, didn't state) | 3 |
| #449 | #381 | runner `--json` coupled to sidecar output filename | 4 |
| #450 | #373 | repeat-finding detector matched only `title` (AC said "title or body") | 2 |
| #451 | #376 | prediction heuristic full-title vs shared-substring | 5 |
| #452 | #374 | `sidecar_start trust_level` on frozen helper (AC6 over-spec) | 1 |
| #453 | #375 | basename matching (test (a) used basename, codex full-path-only) | 5 |
| #454 | #144 | shipped `"no template scored above 0"` instead of literal `"no clear match"` | 6 |

#374 stretched to 4 rounds because AC6 also tripped item 1 (frozen helper). #375 explicitly applied item 1 in the DC and resolved clean in 2 rounds — first dogfood evidence of the audit working pre-emptively.

## Out of scope

- The originating memory `feedback_dc_overspec_frozen_helper` stays as historical narrative; the new ref doc is the authoritative source for item 1 going forward.
- No code changes — documentation-only.

## Test plan

- [x] SKILL.md remains ≤150 lines (currently exactly 150)
- [x] All skill test suites pass (1220 ok, 1 skipped, 0 fail across relay-ready/relay-plan/relay-dispatch/relay-review/relay-merge/relay-sidecar/sidecar-kinds)
- [x] Forward links validate (file paths exist on disk)
- [x] Diffstat matches #455 precedent: `2 +-` per existing file, new doc as standalone addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * Done Criteria 검증을 위한 pre-flight 감사 절차 추가
  * 모호하거나 불완전한 수용 기준을 확인하기 위한 6가지 감사 항목 체크리스트 문서화
  * 검증 프로세스 강화로 재검토 주기 감소

<!-- end of auto-generated comment: release notes by coderabbit.ai -->