### PR TITLE
Add skill inputs drift guard

### DIFF
--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -7,10 +7,12 @@ metadata:
   related-skills: "relay, relay-ready, relay-plan, relay-review, relay-merge"
   keywords: "디스패치, 실행, dispatch, executor, worktree"
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
+- Files: dispatch prompt (`--prompt-file` or `--prompt`), required rubric file, optional Done Criteria file, request/leaf ids, copied files, and retained run manifest.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`.
 
 # Relay Dispatch
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## Use when
 

--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -7,6 +7,10 @@ metadata:
   related-skills: relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge
   keywords: relay-fleet, fleet, fan-out, parallel dispatch, resume, status, 병렬, 재개, 상태
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
+- Files: leaves JSON passed by `--leaves-file`, child prompt/rubric/Done Criteria files, and fleet/child run manifests under `~/.relay/runs/`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`.
 
 # relay-fleet
 
@@ -30,7 +34,7 @@ Optional per-leaf fields are passed through to `dispatch.js`: `request_id`, `lea
 ## Commands
 
 ```bash
-node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --repo . \
   --fleet-id fleet-481 \
   --leaves-file /tmp/fleet-481-leaves.json \
@@ -40,7 +44,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
 Resume after a terminal/session crash:
 
 ```bash
-node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --repo . \
   --fleet-id fleet-481 \
   --resume
@@ -49,7 +53,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
 Read-only aggregate status:
 
 ```bash
-node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --repo . \
   --fleet-id fleet-481 \
   --status
@@ -58,7 +62,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
 Dry-run validates the leaf file and invokes child `dispatch.js --dry-run` for each leaf without writing a fleet manifest:
 
 ```bash
-node ${CLAUDE_SKILL_DIR}/scripts/relay-fleet.js \
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --repo . \
   --fleet-id fleet-481 \
   --leaves-file /tmp/fleet-481-leaves.json \

--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -7,12 +7,14 @@ metadata:
   related-skills: "relay, relay-ready, relay-plan, relay-dispatch, relay-review, dev-backlog"
   keywords: "머지, 병합, merge, finalize, cleanup"
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; examples use `PR_NUM` and `RUN_ID`.
+- Files: reviewed PR, retained run manifest/worktree, optional sprint file, and follow-up issue text.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/gate-check.js`, `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/finalize-run.js`.
 
 # Relay Merge
 
 Explicitly merge a ready-to-merge PR and close the loop. **Requires relay-review PR comment.**
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## Process
 

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -7,11 +7,14 @@ metadata:
   related-skills: "relay, relay-ready, relay-dispatch, relay-review, dev-backlog"
   keywords: "계획, 루브릭, planning, rubric, dispatch prompt"
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; Step 7/8 examples use `RUN_ID`.
+- Files: relay-ready handoff, task file, issue/user text, optional `/tmp/done-criteria-<N>.md`, `/tmp/dispatch-<N>.md`, and `/tmp/rubric-<N>.yaml`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/reliability-report.js`, `${RELAY_SKILL_ROOT:-skills}/relay-plan/scripts/probe-executor-env.js`, `${RELAY_SKILL_ROOT:-skills}/relay-plan/scripts/persist-done-criteria.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`.
+
 # Relay Plan
 
 Build the review anchor, scoring rubric, and dispatch prompt for a relay run. `relay-plan` emits handoff artifacts only; `relay` or an operator runs `relay-dispatch`.
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## Default Path
 

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -7,12 +7,14 @@ metadata:
   related-skills: "relay, relay-plan, relay-dispatch, relay-review"
   keywords: "relay-ready, ready to relay, readiness gate, task readiness, 릴레이 준비, 준비도, 검증, 완료 기준"
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
+- Files: `/tmp/relay-ready-contract.json` with request, handoff, leaf, and Done Criteria fields; generated request artifacts under `~/.relay/requests/<repo-slug>/`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-ready/scripts/persist-request.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`.
 
 # Relay Ready
 
 Use this skill when `/relay` cannot safely bypass straight to planning.
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## When Readiness Is Required
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -8,12 +8,14 @@ metadata:
   related-skills: "relay, relay-ready, relay-plan, relay-dispatch, relay-merge"
   keywords: "리뷰, 검토, review, gate, fresh context"
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; examples use `PR_NUM`, `BRANCH`, `ISSUE_NUM`, and `RUN_ID`; `ANTHROPIC_API_KEY` is required only for `--reviewer claude`.
+- Files: PR diff (`/tmp/pr-diff.txt`), Done Criteria anchor, Score Log/rubric artifacts, run manifest, and optional `/tmp/review-verdict.json`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/resolve-issue-number.sh`, `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js`.
 
 # Relay Review
 
 Independent PR review against the Done Criteria contract and scoring rubric. Use `scripts/review-runner.js` so round count, reviewer invocation, PR comments, and manifest transitions stay script-managed.
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## Context Isolation
 

--- a/skills/relay-sidecar/SKILL.md
+++ b/skills/relay-sidecar/SKILL.md
@@ -7,12 +7,14 @@ metadata:
   keywords: "사이드카, 보조 검토, sidecar, advisory, artifacts"
   entry: scripts/relay-sidecar.js
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
+- Files: existing relay run manifest, resolved run context, PR diff text, and generated sidecar output under `sidecars/<id>/`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-sidecar/scripts/relay-sidecar.js`.
 
 # Relay Sidecar
 
 Use `scripts/relay-sidecar.js` to run an advisory sidecar against an existing relay run. The runner resolves the run manifest, sends run context and PR diff text to the configured sidecar executor, and stores the captured stdout under the run's `sidecars/<id>/` directory.
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## Entry
 

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -7,12 +7,14 @@ metadata:
   related-skills: "relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog"
   keywords: "릴레이, 자동 실행, plan, dispatch, review, merge, relay cycle"
 ---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; role overrides use `RELAY_ORCHESTRATOR`/`RELAY_REVIEWER`; examples use `ISSUE_BODY_FILE`, `RUN_MANIFEST`, `ISSUE_NUMBER`, `PROBE`, `BYPASS`, `SUMMARY`, `NEXT_ACTION`, `RUN_ID`, and `PR_NUM`.
