### PR TITLE
feat(relay-merge): append-learnings.js + post-merge hook (#515)

### DIFF
--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 ## Inputs
 - Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; examples use `PR_NUM` and `RUN_ID`.
 - Files: reviewed PR, retained run manifest/worktree, optional sprint file, and follow-up issue text.
-- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/gate-check.js`, `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/finalize-run.js`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/gate-check.js`, `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/finalize-run.js`, `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/append-learnings.js` (invoked from finalize-run post-merge; structurally bounded writer for target repo's `spec/capabilities.md`).
 
 # Relay Merge
 
@@ -69,6 +69,8 @@ This script:
 - records `cleanup.status` in the manifest
 
 If the retained worktree is dirty, merge still succeeds but cleanup is recorded as `failed` and the manifest moves to `next_action=manual_cleanup_required`.
+
+After the merge state advances to `MERGED` (and before cleanup runs), `finalize-run.js` invokes `append-learnings.js` to write a one-line entry into the matching capability's `## Learnings` block in the target repo's `spec/capabilities.md`. The script is the only writer for that section (anti-adversarial-Goodhart structural defense — see dev-backlog spec-system v0.1 design doc). It no-ops gracefully when `spec/capabilities.md` is absent, the active sprint has no `component:`, or the component does not resolve. Any failure is recorded under `result.learnings` and does not block cleanup.
 
 Emergency, force-finalize, and bootstrap reconciliation paths: see [`references/operator-emergencies.md`](references/operator-emergencies.md).
 

--- a/skills/relay-merge/scripts/append-learnings.js
+++ b/skills/relay-merge/scripts/append-learnings.js
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Append a one-line entry to the matching capability's `## Learnings` block
+ * in <target-repo>/spec/capabilities.md after a successful relay-merge.
+ *
+ * Structurally bounded: this script is the only writer for `## Learnings`,
+ * inserts only between `<!-- LEARN:BEGIN -->` / `<!-- LEARN:END -->` markers,
+ * and refuses to touch any other region. Source: dev-backlog spec-system
+ * v0.1 design doc — anti-adversarial-Goodhart defense.
+ *
+ * Usage:
+ *   ./append-learnings.js --repo <path> --run-id <id> --pr <number> [--synthesis "<one-line>"] [--date YYYY-MM-DD] [--dry-run] [--json]
+ *
+ * Resolution flow:
+ *   1. Find the active sprint file (status: active) under <repo>/backlog/sprints/
+ *   2. Read its `component:` frontmatter; multi-component is comma-separated;
+ *      first declared wins per design doc D4 (and a warn is emitted).
+ *   3. Locate <repo>/spec/capabilities.md and the matching `## Capability: <name>`
+ *      block; require its LEARN:BEGIN/LEARN:END marker pair to be intact.
+ *   4. If no entry already exists for run-id (`run #<id>` substring), append a
+ *      new line in schema-bound format inside the markers.
+ *
+ * Graceful no-ops (status: skipped, exit 0):
+ *   - spec/capabilities.md missing
+ *   - active sprint missing or has no component:
+ *   - component does not match any declared capability
+ *   - entry for this run-id already present (idempotent)
+ *
+ * Loud failures (status: failed, exit 1):
+ *   - markers missing or out of order in the matching block (tampering)
+ *   - malformed inputs
+ *
+ * Designed to be invoked from finalize-run.js; failure must not block merge
+ * cleanup. The caller treats a non-zero exit as a warning, not a fatal error.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const STATUS = Object.freeze({
+  APPENDED: "appended",
+  SKIPPED: "skipped",
+  FAILED: "failed",
+});
+
+const MARKER_BEGIN = "<!-- LEARN:BEGIN -->";
+const MARKER_END = "<!-- LEARN:END -->";
+
+function usage() {
+  return "Usage: append-learnings.js --repo <path> --run-id <id> --pr <number> [--synthesis TEXT] [--date YYYY-MM-DD] [--dry-run] [--json]";
+}
+
+function parseArgs(args) {
+  const options = {
+    repo: null,
+    runId: null,
+    pr: null,
+    synthesis: null,
+    date: null,
+    dryRun: false,
+    json: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") { options.dryRun = true; continue; }
+    if (arg === "--json")    { options.json = true;   continue; }
+    if (arg === "--help" || arg === "-h") return { ...options, help: true };
+
+    const pair = (flag, key) => {
+      if (arg === flag) {
+        const next = args[i + 1];
+        if (!next) return `Missing value for ${flag}. ${usage()}`;
+        options[key] = next; i += 1; return null;
+      }
+      const equalsPrefix = `${flag}=`;
+      if (arg.startsWith(equalsPrefix)) {
+        options[key] = arg.slice(equalsPrefix.length); return null;
+      }
+      return false;
+    };
+
+    const handlers = [
+      ["--repo", "repo"], ["--run-id", "runId"], ["--pr", "pr"],
+      ["--synthesis", "synthesis"], ["--date", "date"],
+    ];
+    let handled = false;
+    let err = null;
+    for (const [flag, key] of handlers) {
+      const result = pair(flag, key);
+      if (result === null) { handled = true; break; }
+      if (typeof result === "string") { err = result; handled = true; break; }
+    }
+    if (err) return { ...options, error: err };
+    if (handled) continue;
+
+    return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+  }
+
+  if (!options.help) {
+    if (!options.repo)  return { ...options, error: `Missing --repo. ${usage()}` };
+    if (!options.runId) return { ...options, error: `Missing --run-id. ${usage()}` };
+    if (!options.pr)    return { ...options, error: `Missing --pr. ${usage()}` };
+  }
+  return options;
+}
+
+function parseFrontmatter(content) {
+  if (!content.startsWith("---\n")) return null;
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return null;
+  return content.slice(4, end);
+}
+
+function readFrontmatterField(fm, field) {
+  if (!fm) return null;
+  const match = fm.match(new RegExp(`^${field}:\\s*(.*)$`, "m"));
+  if (!match) return null;
+  let raw = match[1].trim();
+  if (raw.startsWith('"') && raw.endsWith('"')) raw = raw.slice(1, -1);
+  if (raw.startsWith("'") && raw.endsWith("'")) raw = raw.slice(1, -1);
+  return raw;
+}
+
+function parseComponents(fmValue) {
+  if (!fmValue) return [];
+  return fmValue.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function findActiveSprint(sprintsDir, { readdir = fs.readdirSync, readFile = fs.readFileSync, fileExists = fs.existsSync } = {}) {
+  if (!fileExists(sprintsDir)) return null;
+  const files = readdir(sprintsDir)
+    .filter((f) => f.endsWith(".md") && !f.startsWith("_"))
+    .map((f) => path.join(sprintsDir, f));
+  for (const file of files) {
+    const content = readFile(file, "utf-8");
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+    if (/^status:\s*active\s*$/m.test(fm)) return { file, content };
+  }
+  return null;
+}
+
+function findCapabilityBlock(capabilitiesContent, name) {
+  const lines = capabilitiesContent.split("\n");
+  let start = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(/^## Capability:\s+(\S+)/);
+    if (match && match[1] === name) { start = i; break; }
+  }
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^## Capability:\s+/.test(lines[i])) { end = i; break; }
+  }
+  return { start, end, lines };
+}
+
+function locateMarkers(blockLines, blockStart) {
+  let beginIdx = -1;
+  let endIdx = -1;
+  for (let i = 0; i < blockLines.length; i += 1) {
+    const trimmed = blockLines[i].trim();
+    if (trimmed === MARKER_BEGIN) beginIdx = i + blockStart;
+    if (trimmed === MARKER_END)   endIdx   = i + blockStart;
+  }
+  return { beginIdx, endIdx };
+}
+
+function buildEntry({ date, runId, synthesis, pr }) {
+  const dateStr = date || new Date().toISOString().slice(0, 10);
+  const text = (synthesis || "").trim() || `relay-merge of PR #${pr}`;
+  return `- ${dateStr} (run #${runId}): ${text} [PR #${pr}]`;
+}
+
+function buildSkip(reason, extras = {}) {
+  return { status: STATUS.SKIPPED, reason, ...extras };
+}
+
+function buildFailure(reason, extras = {}) {
+  return { status: STATUS.FAILED, reason, ...extras };
+}
+
+function appendLearningsCore({
+  capabilitiesContent,
+  primaryComponent,
+  secondaryComponents,
+  runId,
+  pr,
+  synthesis,
+  date,
+}) {
+  const block = findCapabilityBlock(capabilitiesContent, primaryComponent);
+  if (!block) {
+    return buildSkip("component_not_found", { primaryComponent });
+  }
+
+  const blockLines = block.lines.slice(block.start, block.end);
+  const { beginIdx, endIdx } = locateMarkers(blockLines, block.start);
+
+  if (beginIdx === -1 || endIdx === -1) {
+    return buildFailure("markers_missing", { primaryComponent });
+  }
+  if (endIdx <= beginIdx) {
+    return buildFailure("markers_tampered", { primaryComponent });
+  }
+
+  const newEntry = buildEntry({ date, runId, synthesis, pr });
+  const runMarker = `run #${runId}`;
+  for (let i = beginIdx + 1; i < endIdx; i += 1) {
+    if (block.lines[i].includes(runMarker)) {
+      return buildSkip("idempotent_match", { primaryComponent, runId });
+    }
+  }
+
+  const before = block.lines.slice(0, endIdx);
+  const after = block.lines.slice(endIdx);
+  const updatedLines = [...before, newEntry, ...after];
+
+  const warnings = [];
+  if (secondaryComponents.length > 0) {
+    warnings.push({
+      kind: "secondary_components_ignored",
+      detail: `D4 first-wins: secondary components ${secondaryComponents.join(", ")} were ignored.`,
+    });
+  }
+
+  return {
+    status: STATUS.APPENDED,
+    primaryComponent,
+    entry: newEntry,
+    updatedContent: updatedLines.join("\n"),
+    warnings,
+  };
+}
+
+function appendLearnings({
+  repo,
+  runId,
+  pr,
+  synthesis = null,
+  date = null,
+  dryRun = false,
+  readFile = fs.readFileSync,
+  writeFile = fs.writeFileSync,
+  fileExists = fs.existsSync,
+  readdir = fs.readdirSync,
+} = {}) {
+  const fsDeps = { readFile, writeFile, fileExists, readdir };
+
+  const capabilitiesPath = path.join(repo, "spec", "capabilities.md");
+  if (!fileExists(capabilitiesPath)) {
+    return buildSkip("capabilities_absent", { capabilitiesPath });
+  }
+
+  const sprintsDir = path.join(repo, "backlog", "sprints");
+  const sprint = findActiveSprint(sprintsDir, fsDeps);
+  if (!sprint) return buildSkip("active_sprint_absent", { sprintsDir });
+
+  const fm = parseFrontmatter(sprint.content);
+  const componentRaw = readFrontmatterField(fm, "component");
+  const components = parseComponents(componentRaw);
+  if (components.length === 0) {
+    return buildSkip("component_empty", { sprintFile: sprint.file });
+  }
+
+  const [primaryComponent, ...secondaryComponents] = components;
+  const capabilitiesContent = readFile(capabilitiesPath, "utf-8");
+
+  const coreResult = appendLearningsCore({
+    capabilitiesContent,
+    primaryComponent,
+    secondaryComponents,
+    runId,
+    pr,
+    synthesis,
+    date,
+  });
+
+  const result = { ...coreResult, capabilitiesPath, sprintFile: sprint.file };
+  if (result.status !== STATUS.APPENDED) return result;
+
+  if (!dryRun) {
+    writeFile(capabilitiesPath, result.updatedContent);
+  }
+  delete result.updatedContent;
+  return result;
+}
+
+function formatHumanReport(result) {
+  if (result.status === STATUS.APPENDED) {
+    const lines = [
+      `Appended to ${result.capabilitiesPath} (capability: ${result.primaryComponent}):`,
+      `  ${result.entry}`,
+    ];
+    for (const w of result.warnings || []) lines.push(`  warning: ${w.detail}`);
+    return lines.join("\n");
+  }
+  if (result.status === STATUS.SKIPPED) {
+    return `skipped: ${result.reason}` + (result.primaryComponent ? ` (component: ${result.primaryComponent})` : "");
+  }
+  return `failed: ${result.reason}` + (result.primaryComponent ? ` (component: ${result.primaryComponent})` : "");
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) { console.error(parsed.error); process.exit(1); }
+  if (parsed.help) { console.log(usage()); return; }
+
+  const result = appendLearnings(parsed);
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatHumanReport(result));
+  }
+
+  if (result.status === STATUS.FAILED) process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  STATUS,
+  MARKER_BEGIN,
+  MARKER_END,
+  parseArgs,
+  parseFrontmatter,
+  readFrontmatterField,
+  parseComponents,
+  findActiveSprint,
+  findCapabilityBlock,
+  locateMarkers,
+  buildEntry,
+  appendLearningsCore,
+  appendLearnings,
+  formatHumanReport,
+};

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -61,6 +61,7 @@ const {
   evaluateReviewGate,
   summarizeRubricAuditForSkip,
 } = require("./review-gate");
