### PR TITLE
Document cross-skill install graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ tests/
 ```
 
 Multi-skill design: each phase is independently invocable. `npx skills add sungjunlee/dev-relay` installs all 6 skills: `relay`, `relay-ready`, `relay-plan`, `relay-dispatch`, `relay-review`, `relay-merge`.
+Cross-skill install dependencies are documented in [references/install-graph.md](references/install-graph.md).
 
 ## Common Commands
 

--- a/references/install-graph.md
+++ b/references/install-graph.md
@@ -1,0 +1,23 @@
+# Cross-Skill Install Graph
+
+`npx skills add sungjunlee/dev-relay` is the turnkey install because it places every sibling skill in one directory. Per-skill installs also work with `npx skills add sungjunlee/dev-relay/<skill>`, but skills that call sibling `scripts/` need those siblings installed adjacent with the expected names.
+
+```
+relay --------+--> relay-ready --> relay-dispatch
+              +--> relay-dispatch
+
+relay-plan ------> relay-dispatch
+
+relay-review      relay-merge      relay-sidecar
+   standalone       standalone       standalone
+```
+
+| Skill | Transitively requires sibling `scripts/` | If installed alone | Supported install path |
+| --- | --- | --- | --- |
+| `relay` | `relay-ready`, `relay-dispatch` | Readiness persistence/probe and dispatch calls fail when those sibling script paths are missing. | Full repo install works; per-skill works only if `relay-ready` and `relay-dispatch` are also installed adjacent. |
+| `relay-ready` | `relay-dispatch` | Continuation paths that call `relay-dispatch/scripts/dispatch.js` fail. | Full repo install works; per-skill works only if `relay-dispatch` is also installed adjacent. |
+| `relay-plan` | `relay-dispatch` | Dispatch and reliability-report calls fail. | Full repo install works; per-skill works only if `relay-dispatch` is also installed adjacent. |
+| `relay-dispatch` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
+| `relay-review` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
+| `relay-merge` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
+| `relay-sidecar` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |

--- a/references/install-graph.md
+++ b/references/install-graph.md
@@ -1,23 +1,32 @@
 # Cross-Skill Install Graph
 
-`npx skills add sungjunlee/dev-relay` is the turnkey install because it places every sibling skill in one directory. Per-skill installs also work with `npx skills add sungjunlee/dev-relay/<skill>`, but skills that call sibling `scripts/` need those siblings installed adjacent with the expected names.
+`npx skills add sungjunlee/dev-relay` is the only operator-supported install path because it places every sibling skill in one directory. Every skill currently reaches across sibling directories through either SKILL.md command paths, JS `require()` calls, or both. Per-skill installs are not supported for operators because they can leave those sibling paths missing and cause module resolution failures.
 
 ```
-relay --------+--> relay-ready --> relay-dispatch
-              +--> relay-dispatch
+relay ----------> relay-ready
+relay ----------> relay-dispatch
 
-relay-plan ------> relay-dispatch
+relay-ready ----> relay-dispatch
+relay-plan -----> relay-dispatch
+relay-dispatch -> relay-plan
 
