### PR TITLE
[codex] bound malformed capability headings

### DIFF
--- a/skills/relay-merge/scripts/append-learnings.js
+++ b/skills/relay-merge/scripts/append-learnings.js
@@ -143,6 +143,10 @@ function parseCapabilityHeading(line) {
   return isValidCapabilityName(name) ? name : null;
 }
 
+function isCapabilityBoundary(line) {
+  return /^## Capability:\s+/.test(line);
+}
+
 function resolveActiveSprint(sprintsDir, { readdir = fs.readdirSync, readFile = fs.readFileSync, fileExists = fs.existsSync } = {}) {
   if (!fileExists(sprintsDir)) return null;
   const files = readdir(sprintsDir)
@@ -179,7 +183,7 @@ function findCapabilityBlock(capabilitiesContent, name) {
 
   let end = lines.length;
   for (let i = start + 1; i < lines.length; i += 1) {
-    if (parseCapabilityHeading(lines[i])) { end = i; break; }
+    if (isCapabilityBoundary(lines[i])) { end = i; break; }
   }
   return { start, end, lines };
 }
@@ -358,6 +362,7 @@ module.exports = {
   parseComponents,
   isValidCapabilityName,
   parseCapabilityHeading,
+  isCapabilityBoundary,
   resolveActiveSprint,
   findActiveSprint,
   findCapabilityBlock,

--- a/tests/relay-merge/scripts/append-learnings.test.js
+++ b/tests/relay-merge/scripts/append-learnings.test.js
@@ -12,6 +12,7 @@ const {
   parseComponents,
   isValidCapabilityName,
   parseCapabilityHeading,
+  isCapabilityBoundary,
   resolveActiveSprint,
   findActiveSprint,
   findCapabilityBlock,
@@ -148,6 +149,7 @@ describe("capability heading grammar", () => {
     assert.equal(isValidCapabilityName("merge finalize"), false);
     assert.equal(parseCapabilityHeading("## Capability: merge finalize"), null);
     assert.equal(parseCapabilityHeading("## Capability: Merge-Finalize"), null);
+    assert.equal(isCapabilityBoundary("## Capability: merge finalize"), true);
   });
 });
 
@@ -218,6 +220,33 @@ describe("findCapabilityBlock", () => {
   it("does not partially match invalid headings with spaces", () => {
     const content = SAMPLE_CAPABILITIES.replace("## Capability: auth", "## Capability: auth api");
     assert.equal(findCapabilityBlock(content, "auth"), null);
+  });
+
+  it("treats malformed capability headings as block boundaries", () => {
+    const content = [
+      "## Capability: auth",
+      "",
+      "### Learnings",
+      "## Capability: billing api",
+      "",
+      "### Learnings",
+      "<!-- LEARN:BEGIN -->",
+      "<!-- LEARN:END -->",
+    ].join("\n");
+    const block = findCapabilityBlock(content, "auth");
+    const text = block.lines.slice(block.start, block.end).join("\n");
+    assert.ok(!text.includes("billing api"));
+
+    const result = appendLearningsCore({
+      capabilitiesContent: content,
+      primaryComponent: "auth",
+      runId: "rBoundary",
+      pr: "608",
+      synthesis: "boundary check",
+      date: "2026-05-23",
+    });
+    assert.equal(result.status, STATUS.FAILED);
+    assert.equal(result.reason, "markers_missing");
   });
 });
 


### PR DESCRIPTION
## Summary
- Treat any `## Capability:` heading as a capability block boundary, even when its name is malformed.
- Keep start matching strict to valid kebab-case capability names.
- Add a regression test proving malformed following headings cannot donate their Learnings markers to the previous valid capability.

## Self-review
Found during post-merge review of #525: malformed capability headings could be ignored as boundaries, causing the previous valid capability block to span too far. This violated the marker-bounded writer contract.

## Validation
- `node --test tests/relay-merge/scripts/append-learnings.test.js`
- `node --test tests/relay-merge/scripts/*.test.js`
- `git diff --check`