### PR TITLE
Add relay-ready request contract schema

### DIFF
--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -25,10 +25,11 @@ Bypass only for a single relay-ready task with a trustworthy review anchor alrea
 ## Output Contract
 
 Persist artifacts under `~/.relay/requests/<repo-slug>/<request-id>/` (request frontmatter, raw request,
-handoff(s), done-criteria snapshot(s), append-only events.jsonl). Field-by-field schema with required/
-optional markings, value enums, and descriptions: see
+handoff(s), done-criteria snapshot(s), append-only events.jsonl). Field-by-field schema with input
+requirements plus persisted request and handoff artifact definitions: see
 [`scripts/request-contract.schema.json`](scripts/request-contract.schema.json). `persist-request.js`
-validates against it on every persistence call.
+validates the input contract on every persistence call; `$defs.RequestArtifact` and
+`$defs.HandoffArtifact` document generated frontmatter for downstream consumers.
 
 ## Persistence Step
 
@@ -47,7 +48,7 @@ Persist it with:
 ${CLAUDE_SKILL_DIR}/scripts/persist-request.js --repo . --contract-file /tmp/relay-ready-contract.json --json
 ```
 
-Optional readiness fields: see schema enum domains.
+Readiness is optional, but if supplied, all readiness dimensions are required; see schema enum domains.
 
 Preflight shaping stays append-only in `events.jsonl`. Use the portable readiness event types:
 - `proposal_presented`

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -38,9 +38,8 @@ Write a JSON contract file with:
 - `request_text`
 - either `handoff` for single-leaf or `handoffs[]` for multi-leaf
 - per leaf: `leaf_id`, `title`, `goal`, `order`
-- optional per leaf: `depends_on`
-- per leaf: `in_scope`, `out_of_scope`, `assumptions`
-- per leaf: `done_criteria_markdown`, `escalation_conditions`
+- per leaf: `done_criteria_markdown`
+- optional per leaf: `depends_on`, `in_scope`, `out_of_scope`, `assumptions`, `escalation_conditions`
 
 Persist it with:
 

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -24,38 +24,11 @@ Bypass only for a single relay-ready task with a trustworthy review anchor alrea
 
 ## Output Contract
 
-Persist all of the following under `~/.relay/requests/<repo-slug>/<request-id>/`:
-- request artifact: `../<request-id>.md`
-- raw request: `raw-request.md`
-- relay-ready handoffs: `relay-ready/<leaf-id>.md`
-- frozen Done Criteria snapshots: `done-criteria/<leaf-id>.md`
-- append-only events: `events.jsonl`
-
-The request artifact frontmatter may also carry:
-- `readiness.clarity`
-- `readiness.granularity`
-- `readiness.dependency`
-- `readiness.verifiability`
-- `readiness.risk`
-- `next_action`
-- `leaf_count`
-- `paths.handoff` + `paths.done_criteria` for single-leaf requests
-- `paths.handoffs` + `paths.done_criteria` for multi-leaf requests
-- `decomposition.leaf_order`
-- `decomposition.dependencies`
-
-Each normalized handoff must contain:
-- `request_id`
-- `leaf_id`
-- `title`
-- `goal`
-- `order`
-- `depends_on`
-- `in_scope`
-- `out_of_scope`
-- `assumptions`
-- `done_criteria_path`
-- `escalation_conditions`
+Persist artifacts under `~/.relay/requests/<repo-slug>/<request-id>/` (request frontmatter, raw request,
+handoff(s), done-criteria snapshot(s), append-only events.jsonl). Field-by-field schema with required/
+optional markings, value enums, and descriptions: see
+[`scripts/request-contract.schema.json`](scripts/request-contract.schema.json). `persist-request.js`
+validates against it on every persistence call.
 
 ## Persistence Step
 
@@ -74,12 +47,7 @@ Persist it with:
 ${CLAUDE_SKILL_DIR}/scripts/persist-request.js --repo . --contract-file /tmp/relay-ready-contract.json --json
 ```
 
