### PR TITLE
Default codex auto recover commit on dispatch

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -54,6 +54,7 @@ const FLAGS = [
   { flag: "--next-action", kind: VALUE, mode: MODE_VERBATIM, valueName: "<name>", rationale: "Operator-supplied manifest text; keep the literal argv token." },
   { flag: "--no-cleanup", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--no-comment", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--no-auto-recover-commit", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit dispatch opt-out from codex default recover-commit after completed-uncommitted; no value is consumed." },
   { flag: "--no-issue-close", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--older-than", kind: VALUE, mode: MODE_PARSED, valueName: "<hours>", rationale: "Numeric threshold; flag-like following tokens should mean the value is missing." },
   { flag: "--out-dir", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied output directory path; keep the literal argv token." },
@@ -122,7 +123,7 @@ const COMMAND_FLAGS = {
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
     "--model", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
     "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
-    "--fleet-id", "--done-criteria-file", "--register", "--no-cleanup", "--auto-recover-commit",
+    "--fleet-id", "--done-criteria-file", "--register", "--no-cleanup", "--auto-recover-commit", "--no-auto-recover-commit",
     "--allow-conflicting-run", "--dry-run", "--json", "--help",
   ],
   "finalize-run": [

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -33,7 +33,8 @@
  *   --done-criteria-file   Persist a frozen Done Criteria anchor path
  *   --register             Register session in executor's app (keeps worktree)
  *   --no-cleanup           Compatibility alias; worktree is retained by default
- *   --auto-recover-commit  Opt-in: run recover-commit after completed-uncommitted (default: off)
+ *   --auto-recover-commit  Run recover-commit after completed-uncommitted (default: on for codex, off otherwise)
+ *   --no-auto-recover-commit  Opt out of codex default auto recover-commit
  *   --dry-run              Show plan without executing
  *   --json                 Output as JSON
  *
@@ -130,7 +131,7 @@ const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
   "--model", "-m", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
   "--request-id", "--leaf-id", "--fleet-id", "--done-criteria-file",
-  "--register", "--no-cleanup", "--auto-recover-commit", "--allow-conflicting-run", "--dry-run", "--json", "--help", "-h",
+  "--register", "--no-cleanup", "--auto-recover-commit", "--no-auto-recover-commit", "--allow-conflicting-run", "--dry-run", "--json", "--help", "-h",
 ];
 const CLI_ARG_OPTIONS = { commandName: "dispatch", reservedFlags: KNOWN_FLAGS };
 const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
@@ -163,7 +164,8 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --done-criteria-file  ${modeLabel("--done-criteria-file")} Persist a frozen Done Criteria anchor path`);
   console.log(`  --register         ${modeLabel("--register")} Register session in executor's app (keeps worktree)`);
   console.log(`  --no-cleanup       ${modeLabel("--no-cleanup")} Compatibility alias; worktree is retained by default`);
-  console.log(`  --auto-recover-commit  ${modeLabel("--auto-recover-commit")} Opt-in: run recover-commit after completed-uncommitted (default: off)`);
+  console.log(`  --auto-recover-commit  ${modeLabel("--auto-recover-commit")} Run recover-commit after completed-uncommitted (default: on for codex, off otherwise)`);
+  console.log(`  --no-auto-recover-commit  ${modeLabel("--no-auto-recover-commit")} Opt out of codex default auto recover-commit`);
   console.log(`  --allow-conflicting-run  ${modeLabel("--allow-conflicting-run")} Bypass the in-flight run check (logs conflicting_run_override event)`);
   console.log(`  --dry-run          ${modeLabel("--dry-run")} Show plan without executing`);
   console.log(`  --json             ${modeLabel("--json")} Output as JSON`);
@@ -256,11 +258,22 @@ try {
 
 const REGISTER = hasCliFlag("--register");
 const NO_CLEANUP = hasCliFlag("--no-cleanup");
-const AUTO_RECOVER_COMMIT = hasCliFlag("--auto-recover-commit");
+const AUTO_RECOVER_COMMIT_REQUESTED = hasCliFlag("--auto-recover-commit");
+const NO_AUTO_RECOVER_COMMIT = hasCliFlag("--no-auto-recover-commit");
+const AUTO_RECOVER_COMMIT = AUTO_RECOVER_COMMIT_REQUESTED
+  ? true
+  : NO_AUTO_RECOVER_COMMIT
+    ? false
+    : EXECUTOR === "codex";
 const ALLOW_CONFLICTING_RUN = hasCliFlag("--allow-conflicting-run");
 const DRY_RUN = hasCliFlag("--dry-run");
 const JSON_OUT = hasCliFlag("--json");
 const RESUME_MODE = !!MANIFEST_INPUT || (!!RUN_ID && !BRANCH);
+
+if (AUTO_RECOVER_COMMIT_REQUESTED && NO_AUTO_RECOVER_COMMIT) {
+  console.error("Error: use either --auto-recover-commit or --no-auto-recover-commit, not both");
+  process.exit(1);
+}
 
 if (FLEET_ID) {
   try {
@@ -1352,7 +1365,7 @@ async function main() {
 
   if (AUTO_RECOVER_COMMIT && status === "completed-uncommitted" && !DRY_RUN) {
     const recoverCommitPath = path.join(__dirname, "recover-commit.js");
-    const reason = `auto-recovered after dispatch returned completed-uncommitted with --auto-recover-commit set (run ${runId})`;
+    const reason = `auto-recovered after dispatch returned completed-uncommitted with auto-recover-commit enabled (run ${runId})`;
     try {
       const recoveryOutput = execFileSync(process.execPath, [
         recoverCommitPath,

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -350,6 +350,28 @@ fs.writeFileSync(output, "work completed without commit\\n", "utf-8");
   return codexPath;
 }
 
+function writeUncommittedClaude(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const claudePath = path.join(binDir, "claude");
+  fs.writeFileSync(claudePath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("claude-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "-p") {
+  process.stderr.write("unsupported fake claude invocation");
+  process.exit(1);
+}
+const cwd = process.cwd();
+fs.appendFileSync(cwd + "/README.md", "dirty\\n", "utf-8");
+process.stdout.write("work completed without commit\\n");
+`, "utf-8");
+  fs.chmodSync(claudePath, 0o755);
+  return claudePath;
+}
+
 function writePartialNoResultCodex(binDir) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -503,10 +525,14 @@ function createExecFileMock({
   return { execFile, calls };
 }
 
-function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, codexMode = "commit" }) {
+function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, codexMode = "commit", executor = "codex" }) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-push-pr-"));
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-push-pr-bin-"));
-  if (codexMode === "noop") {
+  if (executor === "claude" && codexMode === "uncommitted") {
+    writeUncommittedClaude(binDir);
+  } else if (executor === "claude") {
+    writeFakeClaude(binDir);
+  } else if (codexMode === "noop") {
     writeNoOpCodex(binDir);
   } else if (codexMode === "silent") {
     writeSilentCodex(binDir);
@@ -3040,19 +3066,58 @@ test("dispatch marks verified no-op runs as completed-no-op and skips orchestrat
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 
-test("dispatch marks uncommitted result runs as completed-uncommitted and skips orchestrator publication", () => {
+test("dispatch auto-recovers uncommitted codex runs by default", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
+  process.env.RELAY_HOME = relayHome;
   const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
     relayHome,
     ghState: {
-      prCreateUrl: "https://github.com/acme/dev-relay/pull/326",
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/508",
     },
     codexMode: "uncommitted",
   });
 
   const result = JSON.parse(runDispatch(repoRoot, [
-    "-b", "issue-263-uncommitted",
+    "-b", "issue-508-codex-default-auto-recover",
     "--prompt", "work without commit",
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed-uncommitted");
+  assert.equal(result.commitMode, "auto-recovered");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.equal(result.prNumber, 508);
+  assert.match(result.commits, /Recover relay run/);
+  assert.equal(result.uncommitted, null);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.git.pr_number, 508);
+  assert.equal(manifest.git.head_sha, result.headSha);
+  const ghCalls = readJsonLines(ghLogPath);
+  assert(ghCalls.some((args) => args[0] === "pr" && args[1] === "create"));
+  assert(readJsonLines(execLogPath).some(({ command, args }) => command === "git" && args.includes("push")));
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+  const events = readJsonLines(getEventsPath(repoRoot, result.runId));
+  const recoveryEvent = events.find((event) => event.event === "recover_commit");
+  assert(recoveryEvent, JSON.stringify(events, null, 2));
+  assert.match(recoveryEvent.reason, /auto-recover-commit enabled/);
+});
+
+test("dispatch leaves uncommitted non-codex runs unrecovered by default", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/509",
+    },
+    codexMode: "uncommitted",
+    executor: "claude",
+  });
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-508-claude-default-no-recover",
+    "--prompt", "work without commit",
+    "--executor", "claude",
     "--json",
   ], env));
 
@@ -3068,7 +3133,7 @@ test("dispatch marks uncommitted result runs as completed-uncommitted and skips 
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 
-test("dispatch --auto-recover-commit reports auto-recovered commitMode for completed-uncommitted runs (#393)", () => {
+test("dispatch --auto-recover-commit enables recovery for non-codex completed-uncommitted runs (#393)", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
   process.env.RELAY_HOME = relayHome;
   const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
@@ -3077,11 +3142,13 @@ test("dispatch --auto-recover-commit reports auto-recovered commitMode for compl
       prCreateUrl: "https://github.com/acme/dev-relay/pull/393",
     },
     codexMode: "uncommitted",
+    executor: "claude",
   });
 
   const result = JSON.parse(runDispatch(repoRoot, [
-    "-b", "issue-393-auto-recover",
+    "-b", "issue-393-non-codex-auto-recover",
     "--prompt", "work without commit, then auto recover",
+    "--executor", "claude",
     "--auto-recover-commit",
     "--json",
   ], env));
@@ -3103,7 +3170,36 @@ test("dispatch --auto-recover-commit reports auto-recovered commitMode for compl
   const events = readJsonLines(getEventsPath(repoRoot, result.runId));
   const recoveryEvent = events.find((event) => event.event === "recover_commit");
   assert(recoveryEvent, JSON.stringify(events, null, 2));
-  assert.match(recoveryEvent.reason, /--auto-recover-commit set/);
+  assert.match(recoveryEvent.reason, /auto-recover-commit enabled/);
+});
+
+test("dispatch --no-auto-recover-commit disables codex default recovery", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/510",
+    },
+    codexMode: "uncommitted",
+  });
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-508-codex-no-auto-recover",
+    "--prompt", "work without commit",
+    "--no-auto-recover-commit",
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed-uncommitted");
+  assert.equal(result.commitMode, "completed-uncommitted, recover-commit required");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.equal(result.commits, "");
+  assert.match(result.uncommitted, /README\.md/);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 
 test("dispatch uses result-file presence to distinguish silent failure from verified no-op", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 남겼습니다.

커밋: `0c1fff4` (`Default codex auto recover commit on dispatch`)

변경 사항:
- [dispatch.js](/Users/sjlee/.relay/worktrees/50a7bd79/dev-relay/skills/relay-dispatch/scripts/dispatch.js:130): `--no-auto-recover-commit`를 `KNOWN_FLAGS`와 help에 추가
- [dispatch.js](/Users/sjlee/.relay/worktrees/50a7bd79/dev-relay/skills/relay-dispatch/scripts/dispatch.js:261): `codex`는 기본 ON, non-codex는 기본 OFF, 명시 플래그가 기본값을 override하도록 처리
- [cli-schema.js](/Users/sjlee/.relay/worktrees/50a7bd79/dev-relay
```

## Score Log

- Run: issue-508-20260521114330994-342b8687
- Executor: codex
- Branch: issue-508-auto-recover-codex-default