### PR TITLE
fix: tolerate relay-owned rubric cleanup stray

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -11,6 +11,10 @@ const CLEANUP_STATUSES = Object.freeze({
   SKIPPED: "skipped",
 });
 
+const RELAY_OWNED_STRAY_WORKTREE_STATUS_LINES = Object.freeze([
+  "?? rubric.yaml",
+]);
+
 function createCleanupSkeleton() {
   return {
     status: CLEANUP_STATUSES.PENDING,
@@ -70,6 +74,11 @@ function readWorktreeStatus(worktreePath) {
   }
 }
 
+function hasOnlyRelayOwnedStrayStatus(text) {
+  const lines = String(text || "").split(/\r?\n/).filter(Boolean);
+  return lines.length === 1 && RELAY_OWNED_STRAY_WORKTREE_STATUS_LINES.includes(lines[0]);
+}
+
 function isRealpathContainedWithin(basePath, candidatePath) {
   try {
     const realBase = fs.realpathSync.native(basePath);
@@ -123,6 +132,9 @@ function runCleanup({
   const allowPrunedRelayWorktreeRemoval = acceptPrunedRelayOwned
     && validatedPaths.prunedRelayOwnedForCleanup
     && validatedPaths.worktreeLocation === "relay_worktree";
+  const allowRelayOwnedStrayRemoval = worktreeStatus.exists
+    && !worktreeStatus.clean
+    && hasOnlyRelayOwnedStrayStatus(worktreeStatus.text);
   const branchExistsBefore = localBranchExists(repoRoot, branch);
   const errors = [];
 
@@ -130,7 +142,12 @@ function runCleanup({
   let branchDeleted = !deleteMergedBranch || !branch || !branchExistsBefore;
   let pruneRan = false;
 
-  if (worktreeStatus.exists && !worktreeStatus.clean && !allowPrunedRelayWorktreeRemoval) {
+  if (
+    worktreeStatus.exists
+    && !worktreeStatus.clean
+    && !allowPrunedRelayWorktreeRemoval
+    && !allowRelayOwnedStrayRemoval
+  ) {
     errors.push(`dirty worktree: ${worktreeStatus.text}`);
   }
 
@@ -212,7 +229,10 @@ function runCleanup({
       worktreePath,
       worktreeExistsBefore: worktreeStatus.exists,
       worktreeRemoved,
-      worktreeDirty: worktreeStatus.exists && !worktreeStatus.clean && !allowPrunedRelayWorktreeRemoval,
+      worktreeDirty: worktreeStatus.exists
+        && !worktreeStatus.clean
+        && !allowPrunedRelayWorktreeRemoval
+        && !allowRelayOwnedStrayRemoval,
       worktreeStatus: worktreeStatus.text || null,
       branch,
       branchExistedBefore: branchExistsBefore,

--- a/tests/relay-dispatch/scripts/cleanup-stray-rubric.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-stray-rubric.test.js
@@ -1,0 +1,164 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  CLEANUP_STATUSES,
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  runCleanup,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" });
+}
+
+function setupRun() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-cleanup-rubric-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  git(repoRoot, ["init", "-b", "main"]);
+  git(repoRoot, ["config", "user.name", "Relay Cleanup Test"]);
+  git(repoRoot, ["config", "user.email", "relay-cleanup@example.com"]);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  git(repoRoot, ["add", "README.md"]);
+  git(repoRoot, ["commit", "-m", "init"]);
+
+  const branch = "issue-502";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  git(repoRoot, ["worktree", "add", worktreePath, "-b", branch]);
+
+  const runId = createRunId({
+    branch,
+    timestamp: new Date("2026-05-20T00:00:00.000Z"),
+  });
+  const data = {
+    ...createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch,
+      baseBranch: "main",
+      issueNumber: 502,
+      worktreePath,
+      orchestrator: "codex",
+      executor: "codex",
+      reviewer: "codex",
+    }),
+    state: STATES.MERGED,
+    next_action: "cleanup",
+  };
+
+  return { repoRoot, worktreePath, data };
+}
+
+function cleanupResultFor(changeWorktree) {
+  const { repoRoot, worktreePath, data } = setupRun();
+  changeWorktree(worktreePath);
+  return {
+    repoRoot,
+    worktreePath,
+    result: runCleanup({ repoRoot, data }),
+  };
+}
+
+function assertDirtyCleanup(result, worktreePath, expectedPattern, message) {
+  assert.equal(result.updatedData.cleanup.status, CLEANUP_STATUSES.FAILED, message);
+  assert.equal(result.updatedData.next_action, "manual_cleanup_required", message);
+  assert.match(result.updatedData.cleanup.error, /dirty worktree/, message);
+  assert.match(result.updatedData.cleanup.error, expectedPattern, message);
+  assert.equal(result.summary.worktreeDirty, true, message);
+  assert.equal(fs.existsSync(worktreePath), true, message);
+}
+
+test("runCleanup removes a worktree whose only uncommitted content is untracked root rubric.yaml", () => {
+  const { worktreePath, result } = cleanupResultFor((worktree) => {
+    fs.writeFileSync(path.join(worktree, "rubric.yaml"), "rubric:\n", "utf-8");
+  });
+
+  assert.equal(result.updatedData.cleanup.status, CLEANUP_STATUSES.SUCCEEDED);
+  assert.equal(result.updatedData.next_action, "done");
+  assert.equal(result.updatedData.cleanup.worktree_removed, true);
+  assert.equal(result.updatedData.cleanup.error, null);
+  assert.equal(result.summary.worktreeDirty, false);
+  assert.equal(fs.existsSync(worktreePath), false);
+});
+
+test("runCleanup still blocks cleanup when a tracked file is modified", () => {
+  const { worktreePath, result } = cleanupResultFor((worktree) => {
+    fs.writeFileSync(path.join(worktree, "README.md"), "changed\n", "utf-8");
+  });
+
+  assertDirtyCleanup(result, worktreePath, /README\.md/);
+});
+
+test("runCleanup still blocks cleanup when an untracked file is not root rubric.yaml", () => {
+  const { worktreePath, result } = cleanupResultFor((worktree) => {
+    fs.writeFileSync(path.join(worktree, "other.txt"), "leftover\n", "utf-8");
+  });
+
+  assertDirtyCleanup(result, worktreePath, /\?\? other\.txt/);
+});
+
+test("runCleanup still blocks cleanup when root rubric.yaml is not the only uncommitted content", () => {
+  const { worktreePath, result } = cleanupResultFor((worktree) => {
+    fs.writeFileSync(path.join(worktree, "rubric.yaml"), "rubric:\n", "utf-8");
+    fs.writeFileSync(path.join(worktree, "other.txt"), "leftover\n", "utf-8");
+  });
+
+  assertDirtyCleanup(result, worktreePath, /\?\? other\.txt/);
+});
+
+test("runCleanup does not treat rubric.yaml substrings or nested paths as relay-owned strays", () => {
+  const cases = [
+    {
+      name: "nested rubric",
+      mutate(worktree) {
+        fs.mkdirSync(path.join(worktree, "skills"), { recursive: true });
+        fs.writeFileSync(path.join(worktree, "skills", "rubric.yaml"), "nested\n", "utf-8");
+      },
+      pattern: /\?\? skills\/rubric\.yaml/,
+    },
+    {
+      name: "backup file",
+      mutate(worktree) {
+        fs.writeFileSync(path.join(worktree, "rubric.yaml.bak"), "backup\n", "utf-8");
+      },
+      pattern: /\?\? rubric\.yaml\.bak/,
+    },
+    {
+      name: "subdirectory rubric",
+      mutate(worktree) {
+        fs.mkdirSync(path.join(worktree, "sub"), { recursive: true });
+        fs.writeFileSync(path.join(worktree, "sub", "rubric.yaml"), "nested\n", "utf-8");
+      },
+      pattern: /\?\? sub\/rubric\.yaml/,
+    },
+    {
+      name: "tracked rubric modification",
+      mutate(worktree) {
+        fs.writeFileSync(path.join(worktree, "rubric.yaml"), "tracked\n", "utf-8");
+        git(worktree, ["add", "rubric.yaml"]);
+        git(worktree, ["commit", "-m", "track rubric"]);
+        fs.writeFileSync(path.join(worktree, "rubric.yaml"), "modified\n", "utf-8");
+      },
+      pattern: /rubric\.yaml/,
+    },
+    {
+      name: "staged rubric",
+      mutate(worktree) {
+        fs.writeFileSync(path.join(worktree, "rubric.yaml"), "staged\n", "utf-8");
+        git(worktree, ["add", "rubric.yaml"]);
+      },
+      pattern: /rubric\.yaml/,
+    },
+  ];
+
+  for (const entry of cases) {
+    const { worktreePath, result } = cleanupResultFor(entry.mutate);
+    assertDirtyCleanup(result, worktreePath, entry.pattern, entry.name);
+  }
+});


### PR DESCRIPTION
## Dispatch Summary

```text
수정 완료했고 커밋까지 만들었습니다.

커밋: `29fff625af14e531f93e88dcd9ca0ae8bb0d849b`  
메시지: `fix: tolerate relay-owned rubric cleanup stray`

변경:
- `runCleanup`이 `git status --short --untracked-files=all` 결과가 정확히 한 줄 `?? rubric.yaml`일 때만 dirty gate를 통과하도록 제한
- 그 외 수정/스테이징/다른 untracked/nested/substr 경로는 계속 cleanup 차단
- 새 테스트 추가: `tests/relay-dispatch/scripts/cleanup-stray-rubric.test.js`

검증:
- `node --test tests/relay-dispatch/scripts/cleanup-stray-rubric.test.js` 통과
- `node --test tests/relay-dispatch/scripts/
```

### Trust-model audit

The dirty-worktree gate in `runCleanup` is a fail-closed safety check: it refuses to force-remove a worktree that still holds unsaved work. This change **narrows** that gate, and the narrowing is provably exact:

- **Exactly one tolerated artifact.** Tolerance fires only via `hasOnlyRelayOwnedStrayStatus(text)`, which splits the full `git status --short --untracked-files=all` output, drops blank lines, and requires `lines.length === 1` AND that the single line is a member of the `RELAY_OWNED_STRAY_WORKTREE_STATUS_LINES` allowlist. The allowlist contains exactly one entry: `?? rubric.yaml`. Any second status line (modified tracked file, staged change, other untracked path) makes `lines.length !== 1`, so the ONLY-content condition fails and the worktree stays dirty.
- **Exact porcelain-line match, not substring.** The check is `Array.includes(line)` against the frozen allowlist — full-string equality on the parsed porcelain line `?? rubric.yaml`. It is not a `String.includes`/regex/`endsWith` test, so `?? rubric.yaml.bak`, `?? skills/rubric.yaml`, and `?? sub/rubric.yaml` do not match. The status code prefix is part of the compared string, so `M rubric.yaml` (tracked modification) and a staged `A  rubric.yaml` also do not match.
- **Worktree-root scoping enforced.** `git status --short` reports paths relative to the worktree root, so the allowlist entry `?? rubric.yaml` only equals a root-level untracked `rubric.yaml`. Any nested path produces a different porcelain string (`?? sub/rubric.yaml`) and is rejected.
- **Hardcoded trust root.** `RELAY_OWNED_STRAY_WORKTREE_STATUS_LINES` is an `Object.freeze`d constant literal in `cleanup.js`. It is not configurable, not read from the manifest, and not derived from any external input.
- **Fail-closed default preserved.** The dirty-worktree error and `worktreeDirty` summary flag are still raised for every state except the single known relay-owned stray; both the error push and the `summary.worktreeDirty` computation gain only `&& !allowRelayOwnedStrayRemoval`. Any unknown or mixed dirty state still blocks worktree removal exactly as before.

## Score Log

- Run: issue-502-20260520141635927-0d432f07
- Executor: codex
- Branch: issue-502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * Worktree 정리 로직 최적화

* **테스트**
  * Worktree 정리 동작에 대한 테스트 커버리지 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
