### PR TITLE
Unify skill frontmatter schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,22 @@ node skills/relay-merge/scripts/finalize-run.js --run-id <id> --force-finalize-n
 - Manifest state transitions must go through `validateTransition()` — direct state assignment is a bug
 - New executors: drop a file in `skills/relay-dispatch/scripts/executors/` exporting the 6-field adapter contract, register in `executors/index.js`. See `skills/relay-dispatch/scripts/executors/README.md` for the contract and add a row to `tests/relay-dispatch/scripts/executors.test.js`.
 - New reviewers: create `invoke-reviewer-<name>.js` in `relay-review/scripts/`
+
+### SKILL.md frontmatter schema
+
+Every `skills/<skill>/SKILL.md` frontmatter must start with the same required shape:
+
+| Key | Requirement |
+| --- | --- |
+| `name` | Kebab-case skill identifier matching the directory name. |
+| `description` | Single-line trigger description for the skill router. |
+| `compatibility` | Single-line string stating runtime requirements, such as `Requires gh CLI, git, Node.js 18+.` |
+| `metadata.related-skills` | Comma-separated string of sibling skill names. |
+
+Standard optional keys:
+
+| Key | Requirement |
+| --- | --- |
+| `argument-hint` | Prefer natural-language forms such as `[issue-number]` or `[run-id or PR-number]`. `relay-dispatch` intentionally keeps its CLI-spec form because it documents mutually exclusive dispatch modes. |
+| `metadata.keywords` | Comma-separated trigger keywords. Operator-facing skills should include tight bilingual Korean and English tokens. |
+| `context` | Only for skills that need fresh-context isolation; currently `relay-review` uses `context: fork`. |

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -5,6 +5,7 @@ description: Dispatch implementation tasks via worktree isolation. Use when dele
 compatibility: Requires executor CLI (e.g., codex), git, and Node.js 18+.
 metadata:
   related-skills: "relay, relay-ready, relay-plan, relay-review, relay-merge"
+  keywords: "디스패치, 실행, dispatch, executor, worktree"
 ---
 
 # Relay Dispatch

--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -5,6 +5,7 @@ description: Merge a reviewed PR, clean up worktree/branch, and close GitHub iss
 compatibility: Requires gh CLI and git.
 metadata:
   related-skills: "relay, relay-ready, relay-plan, relay-dispatch, relay-review, dev-backlog"
+  keywords: "머지, 병합, merge, finalize, cleanup"
 ---
 
 # Relay Merge

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: relay-plan
+argument-hint: "[issue-number]"
 description: Synthesize task intent, explicit AC when present, repo signals, and task risk into a scored rubric for autonomous iteration. Always used before relay-dispatch — rubric depth scales with task size.
 compatibility: Requires gh CLI.
 metadata:
   related-skills: "relay, relay-ready, relay-dispatch, relay-review, dev-backlog"
   keywords: "계획, 루브릭, planning, rubric, dispatch prompt"
 ---
-
 # Relay Plan
 
 Build a scoring rubric from the task's intended outcome: explicit Acceptance Criteria (AC) when available, inferred Done Criteria when missing or incomplete, repo quality signals, historical relay signal, and task-specific risk. Then generate a dispatch prompt that drives autonomous iteration until convergence.

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: relay-plan
-argument-hint: "[issue-number]"
 description: Synthesize task intent, explicit AC when present, repo signals, and task risk into a scored rubric for autonomous iteration. Always used before relay-dispatch — rubric depth scales with task size.
 compatibility: Requires gh CLI.
 metadata:
   related-skills: "relay, relay-ready, relay-dispatch, relay-review, dev-backlog"
+  keywords: "계획, 루브릭, planning, rubric, dispatch prompt"
 ---
 
 # Relay Plan

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -5,7 +5,7 @@ description: Verify a task is ready to relay — score readiness on clarity, gra
 compatibility: Requires git and Node.js 18+.
 metadata:
   related-skills: "relay, relay-plan, relay-dispatch, relay-review"
-  keywords: "relay-ready, ready to relay, readiness gate, task readiness, 준비도, 검증, 분해, 완료 기준"
+  keywords: "relay-ready, ready to relay, readiness gate, task readiness, 릴레이 준비, 준비도, 검증, 완료 기준"
 ---
 
 # Relay Ready

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -6,6 +6,7 @@ context: fork
 compatibility: Requires gh CLI.
 metadata:
   related-skills: "relay, relay-ready, relay-plan, relay-dispatch, relay-merge"
+  keywords: "리뷰, 검토, review, gate, fresh context"
 ---
 
 # Relay Review

--- a/skills/relay-sidecar/SKILL.md
+++ b/skills/relay-sidecar/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: relay-sidecar
 description: Run artifact-only advisory sidecars for an existing relay run.