-relay-review      relay-merge      relay-sidecar
-   standalone       standalone       standalone
+relay-review ---> relay-dispatch
+relay-merge ----> relay-dispatch
+relay-merge ----> relay-plan
+relay-merge ----> relay-review
+relay-sidecar --> relay-dispatch
 ```
 
-| Skill | Transitively requires sibling `scripts/` | If installed alone | Supported install path |
+The `relay-dispatch` -> `relay-plan` edge is a small JS-level cycle: `skills/relay-dispatch/scripts/reliability-report.js` imports `../../relay-plan/scripts/tdd-flavor`, while relay-plan scripts and SKILL.md commands call back into relay-dispatch.
+
+| Skill | Required siblings (SKILL.md + JS) | If installed alone | Supported install path |
 | --- | --- | --- | --- |
-| `relay` | `relay-ready`, `relay-dispatch` | Readiness persistence/probe and dispatch calls fail when those sibling script paths are missing. | Full repo install works; per-skill works only if `relay-ready` and `relay-dispatch` are also installed adjacent. |
-| `relay-ready` | `relay-dispatch` | Continuation paths that call `relay-dispatch/scripts/dispatch.js` fail. | Full repo install works; per-skill works only if `relay-dispatch` is also installed adjacent. |
-| `relay-plan` | `relay-dispatch` | Dispatch and reliability-report calls fail. | Full repo install works; per-skill works only if `relay-dispatch` is also installed adjacent. |
-| `relay-dispatch` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
-| `relay-review` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
-| `relay-merge` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
-| `relay-sidecar` | None | Nothing - standalone. | Full repo install works; per-skill install works alone. |
+| `relay` | `relay-ready`, `relay-dispatch` | SKILL.md commands reference `../relay-ready/scripts/persist-request.js`, `../relay-ready/scripts/probe-readiness.js`, and `../relay-dispatch/scripts/dispatch.js`; those paths are missing in a relay-only install. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-ready` | `relay-dispatch` | JS imports fail before request persistence/probing can run: `scripts/persist-request.js` requires `../../relay-dispatch/scripts/cli-args`; `scripts/relay-request.js` requires `../../relay-dispatch/scripts/relay-manifest` and `../../relay-dispatch/scripts/manifest/paths`; `scripts/probe-readiness.js` requires `../../relay-dispatch/scripts/relay-events` and `../../relay-dispatch/scripts/cli-args`. SKILL.md also calls `../relay-dispatch/scripts/dispatch.js`. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-plan` | `relay-dispatch` | JS imports fail for planning helpers: `scripts/match-template.js` requires `../../relay-dispatch/scripts/manifest/rubric`; `scripts/persist-done-criteria.js` requires `../../relay-dispatch/scripts/manifest/paths` and `../../relay-dispatch/scripts/cli-args`; `scripts/probe-executor-env.js` requires `../../relay-dispatch/scripts/cli-args` and `../../relay-dispatch/scripts/executors`. SKILL.md also calls `../relay-dispatch/scripts/reliability-report.js` and `../relay-dispatch/scripts/dispatch.js`. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-dispatch` | `relay-plan` | `scripts/reliability-report.js` requires `../../relay-plan/scripts/tdd-flavor`; running reliability reporting from a dispatch-only install fails when relay-plan is absent. This is the closest skill to a root, but it is not fully standalone today. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-review` | `relay-dispatch` | Review entrypoints and helpers import dispatch manifest/event modules: `scripts/review-runner.js` requires `../../relay-dispatch/scripts/manifest/lifecycle`, `manifest/paths`, `manifest/rubric`, `manifest/store`, `relay-events`, and `cli-args`; nested `scripts/review-runner/*` modules require `../../../relay-dispatch/scripts/...`; reviewer adapters require `../../relay-dispatch/scripts/cli-args`; `scripts/reviewer-helpers.js` and `scripts/analyze-flip-flop-pattern.js` also require dispatch modules. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-merge` | `relay-dispatch`, `relay-plan`, `relay-review` | Merge scripts import dispatch modules throughout: `scripts/finalize-run.js`, `scripts/gate-check.js`, `scripts/relay-reconcile-artifact.js`, and `scripts/review-gate.js` require `../../relay-dispatch/scripts/...`. `scripts/sprint-close-report.js` additionally requires `../../relay-review/scripts/review-runner/divergence` and `../../relay-plan/scripts/tdd-flavor`, plus dispatch modules. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-sidecar` | `relay-dispatch` | `scripts/relay-sidecar.js` requires `../../relay-dispatch/scripts/cli-args`, `manifest/paths`, `manifest/store`, `manifest/rubric`, and `sidecar-store`; sidecar execution fails without relay-dispatch installed adjacent. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+
+Keep this file in sync when adding or removing cross-skill script calls. `CLAUDE.md` points users here instead of duplicating the graph.


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 문서 전용 커밋을 `issue-464` 브랜치에 만들었습니다.

커밋: `0e4c6b0 Document cross-skill install graph`

변경 파일:
- [references/install-graph.md](/Users/sjlee/.relay/worktrees/d834eba6/dev-relay/references/install-graph.md): 7개 skill의 cross-skill install/dependency graph, 단독 설치 시 breakage, 지원 install path 정리
- [CLAUDE.md](/Users/sjlee/.relay/worktrees/d834eba6/dev-relay/CLAUDE.md:66): install graph 포인터 1줄 추가

검증:
- `ls skills/*/SKILL.md` → 7개 확인
- 요청한 grep snippet으로 dependency facts 재확인
- `git diff --name-on
```

## Score Log

- Run: issue-464-20260512125609084-99f2ecfe
- Executor: codex
- Branch: issue-464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 다중 스킬 프로젝트의 설치 의존성에 관한 새로운 문서 추가 — 크로스-스킬 설치 그래프(설치 구조, 각 스킬의 종속성 요구사항, 지원되는 설치 경로를 다이어그램 및 표로 제시)
  * 주요 문서에 설치 그래프 참조 링크 추가하여 사용자가 설치 경로를 쉽게 확인 가능

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/471)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->