### PR TITLE
Harden review assurance and independent attempts

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -150,10 +150,10 @@ bootstrap_exempt:
 | `dispatch.last_model` / executor config | Dispatch records the effective model. If no explicit model hint is present, executor defaults come from the skill-bundled `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json` overrides |
 | `policy.merge` | `manual_after_lgtm` — orchestrator must explicitly merge |
 | `policy.reviewer_write` | `forbid` — review runner rejects rounds where reviewer mutated files |
-| `policy.review_assurance` | `standard` keeps current behavior; `hardened` requires stronger review/evidence gates without using agent identity heuristics, including successful advisory artifacts and strict execution evidence. When `execution-evidence.json` includes `verification_runs[]`, hardened gates prefer those actual command-run records; legacy evidence without that array still falls back to `test_exit_code=0` plus a SHA-bound result hash |
+| `policy.review_assurance` | `standard` keeps current behavior; `hardened` requires stronger review/evidence gates without using agent identity heuristics. Hardened review commands must include an advisory reviewer, and passing verdicts require successful advisory artifacts plus strict execution evidence. When `execution-evidence.json` includes `verification_runs[]`, hardened gates prefer those actual command-run records; legacy evidence without that array still falls back to `test_exit_code=0` plus a SHA-bound result hash |
 | `anchor.*` | Immutable review scope — prevents drift across rounds |
 | `review.last_reviewed_sha` | Gate-check blocks merge if HEAD has advanced past this |