+compatibility: Requires relay-dispatch (Epic #367) and Node.js 18+.
 metadata:
+  related-skills: "relay-dispatch"
+  keywords: "사이드카, 보조 검토, sidecar, advisory, artifacts"
   entry: scripts/relay-sidecar.js
-compatibility:
-  relay_epic: "#367"
 ---
 
 # Relay Sidecar

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -5,6 +5,7 @@ description: Execute the full relay cycle — plan, dispatch, review, merge. Use
 compatibility: Requires Claude Code or Codex, gh CLI, git, Node.js 18+.
 metadata:
   related-skills: "relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog"
+  keywords: "릴레이, 자동 실행, plan, dispatch, review, merge, relay cycle"
 ---
 
 # Dev Relay

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -164,8 +164,9 @@ function parseFrontmatter(content) {
   return data;
 }
 
-function assertSkillFrontmatterSchema({ label, content }) {
+function assertSkillFrontmatterSchema({ label, content, path: skillPath = label }) {
   const frontmatter = parseFrontmatter(content);
+  const skillDir = path.basename(path.dirname(skillPath));
   for (const key of ["name", "description", "compatibility", "metadata"]) {
     assert.ok(Object.hasOwn(frontmatter, key), `${label} frontmatter missing required key: ${key}`);
   }
@@ -192,6 +193,28 @@ function assertSkillFrontmatterSchema({ label, content }) {
     "",
     `${label} frontmatter metadata.related-skills must not be empty`,
   );
+  if ("argument-hint" in frontmatter) {
+    assert.ok(
+      typeof frontmatter["argument-hint"] === "string" && frontmatter["argument-hint"].trim().length > 0,
+      `${label}: argument-hint must be a non-empty string`,
+    );
+  }
+  if (frontmatter.metadata && "keywords" in frontmatter.metadata) {
+    assert.ok(
+      typeof frontmatter.metadata.keywords === "string" && frontmatter.metadata.keywords.trim().length > 0,
+      `${label}: metadata.keywords must be a non-empty string`,
+    );
+  }
+  if ("context" in frontmatter && skillDir !== "relay-review") {
+    assert.fail(`${label}: 'context' frontmatter is only allowed on relay-review/SKILL.md`);
+  }
+  if ("context" in frontmatter) {
+    assert.equal(
+      frontmatter.context,
+      "fork",
+      `${label}: 'context' currently must be exactly "fork" (only relay-review uses it)`,
+    );
+  }
 }
 
 function readSkillFiles() {
@@ -343,5 +366,79 @@ test("assertSkillFrontmatterSchema rejects missing or malformed frontmatter", ()
       ].join("\n"),
     }),
     /invalid frontmatter line/,
+  );
+});
+
+test("assertSkillFrontmatterSchema rejects malformed optional frontmatter fields", () => {
+  assert.throws(
+    () => assertSkillFrontmatterSchema({
+      label: "relay-plan/SKILL.md",
+      content: [
+        "---",
+        "name: relay-plan",
+        "argument-hint: ",
+        "description: fixture",
+        "compatibility: Requires Node.js 18+.",
+        "metadata:",
+        "  related-skills: relay",
+        "---",
+        "",
+      ].join("\n"),
+    }),
+    /argument-hint must be a non-empty string/,
+  );
+
+  assert.throws(
+    () => assertSkillFrontmatterSchema({
+      label: "relay-plan/SKILL.md",
+      content: [
+        "---",
+        "name: relay-plan",
+        "description: fixture",
+        "compatibility: Requires Node.js 18+.",
+        "metadata:",
+        "  related-skills: relay",
+        "  keywords: ",
+        "---",
+        "",
+      ].join("\n"),
+    }),
+    /metadata\.keywords must be a non-empty string/,
+  );
+
+  assert.throws(
+    () => assertSkillFrontmatterSchema({
+      label: "relay-plan/SKILL.md",
+      content: [
+        "---",
+        "name: relay-plan",
+        "description: fixture",
+        "compatibility: Requires Node.js 18+.",
+        "context: fork",
+        "metadata:",
+        "  related-skills: relay",
+        "---",
+        "",
+      ].join("\n"),
+    }),
+    /context' frontmatter is only allowed on relay-review\/SKILL\.md/,
+  );
+
+  assert.throws(
+    () => assertSkillFrontmatterSchema({
+      label: "relay-review/SKILL.md",
+      content: [
+        "---",
+        "name: relay-review",
+        "description: fixture",
+        "compatibility: Requires Node.js 18+.",
+        "context: fresh",
+        "metadata:",
+        "  related-skills: relay",
+        "---",
+        "",
+      ].join("\n"),
+    }),
+    /context' currently must be exactly "fork"/,
   );
 });

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -164,14 +164,34 @@ function parseFrontmatter(content) {
   return data;
 }
 