-Optional contract fields:
-- `readiness.clarity`: `high | medium | low`
-- `readiness.granularity`: `single_task | multi_task | unclear`
-- `readiness.dependency`: `none | internal | external`
-- `readiness.verifiability`: `high | medium | low`
-- `readiness.risk`: `low | medium | high`
+Optional readiness fields: see schema enum domains.
 
 Preflight shaping stays append-only in `events.jsonl`. Use the portable readiness event types:
 - `proposal_presented`

--- a/skills/relay-ready/scripts/persist-request.js
+++ b/skills/relay-ready/scripts/persist-request.js
@@ -43,6 +43,12 @@ function validateReadiness(readiness, field, schema, errors) {
   }
 
   const readinessFields = schema?.$defs?.readiness?.properties || {};
+  const requiredReadinessFields = schema?.$defs?.readiness?.required || [];
+  for (const name of requiredReadinessFields) {
+    if (!hasOwn(readiness, name)) {
+      errors.push(`${field}.${name}: is required`);
+    }
+  }
   for (const [name, definition] of Object.entries(readinessFields)) {
     if (!hasOwn(readiness, name)) continue;
     const allowed = definition.enum || [];

--- a/skills/relay-ready/scripts/persist-request.js
+++ b/skills/relay-ready/scripts/persist-request.js
@@ -35,6 +35,11 @@ function validateStringArray(value, field, errors) {
   });
 }
 
