### PR TITLE
Reword relay-review quality inspection contract

### DIFF
--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -111,9 +111,9 @@ Two phases, run in order. Each round re-measures against the **original anchor**
 
 ### Phase 2: Code Quality (only after Phase 1 PASS)
 
-8. Run a code review skill on changed files — check code quality, patterns, conventions, structural issues (use the platform's best-matching skill, e.g., Claude Code: `/review`; if no skill is available, perform the quality review inline inside the structured reviewer round)
-9. Run a code simplification skill on changed files — unnecessary complexity, dead code, verbose patterns (use the platform's best-matching skill, e.g., Claude Code: `/simplify`; if no skill is available, review for simplification inline before returning `verdict=pass`)
-10. Issues found → return `verdict=changes_requested`, then follow the `phase2_fail` back-edge: re-dispatch and restart at Phase 1 because quality fixes can regress spec compliance.
+8. Inspect changed files inline for code quality, patterns, conventions, and structural issues. Adapter-managed reviewers (Codex, Claude, opencode advisory) return findings in the structured verdict; fallback/manual reviewers follow the same contract. Manual or supported environments MAY use helpers such as Claude Code `/review`, but helper availability is optional.
+9. Inspect changed files inline for simplification opportunities: unnecessary complexity, dead code, verbose patterns, and hard-to-review structure. Manual or supported environments MAY use helpers such as `/simplify`; simplification findings are merge-blocking only when they affect maintainability, correctness risk, or reviewability, not style nits.
+10. The structured verdict is the single Phase 2 gating output. No reviewer blocks or fails merely because an external skill command is unavailable. Issues found → return `verdict=changes_requested`, then follow the `phase2_fail` back-edge: re-dispatch and restart at Phase 1 because quality fixes can regress spec compliance.
 
 ### Drift and stuck detection (both phases)
 


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

변경 사항:
- [skills/relay-review/SKILL.md](/Users/sjlee/.relay/worktrees/dcd35f71/dev-relay/skills/relay-review/SKILL.md:114)의 Phase 2 prose만 수정
- `/review`, `/simplify`는 optional helper로만 표현
- structured verdict가 유일한 gating output임을 명시
- simplification block 기준을 maintainability, correctness risk, reviewability로 제한
- 파일은 146라인 유지

검증:
- `node --test tests/skills-lint/scripts/skills-lint.test.js` 통과
- `git diff --check` 통과
- 변경 파일은 `skills/relay-review/SKILL.md` 하나뿐

커밋:
- `4299e56 Reword r
```

## Score Log

- Run: issue-490-20260520114715509-3f3d6b56
- Executor: codex
- Branch: issue-490