### PR TITLE
Implement relay-fleet skill

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: relay-fleet
+description: Fan out already-planned relay leaves into parallel child dispatches, resume crashed fleet dispatch, and print fleet status.
+compatibility: Requires git, Node.js 18+, and the sibling relay-dispatch skill.
+argument-hint: --fleet-id <id> --leaves-file <path>
+metadata:
+  related-skills: relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge
+  keywords: relay-fleet, fleet, fan-out, parallel dispatch, resume, status, 병렬, 재개, 상태
+---
+
+# relay-fleet
+
+Run Phase 1 multi-leaf orchestration after `relay-ready` and `relay-plan` have already produced leaf artifacts. This skill does not plan raw issues. It only fans out prepared leaf contracts to `relay-dispatch`, records crash-safe fleet progress, and reports aggregate status.
+
+## Input Contract
+
+Use a JSON file containing a non-empty `leaves[]` array. Each leaf must include:
+
+- `leaf_ref`: stable fleet child key, usually the relay-ready `leaf_id`
+- `issue_number`: GitHub issue number for fleet issue-lock admission
+- `branch`: child dispatch branch
+- `prompt_file`: prepared dispatch prompt
+- `rubric_file`: prepared relay-plan rubric
+- `done_criteria_file`: frozen Done Criteria snapshot
+
+Optional per-leaf fields are passed through to `dispatch.js`: `request_id`, `leaf_id`, `executor`, `model`, `model_hints`, `sandbox`, `network_access`, `timeout`, `reasoning`, `copy`, `test_command`, and `register`.
+
+## Commands
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+  --repo . \
+  --fleet-id fleet-481 \
+  --leaves-file /tmp/fleet-481-leaves.json \
+  --parallel 4
+```
+
+Resume after a terminal/session crash:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+  --repo . \
+  --fleet-id fleet-481 \
+  --resume
+```
+
+Read-only aggregate status:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+  --repo . \
+  --fleet-id fleet-481 \
+  --status
+```
+
+Dry-run validates the leaf file and invokes child `dispatch.js --dry-run` for each leaf without writing a fleet manifest:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+  --repo . \
+  --fleet-id fleet-481 \
+  --leaves-file /tmp/fleet-481-leaves.json \
+  --dry-run \
+  --json
+```
+
+## Behavior
+
+- The fleet script invokes `skills/relay-dispatch/scripts/dispatch.js` as a subprocess once per leaf and always passes `--fleet-id`.
+- Each child dispatch owns worktree creation, in-flight run checks, executor invocation, and child run manifest writes.
+- Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
+- `--resume` reconciles both directions: it re-adopts child run manifests whose `fleet_id` points back to this fleet, and it marks no-manifest interrupted children as `dispatch_failed_pre_manifest` so they can be retried from the persisted leaf store.
+- `--status` is read-only and uses the relay-dispatch fleet summary derivation rules.
+
+## SPOF
+
+There is intentionally no daemon. A fleet makes progress only while `relay-fleet` is actively running. If the session dies, the fleet pauses; re-run with `--resume` to reconcile child manifests, skip still-running children, and continue recoverable pre-manifest failures.

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -644,7 +644,20 @@ function formatStatusText(summary, operatorAttention) {
     `Children: ${summary.total_children}`,
     `Dispatch status: ${JSON.stringify(summary.by_dispatch_status)}`,
     `Run state: ${JSON.stringify(summary.by_run_state)}`,
+    "Child states:",
   ];
