### PR TITLE
[codex] Enforce relay model-route policy gates

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -124,6 +124,10 @@ const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { execGit } = require("./exec");
 const { resolveReasoningEffort } = require("./rubric-size");
+const {
+  assertRelayPolicyGate,
+  buildPolicyGateFailureEnvelope,
+} = require("./relay-policy-gate");
 
 // ---------------------------------------------------------------------------
 // Args
@@ -849,7 +853,6 @@ async function main() {
   const manifestRunDir = getRunDir(repoRoot, runId);
   enforceRubricPersistence(manifest, manifestRunDir);
 
-  validateExecutorCli();
   const taskPromptResult = readTaskPrompt({ runDir: manifestRunDir, resumeMode: RESUME_MODE });
   let taskPrompt = taskPromptResult.prompt;
   if (!RESUME_MODE && REVIEW_ASSURANCE_RAW === undefined) {
@@ -902,6 +905,30 @@ async function main() {
   const provider = typeof adapter.parseProvider === "function"
     ? (adapter.parseProvider(effectiveDispatchModel) ?? adapter.providerDefault ?? null)
     : (adapter.providerDefault || null);
+  let policyDecision;
+  try {
+    policyDecision = assertRelayPolicyGate({
+      repoRoot,
+      relayHome: RELAY_HOME,
+      phase: "dispatch",
+      executor: EXECUTOR,
+      model: effectiveDispatchModel,
+    });
+  } catch (error) {
+    const envelope = buildPolicyGateFailureEnvelope(error, {
+      runId,
+      manifestPath,
+      executor: EXECUTOR,
+      model: effectiveDispatchModel,
+      phase: "dispatch",
+    });
+    if (JSON_OUT) {
+      console.log(JSON.stringify(envelope, null, 2));
+    } else {
+      console.error(`Error: ${envelope.error}`);
+    }
+    process.exit(1);
+  }
 
   // --- Dry run ---
   if (DRY_RUN) {
@@ -932,6 +959,7 @@ async function main() {
       environment: RESUME_MODE ? (manifest?.environment || null) : "collected-at-dispatch",
       runState: manifest?.state || null,
       dispatchSkipped: false,
+      policy_decision: policyDecision,
     };
     if (planFleetId) {
       plan.fleetId = planFleetId;
@@ -965,11 +993,14 @@ async function main() {
         fleetId: planFleetId,
         doneCriteriaFile: resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null,
         reviewAssurance: REVIEW_ASSURANCE,
+        policyDecision,
         worktreePlan,
       }));
     }
     return;
   }
+
+  validateExecutorCli();
 
   if (!RESUME_MODE) {
     try {
@@ -1479,6 +1510,7 @@ async function main() {
     commitMode,
     executor: EXECUTOR,
     executorNetwork: executorNetworkPolicy,
+    policyDecision,
     codexGitCommonDir,
     worktree: wtPath,
     branch,

--- a/skills/relay-dispatch/scripts/relay-policy-gate.js
+++ b/skills/relay-dispatch/scripts/relay-policy-gate.js
@@ -1,0 +1,136 @@
+const { evaluateRelayRoute, loadRelayPolicy } = require("./relay-policy");
+
+class RelayPolicyGateError extends Error {
+  constructor(decision) {
+    super(formatRelayPolicyGateMessage(decision));
+    this.name = "RelayPolicyGateError";
+    this.decision = decision;
+    this.envelope = {
+      status: "failed",
+      error: this.message,
+      policy_decision: decision,
+    };
+  }
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function resolveActorField({ actorField, phase, executor, reviewer }) {
+  if (actorField === "executor" || actorField === "reviewer") return actorField;
+  if (phase === "review" || phase === "advisory_review") return "reviewer";
+  if (reviewer && !executor) return "reviewer";
+  return "executor";
+}
+
+function normalizeMatchedRoute(decision) {
+  return decision?.matched_route || decision?.matchedRoute || null;
+}
+
+function normalizePolicyDecision(decision, context, loadResult) {
+  const phase = nonEmptyString(decision?.phase) || nonEmptyString(context.phase);
+  const executor = nonEmptyString(context.executor);
+  const reviewer = nonEmptyString(context.reviewer);
+  const actorField = resolveActorField({
+    actorField: context.actorField,
+    phase,
+    executor,
+    reviewer,
+  });
+  return {
+    allowed: decision?.allowed === true,
+    reason: nonEmptyString(decision?.reason) || "invalid_policy",
+    phase,
+    actor_field: actorField,
+    actor: nonEmptyString(decision?.actor) || (actorField === "reviewer" ? reviewer : executor),
+    executor: executor || null,
+    reviewer: reviewer || null,
+    model: nonEmptyString(decision?.model) || null,
+    matched_route: normalizeMatchedRoute(decision),
+    policy: {
+      status: loadResult?.status || null,
+      sources: loadResult?.sources || null,
+    },
+  };
+}
+
+function evaluateRelayPolicyGate({
+  repoRoot = null,
+  relayHome = process.env.RELAY_HOME,
+  phase,
+  executor = null,
+  reviewer = null,
+  actorField = null,
+  model = null,
+  policyOptions = {},
+} = {}) {
+  const loadResult = loadRelayPolicy({
+    repoRoot,
+    relayHome,
+    ...policyOptions,
+  });
+  const routeDecision = evaluateRelayRoute(loadResult, {
+    phase,
+    executor,
+    reviewer,
+    model,
+  });
+  return normalizePolicyDecision(routeDecision, {
+    phase,
+    executor,
+    reviewer,
+    actorField,
+  }, loadResult);
+}
+
+function formatRelayPolicyGateMessage(decision) {
+  const actorField = decision?.actor_field || "actor";
+  const actorValue = decision?.[actorField] || decision?.actor || "(unset)";
+  const parts = [
+    "relay policy denied model route",
+    `phase=${decision?.phase || "(unset)"}`,
+    `${actorField}=${actorValue}`,
+    `model=${decision?.model || "(none)"}`,
+    `reason=${decision?.reason || "unknown"}`,
+  ];
+  if (decision?.matched_route) {
+    parts.push(`matched_route=${decision.matched_route}`);
+  }
+  return parts.join(" ");
+}
+
+function assertRelayPolicyGate(options = {}) {
+  const decision = evaluateRelayPolicyGate(options);
+  if (!decision.allowed) {
+    throw new RelayPolicyGateError(decision);
+  }
+  return decision;
+}
+
+function isRelayPolicyGateError(error) {
+  return error instanceof RelayPolicyGateError
+    || (error?.name === "RelayPolicyGateError" && error?.decision);
+}
+
+function buildPolicyGateFailureEnvelope(errorOrDecision, extra = {}) {
+  const decision = errorOrDecision?.decision || errorOrDecision;
+  const message = errorOrDecision instanceof Error
+    ? errorOrDecision.message
+    : formatRelayPolicyGateMessage(decision);
+  return {
+    ...extra,
+    status: extra.status || "failed",
+    error: message,
+    policy_decision: decision,
+  };
+}
+
+module.exports = {
+  RelayPolicyGateError,
+  assertRelayPolicyGate,
+  buildPolicyGateFailureEnvelope,
+  evaluateRelayPolicyGate,
+  formatRelayPolicyGateMessage,
+  isRelayPolicyGateError,
+};

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -37,6 +37,7 @@ function formatDispatchDryRun({
   fleetId = null,
   doneCriteriaFile = null,
   reviewAssurance = null,
+  policyDecision = null,
   worktreePlan,
 }) {
   const lines = [
@@ -74,6 +75,16 @@ function formatDispatchDryRun({
   }
   if (reviewAssurance) {
     lines.push(`  Assurance: ${reviewAssurance}`);
+  }
+  if (policyDecision) {
+    const actorField = policyDecision.actor_field || "actor";
+    const actorValue = policyDecision[actorField] || policyDecision.actor || "(unset)";
+    const route = policyDecision.matched_route ? ` matched=${policyDecision.matched_route}` : "";
+    lines.push(
+      `  Policy:   ${policyDecision.allowed ? "allowed" : "denied"} ` +
+      `phase=${policyDecision.phase} ${actorField}=${actorValue} ` +
+      `model=${policyDecision.model || "(none)"} reason=${policyDecision.reason}${route}`
+    );
   }
   if (worktreePlan.worktreeinclude.length) {
     lines.push(`  .worktreeinclude: ${worktreePlan.worktreeinclude.join(", ")}`);

--- a/skills/relay-plan/scripts/probe-executor-env.js
+++ b/skills/relay-plan/scripts/probe-executor-env.js
@@ -21,6 +21,8 @@ const {
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 const { getExecutor, listExecutors } = require("../../relay-dispatch/scripts/executors");
+const { resolveExecutorDefaultModel } = require("../../relay-dispatch/scripts/executor-model-config");
+const { evaluateRelayPolicyGate, formatRelayPolicyGateMessage } = require("../../relay-dispatch/scripts/relay-policy-gate");
 
 // ---------------------------------------------------------------------------
 // CLI (only when run directly)
@@ -202,8 +204,25 @@ function run({ repoPath, executor, timeout, projectOnly, jsonOut }) {
   const projectTools = scanProjectTools(repoPath);
 
   let agentProbe = { error: null, raw: null };
+  let policyDecision = null;
   if (!projectOnly) {
-    agentProbe = probeAgent(executor, timeout);
+    const effectiveProbeModel = ["codex", "claude"].includes(executor)
+      ? null
+      : resolveExecutorDefaultModel(executor, { relayHome: process.env.RELAY_HOME });
+    policyDecision = evaluateRelayPolicyGate({
+      repoRoot: repoPath,
+      phase: "probe",
+      executor,
+      model: effectiveProbeModel,
+    });
+    if (policyDecision.allowed) {
+      agentProbe = probeAgent(executor, timeout);
+    } else {
+      agentProbe = {
+        error: `policy disallowed: ${formatRelayPolicyGateMessage(policyDecision)}`,
+        raw: null,
+      };
+    }
   }
 
   const result = {
@@ -214,6 +233,9 @@ function run({ repoPath, executor, timeout, projectOnly, jsonOut }) {
     test_infra: deriveTestInfra(projectTools),
     project_tools: projectTools,
   };
+  if (!projectOnly) {
+    result.policy_decision = policyDecision;
+  }
 
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -19,11 +19,12 @@ const { applyReviewAssurancePolicy } = require("./review-runner/assurance");
 const { buildRedispatchPrompt, buildRubricGateRedispatchPrompt, computeFactorStatusFlips, computeRepeatedIssueCount, decideFlipFlopEscalation, detectChurnGrowth, summarizeLineage, toEscalatedVerdict } = require("./review-runner/redispatch");
 const { applyPolicyViolationToManifest, applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { writePrBodySnapshot } = require("./review-runner/pr-body-snapshot");
-const { loadReviewText, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
+const { loadReviewText, resolveReviewerModel, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { finishAdvisoryReview, parsePositiveSeconds, resolveAdvisoryModel, startAdvisoryReview, validateAdvisoryProfile } = require("./review-runner/advisory");
 const { printResult, printUsage } = require("./review-runner/output");
 const { bindCliArgs, findUnknownFlags } = require("../../relay-dispatch/scripts/cli-args");
+const { assertRelayPolicyGate, buildPolicyGateFailureEnvelope, isRelayPolicyGateError } = require("../../relay-dispatch/scripts/relay-policy-gate");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
@@ -211,11 +212,25 @@ async function run() {
     printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath: null, result, updatedManifest: null, verdictPath: null });
     return;
   }
+  if (!reviewFile) {
+    assertRelayPolicyGate({
+      repoRoot: runRepoPath,
+      phase: "review",
+      reviewer: reviewerName,
+      model: resolveReviewerModel(data, reviewerModel),
+    });
+  }
   if (advisoryReviewerArg) {
     const advisoryModel = resolveAdvisoryModel(data, advisoryReviewerArg, advisoryReviewerModel);
+    const advisoryPolicyDecision = assertRelayPolicyGate({
+      repoRoot: runRepoPath,
+      phase: "advisory_review",
+      reviewer: advisoryReviewerArg,
+      model: advisoryModel,
+    });
     const advisoryPromptText = buildAdvisoryPrompt({ branch, diffText, doneCriteria, doneCriteriaSource, issueNumber, prNumber, profile: advisoryProfile, round, rubricLoad });
     advisoryRun = startAdvisoryReview({ promptText: advisoryPromptText, reviewerModel: advisoryModel, reviewerName: advisoryReviewerArg, reviewRepoPath, round, runDir });
-    result.advisoryReview = { profile: advisoryProfile, reviewer: advisoryReviewerArg, status: "running" };
+    result.advisoryReview = { profile: advisoryProfile, reviewer: advisoryReviewerArg, status: "running", policy_decision: advisoryPolicyDecision };
   }
 
   try {
@@ -392,6 +407,9 @@ async function run() {
 
 if (require.main === module) {
   Promise.resolve(run()).catch((error) => {
+    if (cliArgs.hasFlag("--json") && isRelayPolicyGateError(error)) {
+      console.log(JSON.stringify(buildPolicyGateFailureEnvelope(error, { ok: false }), null, 2));
+    }
     console.error(`Error: ${error.message}`);
     process.exit(1);
   });

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -4,6 +4,7 @@ const path = require("path");
 const { STATES } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
 const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
 const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
+const { assertRelayPolicyGate } = require("../../../relay-dispatch/scripts/relay-policy-gate");
 const { applyPolicyViolationToManifest } = require("./manifest-apply");
 const { git, readText, writeText } = require("./common");
 
@@ -80,6 +81,12 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
   }
 
   const effectiveReviewerModel = resolveReviewerModel(data, reviewerModel);
+  assertRelayPolicyGate({
+    repoRoot: runRepoPath,
+    phase: "review",
+    reviewer: reviewerName,
+    model: effectiveReviewerModel,
+  });
   appendRunEvent(runRepoPath, data.run_id, {
     event: EVENTS.REVIEW_INVOKE,
     state_from: data.state,

--- a/skills/relay-sidecar/scripts/relay-sidecar.js
+++ b/skills/relay-sidecar/scripts/relay-sidecar.js
@@ -29,6 +29,11 @@ const {
   SIDECAR_TRUST_LEVEL,
   upsertSidecarEntry,
 } = require("../../relay-dispatch/scripts/sidecar-store");
+const { resolveExecutorDefaultModel } = require("../../relay-dispatch/scripts/executor-model-config");
+const {
+  assertRelayPolicyGate,
+  buildPolicyGateFailureEnvelope,
+} = require("../../relay-dispatch/scripts/relay-policy-gate");
 const contextRecapKind = require("./kinds/context-recap");
 const docsSyncKind = require("./kinds/docs-sync");
 const testGapKind = require("./kinds/test-gap");
@@ -502,14 +507,47 @@ function main(options = {}) {
     const outputPath = `sidecars/${sidecarId}/${outputName}`;
     const outputDir = getSidecarOutputDir(context.repoRoot, args.runId, sidecarId);
     const outputFullPath = path.join(outputDir, outputName);
+    let effectiveModel = args.model || null;
+    let policyDecision = null;
+    if (args.executor === "opencode") {
+      effectiveModel = effectiveModel || resolveExecutorDefaultModel(args.executor, { relayHome: process.env.RELAY_HOME });
+      try {
+        policyDecision = assertRelayPolicyGate({
+          repoRoot: context.repoRoot,
+          phase: "sidecar",
+          executor: args.executor,
+          model: effectiveModel,
+        });
+      } catch (error) {
+        const failure = buildPolicyGateFailureEnvelope(error, {
+          ok: false,
+          run_id: args.runId,
+          sidecar_id: sidecarId,
+          kind: args.kind,
+          variant: args.variant || null,
+          executor: args.executor,
+          model: effectiveModel,
+          manifest_path: context.manifestPath,
+          run_dir: context.runDir,
+          worktree: context.worktree,
+          pr_number: context.prNumber,
+          output_path: outputPath,
+          failure_reason: error.message,
+        });
+        if (args.json) emitEnvelope(failure, { json: true, stdout });
+        else stderr(`Error: ${error.message}\n`);
+        return { exitCode: 1, envelope: failure };
+      }
+    }
+    const effectiveArgs = { ...args, model: effectiveModel };
     const baselineRecap = deterministicKind
       ? kindModule.buildRecap({ runContext: context.runContext })
       : null;
     const prompt = args.executor === "opencode"
-      ? buildSidecarPrompt({ args, sidecarId, context, kindModule, baselineRecap })
+      ? buildSidecarPrompt({ args: effectiveArgs, sidecarId, context, kindModule, baselineRecap })
       : null;
     const command = args.executor === "opencode"
-      ? buildOpencodeCommand({ prompt, model: args.model, cwd: context.worktree })
+      ? buildOpencodeCommand({ prompt, model: effectiveModel, cwd: context.worktree })
       : { cmd: "none", args: [], cwd: context.worktree, output: baselineRecap };
 
     const baseEnvelope = {
@@ -519,7 +557,8 @@ function main(options = {}) {
       kind: args.kind,
       variant: args.variant || null,
       executor: args.executor,
-      model: args.model || null,
+      model: effectiveModel,
+      policy_decision: policyDecision,
       manifest_path: context.manifestPath,
       run_dir: context.runDir,
       worktree: context.worktree,
@@ -538,21 +577,21 @@ function main(options = {}) {
       id: sidecarId,
       kind: args.kind,
       executor: args.executor,
-      model: args.model || null,
-      provider: parseProvider(args.model),
+      model: effectiveModel,
+      provider: parseProvider(effectiveModel),
     });
 
     let result;
     try {
       upsertSidecarEntry(context.repoRoot, args.runId, makeEntry({
         sidecarId,
-        args,
+        args: effectiveArgs,
         status: "running",
         outputPath,
       }));
       const before = args.executor === "none" ? "" : snapshotWorktree(context.worktree);
       try {
-        result = normalizeRunnerResult(runSidecarExecutor({ args, command, runOpencode }));
+        result = normalizeRunnerResult(runSidecarExecutor({ args: effectiveArgs, command, runOpencode }));
       } catch (error) {
         result = normalizeRunnerResult({
           code: Number.isInteger(error.status) ? error.status : 1,
@@ -589,7 +628,7 @@ function main(options = {}) {
       });
       upsertSidecarEntry(context.repoRoot, args.runId, makeEntry({
         sidecarId,
-        args,
+        args: effectiveArgs,
         status: "completed",
         outputPath,
       }));
@@ -607,7 +646,7 @@ function main(options = {}) {
       });
       upsertSidecarEntry(context.repoRoot, args.runId, makeEntry({
         sidecarId,
-        args,
+        args: effectiveArgs,
         status: "failed",
         outputPath,
       }));

--- a/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.json
+++ b/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.json
@@ -22,5 +22,23 @@
   "reviewAssurance": "standard",
   "environment": "collected-at-dispatch",
   "runState": null,
-  "dispatchSkipped": false
+  "dispatchSkipped": false,
+  "policy_decision": {
+    "allowed": true,
+    "reason": "managed_cli",
+    "phase": "dispatch",
+    "actor_field": "executor",
+    "actor": "codex",
+    "executor": "codex",
+    "reviewer": null,
+    "model": null,
+    "matched_route": null,
+    "policy": {
+      "status": "defaulted",
+      "sources": {
+        "global": "/tmp/issue187-fixtures/relay-home/policy.json",
+        "repo": "/tmp/issue187-fixtures/repo/.relay/policy.json"
+      }
+    }
+  }
 }

--- a/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.txt
+++ b/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.txt
@@ -16,3 +16,4 @@ Dry run:
   Timeout:  2400s
   Rubric:   /tmp/issue187-fixtures/rubric.yaml
   Assurance: standard
+  Policy:   allowed phase=dispatch executor=codex model=(none) reason=managed_cli

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -27,6 +27,7 @@ const {
   RUBRIC_SIZE_MISSING,
   RUBRIC_SIZE_UNPARSEABLE,
 } = require("../../../skills/relay-dispatch/scripts/rubric-size");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const { evaluateReviewGate } = require("../../../skills/relay-merge/scripts/review-gate");
 const { createEnforcementFixture } = require("../../../skills/relay-dispatch/scripts/test-support");
 
@@ -784,7 +785,7 @@ process.env.TMPDIR = ${JSON.stringify(tmpDir)};
     TMPDIR: tmpDir,
   }, preloadPath);
 
-  return { root, repoRoot, rubricFile, env };
+  return { root, repoRoot, relayHome, rubricFile, env };
 }
 
 function normalizeDispatchDryRunOutput(output, { root }) {
@@ -1007,6 +1008,7 @@ test("dispatch resume without redispatch artifact still errors with auto-discove
 test("dispatch stores model_hints for all four phases verbatim", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = {
@@ -1033,6 +1035,7 @@ test("dispatch stores model_hints for all four phases verbatim", () => {
 test("dispatch resume replaces model_hints and records model_hints_updated before redispatch", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = {
@@ -1080,6 +1083,7 @@ test("dispatch resume replaces model_hints and records model_hints_updated befor
 test("dispatch resume without --model-hints preserves stored hints and emits no model_hints_updated event", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = {
@@ -1152,6 +1156,7 @@ test("dispatch model-hints parse error skips manifest write", () => {
 
 test("dispatch precedence D1 regression: CLI override beats manifest hint in executor argv", () => {
   const { repoRoot, relayHome } = setupRepo();
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-d1.json`);
   writeArgCaptureCodex(binDir, capturePath);
@@ -1187,6 +1192,7 @@ test("dispatch precedence D1 regression: CLI override beats manifest hint in exe
 
 test("dispatch precedence D2 regression: CLI override works when manifest hint is absent", () => {
   const { repoRoot, relayHome } = setupRepo();
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-d2.json`);
   writeArgCaptureCodex(binDir, capturePath);
@@ -1222,6 +1228,7 @@ test("dispatch precedence D2 regression: CLI override works when manifest hint i
 test("dispatch precedence D3 regression: manifest hint supplies the effective model when CLI is unset", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-d3.json`);
   writeArgCaptureCodex(binDir, capturePath);
@@ -1458,9 +1465,28 @@ function writeTempRubric(contents) {
   return rubricFile;
 }
 
+function writeRelayPolicy(relayHome, overrides = {}) {
+  fs.mkdirSync(relayHome, { recursive: true });
+  fs.writeFileSync(path.join(relayHome, "policy.json"), JSON.stringify({
+    ...buildDefaultRelayPolicy(),
+    ...overrides,
+  }, null, 2), "utf-8");
+}
+
+function allowCodexDispatchModels(relayHome) {
+  writeRelayPolicy(relayHome, {
+    profile: "allow-codex-dispatch-models",
+    allowed_model_routes: [{ route: "*", phases: ["dispatch"], executors: ["codex"] }],
+  });
+}
+
 test("dispatch opencode executor records provider metadata", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "openai/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode.json`);
   writeArgCaptureOpencode(binDir, capturePath);
@@ -1508,9 +1534,51 @@ test("dispatch opencode executor records provider metadata", () => {
   assert.equal(manifest.dispatch.last_provider, "openai");
 });
 
+test("dispatch denies disallowed executor route before spawning the executor", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-policy-denied-${Date.now()}.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+  const rubricFile = writeTempRubric("size: \"S\"\nrubric:\n  factors: []\n");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-policy-denied",
+    "-p", "must not spawn opencode",
+    "-e", "opencode",
+    "-m", "opencode-go/deepseek-v4-pro",
+    "--rubric-file", rubricFile,
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    },
+  });
+
+  assert.notEqual(proc.status, 0);
+  assert.equal(fs.existsSync(capturePath), false);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.policy_decision.allowed, false);
+  assert.equal(result.policy_decision.phase, "dispatch");
+  assert.equal(result.policy_decision.actor_field, "executor");
+  assert.equal(result.policy_decision.executor, "opencode");
+  assert.equal(result.policy_decision.model, "opencode-go/deepseek-v4-pro");
+  assert.equal(result.policy_decision.reason, "unknown_model_route");
+  assert.match(result.error, /reason=unknown_model_route/);
+});
+
 test("dispatch opencode executor uses bundled default model when no override is supplied", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-bundled-default.json`);
   writeArgCaptureOpencode(binDir, capturePath);
@@ -1543,6 +1611,10 @@ test("dispatch opencode executor uses bundled default model when no override is 
 test("dispatch opencode executor lets RELAY_HOME executors config override bundled model", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
   fs.writeFileSync(path.join(relayHome, "executors.json"), JSON.stringify({
     executors: {
       opencode: {
@@ -1582,6 +1654,7 @@ test("dispatch opencode executor lets RELAY_HOME executors config override bundl
 test("dispatch lets local executor config define defaults for executors absent from bundled config", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  allowCodexDispatchModels(relayHome);
   fs.writeFileSync(path.join(relayHome, "executors.json"), JSON.stringify({
     executors: {
       codex: {
@@ -1637,6 +1710,10 @@ test("dispatch codex executor ignores malformed local executor model config", ()
 test("dispatch opencode default model falls back to bundled config when local config schema is invalid", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
   fs.writeFileSync(path.join(relayHome, "executors.json"), JSON.stringify({
     executors: {
       opencode: {
@@ -1678,6 +1755,10 @@ test("dispatch opencode default model falls back to bundled config when local co
 test("dispatch opencode explicit --model skips malformed local executor model config", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
   fs.writeFileSync(path.join(relayHome, "executors.json"), "{not-json", "utf-8");
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-explicit-malformed-local.json`);
@@ -1708,6 +1789,10 @@ test("dispatch opencode explicit --model skips malformed local executor model co
 test("dispatch opencode default model falls back to bundled config when local config is malformed", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
   fs.writeFileSync(path.join(relayHome, "executors.json"), "{not-json", "utf-8");
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-opencode-malformed-local-default.json`);
@@ -1837,6 +1922,10 @@ test("dispatch leaves claude executor argv untouched by rubric-size reasoning", 
 
 test("dispatch dry-run resolves effective_dispatch_model from model hints and emits zero events", () => {
   const { repoRoot, relayHome, rubricFile } = setupDryRunFixtureRepo();
+  writeRelayPolicy(relayHome, {
+    profile: "allow-codex-hint",
+    allowed_model_routes: [{ route: "opus", phases: ["dispatch"], executors: ["codex"] }],
+  });
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-dry-run-bin-"));
   writeFakeCodex(binDir);
   const env = {
@@ -1861,12 +1950,58 @@ test("dispatch dry-run resolves effective_dispatch_model from model hints and em
   const result = JSON.parse(stdout);
 
   assert.equal(result.effective_dispatch_model, "opus");
+  assert.equal(result.policy_decision.allowed, true);
+  assert.equal(result.policy_decision.reason, "allowed_model_route");
+  assert.equal(result.policy_decision.matched_route, "opus");
   assert.equal(listManifestPaths(repoRoot).length, 0);
+});
+
+test("dispatch dry-run includes managed default policy decision details", () => {
+  const { repoRoot, relayHome, rubricFile } = setupDryRunFixtureRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-dry-run-bin-"));
+  writeFakeCodex(binDir);
+  const stdout = execFileSync("node", [SCRIPT, repoRoot,
+    "-b", "issue-policy-dry-run",
+    "--prompt", "dry run policy decision",
+    "--rubric-file", rubricFile,
+    "--dry-run",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    },
+  });
+  const result = JSON.parse(stdout);
+
+  assert.deepEqual(result.policy_decision, {
+    allowed: true,
+    reason: "managed_cli",
+    phase: "dispatch",
+    actor_field: "executor",
+    actor: "codex",
+    executor: "codex",
+    reviewer: null,
+    model: null,
+    matched_route: null,
+    policy: {
+      status: "defaulted",
+      sources: {
+        global: path.join(relayHome, "policy.json"),
+        repo: path.join(repoRoot, ".relay", "policy.json"),
+      },
+    },
+  });
 });
 
 test("dispatch resume --dry-run with new --model-hints reports the new hint in effective_dispatch_model and does NOT write the manifest or emit events", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
+  allowCodexDispatchModels(relayHome);
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = {

--- a/tests/relay-dispatch/scripts/relay-policy-gate.test.js
+++ b/tests/relay-dispatch/scripts/relay-policy-gate.test.js
@@ -1,0 +1,88 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  RelayPolicyGateError,
+  assertRelayPolicyGate,
+  evaluateRelayPolicyGate,
+} = require("../../../skills/relay-dispatch/scripts/relay-policy-gate");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "relay-policy-gate-"));
+}
+
+function writePolicy(relayHome, policy) {
+  fs.mkdirSync(relayHome, { recursive: true });
+  fs.writeFileSync(path.join(relayHome, "policy.json"), JSON.stringify(policy, null, 2), "utf-8");
+}
+
+test("policy gate allows managed Codex without model under missing config", () => {
+  const decision = evaluateRelayPolicyGate({
+    relayHome: tempDir(),
+    phase: "dispatch",
+    executor: "codex",
+  });
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.phase, "dispatch");
+  assert.equal(decision.actor_field, "executor");
+  assert.equal(decision.executor, "codex");
+  assert.equal(decision.actor, "codex");
+  assert.equal(decision.model, null);
+  assert.equal(decision.reason, "managed_cli");
+  assert.equal(decision.matched_route, null);
+  assert.equal(decision.policy.status, "defaulted");
+});
+
+test("policy gate denies unmanaged executor model routes unless explicitly allowed", () => {
+  assert.throws(
+    () => assertRelayPolicyGate({
+      relayHome: tempDir(),
+      phase: "dispatch",
+      executor: "opencode",
+      model: "opencode-go/deepseek-v4-pro",
+    }),
+    (error) => {
+      assert.ok(error instanceof RelayPolicyGateError);
+      assert.equal(error.decision.allowed, false);
+      assert.equal(error.decision.phase, "dispatch");
+      assert.equal(error.decision.actor_field, "executor");
+      assert.equal(error.decision.executor, "opencode");
+      assert.equal(error.decision.model, "opencode-go/deepseek-v4-pro");
+      assert.equal(error.decision.reason, "unknown_model_route");
+      assert.match(error.message, /phase=dispatch/);
+      assert.match(error.message, /executor=opencode/);
+      assert.match(error.message, /model=opencode-go\/deepseek-v4-pro/);
+      assert.match(error.message, /reason=unknown_model_route/);
+      return true;
+    }
+  );
+});
+
+test("policy gate surfaces matched allow route details", () => {
+  const relayHome = tempDir();
+  writePolicy(relayHome, {
+    ...buildDefaultRelayPolicy(),
+    profile: "allow-opencode",
+    allowed_model_routes: [{
+      route: "opencode-go/*",
+      phases: ["dispatch"],
+      executors: ["opencode"],
+    }],
+  });
+
+  const decision = assertRelayPolicyGate({
+    relayHome,
+    phase: "dispatch",
+    executor: "opencode",
+    model: "opencode-go/deepseek-v4-pro",
+  });
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.reason, "allowed_model_route");
+  assert.equal(decision.matched_route, "opencode-go/*");
+});

--- a/tests/relay-plan/scripts/probe-executor-env.test.js
+++ b/tests/relay-plan/scripts/probe-executor-env.test.js
@@ -218,3 +218,39 @@ test("CLI handles missing executor gracefully", () => {
   assert.ok(output.agent_probe_error);
   assert.equal(output.agent_tools_raw, null);
 });
+
+test("CLI reports policy-disallowed opencode without invoking adapter probe", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-policy-denied-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "probe-policy-home-"));
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-policy-bin-"));
+  const markerPath = path.join(binDir, "opencode-invoked.txt");
+  const opencodePath = path.join(binDir, "opencode");
+  fs.writeFileSync(opencodePath, `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, process.argv.slice(2).join(" "), "utf-8");
+process.stdout.write("opencode-fake\\n");
+`, "utf-8");
+  fs.chmodSync(opencodePath, 0o755);
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "-e", "opencode", "--json"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(markerPath), false);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.agent_tools_raw, null);
+  assert.match(output.agent_probe_error, /policy disallowed/);
+  assert.equal(output.policy_decision.allowed, false);
+  assert.equal(output.policy_decision.phase, "probe");
+  assert.equal(output.policy_decision.actor_field, "executor");
+  assert.equal(output.policy_decision.executor, "opencode");
+  assert.equal(output.policy_decision.model, "opencode-go/deepseek-v4-pro");
+  assert.equal(output.policy_decision.reason, "unknown_model_route");
+});

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -14,6 +14,7 @@ const {
   writeManifest,
   readManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 const {
   DEFAULT_ENFORCEMENT_RUBRIC,
@@ -74,10 +75,27 @@ function setupRepo({
   reviewAssurance = "standard",
   strictEvidence = false,
   roles = { orchestrator: "codex", executor: "codex", reviewer: "codex" },
+  modelPolicy = "allow-opencode-advisory",
 } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-"));
   const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-origin-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  if (modelPolicy === "allow-opencode-advisory") {
+    fs.writeFileSync(path.join(process.env.RELAY_HOME, "policy.json"), JSON.stringify({
+      ...buildDefaultRelayPolicy(),
+      profile: "allow-opencode-advisory",
+      managed_cli: ["codex", "claude", "mirror"],
+      allowed_model_routes: [{
+        route: "opencode-go/*",
+        phases: ["advisory_review"],
+        reviewers: ["opencode"],
+      }, {
+        route: "mirror/*",
+        phases: ["review"],
+        reviewers: ["mirror"],
+      }],
+    }, null, 2), "utf-8");
+  }
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["init", "--bare", remoteRoot], { encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["config", "user.name", "Relay Review Advisory Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -229,6 +247,19 @@ test("review-runner records successful opencode advisory review without gating p
   assert.equal(event.advisory_artifact_hash, hashFile(path.join(runDir, "review-round-1-advisory-opencode.json")));
 });
 
+test("review-runner denies disallowed advisory model before spawning advisory reviewer", () => {
+  const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "default" });
+  const logPath = path.join(repoRoot, "advisory-policy.log");
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot, { logPath });
+
+  assert.throws(
+    () => runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript }),
+    /phase=advisory_review.*reviewer=opencode|reviewer=opencode.*phase=advisory_review/
+  );
+  assert.equal(fs.existsSync(logPath), false);
+});
+
 test("prepare-only with advisory flags writes only the primary prompt bundle", () => {
   const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
 
@@ -347,6 +378,7 @@ test("hardened assurance is generic for Codex-only and non-Codex role bindings",
       label: "non-codex-fixture",
       roles: { orchestrator: "atlas", executor: "forge", reviewer: "mirror" },
       reviewer: "mirror",
+      extraArgs: ["--reviewer-model", "mirror/local-reviewer"],
     },
   ]) {
     await t.test(entry.label, () => {
@@ -366,6 +398,7 @@ test("hardened assurance is generic for Codex-only and non-Codex role bindings",
         primaryScript,
         opencodeScript,
         reviewer: entry.reviewer,
+        extraArgs: entry.extraArgs || [],
       });
       const manifest = readManifest(manifestPath).data;
 

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -8,6 +8,7 @@ const path = require("path");
 const { STATES, updateManifestState } = require("../../../skills/relay-dispatch/scripts/manifest/lifecycle");
 const { ensureRunLayout, getEventsPath } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 const { createManifestSkeleton, readManifest, writeManifest } = require("../../../skills/relay-dispatch/scripts/manifest/store");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const {
   captureGitStatus,
   loadReviewText,
@@ -89,6 +90,13 @@ process.stdout.write(JSON.stringify({
 `);
 }
 
+function writeRelayPolicy(relayHome, overrides = {}) {
+  fs.writeFileSync(path.join(relayHome, "policy.json"), JSON.stringify({
+    ...buildDefaultRelayPolicy(),
+    ...overrides,
+  }, null, 2), "utf-8");
+}
+
 test("reviewer-invoke/resolveReviewerName preserves arg, manifest, env precedence", (t) => {
   const originalReviewer = process.env.RELAY_REVIEWER;
   t.after(() => {
@@ -124,6 +132,10 @@ test("reviewer-invoke/loadReviewText forwards promptPath to the adapter and pers
     process.env.RELAY_HOME = originalRelayHome;
   });
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-review-models",
+    allowed_model_routes: [{ route: "opus", phases: ["review"], reviewers: ["codex"] }],
+  });
 
   const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
   const reviewerScript = writeExecutable(helperDir, "reviewer-reads-prompt.js", `#!/usr/bin/env node
@@ -177,6 +189,10 @@ test("reviewer-invoke precedence R1 regression: CLI reviewerModel beats manifest
     process.env.RELAY_HOME = originalRelayHome;
   });
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-review-models",
+    allowed_model_routes: [{ route: "opus", phases: ["review"], reviewers: ["codex"] }],
+  });
 
   const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
   const reviewerScript = writeReviewerArgEchoScript(helperDir, "reviewer-r1.js");
@@ -222,6 +238,10 @@ test("reviewer-invoke precedence R2 regression: CLI reviewerModel works when man
     process.env.RELAY_HOME = originalRelayHome;
   });
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-review-models",
+    allowed_model_routes: [{ route: "opus", phases: ["review"], reviewers: ["codex"] }],
+  });
 
   const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
   const reviewerScript = writeReviewerArgEchoScript(helperDir, "reviewer-r2.js");
@@ -262,6 +282,10 @@ test("reviewer-invoke precedence R3 regression: manifest hint supplies the effec
     process.env.RELAY_HOME = originalRelayHome;
   });
   process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-review-models",
+    allowed_model_routes: [{ route: "haiku", phases: ["review"], reviewers: ["codex"] }],
+  });
 
   const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
   const reviewerScript = writeReviewerArgEchoScript(helperDir, "reviewer-r3.js");
@@ -299,6 +323,61 @@ test("reviewer-invoke precedence R3 regression: manifest hint supplies the effec
   const reviewInvokeEvent = JSON.parse(eventLines.at(-1));
   assert.equal(reviewInvokeEvent.event, "review_invoke");
   assert.equal(reviewInvokeEvent.model, "haiku");
+});
+
+test("reviewer-invoke/loadReviewText denies disallowed reviewer model before adapter invocation", (t) => {
+  const originalRelayHome = process.env.RELAY_HOME;
+  const { relayHome, repoRoot, runDir, manifestPath, manifest, promptPath, runId } = setupReviewRun();
+  t.after(() => {
+    if (originalRelayHome === undefined) {
+      delete process.env.RELAY_HOME;
+      return;
+    }
+    process.env.RELAY_HOME = originalRelayHome;
+  });
+  process.env.RELAY_HOME = relayHome;
+
+  const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
+  const markerPath = path.join(helperDir, "invoked.txt");
+  const reviewerScript = writeExecutable(helperDir, "reviewer-must-not-run.js", `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, "invoked\\n", "utf-8");
+process.stdout.write("{\\"verdict\\":\\"pass\\"}\\n");
+`);
+
+  assert.throws(() => loadReviewText({
+    body: "# Notes\n",
+    data: manifest,
+    manifestPath,
+    prNumber: 11,
+    promptPath,
+    reviewFile: null,
+    reviewRepoPath: repoRoot,
+    reviewedHeadSha: "abc123",
+    reviewerModel: "openai/gpt-5",
+    reviewerName: "codex",
+    reviewerScript,
+    round: 1,
+    runDir,
+    runRepoPath: repoRoot,
+  }), (error) => {
+    assert.equal(error.decision.allowed, false);
+    assert.equal(error.decision.phase, "review");
+    assert.equal(error.decision.actor_field, "reviewer");
+    assert.equal(error.decision.reviewer, "codex");
+    assert.equal(error.decision.model, "openai/gpt-5");
+    assert.equal(error.decision.reason, "unknown_model_route");
+    assert.match(error.message, /phase=review/);
+    assert.match(error.message, /reviewer=codex/);
+    return true;
+  });
+
+  assert.equal(fs.existsSync(markerPath), false);
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
+  const events = fs.existsSync(getEventsPath(repoRoot, runId))
+    ? fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8")
+    : "";
+  assert.doesNotMatch(events, /review_invoke/);
 });
 
 test("reviewer-invoke precedence R4 regression: reviewer argv stays byte-identical when CLI and manifest hint are both absent", (t) => {

--- a/tests/relay-sidecar/scripts/relay-sidecar.test.js
+++ b/tests/relay-sidecar/scripts/relay-sidecar.test.js
@@ -14,6 +14,7 @@ const {
   readManifest,
   writeManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 const { readSidecarIndex } = require("../../../skills/relay-dispatch/scripts/sidecar-store");
 const { main } = require("../../../skills/relay-sidecar/scripts/relay-sidecar");
@@ -56,12 +57,23 @@ function createRelayOwnedWorktree(repoRoot, relayHome, branch = "sidecar-worktre
   return worktreePath;
 }
 
-function createFixture(t) {
+function createFixture(t, { modelPolicy = "allow-opencode-sidecar" } = {}) {
   const previousRelayHome = process.env.RELAY_HOME;
   const previousRelayWorktreeBase = process.env.RELAY_WORKTREE_BASE;
   const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-sidecar-home-"));
   process.env.RELAY_HOME = relayHome;
   process.env.RELAY_WORKTREE_BASE = path.join(relayHome, "worktrees");
+  if (modelPolicy === "allow-opencode-sidecar") {
+    fs.writeFileSync(path.join(relayHome, "policy.json"), JSON.stringify({
+      ...buildDefaultRelayPolicy(),
+      profile: "allow-opencode-sidecar",
+      allowed_model_routes: [{
+        route: "opencode-go/*",
+        phases: ["sidecar"],
+        executors: ["opencode"],
+      }],
+    }, null, 2), "utf-8");
+  }
 
   t.after(() => {
     if (previousRelayHome === undefined) delete process.env.RELAY_HOME;
@@ -137,6 +149,36 @@ test("--dry-run skips opencode and emits no events", (t) => {
 
   assert.equal(result.exitCode, 0);
   assert.equal(JSON.parse(result.stdout).status, "dry_run");
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+  assert.equal(fs.existsSync(getSidecarsIndexPath(fixture.repoRoot, fixture.runId)), false);
+});
+
+test("policy denial prevents opencode sidecar runner invocation and emits JSON envelope", (t) => {
+  const fixture = createFixture(t, { modelPolicy: "default" });
+  let invoked = false;
+  const result = invoke([
+    "--run-id", fixture.runId,
+    "--kind", "context-recap",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    runOpencode: () => {
+      invoked = true;
+      return { code: 0, stdout: "must not run\n", stderr: "" };
+    },
+  });
+
+  assert.notEqual(result.exitCode, 0);
+  assert.equal(invoked, false);
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.status, "failed");
+  assert.equal(envelope.policy_decision.allowed, false);
+  assert.equal(envelope.policy_decision.phase, "sidecar");
+  assert.equal(envelope.policy_decision.actor_field, "executor");
+  assert.equal(envelope.policy_decision.executor, "opencode");
+  assert.equal(envelope.policy_decision.model, "opencode-go/deepseek-v4-pro");
+  assert.equal(envelope.policy_decision.reason, "unknown_model_route");
   assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
   assert.equal(fs.existsSync(getSidecarsIndexPath(fixture.repoRoot, fixture.runId)), false);
 });


### PR DESCRIPTION
Closes #554

## Summary

- Added a shared relay policy gate helper that loads/evaluates policy routes and formats denial envelopes with phase, actor, model, reason, and matched route details.
- Enforced model-route policy before dispatch executor invocation, review adapter invocation, advisory reviewer spawn, sidecar opencode execution, and executor probe adapter calls.
- Added focused coverage for allowed and denied runtime gates, including dry-run/JSON policy decision details and no-spawn/no-probe denials.

## Verification

### `node --test tests/relay-dispatch/scripts/relay-policy-gate.test.js tests/relay-dispatch/scripts/relay-policy.test.js`

```console
$ node --test tests/relay-dispatch/scripts/relay-policy-gate.test.js tests/relay-dispatch/scripts/relay-policy.test.js
✔ policy gate allows managed Codex without model under missing config (4.808583ms)
✔ policy gate denies unmanaged executor model routes unless explicitly allowed (1.826ms)
✔ policy gate surfaces matched allow route details (5.658917ms)
✔ loadRelayPolicy uses managed Codex and Claude defaults when config is missing (8.341334ms)
✔ malformed global policy load fails closed with status and errors (2.103708ms)
✔ validateRelayPolicy rejects invalid v1 schema shapes (4.775833ms)
✔ global-only policy allows matching model routes and denies unknown routes (2.427708ms)
✔ RELAY_POLICY_PATH overrides the default global policy path (2.215667ms)
✔ repo-local policy can narrow managed CLIs, allowed routes, and unknown-route behavior (3.177541ms)
✔ repo-local policy that widens global policy is rejected (2.744167ms)
✔ denied model routes win over allowed model routes (0.285666ms)
✔ route actor scopes are bound to the evaluated phase (5.573792ms)
✔ unknown route denial can be explicitly disabled for non-managed executors (0.730792ms)
✔ matchRoutePattern supports simple star globs (0.212084ms)
ℹ tests 14
ℹ suites 0
ℹ pass 14
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 335.785875
```

### `node --test tests/relay-review/scripts/review-runner-reviewer-invoke.test.js tests/relay-review/scripts/review-runner-advisory.test.js`

```console
$ node --test tests/relay-review/scripts/review-runner-reviewer-invoke.test.js tests/relay-review/scripts/review-runner-advisory.test.js
Error: relay policy denied model route phase=advisory_review reviewer=opencode model=opencode-go/deepseek-v4-pro reason=unknown_model_route
Error: policy.review_assurance=hardened requires --advisory-reviewer <name> so the round produces advisory evidence. Run with a configured advisory reviewer, or lower the manifest policy before review.
✔ review-runner records successful opencode advisory review without gating primary pass (5305.881041ms)
✔ review-runner denies disallowed advisory model before spawning advisory reviewer (2248.685417ms)
✔ prepare-only with advisory flags writes only the primary prompt bundle (2128.518125ms)
✔ advisory review starts before the primary reviewer completes (6987.2635ms)
✔ invalid advisory JSON is recorded as advisory failure while primary pass still applies (3788.997333ms)
✔ advisory worktree mutation is captured without escalating the manifest (4524.133833ms)
✔ advisory findings do not alter primary redispatch output (4458.386875ms)
✔ hardened review assurance blocks a primary pass without advisory evidence (1291.495083ms)
▶ hardened assurance is generic for Codex-only and non-Codex role bindings
  ✔ codex-only (3797.529083ms)
  ✔ non-codex-fixture (3734.819916ms)
✔ hardened assurance is generic for Codex-only and non-Codex role bindings (7533.808333ms)
✔ Codex-only assurance regression is documented as generic policy coverage (1.194333ms)
✔ production assurance code does not branch on Codex executor and reviewer identity (5.866ms)
▶ hardened review assurance blocks advisory failures and required findings
  ✔ invalid json (4008.399375ms)
  ✔ required finding (4468.238583ms)
✔ hardened review assurance blocks advisory failures and required findings (8477.417833ms)
✔ hardened manual review pass requires an audit reason (5845.516209ms)
✔ reviewer-invoke/resolveReviewerName preserves arg, manifest, env precedence (3.793417ms)
✔ reviewer-invoke/resolveReviewerScript resolves built-in adapters and rejects invalid names (0.943875ms)
✔ reviewer-invoke/loadReviewText forwards promptPath to the adapter and persists the raw response (1216.670875ms)
✔ reviewer-invoke precedence R1 regression: CLI reviewerModel beats manifest hint in reviewer argv (1416.840917ms)
✔ reviewer-invoke precedence R2 regression: CLI reviewerModel works when manifest hint is absent (1164.774333ms)
✔ reviewer-invoke precedence R3 regression: manifest hint supplies the effective reviewer model when CLI is unset (1166.513458ms)
✔ reviewer-invoke/loadReviewText denies disallowed reviewer model before adapter invocation (592.527041ms)
✔ reviewer-invoke precedence R4 regression: reviewer argv stays byte-identical when CLI and manifest hint are both absent (1170.383375ms)
✔ reviewer-invoke/loadReviewText escalates when the reviewer mutates the worktree (1308.772042ms)
✔ reviewer-invoke/captureGitStatus preserves dirty-worktree detection (552.395958ms)
ℹ tests 27
ℹ suites 0
ℹ pass 27
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 53049.169709
```

### `node --test tests/relay-sidecar/scripts/relay-sidecar.test.js tests/relay-plan/scripts/probe-executor-env.test.js`

```console
$ node --test tests/relay-sidecar/scripts/relay-sidecar.test.js tests/relay-plan/scripts/probe-executor-env.test.js
✔ scanProjectTools extracts scripts and frameworks from package.json (4.977291ms)
✔ scanProjectTools extracts Makefile targets (4.683458ms)
✔ scanProjectTools extracts pyproject.toml tools (1.912375ms)
✔ scanProjectTools detects GitHub Actions workflows (40.975292ms)
✔ scanProjectTools handles missing files gracefully (1.033083ms)
✔ scanProjectTools handles malformed package.json gracefully (1.159208ms)
✔ scanProjectTools merges results from package.json + Makefile + pyproject.toml (4.835125ms)
✔ deriveTestInfra exposes runner candidates for TDD fallback (0.904166ms)
✔ probeAgent returns raw text from a fake codex executor (836.04425ms)
✔ probeAgent returns error for unknown executor (2.086416ms)
✔ CLI --project-only works without executor (473.139916ms)
✔ CLI requires --executor when not --project-only (311.995125ms)
✔ CLI rejects invalid timeout (253.507375ms)
✔ CLI handles missing executor gracefully (260.074417ms)
✔ CLI reports policy-disallowed opencode without invoking adapter probe (260.136083ms)
✔ --help exits 0 and lists documented flags (4.45125ms)
✔ --dry-run skips opencode and emits no events (1170.612958ms)
✔ policy denial prevents opencode sidecar runner invocation and emits JSON envelope (990.105875ms)
✔ happy path stores stdout and records advisory result (2928.506542ms)
✔ --kind context-recap --executor none writes deterministic output and records result (3782.548667ms)
✔ --kind test-gap --executor none writes deterministic output and records result (2297.500541ms)
✔ --kind docs-sync --executor none writes deterministic output and records result (3285.373833ms)
✔ --kind test-gap --executor none falls back to PR diff when no review diff exists (2638.500167ms)
✔ --kind test-gap refuses symlinked run-context inputs (683.400208ms)
✔ --kind test-gap --executor opencode uses test-gap augmentation prompt (1472.063041ms)
✔ --kind docs-sync --executor opencode uses docs-sync augmentation prompt (1129.915584ms)
✔ --json keeps runner stdout structured without changing sidecar output path (1333.350375ms)
✔ opencode non-zero emits sidecar_failed and marks index failed (2203.273625ms)
✔ advisory violation detects worktree drift and fails closed (3094.398041ms)
✔ --executor none is rejected for kinds without deterministic builders (545.177958ms)
✔ unknown executor exits non-zero without sidecar events or index changes (638.850666ms)
ℹ tests 31
ℹ suites 0
ℹ pass 31
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 28601.476459
```

### `node --test --test-name-pattern 'dispatch (opencode executor records provider metadata|denies disallowed executor route before spawning the executor|dry-run includes managed default policy decision details)' tests/relay-dispatch/scripts/dispatch.test.js`

```console
$ node --test --test-name-pattern 'dispatch (opencode executor records provider metadata|denies disallowed executor route before spawning the executor|dry-run includes managed default policy decision details)' tests/relay-dispatch/scripts/dispatch.test.js
✔ dispatch opencode executor records provider metadata (3542.579125ms)
✔ dispatch denies disallowed executor route before spawning the executor (742.406ms)
✔ dispatch dry-run includes managed default policy decision details (596.806792ms)
ℹ tests 3
ℹ suites 0
ℹ pass 3
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5152.242417
```
