### PR TITLE
Unify relay skill selection guidance

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -14,7 +14,20 @@ metadata:
 
 # relay-fleet
 
-Run Phase 1 multi-leaf orchestration after `relay-ready` and `relay-plan` have already produced leaf artifacts. This skill does not plan raw issues. It only fans out prepared leaf contracts to `relay-dispatch`, records crash-safe fleet progress, and reports aggregate status.
+## Use when
+
+- Fanning out already planned relay leaves into parallel child dispatches
+- Resuming a crashed fleet dispatch from persisted child/fleet state
+- Printing read-only aggregate status for a fleet
+
+## Do not use when
+
+- Decomposing raw or ambiguous requests into leaves — use `relay-ready`
+- Authoring per-leaf rubrics or dispatch prompts — use `relay-plan`
+- Dispatching a single task or run — use `relay-dispatch`
+- Reviewing child PRs — use `relay-review`
+
+Run Phase 1 multi-leaf orchestration after `relay-ready` and `relay-plan` have already produced leaf artifacts. It only fans out prepared leaf contracts to `relay-dispatch`, records crash-safe fleet progress, and reports aggregate status.
 
 Design rationale, rejected alternatives, non-goals, and the Phase 2/3 roadmap: [references/design.md](references/design.md).
 

--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -14,6 +14,19 @@ metadata:
 
 # Relay Merge
 
+## Use when
+
+- Merging a PR after `relay-review` returns LGTM/pass
+- Finalizing the retained run manifest, worktree, and branch cleanup
+- Recording sprint-file and follow-up issue updates after merge
+
+## Do not use when
+
+- Reviewing executor output — use `relay-review`
+- Delegating implementation or review fixes — use `relay-dispatch`
+- Authoring rubrics or dispatch prompts — use `relay-plan`
+- Shaping an ambiguous task before planning — use `relay-ready`
+
 Explicitly merge a ready-to-merge PR and close the loop. **Requires relay-review PR comment.**
 
 ## Process

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -14,7 +14,20 @@ metadata:
 
 # Relay Plan
 
-Build the review anchor, scoring rubric, and dispatch prompt for a relay run. `relay-plan` emits handoff artifacts only; `relay` or an operator runs `relay-dispatch`.
+## Use when
+
+- Building the review anchor, scored rubric, and dispatch prompt for a relay run
+- Converting task intent, explicit AC, repo signals, and risk into reviewable Done Criteria
+- Persisting planner-authored Done Criteria before dispatch
+
+## Do not use when
+
+- Shaping an ambiguous task before planning — use `relay-ready`
+- Delegating implementation to an executor — use `relay-dispatch`
+- Reviewing executor output — use `relay-review`
+- Merging a reviewed PR — use `relay-merge`
+
+`relay-plan` emits handoff artifacts only; `relay` or an operator runs `relay-dispatch`.
 
 ## Default Path
 
@@ -30,19 +43,15 @@ If `relay-ready` produced a handoff brief, treat it as the source of truth inste
 
 ### 2. Gather planning signals
 
-Read historical relay signal:
-
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/reliability-report.js" --repo . --json
 ```
-
-Read repo-local quality signal:
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-plan/scripts/probe-executor-env.js" . --project-only --json
 ```
 
-Use these as weak inputs only. They inform wording, prerequisites, and available commands; they do not gate dispatch or override the task. Empty/failure cases render as `no historical data available` or `no quality infra detected`; field meanings: `references/signals.md`.
+Read historical relay signal and repo-local quality signal as weak inputs only. They inform wording, prerequisites, and commands; they do not gate dispatch or override the task. Empty/failure cases render as `no historical data available` or `no quality infra detected`; field meanings: `references/signals.md`.
 
 ### 3. Normalize planning inputs
 
@@ -53,8 +62,7 @@ Keep explicit AC, inferred Done Criteria, repo signal, historical signal, and ta
 Identify the evaluation source model:
 - Explicit AC from the task source, when present
 - Inferred Done Criteria from user intent, issue body, relay-ready handoff, and nearby repo conventions
