### PR TITLE
Document relay-review loop transitions

### DIFF
--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -67,17 +67,10 @@ Notes:
 
 Optional advisory path: add an opencode-powered blind-spot lane alongside the primary reviewer:
 ```bash
-node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" \
-  --reviewer codex \
-  --advisory-reviewer opencode \
-  --advisory-profile blindspot \
-  --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer opencode --advisory-profile blindspot --json
 ```
 
-Advisory review is non-gating. Runner-managed advisory invocation starts concurrently with the primary reviewer and records `advisory_review` plus `review-round-N-advisory-<reviewer>-*` artifacts. Advisory findings are not merged into the trusted verdict or redispatch prompt in v1. Advisory failure, timeout, invalid JSON, or write-policy violation is recorded without changing the primary review outcome. Use `--advisory-reviewer-model` to override the model; otherwise opencode uses the same executor model defaults as dispatch (`skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json`).
-
-Current advisory profiles:
-- `blindspot`: look for likely misses from the primary review such as test gaps, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.
+Advisory review is non-gating: it starts concurrently, records `advisory_review` plus artifacts, never changes the trusted verdict or redispatch prompt in v1, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor model defaults. Current profile: `blindspot` checks likely primary-review misses such as test gaps, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.
 
 4. Fallback path for unsupported environments or debugging:
 ```bash
@@ -87,6 +80,15 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo 
 This writes round artifacts under `~/.relay/runs/<repo-slug>/<run-id>/`. See `references/runner-notes.md` for artifact names, retained-checkout behavior, stale-SHA handling, and repeated-issue escalation.
 
 ## Review Loop
+| current_phase | outcome | event | next_phase |
+|---------------|---------|-------|------------|
+| Phase 1 | pass | `phase1_pass` | Phase 2 |
+| Phase 1 | fail | `phase1_fail` | Re-dispatch, then Phase 1 |
+| Phase 2 | pass | `phase2_pass` | Converged |
+| Converged | ready verdict emitted | `converged` | `ready_to_merge` |
+| Phase 2 | fail | `phase2_fail` | Re-dispatch, then Phase 1 |
+| Any phase | same issue 3+ rounds or safety cap hit | `escalated` | Escalated |
+This table is the canonical control-flow spec; the prose below is exposition.
 
 Two phases, run in order. Each round re-measures against the **original anchor**, not the previous round's state.
 
@@ -110,7 +112,7 @@ Two phases, run in order. Each round re-measures against the **original anchor**
 
 8. Run a code review skill on changed files — check code quality, patterns, conventions, structural issues (use the platform's best-matching skill, e.g., Claude Code: `/review`; if no skill is available, perform the quality review inline inside the structured reviewer round)
 9. Run a code simplification skill on changed files — unnecessary complexity, dead code, verbose patterns (use the platform's best-matching skill, e.g., Claude Code: `/simplify`; if no skill is available, review for simplification inline before returning `verdict=pass`)
-10. Issues found → return `verdict=changes_requested`, then re-dispatch and **repeat from step 5** (Phase 1 — quality fixes can regress spec compliance)
+10. Issues found → return `verdict=changes_requested`, then follow the `phase2_fail` back-edge: re-dispatch and restart at Phase 1 because quality fixes can regress spec compliance.
 
 ### Drift and stuck detection (both phases)
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -70,7 +70,7 @@ Optional advisory path: add an opencode-powered blind-spot lane alongside the pr
 node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer opencode --advisory-profile blindspot --json
 ```
 
-Advisory review is non-gating: it starts concurrently, records `advisory_review` plus artifacts, never changes the trusted verdict or redispatch prompt in v1, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor model defaults. Current profile: `blindspot` checks likely primary-review misses such as test gaps, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.
+Advisory review is non-gating: it starts concurrently, records `advisory_review` plus `review-round-N-advisory-<reviewer>-*` artifacts, never changes the trusted verdict or redispatch prompt in v1, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor model defaults from `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json`. Current profile: `blindspot` checks likely primary-review misses such as test gaps, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.
 
 4. Fallback path for unsupported environments or debugging:
 ```bash


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

변경 사항:
- [skills/relay-review/SKILL.md](/Users/sjlee/.relay/worktrees/f03aafb2/dev-relay/skills/relay-review/SKILL.md:83)에 Review Loop 전이 표를 첫 요소로 추가했습니다.
- `phase2_fail` back-edge를 명시적으로 참조하도록 step 10을 수정했습니다.
- advisory 설명을 압축해 파일을 148줄로 유지했습니다.
- `context: fork` 유지했고, 대상 파일 외 변경은 없습니다.

검증:
- `node --test tests/skills-lint/scripts/skills-lint.test.js` 통과
- `wc -l skills/relay-review/SKILL.md` → 148
- 커밋 완료: `d1ebd4a Document relay-review loop transitions`
- 커밋 본문 포함: `Closes #493`
```

## Score Log

- Run: issue-493-20260520061929553-58babf6c
- Executor: codex
- Branch: issue-493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 옵셔널 advisory 라인 실행 및 기록 규칙이 업데이트되었습니다
  * Advisory 실행 커맨드 표기가 정리되었으며, v1에서 verdict 변경이 없음이 명확화되었습니다
  * 리뷰 제어 흐름 단계에 대한 공식 참조 테이블이 추가되었습니다
  * Phase 2 이슈 발견 시 처리 절차가 명확히 정의되었습니다

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->