### PR TITLE
[codex] Summarize override audit events

### DIFF
--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -593,6 +593,15 @@ function sortSummaryObject(entries) {
   return Object.fromEntries([...entries].sort(([left], [right]) => left.localeCompare(right)));
 }
 
+function incrementCountBucket(buckets, key) {
+  const bucketKey = normalizeBucketValue(key);
+  buckets.set(bucketKey, (buckets.get(bucketKey) || 0) + 1);
+}
+
+function sortCountBuckets(buckets) {
+  return sortSummaryObject(buckets.entries());
+}
+
 function buildSidecarOutcomeBuckets(starts, results, failures, fieldName) {
   const buckets = new Map();
   const startBucketsBySidecar = new Map();
@@ -614,6 +623,90 @@ function buildSidecarOutcomeBuckets(starts, results, failures, fieldName) {
   }
 
   return sortSummaryObject(buckets.entries());
+}
+
+const OVERRIDE_AUDIT_EVENT_NAMES = new Set([
+  EVENTS.EXECUTION_EVIDENCE_REBRANDED,
+  EVENTS.FORCE_FINALIZE,
+]);
+
+function hasOwnField(value, fieldName) {
+  return Object.prototype.hasOwnProperty.call(value || {}, fieldName);
+}
+
+function hasNonEmptyField(value, fieldName) {
+  return hasOwnField(value, fieldName) && String(value[fieldName] ?? "").trim() !== "";
+}
+
+function isOverrideAuditEvent(event) {
+  return Boolean(event?.override_class !== undefined || OVERRIDE_AUDIT_EVENT_NAMES.has(event?.event));
+}
+
+function overrideTransitionKey(event) {
+  return `${normalizeBucketValue(event?.prior_state || event?.state_from)}->${normalizeBucketValue(event?.state_to)}`;
+}
+
+function buildOverrideAuditSummary(events) {
+  const auditEvents = events.filter(isOverrideAuditEvent);
+  const byOverrideClass = new Map();
+  const byOperatorInitiated = new Map();
+  const affectedTransitions = new Map();
+  const fieldPresence = {
+    affected_head_sha: { present: 0, missing: 0 },
+    required_reason: { present: 0, missing: 0 },
+  };
+  const findings = [];
+  let currentShapeEvents = 0;
+  let legacyShapeEvents = 0;
+
+  for (const event of auditEvents) {
+    const currentShape = hasOwnField(event, "override_class");
+    if (currentShape) {
+      currentShapeEvents += 1;
+    } else {
+      legacyShapeEvents += 1;
+    }
+
+    incrementCountBucket(
+      byOverrideClass,
+      hasNonEmptyField(event, "override_class") ? event.override_class : "unknown"
+    );
+    incrementCountBucket(
+      byOperatorInitiated,
+      typeof event.operator_initiated === "boolean" ? String(event.operator_initiated) : "unknown"
+    );
+    incrementCountBucket(affectedTransitions, overrideTransitionKey(event));
+
+    const missingFields = [];
+    for (const fieldName of Object.keys(fieldPresence)) {
+      const presenceKey = hasNonEmptyField(event, fieldName) ? "present" : "missing";
+      fieldPresence[fieldName][presenceKey] += 1;
+      if (currentShape && presenceKey === "missing") {
+        missingFields.push(fieldName);
+      }
+    }
+
+    if (missingFields.length > 0) {
+      findings.push({
+        run_id: event.run_id || "unknown",
+        event: event.event || "unknown",
+        override_class: hasNonEmptyField(event, "override_class") ? event.override_class : "unknown",
+        missing_fields: missingFields,
+      });
+    }
+  }
+
+  return {
+    total_events: auditEvents.length,
+    current_shape_events: currentShapeEvents,
+    legacy_shape_events: legacyShapeEvents,
+    malformed_current_shape_events: findings.length,
+    by_override_class: sortCountBuckets(byOverrideClass),
+    by_operator_initiated: sortCountBuckets(byOperatorInitiated),
+    field_presence: fieldPresence,
+    affected_transitions: sortCountBuckets(affectedTransitions),
+    findings,
+  };
 }
 
 function buildSidecarCountBuckets(starts, fieldName) {
@@ -980,6 +1073,7 @@ function buildReport({ repoRoot, staleHours, now, manifests, events, includeSide
     rubric_insights: buildRubricInsights(events, manifests),
     qualitative_signals: buildQualitativeSignals(manifests, events),
     guidance_pack_insights: buildGuidancePackInsights(manifests, events),
+    override_audit: buildOverrideAuditSummary(events),
   };
 
   if (includeSidecarInsights) {
@@ -1071,6 +1165,16 @@ function buildDispatchReports(opts) {
     model: buildDispatchDimensionReport(opts, "model"),
     provider: buildDispatchDimensionReport(opts, "provider"),
   };
+}
+
+function formatCountSummary(buckets) {
+  return Object.entries(buckets || {})
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) => (
+      Number(rightValue || 0) - Number(leftValue || 0)
+      || leftKey.localeCompare(rightKey)
+    ))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
 }
 
 // `review_apply` can be emitted for a system-forced escalation before any