-- Repo quality signal from probes and available commands
-- Historical relay signal from stuck factors and score divergence
+- Repo/historical signals from probes, available commands, stuck factors, and score divergence
 - Task-specific risk from touched domains, trust boundaries, data loss, migrations, UX flows, or operational failure modes
 
 If AC are missing, vague, or incomplete, write observable Done Criteria first. Treat explicit AC as high-priority evidence, not the only source. Before freezing, run the [pre-flight ambiguity audit](references/dc-preflight-audit.md). If the final review anchor is planner-authored or differs from the task source, persist it in step 7.
@@ -109,11 +117,7 @@ Skip this step when the issue or relay-ready handoff already provides the final 
 
 Write the dispatch prompt and rubric YAML to temp files. The prompt uses `../relay/references/prompt-template.md` and appends Setup, optional Working Guidance, Scoring Rubric, Iteration Protocol, and Score Log sections. Full iteration protocol and Score Log format: `references/iteration-protocol.md`.
 
-Return a handoff summary with:
-- dispatch prompt path, e.g. `/tmp/dispatch-<N>.md`
-- rubric YAML path, e.g. `/tmp/rubric-<N>.yaml`
-- Done Criteria anchor path, when persisted
-- recommended `relay-dispatch` command for the orchestrator/operator to run, including `--run-id "$RUN_ID"` and `--done-criteria-file <done-criteria-path>` when Step 7 persisted Done Criteria
+Return a handoff summary with dispatch prompt path, rubric YAML path, Done Criteria anchor path when persisted, and the recommended `relay-dispatch` command, including `--run-id "$RUN_ID"` and `--done-criteria-file <done-criteria-path>` when Step 7 persisted Done Criteria.
 
 When Step 7 persisted Done Criteria, the dispatch handoff must preserve both anchors:
 

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -27,13 +27,6 @@ metadata:
 - Reviewing executor output — use `relay-review`
 - Merging a reviewed PR — use `relay-merge`
 