-| `review.last_reviewer` | Tracks the acting reviewer for the latest round without mutating `roles.reviewer`; analytics must still use `review_apply.reviewer` as the round-level source of truth |
+| `review.last_reviewer` | Tracks the acting reviewer for the latest round without mutating `roles.reviewer`; escalated same-adapter retry requires an `--independent-review-reason`; analytics must still use `review_apply.reviewer` as the round-level source of truth |
 | `bootstrap_exempt.*` | Optional operator-declared reconciliation for runs that predate an artifact writer but are closed after that writer lands |
 
 ### Bootstrap exemptions

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -41,6 +41,7 @@ const FLAGS = [
   { flag: "--force-finalize-nonready", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--head-sha", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Structured SHA field; flag-like following tokens should mean the value is missing." },
   { flag: "--help", aliases: ["-h"], kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--independent-review-reason", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit reason for a same-adapter independent review attempt; preserve the operator-supplied text." },
   { flag: "--issue", kind: VALUE, mode: MODE_PARSED, valueName: "<N>", rationale: "Numeric selector; flag-like following tokens should mean the value is missing." },
   { flag: "--json", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--last-reviewed-sha", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Structured SHA field; flag-like following tokens should mean the value is missing." },
@@ -178,7 +179,7 @@ const COMMAND_FLAGS = {
     "--diff-file", "--review-file", "--reviewer", "--reviewer-script",
     "--reviewer-model", "--advisory-reviewer", "--advisory-profile",
     "--advisory-reviewer-model", "--advisory-timeout", "--prepare-only",
-    "--manual-review-reason", "--no-comment", "--json", "--help",
+    "--manual-review-reason", "--independent-review-reason", "--no-comment", "--json", "--help",
   ],
   "update-manifest-state": [
     "--manifest", "--repo", "--run-id", "--branch", "--state", "--next-action",

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -72,7 +72,7 @@ Optional advisory path: add an opencode blind-spot lane alongside the primary re
 node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer opencode --advisory-profile blindspot --json
 ```
 
-Advisory review is non-gating for `policy.review_assurance=standard`: it starts concurrently, records `advisory_review` plus `review-round-N-advisory-<reviewer>-*`, never changes the trusted verdict or redispatch prompt, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. For `policy.review_assurance=hardened`, advisory evidence is required and failures or required findings block a passing primary verdict; execution evidence must be strict. When `execution-evidence.json` includes `verification_runs[]`, hardened gates prefer those actual command-run records; otherwise they fall back to legacy `test_exit_code=0` plus a SHA-bound result hash. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor defaults plus optional `~/.relay/executors.json`. Current profile: `blindspot` checks likely misses such as test gaps, bypass paths, edge cases, stale docs, and operational failure modes.
+Advisory review is non-gating for `policy.review_assurance=standard`: it starts concurrently, records `advisory_review` plus `review-round-N-advisory-<reviewer>-*`, never changes the trusted verdict or redispatch prompt, and records failures/timeouts/invalid JSON/write-policy violations without changing the primary outcome. For `policy.review_assurance=hardened`, the runner fails fast unless the command includes `--advisory-reviewer <name>`; advisory failures or required findings block a passing primary verdict, and execution evidence must be strict. When `execution-evidence.json` includes `verification_runs[]`, hardened gates prefer those actual command-run records; otherwise they fall back to legacy `test_exit_code=0` plus a SHA-bound result hash. Use `--advisory-reviewer-model` to override; otherwise opencode uses dispatch executor defaults plus optional `~/.relay/executors.json`. Current profile: `blindspot` checks likely misses such as test gaps, bypass paths, edge cases, stale docs, and operational failure modes.
 
 4. Fallback path for unsupported environments or debugging:
 ```bash
@@ -139,6 +139,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo 
 ```
 
 The runner validates the verdict, writes the PR audit comment, updates manifest state, and records round artifacts. For hardened runs, a passing manual verdict requires an explicit `--manual-review-reason` audit reason. See `references/runner-notes.md` for the full audit-trail and backward-compatibility behavior.
+
+When an escalated run needs another review attempt, pass a different `--reviewer` when available. If the same adapter is intentionally reused, include `--independent-review-reason <text>` to document why the attempt is independent enough to spend the single reviewer-swap quota.
 
 ## Re-dispatch (when issues found)
 

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -41,10 +41,15 @@ When applying a verdict, the runner:
 
 - validates the JSON verdict
 - optionally invokes the reviewer adapter itself when `--reviewer <name>` is used
+- fails fast for `policy.review_assurance=hardened` unless `--advisory-reviewer <name>` is present, except in `--prepare-only` mode
 - computes and overrides `quality_execution_status` from `execution-evidence.json`; strict gates prefer `verification_runs[]` when present and otherwise use the legacy `test_*` fields
 - rejects the round if the reviewer mutates the repo and escalates the manifest
 - writes the PR audit comment
 - updates the relay manifest to `ready_to_merge`, `changes_requested`, or `escalated`
+
+## Independent Review Attempts
+
+Escalated runs may be reopened for one independent review attempt. A different `--reviewer` records a `reviewer_swap` event with `reason=different_reviewer:<from>-><to>`. Reusing the same adapter requires `--independent-review-reason <text>` so the audit trail explains how the attempt is independent, such as a fresh ephemeral context, different model hint, or materially different prompt bundle.
 
 ## Backward Compatibility
 

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -26,7 +26,7 @@ const { printResult, printUsage } = require("./review-runner/output");
 const { bindCliArgs, findUnknownFlags } = require("../../relay-dispatch/scripts/cli-args");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
   commandName: "review-runner",
   reservedFlags: KNOWN_FLAGS,
@@ -56,6 +56,7 @@ async function run() {
   const reviewerArg = cliArgs.getArg("--reviewer");
   const reviewerScriptArg = cliArgs.getArg("--reviewer-script");
   const reviewerModel = cliArgs.getArg("--reviewer-model");
+  const independentReviewReason = cliArgs.getArg("--independent-review-reason");
   const advisoryReviewerArg = cliArgs.getArg("--advisory-reviewer");
   const advisoryProfileArg = cliArgs.getArg("--advisory-profile");
   const advisoryReviewerModel = cliArgs.getArg("--advisory-reviewer-model");
@@ -84,7 +85,14 @@ async function run() {
   const { body, manifestPath } = manifest;
   let { data } = manifest;
 
-  data = maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath);
+  if (isHardenedReviewAssurance(data) && !prepareOnly && !advisoryReviewerArg) {
+    throw new Error(
+      "policy.review_assurance=hardened requires --advisory-reviewer <name> so the round produces advisory evidence. " +
+      "Run with --advisory-reviewer opencode --advisory-profile blindspot, or lower the manifest policy before review."
+    );
+  }
+
+  data = maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath, { independentReviewReason });
 
   if (data.state !== STATES.REVIEW_PENDING) {
     throw new Error(`Review runner requires state=review_pending, got '${data.state}'`);

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -88,7 +88,7 @@ async function run() {
   if (isHardenedReviewAssurance(data) && !prepareOnly && !advisoryReviewerArg) {
     throw new Error(
       "policy.review_assurance=hardened requires --advisory-reviewer <name> so the round produces advisory evidence. " +
-      "Run with --advisory-reviewer opencode --advisory-profile blindspot, or lower the manifest policy before review."
+      "Run with a configured advisory reviewer, or lower the manifest policy before review."
     );
   }
 

--- a/skills/relay-review/scripts/review-runner/output.js
+++ b/skills/relay-review/scripts/review-runner/output.js
@@ -16,6 +16,7 @@ function printUsage() {
   console.log(`  --reviewer <name>            ${modeLabel("--reviewer")} Reviewer adapter to invoke (codex|claude|...)`);
   console.log(`  --reviewer-script <path>     ${modeLabel("--reviewer-script")} Override adapter script path`);
   console.log(`  --reviewer-model <name>      ${modeLabel("--reviewer-model")} Reviewer model override`);
+  console.log(`  --independent-review-reason <text> ${modeLabel("--independent-review-reason")} Evidence for same-reviewer escalated retry`);
   console.log(`  --advisory-reviewer <name>   ${modeLabel("--advisory-reviewer")} Optional non-gating reviewer adapter`);
   console.log(`  --advisory-profile <name>    ${modeLabel("--advisory-profile")} Advisory focus profile (default: blindspot)`);
   console.log(`  --advisory-reviewer-model <name> ${modeLabel("--advisory-reviewer-model")} Advisory model override`);

--- a/skills/relay-review/scripts/review-runner/reviewer-swap.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-swap.js
@@ -3,18 +3,20 @@ const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/stor
 const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { resolveReviewerName } = require("./reviewer-invoke");
 
-function maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath) {
+function maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath, options = {}) {
   if (data.state !== STATES.ESCALATED) return data;
   if (!reviewerArg) return data;
 
   const newReviewerName = resolveReviewerName(data, reviewerArg);
   const lastReviewer = data.review?.last_reviewer || null;
-  if (newReviewerName === lastReviewer) {
+  const independentReviewReason = String(options.independentReviewReason || "").trim();
+  if (newReviewerName === lastReviewer && !independentReviewReason) {
     throw new Error(
-      `Reviewer-swap requires a different reviewer; --reviewer '${newReviewerName}' matches review.last_reviewer. ` +
-      "Pass a different adapter (e.g., --reviewer claude) or close the run."
+      `Independent review attempt requires evidence; --reviewer '${newReviewerName}' matches review.last_reviewer. ` +
+      "Pass a different adapter, or provide --independent-review-reason <text> for a same-adapter fresh-context attempt."
     );
   }
+  const reason = independentReviewReason || `different_reviewer:${lastReviewer || "unknown"}->${newReviewerName}`;
 
   const swappedManifest = forceTransitionState(data, STATES.REVIEW_PENDING, "run_review");
   swappedManifest.review = {
@@ -28,6 +30,7 @@ function maybeSwapReviewer(data, reviewerArg, body, manifestPath, runRepoPath) {
     state_to: STATES.REVIEW_PENDING,
     from_reviewer: lastReviewer,
     to_reviewer: newReviewerName,
+    reason,
     reviewer_swap_count: swappedManifest.review.reviewer_swap_count,
   });
   return swappedManifest;

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -304,22 +304,23 @@ test("hardened review assurance blocks a primary pass without advisory evidence"
   });
   const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
 
-  const result = JSON.parse(execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--run-id", runId,
-    "--pr", "429",
-    "--done-criteria-file", doneCriteriaPath,
-    "--diff-file", diffPath,
-    "--reviewer", "codex",
-    "--reviewer-script", primaryScript,
-    "--no-comment",
-    "--json",
-  ], { encoding: "utf-8" }));
+  assert.throws(
+    () => execFileSync("node", [
+      SCRIPT,
+      "--repo", repoRoot,
+      "--run-id", runId,
+      "--pr", "429",
+      "--done-criteria-file", doneCriteriaPath,
+      "--diff-file", diffPath,
+      "--reviewer", "codex",
+      "--reviewer-script", primaryScript,
+      "--no-comment",
+      "--json",
+    ], { encoding: "utf-8" }),
+    /policy\.review_assurance=hardened requires --advisory-reviewer/
+  );
 
-  assert.equal(result.nextState, STATES.CHANGES_REQUESTED);
-  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
-  assert.match(fs.readFileSync(result.verdictPath, "utf-8"), /Missing hardened advisory review/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
 });
 
 test("hardened review assurance blocks advisory failures and required findings", async (t) => {
@@ -351,6 +352,7 @@ test("hardened manual review pass requires an audit reason", () => {
   });
   const reviewFile = path.join(repoRoot, "manual-verdict.json");
   fs.writeFileSync(reviewFile, JSON.stringify(passVerdict()), "utf-8");
+  const opencodeScript = writeFakeOpencode(repoRoot);
 
   const result = JSON.parse(execFileSync("node", [
     SCRIPT,
@@ -360,9 +362,13 @@ test("hardened manual review pass requires an audit reason", () => {
     "--done-criteria-file", doneCriteriaPath,
     "--diff-file", diffPath,
     "--review-file", reviewFile,
+    "--advisory-reviewer", "opencode",
     "--no-comment",
     "--json",
-  ], { encoding: "utf-8" }));
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_OPENCODE_BIN: opencodeScript },
+  }));
 
   assert.equal(result.nextState, STATES.CHANGES_REQUESTED);
   assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);

--- a/tests/relay-review/scripts/review-runner-reviewer-swap.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-swap.test.js
@@ -83,6 +83,7 @@ test("reviewer-swap/transitions escalated -> review_pending with different revie
   assert.ok(swapEvent, "reviewer_swap event should be appended");
   assert.equal(swapEvent.from_reviewer, "codex");
   assert.equal(swapEvent.to_reviewer, "claude");
+  assert.equal(swapEvent.reason, "different_reviewer:codex->claude");
   assert.equal(swapEvent.state_from, STATES.ESCALATED);
   assert.equal(swapEvent.state_to, STATES.REVIEW_PENDING);
 });
@@ -91,14 +92,36 @@ test("reviewer-swap/rejects same-reviewer retry", () => {
   const { data, manifestPath, repoRoot } = setupEscalatedRun({ lastReviewer: "codex" });
   assert.throws(
     () => maybeSwapReviewer(data, "codex", "", manifestPath, repoRoot),
-    /matches review\.last_reviewer/
+    /requires evidence/
   );
+});
+
+test("reviewer-swap/allows same reviewer with independent review reason", () => {
+  const { data, manifestPath, repoRoot, runId } = setupEscalatedRun({ lastReviewer: "codex" });
+  const reason = "same adapter but fresh ephemeral context and different model hint";
+  const swapped = maybeSwapReviewer(data, "codex", "", manifestPath, repoRoot, {
+    independentReviewReason: reason,
+  });
+
+  assert.equal(swapped.state, STATES.REVIEW_PENDING);
+  assert.equal(swapped.review.reviewer_swap_count, 1);
+
+  const events = fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const swapEvent = events.find((event) => event.event === "reviewer_swap");
+  assert.equal(swapEvent.from_reviewer, "codex");
+  assert.equal(swapEvent.to_reviewer, "codex");
+  assert.equal(swapEvent.reason, reason);
 });
 
 test("reviewer-swap/rejects a second swap after the quota is used", () => {
   const { data, manifestPath, repoRoot } = setupEscalatedRun({ lastReviewer: "codex", swapCount: 1 });
   assert.throws(
-    () => maybeSwapReviewer(data, "claude", "", manifestPath, repoRoot),
+    () => maybeSwapReviewer(data, "claude", "", manifestPath, repoRoot, {
+      independentReviewReason: "fresh context",
+    }),
     /reviewer_swap_count=1 \(max 1 per run\)/
   );
 });


### PR DESCRIPTION
## Summary
- fail fast when `policy.review_assurance=hardened` review runs omit an advisory reviewer
- generalize escalated reviewer recovery into an independent review attempt, allowing same-adapter retries only with an explicit audit reason
- document the hardened/advisory and independent-attempt contracts, and register the new CLI flag schema

Fixes #536
Fixes #538

## Verification
- `node --test tests/relay-review/scripts/review-runner-reviewer-swap.test.js`
- `node --test tests/relay-review/scripts/review-runner-advisory.test.js`
- `node --test tests/relay-review/scripts/review-runner-reviewer-swap.test.js tests/relay-review/scripts/review-runner-advisory.test.js`
- `node --test --test-name-pattern "review-runner facade" tests/relay-review/scripts/review-runner.test.js`
- `node --test tests/relay-dispatch/scripts/cli-schema.test.js`
- `node --test tests/relay-review/scripts/*.test.js`
- `git diff --check`