+const { appendLearnings } = require("./append-learnings");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
@@ -542,6 +543,20 @@ function main() {
     }
   }
 
+  let learningsResult = null;
+  if (updated.state === STATES.MERGED && !dryRun) {
+    try {
+      learningsResult = appendLearnings({
+        repo: repoPath,
+        runId: updated.run_id,
+        pr: String(prNumber),
+        synthesis: updated.issue?.title || null,
+      });
+    } catch (error) {
+      learningsResult = { status: "failed", reason: "exception", message: summarizeFailure(error) };
+    }
+  }
+
   const cleanupResult = runCleanup({
     repoRoot: repoPath,
     data: updated,
@@ -586,6 +601,7 @@ function main() {
     issueClosed,
     issueCloseWarning,
     cleanup: cleanupResult.summary,
+    learnings: learningsResult,
     dryRun,
     forceFinalized: forceFinalizeNonready,
     forceFinalizeReason: forceFinalizeNonready ? forceFinalizeReason : null,

--- a/tests/relay-merge/scripts/append-learnings.test.js
+++ b/tests/relay-merge/scripts/append-learnings.test.js
@@ -1,0 +1,420 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATUS,
+  parseArgs,
+  parseFrontmatter,
+  readFrontmatterField,
+  parseComponents,
+  findActiveSprint,
+  findCapabilityBlock,
+  locateMarkers,
+  buildEntry,
+  appendLearningsCore,
+  appendLearnings,
+  formatHumanReport,
+} = require("../../../skills/relay-merge/scripts/append-learnings.js");
+
+const SAMPLE_CAPABILITIES = `# Project Capabilities
+
+## Capability: auth
+**Goal:** something
+
+### Learnings
+<!-- LEARN:BEGIN -->
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |
+
+---
+
+## Capability: billing
+**Goal:** something else
+
+### Learnings
+<!-- LEARN:BEGIN -->
+- 2026-04-01 (run #001): seed entry [PR #1]
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |
+`;
+
+function makeRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "append-learnings-"));
+}
+
+function seedFixture(repo, { activeComponent = "auth", capabilities = SAMPLE_CAPABILITIES, sprintExtras = "" } = {}) {
+  fs.mkdirSync(path.join(repo, "spec"), { recursive: true });
+  fs.mkdirSync(path.join(repo, "backlog", "sprints"), { recursive: true });
+  fs.writeFileSync(path.join(repo, "spec", "capabilities.md"), capabilities);
+  const sprintBody = `---
+milestone: x
+status: active
+started: 2026-05-23
+due: TBD
+objectives: []
+component: "${activeComponent}"
+${sprintExtras}---
+
+# Sprint
+`;
+  fs.writeFileSync(path.join(repo, "backlog", "sprints", "2026-05-x.md"), sprintBody);
+}
+
+describe("parseArgs", () => {
+  it("requires --repo, --run-id, --pr", () => {
+    assert.match(parseArgs([]).error, /Missing --repo/);
+    assert.match(parseArgs(["--repo", "."]).error, /Missing --run-id/);
+    assert.match(parseArgs(["--repo", ".", "--run-id", "r"]).error, /Missing --pr/);
+  });
+
+  it("parses required + optional flags", () => {
+    const parsed = parseArgs([
+      "--repo", "/x", "--run-id", "r1", "--pr", "42",
+      "--synthesis", "did the thing", "--date", "2026-05-23",
+      "--dry-run", "--json",
+    ]);
+    assert.equal(parsed.repo, "/x");
+    assert.equal(parsed.runId, "r1");
+    assert.equal(parsed.pr, "42");
+    assert.equal(parsed.synthesis, "did the thing");
+    assert.equal(parsed.date, "2026-05-23");
+    assert.equal(parsed.dryRun, true);
+    assert.equal(parsed.json, true);
+  });
+
+  it("accepts the = form", () => {
+    const parsed = parseArgs(["--repo=/x", "--run-id=r1", "--pr=42"]);
+    assert.equal(parsed.repo, "/x");
+    assert.equal(parsed.runId, "r1");
+    assert.equal(parsed.pr, "42");
+  });
+
+  it("errors on unknown argument", () => {
+    assert.match(parseArgs(["--repo", "/x", "--run-id", "r", "--pr", "1", "--bogus"]).error, /Unknown argument/);
+  });
+});
+
+describe("parseFrontmatter / readFrontmatterField", () => {
+  it("extracts simple fields", () => {
+    const fm = parseFrontmatter("---\ncomponent: \"auth\"\nstatus: active\n---\nbody");
+    assert.equal(readFrontmatterField(fm, "component"), "auth");
+    assert.equal(readFrontmatterField(fm, "status"), "active");
+  });
+
+  it("strips quotes (single + double)", () => {
+    assert.equal(readFrontmatterField("component: 'auth'", "component"), "auth");
+    assert.equal(readFrontmatterField('component: "auth"', "component"), "auth");
+  });
+
+  it("returns null when field absent", () => {
+    assert.equal(readFrontmatterField("milestone: x", "component"), null);
+  });
+});
+
+describe("parseComponents", () => {
+  it("splits comma-separated multi", () => {
+    assert.deepEqual(parseComponents("a, b , c"), ["a", "b", "c"]);
+  });
+
+  it("handles empty / null", () => {
+    assert.deepEqual(parseComponents(""), []);
+    assert.deepEqual(parseComponents(null), []);
+  });
+
+  it("returns single-element list for one value", () => {
+    assert.deepEqual(parseComponents("auth"), ["auth"]);
+  });
+});
+
+describe("findActiveSprint", () => {
+  it("returns the one sprint with status: active", () => {
+    const repo = makeRepo();
+    try {
+      const dir = path.join(repo, "backlog", "sprints");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "a.md"), "---\nstatus: completed\n---\n");
+      fs.writeFileSync(path.join(dir, "b.md"), "---\nstatus: active\n---\n");
+      const result = findActiveSprint(dir);
+      assert.ok(result);
+      assert.ok(result.file.endsWith("b.md"));
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when no active sprint", () => {
+    const repo = makeRepo();
+    try {
+      const dir = path.join(repo, "backlog", "sprints");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "a.md"), "---\nstatus: completed\n---\n");
+      assert.equal(findActiveSprint(dir), null);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when sprints dir is missing", () => {
+    assert.equal(findActiveSprint("/no/such/dir"), null);
+  });
+});
+
+describe("findCapabilityBlock", () => {
+  it("locates the matching block bounded by next ## Capability or EOF", () => {
+    const block = findCapabilityBlock(SAMPLE_CAPABILITIES, "auth");
+    assert.ok(block);
+    assert.ok(block.start >= 0);
+    assert.ok(block.end > block.start);
+    const text = block.lines.slice(block.start, block.end).join("\n");
+    assert.match(text, /## Capability: auth/);
+    assert.ok(!/## Capability: billing/.test(text));
+  });
+
+  it("returns null for unknown capability", () => {
+    assert.equal(findCapabilityBlock(SAMPLE_CAPABILITIES, "ghost"), null);
+  });
+});
+
+describe("locateMarkers", () => {
+  it("finds BEGIN and END markers within block", () => {
+    const block = findCapabilityBlock(SAMPLE_CAPABILITIES, "auth");
+    const blockLines = block.lines.slice(block.start, block.end);
+    const m = locateMarkers(blockLines, block.start);
+    assert.ok(m.beginIdx >= block.start);
+    assert.ok(m.endIdx > m.beginIdx);
+  });
+
+  it("returns -1 when markers absent", () => {
+    const lines = ["## Capability: solo", "no markers here"];
+    const m = locateMarkers(lines, 0);
+    assert.equal(m.beginIdx, -1);
+    assert.equal(m.endIdx, -1);
+  });
+});
+
+describe("buildEntry", () => {
+  it("renders the schema-bound format", () => {
+    const entry = buildEntry({ date: "2026-05-23", runId: "r1", synthesis: "did it", pr: "42" });
+    assert.equal(entry, "- 2026-05-23 (run #r1): did it [PR #42]");
+  });
+
+  it("falls back to a synthesis stub when none provided", () => {
+    const entry = buildEntry({ date: "2026-05-23", runId: "r1", synthesis: null, pr: "42" });
+    assert.match(entry, /relay-merge of PR #42/);
+  });
+});
+
+describe("appendLearningsCore — fixture-driven", () => {
+  it("happy path appends inside markers", () => {
+    const result = appendLearningsCore({
+      capabilitiesContent: SAMPLE_CAPABILITIES,
+      primaryComponent: "auth",
+      secondaryComponents: [],
+      runId: "r2",
+      pr: "99",
+      synthesis: "added retry policy",
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.APPENDED);
+    assert.match(result.entry, /run #r2.*PR #99/);
+    const beginIdx = result.updatedContent.indexOf("<!-- LEARN:BEGIN -->");
+    const entryIdx = result.updatedContent.indexOf(result.entry);
+    const endIdx = result.updatedContent.indexOf("<!-- LEARN:END -->");
+    assert.ok(beginIdx < entryIdx && entryIdx < endIdx, "entry must sit between markers");
+  });
+
+  it("idempotent: same run-id is a no-op skip", () => {
+    const result = appendLearningsCore({
+      capabilitiesContent: SAMPLE_CAPABILITIES,
+      primaryComponent: "billing",
+      secondaryComponents: [],
+      runId: "001", // already seeded under billing
+      pr: "1",
+      synthesis: "duplicate attempt",
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.SKIPPED);
+    assert.equal(result.reason, "idempotent_match");
+  });
+
+  it("unmatched component is a skip, not a failure", () => {
+    const result = appendLearningsCore({
+      capabilitiesContent: SAMPLE_CAPABILITIES,
+      primaryComponent: "ghost",
+      secondaryComponents: [],
+      runId: "r3",
+      pr: "10",
+      synthesis: null,
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.SKIPPED);
+    assert.equal(result.reason, "component_not_found");
+  });
+
+  it("multi-component records a D4 warning for secondary entries", () => {
+    const result = appendLearningsCore({
+      capabilitiesContent: SAMPLE_CAPABILITIES,
+      primaryComponent: "auth",
+      secondaryComponents: ["billing"],
+      runId: "r4",
+      pr: "11",
+      synthesis: "multi",
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.APPENDED);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].kind, "secondary_components_ignored");
+    assert.match(result.warnings[0].detail, /billing/);
+  });
+
+  it("tampered: BEGIN marker missing → failure (not silent)", () => {
+    const tampered = SAMPLE_CAPABILITIES.replace("<!-- LEARN:BEGIN -->\n", "");
+    const result = appendLearningsCore({
+      capabilitiesContent: tampered,
+      primaryComponent: "auth",
+      secondaryComponents: [],
+      runId: "r5",
+      pr: "12",
+      synthesis: null,
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.FAILED);
+    assert.equal(result.reason, "markers_missing");
+  });
+
+  it("tampered: END before BEGIN → markers_tampered", () => {
+    const swapped = SAMPLE_CAPABILITIES.replace(
+      /<!-- LEARN:BEGIN -->\n<!-- LEARN:END -->/,
+      "<!-- LEARN:END -->\n<!-- LEARN:BEGIN -->",
+    );
+    const result = appendLearningsCore({
+      capabilitiesContent: swapped,
+      primaryComponent: "auth",
+      secondaryComponents: [],
+      runId: "r6",
+      pr: "13",
+      synthesis: null,
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.FAILED);
+    assert.equal(result.reason, "markers_tampered");
+  });
+});
+
+describe("appendLearnings — end-to-end with fs", () => {
+  it("happy path writes capabilities.md", () => {
+    const repo = makeRepo();
+    try {
+      seedFixture(repo, { activeComponent: "auth" });
+      const result = appendLearnings({
+        repo, runId: "rE1", pr: "501", synthesis: "e2e happy", date: "2026-05-23",
+      });
+      assert.equal(result.status, STATUS.APPENDED);
+      const written = fs.readFileSync(path.join(repo, "spec", "capabilities.md"), "utf-8");
+      assert.match(written, /run #rE1.*PR #501/);
+      assert.match(written, /e2e happy/);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run does not write but reports appended", () => {
+    const repo = makeRepo();
+    try {
+      seedFixture(repo, { activeComponent: "auth" });
+      const original = fs.readFileSync(path.join(repo, "spec", "capabilities.md"), "utf-8");
+      const result = appendLearnings({
+        repo, runId: "rE2", pr: "502", synthesis: "dry", date: "2026-05-23", dryRun: true,
+      });
+      assert.equal(result.status, STATUS.APPENDED);
+      const after = fs.readFileSync(path.join(repo, "spec", "capabilities.md"), "utf-8");
+      assert.equal(after, original);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("missing capabilities.md → skipped, exit 0 path", () => {
+    const repo = makeRepo();
+    try {
+      // no spec/, no sprints/
+      const result = appendLearnings({
+        repo, runId: "rE3", pr: "503",
+      });
+      assert.equal(result.status, STATUS.SKIPPED);
+      assert.equal(result.reason, "capabilities_absent");
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("no active sprint → skipped", () => {
+    const repo = makeRepo();
+    try {
+      fs.mkdirSync(path.join(repo, "spec"), { recursive: true });
+      fs.writeFileSync(path.join(repo, "spec", "capabilities.md"), SAMPLE_CAPABILITIES);
+      const result = appendLearnings({ repo, runId: "rE4", pr: "504" });
+      assert.equal(result.status, STATUS.SKIPPED);
+      assert.equal(result.reason, "active_sprint_absent");
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("empty component: → skipped (no live-update target)", () => {
+    const repo = makeRepo();
+    try {
+      seedFixture(repo, { activeComponent: "" });
+      const result = appendLearnings({ repo, runId: "rE5", pr: "505" });
+      assert.equal(result.status, STATUS.SKIPPED);
+      assert.equal(result.reason, "component_empty");
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("idempotent across invocations: re-running adds nothing", () => {
+    const repo = makeRepo();
+    try {
+      seedFixture(repo, { activeComponent: "auth" });
+      const first = appendLearnings({ repo, runId: "rIdem", pr: "601", synthesis: "first", date: "2026-05-23" });
+      assert.equal(first.status, STATUS.APPENDED);
+      const writtenAfterFirst = fs.readFileSync(path.join(repo, "spec", "capabilities.md"), "utf-8");
+      const second = appendLearnings({ repo, runId: "rIdem", pr: "601", synthesis: "first", date: "2026-05-23" });
+      assert.equal(second.status, STATUS.SKIPPED);
+      assert.equal(second.reason, "idempotent_match");
+      const writtenAfterSecond = fs.readFileSync(path.join(repo, "spec", "capabilities.md"), "utf-8");
+      assert.equal(writtenAfterFirst, writtenAfterSecond);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("formatHumanReport", () => {
+  it("renders the appended path", () => {
+    const out = formatHumanReport({
+      status: STATUS.APPENDED,
+      capabilitiesPath: "/x/spec/capabilities.md",
+      primaryComponent: "auth",
+      entry: "- 2026-05-23 (run #r1): did it [PR #42]",
+      warnings: [],
+    });
+    assert.match(out, /Appended/);
+    assert.match(out, /did it/);
+  });
+
+  it("renders skip and failed paths", () => {
+    assert.match(formatHumanReport({ status: STATUS.SKIPPED, reason: "component_empty" }), /skipped/);
+    assert.match(formatHumanReport({ status: STATUS.FAILED, reason: "markers_missing" }), /failed/);
+  });
+});


### PR DESCRIPTION
Closes #515 — mirror of [\`sungjunlee/dev-backlog#104\`](https://github.com/sungjunlee/dev-backlog/issues/104). PR-3 part B of the cross-repo spec-system v0.1 plan.

dev-backlog's spec-system layered design adds a middle layer (\`spec/capabilities.md\`) with a structurally-bounded live-feedback channel. After a successful relay-merge, this PR appends a one-line entry to the matching capability's \`## Learnings\` block in the target repo. The script is the **only writer** for \`## Learnings\` — anti-adversarial-Goodhart structural defense per the design doc.

## What lands

**\`skills/relay-merge/scripts/append-learnings.js\`** (~265 LOC including helpers)

- Reads the target repo's active sprint file, extracts \`component:\` from frontmatter. Multi-component values (comma-separated) follow dev-backlog's design doc **D4 — first-declared wins**; secondary entries are recorded as warnings.
- Locates \`## Capability: <component>\` in \`spec/capabilities.md\` and appends a schema-bound entry **only** inside the \`<!-- LEARN:BEGIN -->\` / \`<!-- LEARN:END -->\` marker pair. Format:
  \`\`\`
  - YYYY-MM-DD (run #<id>): <one-line> [PR #N]
  \`\`\`
- Refuses to write outside the marker pair (the structural defense — the working agent has zero write access to spec content).
- **Loud failure** on tampered markers (BEGIN missing, END missing, or END before BEGIN).
- **Graceful no-ops** (status: skipped, exit 0): \`spec/capabilities.md\` absent, active sprint absent, component empty, component does not match any declared capability.
- **Idempotent on run-id:** a second invocation with the same \`run #<id>\` is a no-op; the entry is not duplicated.

**\`skills/relay-merge/scripts/finalize-run.js\`** — after \`STATES.MERGED\` is set and before \`runCleanup\` runs, invokes \`appendLearnings\` with \`manifest.run_id\`, the PR number, and the issue title as default synthesis. The result is surfaced under \`result.learnings\` for downstream consumers. **Failure does not block cleanup** or affect manifest state — append-learnings is a best-effort post-merge side effect.

**\`skills/relay-merge/SKILL.md\`** (119 lines, under the 150 ceiling) — documents the post-merge append step + structural-defense rationale; sibling-scripts inputs list adds the new script.

## Acceptance criteria

- [x] Script appends only between markers; cannot touch other regions — covered by the \`tampered-markers\` fixture (fails loud)
- [x] Schema-bound entry format; rejects malformed inputs (parser-level validation in \`buildEntry\`)
- [x] Idempotent on same run-id; the \`idempotent_match\` skip is verified end-to-end across two fs invocations
- [x] Graceful no-ops: missing \`spec/capabilities.md\` / missing \`component:\` / unmatched capability / missing markers — each has a dedicated fixture
- [x] \`node --test tests/relay-merge/scripts/append-learnings.test.js\` passes — **33 tests** across the 6 AC fixtures + helpers + e2e
- [x] Multi-component conflict rule per dev-backlog design doc D4: first declared + warn
- [x] \`finalize-run.js\` invokes append-learnings post-merge; failure does not block cleanup
- [x] \`relay-merge/SKILL.md\` documents the new step; stays under the 150-line ceiling

## Test plan

- [x] 33 new tests pass for append-learnings.js
- [x] All 32 finalize-run.js tests still pass after the hook insertion
- [x] Full relay-merge suite green: **144 tests / 0 fail**

## Dependencies

- dev-backlog #101 (capabilities.md template with magic markers) — merged in PR #108
- dev-backlog #103 (component frontmatter on sprint files) — merged in PR #116
- This PR is the only piece left of the cross-repo plan