### PR TITLE
Normalize sprint frontmatter + ignore derived triage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ memory/
 
 # AI-generated planning artifacts
 docs/superpowers/
+
+# Backlog triage derived artifacts (snapshots + reports)
+# GitHub Issues remain source of truth; reports regenerate from `gh` fetch.
+backlog/triage/

--- a/backlog/sprints/2026-04-agentic-patterns-phase-0.md
+++ b/backlog/sprints/2026-04-agentic-patterns-phase-0.md
@@ -1,8 +1,9 @@
 ---
 milestone: Agentic Patterns Phase 0 — Wire What Exists
-status: active
+status: completed
 started: 2026-04-12
-due: TBD
+completed: 2026-04-18
+note: All action items shipped. #154 (gstack-codex adversarial benchmark) deferred to open backlog as awaiting-consumer.
 ---
 
 # agentic-patterns-phase-0

--- a/backlog/sprints/2026-05-execution-guidance-layer.md
+++ b/backlog/sprints/2026-05-execution-guidance-layer.md
@@ -2,7 +2,7 @@
 milestone: Sprint 2026-05 - Execution Guidance Layer
 status: completed
 started: 2026-05-02
-due: 2026-05-09
+completed: 2026-05-02
 ---
 
 # 2026-05 Execution Guidance Layer

--- a/backlog/sprints/2026-05-relay-ready.md
+++ b/backlog/sprints/2026-05-relay-ready.md
@@ -1,9 +1,10 @@
 ---
 milestone: Relay Intake / Preflight
-status: active
+status: completed
 started: 2026-05-07
-due: TBD
+completed: 2026-05-08
 epic: 431
+note: Phase 1+2 shipped (#432–#437). Phase 3 (#438/#439) tracked as open backlog under same milestone, blocked on ≥20 readiness_probe events accumulating naturally.
 ---
 
 # relay-ready (Epic #431)

--- a/backlog/sprints/2026-05-sidecar-mvp.md
+++ b/backlog/sprints/2026-05-sidecar-mvp.md
@@ -1,6 +1,6 @@
 ---
 milestone: Sprint 2026-05 — Sidecar MVP
-status: complete
+status: completed
 started: 2026-05-08
 completed: 2026-05-08
 epic: 367


### PR DESCRIPTION
## Summary

Two narrow housekeeping commits surfaced during a `/gstack-plan-eng-review` + `/simplify` audit of the dev-relay backlog:

- **`.gitignore`**: exclude `backlog/triage/` (snapshots and reports are derived from `gh` per the `backlog-triage` skill design — GitHub Issues stay the source of truth, mirrors the existing `memory/` exclusion).
- **4 sprint frontmatter normalizations**: `phase-0` and `relay-ready` had drifted to `status: active` weeks after their last action items shipped (children moved to open backlog as awaiting-consumer / observation-gated). `execution-guidance` was missing a `completed:` date. `sidecar-mvp` used `complete` instead of the consistent `completed`.

Going forward: use `completed` (not `complete`) and always include a `completed:` date when status flips.

## Test plan

- [x] `git status` clean after each commit
- [x] `.gitignore` change verified by re-running `git status` — previously-untracked `backlog/triage/` files no longer surface
- [x] Each frontmatter file's YAML still parses (head -10 visual check)
- [x] No code paths touched — no test suite run required

## Notes

A third candidate change (`extractRubricSize` regex fix proposed during the audit) was **cancelled** after live verification showed the fix already shipped in #346 / PR #350 (`2826504`) — the MEMORY.md index summary line was stale relative to its body's RESOLVED note. Memory entries corrected in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 스프린트 추적 메타데이터 업데이트 및 완료된 항목 정리
  * 백로그 관리 구조 최적화를 위한 설정 업데이트

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/461)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->