### PR TITLE
Document relay-review rubric resolution

### DIFF
--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -102,6 +102,7 @@ Two phases, run in order. Each round re-measures against the **original anchor**
    - **Security**: Auth/token handling, input validation, injection risks?
 
 6. **Rubric verification** (when Score Log present):
+   - Do not copy `rubric.yaml` or run artifacts into the worktree; runner rubric resolution is run-dir-relative by design (see `references/runner-notes.md`)
    - The reviewer evaluates `quality_review_status` by inspection; the runner independently verifies `quality_execution_status` via a SHA-bound execution-evidence artifact. The reviewer cannot execute code, so quality evidence comes from two trust roots.
    - Re-score ALL evaluated quality factors with fresh eyes (0-10) and include numeric `score` / `target_score`; contract factors stay pass/fail and may use `null` numeric fields
    - Any required factor below target → issue

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -19,6 +19,8 @@ When it must infer a GitHub issue, it tries:
 
 It ignores `Refs`, `Related`, and incidental issue prose. Multiple inferred closing refs fail instead of silently selecting one.
 
+Rubric resolution is run-dir-native. `review-runner.js` calls `loadRubricFromRunDir(runDir, data)`, which resolves `anchor.rubric_path` relative to the run directory and reads the rubric directly from there. Reviewers must not copy `rubric.yaml` or any other run artifact into the worktree; if `rubricStatus` looks unsatisfied, investigate run-directory path resolution instead of working around it with a worktree copy.
+
 ## Generated Artifacts
 
 Prepared or invoked rounds write artifacts under `~/.relay/runs/<repo-slug>/<run-id>/`:


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

변경 사항:
- [runner-notes.md](/Users/sjlee/.relay/worktrees/dad2a2e4/dev-relay/skills/relay-review/references/runner-notes.md:22)에 `review-runner.js`가 `loadRubricFromRunDir(runDir, data)`로 run dir 기준 `anchor.rubric_path`를 해석한다는 설명을 추가했습니다.
- [SKILL.md](/Users/sjlee/.relay/worktrees/dad2a2e4/dev-relay/skills/relay-review/SKILL.md:105)에 `rubric.yaml` 또는 run artifact를 worktree로 복사하지 말라는 포인터를 추가했습니다.
- `SKILL.md`는 147라인으로 150라인 제한 내입니다.

검증:
- `node --test tests/skills-lint/scripts/skills-lint
```

## Score Log

- Run: issue-506-20260520230536784-2ceffddf
- Executor: codex
- Branch: issue-506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서 업데이트

* **문서**
  * Rubric 검증 지침을 업데이트하여 run artifacts를 작업 트리로 복사하면 안 된다는 제약을 명확히 함
  * Rubric 해석이 run 디렉토리 기반으로 동작하며 직접 로드되는 방식을 상세히 설명
  * Rubric 상태 문제 발생 시 작업 트리 복사 대신 run 디렉토리 경로 해석을 검증하도록 안내

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->