### PR TITLE
Move relay merge emergency docs

### DIFF
--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -52,48 +52,7 @@ This script:
 
 If the retained worktree is dirty, merge still succeeds but cleanup is recorded as `failed` and the manifest moves to `next_action=manual_cleanup_required`.
 
-Emergency escape hatch:
-
-```bash
-node ${CLAUDE_SKILL_DIR}/scripts/finalize-run.js --repo . --run-id "$RUN_ID" --skip-review "hotfix" --json
-```
-
-`finalize-run.js --skip-review` bypasses reviewer invocation, so `model_hints.review` is a non-consumer on that path.
-
-#### Operator-only force finalize for non-ready runs
-
-```bash
-node ${CLAUDE_SKILL_DIR}/scripts/finalize-run.js --repo . --run-id "$RUN_ID" \
-  --force-finalize-nonready --reason "reviewer-swap exhausted, diff clean per manual inspection" --json
-```
-
-Use this only when an operator has independently checked that the PR is mergeable but the manifest cannot reach `ready_to_merge`.
-Typical cases: state stuck at `escalated` with a clean diff; reviewer-swap unavailable; manifest/PR state desync.
-This path is loud on purpose: it records a `force_finalize` event before merge and writes `last_force` into the manifest.
-`--force-finalize-nonready` requires `--reason <non-empty-text>`.
-`--dry-run` is observation-only on this path: it does not append `force_finalize`.
-
-Do not use it for retry loops.
-Do not use it as a test shortcut.
-Do not use it to paper over a wrong manifest state that should be repaired instead.
-
-Audit every use:
-
-```bash
-jq 'select(.event == "force_finalize")' ~/.relay/runs/<repo-slug>/<run-id>/events.jsonl
-```
-
-#### Bootstrap artifact reconciliation
-
-When a run predates an artifact writer that the run itself introduced, use the structured reconciliation command instead of encoding that fact in a force-finalize reason:
-
-```bash
-node ${CLAUDE_SKILL_DIR}/scripts/relay-reconcile-artifact.js --repo . --run-id "$RUN_ID" \
-  --artifact-path "~/.relay/runs/<repo-slug>/<run-id>/execution-evidence.json" \
-  --writer-pr 267 --reason "run predates the artifact writer" --json
-```
-
-This stamps `bootstrap_exempt` in the manifest, emits `force_finalize` with `bootstrap_exempt: true`, and marks the run merged without invoking the PR merge path.
+Emergency, force-finalize, and bootstrap reconciliation paths: see [`references/operator-emergencies.md`](references/operator-emergencies.md).
 
 ### 2. Sprint file update (if available)
 

--- a/skills/relay-merge/references/operator-emergencies.md
+++ b/skills/relay-merge/references/operator-emergencies.md
@@ -1,0 +1,46 @@
+# Operator Emergencies
+
+These are operator-only emergency paths for relay-merge. The standard merge path lives in `skills/relay-merge/SKILL.md` § 1.
+
+Emergency escape hatch:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/finalize-run.js --repo . --run-id "$RUN_ID" --skip-review "hotfix" --json
+```
+
+`finalize-run.js --skip-review` bypasses reviewer invocation, so `model_hints.review` is a non-consumer on that path.
+
+#### Operator-only force finalize for non-ready runs
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/finalize-run.js --repo . --run-id "$RUN_ID" \
+  --force-finalize-nonready --reason "reviewer-swap exhausted, diff clean per manual inspection" --json
+```
+
+Use this only when an operator has independently checked that the PR is mergeable but the manifest cannot reach `ready_to_merge`.
+Typical cases: state stuck at `escalated` with a clean diff; reviewer-swap unavailable; manifest/PR state desync.
+This path is loud on purpose: it records a `force_finalize` event before merge and writes `last_force` into the manifest.
+`--force-finalize-nonready` requires `--reason <non-empty-text>`.
+`--dry-run` is observation-only on this path: it does not append `force_finalize`.
+
+Do not use it for retry loops.
+Do not use it as a test shortcut.
+Do not use it to paper over a wrong manifest state that should be repaired instead.
+
+Audit every use:
+
+```bash
+jq 'select(.event == "force_finalize")' ~/.relay/runs/<repo-slug>/<run-id>/events.jsonl
+```
+
+#### Bootstrap artifact reconciliation
+
+When a run predates an artifact writer that the run itself introduced, use the structured reconciliation command instead of encoding that fact in a force-finalize reason:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/relay-reconcile-artifact.js --repo . --run-id "$RUN_ID" \
+  --artifact-path "~/.relay/runs/<repo-slug>/<run-id>/execution-evidence.json" \
+  --writer-pr 267 --reason "run predates the artifact writer" --json
+```
+
+This stamps `bootstrap_exempt` in the manifest, emits `force_finalize` with `bootstrap_exempt: true`, and marks the run merged without invoking the PR merge path.


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

변경 사항:
- `skills/relay-merge/references/operator-emergencies.md` 새로 생성
- `skills/relay-merge/SKILL.md`의 세 escape-hatch 섹션을 한 줄 포인터로 교체
- 커밋 생성: `43f789b Move relay merge emergency docs`

검증:
- `node --test tests/skills-lint/scripts/*.test.js` 통과
- `git diff --name-only main...HEAD` 결과는 요청된 두 파일만 포함
- 작업 트리 깨끗함
```

## Score Log

- Run: issue-468-20260512143137336-fbba897d
- Executor: codex
- Branch: issue-468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* relay-merge 스킬의 긴급 절차 지침이 통합되었습니다.
* 연산자용 긴급 경로, 강제 완료, 부트스트랩 재조정 절차를 다루는 새로운 참고 문서가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/475)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->