### PR TITLE
fix(relay-merge): fail closed on non-success checks

### DIFF
--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -63,6 +63,8 @@ const {
 } = require("./review-gate");
 const { STATUS: LEARNING_STATUS, appendLearnings } = require("./append-learnings");
 
+const ALLOWED_CHECK_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
   "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method", "--skip-review",
@@ -132,8 +134,43 @@ function fetchPreMergeContext(repoPath, prNumber) {
     commits: parsed.commits || [],
     mergeable: parsed.mergeable || null,
     checks,
-    failing: checks.filter((c) => c.conclusion === "FAILURE"),
+    unsafeChecks: checks.filter(isUnsafeStatusCheck),
   };
+}
+
+function normalizeStatusCheckValue(value) {
+  return String(value || "").trim().toUpperCase();
+}
+
+function statusCheckName(check) {
+  return check?.name || check?.context || "unknown";
+}
+
+function describeStatusCheck(check) {
+  const status = normalizeStatusCheckValue(check?.status);
+  const conclusion = normalizeStatusCheckValue(check?.conclusion);
+  const state = normalizeStatusCheckValue(check?.state);
+  const details = [];
+  if (status) details.push(`status=${status}`);
+  if (conclusion) details.push(`conclusion=${conclusion}`);
+  if (state) details.push(`state=${state}`);
+  if (!details.length) details.push("state=UNKNOWN");
+  return `${statusCheckName(check)} (${details.join(", ")})`;
+}
+
+function isUnsafeStatusCheck(check) {
+  const status = normalizeStatusCheckValue(check?.status);
+  if (status && status !== "COMPLETED") return true;
+
+  const conclusion = normalizeStatusCheckValue(check?.conclusion);
+  if (conclusion) {
+    return !ALLOWED_CHECK_CONCLUSIONS.has(conclusion);
+  }
+
+  const state = normalizeStatusCheckValue(check?.state);
+  if (state) return state !== "SUCCESS";
+
+  return true;
 }
 
 function fetchPrMergeState(repoPath, prNumber) {
@@ -151,10 +188,10 @@ function assertPreMergeSafety(preMerge, prNumber) {
       `PR #${prNumber} has merge conflicts with the base branch. Resolve conflicts and push, then retry.`
     );
   }
-  if (preMerge.failing.length > 0) {
-    const names = preMerge.failing.map((c) => c.name || c.context || "unknown").join(", ");
+  if (preMerge.unsafeChecks.length > 0) {
+    const names = preMerge.unsafeChecks.map(describeStatusCheck).join(", ");
     throw new Error(
-      `PR #${prNumber} has failing CI checks: ${names}. Fix these before merging.`
+      `PR #${prNumber} has non-success CI checks: ${names}. Fix these before merging.`
     );
   }
 }

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -1238,7 +1238,7 @@ test("finalize-run blocks merge when PR has merge conflicts", () => {
   assert.equal(manifest.state, STATES.READY_TO_MERGE);
 });
 
-test("finalize-run blocks merge when CI checks are failing", () => {
+test("finalize-run blocks merge when CI checks are not successful", () => {
   const { repoRoot, manifestPath, branch } = setupRepo();
   const logPath = path.join(repoRoot, "gh.log");
   const fakeGh = writeFakeGh(logPath, {
@@ -1271,10 +1271,79 @@ test("finalize-run blocks merge when CI checks are failing", () => {
     encoding: "utf-8",
     stdio: "pipe",
     env: { ...process.env, RELAY_GH_BIN: fakeGh },
-  }), /failing CI checks: test-unit/);
+  }), /non-success CI checks: test-unit \(conclusion=FAILURE\)/);
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.READY_TO_MERGE);
+});
+
+[
+  { label: "cancelled", check: { name: "test-cancelled", conclusion: "CANCELLED" }, expected: /test-cancelled \(conclusion=CANCELLED\)/ },
+  { label: "timed out", check: { name: "test-timeout", conclusion: "TIMED_OUT" }, expected: /test-timeout \(conclusion=TIMED_OUT\)/ },
+  { label: "action required", check: { name: "deploy-approval", conclusion: "ACTION_REQUIRED" }, expected: /deploy-approval \(conclusion=ACTION_REQUIRED\)/ },
+  { label: "error", check: { name: "test-error", conclusion: "ERROR" }, expected: /test-error \(conclusion=ERROR\)/ },
+  { label: "pending check run", check: { name: "test-pending", status: "IN_PROGRESS", conclusion: null }, expected: /test-pending \(status=IN_PROGRESS\)/ },
+  { label: "queued check run", check: { name: "test-queued", status: "QUEUED", conclusion: null }, expected: /test-queued \(status=QUEUED\)/ },
+  { label: "unknown check", check: { name: "test-unknown", conclusion: null }, expected: /test-unknown \(state=UNKNOWN\)/ },
+  { label: "pending status context", check: { context: "ci/status", state: "PENDING" }, expected: /ci\/status \(state=PENDING\)/ },
+].forEach(({ label, check, expected }) => {
+  test(`finalize-run blocks ${label} CI check state`, () => {
+    const { repoRoot, manifestPath, branch } = setupRepo();
+    const logPath = path.join(repoRoot, "gh.log");
+    const fakeGh = writeFakeGh(logPath, {
+      comments: [DEFAULT_REVIEW_COMMENT],
+      commits: [
+        {
+          oid: execFileSync("git", ["-C", repoRoot, "rev-parse", branch], { encoding: "utf-8", stdio: "pipe" }).trim(),
+          committedDate: DEFAULT_COMMIT_DATE,
+        },
+      ],
+      statusCheckRollup: [
+        { name: "lint", conclusion: "SUCCESS" },
+        check,
+      ],
+    });
+
+    assert.throws(() => execFileSync("node", [
+      SCRIPT,
+      "--repo", repoRoot,
+      "--branch", branch,
+      "--pr", "123",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_GH_BIN: fakeGh },
+    }), expected);
+
+    const manifest = readManifest(manifestPath).data;
+    assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  });
+});
+
+test("finalize-run allows successful neutral and skipped CI check states", () => {
+  const fixture = setupRepo();
+
+  const result = execFinalize(fixture, {
+    ghOptions: {
+      comments: [DEFAULT_REVIEW_COMMENT],
+      commits: [
+        {
+          oid: fixture.headSha,
+          committedDate: DEFAULT_COMMIT_DATE,
+        },
+      ],
+      statusCheckRollup: [
+        { name: "lint", conclusion: "SUCCESS" },
+        { name: "optional", conclusion: "NEUTRAL" },
+        { name: "docs-only", conclusion: "SKIPPED" },
+        { context: "legacy-status", state: "SUCCESS" },
+      ],
+    },
+  });
+
+  assert.equal(result.result.state, STATES.MERGED);
 });
 
 test("finalize-run preserves terminal state when gh merge does not complete immediately", () => {


### PR DESCRIPTION
## Summary

- Treat PR status checks as an allowlist before merge finalization
- Allow only success, neutral, skipped, and legacy status context success states
- Include blocked check names and status/conclusion/state details in merge errors

Closes #539

## Verification

- node --test tests/relay-merge/scripts/finalize-run.test.js
- node --test tests/relay-merge/scripts/*.test.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * CI 체크 검증 로직을 강화했습니다. 성공, 중립, 건너뜀 상태만 허용하고 기타 상태는 머지를 차단합니다.

* **테스트**
  * 다양한 CI 체크 상태에 대한 테스트 케이스를 추가했습니다. 머지 안전성 검증이 정확하게 작동하는지 확인합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->