### PR TITLE
Fix relay readiness probe heading

### DIFF
--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -33,17 +33,7 @@ Fast path: bypass relay-ready only when the input is already one relay-ready tas
 
 If no issue number, use a descriptive branch name (e.g., `feat/<slug>`) and skip issue-close in Step 6.
 
-### Readiness path
-
-If readiness is required, persist a single-leaf contract first:
-
-```bash
-${CLAUDE_SKILL_DIR}/../relay-ready/scripts/persist-request.js --repo . --contract-file /tmp/relay-ready-contract.json --json
-```
-
-Carry forward the handoff brief, frozen Done Criteria snapshot, and linkage: `request_id`, `leaf_id`.
-
-## Readiness probe + chain prompt
+## Step 1.7: Readiness probe + chain prompt
 Before Step 2, run this unless bypassed by a prior relay-ready artifact with `readiness_score` and frozen review anchor, explicit `--bypass-readiness`, or a sprint-batch entry already linked to a relay-ready handoff:
 
 ```bash

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -33,6 +33,16 @@ Fast path: bypass relay-ready only when the input is already one relay-ready tas
 
 If no issue number, use a descriptive branch name (e.g., `feat/<slug>`) and skip issue-close in Step 6.
 
+## Step 1.5: Check for in-flight work
+
+Check if this issue already has a PR in progress:
+```bash
+PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
+```
+- PR exists and open → **skip Steps 2-3**, go directly to Step 4 (review)
+- PR exists and merged → update sprint file to `[x]` (if exists), done
+- PR not found → continue to Step 2
+
 ## Step 1.7: Readiness probe + chain prompt
 Before Step 2, run this unless bypassed by a prior relay-ready artifact with `readiness_score` and frozen review anchor, explicit `--bypass-readiness`, or a sprint-batch entry already linked to a relay-ready handoff:
 
@@ -52,16 +62,6 @@ Branch labels and events:
 - `chain-n` / `bypass_override_by_user`: emit with current scores and proceed to Step 2.
 - `chain-abort` / `readiness_check_failed`: emit with current scores, close the run.
 - `noninteractive-fail` / `readiness_check_failed_nontty`: emit when `BYPASS=false` and no prompt is allowed, then close the run.
-
-## Step 1.5: Check for in-flight work
-
-Check if this issue already has a PR in progress:
-```bash
-PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
-```
-- PR exists and open → **skip Steps 2-3**, go directly to Step 4 (review)
-- PR exists and merged → update sprint file to `[x]` (if exists), done
-- PR not found → continue to Step 2
 
 ## Step 2: Plan
 

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -41,7 +41,7 @@ PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
 ```
 - PR exists and open → **skip Steps 2-3**, go directly to Step 4 (review)
 - PR exists and merged → update sprint file to `[x]` (if exists), done
-- PR not found → continue to Step 2
+- PR not found → continue to Step 1.7
 
 ## Step 1.7: Readiness probe + chain prompt
 Before Step 2, run this unless bypassed by a prior relay-ready artifact with `readiness_score` and frozen review anchor, explicit `--bypass-readiness`, or a sprint-batch entry already linked to a relay-ready handoff:


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

`skills/relay/SKILL.md`에서 `### Readiness path` 섹션을 삭제했고, `## Readiness probe + chain prompt`를 `## Step 1.7: Readiness probe + chain prompt`로 rename했습니다. 다른 파일은 수정하지 않았습니다.

검증:
- `node --test tests/skills-lint/scripts/*.test.js` 통과
- `git diff --name-only main...HEAD` 결과: `skills/relay/SKILL.md`만 포함
- 작업 트리 clean
- 커밋 생성: `ad45c1c Fix relay readiness probe heading`
```

## Score Log

- Run: issue-465-20260512131231465-71051b29
- Executor: codex
- Branch: issue-465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 릴레이 흐름을 재구조화하여 중간에 진행중(in‑flight) 작업 확인 단계(기존 1.5 위치 변경)를 추가했습니다.
  * 준비 상태 전용 프로브와 체인 프롬프트(새로운 1.7 단계)를 도입해 준비성 처리를 명확히 분리했습니다.
  * 이전의 단일 리프 준비 경로(영속화 방식)를 제거하고 단계 순서를 재배치해 워크플로우를 간소화했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/472)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->