-## When Readiness Is Required
-
-Run the readiness gate when any of these are true:
-- the request is free-form or ambiguous
-- the task may contain multiple steps or multiple leaves
-- the issue/task text is too broad to review safely as-is
-
 ## Output Contract
 
 Persist artifacts under `~/.relay/requests/<repo-slug>/<request-id>/` (request frontmatter, raw request,

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -14,17 +14,25 @@ metadata:
 
 # Relay Ready
 
-Use this skill when `/relay` cannot safely bypass straight to planning.
+## Use when
+
+- `/relay` cannot safely bypass straight to planning
+- The request is ambiguous, too broad, or may need multiple ordered leaves
+- No stable Done Criteria or review anchor exists yet
+
+## Do not use when
+
+- Authoring rubrics or dispatch prompts — use `relay-plan`
+- Delegating implementation work — use `relay-dispatch`
+- Reviewing executor output — use `relay-review`
+- Merging a reviewed PR — use `relay-merge`
 
 ## When Readiness Is Required
 
 Run the readiness gate when any of these are true:
 - the request is free-form or ambiguous
 - the task may contain multiple steps or multiple leaves
-- no stable Done Criteria anchor exists yet
 - the issue/task text is too broad to review safely as-is
-
-Bypass only for a single relay-ready task with a trustworthy review anchor already available.
 
 ## Output Contract
 

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -15,21 +15,28 @@ metadata:
 
 # Relay Review
 
-Independent PR review against the Done Criteria contract and scoring rubric. Use `scripts/review-runner.js` so round count, reviewer invocation, PR comments, and manifest transitions stay script-managed.
+## Use when
+
+- Reviewing an executor PR against frozen Done Criteria and rubric anchors
+- Running `review-runner.js` for isolated reviewer invocation, PR comments, and manifest transitions
+- Producing a pass, changes-requested, or escalated relay review verdict
+
+## Do not use when
+
+- Shaping an ambiguous task before planning — use `relay-ready`
+- Authoring rubrics or dispatch prompts — use `relay-plan`
+- Delegating initial implementation or requested fixes — use `relay-dispatch`
+- Merging a reviewed PR — use `relay-merge`
 
 ## Context Isolation
 
-Reviews MUST run in a fresh context — no prior planning, dispatch, or conversation history. This prevents planning bias from influencing the verdict.
+Reviews MUST run in a fresh context — no prior planning, dispatch, or conversation history. Standard path: `review-runner.js --reviewer codex` or `--reviewer claude`; adapter scripts enforce isolation.
 
-| Platform | Mechanism | How |
-|----------|-----------|-----|
-| Claude Code | `context: fork` frontmatter | Automatic — this SKILL.md's frontmatter triggers it |
-| Codex (reviewer adapter) | `--ephemeral --sandbox read-only` | Automatic — `invoke-reviewer-codex.js` passes these flags |
-| Claude (reviewer adapter) | `--bare --no-session-persistence` | Automatic — `invoke-reviewer-claude.js` passes these flags |
-| Codex (manual inline review) | Start a new session | Manual — do not continue from the dispatch session |
-| Other / Fallback | Prefix prompt | Prepend: "You are reviewing code you did NOT write. You have no context about why it was written this way." |
-
-Standard path: run `review-runner.js --reviewer codex` or `--reviewer claude`. In that path, isolation is already enforced by the adapter scripts. The manual "start a new session" rule applies only to inline reviews outside `review-runner`.
+- Claude Code: `context: fork` frontmatter triggers isolation.
+- Codex adapter: `invoke-reviewer-codex.js` passes `--ephemeral --sandbox read-only`.
+- Claude adapter: `invoke-reviewer-claude.js` passes `--bare --no-session-persistence`.
+- Manual inline review: start a new session; do not continue from dispatch.
+- Other fallback: prefix the prompt with "You are reviewing code you did NOT write. You have no context about why it was written this way."
 
 ## Setup: Establish the anchor
 
@@ -55,22 +62,17 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo 
 
 Run the runner in the foreground. Do NOT background it, detach it, or return with "I'll wait for the background runner." The relay-review result is the runner's verdict; do not return until the runner exits and the new `review-round-N-verdict.json` exists.
 
-Supported built-in adapters:
-- `--reviewer codex`
-- `--reviewer claude`
+Supported built-in adapters: `--reviewer codex`, `--reviewer claude`.
 
-Notes:
-- `codex` uses a read-only structured-output adapter and must return a full two-phase verdict.
-- `claude --bare` uses a separate token from the interactive Claude OAuth session; for `--reviewer claude` (direct or reviewer-swap), set `ANTHROPIC_API_KEY` or run `claude login --api-key`.
-- Model precedence for reviewer invocation is `--reviewer-model` -> `manifest.model_hints.review` -> reviewer default.
-- When the runner invokes the reviewer itself, it records a `review_invoke` event with the effective `model` value (or `null` when unset).
+Notes: `codex` uses a read-only structured-output adapter and must return a full two-phase verdict. `claude --bare` uses a separate token from interactive Claude OAuth; for `--reviewer claude`, set `ANTHROPIC_API_KEY` or run `claude login --api-key`.
+Model precedence is `--reviewer-model` -> `manifest.model_hints.review` -> reviewer default. Runner invocation records a `review_invoke` event with the effective `model` value (or `null`).
 
-Optional advisory path: add an opencode-powered blind-spot lane alongside the primary reviewer:
+Optional advisory path: add an opencode blind-spot lane alongside the primary reviewer:
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer opencode --advisory-profile blindspot --json
 ```
 
-Advisory review is non-gating: it starts concurrently, records `advisory_review` plus `review-round-N-advisory-<reviewer>-*` artifacts, never changes the trusted verdict or redispatch prompt in v1, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor model defaults from `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json`. Current profile: `blindspot` checks likely primary-review misses such as test gaps, bypass paths, edge cases, integration boundaries, stale docs, and operational failure modes.
+Advisory review is non-gating: it starts concurrently, records `advisory_review` plus `review-round-N-advisory-<reviewer>-*`, never changes the trusted verdict or redispatch prompt, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor defaults plus optional `~/.relay/executors.json`. Current profile: `blindspot` checks likely misses such as test gaps, bypass paths, edge cases, stale docs, and operational failure modes.
 
 4. Fallback path for unsupported environments or debugging:
 ```bash
@@ -88,7 +90,6 @@ This writes round artifacts under `~/.relay/runs/<repo-slug>/<run-id>/`. See `re
 | Converged | ready verdict emitted | `converged` | `ready_to_merge` |
 | Phase 2 | fail | `phase2_fail` | Re-dispatch, then Phase 1 |
 | Any phase | same issue 3+ rounds or safety cap hit | `escalated` | Escalated |
-This table is the canonical control-flow spec; the prose below is exposition.
 
 Two phases, run in order. Each round re-measures against the **original anchor**, not the previous round's state.
 
@@ -125,10 +126,7 @@ Before any re-dispatch, check:
 
 ### Converge
 
-11. Both phases pass → produce a structured verdict with:
-    - `verdict=pass`
-    - `next_action=ready_to_merge`
-    - `issues=[]`
+11. Both phases pass → produce a structured verdict with `verdict=pass`, `next_action=ready_to_merge`, and `issues=[]`.
 
 **Safety cap: 20 rounds total.** Ceiling, not target — most PRs converge in 1-3 rounds. Hitting the cap means something is structurally wrong; escalate.
 

--- a/skills/relay-sidecar/SKILL.md
+++ b/skills/relay-sidecar/SKILL.md
@@ -14,7 +14,20 @@ metadata:
 
 # Relay Sidecar
 
-Use `scripts/relay-sidecar.js` to run an advisory sidecar against an existing relay run. The runner resolves the run manifest, sends run context and PR diff text to the configured sidecar executor, and stores the captured stdout under the run's `sidecars/<id>/` directory.
+## Use when
+
+- Running an artifact-only advisory sidecar for an existing relay run
+- Capturing supplemental context recap, test-gap, docs-sync, or similar output
+- Producing non-gating sidecar artifacts under a run's `sidecars/<id>/` directory
+
+## Do not use when
+
+- Reviewing a PR for the relay gate — use `relay-review`
+- Dispatching implementation work — use `relay-dispatch`
+- Authoring rubrics or dispatch prompts — use `relay-plan`
+- Merging or finalizing a PR — use `relay-merge`
+
+The runner resolves the run manifest, sends run context and PR diff text to the configured sidecar executor, and stores captured stdout under the run's `sidecars/<id>/` directory.
 
 ## Entry
 


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 지정된 6개 `SKILL.md`에 `## Use when` / `## Do not use when` 섹션을 추가했고, 중복 라우팅 문구는 상단 섹션으로 통합했습니다. `relay-plan`과 `relay-review`는 기존 정보를 압축해 각각 148줄, 146줄로 150줄 미만을 유지했습니다.

검증:
- `node --test tests/skills-lint/scripts/skills-lint.test.js` 통과
- 커스텀 체크: 6개 파일 모두 Use/Do-not bullet 수 2-4개, Do-not 라우팅 모두 `relay-*` sibling 명시
- `git diff --check` 통과
- 변경 파일은 지정된 6개뿐

커밋 완료:
`b9e6be6 Unify relay skill selection guidance`

커밋 본문에 `Closes #495` 포함했습니다.
```

## Score Log

- Run: issue-495-20260520065136092-38ab3e25
- Executor: codex
- Branch: issue-495