@@ -1232,6 +1336,26 @@ function main() {
     if (report.sidecar_insights.predicted_findings_match_rate !== null) {
       console.log(`    predicted_findings_match_rate: ${report.sidecar_insights.predicted_findings_match_rate}`);
       console.log(`    predicted_findings_runs_examined: ${report.sidecar_insights.predicted_findings_runs_examined}`);
+    }
+  }
+  if (report.override_audit?.total_events > 0) {
+    const audit = report.override_audit;
+    console.log("  override_audit:");
+    console.log(
+      `    total_events=${audit.total_events} ` +
+      `current_shape=${audit.current_shape_events} ` +
+      `legacy_shape=${audit.legacy_shape_events} ` +
+      `malformed=${audit.malformed_current_shape_events}`
+    );
+    console.log(`    by_override_class: ${formatCountSummary(audit.by_override_class) || "n/a"}`);
+    console.log(`    operator_initiated: ${formatCountSummary(audit.by_operator_initiated) || "n/a"}`);
+    console.log(
+      `    missing_required_fields: affected_head_sha=${audit.field_presence.affected_head_sha.missing} ` +
+      `required_reason=${audit.field_presence.required_reason.missing}`
+    );
+    console.log(`    affected_transitions: ${formatCountSummary(audit.affected_transitions) || "n/a"}`);
+    if (audit.findings.length > 0) {
+      console.log(`    findings: ${audit.findings.length} malformed current-shape event(s)`);
     }
   }
   if (hasCliFlag("--by-actor")) {

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -228,6 +228,21 @@ function appendSidecarFailed(repoRoot, runId, {
   });
 }
 
