### PR TITLE
Clarify relay-plan rubric planning docs

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -43,8 +43,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/probe-executor-env.js . --project-only --json
 
 Use `probe_signal.test_infra`, `lint_format`, `type_check`, `ci`, and `scripts` to inform rubric design, prerequisites, and Available Tools. The signal exposes data; it does not pick. No-signal/failure cases render as `no quality infra detected`; details: `references/signals.md`. The `test_infra` field is consumed by `references/rubric-pattern-tdd-flavor.md` and `scripts/tdd-suggestion.js`.
 
-### 3.5 Match a template from probe signals (optional starting point)
-Optionally ask for a deterministic starter template:
+Optionally, ask `match-template.js` for a deterministic starter template based on the probe signal:
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/match-template.js --probe-file /tmp/probe.json --json
 ```
@@ -115,6 +114,7 @@ Apply to all task sizes: rewrite HOW into observable WHAT, merge overlaps, remov
 
 ### 8. Persist planner-authored Done Criteria
 
+Persist now so the optional review in §9 sees the same anchor as the reviewer will; persistence is not a commitment, just an anchor write.
 If operator planning writes the final Done Criteria, persist that decision before dispatch so fresh-context review uses the same anchor. This includes AC-missing inputs, user-provided descriptions, and any case where planning expands, rejects, or narrows issue-body AC:
 
 ```bash


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. `issue-467` 브랜치에 커밋했습니다.

커밋: `5f426dc Clarify relay-plan rubric planning docs`

검증:
- `skills/relay-plan/SKILL.md` 라인 수: 150
- `node --test tests/skills-lint/scripts/*.test.js`: 통과
- `git diff --name-only main...HEAD`: `skills/relay-plan/SKILL.md`만 포함
- 작업트리 clean
```

## Score Log

- Run: issue-467-20260512143136046-9973a2e8
- Executor: codex
- Branch: issue-467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서화

* 중계 계획 문서가 업데이트되어 프로브 신호 기반 템플릿 요청 옵션이 추가되었습니다.
* 템플릿 스캐폴드가 자동 적용되지 않음이 명확히 되었습니다.
* 플래너가 작성한 완료 기준 유지 단계에 대한 설명이 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/474)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->