### PR TITLE
Add relay fleet durable substrate

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -36,6 +36,7 @@ const FLAGS = [
   { flag: "--dry-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--executor", aliases: ["-e"], kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed selector; flag-like following tokens should mean the value is missing." },
   { flag: "--file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied input file path; keep the literal argv token." },
+  { flag: "--fleet-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay fleet identifier; flag-like following tokens should mean the value is missing." },
   { flag: "--force", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--force-finalize-nonready", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--head-sha", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Structured SHA field; flag-like following tokens should mean the value is missing." },
@@ -121,7 +122,7 @@ const COMMAND_FLAGS = {
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
     "--model", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
     "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
-    "--done-criteria-file", "--register", "--no-cleanup", "--auto-recover-commit",
+    "--fleet-id", "--done-criteria-file", "--register", "--no-cleanup", "--auto-recover-commit",
     "--allow-conflicting-run", "--dry-run", "--json", "--help",
   ],
   "finalize-run": [

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -88,9 +88,14 @@ const {
   getRunDir,
   inferIssueNumber,
   looksLikeGitRepo,
+  requireValidFleetId,
   sameFilesystemLocation,
   validateManifestPaths,
 } = require("./manifest/paths");
+const {
+  acquireIssueLock,
+  releaseIssueLock,
+} = require("./manifest/fleet");
 const {
   findInflightRunsForIssue,
   formatInflightCollisionError,
@@ -124,7 +129,7 @@ const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
   "--model", "-m", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
-  "--request-id", "--leaf-id", "--done-criteria-file",
+  "--request-id", "--leaf-id", "--fleet-id", "--done-criteria-file",
   "--register", "--no-cleanup", "--auto-recover-commit", "--allow-conflicting-run", "--dry-run", "--json", "--help", "-h",
 ];
 const CLI_ARG_OPTIONS = { commandName: "dispatch", reservedFlags: KNOWN_FLAGS };
@@ -154,6 +159,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --rubric-grandfathered  ${modeLabel("--rubric-grandfathered")} Retired alias; remove anchor.rubric_grandfathered manually`);
   console.log(`  --request-id       ${modeLabel("--request-id")} Link the run back to a relay-ready request`);
   console.log(`  --leaf-id          ${modeLabel("--leaf-id")} Link the run back to a relay-ready leaf handoff`);
+  console.log(`  --fleet-id         ${modeLabel("--fleet-id")} Link the run back to a relay fleet`);
   console.log(`  --done-criteria-file  ${modeLabel("--done-criteria-file")} Persist a frozen Done Criteria anchor path`);
   console.log(`  --register         ${modeLabel("--register")} Register session in executor's app (keeps worktree)`);
   console.log(`  --no-cleanup       ${modeLabel("--no-cleanup")} Compatibility alias; worktree is retained by default`);
@@ -199,6 +205,7 @@ const TEST_COMMAND = readArg(args, "--test-command", undefined, CLI_ARG_OPTIONS)
 const RUBRIC_GRANDFATHERED = hasCliFlag("--rubric-grandfathered");
 const REQUEST_ID = readArg(args, "--request-id", undefined, CLI_ARG_OPTIONS);
 const LEAF_ID = readArg(args, "--leaf-id", undefined, CLI_ARG_OPTIONS);
+const FLEET_ID = readArg(args, "--fleet-id", undefined, CLI_ARG_OPTIONS);
 const DONE_CRITERIA_FILE = readArg(args, "--done-criteria-file", undefined, CLI_ARG_OPTIONS);
 const TIMEOUT = parseInt(readArg(args, "--timeout", defaultTimeout, CLI_ARG_OPTIONS), 10);
 if (isNaN(TIMEOUT) || TIMEOUT <= 0) {
@@ -254,6 +261,15 @@ const ALLOW_CONFLICTING_RUN = hasCliFlag("--allow-conflicting-run");
 const DRY_RUN = hasCliFlag("--dry-run");
 const JSON_OUT = hasCliFlag("--json");
 const RESUME_MODE = !!MANIFEST_INPUT || (!!RUN_ID && !BRANCH);
+
+if (FLEET_ID) {
+  try {
+    requireValidFleetId(FLEET_ID);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
@@ -374,7 +390,7 @@ function terminateProcessTree(pid) {
   } catch {}
 }
 
-function validateResumeRequestLinkage(manifest, { requestId, leafId, doneCriteriaPath }) {
+function validateResumeRequestLinkage(manifest, { requestId, leafId, fleetId, doneCriteriaPath }) {
   const checks = [
     {
       field: "source.request_id",
@@ -385,6 +401,11 @@ function validateResumeRequestLinkage(manifest, { requestId, leafId, doneCriteri
       field: "source.leaf_id",
       existing: manifest?.source?.leaf_id || null,
       incoming: leafId || null,
+    },
+    {
+      field: "fleet_id",
+      existing: manifest?.fleet_id || null,
+      incoming: fleetId || null,
     },
     {
       field: "anchor.done_criteria_path",
@@ -631,6 +652,27 @@ async function main() {
   let manifest;
   let copiedFiles = [];
   let createdWorktree = false;
+  let executorPid = null;
+  let fleetIssueLock = null;
+
+  function releaseFleetIssueLock() {
+    if (!fleetIssueLock) return;
+    releaseIssueLock(fleetIssueLock);
+    fleetIssueLock = null;
+  }
+
+  function cleanup() {
+    terminateProcessTree(executorPid);
+    releaseFleetIssueLock();
+    if (createdWorktree) {
+      removeWorktree({ repoRoot, worktreePath: wtPath });
+    }
+    process.exit(1);
+  }
+
+  process.once("exit", releaseFleetIssueLock);
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
 
   if (RESUME_MODE) {
     const manifestRecord = resolveManifestRecord({
@@ -716,6 +758,19 @@ async function main() {
       process.exit(1);
     }
     runId = runId || createRunId({ issueNumber, branch });
+    if (FLEET_ID && issueForCollisionCheck && !DRY_RUN) {
+      try {
+        fleetIssueLock = acquireIssueLock({
+          repoRoot,
+          issueNumber: issueForCollisionCheck,
+          fleetId: FLEET_ID,
+          runId,
+        });
+      } catch (error) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    }
     manifestPath = getManifestPath(repoRoot, runId);
     const runDir = getRunDir(repoRoot, runId);
     if (fs.existsSync(manifestPath) || (fs.existsSync(runDir) && !isPlannerAnchorOnlyRunDir(runDir))) {
@@ -741,6 +796,7 @@ async function main() {
       validateResumeRequestLinkage(manifest, {
         requestId: REQUEST_ID,
         leafId: LEAF_ID,
+        fleetId: FLEET_ID,
         doneCriteriaPath: resolvedDoneCriteriaPath,
       });
     } catch (error) {
@@ -800,6 +856,7 @@ async function main() {
 
   // --- Dry run ---
   if (DRY_RUN) {
+    const planFleetId = FLEET_ID || manifest?.fleet_id || null;
     const worktreePlan = createWorktree({
       repoRoot,
       worktreePath: wtPath,
@@ -826,6 +883,9 @@ async function main() {
       runState: manifest?.state || null,
       dispatchSkipped: false,
     };
+    if (planFleetId) {
+      plan.fleetId = planFleetId;
+    }
     if (MODEL_HINTS !== undefined || manifest?.model_hints !== undefined) {
       plan.model_hints = MODEL_HINTS ?? manifest?.model_hints ?? null;
     }
@@ -852,24 +912,13 @@ async function main() {
         rubricFile: RUBRIC_FILE || null,
         requestId: REQUEST_ID || manifest?.source?.request_id || null,
         leafId: LEAF_ID || manifest?.source?.leaf_id || null,
+        fleetId: planFleetId,
         doneCriteriaFile: resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null,
         worktreePlan,
       }));
     }
     return;
   }
-
-  // --- Cleanup on unexpected exit ---
-  let executorPid = null;
-  function cleanup() {
-    terminateProcessTree(executorPid);
-    if (createdWorktree) {
-      removeWorktree({ repoRoot, worktreePath: wtPath });
-    }
-    process.exit(1);
-  }
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
 
   if (!RESUME_MODE) {
     try {
@@ -938,6 +987,7 @@ async function main() {
         leafId: LEAF_ID,
       }),
       modelHints: MODEL_HINTS,
+      fleetId: FLEET_ID,
     });
     manifest = {
       ...manifest,
@@ -1396,6 +1446,9 @@ async function main() {
     diffStat,
     resultPreview: resultText.slice(0, 500),
   };
+  if (manifest.fleet_id) {
+    result.fleetId = manifest.fleet_id;
+  }
 
   if (JSON_OUT) {
     console.log(JSON.stringify(result, null, 2));

--- a/skills/relay-dispatch/scripts/manifest/fleet.js
+++ b/skills/relay-dispatch/scripts/manifest/fleet.js
@@ -185,6 +185,9 @@ function updateFleetManifest(repoRoot, fleetId, updater) {
   if (updated.fleet_id !== record.data.fleet_id) {
     throw new Error("updateFleetManifest cannot change fleet_id");
   }
+  if (updated.fleet_state !== record.data.fleet_state) {
+    validateTransition(record.data.fleet_state, updated.fleet_state);
+  }
   return writeFleetManifest(repoRoot, updated, record.body);
 }
 

--- a/skills/relay-dispatch/scripts/manifest/fleet.js
+++ b/skills/relay-dispatch/scripts/manifest/fleet.js
@@ -1,0 +1,478 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  getFleetIssueLockPath,
+  getFleetManifestPath,
+  getFleetsDir,
+  getManifestPath,
+  listFleetManifestPaths,
+  nowIso,
+  requireValidFleetId,
+  requireValidRunId,
+} = require("./paths");
+const { readManifest, writeManifest } = require("./store");
+
+const STATES = Object.freeze({
+  DRAFT: "draft",
+  DISPATCHING: "dispatching",
+  DISPATCHED: "dispatched",
+  CLOSED: "closed",
+});
+
+const ALLOWED_TRANSITIONS = Object.freeze({
+  [STATES.DRAFT]: new Set([STATES.DISPATCHING]),
+  [STATES.DISPATCHING]: new Set([STATES.DISPATCHED]),
+  [STATES.DISPATCHED]: new Set([STATES.CLOSED]),
+  [STATES.CLOSED]: new Set(),
+});
+
+const DISPATCH_STATUS = Object.freeze({
+  PENDING: "pending",
+  DISPATCHING: "dispatching",
+  DISPATCHED: "dispatched",
+  DISPATCH_FAILED_PRE_MANIFEST: "dispatch_failed_pre_manifest",
+});
+
+const DEFAULT_ISSUE_LOCK_STALE_MS = 6 * 60 * 60 * 1000;
+const FLEET_TOP_LEVEL_KEYS = Object.freeze(["fleet_id", "fleet_state", "children", "timestamps"]);
+const CHILD_KEYS = Object.freeze(["leaf_ref", "run_id", "dispatch_status"]);
+
+class FleetIssueLockError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "FleetIssueLockError";
+    this.details = details;
+  }
+}
+
+function validateTransition(fromState, toState) {
+  if (!Object.values(STATES).includes(fromState)) {
+    throw new Error(`Unknown relay fleet state: ${fromState}`);
+  }
+  if (!Object.values(STATES).includes(toState)) {
+    throw new Error(`Unknown relay fleet state: ${toState}`);
+  }
+  if (!ALLOWED_TRANSITIONS[fromState].has(toState)) {
+    throw new Error(`Invalid relay fleet state transition: ${fromState} -> ${toState}`);
+  }
+}
+
+function validateDispatchStatus(status) {
+  if (!Object.values(DISPATCH_STATUS).includes(status)) {
+    throw new Error(`Unknown relay fleet dispatch_status: ${status}`);
+  }
+}
+
+function assertExactKeys(object, allowedKeys, label) {
+  for (const key of Object.keys(object || {})) {
+    if (!allowedKeys.includes(key)) {
+      throw new Error(`${label} may only contain ${allowedKeys.join(", ")}; unexpected key: ${key}`);
+    }
+  }
+}
+
+function normalizeFleetChild(child) {
+  if (!child || typeof child !== "object" || Array.isArray(child)) {
+    throw new Error("fleet child must be an object");
+  }
+  assertExactKeys(child, CHILD_KEYS, "fleet child");
+
+  const leafRef = typeof child.leaf_ref === "string" ? child.leaf_ref.trim() : "";
+  if (!leafRef) {
+    throw new Error(`fleet child leaf_ref must be a non-empty string, got: ${JSON.stringify(child.leaf_ref)}`);
+  }
+
+  const runId = child.run_id === null || child.run_id === undefined || child.run_id === ""
+    ? null
+    : requireValidRunId(child.run_id);
+  const dispatchStatus = child.dispatch_status || DISPATCH_STATUS.PENDING;
+  validateDispatchStatus(dispatchStatus);
+
+  if (runId === null && dispatchStatus === DISPATCH_STATUS.DISPATCHED) {
+    throw new Error("fleet child with dispatch_status='dispatched' must carry run_id");
+  }
+  if (runId !== null && dispatchStatus === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST) {
+    throw new Error("fleet child dispatch_failed_pre_manifest must have run_id: null");
+  }
+
+  return {
+    leaf_ref: leafRef,
+    run_id: runId,
+    dispatch_status: dispatchStatus,
+  };
+}
+
+function normalizeTimestamps(timestamps) {
+  const now = nowIso();
+  if (!timestamps || typeof timestamps !== "object" || Array.isArray(timestamps)) {
+    return { created_at: now, updated_at: now };
+  }
+  return {
+    created_at: timestamps.created_at || now,
+    updated_at: timestamps.updated_at || timestamps.created_at || now,
+  };
+}
+
+function normalizeFleetManifest(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("fleet manifest must be an object");
+  }
+  assertExactKeys(data, FLEET_TOP_LEVEL_KEYS, "fleet manifest");
+
+  const fleetId = requireValidFleetId(data.fleet_id);
+  const fleetState = data.fleet_state || STATES.DRAFT;
+  if (!Object.values(STATES).includes(fleetState)) {
+    throw new Error(`Unknown relay fleet state: ${fleetState}`);
+  }
+  const children = Array.isArray(data.children)
+    ? data.children.map(normalizeFleetChild)
+    : [];
+
+  return {
+    fleet_id: fleetId,
+    fleet_state: fleetState,
+    children,
+    timestamps: normalizeTimestamps(data.timestamps),
+  };
+}
+
+function createFleetManifestSkeleton({ fleetId, children = [] }) {
+  const createdAt = nowIso();
+  return normalizeFleetManifest({
+    fleet_id: fleetId,
+    fleet_state: STATES.DRAFT,
+    children,
+    timestamps: {
+      created_at: createdAt,
+      updated_at: createdAt,
+    },
+  });
+}
+
+function writeFleetManifest(repoRoot, manifest, body = "") {
+  const normalized = normalizeFleetManifest(manifest);
+  const manifestPath = getFleetManifestPath(repoRoot, normalized.fleet_id);
+  writeManifest(manifestPath, normalized, body);
+  return { manifestPath, data: normalized };
+}
+
+function createFleetManifest(repoRoot, { fleetId, children = [] } = {}) {
+  const manifest = createFleetManifestSkeleton({ fleetId, children });
+  return writeFleetManifest(repoRoot, manifest);
+}
+
+function readFleetManifest(repoRoot, fleetId) {
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  const record = readManifest(manifestPath);
+  return {
+    manifestPath,
+    data: normalizeFleetManifest(record.data),
+    body: record.body,
+  };
+}
+
+function updateFleetManifest(repoRoot, fleetId, updater) {
+  if (typeof updater !== "function") {
+    throw new Error("updateFleetManifest requires an updater function");
+  }
+  const record = readFleetManifest(repoRoot, fleetId);
+  const updated = normalizeFleetManifest(updater(record.data));
+  if (updated.fleet_id !== record.data.fleet_id) {
+    throw new Error("updateFleetManifest cannot change fleet_id");
+  }
+  return writeFleetManifest(repoRoot, updated, record.body);
+}
+
+function deleteFleetManifest(repoRoot, fleetId) {
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  if (!fs.existsSync(manifestPath)) return false;
+  fs.unlinkSync(manifestPath);
+  return true;
+}
+
+function listFleetManifests(repoRoot) {
+  return listFleetManifestPaths(repoRoot)
+    .map((manifestPath) => {
+      const record = readManifest(manifestPath);
+      return {
+        manifestPath,
+        data: normalizeFleetManifest(record.data),
+        body: record.body,
+      };
+    })
+    .sort((left, right) => {
+      const leftKey = left.data.timestamps.updated_at || left.data.timestamps.created_at || path.basename(left.manifestPath);
+      const rightKey = right.data.timestamps.updated_at || right.data.timestamps.created_at || path.basename(right.manifestPath);
+      return rightKey.localeCompare(leftKey);
+    });
+}
+
+function updateFleetState(fleet, toState) {
+  const normalized = normalizeFleetManifest(fleet);
+  validateTransition(normalized.fleet_state, toState);
+  return {
+    ...normalized,
+    fleet_state: toState,
+    timestamps: {
+      ...normalized.timestamps,
+      updated_at: nowIso(),
+    },
+  };
+}
+
+function upsertFleetChild(fleet, child) {
+  const normalized = normalizeFleetManifest(fleet);
+  const normalizedChild = normalizeFleetChild(child);
+  const existingIndex = normalized.children.findIndex((entry) => entry.leaf_ref === normalizedChild.leaf_ref);
+  const children = normalized.children.slice();
+  if (existingIndex === -1) {
+    children.push(normalizedChild);
+  } else {
+    children[existingIndex] = normalizedChild;
+  }
+  return {
+    ...normalized,
+    children,
+    timestamps: {
+      ...normalized.timestamps,
+      updated_at: nowIso(),
+    },
+  };
+}
+
+function increment(map, key) {
+  map[key] = (map[key] || 0) + 1;
+}
+
+// Derived-summary rules:
+// - Fleet manifests store dispatch intent only: leaf_ref, run_id, and dispatch_status.
+// - A child with run_id:null is counted from dispatch_status alone; pre-manifest
+//   failures remain visible as dispatch_failed_pre_manifest without inventing
+//   child runtime state.
+// - A child with run_id reads ~/.relay/runs/<repo-slug>/<run-id>.md on demand
+//   and counts that child manifest's state. Missing/unreadable manifests are
+//   reported as missing_manifest in the read-time summary.
+// - Review and merge facts are never copied into the fleet manifest. Any mixed
+//   picture, such as dispatched + escalated + pre-manifest-failed children, is
+//   normal and must be derived on read.
+function deriveFleetSummary(repoRoot, fleet) {
+  const normalized = normalizeFleetManifest(fleet);
+  const byDispatchStatus = {};
+  const byRunState = {};
+  const children = [];
+
+  for (const child of normalized.children) {
+    increment(byDispatchStatus, child.dispatch_status);
+    const summaryChild = {
+      leaf_ref: child.leaf_ref,
+      run_id: child.run_id,
+      dispatch_status: child.dispatch_status,
+      run_state: null,
+      manifest_path: null,
+      error: null,
+    };
+
+    if (!child.run_id) {
+      summaryChild.run_state = "no_run_manifest";
+      increment(byRunState, summaryChild.run_state);
+      children.push(summaryChild);
+      continue;
+    }
+
+    const childManifestPath = getManifestPath(repoRoot, child.run_id);
+    summaryChild.manifest_path = childManifestPath;
+    try {
+      const childRecord = readManifest(childManifestPath);
+      summaryChild.run_state = childRecord.data?.state || "unknown";
+    } catch (error) {
+      summaryChild.run_state = "missing_manifest";
+      summaryChild.error = String(error.message || error);
+    }
+    increment(byRunState, summaryChild.run_state);
+    children.push(summaryChild);
+  }
+
+  return {
+    fleet_id: normalized.fleet_id,
+    fleet_state: normalized.fleet_state,
+    total_children: normalized.children.length,
+    by_dispatch_status: byDispatchStatus,
+    by_run_state: byRunState,
+    children,
+  };
+}
+
+function lockRecordIsForHolder(record, lock) {
+  return record
+    && lock
+    && record.token === lock.token
+    && record.fleet_id === lock.fleetId
+    && Number(record.issue_number) === Number(lock.issueNumber);
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === "EPERM";
+  }
+}
+
+function readIssueLockRecord(lockPath) {
+  const text = fs.readFileSync(lockPath, "utf-8");
+  return JSON.parse(text);
+}
+
+function isIssueLockStale(record, stat, { staleMs, nowMs }) {
+  const acquiredMs = Date.parse(record?.acquired_at || "");
+  const ageFromRecord = Number.isFinite(acquiredMs) ? nowMs - acquiredMs : null;
+  const ageFromMtime = stat?.mtimeMs ? nowMs - stat.mtimeMs : null;
+  if (ageFromRecord !== null && ageFromRecord > staleMs) return true;
+  if (ageFromRecord === null && ageFromMtime !== null && ageFromMtime > staleMs) return true;
+  if (record?.hostname && record.hostname !== os.hostname()) return false;
+  if (Number.isInteger(record?.pid) && record.pid > 0 && !processIsAlive(record.pid)) return true;
+  return false;
+}
+
+function formatIssueLockCollision(lockPath, existing) {
+  const holder = existing && typeof existing === "object"
+    ? [
+        `fleet_id=${existing.fleet_id || "(unknown)"}`,
+        `run_id=${existing.run_id || "(none)"}`,
+        `pid=${existing.pid || "(unknown)"}`,
+        `acquired_at=${existing.acquired_at || "(unknown)"}`,
+      ].join(", ")
+    : "unreadable lock holder";
+  return `Refusing to dispatch: fleet issue lock is already held at ${lockPath} (${holder}).`;
+}
+
+function acquireIssueLock({
+  repoRoot,
+  issueNumber,
+  fleetId,
+  runId = null,
+  staleMs = DEFAULT_ISSUE_LOCK_STALE_MS,
+  now = () => new Date(),
+} = {}) {
+  const parsedIssue = Number(issueNumber);
+  if (!Number.isInteger(parsedIssue) || parsedIssue <= 0) {
+    throw new Error(`issueNumber must be a positive integer, got: ${JSON.stringify(issueNumber)}`);
+  }
+  const normalizedFleetId = requireValidFleetId(fleetId);
+  const normalizedRunId = runId === null || runId === undefined ? null : requireValidRunId(runId);
+  const lockPath = getFleetIssueLockPath(repoRoot, parsedIssue);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  const token = crypto.randomBytes(16).toString("hex");
+  const acquiredAt = now().toISOString();
+  const record = {
+    issue_number: parsedIssue,
+    fleet_id: normalizedFleetId,
+    run_id: normalizedRunId,
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquired_at: acquiredAt,
+    stale_after_ms: staleMs,
+    token,
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let fd = null;
+    try {
+      fd = fs.openSync(lockPath, "wx");
+      fs.writeFileSync(fd, `${JSON.stringify(record, null, 2)}\n`, "utf-8");
+      fs.closeSync(fd);
+      fd = null;
+      return {
+        lockPath,
+        issueNumber: parsedIssue,
+        fleetId: normalizedFleetId,
+        runId: normalizedRunId,
+        token,
+      };
+    } catch (error) {
+      if (fd !== null) {
+        try { fs.closeSync(fd); } catch {}
+      }
+      if (error.code !== "EEXIST") {
+        throw error;
+      }
+
+      let existing = null;
+      let stat = null;
+      try {
+        stat = fs.statSync(lockPath);
+        existing = readIssueLockRecord(lockPath);
+      } catch {
+        const nowMs = now().getTime();
+        if (stat?.mtimeMs && nowMs - stat.mtimeMs > staleMs) {
+          try {
+            fs.unlinkSync(lockPath);
+            continue;
+          } catch {}
+        }
+        throw new FleetIssueLockError(formatIssueLockCollision(lockPath, null), { lockPath });
+      }
+
+      if (isIssueLockStale(existing, stat, { staleMs, nowMs: now().getTime() })) {
+        try {
+          fs.unlinkSync(lockPath);
+          continue;
+        } catch {
+          throw new FleetIssueLockError(formatIssueLockCollision(lockPath, existing), { lockPath, existing });
+        }
+      }
+
+      throw new FleetIssueLockError(formatIssueLockCollision(lockPath, existing), { lockPath, existing });
+    }
+  }
+
+  throw new FleetIssueLockError(`Unable to acquire fleet issue lock after stale cleanup: ${lockPath}`, { lockPath });
+}
+
+function releaseIssueLock(lock) {
+  if (!lock?.lockPath) return false;
+  try {
+    const record = readIssueLockRecord(lock.lockPath);
+    if (!lockRecordIsForHolder(record, lock)) {
+      return false;
+    }
+    fs.unlinkSync(lock.lockPath);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") return false;
+    return false;
+  }
+}
+
+module.exports = {
+  ALLOWED_TRANSITIONS,
+  DEFAULT_ISSUE_LOCK_STALE_MS,
+  DISPATCH_STATUS,
+  FleetIssueLockError,
+  STATES,
+  acquireIssueLock,
+  createFleetManifest,
+  createFleetManifestSkeleton,
+  deleteFleetManifest,
+  deriveFleetSummary,
+  getFleetsDir,
+  listFleetManifests,
+  normalizeFleetChild,
+  normalizeFleetManifest,
+  releaseIssueLock,
+  updateFleetManifest,
+  updateFleetState,
+  upsertFleetChild,
+  validateDispatchStatus,
+  validateTransition,
+  writeFleetManifest,
+  readFleetManifest,
+};

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -25,6 +25,10 @@ function getRunsBase() {
   return process.env.RELAY_RUNS_BASE || path.join(getRelayHome(), "runs");
 }
 
+function getFleetsBase() {
+  return path.join(getRelayHome(), "fleets");
+}
+
 function getRelayWorktreeBase() {
   const base = process.env.RELAY_WORKTREE_BASE || path.join(getRelayHome(), "worktrees");
   if (!path.isAbsolute(base)) {
@@ -197,6 +201,34 @@ function requireValidRunId(runId) {
   return validation.runId;
 }
 
+const FLEET_ID_PATTERN = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+
+function requireValidFleetId(fleetId) {
+  const normalizedFleetId = typeof fleetId === "string" ? fleetId.trim() : "";
+  if (!normalizedFleetId) {
+    throw new Error(`fleet_id must be a non-empty path segment, got: ${JSON.stringify(fleetId)}`);
+  }
+  if (normalizedFleetId === "." || normalizedFleetId === "..") {
+    throw new Error(`fleet_id may not be "." or ".." (got ${JSON.stringify(normalizedFleetId)}).`);
+  }
+  if (normalizedFleetId.includes("/") || normalizedFleetId.includes("\\")) {
+    throw new Error(`fleet_id must be a single path segment (got ${JSON.stringify(normalizedFleetId)}).`);
+  }
+  if (
+    path.basename(normalizedFleetId) !== normalizedFleetId
+    || path.win32.basename(normalizedFleetId) !== normalizedFleetId
+  ) {
+    throw new Error(`fleet_id must resolve to a single path segment (got ${JSON.stringify(normalizedFleetId)}).`);
+  }
+  if (!FLEET_ID_PATTERN.test(normalizedFleetId)) {
+    throw new Error(
+      `fleet_id must contain lowercase letters, numbers, dots, underscores, or dashes ` +
+      `without leading/trailing separators (got ${JSON.stringify(normalizedFleetId)}).`
+    );
+  }
+  return normalizedFleetId;
+}
+
 function createRunId({ issueNumber, branch, timestamp = new Date() } = {}) {
   const prefix = issueNumber ? `issue-${issueNumber}` : slugify(branch || "run");
   const iso = timestamp.toISOString().replace(/[-:TZ.]/g, "").slice(0, 17);
@@ -206,6 +238,26 @@ function createRunId({ issueNumber, branch, timestamp = new Date() } = {}) {
 
 function getRunsDir(repoRoot) {
   return path.join(getRunsBase(), getRepoSlug(repoRoot));
+}
+
+function getFleetsDir(repoRoot) {
+  return path.join(getFleetsBase(), getRepoSlug(repoRoot));
+}
+
+function getFleetManifestPath(repoRoot, fleetId) {
+  return path.join(getFleetsDir(repoRoot), `${requireValidFleetId(fleetId)}.md`);
+}
+
+function getFleetLocksDir(repoRoot) {
+  return path.join(getFleetsDir(repoRoot), "locks");
+}
+
+function getFleetIssueLockPath(repoRoot, issueNumber) {
+  const parsedIssue = Number(issueNumber);
+  if (!Number.isInteger(parsedIssue) || parsedIssue <= 0) {
+    throw new Error(`issueNumber must be a positive integer, got: ${JSON.stringify(issueNumber)}`);
+  }
+  return path.join(getFleetLocksDir(repoRoot), `issue-${parsedIssue}.lock`);
 }
 
 function getRunDir(repoRoot, runId) {
@@ -258,6 +310,14 @@ function listManifestPaths(repoRoot) {
   return fs.readdirSync(runsDir)
     .filter((name) => name.endsWith(".md"))
     .map((name) => path.join(runsDir, name));
+}
+
+function listFleetManifestPaths(repoRoot) {
+  const fleetsDir = getFleetsDir(repoRoot);
+  if (!fs.existsSync(fleetsDir)) return [];
+  return fs.readdirSync(fleetsDir)
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => path.join(fleetsDir, name));
 }
 
 function ensureRunLayout(repoRoot, runId) {
@@ -474,6 +534,11 @@ module.exports = {
   getCanonicalRepoRoot,
   getEventsPath,
   getExpectedManifestRepoRoot,
+  getFleetIssueLockPath,
+  getFleetLocksDir,
+  getFleetManifestPath,
+  getFleetsBase,
+  getFleetsDir,
   getManifestPath,
   getRelayHome,
   getRelayWorktreeBase,
@@ -487,10 +552,12 @@ module.exports = {
   getWorktreeGitCommonDir,
   inferIssueNumber,
   isPathContainedWithin,
+  listFleetManifestPaths,
   listManifestPaths,
   looksLikeGitRepo,
   nowIso,
   parsePositiveInt,
+  requireValidFleetId,
   requireValidRunId,
   sameFilesystemLocation,
   summarizeFailure,

--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -6,6 +6,7 @@ const {
   ensureRunLayout,
   listManifestPaths,
   nowIso,
+  requireValidFleetId,
   requireValidRunId,
 } = require("./paths");
 
@@ -175,6 +176,7 @@ function createManifestSkeleton({
   doneCriteriaPath = null,
   doneCriteriaSource = null,
   modelHints = undefined,
+  fleetId = undefined,
 }) {
   const { STATES } = require("./lifecycle");
   const { createCleanupSkeleton } = require("./cleanup");
@@ -249,6 +251,10 @@ function createManifestSkeleton({
 
   if (modelHints !== undefined) {
     manifest.model_hints = modelHints;
+  }
+
+  if (fleetId !== undefined) {
+    manifest.fleet_id = fleetId ? requireValidFleetId(fleetId) : null;
   }
 
   return manifest;

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -34,6 +34,7 @@ function formatDispatchDryRun({
   rubricFile = null,
   requestId = null,
   leafId = null,
+  fleetId = null,
   doneCriteriaFile = null,
   worktreePlan,
 }) {
@@ -63,6 +64,9 @@ function formatDispatchDryRun({
   }
   if (leafId) {
     lines.push(`  Leaf:     ${leafId}`);
+  }
+  if (fleetId) {
+    lines.push(`  Fleet:    ${fleetId}`);
   }
   if (doneCriteriaFile) {
     lines.push(`  Done AC:  ${doneCriteriaFile}`);

--- a/tests/relay-dispatch/scripts/manifest-direct-imports.test.js
+++ b/tests/relay-dispatch/scripts/manifest-direct-imports.test.js
@@ -27,3 +27,4 @@ require("./manifest/rubric.test");
 require("./manifest/cleanup.test");
 require("./manifest/attempts.test");
 require("./manifest/environment.test");
+require("./manifest/fleet.test");

--- a/tests/relay-dispatch/scripts/manifest/fleet.test.js
+++ b/tests/relay-dispatch/scripts/manifest/fleet.test.js
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  createFleetManifest,
+  readFleetManifest,
+  STATES,
+  updateFleetManifest,
+} = require("../../../../skills/relay-dispatch/scripts/manifest/fleet");
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Fleet Test"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-fleet@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+test("manifest/fleet updateFleetManifest rejects direct fleet_state assignment that skips the state machine", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-fleet-repo-"));
+  initGitRepo(repoRoot);
+  const fleetId = "issue-477";
+
+  createFleetManifest(repoRoot, { fleetId });
+
+  assert.throws(
+    () => updateFleetManifest(repoRoot, fleetId, (fleet) => ({
+      ...fleet,
+      fleet_state: STATES.CLOSED,
+    })),
+    /Invalid relay fleet state transition: draft -> closed/
+  );
+  assert.equal(readFleetManifest(repoRoot, fleetId).data.fleet_state, STATES.DRAFT);
+});

--- a/tests/relay-fleet/scripts/fleet.test.js
+++ b/tests/relay-fleet/scripts/fleet.test.js
@@ -1,0 +1,393 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
+
+const {
+  getFleetIssueLockPath,
+  getFleetManifestPath,
+  getManifestPath,
+  getRunDir,
+} = require("../../../skills/relay-dispatch/scripts/manifest/paths");
+const {
+  createManifestSkeleton,
+  readManifest,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/store");
+const {
+  STATES: RUN_STATES,
+  updateManifestState,
+} = require("../../../skills/relay-dispatch/scripts/manifest/lifecycle");
+const {
+  ALLOWED_TRANSITIONS,
+  DISPATCH_STATUS,
+  FleetIssueLockError,
+  STATES,
+  acquireIssueLock,
+  createFleetManifest,
+  createFleetManifestSkeleton,
+  deleteFleetManifest,
+  deriveFleetSummary,
+  readFleetManifest,
+  releaseIssueLock,
+  updateFleetState,
+  upsertFleetChild,
+  validateTransition,
+  writeFleetManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/fleet");
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Fleet Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-fleet@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+}
+
+function setupRepo(prefix = "relay-fleet-") {
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  process.env.RELAY_HOME = relayHome;
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  initGitRepo(repoRoot);
+  return { relayHome, repoRoot };
+}
+
+function writeNoOpCodex(binDir) {
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const outputIndex = args.indexOf("-o");
+if (outputIndex === -1) {
+  process.stderr.write("missing -o output path");
+  process.exit(1);
+}
+fs.writeFileSync(args[outputIndex + 1], "ok\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+}
+
+function writeRunManifest(repoRoot, { runId, branch, toState }) {
+  const manifestPath = getManifestPath(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 477,
+    worktreePath: path.join(repoRoot, "wt", branch),
+  });
+  if (toState === RUN_STATES.DISPATCHED) {
+    manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+  } else if (toState === RUN_STATES.ESCALATED) {
+    manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+    manifest = updateManifestState(manifest, RUN_STATES.ESCALATED, "inspect_dispatch_failure");
+  }
+  fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+  writeManifest(manifestPath, manifest);
+  return manifestPath;
+}
+
+test("fleet manifest CRUD round-trips exact fleet fields and nullable pre-manifest child", () => {
+  const { repoRoot } = setupRepo();
+  assert.equal(Object.isFrozen(DISPATCH_STATUS), true);
+
+  const created = createFleetManifest(repoRoot, {
+    fleetId: "fleet-phase-1",
+    children: [
+      {
+        leaf_ref: "leaf-a",
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      },
+    ],
+  });
+  assert.equal(created.manifestPath, getFleetManifestPath(repoRoot, "fleet-phase-1"));
+
+  const readBack = readFleetManifest(repoRoot, "fleet-phase-1");
+  assert.deepEqual(Object.keys(readBack.data), ["fleet_id", "fleet_state", "children", "timestamps"]);
+  assert.equal(readBack.data.fleet_id, "fleet-phase-1");
+  assert.equal(readBack.data.fleet_state, STATES.DRAFT);
+  assert.deepEqual(readBack.data.children, [{
+    leaf_ref: "leaf-a",
+    run_id: null,
+    dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+  }]);
+
+  const updated = upsertFleetChild(readBack.data, {
+    leaf_ref: "leaf-b",
+    run_id: null,
+    dispatch_status: DISPATCH_STATUS.PENDING,
+  });
+  writeFleetManifest(repoRoot, updated);
+  assert.equal(readFleetManifest(repoRoot, "fleet-phase-1").data.children.length, 2);
+  assert.equal(deleteFleetManifest(repoRoot, "fleet-phase-1"), true);
+  assert.equal(fs.existsSync(created.manifestPath), false);
+});
+
+test("fleet state machine accepts every valid pair and rejects every invalid pair", () => {
+  const states = Object.values(STATES);
+  for (const fromState of states) {
+    for (const toState of states) {
+      if (ALLOWED_TRANSITIONS[fromState].has(toState)) {
+        assert.doesNotThrow(() => validateTransition(fromState, toState), `${fromState} -> ${toState}`);
+      } else {
+        assert.throws(
+          () => validateTransition(fromState, toState),
+          /Invalid relay fleet state transition/,
+          `${fromState} -> ${toState}`
+        );
+      }
+    }
+  }
+
+  assert.throws(() => validateTransition("bad", STATES.DRAFT), /Unknown relay fleet state/);
+  assert.throws(() => validateTransition(STATES.DRAFT, "bad"), /Unknown relay fleet state/);
+});
+
+test("updateFleetState applies the draft-dispatching-dispatched-closed chain", () => {
+  let fleet = createFleetManifestSkeleton({ fleetId: "fleet-state-chain" });
+  fleet = updateFleetState(fleet, STATES.DISPATCHING);
+  assert.equal(fleet.fleet_state, STATES.DISPATCHING);
+  fleet = updateFleetState(fleet, STATES.DISPATCHED);
+  assert.equal(fleet.fleet_state, STATES.DISPATCHED);
+  fleet = updateFleetState(fleet, STATES.CLOSED);
+  assert.equal(fleet.fleet_state, STATES.CLOSED);
+  assert.throws(() => updateFleetState(fleet, STATES.DRAFT), /Invalid relay fleet state transition/);
+});
+
+test("deriveFleetSummary computes mixed child state from fleet children plus child manifests", () => {
+  const { repoRoot } = setupRepo("relay-fleet-summary-");
+  const dispatchedRun = "issue-477-20260514010101000-a1b2c3d4";
+  const escalatedRun = "issue-477-20260514010102000-a1b2c3d4";
+  const missingRun = "issue-477-20260514010103000-a1b2c3d4";
+  writeRunManifest(repoRoot, {
+    runId: dispatchedRun,
+    branch: "issue-477-dispatched",
+    toState: RUN_STATES.DISPATCHED,
+  });
+  writeRunManifest(repoRoot, {
+    runId: escalatedRun,
+    branch: "issue-477-escalated",
+    toState: RUN_STATES.ESCALATED,
+  });
+
+  const fleet = createFleetManifestSkeleton({
+    fleetId: "fleet-summary",
+    children: [
+      { leaf_ref: "leaf-dispatched", run_id: dispatchedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-escalated", run_id: escalatedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      {
+        leaf_ref: "leaf-pre-manifest",
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      },
+      { leaf_ref: "leaf-missing", run_id: missingRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    ],
+  });
+
+  const summary = deriveFleetSummary(repoRoot, fleet);
+  assert.equal(summary.total_children, 4);
+  assert.deepEqual(summary.by_dispatch_status, {
+    [DISPATCH_STATUS.DISPATCHED]: 3,
+    [DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST]: 1,
+  });
+  assert.equal(summary.by_run_state[RUN_STATES.DISPATCHED], 1);
+  assert.equal(summary.by_run_state[RUN_STATES.ESCALATED], 1);
+  assert.equal(summary.by_run_state.no_run_manifest, 1);
+  assert.equal(summary.by_run_state.missing_manifest, 1);
+  assert.equal(summary.children.find((child) => child.leaf_ref === "leaf-pre-manifest").run_id, null);
+});
+
+test("child manifest skeleton writes fleet_id on first manifest write when supplied", () => {
+  const { repoRoot } = setupRepo("relay-fleet-back-pointer-");
+  const runId = "issue-477-20260514020202000-a1b2c3d4";
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-477-back-pointer",
+    baseBranch: "main",
+    issueNumber: 477,
+    worktreePath: path.join(repoRoot, "wt"),
+    fleetId: "fleet-back-pointer",
+  });
+  fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+  writeManifest(manifestPath, manifest);
+
+  assert.equal(readManifest(manifestPath).data.fleet_id, "fleet-back-pointer");
+
+  const nonFleet = createManifestSkeleton({
+    repoRoot,
+    runId: "issue-478-20260514020203000-a1b2c3d4",
+    branch: "issue-478-no-fleet",
+    baseBranch: "main",
+    issueNumber: 478,
+    worktreePath: path.join(repoRoot, "wt-2"),
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(nonFleet, "fleet_id"), false);
+});
+
+test("fleet issue lock blocks concurrent same-issue acquisition and releases cleanly", () => {
+  const { repoRoot } = setupRepo("relay-fleet-lock-");
+  const first = acquireIssueLock({
+    repoRoot,
+    issueNumber: 477,
+    fleetId: "fleet-one",
+    runId: "issue-477-20260514030303000-a1b2c3d4",
+  });
+  assert.equal(fs.existsSync(first.lockPath), true);
+  assert.throws(
+    () => acquireIssueLock({
+      repoRoot,
+      issueNumber: 477,
+      fleetId: "fleet-two",
+      runId: "issue-477-20260514030304000-a1b2c3d4",
+    }),
+    FleetIssueLockError
+  );
+  assert.equal(releaseIssueLock(first), true);
+
+  const second = acquireIssueLock({
+    repoRoot,
+    issueNumber: 477,
+    fleetId: "fleet-two",
+    runId: "issue-477-20260514030304000-a1b2c3d4",
+  });
+  assert.equal(releaseIssueLock(second), true);
+});
+
+test("fleet issue lock recovers stale holders", () => {
+  const { repoRoot } = setupRepo("relay-fleet-stale-lock-");
+  const lockPath = getFleetIssueLockPath(repoRoot, 477);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  fs.writeFileSync(lockPath, JSON.stringify({
+    issue_number: 477,
+    fleet_id: "fleet-stale",
+    run_id: null,
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquired_at: "2000-01-01T00:00:00.000Z",
+    stale_after_ms: 1,
+    token: "stale-token",
+  }), "utf-8");
+
+  const lock = acquireIssueLock({
+    repoRoot,
+    issueNumber: 477,
+    fleetId: "fleet-fresh",
+    runId: "issue-477-20260514040404000-a1b2c3d4",
+    staleMs: 1,
+    now: () => new Date("2026-05-14T00:00:00.000Z"),
+  });
+  const record = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+  assert.equal(record.fleet_id, "fleet-fresh");
+  assert.equal(releaseIssueLock(lock), true);
+});
+
+test("fleet issue lock recovers unreadable stale lock files by mtime", () => {
+  const { repoRoot } = setupRepo("relay-fleet-corrupt-stale-lock-");
+  const lockPath = getFleetIssueLockPath(repoRoot, 477);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  fs.writeFileSync(lockPath, "{not-json", "utf-8");
+  const oldDate = new Date("2000-01-01T00:00:00.000Z");
+  fs.utimesSync(lockPath, oldDate, oldDate);
+
+  const lock = acquireIssueLock({
+    repoRoot,
+    issueNumber: 477,
+    fleetId: "fleet-fresh",
+    runId: "issue-477-20260514040405000-a1b2c3d4",
+    staleMs: 1,
+    now: () => new Date("2026-05-14T00:00:00.000Z"),
+  });
+
+  const record = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+  assert.equal(record.fleet_id, "fleet-fresh");
+  assert.equal(releaseIssueLock(lock), true);
+});
+
+test("dispatch --fleet-id writes the child back-pointer and releases the issue lock", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dispatch-");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-fleet-bin-"));
+  writeNoOpCodex(binDir);
+  const rubricPath = path.join(os.tmpdir(), `relay-fleet-rubric-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricPath, "rubric:\n  size_class: S\n", "utf-8");
+
+  const result = spawnSync(process.execPath, [
+    DISPATCH_SCRIPT,
+    repoRoot,
+    "-b", "issue-477-fleet-dispatch",
+    "-p", "issue-477 fleet dispatch",
+    "--executor", "codex",
+    "--rubric-file", rubricPath,
+    "--fleet-id", "fleet-dispatch",
+    "--timeout", "5",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  const manifest = readManifest(payload.manifestPath).data;
+  assert.equal(manifest.fleet_id, "fleet-dispatch");
+  assert.equal(payload.fleetId, "fleet-dispatch");
+  assert.equal(fs.existsSync(getFleetIssueLockPath(repoRoot, 477)), false);
+});
+
+test("dispatch --fleet-id refuses an active same-issue fleet lock before executor spawn", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dispatch-lock-");
+  const lock = acquireIssueLock({
+    repoRoot,
+    issueNumber: 477,
+    fleetId: "fleet-held",
+    runId: "issue-477-20260514050505000-a1b2c3d4",
+  });
+  const rubricPath = path.join(os.tmpdir(), `relay-fleet-rubric-lock-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricPath, "rubric:\n  size_class: S\n", "utf-8");
+
+  try {
+    const result = spawnSync(process.execPath, [
+      DISPATCH_SCRIPT,
+      repoRoot,
+      "-b", "issue-477-fleet-locked",
+      "-p", "issue-477 fleet dispatch",
+      "--executor", "codex",
+      "--rubric-file", rubricPath,
+      "--fleet-id", "fleet-blocked",
+      "--timeout", "5",
+      "--json",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        RELAY_HOME: relayHome,
+      },
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /fleet issue lock is already held/);
+    assert.equal(result.stderr.includes("codex CLI not found"), false);
+  } finally {
+    releaseIssueLock(lock);
+  }
+});


### PR DESCRIPTION
## Dispatch Summary

```text
**완료**

커밋했습니다: `5453920 Add relay fleet durable substrate`

구현 요약:
- [fleet.js](/Users/sjlee/.relay/worktrees/36749ad1/dev-relay/skills/relay-dispatch/scripts/manifest/fleet.js): fleet manifest CRUD, `validateTransition`, `DISPATCH_STATUS`, derived summary, stale-recoverable issue lock.
- [paths.js](/Users/sjlee/.relay/worktrees/36749ad1/dev-relay/skills/relay-dispatch/scripts/manifest/paths.js): `~/.relay/fleets/<repo-slug>/<fleet-id>.md` 및 issue lock path helpers.
- [store.js](/Users/sjlee/.r
```

## Score Log

- Run: issue-477-20260514125541775-746583a3
- Executor: codex
- Branch: issue-477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * `--fleet-id` 옵션을 통해 Fleet 단위 작업 실행 지원
  * Fleet 레벨에서 동시성 제어 및 이슈 락 메커니즘 추가
  * Fleet 상태 관리(DRAFT → DISPATCHING → DISPATCHED → CLOSED) 및 자식 작업 추적 기능 구현

* **Tests**
  * Fleet 매니페스트 관리, 상태 전이, 동시성 제어에 대한 통합 테스트 스위트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/482)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->