### PR TITLE
Fold trust_level into sidecar start events (#457)

### DIFF
--- a/skills/relay-dispatch/scripts/sidecar-store.js
+++ b/skills/relay-dispatch/scripts/sidecar-store.js
@@ -149,6 +149,7 @@ function appendSidecarStart(repoRoot, runId, { id, kind, executor, model, provid
     sidecar_id: requireNonEmptyString(id, "id"),
     kind: requireNonEmptyString(kind, "kind"),
     executor: requireNonEmptyString(executor, "executor"),
+    trust_level: SIDECAR_TRUST_LEVEL,
     ...(model !== undefined ? { model: normalizeNullableString(model, "model") } : {}),
     ...(provider !== undefined ? { provider: normalizeNullableString(provider, "provider") } : {}),
   };

--- a/skills/relay-sidecar/scripts/relay-sidecar.js
+++ b/skills/relay-sidecar/scripts/relay-sidecar.js
@@ -22,7 +22,6 @@ const {
   readTextFileWithoutFollowingSymlinks,
   writeTextFileWithoutFollowingSymlinks,
 } = require("../../relay-dispatch/scripts/manifest/rubric");
-const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 const {
   appendSidecarFailed,
   appendSidecarResult,
@@ -535,25 +534,13 @@ function main(options = {}) {
     }
 
     const startedAt = Date.now();
-    if (args.kind === testGapKind.KIND_NAME) {
-      appendRunEvent(context.repoRoot, args.runId, {
-        event: EVENTS.SIDECAR_START,
-        sidecar_id: sidecarId,
-        kind: args.kind,
-        executor: args.executor,
-        model: args.model || null,
-        provider: parseProvider(args.model),
-        trust_level: SIDECAR_TRUST_LEVEL,
-      });
-    } else {
-      appendSidecarStart(context.repoRoot, args.runId, {
-        id: sidecarId,
-        kind: args.kind,
-        executor: args.executor,
-        model: args.model || null,
-        provider: parseProvider(args.model),
-      });
-    }
+    appendSidecarStart(context.repoRoot, args.runId, {
+      id: sidecarId,
+      kind: args.kind,
+      executor: args.executor,
+      model: args.model || null,
+      provider: parseProvider(args.model),
+    });
 
     let result;
     try {

--- a/tests/relay-dispatch/scripts/sidecar-store.test.js
+++ b/tests/relay-dispatch/scripts/sidecar-store.test.js
@@ -184,6 +184,7 @@ test("sidecar lifecycle helpers append advisory events without manifest state tr
   assert.equal(started.executor, "codex");
   assert.equal(started.model, "gpt-5");
   assert.equal(started.provider, "openai");
+  assert.equal(started.trust_level, SIDECAR_TRUST_LEVEL);
   assert.equal(completed.event, EVENTS.SIDECAR_RESULT);
   assert.equal(completed.output_path, "sidecars/lint-report/result.json");
   assert.equal(completed.trust_level, SIDECAR_TRUST_LEVEL);

--- a/tests/relay-sidecar/scripts/relay-sidecar.test.js
+++ b/tests/relay-sidecar/scripts/relay-sidecar.test.js
@@ -309,7 +309,7 @@ test("--kind docs-sync --executor none writes deterministic output and records r
   assert.equal(events.length, 2);
   assert.equal(events[0].event, "sidecar_start");
   assert.equal(events[0].executor, "none");
-  assert.equal(Object.hasOwn(events[0], "trust_level"), false);
+  assert.equal(events[0].trust_level, "advisory");
   assert.equal(events[1].event, "sidecar_result");
   assert.equal(events[1].trust_level, "advisory");
   assert.equal(events[1].output_path, `sidecars/${sidecarId}/output.md`);


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 단일 커밋 생성됨: `fbc89b3 Fold trust_level into sidecar start events (#457)`

**Completion Audit**
- AC1: [sidecar-store.js](/Users/sjlee/.relay/worktrees/c0819448/dev-relay/skills/relay-dispatch/scripts/sidecar-store.js:146) `appendSidecarStart`가 `trust_level: SIDECAR_TRUST_LEVEL`를 고정 필드로 emit합니다.
- AC2: [relay-sidecar.js](/Users/sjlee/.relay/worktrees/c0819448/dev-relay/skills/relay-sidecar/scripts/relay-sidecar.js:537) `test-gap` bypass 제거, 모든 kind가 `appendSidecarStart`를 호출합니다. `appendRunEv
```

## Score Log

- Run: issue-457-20260509034353918-f17d0dcd
- Executor: codex
- Branch: issue-457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사이드카 시작 이벤트에 트러스트 레벨 정보가 일관되게 포함됩니다.
  * 모든 사이드카 종류에 대해 동작이 통일되었습니다.

* **테스트**
  * 사이드카 시작 이벤트의 트러스트 레벨 필드 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->