### PR TITLE
Fix stalled relay review guidance

### DIFF
--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -49,6 +49,8 @@ RUN_ID=<run-id-from-dispatch>
 node ${CLAUDE_SKILL_DIR}/scripts/review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --json
 ```
 
+Run the runner in the foreground. Do NOT background it, detach it, or return with "I'll wait for the background runner." The relay-review result is the runner's verdict; do not return until the runner exits and the new `review-round-N-verdict.json` exists.
+
 Supported built-in adapters:
 - `--reviewer codex`
 - `--reviewer claude`

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -119,11 +119,11 @@ The rubric from relay-plan anchors each iteration — prevents context drift acr
 
 Do NOT review inline — relay-review must run in an isolated context to prevent planning bias.
 
-Before invoking relay-review, record manifest `review.rounds` and `review.latest_verdict`. After it returns, re-read the manifest: `review.rounds` must increment or `review.latest_verdict` must no longer be `pending`. If neither changed, treat review as stalled and recover by running the runner directly in the foreground:
+Before invoking relay-review, record manifest `review.rounds` as `previousRounds` and `review.latest_verdict` as `previousVerdict`. After it returns, re-read the manifest and compare against that snapshot: `review.rounds` must be greater than `previousRounds` or `review.latest_verdict` must differ from `previousVerdict`. A stale non-pending verdict from an earlier round does not count as advancement. If neither recorded value changed, treat review as stalled and recover by running the runner directly in the foreground:
 ```bash
 node ${CLAUDE_SKILL_DIR}/../relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --json
 ```
-Wait for exit, then repeat the manifest-advanced check before Step 5.
+Wait for exit, then re-read the manifest and repeat the same snapshot comparison against `previousRounds` and `previousVerdict` before Step 5.
 
 ## Step 5: Ready to Merge
 

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -119,6 +119,12 @@ The rubric from relay-plan anchors each iteration — prevents context drift acr
 
 Do NOT review inline — relay-review must run in an isolated context to prevent planning bias.
 
+Before invoking relay-review, record manifest `review.rounds` and `review.latest_verdict`. After it returns, re-read the manifest: `review.rounds` must increment or `review.latest_verdict` must no longer be `pending`. If neither changed, treat review as stalled and recover by running the runner directly in the foreground:
+```bash
+node ${CLAUDE_SKILL_DIR}/../relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --json
+```
+Wait for exit, then repeat the manifest-advanced check before Step 5.
+
 ## Step 5: Ready to Merge
 
 If relay-review returns LGTM, the review runner should already have recorded the run as `ready_to_merge`. Do not mark the sprint task complete yet. Only run relay-merge when the user explicitly wants to land the PR.


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 커밋까지 끝났습니다.

커밋: `d258574 Fix stalled relay review guidance`

변경 내용:
- [skills/relay-review/SKILL.md](/Users/sjlee/.relay/worktrees/670a086b/dev-relay/skills/relay-review/SKILL.md:52): `review-runner.js`를 foreground로 실행하고, background/detach/early return을 금지하며, runner 종료와 `review-round-N-verdict.json` 존재 전에는 반환하지 않도록 명시했습니다.
- [skills/relay/SKILL.md](/Users/sjlee/.relay/worktrees/670a086b/dev-relay/skills/relay/SKILL.md:122): Step 4 이후 manifest의 `review.rounds` 증가 또는 `review.latest_verdic
```

## Score Log

- Run: issue-484-20260514230454631-6dd988c8
- Executor: codex
- Branch: issue-484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 리뷰 실행기 포그라운드 실행 지침 강화 및 결과 반환 대기 조건 명시
  * 리뷰 프로세스 정체 감지 및 복구 절차 추가 (상태 확인 및 직접 실행 가이드)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/485)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->