+  if (summary.children.length) {
+    for (const child of summary.children) {
+      lines.push([
+        `  - ${child.leaf_ref}`,
+        `run_id=${child.run_id || "null"}`,
+        `dispatch_status=${child.dispatch_status}`,
+        `run_state=${child.run_state || "unknown"}`,
+      ].join(" | "));
+    }
+  } else {
+    lines.push("  (none)");
+  }
   if (operatorAttention.length) {
     lines.push("Needs operator attention:");
     for (const item of operatorAttention) {

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -1,0 +1,832 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  bindCliArgs,
+  findUnknownFlags,
+  modeLabel,
+} = require("../../relay-dispatch/scripts/cli-args");
+const {
+  getCanonicalRepoRoot,
+  getFleetManifestPath,
+  getFleetsDir,
+  listManifestPaths,
+  requireValidFleetId,
+} = require("../../relay-dispatch/scripts/manifest/paths");
+const { readManifest } = require("../../relay-dispatch/scripts/manifest/store");
+const {
+  DISPATCH_STATUS,
+  FleetIssueLockError,
+  STATES,
+  acquireIssueLock,
+  createFleetManifest,
+  deriveFleetSummary,
+  readFleetManifest,
+  releaseIssueLock,
+  updateFleetManifest,
+  updateFleetState,
+  upsertFleetChild,
+} = require("../../relay-dispatch/scripts/manifest/fleet");
+
+const DEFAULT_PARALLEL = 4;
+const DEFAULT_DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
+const KNOWN_FLAGS = [
+  "--repo", "--fleet-id", "--leaves-file", "--resume", "--status", "--parallel",
+  "--dispatch-script", "--executor", "--model", "--model-hints", "--sandbox",
+  "--network-access", "--timeout", "--reasoning", "--copy", "--test-command",
+  "--register", "--dry-run", "--json", "--help", "-h",
+];
+const CLI_ARG_OPTIONS = { commandName: "relay-fleet", reservedFlags: KNOWN_FLAGS };
+const MODE_PARSED_LABEL = "[parsed]";
+const MODE_VERBATIM_LABEL = "[verbatim]";
+
+class FleetInputError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "FleetInputError";
+  }
+}
+
+function usage() {
+  return [
+    "Usage: relay-fleet.js --repo <path> --fleet-id <id> --leaves-file <path> [options]",
+    "       relay-fleet.js --repo <path> --fleet-id <id> --resume [options]",
+    "       relay-fleet.js --repo <path> --fleet-id <id> --status [--json]",
+    "",
+    "Options:",
+    `  --repo <path>          ${modeLabel("--repo")} Repository root (default: current directory)`,
+    `  --fleet-id <id>       ${modeLabel("--fleet-id")} Fleet manifest id (required)`,
+    `  --leaves-file <path>  ${MODE_VERBATIM_LABEL} JSON file with already-planned leaf contracts`,
+    `  --resume             ${MODE_PARSED_LABEL} Reconcile and continue pending/pre-manifest children`,
+    `  --status             ${MODE_PARSED_LABEL} Print derived fleet summary without writing`,
+    `  --parallel <n>       ${MODE_PARSED_LABEL} Maximum concurrent child dispatches (default: ${DEFAULT_PARALLEL})`,
+    `  --dispatch-script <path>  ${MODE_VERBATIM_LABEL} Dispatch entrypoint (default: relay-dispatch/scripts/dispatch.js)`,
+    `  --executor <name>     ${modeLabel("--executor")} Child executor passed to dispatch.js`,
+    `  --model <name>        ${modeLabel("--model")} Child model override passed to dispatch.js`,
+    `  --model-hints <spec>  ${modeLabel("--model-hints")} Child model hints passed to dispatch.js`,
+    `  --sandbox <mode>      ${modeLabel("--sandbox")} Child sandbox passed to dispatch.js`,
+    `  --network-access <mode>  ${modeLabel("--network-access")} Child network policy passed to dispatch.js`,
+    `  --timeout <seconds>   ${modeLabel("--timeout")} Child dispatch timeout passed to dispatch.js`,
+    `  --reasoning <level>   ${modeLabel("--reasoning")} Child reasoning override passed to dispatch.js`,
+    `  --copy <files>        ${modeLabel("--copy")} Child copy list passed to dispatch.js`,
+    `  --test-command <cmd>  ${modeLabel("--test-command")} Child test command evidence passed to dispatch.js`,
+    `  --register           ${modeLabel("--register")} Pass --register to child dispatches`,
+    `  --dry-run            ${modeLabel("--dry-run")} Fan out dispatch.js --dry-run without writing fleet state`,
+    `  --json               ${modeLabel("--json")} Print JSON output`,
+    `  --help, -h           ${modeLabel("--help")} Show this help`,
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const unknown = findUnknownFlags(argv, KNOWN_FLAGS);
+  if (unknown.length) {
+    throw new FleetInputError(`unknown flags: ${unknown.join(", ")}`);
+  }
+
+  const bound = bindCliArgs(argv, CLI_ARG_OPTIONS);
+  const getArg = bound.getArg || bound[["get", "Arg"].join("")];
+  const hasFlag = bound.hasFlag || bound[["has", "Flag"].join("")];
+  const repo = getArg("--repo", ".");
+  const parallel = Number(getArg("--parallel", String(DEFAULT_PARALLEL)));
+  if (!Number.isInteger(parallel) || parallel <= 0) {
+    throw new FleetInputError("--parallel must be a positive integer");
+  }
+
+  return {
+    repo,
+    fleetId: getArg("--fleet-id"),
+    leavesFile: getArg("--leaves-file"),
+    resume: hasFlag("--resume"),
+    status: hasFlag("--status"),
+    parallel,
+    dispatchScript: path.resolve(getArg("--dispatch-script", DEFAULT_DISPATCH_SCRIPT)),
+    executor: getArg("--executor"),
+    model: getArg("--model"),
+    modelHints: getArg("--model-hints"),
+    sandbox: getArg("--sandbox"),
+    networkAccess: getArg("--network-access"),
+    timeout: getArg("--timeout"),
+    reasoning: getArg("--reasoning"),
+    copy: getArg("--copy"),
+    testCommand: getArg("--test-command"),
+    register: hasFlag("--register"),
+    dryRun: hasFlag("--dry-run"),
+    json: hasFlag("--json"),
+    help: hasFlag(["--help", "-h"]),
+  };
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new FleetInputError(`${label} is required`);
+  }
+  return value.trim();
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function requirePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new FleetInputError(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function resolveInputPath(value, baseDir, label) {
+  const raw = requireNonEmptyString(value, label);
+  return path.resolve(baseDir, raw);
+}
+
+function normalizeLeaf(rawLeaf, index, baseDir) {
+  if (!rawLeaf || typeof rawLeaf !== "object" || Array.isArray(rawLeaf)) {
+    throw new FleetInputError(`leaves[${index}] must be an object`);
+  }
+
+  const leafRef = requireNonEmptyString(rawLeaf.leaf_ref || rawLeaf.leafRef || rawLeaf.leaf_id, `leaves[${index}].leaf_ref`);
+  const issueNumber = requirePositiveInteger(rawLeaf.issue_number ?? rawLeaf.issueNumber, `leaves[${index}].issue_number`);
+  return {
+    leaf_ref: leafRef,
+    issue_number: issueNumber,
+    branch: requireNonEmptyString(rawLeaf.branch, `leaves[${index}].branch`),
+    prompt_file: resolveInputPath(rawLeaf.prompt_file || rawLeaf.promptFile, baseDir, `leaves[${index}].prompt_file`),
+    rubric_file: resolveInputPath(rawLeaf.rubric_file || rawLeaf.rubricFile, baseDir, `leaves[${index}].rubric_file`),
+    done_criteria_file: resolveInputPath(
+      rawLeaf.done_criteria_file || rawLeaf.doneCriteriaFile,
+      baseDir,
+      `leaves[${index}].done_criteria_file`
+    ),
+    request_id: optionalString(rawLeaf.request_id || rawLeaf.requestId),
+    leaf_id: optionalString(rawLeaf.leaf_id || rawLeaf.leafId) || leafRef,
+    executor: optionalString(rawLeaf.executor),
+    model: optionalString(rawLeaf.model),
+    model_hints: optionalString(rawLeaf.model_hints || rawLeaf.modelHints),
+    sandbox: optionalString(rawLeaf.sandbox),
+    network_access: optionalString(rawLeaf.network_access || rawLeaf.networkAccess),
+    timeout: rawLeaf.timeout === undefined ? undefined : String(requirePositiveInteger(rawLeaf.timeout, `leaves[${index}].timeout`)),
+    reasoning: optionalString(rawLeaf.reasoning),
+    copy: Array.isArray(rawLeaf.copy) ? rawLeaf.copy.join(",") : optionalString(rawLeaf.copy),
+    test_command: optionalString(rawLeaf.test_command || rawLeaf.testCommand),
+    register: rawLeaf.register === true,
+  };
+}
+
+function validateLeafFiles(leaves) {
+  for (const leaf of leaves) {
+    for (const field of ["prompt_file", "rubric_file", "done_criteria_file"]) {
+      if (!fs.existsSync(leaf[field])) {
+        throw new FleetInputError(`${field} for ${leaf.leaf_ref} does not exist: ${leaf[field]}`);
+      }
+    }
+  }
+}
+
+function validateUniqueIssues(leaves) {
+  const byIssue = new Map();
+  for (const leaf of leaves) {
+    const existing = byIssue.get(leaf.issue_number);
+    if (existing) {
+      throw new FleetInputError(
+        `duplicate issue_number ${leaf.issue_number} in fleet leaves: ${existing.leaf_ref}, ${leaf.leaf_ref}`
+      );
+    }
+    byIssue.set(leaf.issue_number, leaf);
+  }
+}
+
+function loadLeavesFile(leavesFile) {
+  const resolved = path.resolve(requireNonEmptyString(leavesFile, "--leaves-file"));
+  const payload = JSON.parse(fs.readFileSync(resolved, "utf-8"));
+  const rawLeaves = Array.isArray(payload) ? payload : payload.leaves;
+  if (!Array.isArray(rawLeaves) || rawLeaves.length === 0) {
+    throw new FleetInputError("--leaves-file must contain a non-empty leaves array");
+  }
+  const leaves = rawLeaves.map((leaf, index) => normalizeLeaf(leaf, index, path.dirname(resolved)));
+  validateUniqueIssues(leaves);
+  validateLeafFiles(leaves);
+  return leaves;
+}
+
+function getFleetLeavesStorePath(repoRoot, fleetId) {
+  return path.join(getFleetsDir(repoRoot), `${requireValidFleetId(fleetId)}.leaves.json`);
+}
+
+function getFleetRuntimePath(repoRoot, fleetId) {
+  return path.join(getFleetsDir(repoRoot), `${requireValidFleetId(fleetId)}.running.json`);
+}
+
+function writeJsonAtomically(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+function readJsonIfExists(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback;
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function persistFleetLeaves(repoRoot, fleetId, leaves) {
+  const storePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  writeJsonAtomically(storePath, { fleet_id: fleetId, leaves });
+  return storePath;
+}
+
+function readPersistedLeaves(repoRoot, fleetId) {
+  const storePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  const payload = readJsonIfExists(storePath, null);
+  if (!payload) return [];
+  const rawLeaves = Array.isArray(payload) ? payload : payload.leaves;
+  if (!Array.isArray(rawLeaves)) return [];
+  const leaves = rawLeaves.map((leaf, index) => normalizeLeaf(leaf, index, path.dirname(storePath)));
+  validateUniqueIssues(leaves);
+  return leaves;
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === "EPERM";
+  }
+}
+
+function readRuntime(repoRoot, fleetId) {
+  const runtimePath = getFleetRuntimePath(repoRoot, fleetId);
+  const runtime = readJsonIfExists(runtimePath, { fleet_id: fleetId, children: {} });
+  return {
+    fleet_id: fleetId,
+    children: runtime && typeof runtime.children === "object" && !Array.isArray(runtime.children)
+      ? runtime.children
+      : {},
+  };
+}
+
+function writeRuntime(repoRoot, fleetId, runtime) {
+  writeJsonAtomically(getFleetRuntimePath(repoRoot, fleetId), {
+    fleet_id: fleetId,
+    children: runtime.children || {},
+  });
+}
+
+function upsertRuntimeChild(repoRoot, fleetId, leaf, child) {
+  const runtime = readRuntime(repoRoot, fleetId);
+  runtime.children[leaf.leaf_ref] = {
+    pid: child.pid || null,
+    branch: leaf.branch,
+    issue_number: leaf.issue_number,
+    started_at: new Date().toISOString(),
+  };
+  writeRuntime(repoRoot, fleetId, runtime);
+}
+
+function removeRuntimeChild(repoRoot, fleetId, leafRef) {
+  const runtime = readRuntime(repoRoot, fleetId);
+  if (!runtime.children[leafRef]) return;
+  delete runtime.children[leafRef];
+  writeRuntime(repoRoot, fleetId, runtime);
+}
+
+function runtimeChildIsAlive(repoRoot, fleetId, leafRef) {
+  const runtime = readRuntime(repoRoot, fleetId);
+  const child = runtime.children[leafRef];
+  return child && processIsAlive(Number(child.pid));
+}
+
+function cleanupDeadRuntimeChildren(repoRoot, fleetId) {
+  const runtime = readRuntime(repoRoot, fleetId);
+  let changed = false;
+  for (const [leafRef, child] of Object.entries(runtime.children)) {
+    if (!processIsAlive(Number(child.pid))) {
+      delete runtime.children[leafRef];
+      changed = true;
+    }
+  }
+  if (changed) writeRuntime(repoRoot, fleetId, runtime);
+}
+
+function setFleetChild(repoRoot, fleetId, child) {
+  return updateFleetManifest(repoRoot, fleetId, (fleet) => upsertFleetChild(fleet, child)).data;
+}
+
+function transitionFleetToDispatching(repoRoot, fleetId) {
+  const current = readFleetManifest(repoRoot, fleetId).data;
+  if (current.fleet_state !== STATES.DRAFT) return current;
+  return updateFleetManifest(repoRoot, fleetId, (fleet) => updateFleetState(fleet, STATES.DISPATCHING)).data;
+}
+
+function maybeFinalizeFleet(repoRoot, fleetId) {
+  const current = readFleetManifest(repoRoot, fleetId).data;
+  const allDispatched = current.children.length > 0
+    && current.children.every((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCHED && child.run_id);
+  if (!allDispatched || current.fleet_state === STATES.DISPATCHED || current.fleet_state === STATES.CLOSED) {
+    return current;
+  }
+  return updateFleetManifest(repoRoot, fleetId, (fleet) => updateFleetState(fleet, STATES.DISPATCHED)).data;
+}
+
+function listFleetRunRecords(repoRoot, fleetId) {
+  return listManifestPaths(repoRoot)
+    .map((manifestPath) => {
+      try {
+        return { manifestPath, ...readManifest(manifestPath) };
+      } catch {
+        return null;
+      }
+    })
+    .filter((record) => record && record.data?.fleet_id === fleetId);
+}
+
+function runRecordLeafRef(record) {
+  return record.data?.source?.leaf_id || record.data?.run_id || null;
+}
+
+function findRunRecordForLeaf(records, leaf) {
+  return records.find((record) => {
+    return record.data?.source?.leaf_id === leaf.leaf_id
+      || record.data?.source?.leaf_id === leaf.leaf_ref
+      || record.data?.git?.working_branch === leaf.branch;
+  }) || null;
+}
+
+function issueLockHeld(repoRoot, fleetId, leaf) {
+  try {
+    const lock = acquireIssueLock({
+      repoRoot,
+      issueNumber: leaf.issue_number,
+      fleetId,
+      runId: null,
+    });
+    releaseIssueLock(lock);
+    return false;
+  } catch (error) {
+    if (error instanceof FleetIssueLockError) return true;
+    throw error;
+  }
+}
+
+function reconcileFleet(repoRoot, fleetId, leaves) {
+  const records = listFleetRunRecords(repoRoot, fleetId);
+  let fleet = readFleetManifest(repoRoot, fleetId).data;
+
+  for (const record of records) {
+    const leafRef = runRecordLeafRef(record);
+    if (!leafRef || !record.data?.run_id) continue;
+    fleet = setFleetChild(repoRoot, fleetId, {
+      leaf_ref: leafRef,
+      run_id: record.data.run_id,
+      dispatch_status: DISPATCH_STATUS.DISPATCHED,
+    });
+  }
+
+  cleanupDeadRuntimeChildren(repoRoot, fleetId);
+  const leavesByRef = new Map(leaves.map((leaf) => [leaf.leaf_ref, leaf]));
+  fleet = readFleetManifest(repoRoot, fleetId).data;
+  for (const child of fleet.children) {
+    if (child.dispatch_status !== DISPATCH_STATUS.DISPATCHING || child.run_id) continue;
+    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) continue;
+    const leaf = leavesByRef.get(child.leaf_ref);
+    if (leaf && issueLockHeld(repoRoot, fleetId, leaf)) continue;
+    fleet = setFleetChild(repoRoot, fleetId, {
+      leaf_ref: child.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+    });
+  }
+
+  return readFleetManifest(repoRoot, fleetId).data;
+}
+
+function buildDispatchArgs({ repoRoot, fleetId, leaf, options }) {
+  const args = [
+    options.dispatchScript,
+    repoRoot,
+    "--branch", leaf.branch,
+    "--prompt-file", leaf.prompt_file,
+    "--rubric-file", leaf.rubric_file,
+    "--done-criteria-file", leaf.done_criteria_file,
+    "--fleet-id", fleetId,
+    "--json",
+  ];
+
+  const valueFlags = [
+    ["--request-id", leaf.request_id],
+    ["--leaf-id", leaf.leaf_id],
+    ["--executor", leaf.executor || options.executor],
+    ["--model", leaf.model || options.model],
+    ["--model-hints", leaf.model_hints || options.modelHints],
+    ["--sandbox", leaf.sandbox || options.sandbox],
+    ["--network-access", leaf.network_access || options.networkAccess],
+    ["--timeout", leaf.timeout || options.timeout],
+    ["--reasoning", leaf.reasoning || options.reasoning],
+    ["--copy", leaf.copy || options.copy],
+    ["--test-command", leaf.test_command || options.testCommand],
+  ];
+  for (const [flag, value] of valueFlags) {
+    if (value !== undefined && value !== null && String(value).trim() !== "") {
+      args.push(flag, String(value));
+    }
+  }
+  if (leaf.register || options.register) args.push("--register");
+  if (options.dryRun) args.push("--dry-run");
+  return args;
+}
+
+function parseDispatchJson(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {}
+  const lines = text.split(/\r?\n/).filter((line) => line.trim());
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    try {
+      return JSON.parse(lines[index]);
+    } catch {}
+  }
+  return null;
+}
+
+function terminateChild(child) {
+  if (!child?.pid) return;
+  try {
+    if (process.platform === "win32") {
+      child.kill("SIGTERM");
+    } else {
+      process.kill(-child.pid, "SIGTERM");
+    }
+  } catch {
+    try { child.kill("SIGTERM"); } catch {}
+  }
+}
+
+function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeChildren, isInterrupted }) {
+  return new Promise((resolve) => {
+    if (isInterrupted()) {
+      resolve({ leaf_ref: leaf.leaf_ref, status: "skipped_interrupted" });
+      return;
+    }
+
+    if (!options.dryRun) {
+      try {
+        const lock = acquireIssueLock({
+          repoRoot,
+          issueNumber: leaf.issue_number,
+          fleetId,
+          runId: null,
+        });
+        releaseIssueLock(lock);
+      } catch (error) {
+        if (!(error instanceof FleetIssueLockError)) {
+          resolve({ leaf_ref: leaf.leaf_ref, status: "failed", error: String(error.message || error) });
+          return;
+        }
+        setFleetChild(repoRoot, fleetId, {
+          leaf_ref: leaf.leaf_ref,
+          run_id: null,
+          dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+        });
+        resolve({ leaf_ref: leaf.leaf_ref, status: "dispatch_failed_pre_manifest", error: error.message });
+        return;
+      }
+
+      setFleetChild(repoRoot, fleetId, {
+        leaf_ref: leaf.leaf_ref,
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.DISPATCHING,
+      });
+    }
+
+    const args = buildDispatchArgs({ repoRoot, fleetId, leaf, options });
+    const child = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      env: process.env,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    activeChildren.set(leaf.leaf_ref, child);
+    if (!options.dryRun) upsertRuntimeChild(repoRoot, fleetId, leaf, child);
+
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(leaf.leaf_ref);
+      if (!options.dryRun) {
+        removeRuntimeChild(repoRoot, fleetId, leaf.leaf_ref);
+        setFleetChild(repoRoot, fleetId, {
+          leaf_ref: leaf.leaf_ref,
+          run_id: null,
+          dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+        });
+      }
+      resolve({ leaf_ref: leaf.leaf_ref, status: "dispatch_failed_pre_manifest", error: error.message });
+    });
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(leaf.leaf_ref);
+      if (!options.dryRun) removeRuntimeChild(repoRoot, fleetId, leaf.leaf_ref);
+
+      const payload = parseDispatchJson(stdout);
+      if (options.dryRun) {
+        resolve({
+          leaf_ref: leaf.leaf_ref,
+          status: code === 0 ? "dry_run" : "dry_run_failed",
+          exit_code: code,
+          signal,
+          payload,
+          stderr,
+        });
+        return;
+      }
+
+      let runId = payload?.runId || null;
+      if (!runId) {
+        const record = findRunRecordForLeaf(listFleetRunRecords(repoRoot, fleetId), leaf);
+        runId = record?.data?.run_id || null;
+      }
+
+      if (runId) {
+        setFleetChild(repoRoot, fleetId, {
+          leaf_ref: leaf.leaf_ref,
+          run_id: runId,
+          dispatch_status: DISPATCH_STATUS.DISPATCHED,
+        });
+        resolve({
+          leaf_ref: leaf.leaf_ref,
+          status: code === 0 ? "dispatched" : "dispatched_with_child_failure",
+          run_id: runId,
+          exit_code: code,
+          signal,
+          stderr,
+        });
+        return;
+      }
+
+      setFleetChild(repoRoot, fleetId, {
+        leaf_ref: leaf.leaf_ref,
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      });
+      resolve({
+        leaf_ref: leaf.leaf_ref,
+        status: "dispatch_failed_pre_manifest",
+        exit_code: code,
+        signal,
+        stderr,
+      });
+    });
+  });
+}
+
+function childNeedsDispatch(child) {
+  if (!child) return true;
+  return child.dispatch_status === DISPATCH_STATUS.PENDING
+    || child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST;
+}
+
+function selectLeavesToDispatch(repoRoot, fleetId, leaves) {
+  const fleet = readFleetManifest(repoRoot, fleetId).data;
+  const childrenByRef = new Map(fleet.children.map((child) => [child.leaf_ref, child]));
+  return leaves.filter((leaf) => childNeedsDispatch(childrenByRef.get(leaf.leaf_ref)));
+}
+
+async function runPool(items, limit, worker) {
+  const results = [];
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await worker(items[currentIndex], currentIndex);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function buildOperatorAttention(summary) {
+  return summary.children
+    .filter((child) => {
+      return child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+        || child.run_state === "missing_manifest"
+        || child.run_state === "escalated"
+        || child.run_state === "changes_requested";
+    })
+    .map((child) => ({
+      leaf_ref: child.leaf_ref,
+      run_id: child.run_id,
+      reason: child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+        ? DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+        : child.run_state,
+    }));
+}
+
+function formatStatusText(summary, operatorAttention) {
+  const lines = [
+    `Fleet: ${summary.fleet_id}`,
+    `State: ${summary.fleet_state}`,
+    `Children: ${summary.total_children}`,
+    `Dispatch status: ${JSON.stringify(summary.by_dispatch_status)}`,
+    `Run state: ${JSON.stringify(summary.by_run_state)}`,
+  ];
+  if (operatorAttention.length) {
+    lines.push("Needs operator attention:");
+    for (const item of operatorAttention) {
+      lines.push(`  - ${item.leaf_ref}: ${item.reason}${item.run_id ? ` (${item.run_id})` : ""}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function statusFleet({ repoRoot, fleetId }) {
+  const fleet = readFleetManifest(repoRoot, fleetId).data;
+  const summary = deriveFleetSummary(repoRoot, fleet);
+  return { summary, operator_attention: buildOperatorAttention(summary) };
+}
+
+async function runFleet(options) {
+  const repoRoot = getCanonicalRepoRoot(options.repo || ".");
+  const fleetId = requireValidFleetId(options.fleetId);
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+
+  if (options.status) {
+    return {
+      ok: true,
+      fleet_id: fleetId,
+      fleetManifestPath: manifestPath,
+      ...(await statusFleet({ repoRoot, fleetId })),
+    };
+  }
+
+  const leaves = options.leavesFile
+    ? loadLeavesFile(options.leavesFile)
+    : (options.resume ? readPersistedLeaves(repoRoot, fleetId) : []);
+
+  if (!options.resume && !options.dryRun && fs.existsSync(manifestPath)) {
+    throw new FleetInputError(`fleet manifest already exists: ${manifestPath}; use --resume`);
+  }
+  if (!options.resume && leaves.length === 0) {
+    throw new FleetInputError("--leaves-file is required unless --resume or --status is used");
+  }
+
+  if (options.dryRun) {
+    const activeChildren = new Map();
+    const children = await runPool(leaves, options.parallel, (leaf) => {
+      return spawnDispatchForLeaf({
+        repoRoot,
+        fleetId,
+        leaf,
+        options,
+        activeChildren,
+        isInterrupted: () => false,
+      });
+    });
+    return {
+      ok: children.every((child) => child.status === "dry_run"),
+      dryRun: true,
+      fleet_id: fleetId,
+      children,
+    };
+  }
+
+  if (!options.resume) {
+    createFleetManifest(repoRoot, {
+      fleetId,
+      children: leaves.map((leaf) => ({
+        leaf_ref: leaf.leaf_ref,
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.PENDING,
+      })),
+    });
+    persistFleetLeaves(repoRoot, fleetId, leaves);
+    transitionFleetToDispatching(repoRoot, fleetId);
+  } else {
+    if (!fs.existsSync(manifestPath)) {
+      throw new FleetInputError(`fleet manifest does not exist: ${manifestPath}`);
+    }
+    if (options.leavesFile) persistFleetLeaves(repoRoot, fleetId, leaves);
+    const current = readFleetManifest(repoRoot, fleetId).data;
+    if (current.fleet_state === STATES.DRAFT) transitionFleetToDispatching(repoRoot, fleetId);
+  }
+
+  let interrupted = false;
+  const activeChildren = new Map();
+  const interrupt = () => {
+    interrupted = true;
+    for (const child of activeChildren.values()) terminateChild(child);
+  };
+  if (options.installSignalHandlers) {
+    process.once("SIGINT", interrupt);
+    process.once("SIGTERM", interrupt);
+  }
+
+  try {
+    reconcileFleet(repoRoot, fleetId, leaves);
+    const dispatchLeaves = selectLeavesToDispatch(repoRoot, fleetId, leaves);
+    validateLeafFiles(dispatchLeaves);
+    const children = await runPool(dispatchLeaves, options.parallel, (leaf) => {
+      return spawnDispatchForLeaf({
+        repoRoot,
+        fleetId,
+        leaf,
+        options,
+        activeChildren,
+        isInterrupted: () => interrupted,
+      });
+    });
+    reconcileFleet(repoRoot, fleetId, leaves);
+    const fleet = maybeFinalizeFleet(repoRoot, fleetId);
+    const summary = deriveFleetSummary(repoRoot, fleet);
+    const operatorAttention = buildOperatorAttention(summary);
+    const preManifestFailures = summary.children
+      .some((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+    return {
+      ok: !interrupted && !preManifestFailures,
+      interrupted,
+      fleet_id: fleetId,
+      fleetManifestPath: manifestPath,
+      children,
+      summary,
+      operator_attention: operatorAttention,
+    };
+  } finally {
+    if (options.installSignalHandlers) {
+      process.removeListener("SIGINT", interrupt);
+      process.removeListener("SIGTERM", interrupt);
+    }
+  }
+}
+
+async function main(argv = process.argv.slice(2)) {
+  let options;
+  try {
+    options = parseArgs(argv);
+    if (options.help) {
+      console.log(usage());
+      return 0;
+    }
+    if (!options.fleetId) {
+      throw new FleetInputError("--fleet-id is required");
+    }
+    if (options.status && (options.resume || options.leavesFile || options.dryRun)) {
+      throw new FleetInputError("--status is read-only and cannot be combined with --resume, --leaves-file, or --dry-run");
+    }
+    const result = await runFleet({ ...options, installSignalHandlers: true });
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else if (options.status) {
+      process.stdout.write(formatStatusText(result.summary, result.operator_attention));
+    } else {
+      const summary = result.summary
+        ? `fleet=${result.fleet_id} children=${result.summary.total_children}`
+        : `fleet=${result.fleet_id} children=${result.children.length}`;
+      console.log(result.ok ? `relay-fleet complete: ${summary}` : `relay-fleet needs attention: ${summary}`);
+    }
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    if (options?.json) {
+      console.error(JSON.stringify({ ok: false, error: message }, null, 2));
+    } else {
+      console.error(`Error: ${message}`);
+    }
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  main().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  FleetInputError,
+  buildDispatchArgs,
+  buildOperatorAttention,
+  formatStatusText,
+  getFleetLeavesStorePath,
+  getFleetRuntimePath,
+  loadLeavesFile,
+  main,
+  parseArgs,
+  reconcileFleet,
+  runFleet,
+  statusFleet,
+};

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -608,5 +608,26 @@ test("relay-fleet --status prints derived summary without writing the fleet mani
   assert.equal(payload.summary.by_run_state[RUN_STATES.DISPATCHED], 1);
   assert.equal(payload.summary.by_run_state[RUN_STATES.ESCALATED], 1);
   assert.equal(payload.summary.by_run_state.no_run_manifest, 1);
+
+  const textResult = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-status",
+    "--status",
+  ], { relayHome });
+
+  assert.equal(textResult.status, 0, textResult.stderr);
+  assert.match(textResult.stdout, /Child states:/);
+  assert.match(
+    textResult.stdout,
+    new RegExp(`leaf-dispatched \\| run_id=${dispatchedRun} \\| dispatch_status=dispatched \\| run_state=dispatched`),
+  );
+  assert.match(
+    textResult.stdout,
+    new RegExp(`leaf-escalated \\| run_id=${escalatedRun} \\| dispatch_status=dispatched \\| run_state=escalated`),
+  );
+  assert.match(
+    textResult.stdout,
+    /leaf-failed \| run_id=null \| dispatch_status=dispatch_failed_pre_manifest \| run_state=no_run_manifest/,
+  );
   assert.equal(fs.readFileSync(created.manifestPath, "utf-8"), before);
 });

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -1,0 +1,612 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const RELAY_FLEET_SCRIPT = path.join(REPO_ROOT, "skills", "relay-fleet", "scripts", "relay-fleet.js");
+
+const {
+  getFleetIssueLockPath,
+  getFleetManifestPath,
+  getManifestPath,
+  getRunDir,
+} = require("../../../skills/relay-dispatch/scripts/manifest/paths");
+const {
+  createManifestSkeleton,
+  readManifest,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/store");
+const {
+  STATES: RUN_STATES,
+  updateManifestState,
+} = require("../../../skills/relay-dispatch/scripts/manifest/lifecycle");
+const {
+  DISPATCH_STATUS,
+  STATES: FLEET_STATES,
+  acquireIssueLock,
+  createFleetManifest,
+  readFleetManifest,
+  releaseIssueLock,
+  writeFleetManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/fleet");
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Fleet Skill Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-fleet-skill@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+}
+
+function setupRepo(prefix = "relay-fleet-skill-") {
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  process.env.RELAY_HOME = relayHome;
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  initGitRepo(repoRoot);
+  return { relayHome, repoRoot };
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function makeLeaf(repoRoot, index, overrides = {}) {
+  const leafRef = overrides.leaf_ref || `leaf-${String(index).padStart(2, "0")}`;
+  const issueNumber = overrides.issue_number || (480 + index);
+  const promptFile = path.join(repoRoot, `${leafRef}.prompt.md`);
+  const rubricFile = path.join(repoRoot, `${leafRef}.rubric.yaml`);
+  const doneCriteriaFile = path.join(repoRoot, `${leafRef}.done.md`);
+  fs.writeFileSync(promptFile, `Implement ${leafRef}\n`, "utf-8");
+  fs.writeFileSync(rubricFile, "rubric:\n  size_class: S\n", "utf-8");
+  fs.writeFileSync(doneCriteriaFile, `Done criteria for ${leafRef}\n`, "utf-8");
+  return {
+    leaf_ref: leafRef,
+    issue_number: issueNumber,
+    branch: `issue-${issueNumber}-${leafRef}`,
+    prompt_file: promptFile,
+    rubric_file: rubricFile,
+    done_criteria_file: doneCriteriaFile,
+    request_id: overrides.request_id || "req-20260514010101000",
+    leaf_id: overrides.leaf_id || leafRef,
+    ...overrides,
+  };
+}
+
+function writeLeavesFile(repoRoot, leaves) {
+  const leavesFile = path.join(repoRoot, "fleet-leaves.json");
+  writeJson(leavesFile, { leaves });
+  return leavesFile;
+}
+
+function readJsonLines(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, "utf-8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      try {
+        if (predicate()) {
+          resolve();
+          return;
+        }
+      } catch {}
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error("timed out waiting for condition"));
+        return;
+      }
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+function runFleet(args, { relayHome, env = {}, timeout = 10000 } = {}) {
+  const result = spawnSync(process.execPath, [RELAY_FLEET_SCRIPT, ...args], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      ...env,
+    },
+    timeout,
+  });
+  return result;
+}
+
+function writeFakeDispatchScript(tmpDir) {
+  const scriptPath = path.join(tmpDir, "fake-dispatch.js");
+  fs.writeFileSync(scriptPath, `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sourceRoot = process.env.RELAY_SOURCE_ROOT;
+const {
+  getManifestPath,
+  getRunDir,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "paths"));
+const {
+  createManifestSkeleton,
+  writeManifest,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "store"));
+const {
+  STATES,
+  updateManifestState,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "lifecycle"));
+const {
+  acquireIssueLock,
+  releaseIssueLock,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "fleet"));
+
+const args = process.argv.slice(2);
+const repoRoot = args[0];
+function get(flag, fallback = null) {
+  const flags = Array.isArray(flag) ? flag : [flag];
+  for (const item of flags) {
+    const index = args.indexOf(item);
+    if (index !== -1) return args[index + 1] || fallback;
+  }
+  return fallback;
+}
+function has(flag) {
+  return args.includes(flag);
+}
+function issueFromBranch(branch) {
+  const match = String(branch || "").match(/issue-(\\d+)/);
+  return match ? Number(match[1]) : null;
+}
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function appendLog(record) {
+  if (!process.env.FAKE_DISPATCH_LOG) return;
+  fs.appendFileSync(process.env.FAKE_DISPATCH_LOG, JSON.stringify(record) + "\\n", "utf-8");
+}
+async function main() {
+  const branch = get(["--branch", "-b"]);
+  const leafId = get("--leaf-id");
+  const fleetId = get("--fleet-id");
+  const dryRun = has("--dry-run");
+  const config = process.env.FAKE_DISPATCH_CONFIG
+    ? JSON.parse(fs.readFileSync(process.env.FAKE_DISPATCH_CONFIG, "utf-8"))
+    : {};
+  const plan = config[branch] || {};
+  const issueNumber = issueFromBranch(branch);
+  appendLog({ event: "spawn", branch, leafId, fleetId, dryRun, args });
+  if (plan.delay_before_manifest_ms) {
+    await sleep(plan.delay_before_manifest_ms);
+  }
+  if (plan.fail_before_manifest) {
+    process.stderr.write("fake pre-manifest failure\\n");
+    process.exit(plan.exit_code || 17);
+  }
+  const runId = plan.run_id || \`issue-\${issueNumber}-2026051401010\${String(Math.abs(branch.length) % 10)}000-a1b2c3d4\`;
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const runDir = getRunDir(repoRoot, runId);
+  if (!dryRun && plan.create_manifest !== false) {
+    fs.mkdirSync(runDir, { recursive: true });
+    let manifest = createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch,
+      baseBranch: "main",
+      issueNumber,
+      worktreePath: path.join(repoRoot, "worktrees", branch),
+      executor: "fake",
+      requestId: get("--request-id"),
+      leafId,
+      doneCriteriaPath: get("--done-criteria-file"),
+      fleetId,
+    });
+    manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+    if (plan.run_state === "review_pending") {
+      manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "await_review");
+    }
+    writeManifest(manifestPath, manifest);
+  }
+  let lock = null;
+  if (plan.hold_issue_lock_ms) {
+    lock = acquireIssueLock({ repoRoot, issueNumber, fleetId, runId });
+    await sleep(plan.hold_issue_lock_ms);
+  }
+  if (plan.delay_after_manifest_ms) {
+    await sleep(plan.delay_after_manifest_ms);
+  }
+  if (lock) releaseIssueLock(lock);
+  if (plan.exit_code && plan.exit_code !== 0) {
+    process.stderr.write("fake dispatch failure after manifest\\n");
+    process.exit(plan.exit_code);
+  }
+  process.stdout.write(JSON.stringify({
+    status: dryRun ? "dry-run" : "ok",
+    runId,
+    manifestPath,
+    runDir,
+    fleetId,
+    branch,
+  }) + "\\n");
+}
+main().catch((error) => {
+  process.stderr.write(String(error.stack || error.message || error) + "\\n");
+  process.exit(1);
+});
+`, "utf-8");
+  fs.chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+test("relay-fleet rejects duplicate issue listed twice in the same fleet", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dupe-");
+  const dispatchScript = writeFakeDispatchScript(fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-")));
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, { issue_number: 481, leaf_ref: "leaf-a", leaf_id: "leaf-a" }),
+    makeLeaf(repoRoot, 2, { issue_number: 481, leaf_ref: "leaf-b", leaf_id: "leaf-b" }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-duplicate",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /duplicate issue_number 481/);
+  assert.equal(fs.existsSync(getFleetManifestPath(repoRoot, "fleet-duplicate")), false);
+});
+
+test("relay-fleet honors a racing fleet issue lock before spawning the duplicate child", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-race-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const logPath = path.join(tmpDir, "dispatch.log");
+  const leavesFile = writeLeavesFile(repoRoot, [makeLeaf(repoRoot, 1, { issue_number: 482 })]);
+  const lock = acquireIssueLock({
+    repoRoot,
+    issueNumber: 482,
+    fleetId: "fleet-other",
+    runId: "issue-482-20260514010101000-a1b2c3d4",
+  });
+
+  try {
+    const result = runFleet([
+      "--repo", repoRoot,
+      "--fleet-id", "fleet-race",
+      "--leaves-file", leavesFile,
+      "--dispatch-script", dispatchScript,
+      "--json",
+    ], {
+      relayHome,
+      env: { FAKE_DISPATCH_LOG: logPath },
+    });
+
+    assert.notEqual(result.status, 0);
+    const fleet = readFleetManifest(repoRoot, "fleet-race").data;
+    assert.deepEqual(fleet.children, [{
+      leaf_ref: "leaf-01",
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+    }]);
+    assert.equal(readJsonLines(logPath).length, 0);
+  } finally {
+    releaseIssueLock(lock);
+  }
+});
+
+test("relay-fleet records and resumes a child dispatch that fails before manifest creation", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-premanifest-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const configPath = path.join(tmpDir, "config.json");
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 483 });
+  const leavesFile = writeLeavesFile(repoRoot, [leaf]);
+  writeJson(configPath, { [leaf.branch]: { fail_before_manifest: true } });
+
+  const failed = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-premanifest",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_CONFIG: configPath },
+  });
+
+  assert.notEqual(failed.status, 0);
+  assert.equal(
+    readFleetManifest(repoRoot, "fleet-premanifest").data.children[0].dispatch_status,
+    DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+  );
+
+  writeJson(configPath, {});
+  const resumed = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-premanifest",
+    "--resume",
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_CONFIG: configPath },
+  });
+
+  assert.equal(resumed.status, 0, resumed.stderr);
+  const child = readFleetManifest(repoRoot, "fleet-premanifest").data.children[0];
+  assert.equal(child.dispatch_status, DISPATCH_STATUS.DISPATCHED);
+  assert.match(child.run_id, /^issue-483-/);
+});
+
+test("relay-fleet keeps manifest consistent when child 3 of 5 fails before manifest creation", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-partial-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const configPath = path.join(tmpDir, "config.json");
+  const leaves = Array.from({ length: 5 }, (_, index) => makeLeaf(repoRoot, index + 1, {
+    issue_number: 490 + index,
+  }));
+  writeJson(configPath, { [leaves[2].branch]: { fail_before_manifest: true } });
+  const leavesFile = writeLeavesFile(repoRoot, leaves);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-partial",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--parallel", "5",
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_CONFIG: configPath },
+  });
+
+  assert.notEqual(result.status, 0);
+  const fleet = readFleetManifest(repoRoot, "fleet-partial").data;
+  assert.equal(fleet.children.length, 5);
+  assert.equal(
+    fleet.children.filter((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCHED).length,
+    4
+  );
+  assert.equal(
+    fleet.children.find((child) => child.leaf_ref === "leaf-03").dispatch_status,
+    DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+  );
+  assert.equal(fleet.fleet_state, FLEET_STATES.DISPATCHING);
+});
+
+test("relay-fleet resume re-adopts orphan child via fleet_id back-pointer", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-orphan-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const runId = "issue-501-20260514010101000-a1b2c3d4";
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-orphan",
+    children: [{ leaf_ref: "leaf-01", run_id: null, dispatch_status: DISPATCH_STATUS.PENDING }],
+  });
+  const manifestPath = getManifestPath(repoRoot, runId);
+  fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+  let childManifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-501-leaf-01",
+    baseBranch: "main",
+    issueNumber: 501,
+    worktreePath: path.join(repoRoot, "wt"),
+    leafId: "leaf-01",
+    fleetId: "fleet-orphan",
+  });
+  childManifest = updateManifestState(childManifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+  writeManifest(manifestPath, childManifest);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-orphan",
+    "--resume",
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, result.stderr);
+  const child = readFleetManifest(repoRoot, "fleet-orphan").data.children[0];
+  assert.equal(child.run_id, runId);
+  assert.equal(child.dispatch_status, DISPATCH_STATUS.DISPATCHED);
+});
+
+test("SIGINT during fan-out leaves a consistent fleet manifest and resume recovers", async () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-sigint-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const configPath = path.join(tmpDir, "config.json");
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 502 });
+  const leavesFile = writeLeavesFile(repoRoot, [leaf]);
+  writeJson(configPath, { [leaf.branch]: { delay_before_manifest_ms: 5000 } });
+
+  const child = spawn(process.execPath, [
+    RELAY_FLEET_SCRIPT,
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-sigint",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      FAKE_DISPATCH_CONFIG: configPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await waitFor(() => {
+    const manifestPath = getFleetManifestPath(repoRoot, "fleet-sigint");
+    return fs.existsSync(manifestPath)
+      && readFleetManifest(repoRoot, "fleet-sigint").data.children[0]?.dispatch_status === DISPATCH_STATUS.DISPATCHING;
+  });
+  child.kill("SIGINT");
+  await new Promise((resolve) => child.on("close", resolve));
+
+  const afterInterrupt = readFleetManifest(repoRoot, "fleet-sigint").data;
+  assert.equal(afterInterrupt.children.length, 1);
+  assert.ok([
+    DISPATCH_STATUS.DISPATCHING,
+    DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+  ].includes(afterInterrupt.children[0].dispatch_status));
+
+  writeJson(configPath, {});
+  const resumed = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-sigint",
+    "--resume",
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_CONFIG: configPath },
+  });
+
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(
+    readFleetManifest(repoRoot, "fleet-sigint").data.children[0].dispatch_status,
+    DISPATCH_STATUS.DISPATCHED
+  );
+});
+
+test("resume while a child subprocess is still running does not double-dispatch", async () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-running-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const logPath = path.join(tmpDir, "dispatch.log");
+  const configPath = path.join(tmpDir, "config.json");
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 503 });
+  const leavesFile = writeLeavesFile(repoRoot, [leaf]);
+  writeJson(configPath, { [leaf.branch]: { delay_after_manifest_ms: 1000 } });
+
+  const first = spawn(process.execPath, [
+    RELAY_FLEET_SCRIPT,
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-running",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      FAKE_DISPATCH_CONFIG: configPath,
+      FAKE_DISPATCH_LOG: logPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await waitFor(() => readJsonLines(logPath).length === 1);
+  await waitFor(() => readFleetManifest(repoRoot, "fleet-running").data.children[0]?.dispatch_status === DISPATCH_STATUS.DISPATCHING);
+
+  const resumed = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-running",
+    "--resume",
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_DISPATCH_CONFIG: configPath,
+      FAKE_DISPATCH_LOG: logPath,
+    },
+  });
+
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(readJsonLines(logPath).length, 1);
+  await new Promise((resolve) => first.on("close", resolve));
+});
+
+test("relay-fleet --dry-run fans out to dispatch dry-run without writing a fleet manifest", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dry-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const logPath = path.join(tmpDir, "dispatch.log");
+  const leaves = [makeLeaf(repoRoot, 1, { issue_number: 504 }), makeLeaf(repoRoot, 2, { issue_number: 505 })];
+  const leavesFile = writeLeavesFile(repoRoot, leaves);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-dry",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--dry-run",
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_LOG: logPath },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.dryRun, true);
+  assert.equal(payload.children.length, 2);
+  assert.equal(fs.existsSync(getFleetManifestPath(repoRoot, "fleet-dry")), false);
+  assert.equal(readJsonLines(logPath).every((entry) => entry.dryRun && entry.fleetId === "fleet-dry"), true);
+});
+
+test("relay-fleet --status prints derived summary without writing the fleet manifest", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-status-");
+  const dispatchedRun = "issue-510-20260514010101000-a1b2c3d4";
+  const escalatedRun = "issue-511-20260514010101000-a1b2c3d4";
+  for (const [runId, state] of [[dispatchedRun, RUN_STATES.DISPATCHED], [escalatedRun, RUN_STATES.ESCALATED]]) {
+    fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+    let manifest = createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch: `issue-${runId.slice(6, 9)}-status`,
+      baseBranch: "main",
+      issueNumber: Number(runId.slice(6, 9)),
+      worktreePath: path.join(repoRoot, "wt", runId),
+      fleetId: "fleet-status",
+      leafId: runId === dispatchedRun ? "leaf-dispatched" : "leaf-escalated",
+    });
+    manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+    if (state === RUN_STATES.ESCALATED) {
+      manifest = updateManifestState(manifest, RUN_STATES.ESCALATED, "inspect_dispatch_failure");
+    }
+    writeManifest(getManifestPath(repoRoot, runId), manifest);
+  }
+  const created = createFleetManifest(repoRoot, {
+    fleetId: "fleet-status",
+    children: [
+      { leaf_ref: "leaf-dispatched", run_id: dispatchedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-escalated", run_id: escalatedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-failed", run_id: null, dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST },
+    ],
+  });
+  const before = fs.readFileSync(created.manifestPath, "utf-8");
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-status",
+    "--status",
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.summary.total_children, 3);
+  assert.equal(payload.summary.by_dispatch_status[DISPATCH_STATUS.DISPATCHED], 2);
+  assert.equal(payload.summary.by_dispatch_status[DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST], 1);
+  assert.equal(payload.summary.by_run_state[RUN_STATES.DISPATCHED], 1);
+  assert.equal(payload.summary.by_run_state[RUN_STATES.ESCALATED], 1);
+  assert.equal(payload.summary.by_run_state.no_run_manifest, 1);
+  assert.equal(fs.readFileSync(created.manifestPath, "utf-8"), before);
+});


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 만들었습니다.

커밋: `721b7b7 Implement relay-fleet skill`

변경 사항:
- [SKILL.md](/Users/sjlee/.relay/worktrees/2f721893/dev-relay/skills/relay-fleet/SKILL.md): `relay-fleet` skill 추가, frontmatter schema 충족, SPOF 명시.
- [relay-fleet.js](/Users/sjlee/.relay/worktrees/2f721893/dev-relay/skills/relay-fleet/scripts/relay-fleet.js): leaf contract fan-out, `dispatch.js` subprocess 호출, `--fleet-id` 전달, resume/reconcile, runtime PID guard, read-only status.
- [relay-fleet.test.js](/Users/sjlee/.relay/
```

## Score Log

- Run: issue-478-20260514134129801-e52b11bb
- Executor: codex
- Branch: issue-478