### PR TITLE
Use output_path indirection for sidecar reports (#459)

### DIFF
--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 const { STATES } = require("./manifest/lifecycle");
-const { getRunDir, getSidecarOutputDir } = require("./manifest/paths");
+const { getRunDir } = require("./manifest/paths");
 const { readTextFileWithoutFollowingSymlinks } = require("./manifest/rubric");
 const { listManifestRecords } = require("./manifest/store");
 const { modeLabel, readArg, schemaHasFlag } = require("./cli-args");
@@ -654,8 +654,8 @@ function readReviewIssueTitles(runDir) {
   return titles;
 }
 
-function readSidecarOutput(repoRoot, runId, sidecarId) {
-  const outputPath = path.join(getSidecarOutputDir(repoRoot, runId, sidecarId), "output.md");
+function readSidecarOutput(repoRoot, runId, outputPathRelative) {
+  const outputPath = path.join(getRunDir(repoRoot, runId), outputPathRelative);
   const output = readTextFileWithoutFollowingSymlinks(outputPath);
   if (!output || /\u0000/.test(output)) {
     return null;
@@ -718,7 +718,7 @@ function computeSidecarPredictionRate({ events, repoRoot }) {
     const outputTexts = [];
     for (const event of resultEvents) {
       try {
-        const outputText = readSidecarOutput(repoRoot, runId, event.sidecar_id);
+        const outputText = readSidecarOutput(repoRoot, runId, event.output_path);
         if (outputText !== null) {
           outputTexts.push(outputText.toLowerCase());
         }

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -235,6 +235,13 @@ function writeSidecarOutput(repoRoot, runId, sidecarId, content) {
   fs.writeFileSync(path.join(outputDir, "output.md"), content, "utf-8");
 }
 
+function writeSidecarOutputAt(repoRoot, runId, outputPathRelative, content) {
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  const outputPath = path.join(runDir, outputPathRelative);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, content, "utf-8");
+}
+
 function writeReviewVerdict(repoRoot, runId, round, issues) {
   const { runDir } = ensureRunLayout(repoRoot, runId);
   fs.writeFileSync(
@@ -942,6 +949,34 @@ test("reliability-report counts sidecar output substrings of review titles as pr
 
   assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 1);
   assert.equal(report.sidecar_insights.predicted_findings_match_rate, 0.5);
+});
+
+test("reliability-report reads sidecar output via event.output_path indirection", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-sidecar-output-path-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const runId = createRunId({ branch: "run-sidecar-output-path", timestamp: new Date("2026-04-12T02:09:45.000Z") });
+  const sidecarId = "sc-custom-output";
+  const outputPath = `sidecars/${sidecarId}/custom-output.md`;
+
+  writeRun(repoRoot, { runId, state: STATES.CHANGES_REQUESTED, rounds: 1, updatedAt: recentTs });
+  appendSidecarStart(repoRoot, runId, { sidecarId, kind: "context-recap", executor: "codex" });
+  appendRunEvent(repoRoot, runId, {
+    event: "sidecar_result",
+    sidecar_id: sidecarId,
+    kind: "context-recap",
+    output_path: outputPath,
+    trust_level: "advisory",
+  });
+  writeSidecarOutputAt(repoRoot, runId, outputPath, "The sidecar predicted missing custom output path coverage.");
+  writeReviewVerdict(repoRoot, runId, 1, [
+    { title: "Missing custom output path coverage", body: "Read event output_path.", file: "report.js", line: 7, category: "contract", severity: "high" },
+  ]);
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+
+  assert.equal(report.sidecar_insights.predicted_findings_runs_examined, 1);
+  assert.ok(report.sidecar_insights.predicted_findings_match_rate > 0);
 });
 
 test("reliability-report keeps sidecar prediction null when results have no review verdicts", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 단일 커밋도 생성했습니다: `bf420cf Use output_path indirection for sidecar reports (#459)`.

**변경 사항**
- [reliability-report.js](/Users/sjlee/.relay/worktrees/35541417/dev-relay/skills/relay-dispatch/scripts/reliability-report.js:657)
  - `readSidecarOutput(repoRoot, runId, outputPathRelative)`로 변경
  - `path.join(getRunDir(repoRoot, runId), outputPathRelative)`로 읽도록 수정
  - `getSidecarOutputDir` import 제거
  - `output.md` literal은 이 파일에서 제거됨
- [reliability-report.js](/Users/sjlee/.relay/worktrees/355
```

## Score Log

- Run: issue-459-20260509053824518-d475e64e
- Executor: codex
- Branch: issue-459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 사이드카 출력 파일 경로 처리 메커니즘을 개선하여 더욱 견고한 파일 접근을 지원합니다.

* **테스트**
  * 신뢰성 리포트 기능의 사이드카 예측 로직 검증을 위한 새로운 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->