### PR TITLE
[codex] Add Codex-only assurance regression

### DIFF
--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -47,6 +47,10 @@ When applying a verdict, the runner:
 - writes the PR audit comment
 - updates the relay manifest to `ready_to_merge`, `changes_requested`, or `escalated`
 
+## Codex-only Operation Regression
+
+Codex-only operation is covered as a regression for `policy.review_assurance=hardened`, not a Codex-only policy special case. When `roles.orchestrator`, `roles.executor`, and `roles.reviewer` are all `codex`, the runner still follows the same manifest policy contract used by any other role names. Advisory evidence is required for passing hardened rounds, advisory required findings block the pass, and strict execution evidence must bind to the reviewed head.
+
 ## Independent Review Attempts
 
 Escalated runs may be reopened for one independent review attempt. A different `--reviewer` records a `reviewer_swap` event with `reason=different_reviewer:<from>-><to>`. Reusing the same adapter requires `--independent-review-reason <text>` so the audit trail explains how the attempt is independent, such as a fresh ephemeral context, different model hint, or materially different prompt bundle.

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -70,7 +70,11 @@ function changesRequestedVerdict() {
   };
 }
 
-function setupRepo({ reviewAssurance = "standard", strictEvidence = false } = {}) {
+function setupRepo({
+  reviewAssurance = "standard",
+  strictEvidence = false,
+  roles = { orchestrator: "codex", executor: "codex", reviewer: "codex" },
+} = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-"));
   const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-origin-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
@@ -97,9 +101,9 @@ function setupRepo({ reviewAssurance = "standard", strictEvidence = false } = {}
     baseBranch: "main",
     issueNumber: 429,
     worktreePath,
-    orchestrator: "codex",
-    executor: "codex",
-    reviewer: "codex",
+    orchestrator: roles.orchestrator,
+    executor: roles.executor,
+    reviewer: roles.reviewer,
     reviewAssurance,
   });
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
@@ -177,7 +181,16 @@ if (logPath) fs.appendFileSync(logPath, "advisory-end " + Date.now() + "\\n");
   return filePath;
 }
 
-function runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript, extraArgs = [] }) {
+function runReview({
+  repoRoot,
+  runId,
+  doneCriteriaPath,
+  diffPath,
+  primaryScript,
+  opencodeScript,
+  reviewer = "codex",
+  extraArgs = [],
+}) {
   return JSON.parse(execFileSync("node", [
     SCRIPT,
     "--repo", repoRoot,
@@ -185,7 +198,7 @@ function runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript,
     "--pr", "429",
     "--done-criteria-file", doneCriteriaPath,
     "--diff-file", diffPath,
-    "--reviewer", "codex",
+    "--reviewer", reviewer,
     "--reviewer-script", primaryScript,
     "--advisory-reviewer", "opencode",
     "--no-comment",
@@ -321,6 +334,84 @@ test("hardened review assurance blocks a primary pass without advisory evidence"
   );
 
   assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
+});
+
+test("hardened assurance is generic for Codex-only and non-Codex role bindings", async (t) => {
+  for (const entry of [
+    {
+      label: "codex-only",
+      roles: { orchestrator: "codex", executor: "codex", reviewer: "codex" },
+      reviewer: "codex",
+    },
+    {
+      label: "non-codex-fixture",
+      roles: { orchestrator: "atlas", executor: "forge", reviewer: "mirror" },
+      reviewer: "mirror",
+    },
+  ]) {
+    await t.test(entry.label, () => {
+      const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo({
+        reviewAssurance: "hardened",
+        strictEvidence: true,
+        roles: entry.roles,
+      });
+      const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+      const opencodeScript = writeFakeOpencode(repoRoot);
+
+      const result = runReview({
+        repoRoot,
+        runId,
+        doneCriteriaPath,
+        diffPath,
+        primaryScript,
+        opencodeScript,
+        reviewer: entry.reviewer,
+      });
+      const manifest = readManifest(manifestPath).data;
+
+      assert.equal(result.nextState, STATES.READY_TO_MERGE);
+      assert.equal(manifest.state, STATES.READY_TO_MERGE);
+      assert.deepEqual(manifest.roles, entry.roles);
+      assert.equal(manifest.policy.review_assurance, "hardened");
+      assert.equal(manifest.review.last_reviewer, entry.reviewer);
+    });
+  }
+});
+
+test("Codex-only assurance regression is documented as generic policy coverage", () => {
+  const notes = fs.readFileSync(
+    path.join(__dirname, "..", "..", "..", "skills", "relay-review", "references", "runner-notes.md"),
+    "utf-8"
+  );
+
+  assert.match(notes, /Codex-only operation regression/i);
+  assert.match(notes, /policy\.review_assurance=hardened/i);
+  assert.match(notes, /not a Codex-only policy special case/i);
+});
+
+test("production assurance code does not branch on Codex executor and reviewer identity", () => {
+  const productionFiles = [
+    "skills/relay-review/scripts/review-runner.js",
+    "skills/relay-review/scripts/review-runner/assurance.js",
+    "skills/relay-merge/scripts/review-gate.js",
+    "skills/relay-merge/scripts/gate-check.js",
+    "skills/relay-merge/scripts/finalize-run.js",
+    "skills/relay-dispatch/scripts/relay-manifest.js",
+    "skills/relay-dispatch/scripts/manifest/store.js",
+  ];
+
+  const forbiddenBranch = new RegExp([
+    String.raw`(?:executor|roles\.executor)[\s\S]{0,80}(?:["']codex["'])`,
+    String.raw`[\s\S]{0,160}(?:reviewer|roles\.reviewer)[\s\S]{0,80}(?:["']codex["'])`,
+    "|",
+    String.raw`(?:reviewer|roles\.reviewer)[\s\S]{0,80}(?:["']codex["'])`,
+    String.raw`[\s\S]{0,160}(?:executor|roles\.executor)[\s\S]{0,80}(?:["']codex["'])`,
+  ].join(""), "i");
+
+  for (const relativePath of productionFiles) {
+    const source = fs.readFileSync(path.join(__dirname, "..", "..", "..", relativePath), "utf-8");
+    assert.doesNotMatch(source, forbiddenBranch, relativePath);
+  }
 });
 
 test("hardened review assurance blocks advisory failures and required findings", async (t) => {


### PR DESCRIPTION
## Summary

- add a focused hardened-assurance regression that runs the same review path with Codex/Codex/Codex and non-Codex role bindings
- assert production assurance code does not branch on Codex executor+reviewer identity
- document Codex-only operation as generic policy coverage, not a policy special case

Closes #533

## Validation

- timeout 120s node --test tests/relay-review/scripts/review-runner-advisory.test.js
- timeout 120s node --test tests/relay-merge/scripts/review-gate.test.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 강화된 정책에서 Codex 전용 동작이 표준 역할 정책을 따른다는 내용을 문서화했습니다.

* **Tests**
  * 강화된 검토 보증이 모든 역할 바인딩에서 일관되게 작동하는지 검증하는 테스트 케이스를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->