+function validateOptionalStringArray(value, field, errors) {
+  if (value === undefined) return;
+  validateStringArray(value, field, errors);
+}
+
 function validateReadiness(readiness, field, schema, errors) {
   if (readiness === undefined) return;
   if (!isObject(readiness)) {
@@ -68,7 +73,7 @@ function validateLeafHandoff(handoff, field, schema, errors, defaultOrder) {
     validateString(handoff[name], `${field}.${name}`, errors);
   }
   for (const name of ["in_scope", "out_of_scope", "assumptions", "escalation_conditions"]) {
-    validateStringArray(handoff[name], `${field}.${name}`, errors);
+    validateOptionalStringArray(handoff[name], `${field}.${name}`, errors);
   }
   if (hasOwn(handoff, "depends_on")) {
     validateStringArray(handoff.depends_on, `${field}.depends_on`, errors);

--- a/skills/relay-ready/scripts/persist-request.js
+++ b/skills/relay-ready/scripts/persist-request.js
@@ -9,6 +9,107 @@ const {
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 
+function isObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(object, field) {
+  return Object.prototype.hasOwnProperty.call(object, field);
+}
+
+function validateString(value, field, errors) {
+  if (typeof value !== "string" || !value.trim()) {
+    errors.push(`${field}: is required`);
+  }
+}
+
+function validateStringArray(value, field, errors) {
+  if (!Array.isArray(value)) {
+    errors.push(`${field}: must be an array`);
+    return;
+  }
+  value.forEach((entry, index) => {
+    if (typeof entry !== "string" || !entry.trim()) {
+      errors.push(`${field}[${index}]: must be a non-empty string`);
+    }
+  });
+}
+
+function validateReadiness(readiness, field, schema, errors) {
+  if (readiness === undefined) return;
+  if (!isObject(readiness)) {
+    errors.push(`${field}: must be an object`);
+    return;
+  }
+
+  const readinessFields = schema?.$defs?.readiness?.properties || {};
+  for (const [name, definition] of Object.entries(readinessFields)) {
+    if (!hasOwn(readiness, name)) continue;
+    const allowed = definition.enum || [];
+    if (allowed.length && !allowed.includes(readiness[name])) {
+      errors.push(`${field}.${name}: must be one of: ${allowed.join(", ")}`);
+    }
+  }
+}
+
+function validateLeafHandoff(handoff, field, schema, errors, defaultOrder) {
+  if (!isObject(handoff)) {
+    errors.push(`${field}: must be an object`);
+    return;
+  }
+
+  for (const name of ["leaf_id", "title", "goal", "done_criteria_markdown"]) {
+    validateString(handoff[name], `${field}.${name}`, errors);
+  }
+  for (const name of ["in_scope", "out_of_scope", "assumptions", "escalation_conditions"]) {
+    validateStringArray(handoff[name], `${field}.${name}`, errors);
+  }
+  if (hasOwn(handoff, "depends_on")) {
+    validateStringArray(handoff.depends_on, `${field}.depends_on`, errors);
+  }
+  if (!hasOwn(handoff, "order") && defaultOrder === undefined) {
+    errors.push(`${field}.order: is required`);
+  } else if (hasOwn(handoff, "order") && (!Number.isInteger(handoff.order) || handoff.order < 1)) {
+    errors.push(`${field}.order: must be a positive integer`);
+  }
+  validateReadiness(handoff.readiness, `${field}.readiness`, schema, errors);
+}
+
+function validateContractAgainstSchema(contract, schema) {
+  const errors = [];
+  if (!isObject(contract)) return "contract: must be an object";
+
+  if (!isObject(contract.source)) {
+    errors.push("source: is required");
+  } else {
+    validateString(contract.source.kind, "source.kind", errors);
+  }
+  validateString(contract.request_text, "request_text", errors);
+
+  const hasHandoff = hasOwn(contract, "handoff");
+  const hasHandoffs = hasOwn(contract, "handoffs");
+  if (hasHandoff === hasHandoffs) {
+    errors.push("handoff: exactly one of handoff or handoffs is required");
+  } else if (hasHandoffs) {
+    if (!Array.isArray(contract.handoffs) || contract.handoffs.length === 0) {
+      errors.push("handoffs: must be a non-empty array");
+    } else {
+      contract.handoffs.forEach((handoff, index) => {
+        validateLeafHandoff(handoff, `handoffs[${index}]`, schema, errors);
+      });
+    }
+  } else {
+    validateLeafHandoff(contract.handoff, "handoff", schema, errors, 1);
+  }
+
+  validateReadiness(contract.readiness, "readiness", schema, errors);
+  if (hasOwn(contract, "next_action")) {
+    validateString(contract.next_action, "next_action", errors);
+  }
+
+  return errors[0] || null;
+}
+
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--contract-file", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
@@ -48,6 +149,13 @@ try {
   contract = JSON.parse(fs.readFileSync(resolvedContractFile, "utf-8"));
 } catch (error) {
   console.error(`Error: failed to parse contract JSON: ${error.message}`);
+  process.exit(1);
+}
+
+const schema = JSON.parse(fs.readFileSync(path.join(__dirname, "request-contract.schema.json"), "utf-8"));
+const validationError = validateContractAgainstSchema(contract, schema);
+if (validationError) {
+  console.error(`Error: contract validation failed: ${validationError}`);
   process.exit(1);
 }
 

--- a/skills/relay-ready/scripts/request-contract.schema.json
+++ b/skills/relay-ready/scripts/request-contract.schema.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/sungjunlee/dev-relay/schemas/relay-ready/request-contract.schema.json",
+  "title": "Relay Ready Request Persistence Contract",
+  "description": "Canonical additive-tolerant input contract for skills/relay-ready/scripts/persist-request.js. The CLI validates this shape before relay-request.js performs semantic normalization and artifact persistence.",
+  "type": "object",
+  "required": [
+    "source",
+    "request_text"
+  ],
+  "oneOf": [
+    {
+      "description": "Single-leaf relay-ready request.",
+      "required": [
+        "handoff"
+      ],
+      "not": {
+        "required": [
+          "handoffs"
+        ]
+      }
+    },
+    {
+      "description": "Multi-leaf relay-ready request.",
+      "required": [
+        "handoffs"
+      ],
+      "not": {
+        "required": [
+          "handoff"
+        ]
+      }
+    }
+  ],
+  "properties": {
+    "source": {
+      "type": "object",
+      "description": "Origin metadata for the request. Unknown source metadata is preserved as producer-specific context.",
+      "required": [
+        "kind"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source type for the request, such as raw_text or github_issue."
+        }
+      }
+    },
+    "request_text": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Raw user request text to persist as raw-request.md and use as the request artifact body anchor."
+    },
+    "handoff": {
+      "$ref": "#/$defs/singleLeafHandoff",
+      "description": "Single relay-ready leaf handoff. Exactly one of handoff or handoffs must be provided."
+    },
+    "handoffs": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered multi-leaf relay-ready handoffs. Exactly one of handoff or handoffs must be provided.",
+      "items": {
+        "$ref": "#/$defs/multiLeafHandoff"
+      }
+    },
+    "readiness": {
+      "$ref": "#/$defs/readiness",
+      "description": "Request-level readiness scores copied to the request artifact frontmatter."
+    },
+    "next_action": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional producer hint for the immediate next relay step. persist-request.js currently persists relay_plan after a successful handoff freeze."
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "stringArray": {
+      "type": "array",
+      "description": "Array of strings. Empty arrays are allowed when there is nothing to list.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "description": "Readiness dimensions used by relay-ready to explain whether the request is clear, leaf-sized, dependency-aware, verifiable, and risk-bounded.",
+      "additionalProperties": true,
+      "properties": {
+        "clarity": {
+          "type": "string",
+          "description": "How clearly the request states the desired behavior and constraints.",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "granularity": {
+          "type": "string",
+          "description": "Whether the request is already one relay-sized task, multiple tasks, or unclear.",
+          "enum": [
+            "single_task",
+            "multi_task",
+            "unclear"
+          ]
+        },
+        "dependency": {
+          "type": "string",
+          "description": "Whether the request has no dependencies, internal dependencies, or external dependencies.",
+          "enum": [
+            "none",
+            "internal",
+            "external"
+          ]
+        },
+        "verifiability": {
+          "type": "string",
+          "description": "How directly a reviewer can verify completion from the Done Criteria and handoff.",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "risk": {
+          "type": "string",
+          "description": "Implementation and review risk for the request.",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        }
+      }
+    },
+    "leafHandoffBase": {
+      "type": "object",
+      "description": "Fields shared by a relay-ready leaf handoff. Unknown leaf metadata is allowed so producers can add forward-compatible annotations.",
+      "required": [
+        "leaf_id",
+        "title",
+        "goal",
+        "in_scope",
+        "out_of_scope",
+        "assumptions",
+        "done_criteria_markdown",
+        "escalation_conditions"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "leaf_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable leaf identifier used by relay-plan, relay-dispatch, and review anchors."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short human-readable leaf title."
+        },
+        "goal": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Concrete outcome this leaf must achieve."
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Positive execution order. Required for multi-leaf handoffs; single-leaf handoffs default to 1 when omitted for existing producer compatibility.",
+          "default": 1
+        },
+        "depends_on": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Optional list of earlier leaf_id values that must be completed before this leaf."
+        },
+        "in_scope": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Work explicitly included in this leaf."
+        },
+        "out_of_scope": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Work explicitly excluded from this leaf."
+        },
+        "assumptions": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Assumptions that make the handoff relay-ready."
+        },
+        "done_criteria_markdown": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Frozen Done Criteria markdown that will be written to done-criteria/<leaf-id>.md."
+        },
+        "escalation_conditions": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Conditions that should stop execution and escalate back to the orchestrator."
+        },
+        "readiness": {
+          "$ref": "#/$defs/readiness",
+          "description": "Optional leaf-level readiness scores. When present, they must not conflict with other leaf or request readiness values."
+        }
+      }
+    },
+    "singleLeafHandoff": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/leafHandoffBase"
+        }
+      ],
+      "description": "Single-leaf handoff. Producers should provide order explicitly, but persistRequestContract normalizes a missing order to 1 for this form."
+    },
+    "multiLeafHandoff": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/leafHandoffBase"
+        },
+        {
+          "required": [
+            "order"
+          ]
+        }
+      ],
+      "description": "Multi-leaf handoff item. order is required so decomposition.leaf_order and dependency validation are deterministic."
+    }
+  }
+}

