### PR TITLE
Document relay-sidecar discoverability

### DIFF
--- a/skills/relay-sidecar/SKILL.md
+++ b/skills/relay-sidecar/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relay-sidecar
 description: Run artifact-only advisory sidecars for an existing relay run.
-compatibility: Requires relay-dispatch (Epic #367) and Node.js 18+.
+compatibility: Requires relay-dispatch and Node.js 18+.
 metadata:
   related-skills: "relay-dispatch"
   keywords: "사이드카, 보조 검토, sidecar, advisory, artifacts"
@@ -13,6 +13,8 @@ metadata:
 - Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-sidecar/scripts/relay-sidecar.js`.
 
 # Relay Sidecar
+
+`relay-sidecar` is an ADVISORY AUXILIARY skill for existing relay runs. It is NOT part of the mandatory plan → dispatch → review → merge lifecycle, and `/relay` does not require a sidecar step.
 
 ## Use when
 
@@ -48,4 +50,4 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-sidecar/scripts/relay-sidecar.js" --run-
 
 ## Trust Boundary
 
-Sidecar output is advisory only and does not count as execution evidence or reviewer proof. This follows the Epic #367 trust model and the opencode policy in `docs/reviewer-policy-opencode.md`.
+Sidecar output is advisory only and does not count as execution evidence or reviewer proof. Use relay-review for gate decisions; sidecar artifacts can inform operators, but they never satisfy implementation, review, or merge proof requirements. This follows the opencode policy in `docs/reviewer-policy-opencode.md`.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -4,7 +4,7 @@ argument-hint: "[issue-number or task description]"
 description: Execute the full relay cycle — plan, dispatch, review, merge. Use when implementing a GitHub issue or task through autonomous executor dispatch. Integrates with dev-backlog sprint files.
 compatibility: Requires Claude Code or Codex, gh CLI, git, Node.js 18+.
 metadata:
-  related-skills: "relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog"
+  related-skills: "relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge, relay-sidecar, dev-backlog"
   keywords: "릴레이, 자동 실행, plan, dispatch, review, merge, relay cycle"
 ---
 ## Inputs


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

변경 사항:
- `skills/relay/SKILL.md`의 `metadata.related-skills`에 `relay-sidecar` 추가
- `skills/relay-sidecar/SKILL.md`에 ADVISORY AUXILIARY 상태 명시
- sidecar가 필수 `plan → dispatch → review → merge` 라이프사이클이 아니며, `/relay` 필수 단계가 아니라고 명확화
- sidecar 출력은 advisory only이고 실행 증거나 reviewer proof가 될 수 없다는 trust boundary 강화
- `references/install-graph.md`는 이미 충분해 변경하지 않음

검증:
- `node --test tests/skills-lint/scripts/skills-lint.test.js` 통과
- `skills/relay/SKILL.md`: 136줄
- `skills/relay-sidecar/SKILL.md`: 
```

## Score Log

- Run: issue-491-20260520114716370-fb4792fb
- Executor: codex
- Branch: issue-491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * relay-sidecar 스킬 문서의 호환성 설명 정리 및 개선
  * relay-sidecar가 선택적 보조 스킬이며 필수 라이프사이클의 일부가 아님을 명시
  * 신뢰 모델 정책 기준 문서 참조로 업데이트
  * relay 스킬과의 연계 정보 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->