+- Files: task/issue text, optional sprint file, readiness probe inputs, `/tmp/dispatch-<N>.md`, and `/tmp/rubric-<N>.yaml`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-ready/scripts/probe-readiness.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`, `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js`.
 
 # Dev Relay
 
 Execute the plan → dispatch → review cycle. Stop at `ready_to_merge` unless the user explicitly asks to merge. Follow ALL steps below in order.
-
-Command examples use `${RELAY_SKILL_ROOT:-skills}`; set `RELAY_SKILL_ROOT` to the directory containing sibling relay skills when running from an installed bundle outside this repo.
 
 ## Role Defaults
 
@@ -42,9 +44,7 @@ Check if this issue already has a PR in progress:
 ```bash
 PR_NUM=$(gh pr list --head issue-<N> --json number -q '.[0].number')
 ```
-- PR exists and open → **skip Steps 2-3**, go directly to Step 4 (review)
-- PR exists and merged → update sprint file to `[x]` (if exists), done
-- PR not found → continue to Step 1.7
+PR status: open → skip Steps 2-3 and review; merged → update sprint file to `[x]` if present; not found → continue to Step 1.7.
 
 ## Step 1.7: Readiness probe + chain prompt
 Before Step 2, run this unless bypassed by a prior relay-ready artifact with `readiness_score` and frozen review anchor, explicit `--bypass-readiness`, or a sprint-batch entry already linked to a relay-ready handoff:
@@ -123,7 +123,7 @@ Do NOT review inline — relay-review must run in an isolated context to prevent
 
 Before invoking relay-review, record manifest `review.rounds` as `previousRounds` and `review.latest_verdict` as `previousVerdict`. After it returns, re-read the manifest and compare against that snapshot: `review.rounds` must be greater than `previousRounds` or `review.latest_verdict` must differ from `previousVerdict`. A stale non-pending verdict from an earlier round does not count as advancement. If neither recorded value changed, treat review as stalled and recover by running the runner directly in the foreground:
 ```bash