--- a/skills/relay-ready/scripts/request-contract.schema.json
+++ b/skills/relay-ready/scripts/request-contract.schema.json
@@ -312,11 +312,7 @@
         "leaf_id",
         "title",
         "goal",
-        "in_scope",
-        "out_of_scope",
-        "assumptions",
-        "done_criteria_markdown",
-        "escalation_conditions"
+        "done_criteria_markdown"
       ],
       "additionalProperties": true,
       "properties": {
@@ -343,19 +339,23 @@
         },
         "depends_on": {
           "$ref": "#/$defs/stringArray",
-          "description": "Optional list of earlier leaf_id values that must be completed before this leaf."
+          "description": "Optional list of earlier leaf_id values that must be completed before this leaf.",
+          "default": []
         },
         "in_scope": {
           "$ref": "#/$defs/stringArray",
-          "description": "Work explicitly included in this leaf."
+          "description": "Optional work explicitly included in this leaf. Defaults to an empty list when omitted.",
+          "default": []
         },
         "out_of_scope": {
           "$ref": "#/$defs/stringArray",
-          "description": "Work explicitly excluded from this leaf."
+          "description": "Optional work explicitly excluded from this leaf. Defaults to an empty list when omitted.",
+          "default": []
         },
         "assumptions": {
           "$ref": "#/$defs/stringArray",
-          "description": "Assumptions that make the handoff relay-ready."
+          "description": "Optional assumptions that make the handoff relay-ready. Defaults to an empty list when omitted.",
+          "default": []
         },
         "done_criteria_markdown": {
           "type": "string",
@@ -364,7 +364,8 @@
         },
         "escalation_conditions": {
           "$ref": "#/$defs/stringArray",
-          "description": "Conditions that should stop execution and escalate back to the orchestrator."
+          "description": "Optional conditions that should stop execution and escalate back to the orchestrator. Defaults to an empty list when omitted.",
+          "default": []
         },
         "readiness": {
           "$ref": "#/$defs/readiness",

--- a/skills/relay-ready/scripts/request-contract.schema.json
+++ b/skills/relay-ready/scripts/request-contract.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/sungjunlee/dev-relay/schemas/relay-ready/request-contract.schema.json",
   "title": "Relay Ready Request Persistence Contract",
-  "description": "Canonical additive-tolerant input contract for skills/relay-ready/scripts/persist-request.js. The CLI validates this shape before relay-request.js performs semantic normalization and artifact persistence.",
+  "description": "Canonical additive-tolerant full relay-ready request persistence contract. The top-level schema defines the input accepted by skills/relay-ready/scripts/persist-request.js. $defs.RequestArtifact and $defs.HandoffArtifact document the persisted frontmatter artifacts generated for downstream relay-plan and relay-dispatch consumers. The CLI validates only the input shape before relay-request.js performs semantic normalization and artifact persistence.",
   "type": "object",
   "required": [
     "source",
@@ -89,6 +89,13 @@
       "type": "object",
       "description": "Readiness dimensions used by relay-ready to explain whether the request is clear, leaf-sized, dependency-aware, verifiable, and risk-bounded.",
       "additionalProperties": true,
+      "required": [
+        "clarity",
+        "granularity",
+        "dependency",
+        "verifiability",
+        "risk"
+      ],
       "properties": {
         "clarity": {
           "type": "string",
@@ -134,6 +141,187 @@
             "medium",
             "high"
           ]
+        }
+      }
+    },
+    "RequestArtifact": {
+      "type": "object",
+      "description": "Persisted request artifact frontmatter written to ~/.relay/requests/<repo-slug>/<request-id>.md. All fields are optional in this definition because preflight and relay-ready artifacts may be partially populated over time.",
+      "additionalProperties": true,
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Request identifier set by the persister."
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Current request artifact state, such as relay_ready."
+        },
+        "leaf_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Single-leaf identifier when the request resolves to one relay-ready leaf."
+        },
+        "leaf_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of relay-ready leaf handoffs persisted for this request."
+        },
+        "next_action": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Immediate next relay action for the orchestrator."
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Original request source kind."
+            }
+          }
+        },
+        "readiness": {
+          "$ref": "#/$defs/readiness",
+          "description": "Request-level readiness scores copied from the accepted relay-ready contract."
+        },
+        "paths": {
+          "type": "object",
+          "description": "Persisted artifact paths. Single-leaf requests use paths.handoff and a string paths.done_criteria; multi-leaf requests use paths.handoffs and an array paths.done_criteria.",
+          "additionalProperties": true,
+          "properties": {
+            "raw_request": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Path to raw-request.md."
+            },
+            "handoff": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Single-leaf relay-ready handoff path."
+            },
+            "handoffs": {
+              "$ref": "#/$defs/stringArray",
+              "description": "Ordered multi-leaf relay-ready handoff paths."
+            },
+            "done_criteria": {
+              "description": "Frozen Done Criteria path for a single-leaf request, or ordered Done Criteria paths for a multi-leaf request.",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "$ref": "#/$defs/stringArray"
+                }
+              ]
+            }
+          }
+        },
+        "decomposition": {
+          "type": "object",
+          "description": "Multi-leaf ordering and dependency graph consumed by downstream relay phases.",
+          "additionalProperties": true,
+          "properties": {
+            "leaf_order": {
+              "$ref": "#/$defs/stringArray",
+              "description": "Ordered leaf_id values."
+            },
+            "dependencies": {
+              "type": "object",
+              "description": "Map of leaf_id to the leaf_id values it depends on.",
+              "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+              }
+            }
+          }
+        },
+        "timestamps": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "created_at": {
+              "type": "string",
+              "minLength": 1
+            },
+            "updated_at": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "HandoffArtifact": {
+      "type": "object",
+      "description": "Persisted relay-ready/<leaf-id>.md frontmatter generated for relay-plan and dispatch handoff consumers.",
+      "required": [
+        "request_id",
+        "leaf_id",
+        "title",
+        "goal",
+        "order",
+        "in_scope",
+        "out_of_scope",
+        "assumptions",
+        "done_criteria_path",
+        "escalation_conditions"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Parent relay-ready request identifier."
+        },
+        "leaf_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable leaf identifier used by relay-plan, relay-dispatch, and review anchors."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short human-readable leaf title."
+        },
+        "goal": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Concrete outcome this leaf must achieve."
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Positive execution order for this leaf."
+        },
+        "depends_on": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Optional list of earlier leaf_id values that must be completed before this leaf."
+        },
+        "in_scope": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Work explicitly included in this leaf."
+        },
+        "out_of_scope": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Work explicitly excluded from this leaf."
+        },
+        "assumptions": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Assumptions that make the handoff relay-ready."
+        },
+        "done_criteria_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Frozen Done Criteria snapshot path for this leaf."
+        },
+        "escalation_conditions": {
+          "$ref": "#/$defs/stringArray",
+          "description": "Conditions that should stop execution and escalate back to the orchestrator."
         }
       }
     },