+function appendRawRunEvent(repoRoot, runId, eventData) {
+  const { runDir } = ensureRunLayout(repoRoot, runId);
+  fs.appendFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
+    ts: "2026-05-24T00:00:00.000Z",
+    actor: "Relay Test",
+    run_id: runId,
+    state_from: null,
+    state_to: null,
+    head_sha: null,
+    round: null,
+    reason: null,
+    ...eventData,
+  })}\n`, "utf-8");
+}
+
 function writeSidecarOutput(repoRoot, runId, sidecarId, content) {
   const { runDir } = ensureRunLayout(repoRoot, runId);
   const outputDir = path.join(runDir, "sidecars", sidecarId);
@@ -335,6 +350,100 @@ test("reliability-report derives the core scorecard from manifests and events", 
   assert.equal(report.metrics.median_rounds_to_ready, 3);
   assert.equal(report.metrics.stale_open_runs_72h, 1);
   assert.equal(report.bootstrap_exempt_runs, 1);
+});
+
+test("reliability-report summarizes override audit events without treating legacy shapes as corrupt", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-override-audit-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const forceRun = createRunId({ branch: "force-finalize", timestamp: new Date("2026-05-24T00:00:00.000Z") });
+  const rebrandRun = createRunId({ branch: "rebrand-evidence", timestamp: new Date("2026-05-24T00:00:01.000Z") });
+  const legacyRun = createRunId({ branch: "legacy-override", timestamp: new Date("2026-05-24T00:00:02.000Z") });
+  const malformedRun = createRunId({ branch: "malformed-override", timestamp: new Date("2026-05-24T00:00:03.000Z") });
+
+  for (const runId of [forceRun, rebrandRun, legacyRun, malformedRun]) {
+    writeRun(repoRoot, {
+      runId,
+      state: STATES.REVIEW_PENDING,
+      rounds: 1,
+      updatedAt: recentTs,
+    });
+  }
+
+  appendRunEvent(repoRoot, forceRun, {
+    event: "force_finalize",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.MERGED,
+    override_class: "force_finalize_nonready",
+    affected_head_sha: "a".repeat(40),
+    prior_state: STATES.REVIEW_PENDING,
+    required_reason: "operator verified by hand",
+    operator_initiated: true,
+  });
+  appendRunEvent(repoRoot, rebrandRun, {
+    event: "execution_evidence_rebranded",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.REVIEW_PENDING,
+    override_class: "execution_evidence_rebrand",
+    affected_head_sha: "b".repeat(40),
+    prior_state: STATES.REVIEW_PENDING,
+    required_reason: "evidence needed new head sha",
+    operator_initiated: true,
+  });
+  appendRawRunEvent(repoRoot, legacyRun, {
+    event: "force_finalize",
+    state_from: STATES.READY_TO_MERGE,
+    state_to: STATES.MERGED,
+    reason: "legacy force finalize before override audit fields",
+  });
+  appendRawRunEvent(repoRoot, malformedRun, {
+    event: "force_finalize",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.MERGED,
+    override_class: "force_finalize_nonready",
+    affected_head_sha: "",
+    required_reason: null,
+    operator_initiated: false,
+  });
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+  const text = execFileSync("node", [SCRIPT, "--repo", repoRoot], { encoding: "utf-8" });
+
+  assert.deepEqual(report.override_audit, {
+    total_events: 4,
+    current_shape_events: 3,
+    legacy_shape_events: 1,
+    malformed_current_shape_events: 1,
+    by_override_class: {
+      execution_evidence_rebrand: 1,
+      force_finalize_nonready: 2,
+      unknown: 1,
+    },
+    by_operator_initiated: {
+      false: 1,
+      true: 2,
+      unknown: 1,
+    },
+    field_presence: {
+      affected_head_sha: { present: 2, missing: 2 },
+      required_reason: { present: 2, missing: 2 },
+    },
+    affected_transitions: {
+      "ready_to_merge->merged": 1,
+      "review_pending->merged": 2,
+      "review_pending->review_pending": 1,
+    },
+    findings: [{
+      run_id: malformedRun,
+      event: "force_finalize",
+      override_class: "force_finalize_nonready",
+      missing_fields: ["affected_head_sha", "required_reason"],
+    }],
+  });
+  assert.match(text, /override_audit:/);
+  assert.match(text, /total_events=4 current_shape=3 legacy_shape=1 malformed=1/);
+  assert.match(text, /by_override_class: force_finalize_nonready=2, execution_evidence_rebrand=1, unknown=1/);
+  assert.match(text, /findings: 1 malformed current-shape event/);
 });
 
 test("reliability-report aggregates factor analysis across runs and rounds", () => {


### PR DESCRIPTION
## Summary

- add `override_audit` to reliability-report JSON output
- summarize override classes, operator-initiation buckets, required field presence, transitions, legacy shapes, and malformed current-shape findings
- render a compact text override audit section when audited events exist

Closes #547

## Validation

- timeout 120s node --test tests/relay-dispatch/scripts/reliability-report.test.js
- timeout 120s node --test tests/relay-dispatch/scripts/relay-events.test.js
- node skills/relay-dispatch/scripts/reliability-report.js --repo . --json includes `override_audit`
- node skills/relay-dispatch/scripts/reliability-report.js --repo . prints an `override_audit` section when audited events exist
- git diff --check