### PR TITLE
[codex] Add relay-config policy CLI

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -34,6 +34,7 @@ const FLAGS = [
   { flag: "--diff-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied fixture path; keep the literal argv token." },
   { flag: "--done-criteria-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied anchor path; keep the literal argv token." },
   { flag: "--dry-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--effective", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--executor", aliases: ["-e"], kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed selector; flag-like following tokens should mean the value is missing." },
   { flag: "--file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied input file path; keep the literal argv token." },
   { flag: "--fleet-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay fleet identifier; flag-like following tokens should mean the value is missing." },
@@ -60,6 +61,7 @@ const FLAGS = [
   { flag: "--older-than", kind: VALUE, mode: MODE_PARSED, valueName: "<hours>", rationale: "Numeric threshold; flag-like following tokens should mean the value is missing." },
   { flag: "--out-dir", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied output directory path; keep the literal argv token." },
   { flag: "--pin", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--phase", kind: VALUE, mode: MODE_PARSED, valueName: "<phase[,phase...]>", rationale: "Closed phase selector; flag-like following tokens should mean the value is missing." },
   { flag: "--post-comment", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--pr", kind: VALUE, mode: MODE_PARSED, valueName: "<number>", rationale: "Numeric PR selector; flag-like following tokens should mean the value is missing." },
   { flag: "--pr-body-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied PR body path; keep the literal argv token." },
@@ -67,6 +69,7 @@ const FLAGS = [
   { flag: "--pr-title", kind: VALUE, mode: MODE_VERBATIM, valueName: "<text>", rationale: "Operator-supplied PR title; preserve free text and embedded flag-like tokens." },
   { flag: "--prepare-only", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--print", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--profile", kind: VALUE, mode: MODE_PARSED, valueName: "<company|personal>", allowedValues: ["company", "personal"], rationale: "Closed relay policy setup profile; flag-like following tokens should mean the value is missing." },
   { flag: "--project-only", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--prompt", aliases: ["-p"], kind: VALUE, mode: MODE_VERBATIM, valueName: "<text>", rationale: "Operator-supplied prompt text; keep the literal argv token." },
   { flag: "--prompt-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied prompt path; keep the literal argv token." },
@@ -162,6 +165,10 @@ const COMMAND_FLAGS = {
   "recover-commit": [
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",
     "--dry-run", "--json", "--help",
+  ],
+  "relay-config": [
+    "--profile", "--effective", "--phase", "--executor", "--reviewer", "--model",
+    "--json", "--help",
   ],
   "rebrand-evidence": [
     "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const {
+  buildDefaultRelayPolicy,
+  evaluateRelayRoute,
+  loadRelayPolicy,
+  resolveRelayPolicyPath,
+  validateRelayPolicy,
+} = require("./relay-policy");
+const {
+  findUnknownFlags,
+  getPositionals,
+  modeLabel,
+  readArg,
+  schemaHasFlag,
+} = require("./cli-args");
+
+const args = process.argv.slice(2);
+const COMMAND_NAME = "relay-config";
+const CLI_ARG_OPTIONS = { commandName: COMMAND_NAME };
+const VALID_PHASES = ["dispatch", "review", "advisory_review", "sidecar"];
+const EXECUTOR_PHASES = new Set(["dispatch", "sidecar"]);
+const REVIEWER_PHASES = new Set(["review", "advisory_review"]);
+const DEFAULT_PATHS = new Set([
+  "dispatch.executor",
+  "review.reviewer",
+  "advisory_review.reviewer",
+  "sidecar.executor",
+]);
+const DOCTOR_TOOLS = ["codex", "claude", "opencode", "pi"];
+
+function hasCliFlag(flag) {
+  return schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function printHelp() {
+  console.log("Usage: relay-config.js <command> [options]");
+  console.log("");
+  console.log("Configure relay provider/model route policy. Executor/reviewer names are harnesses; provider/model route strings are the policy boundary.");
+  console.log("");
+  console.log("Commands:");
+  console.log(`  init --profile <company|personal> ${modeLabel("--profile")} [--json ${modeLabel("--json")}]`);
+  console.log(`  show --effective ${modeLabel("--effective")} [--json ${modeLabel("--json")}]`);
+  console.log(`  doctor [--json ${modeLabel("--json")}]`);
+  console.log(`  check --phase <phase> ${modeLabel("--phase")} --executor <name> ${modeLabel("--executor")} [--reviewer <name> ${modeLabel("--reviewer")}] [--model <provider/model> ${modeLabel("--model")}] [--json ${modeLabel("--json")}]`);
+  console.log("  set-default <path> <value> [--json]");
+  console.log(`  allow-route <pattern> --phase <csv> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
+  console.log(`  deny-route <pattern> [--phase <csv> ${modeLabel("--phase")}] [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
+  console.log("");
+  console.log("Supported default paths:");
+  console.log("  dispatch.executor, review.reviewer, advisory_review.reviewer, sidecar.executor");
+  console.log("");
+  console.log(`Options: --help ${modeLabel("--help")}`);
+}
+
+function relayPolicyPath() {
+  return resolveRelayPolicyPath();
+}
+
+function writePolicy(policyPath, policy) {
+  const normalized = validateRelayPolicy(policy, policyPath);
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+  fs.writeFileSync(policyPath, `${JSON.stringify(normalized, null, 2)}\n`, "utf-8");
+  return normalized;
+}
+
+function loadGlobalPolicyForMutation() {
+  const policyPath = relayPolicyPath();
+  const result = loadRelayPolicy({ globalPath: policyPath, repoRoot: null });
+  if (!result.ok) {
+    const error = result.errors[0];
+    throw new Error(error ? error.message : "failed to load relay policy");
+  }
+  return {
+    policyPath,
+    policy: result.policy,
+  };
+}
+
+function buildProfilePolicy(profile) {
+  return validateRelayPolicy(
+    {
+      ...buildDefaultRelayPolicy(),
+      profile,
+    },
+    `${profile} relay policy`
+  );
+}
+
+function requireValue(value, label) {
+  const normalized = nonEmptyString(value);
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function parsePhases(rawValue, { required } = { required: false }) {
+  const raw = nonEmptyString(rawValue);
+  if (!raw) {
+    if (required) {
+      throw new Error(`--phase is required and must include one or more of: ${VALID_PHASES.join(", ")}`);
+    }
+    return undefined;
+  }
+
+  const phases = [];
+  for (const token of raw.split(",")) {
+    const phase = token.trim();
+    if (!phase) continue;
+    if (!VALID_PHASES.includes(phase)) {
+      throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
+    }
+    if (!phases.includes(phase)) phases.push(phase);
+  }
+
+  if (!phases.length) {
+    throw new Error(`--phase is required and must include one or more of: ${VALID_PHASES.join(", ")}`);
+  }
+  return phases;
+}
+
+function routeEntry(pattern, { phases, executor, reviewer }) {
+  const route = requireValue(pattern, "route pattern");
+  const entry = { route };
+  if (phases !== undefined) entry.phases = phases;
+
+  const executorName = nonEmptyString(executor);
+  const reviewerName = nonEmptyString(reviewer);
+  if (!executorName && !reviewerName) return entry;
+
+  const hasExecutorPhase = !phases || phases.some((phase) => EXECUTOR_PHASES.has(phase));
+  const hasReviewerPhase = !phases || phases.some((phase) => REVIEWER_PHASES.has(phase));
+
+  if (executorName && reviewerName) {
+    if (hasExecutorPhase) entry.executors = [executorName];
+    if (hasReviewerPhase) entry.reviewers = [reviewerName];
+    return entry;
+  }
+
+  if (executorName) {
+    if (hasExecutorPhase) entry.executors = [executorName];
+    if (hasReviewerPhase) entry.reviewers = [executorName];
+    return entry;
+  }
+
+  if (reviewerName) {
+    if (hasExecutorPhase) entry.executors = [reviewerName];
+    if (hasReviewerPhase) entry.reviewers = [reviewerName];
+  }
+  return entry;
+}
+
+function outputMutation({ jsonOut, action, policyPath, policy, entry = null, defaultPath = null }) {
+  if (jsonOut) {
+    printJson({
+      ok: true,
+      action,
+      path: policyPath,
+      defaultPath,
+      entry,
+      policy,
+    });
+    return;
+  }
+  console.log(`relay-config: ${action} wrote ${policyPath}`);
+}
+
+function commandInit(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("init does not accept positional arguments");
+  }
+  const profile = requireValue(readArg(args, "--profile", undefined, CLI_ARG_OPTIONS), "--profile");
+  const policyPath = relayPolicyPath();
+  const policy = writePolicy(policyPath, buildProfilePolicy(profile));
+  if (jsonOut) {
+    printJson({
+      ok: true,
+      action: "init",
+      profile,
+      path: policyPath,
+      policy,
+    });
+  } else {
+    console.log(`relay-config: initialized ${profile} policy at ${policyPath}`);
+  }
+}
+
+function commandShow(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("show does not accept positional arguments");
+  }
+  if (!hasCliFlag("--effective")) {
+    throw new Error("show requires --effective");
+  }
+
+  const result = loadRelayPolicy({ repoRoot: process.cwd() });
+  if (jsonOut) {
+    printJson(result);
+  } else if (result.ok) {
+    console.log(`relay-config: effective policy status ${result.status}`);
+    console.log(`global: ${result.sources.global}`);
+    if (result.sources.repo) console.log(`repo: ${result.sources.repo}`);
+    console.log(JSON.stringify(result.policy, null, 2));
+  } else {
+    console.log("relay-config: effective policy failed to load");
+    for (const error of result.errors) {
+      console.log(`${error.reason}: ${error.message}`);
+    }
+  }
+  if (!result.ok) process.exitCode = 1;
+}
+
+function pathEntries() {
+  return String(process.env.PATH || "")
+    .split(path.delimiter)
+    .filter(Boolean);
+}
+
+function findOnPath(binaryName) {
+  for (const dir of pathEntries()) {
+    const candidate = path.join(dir, binaryName);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep scanning PATH entries.
+    }
+  }
+  return null;
+}
+
+function defaultActors(policy) {
+  return [
+    policy.defaults.dispatch?.executor,
+    policy.defaults.review?.reviewer,
+    policy.defaults.advisory_review?.reviewer,
+    policy.defaults.sidecar?.executor,
+  ].filter(Boolean);
+}
+
+function routeActors(policy) {
+  const actors = [];
+  for (const listName of ["allowed_model_routes", "denied_model_routes"]) {
+    for (const entry of policy[listName]) {
+      actors.push(...(entry.executors || []), ...(entry.reviewers || []));
+    }
+  }
+  return actors;
+}
+
+function actorHasConfiguredAllowedRoute(policy, actor) {
+  return policy.allowed_model_routes.some((entry) => {
+    const hasActorScope = entry.executors !== undefined || entry.reviewers !== undefined;
+    if (!hasActorScope) return true;
+    return Boolean(entry.executors?.includes(actor) || entry.reviewers?.includes(actor));
+  });
+}
+
+function doctorTool(policy, name) {
+  const executable = findOnPath(name);
+  const dispatchDecision = evaluateRelayRoute(policy, { phase: "dispatch", executor: name });
+  let policyStatus = dispatchDecision.allowed ? "allowed" : "policy-disallowed";
+  let reason = dispatchDecision.reason;
+
+  if (!dispatchDecision.allowed && actorHasConfiguredAllowedRoute(policy, name)) {
+    policyStatus = "route-configured";
+    reason = "provider_model_route_required";
+  }
+
+  return {
+    name,
+    installed: Boolean(executable),
+    path: executable,
+    policy: policyStatus,
+    reason,
+  };
+}
+
+function commandDoctor(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("doctor does not accept positional arguments");
+  }
+  const result = loadRelayPolicy({ repoRoot: process.cwd() });
+  if (!result.ok) {
+    if (jsonOut) printJson({ ok: false, status: result.status, sources: result.sources, errors: result.errors });
+    else {
+      console.error("relay-config doctor: policy failed to load");
+      for (const error of result.errors) console.error(`${error.reason}: ${error.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const toolNames = [...new Set([
+    ...DOCTOR_TOOLS,
+    ...result.policy.managed_cli,
+    ...defaultActors(result.policy),
+    ...routeActors(result.policy),
+  ])].sort();
+  const tools = toolNames.map((name) => doctorTool(result.policy, name));
+  const output = {
+    ok: true,
+    status: result.status,
+    sources: result.sources,
+    tools,
+  };
+
+  if (jsonOut) {
+    printJson(output);
+  } else {
+    console.log(`relay-config doctor: policy ${result.status}`);
+    for (const tool of tools) {
+      const installed = tool.installed ? `installed at ${tool.path}` : "not installed on PATH";
+      console.log(`${tool.name}: ${installed}; ${tool.policy} (${tool.reason})`);
+    }
+  }
+}
+
+function commandCheck(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("check does not accept positional arguments");
+  }
+
+  const phase = requireValue(readArg(args, "--phase", undefined, CLI_ARG_OPTIONS), "--phase");
+  if (!VALID_PHASES.includes(phase)) {
+    throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
+  }
+  const executor = requireValue(readArg(args, "--executor", undefined, CLI_ARG_OPTIONS), "--executor");
+  const reviewer = readArg(args, "--reviewer", undefined, CLI_ARG_OPTIONS);
+  const model = readArg(args, "--model", undefined, CLI_ARG_OPTIONS);
+  const result = loadRelayPolicy({ repoRoot: process.cwd() });
+  const decision = evaluateRelayRoute(result, { phase, executor, reviewer, model });
+  const output = {
+    ok: decision.allowed,
+    status: result.status,
+    sources: result.sources,
+    decision,
+  };
+
+  if (jsonOut) {
+    printJson(output);
+  } else {
+    const label = decision.allowed ? "allowed" : "denied";
+    console.log(`${label}: ${decision.reason}`);
+    if (decision.matchedRoute) console.log(`matched route: ${decision.matchedRoute}`);
+  }
+
+  if (!decision.allowed) process.exitCode = 1;
+}
+
+function commandSetDefault(positionals, jsonOut) {
+  if (positionals.length !== 3) {
+    throw new Error("set-default requires <path> <value>");
+  }
+  const defaultPath = positionals[1];
+  const value = requireValue(positionals[2], "default value");
+  if (!DEFAULT_PATHS.has(defaultPath)) {
+    throw new Error(`unsupported default path: ${defaultPath}`);
+  }
+
+  const { policyPath, policy } = loadGlobalPolicyForMutation();
+  const [phase, field] = defaultPath.split(".");
+  policy.defaults[phase] = {
+    ...(policy.defaults[phase] || {}),
+    [field]: value,
+  };
+  const updated = writePolicy(policyPath, policy);
+  outputMutation({ jsonOut, action: "set-default", policyPath, policy: updated, defaultPath });
+}
+
+function commandRouteMutation(positionals, jsonOut, { action, listName, requirePhase }) {
+  if (positionals.length !== 2) {
+    throw new Error(`${action} requires <pattern>`);
+  }
+  const pattern = positionals[1];
+  const phases = parsePhases(readArg(args, "--phase", undefined, CLI_ARG_OPTIONS), { required: requirePhase });
+  const executor = readArg(args, "--executor", undefined, CLI_ARG_OPTIONS);
+  const reviewer = readArg(args, "--reviewer", undefined, CLI_ARG_OPTIONS);
+  const entry = routeEntry(pattern, { phases, executor, reviewer });
+
+  const { policyPath, policy } = loadGlobalPolicyForMutation();
+  policy[listName].push(entry);
+  const updated = writePolicy(policyPath, policy);
+  outputMutation({ jsonOut, action, policyPath, policy: updated, entry });
+}
+
+function main() {
+  if (!args.length || hasCliFlag(["--help", "-h"])) {
+    printHelp();
+    return;
+  }
+
+  const unknownFlags = findUnknownFlags(args, COMMAND_NAME);
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+
+  const jsonOut = hasCliFlag("--json");
+  const positionals = getPositionals(args, COMMAND_NAME);
+  const command = positionals[0];
+  if (!command) {
+    throw new Error("command is required");
+  }
+
+  switch (command) {
+    case "init":
+      commandInit(positionals, jsonOut);
+      break;
+    case "show":
+      commandShow(positionals, jsonOut);
+      break;
+    case "doctor":
+      commandDoctor(positionals, jsonOut);
+      break;
+    case "check":
+      commandCheck(positionals, jsonOut);
+      break;
+    case "set-default":
+      commandSetDefault(positionals, jsonOut);
+      break;
+    case "allow-route":
+      commandRouteMutation(positionals, jsonOut, {
+        action: "allow-route",
+        listName: "allowed_model_routes",
+        requirePhase: true,
+      });
+      break;
+    case "deny-route":
+      commandRouteMutation(positionals, jsonOut, {
+        action: "deny-route",
+        listName: "denied_model_routes",
+        requirePhase: false,
+      });
+      break;
+    default:
+      throw new Error(`unknown command: ${command}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  if (hasCliFlag("--json")) {
+    printJson({
+      ok: false,
+      error: error.message,
+    });
+  } else {
+    console.error(`Error: ${error.message}`);
+  }
+  process.exit(1);
+}

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -30,6 +30,20 @@ const DEFAULT_PATHS = new Set([
   "sidecar.executor",
 ]);
 const DOCTOR_TOOLS = ["codex", "claude", "opencode", "pi"];
+const SUBCOMMAND_FLAGS = {
+  init: new Set(["--profile", "--json", "--help"]),
+  show: new Set(["--effective", "--json", "--help"]),
+  doctor: new Set(["--json", "--help"]),
+  check: new Set(["--phase", "--executor", "--reviewer", "--model", "--json", "--help"]),
+  "set-default": new Set(["--json", "--help"]),
+  "allow-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
+  "deny-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
+};
+const RELAY_CONFIG_FLAG_ALIASES = new Map([
+  ["-h", "--help"],
+  ["-e", "--executor"],
+  ["-m", "--model"],
+]);
 
 function hasCliFlag(flag) {
   return schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
@@ -61,6 +75,26 @@ function printHelp() {
   console.log("  dispatch.executor, review.reviewer, advisory_review.reviewer, sidecar.executor");
   console.log("");
   console.log(`Options: --help ${modeLabel("--help")}`);
+}
+
+function flagName(token) {
+  const text = String(token);
+  const separator = text.indexOf("=");
+  const raw = separator === -1 ? text : text.slice(0, separator);
+  return RELAY_CONFIG_FLAG_ALIASES.get(raw) || raw;
+}
+
+function unsupportedFlagsForCommand(command, argv) {
+  const allowed = SUBCOMMAND_FLAGS[command];
+  if (!allowed) return [];
+
+  const unsupported = [];
+  for (const token of argv) {
+    if (!String(token).startsWith("-")) continue;
+    const flag = flagName(token);
+    if (!allowed.has(flag)) unsupported.push(flag);
+  }
+  return [...new Set(unsupported)];
 }
 
 function relayPolicyPath() {
@@ -410,6 +444,14 @@ function main() {
   if (!command) {
     throw new Error("command is required");
   }
+  if (!Object.prototype.hasOwnProperty.call(SUBCOMMAND_FLAGS, command)) {
+    throw new Error(`unknown command: ${command}`);
+  }
+
+  const unsupportedFlags = unsupportedFlagsForCommand(command, args);
+  if (unsupportedFlags.length) {
+    throw new Error(`unsupported flags for ${command}: ${unsupportedFlags.join(", ")}`);
+  }
 
   switch (command) {
     case "init":
@@ -441,8 +483,6 @@ function main() {
         requirePhase: false,
       });
       break;
-    default:
-      throw new Error(`unknown command: ${command}`);
   }
 }
 

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -155,6 +155,7 @@ const HELP_COMMANDS = [
   ["persist-request", path.join(__dirname, "..", "..", "..", "skills", "relay-ready", "scripts", "persist-request.js")],
   ["probe-executor-env", path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "scripts", "probe-executor-env.js")],
   ["recover-commit", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-commit.js")],
+  ["relay-config", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "relay-config.js")],
   ["rebrand-evidence", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "rebrand-evidence.js")],
   ["recover-state", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-state.js")],
   ["reliability-report", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "reliability-report.js")],

--- a/tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
+++ b/tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
@@ -21,6 +21,8 @@ const CLI_TARGETS = [
     ["--repo", ".", "--run-id", "fake", "--reason", "test", "--no-merge"], "--no-merge"],
   ["relay-dispatch", "skills/relay-dispatch/scripts/cleanup-worktrees.js",
     ["--repo", ".", "--no-merge"], "--no-merge"],
+  ["relay-dispatch", "skills/relay-dispatch/scripts/relay-config.js",
+    ["init", "--profile", "company", "--no-merge"], "--no-merge"],
   ["relay-dispatch", "skills/relay-dispatch/scripts/recover-state.js",
     ["--repo", ".", "--run-id", "fake", "--to", "review_pending",
      "--reason", "test", "--no-merge"], "--no-merge"],

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -1,0 +1,310 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const {
+  validateRelayPolicy,
+} = require("../../../skills/relay-dispatch/scripts/relay-policy");
+
+const REPO_ROOT = path.join(__dirname, "..", "..", "..");
+const SCRIPT = path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "relay-config.js");
+
+function tempDir(prefix = "relay-config-") {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function envFor(relayHome, extra = {}) {
+  const env = {
+    ...process.env,
+    ...extra,
+    RELAY_HOME: relayHome,
+  };
+  if (!Object.prototype.hasOwnProperty.call(extra, "RELAY_POLICY_PATH")) {
+    delete env.RELAY_POLICY_PATH;
+  }
+  return env;
+}
+
+function runConfig(args, { relayHome = tempDir(), cwd = REPO_ROOT, env = {} } = {}) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd,
+    env: envFor(relayHome, env),
+    encoding: "utf-8",
+  });
+  return {
+    ...result,
+    relayHome,
+    combined: `${result.stdout}\n${result.stderr}`,
+  };
+}
+
+function parseJson(result) {
+  assert.equal(result.stderr, "", result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+function readPolicy(relayHome) {
+  const policyPath = path.join(relayHome, "policy.json");
+  const policy = JSON.parse(fs.readFileSync(policyPath, "utf-8"));
+  return validateRelayPolicy(policy, policyPath);
+}
+
+function writeExecutable(filePath, body = "#!/bin/sh\nexit 0\n") {
+  fs.writeFileSync(filePath, body, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+}
+
+test("init --profile company writes a company-safe global policy", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig(["init", "--profile", "company", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.profile, "company");
+  assert.equal(output.path, path.join(relayHome, "policy.json"));
+
+  const policy = readPolicy(relayHome);
+  assert.equal(policy.profile, "company");
+  assert.deepEqual(policy.defaults, {
+    dispatch: { executor: "codex" },
+    review: { reviewer: "codex" },
+    advisory_review: null,
+    sidecar: null,
+  });
+  assert.deepEqual(policy.managed_cli, ["codex", "claude"]);
+  assert.deepEqual(policy.allowed_model_routes, []);
+  assert.deepEqual(policy.denied_model_routes, []);
+  assert.equal(policy.deny_unknown_model_routes, true);
+  assert.equal(Object.prototype.hasOwnProperty.call(policy.defaults.dispatch, "model"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(policy.defaults.review, "model"), false);
+});
+
+test("init --profile personal remains explicit and does not add OpenCode or Pi routes", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig(["init", "--profile", "personal", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const policy = readPolicy(relayHome);
+  assert.equal(policy.profile, "personal");
+  assert.deepEqual(policy.managed_cli, ["codex", "claude"]);
+  assert.deepEqual(policy.allowed_model_routes, []);
+  assert.deepEqual(policy.denied_model_routes, []);
+  assert.equal(policy.deny_unknown_model_routes, true);
+});
+
+test("show --effective emits deterministic JSON for the loaded effective policy", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig(["show", "--effective", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.status, "ok");
+  assert.equal(output.sources.global, path.join(relayHome, "policy.json"));
+  assert.equal(output.policy.profile, "company");
+});
+
+test("doctor uses local PATH only and labels installed disallowed harnesses as policy-disallowed", () => {
+  const relayHome = tempDir();
+  const binDir = tempDir("relay-config-bin-");
+  writeExecutable(path.join(binDir, "opencode"));
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig(["doctor", "--json"], {
+    relayHome,
+    env: { PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}` },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  const opencode = output.tools.find((tool) => tool.name === "opencode");
+  assert.deepEqual(
+    {
+      installed: opencode.installed,
+      policy: opencode.policy,
+      reason: opencode.reason,
+    },
+    {
+      installed: true,
+      policy: "policy-disallowed",
+      reason: "missing_model_route",
+    }
+  );
+});
+
+test("check exits zero for allowed managed CLI routes and reports the decision reason", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig(["check", "--phase", "dispatch", "--executor", "codex", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.decision.allowed, true);
+  assert.equal(output.decision.reason, "managed_cli");
+});
+
+test("check exits non-zero for missing and unknown OpenCode/Pi provider routes", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const missing = runConfig(["check", "--phase", "dispatch", "--executor", "opencode", "--json"], { relayHome });
+  assert.notEqual(missing.status, 0, missing.combined);
+  assert.equal(parseJson(missing).decision.reason, "missing_model_route");
+
+  const unknown = runConfig([
+    "check",
+    "--phase",
+    "dispatch",
+    "--executor",
+    "opencode",
+    "--model",
+    "kakao/opencode-glm-5-fp8",
+    "--json",
+  ], { relayHome });
+  assert.notEqual(unknown.status, 0, unknown.combined);
+  assert.equal(parseJson(unknown).decision.reason, "unknown_model_route");
+});
+
+test("set-default mutates supported default actor paths and preserves v1 policy shape", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const sidecar = runConfig(["set-default", "sidecar.executor", "opencode", "--json"], { relayHome });
+  assert.equal(sidecar.status, 0, sidecar.combined);
+  const advisory = runConfig(["set-default", "advisory_review.reviewer", "claude", "--json"], { relayHome });
+  assert.equal(advisory.status, 0, advisory.combined);
+
+  const policy = readPolicy(relayHome);
+  assert.deepEqual(policy.defaults.sidecar, { executor: "opencode" });
+  assert.deepEqual(policy.defaults.advisory_review, { reviewer: "claude" });
+});
+
+test("allow-route maps mixed executor phases to executors and reviewer phases to reviewers", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const mutation = runConfig([
+    "allow-route",
+    "kakao/opencode-glm-*",
+    "--executor",
+    "opencode",
+    "--phase",
+    "sidecar,advisory_review,dispatch",
+    "--json",
+  ], { relayHome });
+  assert.equal(mutation.status, 0, mutation.combined);
+
+  const [entry] = readPolicy(relayHome).allowed_model_routes;
+  assert.equal(entry.route, "kakao/opencode-glm-*");
+  assert.deepEqual(new Set(entry.phases), new Set(["sidecar", "advisory_review", "dispatch"]));
+  assert.deepEqual(entry.executors, ["opencode"]);
+  assert.deepEqual(entry.reviewers, ["opencode"]);
+
+  const dispatch = runConfig([
+    "check",
+    "--phase",
+    "dispatch",
+    "--executor",
+    "opencode",
+    "--model",
+    "kakao/opencode-glm-5-fp8",
+    "--json",
+  ], { relayHome });
+  assert.equal(dispatch.status, 0, dispatch.combined);
+  assert.equal(parseJson(dispatch).decision.reason, "allowed_model_route");
+
+  const advisory = runConfig([
+    "check",
+    "--phase",
+    "advisory_review",
+    "--executor",
+    "opencode",
+    "--reviewer",
+    "opencode",
+    "--model",
+    "kakao/opencode-glm-5-fp8",
+    "--json",
+  ], { relayHome });
+  assert.equal(advisory.status, 0, advisory.combined);
+  assert.equal(parseJson(advisory).decision.reason, "allowed_model_route");
+});
+
+test("deny-route preserves route scopes and denied routes win during check", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+  assert.equal(runConfig([
+    "allow-route",
+    "kakao/opencode-glm-*",
+    "--executor",
+    "opencode",
+    "--phase",
+    "dispatch",
+    "--json",
+  ], { relayHome }).status, 0);
+
+  const mutation = runConfig([
+    "deny-route",
+    "kakao/opencode-glm-bad",
+    "--executor",
+    "opencode",
+    "--phase",
+    "dispatch",
+    "--json",
+  ], { relayHome });
+  assert.equal(mutation.status, 0, mutation.combined);
+
+  const [entry] = readPolicy(relayHome).denied_model_routes;
+  assert.deepEqual(entry, {
+    route: "kakao/opencode-glm-bad",
+    phases: ["dispatch"],
+    executors: ["opencode"],
+  });
+
+  const denied = runConfig([
+    "check",
+    "--phase",
+    "dispatch",
+    "--executor",
+    "opencode",
+    "--model",
+    "kakao/opencode-glm-bad",
+    "--json",
+  ], { relayHome });
+  assert.notEqual(denied.status, 0, denied.combined);
+  assert.equal(parseJson(denied).decision.reason, "denied_model_route");
+});
+
+test("invalid args fail closed with non-zero exits", () => {
+  const relayHome = tempDir();
+
+  const unknown = runConfig(["init", "--profile", "company", "--bogus"], { relayHome });
+  assert.notEqual(unknown.status, 0, unknown.combined);
+  assert.match(unknown.combined, /unknown flag.*--bogus/i);
+
+  const profile = runConfig(["init", "--profile", "enterprise"], { relayHome });
+  assert.notEqual(profile.status, 0, profile.combined);
+  assert.match(profile.combined, /--profile must be one of: company, personal/);
+
+  const pathResult = runConfig(["set-default", "dispatch.model", "openai/gpt-5"], { relayHome });
+  assert.notEqual(pathResult.status, 0, pathResult.combined);
+  assert.match(pathResult.combined, /unsupported default path: dispatch\.model/);
+});
+
+test("help explains harness actors and provider/model route boundaries", () => {
+  const result = runConfig(["--help"]);
+
+  assert.equal(result.status, 0, result.combined);
+  assert.match(result.stdout, /executor\/reviewer names are harnesses/i);
+  assert.match(result.stdout, /provider\/model route strings are the policy boundary/i);
+});

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -301,6 +301,23 @@ test("invalid args fail closed with non-zero exits", () => {
   assert.match(pathResult.combined, /unsupported default path: dispatch\.model/);
 });
 
+test("subcommands reject known relay-config flags outside their supported grammar", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const init = runConfig(["init", "--profile", "company", "--model", "foo"], { relayHome });
+  assert.notEqual(init.status, 0, init.combined);
+  assert.match(init.combined, /unsupported flags for init: --model/);
+
+  const doctor = runConfig(["doctor", "--profile", "company"], { relayHome });
+  assert.notEqual(doctor.status, 0, doctor.combined);
+  assert.match(doctor.combined, /unsupported flags for doctor: --profile/);
+
+  const show = runConfig(["show", "--effective", "--executor", "codex"], { relayHome });
+  assert.notEqual(show.status, 0, show.combined);
+  assert.match(show.combined, /unsupported flags for show: --executor/);
+});
+
 test("help explains harness actors and provider/model route boundaries", () => {
   const result = runConfig(["--help"]);
 


### PR DESCRIPTION
## Summary

- Add `skills/relay-dispatch/scripts/relay-config.js` for policy setup, inspection, doctor checks, route checks, default mutation, and allow/deny route mutation.
- Register relay-config flags in the shared CLI schema and unknown-flag wiring.
- Add CLI coverage for company/personal init, show, doctor, check allowed/denied, set-default, allow-route, deny-route, invalid args, and JSON behavior.

## Notes

- The generated company and personal profiles use the `relay-policy.js` default shape and do not pin Codex or Claude model names.
- OpenCode/Pi remain denied by default until explicit provider/model routes are configured.
- Route mutations encode executor phases under `executors` and reviewer phases under `reviewers`.
- This does not wire policy enforcement into dispatch, review, or sidecar runtime paths.

## Verification

```text
$ node --test tests/relay-dispatch/scripts/relay-config.test.js
✔ init --profile company writes a company-safe global policy (304.897625ms)
✔ init --profile personal remains explicit and does not add OpenCode or Pi routes (254.265958ms)
✔ show --effective emits deterministic JSON for the loaded effective policy (489.917ms)
✔ doctor uses local PATH only and labels installed disallowed harnesses as policy-disallowed (605.221417ms)
✔ check exits zero for allowed managed CLI routes and reports the decision reason (454.518625ms)
✔ check exits non-zero for missing and unknown OpenCode/Pi provider routes (589.433041ms)
✔ set-default mutates supported default actor paths and preserves v1 policy shape (641.275875ms)
✔ allow-route maps mixed executor phases to executors and reviewer phases to reviewers (788.991ms)
✔ deny-route preserves route scopes and denied routes win during check (807.822917ms)
✔ invalid args fail closed with non-zero exits (984.818625ms)
✔ help explains harness actors and provider/model route boundaries (241.944708ms)
ℹ tests 11
ℹ suites 0
ℹ pass 11
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 6501.433417
```

```text
$ node --test tests/relay-dispatch/scripts/relay-policy.test.js
✔ loadRelayPolicy uses managed Codex and Claude defaults when config is missing (5.438417ms)
✔ malformed global policy load fails closed with status and errors (1.804625ms)
✔ validateRelayPolicy rejects invalid v1 schema shapes (0.623ms)
✔ global-only policy allows matching model routes and denies unknown routes (1.822666ms)
✔ RELAY_POLICY_PATH overrides the default global policy path (2.049084ms)
✔ repo-local policy can narrow managed CLIs, allowed routes, and unknown-route behavior (2.707375ms)
✔ repo-local policy that widens global policy is rejected (1.737917ms)
✔ denied model routes win over allowed model routes (0.190084ms)
✔ route actor scopes are bound to the evaluated phase (0.261791ms)
✔ unknown route denial can be explicitly disabled for non-managed executors (1.402ms)
✔ matchRoutePattern supports simple star globs (0.146916ms)
ℹ tests 11
ℹ suites 0
ℹ pass 11
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 193.775375
```

```text
$ node --test tests/relay-dispatch/scripts/cli-schema.test.js tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
✔ every registered command flag has an explicit parsed/verbatim mode (2.793917ms)
✔ unregistered flag reads fail closed (0.547125ms)
✔ --artifact-path verbatim mode preserves adversarial values through argv (1481.103375ms)
✔ --branch verbatim mode preserves adversarial values through argv (1536.393166ms)
✔ --contract-file verbatim mode preserves adversarial values through argv (2131.778041ms)
✔ --copy verbatim mode preserves adversarial values through argv (1697.31ms)
✔ --diff-file verbatim mode preserves adversarial values through argv (1225.53825ms)
✔ --done-criteria-file verbatim mode preserves adversarial values through argv (1256.699583ms)
✔ --file verbatim mode preserves adversarial values through argv (1253.868792ms)
✔ --independent-review-reason verbatim mode preserves adversarial values through argv (1270.690167ms)
✔ --manifest verbatim mode preserves adversarial values through argv (1213.611833ms)
✔ --next-action verbatim mode preserves adversarial values through argv (1324.429041ms)
✔ --out-dir verbatim mode preserves adversarial values through argv (1498.930417ms)
✔ --pr-body-file verbatim mode preserves adversarial values through argv (1932.411792ms)
✔ --pr-title verbatim mode preserves adversarial values through argv (1774.660292ms)
✔ --prompt verbatim mode preserves adversarial values through argv (1350.944708ms)
✔ --prompt-file verbatim mode preserves adversarial values through argv (1926.875625ms)
✔ --reason verbatim mode preserves adversarial values through argv (2427.023792ms)
✔ --repo verbatim mode preserves adversarial values through argv (1996.082459ms)
✔ --review-file verbatim mode preserves adversarial values through argv (1735.654792ms)
✔ --manual-review-reason verbatim mode preserves adversarial values through argv (1846.22275ms)
✔ --reviewer-script verbatim mode preserves adversarial values through argv (2003.950375ms)
✔ --rubric-file verbatim mode preserves adversarial values through argv (1892.425125ms)
✔ --runs-dir verbatim mode preserves adversarial values through argv (2023.887959ms)
✔ --skip verbatim mode preserves adversarial values through argv (1873.547625ms)
✔ --skip-review verbatim mode preserves adversarial values through argv (1861.768417ms)
✔ --test-command verbatim mode preserves adversarial values through argv (1766.958084ms)
✔ --text verbatim mode preserves adversarial values through argv (1752.735583ms)
✔ --title verbatim mode preserves adversarial values through argv (1944.264ms)
✔ --topic verbatim mode preserves adversarial values through argv (1859.612042ms)
✔ --worktree-path verbatim mode preserves adversarial values through argv (1938.563458ms)
✔ verbatim values that look like flags do not activate sibling flags (0.964667ms)
✔ --advisory-profile parsed mode treats --prefix input as missing through argv (340.555542ms)
✔ --advisory-reviewer parsed mode treats --prefix input as missing through argv (337.028708ms)
✔ --advisory-reviewer-model parsed mode treats --prefix input as missing through argv (347.950792ms)
✔ --advisory-timeout parsed mode treats --prefix input as missing through argv (325.470792ms)
✔ --executor parsed mode treats --prefix input as missing through argv (389.920542ms)
✔ --fleet-id parsed mode treats --prefix input as missing through argv (396.166292ms)
✔ --head-sha parsed mode treats --prefix input as missing through argv (349.273542ms)
✔ --issue parsed mode treats --prefix input as missing through argv (346.535875ms)
✔ --last-reviewed-sha parsed mode treats --prefix input as missing through argv (331.184084ms)
✔ --leaf-id parsed mode treats --prefix input as missing through argv (318.52875ms)
✔ --max-rounds parsed mode treats --prefix input as missing through argv (317.087458ms)
✔ --merge-method parsed mode treats --prefix input as missing through argv (309.865958ms)
✔ --model parsed mode treats --prefix input as missing through argv (314.802792ms)
✔ --model-hints parsed mode treats --prefix input as missing through argv (295.36325ms)
✔ --network-access parsed mode treats --prefix input as missing through argv (329.180458ms)
✔ --older-than parsed mode treats --prefix input as missing through argv (318.207209ms)
✔ --phase parsed mode treats --prefix input as missing through argv (327.146042ms)
✔ --pr parsed mode treats --prefix input as missing through argv (323.726166ms)
✔ --pr-number parsed mode treats --prefix input as missing through argv (324.054125ms)
✔ --profile parsed mode treats --prefix input as missing through argv (329.788334ms)
✔ --reasoning parsed mode treats --prefix input as missing through argv (358.903333ms)
✔ --repeated-issue-count parsed mode treats --prefix input as missing through argv (323.155709ms)
✔ --request-id parsed mode treats --prefix input as missing through argv (332.749875ms)
✔ --review-assurance parsed mode treats --prefix input as missing through argv (359.127208ms)
✔ --reviewer parsed mode treats --prefix input as missing through argv (430.095709ms)
✔ --reviewer-model parsed mode treats --prefix input as missing through argv (345.422083ms)
✔ --rounds parsed mode treats --prefix input as missing through argv (373.845583ms)
✔ --run-id parsed mode treats --prefix input as missing through argv (350.453042ms)
✔ --sandbox parsed mode treats --prefix input as missing through argv (347.267166ms)
✔ --stale-hours parsed mode treats --prefix input as missing through argv (328.802291ms)
✔ --state parsed mode treats --prefix input as missing through argv (334.698792ms)
✔ --timeout parsed mode treats --prefix input as missing through argv (334.926792ms)
✔ --to parsed mode treats --prefix input as missing through argv (327.76025ms)
✔ --verdict parsed mode treats --prefix input as missing through argv (276.644958ms)
✔ --window-days parsed mode treats --prefix input as missing through argv (267.242416ms)
✔ --writer-pr parsed mode treats --prefix input as missing through argv (267.92725ms)
✔ --flag value and --flag=value forms both work (1.058833ms)
✔ flag audit markdown enumerates every migrated flag (19.8755ms)
✔ recover-commit flags are registered with explicit required modes (0.400083ms)
✔ analyze-flip-flop-pattern help cites parsed/verbatim mode for listed flags (155.572666ms)
✔ cleanup-worktrees help cites parsed/verbatim mode for listed flags (155.561167ms)
✔ close-run help cites parsed/verbatim mode for listed flags (151.9315ms)
✔ create-worktree help cites parsed/verbatim mode for listed flags (156.321792ms)
✔ dispatch help cites parsed/verbatim mode for listed flags (174.110208ms)
✔ finalize-run help cites parsed/verbatim mode for listed flags (155.964292ms)
✔ gate-check help cites parsed/verbatim mode for listed flags (156.150125ms)
✔ invoke-reviewer-claude help cites parsed/verbatim mode for listed flags (150.373417ms)
✔ invoke-reviewer-codex help cites parsed/verbatim mode for listed flags (146.859542ms)
✔ persist-request help cites parsed/verbatim mode for listed flags (153.310375ms)
✔ probe-executor-env help cites parsed/verbatim mode for listed flags (147.840292ms)
✔ recover-commit help cites parsed/verbatim mode for listed flags (136.80275ms)
✔ relay-config help cites parsed/verbatim mode for listed flags (114.976333ms)
✔ rebrand-evidence help cites parsed/verbatim mode for listed flags (129.878625ms)
✔ recover-state help cites parsed/verbatim mode for listed flags (124.999209ms)
✔ reliability-report help cites parsed/verbatim mode for listed flags (127.60575ms)
✔ review-runner help cites parsed/verbatim mode for listed flags (138.543083ms)
✔ update-manifest-state help cites parsed/verbatim mode for listed flags (123.775291ms)
✔ relay-merge: finalize-run.js rejects unknown flag --no-merge (139.426875ms)
✔ relay-merge: gate-check.js rejects unknown flag --no-merge (136.81525ms)
✔ relay-dispatch: dispatch.js rejects unknown flag --no-merge (140.928084ms)
✔ relay-dispatch: close-run.js rejects unknown flag --no-merge (130.763083ms)
✔ relay-dispatch: cleanup-worktrees.js rejects unknown flag --no-merge (130.096375ms)
✔ relay-dispatch: relay-config.js rejects unknown flag --no-merge (135.904708ms)
✔ relay-dispatch: recover-state.js rejects unknown flag --no-merge (170.256292ms)
✔ relay-review: review-runner.js rejects unknown flag --no-merge (200.858209ms)
ℹ tests 97
ℹ suites 0
ℹ pass 97
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 64659.317541
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * `relay-config` 명령어 추가: 릴레이 정책을 초기화, 조회, 진단, 검증, 설정 및 관리할 수 있습니다.
  * 새로운 CLI 플래그 추가: `--effective`, `--phase`, `--profile`로 더 세밀한 제어가 가능해졌습니다.

* **테스트**
  * `relay-config` 명령어에 대한 종합 테스트 커버리지 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->