--- a/skills/relay-ready/scripts/request-contract.schema.json
+++ b/skills/relay-ready/scripts/request-contract.schema.json
@@ -258,18 +258,14 @@
     },
     "HandoffArtifact": {
       "type": "object",
-      "description": "Persisted relay-ready/<leaf-id>.md frontmatter generated for relay-plan and dispatch handoff consumers.",
+      "description": "YAML frontmatter of the persisted relay-ready/<leaf-id>.md handoff artifact. The markdown body of the handoff additionally contains rendered sections for in_scope, out_of_scope, assumptions, done_criteria_markdown, and escalation_conditions — those are body content, not frontmatter, and are covered by the input handoff schema during persistence.",
       "required": [
         "request_id",
         "leaf_id",
         "title",
         "goal",
         "order",
-        "in_scope",
-        "out_of_scope",
-        "assumptions",
-        "done_criteria_path",
-        "escalation_conditions"
+        "done_criteria_path"
       ],
       "additionalProperties": true,
       "properties": {
@@ -302,26 +298,10 @@
           "$ref": "#/$defs/stringArray",
           "description": "Optional list of earlier leaf_id values that must be completed before this leaf."
         },
-        "in_scope": {
-          "$ref": "#/$defs/stringArray",
-          "description": "Work explicitly included in this leaf."
-        },
-        "out_of_scope": {
-          "$ref": "#/$defs/stringArray",
-          "description": "Work explicitly excluded from this leaf."
-        },
-        "assumptions": {
-          "$ref": "#/$defs/stringArray",
-          "description": "Assumptions that make the handoff relay-ready."
-        },
         "done_criteria_path": {
           "type": "string",
           "minLength": 1,
           "description": "Frozen Done Criteria snapshot path for this leaf."
-        },
-        "escalation_conditions": {
-          "$ref": "#/$defs/stringArray",
-          "description": "Conditions that should stop execution and escalate back to the orchestrator."
         }
       }
     },