-node ${CLAUDE_SKILL_DIR}/../relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --json
 ```
 Wait for exit, then re-read the manifest and repeat the same snapshot comparison against `previousRounds` and `previousVerdict` before Step 5.
 

--- a/tests/skills-lint/scripts/skill-inputs-drift.test.js
+++ b/tests/skills-lint/scripts/skill-inputs-drift.test.js
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SKILL_PATHS = [
+  "skills/relay/SKILL.md",
+  "skills/relay-ready/SKILL.md",
+  "skills/relay-plan/SKILL.md",
+  "skills/relay-dispatch/SKILL.md",
+  "skills/relay-review/SKILL.md",
+  "skills/relay-merge/SKILL.md",
+  "skills/relay-fleet/SKILL.md",
+  "skills/relay-sidecar/SKILL.md",
+];
+
+function readTargetSkillFiles() {
+  return SKILL_PATHS.map((relativePath) => ({
+    relativePath,
+    content: fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8"),
+  }));
+}
+
+function splitLines(text) {
+  return text.split(/\r\n|\n|\r/);
+}
+
+test("target dev-relay skills contain exactly one Inputs section immediately after frontmatter", () => {
+  readTargetSkillFiles().forEach(({ relativePath, content }) => {
+    const headings = content.match(/^## Inputs$/gm) || [];
+    assert.equal(headings.length, 1, `${relativePath} must contain exactly one ## Inputs heading`);
+
+    const lines = splitLines(content);
+    const frontmatterEnd = lines.findIndex((line, index) => index > 0 && line === "---");
+    assert.ok(frontmatterEnd > 0, `${relativePath} must contain YAML frontmatter`);
+    assert.equal(lines[frontmatterEnd + 1], "## Inputs", `${relativePath} must put ## Inputs immediately after frontmatter`);
+  });
+});
+
+test("RELAY_SKILL_ROOT script references resolve to files", () => {
+  const pattern = /\$\{RELAY_SKILL_ROOT:-skills\}\/([A-Za-z0-9._-]+)\/scripts\/([A-Za-z0-9._/-]+)/g;
+
+  readTargetSkillFiles().forEach(({ relativePath, content }) => {
+    pattern.lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      const repoRelativePath = path.join("skills", match[1], "scripts", match[2]);
+      assert.ok(
+        fs.existsSync(path.join(REPO_ROOT, repoRelativePath)),
+        `${relativePath} references missing script ${match[0]} -> ${repoRelativePath}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋 완료했습니다.

커밋: `4fe24e722207a94a5abe6ef8816bfd696bb713f6`  
메시지: `Add skill inputs drift guard`  
본문에 `Closes #492` 포함됨. 작업트리는 clean 상태입니다.

**변경 요약**
- 8개 `SKILL.md`에 `## Inputs` 블록 추가.
- `relay`/`relay-fleet`에 남아 있던 `CLAUDE_SKILL_DIR` 예시를 `${RELAY_SKILL_ROOT:-skills}` 규칙으로 정리.
- 새 drift guard 추가: [skill-inputs-drift.test.js](/Users/sjlee/.relay/worktrees/901353f8/dev-relay/tests/skills-lint/scripts/skill-inputs-drift.test.js:29)

**검증**
- `node --test tests/skills-lint/scripts/skill-inpu
```

## Score Log

- Run: issue-492-20260520034847715-3d759001
- Executor: codex
- Branch: issue-492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 스킬 문서들에 입력 요구사항(환경변수, 필수 파일, 스크립트 경로) 섹션이 추가되었습니다.
  * 스킬별 실행에 필요한 설정 정보가 표준화된 형식으로 명확히 제시됩니다.

* **Tests**
  * 스킬 문서 형식 준수 여부를 자동 검증하는 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->