-function assertFrontmatterUniversalSubset({ label, content }) {
+function assertSkillFrontmatterSchema({ label, content }) {
   const frontmatter = parseFrontmatter(content);
-  for (const key of ["name", "description", "metadata"]) {
+  for (const key of ["name", "description", "compatibility", "metadata"]) {
     assert.ok(Object.hasOwn(frontmatter, key), `${label} frontmatter missing required key: ${key}`);
   }
+  assert.equal(typeof frontmatter.name, "string", `${label} frontmatter name must be a string`);
+  assert.match(frontmatter.name, /^[a-z0-9]+(?:-[a-z0-9]+)*$/, `${label} frontmatter name must be kebab-case`);
+  assert.equal(frontmatter.name, path.basename(path.dirname(label)), `${label} frontmatter name must match its directory`);
+  assert.equal(typeof frontmatter.description, "string", `${label} frontmatter description must be a string`);
+  assert.notEqual(frontmatter.description.trim(), "", `${label} frontmatter description must not be empty`);
+  assert.equal(typeof frontmatter.compatibility, "string", `${label} frontmatter compatibility must be a string`);
+  assert.notEqual(frontmatter.compatibility.trim(), "", `${label} frontmatter compatibility must not be empty`);
   assert.equal(typeof frontmatter.metadata, "object", `${label} frontmatter metadata must be a map`);
   assert.notEqual(frontmatter.metadata, null, `${label} frontmatter metadata must be a map`);
-  // relay-sidecar intentionally lacks metadata.related-skills and uses nested compatibility; #469 will widen this schema later.
+  assert.ok(
+    Object.hasOwn(frontmatter.metadata, "related-skills"),
+    `${label} frontmatter metadata missing required key: related-skills`,
+  );
+  assert.equal(
+    typeof frontmatter.metadata["related-skills"],
+    "string",
+    `${label} frontmatter metadata.related-skills must be a string`,
+  );
+  assert.notEqual(
+    frontmatter.metadata["related-skills"].trim(),
+    "",
+    `${label} frontmatter metadata.related-skills must not be empty`,
+  );
 }
 
 function readSkillFiles() {
@@ -195,7 +215,7 @@ test("all skills/SKILL.md files satisfy the lint contract", () => {
     assertLineCount(skillFile);
     assertBashBlocksParse(skillFile);
     assertCrossSkillPathsExist(skillFile);
-    assertFrontmatterUniversalSubset(skillFile);
+    assertSkillFrontmatterSchema(skillFile);
   });
 });
 
@@ -267,9 +287,9 @@ test("assertCrossSkillPathsExist rejects missing cross-skill script references",
   );
 });
 
-test("assertFrontmatterUniversalSubset rejects missing or malformed frontmatter", () => {
+test("assertSkillFrontmatterSchema rejects missing or malformed frontmatter", () => {
   assert.throws(
-    () => assertFrontmatterUniversalSubset({
+    () => assertSkillFrontmatterSchema({
       label: "missing/SKILL.md",
       content: "# Missing frontmatter\n",
     }),
@@ -277,21 +297,40 @@ test("assertFrontmatterUniversalSubset rejects missing or malformed frontmatter"
   );
 
   assert.throws(
-    () => assertFrontmatterUniversalSubset({
-      label: "missing-metadata/SKILL.md",
+    () => assertSkillFrontmatterSchema({
+      label: "missing-compatibility/SKILL.md",
       content: [
         "---",
-        "name: fixture",
+        "name: missing-compatibility",
         "description: fixture",
+        "metadata:",
+        "  related-skills: relay",
         "---",
         "",
       ].join("\n"),
     }),
-    /missing required key: metadata/,
+    /missing required key: compatibility/,
   );
 
   assert.throws(
-    () => assertFrontmatterUniversalSubset({
+    () => assertSkillFrontmatterSchema({
+      label: "missing-related-skills/SKILL.md",
+      content: [
+        "---",
+        "name: missing-related-skills",
+        "description: fixture",
+        "compatibility: Requires Node.js 18+.",
+        "metadata:",
+        "  entry: scripts/example.js",
+        "---",
+        "",
+      ].join("\n"),
+    }),
+    /metadata missing required key: related-skills/,
+  );
+
+  assert.throws(
+    () => assertSkillFrontmatterSchema({
       label: "malformed/SKILL.md",
       content: [
         "---",


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. `issue-469` 브랜치에 커밋했습니다.

커밋: `3634b09 Unify skill frontmatter schema`

변경 요약:
- `CLAUDE.md`에 canonical `SKILL.md` frontmatter schema 문서 추가
- `skills-lint`를 4개 필수 키 검증으로 강화: `name`, `description`, `compatibility`, `metadata.related-skills`
- negative coverage 추가: `compatibility` 누락, `metadata.related-skills` 누락
- 7개 `SKILL.md` frontmatter 정렬
- `relay-sidecar`의 `compatibility` map을 string으로 변경하고 `related-skills` 추가
- Path A로 한영 `metadata.keywords`를 추가
- `relay-review`의 `context: fork` 보존

```

## Score Log

- Run: issue-469-20260512144007780-f2cc58bf
- Executor: codex
- Branch: issue-469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * SKILL.md의 frontmatter 필수/선택 키를 정의하는 표준 스키마를 추가했습니다.
  * 여러 스킬에 한글/영문 검색 키워드를 추가하거나 일부 키워드를 정리했습니다.
  * 일부 스킬의 호환성 설명(예: relay-sidecar)을 명확히 업데이트했습니다.

* **테스트**
  * 스킬 frontmatter 유효성 검사를 강화해 필수 키·형식·특정 필드(예: context) 규칙을 엄격히 검증합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/476)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->