--- a/tests/relay-ready/scripts/request-store.test.js
+++ b/tests/relay-ready/scripts/request-store.test.js
@@ -296,6 +296,65 @@ test("persist-request CLI persists the single-leaf request bundle", () => {
   assert.ok(fs.existsSync(result.doneCriteriaPath));
 });
 
+test("persist-request CLI accepts missing optional per-leaf arrays", () => {
+  const { repoRoot } = setupRepo();
+  const contractPath = path.join(repoRoot, "contract-without-optional-arrays.json");
+  const {
+    in_scope,
+    out_of_scope,
+    assumptions,
+    escalation_conditions,
+    ...handoff
+  } = createContract().handoff;
+
+  fs.writeFileSync(
+    contractPath,
+    `${JSON.stringify(createContract({ handoff }), null, 2)}\n`,
+    "utf-8",
+  );
+
+  const stdout = execFileSync("node", [
+    PERSIST_SCRIPT,
+    "--repo", repoRoot,
+    "--contract-file", contractPath,
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.leafId, "leaf-01");
+  assert.ok(fs.existsSync(result.handoffPath));
+});
+
+test("persist-request CLI rejects optional per-leaf arrays when present with a non-array value", () => {
+  for (const field of ["in_scope", "out_of_scope", "assumptions", "escalation_conditions"]) {
+    const { repoRoot } = setupRepo();
+    const contractPath = path.join(repoRoot, `contract-invalid-${field}.json`);
+    fs.writeFileSync(
+      contractPath,
+      `${JSON.stringify(createContract({
+        handoff: {
+          ...createContract().handoff,
+          [field]: "not an array",
+        },
+      }), null, 2)}\n`,
+      "utf-8",
+    );
+
+    assert.throws(
+      () => execFileSync("node", [
+        PERSIST_SCRIPT,
+        "--repo", repoRoot,
+        "--contract-file", contractPath,
+        "--json",
+      ], { encoding: "utf-8", stdio: "pipe" }),
+      (error) => {
+        assert.match(String(error.stderr), new RegExp(`contract validation failed: handoff\\.${field}: must be an array`));
+        return true;
+      },
+    );
+  }
+});
+
 test("persist-request CLI returns multi-leaf paths in execution order", () => {
   const { repoRoot } = setupRepo();
   const contractPath = path.join(repoRoot, "multi-contract.json");

--- a/tests/relay-ready/scripts/request-store.test.js
+++ b/tests/relay-ready/scripts/request-store.test.js
@@ -317,6 +317,30 @@ test("persist-request CLI returns multi-leaf paths in execution order", () => {
   assert.equal(result.doneCriteriaPaths.length, 2);
 });
 
+test("persist-request CLI rejects readiness objects missing a required field before persistence", () => {
+  const { repoRoot } = setupRepo();
+  const contractPath = path.join(repoRoot, "contract-missing-readiness.json");
+  const { risk, ...incompleteReadiness } = createReadiness();
+  fs.writeFileSync(
+    contractPath,
+    `${JSON.stringify(createContract({ readiness: incompleteReadiness }), null, 2)}\n`,
+    "utf-8",
+  );
+
+  assert.throws(
+    () => execFileSync("node", [
+      PERSIST_SCRIPT,
+      "--repo", repoRoot,
+      "--contract-file", contractPath,
+      "--json",
+    ], { encoding: "utf-8", stdio: "pipe" }),
+    (error) => {
+      assert.match(String(error.stderr), /contract validation failed: readiness\.risk: is required/);
+      return true;
+    },
+  );
+});
+
 test("persistRequestContract stores readiness dimensions in request frontmatter when provided", () => {
   const { repoRoot } = setupRepo();
   const readiness = createReadiness({ risk: "low" });

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -8,6 +8,13 @@ const path = require("node:path");
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SKILLS_DIR = path.join(REPO_ROOT, "skills");
 const MAX_SKILL_MD_LINES = 150;
+const RELAY_READY_REQUEST_CONTRACT_SCHEMA = path.join(
+  REPO_ROOT,
+  "skills",
+  "relay-ready",
+  "scripts",
+  "request-contract.schema.json",
+);
 
 function splitLines(text) {
   return text.split(/\r\n|\n|\r/);
@@ -190,6 +197,14 @@ test("all skills/SKILL.md files satisfy the lint contract", () => {
     assertCrossSkillPathsExist(skillFile);
     assertFrontmatterUniversalSubset(skillFile);
   });
+});
+
+test("relay-ready request contract schema exists and is parseable JSON", () => {
+  assert.ok(fs.existsSync(RELAY_READY_REQUEST_CONTRACT_SCHEMA), "relay-ready request contract schema is missing");
+
+  const schema = JSON.parse(fs.readFileSync(RELAY_READY_REQUEST_CONTRACT_SCHEMA, "utf-8"));
+  assert.equal(typeof schema.$schema, "string", "request contract schema must declare $schema");
+  assert.match(JSON.stringify(schema), /"enum"/, "request contract schema must define enum domains");
 });
 
 test("assertLineCount rejects SKILL.md files over 150 lines", () => {

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -205,6 +205,22 @@ test("relay-ready request contract schema exists and is parseable JSON", () => {
   const schema = JSON.parse(fs.readFileSync(RELAY_READY_REQUEST_CONTRACT_SCHEMA, "utf-8"));
   assert.equal(typeof schema.$schema, "string", "request contract schema must declare $schema");
   assert.match(JSON.stringify(schema), /"enum"/, "request contract schema must define enum domains");
+  assert.deepEqual(
+    schema.$defs.readiness.required,
+    ["clarity", "granularity", "dependency", "verifiability", "risk"],
+    "readiness must require every field relay-request.js normalizes",
+  );
+  assert.ok(schema.$defs.RequestArtifact, "request contract schema must document persisted request artifacts");
+  assert.equal(
+    schema.$defs.RequestArtifact.properties.paths.properties.done_criteria.anyOf.length,
+    2,
+    "request artifact paths.done_criteria must document single-leaf and multi-leaf shapes",
+  );
+  assert.ok(schema.$defs.HandoffArtifact, "request contract schema must document persisted handoff artifacts");
+  assert.ok(
+    schema.$defs.HandoffArtifact.required.includes("done_criteria_path"),
+    "handoff artifact schema must require done_criteria_path",
+  );
 });
 
 test("assertLineCount rejects SKILL.md files over 150 lines", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 커밋: `eb18dbd Add relay-ready request contract schema` on `issue-466`.

변경 요약:
- [request-contract.schema.json](/Users/sjlee/.relay/worktrees/65c1af29/dev-relay/skills/relay-ready/scripts/request-contract.schema.json:1) 추가
- [persist-request.js](/Users/sjlee/.relay/worktrees/65c1af29/dev-relay/skills/relay-ready/scripts/persist-request.js:78)에 `validateContractAgainstSchema` 추가 및 schema 로드 배선
- [SKILL.md](/Users/sjlee/.relay/worktrees/65c1af29/dev-relay/skills/relay-ready/SKILL.md:24) Out
```

## Score Log

- Run: issue-466-20260512132848212-71fb2b72
- Executor: codex
- Branch: issue-466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 요청 저장 전에 JSON 스키마 기반 계약 검증을 도입해 유효하지 않은 입력은 저장되지 않음

* **문서**
  * 출력 규약을 스키마 참조 방식의 “Output Contract”로 재구성해 필드 정의 간소화
  * 준비도(readiness) 설명을 축소하고 허용값을 스키마 열거로 대체

* **테스트**
  * 스키마 존재·구조 검증 및 스키마 기반 입력 수용/거부 동작을 검증하는 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/473)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->