### PR TITLE
Implement routing rule tag selection

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -99,6 +99,7 @@ const FLAGS = [
   { flag: "--skip-review", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit skip reason must be recorded exactly and must not be blank." },
   { flag: "--stale-hours", kind: VALUE, mode: MODE_PARSED, valueName: "<hours>", rationale: "Numeric threshold; flag-like following tokens should mean the value is missing." },
   { flag: "--state", kind: VALUE, mode: MODE_PARSED, valueName: "<state>", rationale: "Closed manifest state selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--tags", kind: VALUE, mode: MODE_PARSED, valueName: "<csv>", rationale: "Explicit routing tags; flag-like following tokens should mean the value is missing." },
   { flag: "--test-command", kind: VALUE, mode: MODE_VERBATIM, valueName: "<cmd>", rationale: "Execution evidence must preserve the operator-supplied command token exactly." },
   { flag: "--text", kind: VALUE, mode: MODE_VERBATIM, valueName: "<text>", rationale: "Operator-supplied Done Criteria text body; keep the literal argv token." },
   { flag: "--timeout", kind: VALUE, mode: MODE_PARSED, valueName: "<seconds>", rationale: "Numeric timeout; flag-like following tokens should mean the value is missing." },
@@ -130,7 +131,7 @@ const COMMAND_FLAGS = {
     "--model", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
     "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
     "--fleet-id", "--done-criteria-file", "--review-assurance", "--register", "--no-cleanup", "--auto-recover-commit", "--no-auto-recover-commit",
-    "--allow-conflicting-run", "--dry-run", "--json", "--help",
+    "--tags", "--allow-conflicting-run", "--dry-run", "--json", "--help",
   ],
   "finalize-run": [
     "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method",

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -28,6 +28,7 @@
  *   --rubric-file <path>   REQUIRED: copy rubric YAML to run dir (persists for review)
  *   --test-command <cmd>   Record the executor-side test command in execution evidence
  *   --review-assurance <level> standard | hardened (default: standard)
+ *   --tags <csv>          Explicit routing tags; override inferred routing tags
  *   --rubric-grandfathered Retired alias; dispatch rejects it
  *   --request-id <id>      Link the run back to a relay-ready request
  *   --leaf-id <id>         Link the run back to a relay-ready leaf handoff
@@ -128,6 +129,8 @@ const {
   assertRelayPolicyGate,
   buildPolicyGateFailureEnvelope,
 } = require("./relay-policy-gate");
+const { loadRelayPolicy } = require("./relay-policy");
+const { resolveRoutingDecision } = require("./relay-routing");
 
 // ---------------------------------------------------------------------------
 // Args
@@ -138,7 +141,7 @@ const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
   "--model", "-m", "--model-hints", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
-  "--request-id", "--leaf-id", "--fleet-id", "--done-criteria-file", "--review-assurance",
+  "--request-id", "--leaf-id", "--fleet-id", "--done-criteria-file", "--review-assurance", "--tags",
   "--register", "--no-cleanup", "--auto-recover-commit", "--no-auto-recover-commit", "--allow-conflicting-run", "--dry-run", "--json", "--help", "-h",
 ];
 const CLI_ARG_OPTIONS = { commandName: "dispatch", reservedFlags: KNOWN_FLAGS };
@@ -166,6 +169,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --rubric-file      ${modeLabel("--rubric-file")} REQUIRED: copy rubric YAML to run dir (persists for review)`);
   console.log(`  --test-command     ${modeLabel("--test-command")} Record the executor-side test command in execution evidence`);
   console.log(`  --review-assurance ${modeLabel("--review-assurance")} Review assurance: standard | hardened (default: standard)`);
+  console.log(`  --tags             ${modeLabel("--tags")} Explicit routing tags; override inferred routing tags`);
   console.log(`  --rubric-grandfathered  ${modeLabel("--rubric-grandfathered")} Retired alias; remove anchor.rubric_grandfathered manually`);
   console.log(`  --request-id       ${modeLabel("--request-id")} Link the run back to a relay-ready request`);
   console.log(`  --leaf-id          ${modeLabel("--leaf-id")} Link the run back to a relay-ready leaf handoff`);
@@ -219,6 +223,7 @@ const LEAF_ID = readArg(args, "--leaf-id", undefined, CLI_ARG_OPTIONS);
 const FLEET_ID = readArg(args, "--fleet-id", undefined, CLI_ARG_OPTIONS);
 const DONE_CRITERIA_FILE = readArg(args, "--done-criteria-file", undefined, CLI_ARG_OPTIONS);
 const REVIEW_ASSURANCE_RAW = readArg(args, "--review-assurance", undefined, CLI_ARG_OPTIONS);
+const ROUTING_TAGS = readArg(args, "--tags", "", CLI_ARG_OPTIONS);
 let REVIEW_ASSURANCE;
 try {
   REVIEW_ASSURANCE = normalizeReviewAssurance(REVIEW_ASSURANCE_RAW || "standard");
@@ -666,6 +671,48 @@ function summarizeCommitMode({ status, gitLog, uncommitted }) {
   return status;
 }
 
+function readFileIfExists(filePath) {
+  if (!filePath) return null;
+  try {
+    return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf-8") : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveRoutingRubricText({ rubricFile, manifest, runDir }) {
+  if (rubricFile) return readFileIfExists(path.resolve(rubricFile));
+  const rubricPath = manifest?.anchor?.rubric_path;
+  if (!rubricPath || !runDir) return null;
+  return readFileIfExists(path.join(runDir, rubricPath));
+}
+
+function collectChangedFilesForRouting(repoDir, baseBranch) {
+  const candidates = [];
+  if (baseBranch) {
+    candidates.push([`${baseBranch}...HEAD`]);
+    candidates.push([`origin/${baseBranch}...HEAD`]);
+  }
+  candidates.push(["--cached"]);
+
+  for (const argsForDiff of candidates) {
+    try {
+      const output = execGit(repoDir, ["diff", "--name-only", ...argsForDiff]);
+      if (output) return output.split("\n").filter(Boolean);
+    } catch {}
+  }
+
+  try {
+    return execGit(repoDir, ["status", "--porcelain"])
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.slice(3).trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -930,6 +977,21 @@ async function main() {
     process.exit(1);
   }
 
+  const effectivePolicy = loadRelayPolicy({ repoRoot, relayHome: RELAY_HOME });
+  const routingDecision = resolveRoutingDecision({
+    policy: effectivePolicy.policy || {},
+    cliTags: ROUTING_TAGS,
+    taskProfile: manifest?.advisory?.guidance?.task_profile_summary || null,
+    promptText: taskPrompt,
+    rubricText: resolveRoutingRubricText({
+      rubricFile: RUBRIC_FILE,
+      manifest,
+      runDir: manifestRunDir,
+    }),
+    changedFiles: collectChangedFilesForRouting(RESUME_MODE ? wtPath : repoRoot, baseBranch),
+    testCommands: TEST_COMMAND ? [TEST_COMMAND] : [],
+  });
+
   // --- Dry run ---
   if (DRY_RUN) {
     const planFleetId = FLEET_ID || manifest?.fleet_id || null;
@@ -960,6 +1022,7 @@ async function main() {
       runState: manifest?.state || null,
       dispatchSkipped: false,
       policy_decision: policyDecision,
+      routing_decision: routingDecision,
     };
     if (planFleetId) {
       plan.fleetId = planFleetId;
@@ -994,6 +1057,7 @@ async function main() {
         doneCriteriaFile: resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null,
         reviewAssurance: REVIEW_ASSURANCE,
         policyDecision,
+        routingDecision,
         worktreePlan,
       }));
     }
@@ -1078,6 +1142,7 @@ async function main() {
         ...(manifest.policy || {}),
         executor_network: executorNetworkPolicy,
       },
+      routing: routingDecision,
     };
     ensureRunLayout(repoRoot, runId);
     writeManifest(manifestPath, manifest);
@@ -1088,6 +1153,7 @@ async function main() {
         ...(manifest.policy || {}),
         executor_network: executorNetworkPolicy,
       },
+      routing: routingDecision,
     };
     writeManifest(manifestPath, manifest);
   }
@@ -1511,6 +1577,7 @@ async function main() {
     executor: EXECUTOR,
     executorNetwork: executorNetworkPolicy,
     policyDecision,
+    routingDecision,
     codexGitCommonDir,
     worktree: wtPath,
     branch,

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -1,0 +1,370 @@
+"use strict";
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function pushUnique(target, values) {
+  for (const value of values || []) {
+    if (!target.includes(value)) target.push(value);
+  }
+  return target;
+}
+
+function normalizeTags(input) {
+  const raw = [];
+  if (Array.isArray(input)) {
+    for (const item of input) raw.push(...normalizeTags(item));
+  } else if (typeof input === "string") {
+    const parts = input.includes(",") ? input.split(",") : [input];
+    for (const part of parts) {
+      const tag = part.trim().replace(/^['"]|['"]$/g, "").trim().toLowerCase();
+      if (tag) raw.push(tag);
+    }
+  }
+  return pushUnique([], raw);
+}
+
+function normalizePathForClassification(filePath) {
+  return String(filePath || "")
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .trim();
+}
+
+function isDocsPath(filePath) {
+  const normalized = normalizePathForClassification(filePath);
+  if (!normalized) return false;
+  const basename = normalized.split("/").pop();
+  return /^README.*\.md$/i.test(basename)
+    || normalized.startsWith("docs/")
+    || /^skills\/[^/]+\/SKILL\.md$/i.test(normalized);
+}
+
+function isTestPath(filePath) {
+  const normalized = normalizePathForClassification(filePath);
+  if (!normalized) return false;
+  return normalized.startsWith("tests/")
+    || normalized.includes("/tests/")
+    || normalized.includes("/__tests__/")
+    || /\.(?:test|spec)\.[cm]?[jt]sx?$/i.test(normalized);
+}
+
+function classifyChangedFiles(changedFiles = []) {
+  const files = (changedFiles || []).map(normalizePathForClassification).filter(Boolean);
+  const tags = [];
+  if (!files.length) return tags;
+
+  const docsCount = files.filter(isDocsPath).length;
+  if (docsCount > 0) tags.push("docs");
+  if (docsCount > 0 && docsCount === files.length) tags.push("docs-only");
+
+  if (files.some(isTestPath)) {
+    tags.push("tests", "test-gap");
+  }
+  return tags;
+}
+
+function tagsFromTaskProfile(profile) {
+  if (!isPlainObject(profile)) return [];
+  const tags = [];
+  for (const field of ["tags", "labels", "domains", "risk_tags", "guidance_packs"]) {
+    pushUnique(tags, normalizeTags(profile[field]));
+  }
+  return tags;
+}
+
+function tagsFromRubricObject(rubric) {
+  if (!isPlainObject(rubric)) return [];
+  const tags = [];
+  pushUnique(tags, tagsFromTaskProfile(rubric));
+  pushUnique(tags, tagsFromTaskProfile(rubric.task_profile));
+  pushUnique(tags, tagsFromTaskProfile(rubric.taskProfile));
+  pushUnique(tags, tagsFromTaskProfile(rubric.profile));
+  pushUnique(tags, tagsFromTaskProfile(rubric.metadata));
+  return tags;
+}
+
+function tagsFromCoverageText(text) {
+  const raw = String(text || "");
+  if (!raw.trim()) return [];
+  const tags = [];
+  if (/\b(?:node --test|pytest|vitest|jest|coverage|test[-_\s]?gap|test_command|test-command)\b/i.test(raw)) {
+    tags.push("test-gap");
+  }
+  if (/\b(?:docs?|readme|documentation)\b/i.test(raw)) {
+    tags.push("docs");
+  }
+  return tags;
+}
+
+function parseTaskProfileFromText(text) {
+  const raw = String(text || "").replace(/\r\n/g, "\n");
+  if (!raw.includes("task_profile:")) return null;
+  const fenced = raw.match(/```(?:yaml|yml)?\s*\n([\s\S]*?^```)$/m);
+  const body = fenced ? fenced[1].replace(/\n```$/, "") : raw;
+  const lines = body.split("\n");
+  const start = lines.findIndex((line) => line.trim() === "task_profile:");
+  if (start === -1) return null;
+
+  const profile = {};
+  let currentArrayKey = null;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim()) continue;
+    if (/^\S/.test(line)) break;
+
+    const keyValue = /^ {2}([A-Za-z0-9_]+):(?:\s*(.*))?$/.exec(line);
+    if (keyValue) {
+      const key = keyValue[1];
+      const value = keyValue[2] || "";
+      currentArrayKey = null;
+      if (/^\[.*\]$/.test(value.trim())) {
+        profile[key] = normalizeTags(value.replace(/^\[/, "").replace(/\]$/, ""));
+      } else if (value.trim()) {
+        profile[key] = normalizeTags(value);
+      } else {
+        profile[key] = [];
+        currentArrayKey = key;
+      }
+      continue;
+    }
+
+    const listItem = /^ {4}-\s*(.*)$/.exec(line);
+    if (listItem && currentArrayKey) {
+      profile[currentArrayKey].push(...normalizeTags(listItem[1]));
+      profile[currentArrayKey] = normalizeTags(profile[currentArrayKey]);
+    }
+  }
+  return profile;
+}
+
+function collectRoutingTagSources({
+  cliTags = [],
+  issueLabels = [],
+  labels = [],
+  taskProfile = null,
+  promptText = null,
+  rubric = null,
+  rubricText = null,
+  changedFiles = [],
+  testCommands = [],
+} = {}) {
+  const parsedPromptProfile = parseTaskProfileFromText(promptText);
+  const sourceTags = {
+    cli: normalizeTags(cliTags),
+    issue_labels: normalizeTags([...normalizeTags(issueLabels), ...normalizeTags(labels)]),
+    task_profile: normalizeTags([
+      ...tagsFromTaskProfile(taskProfile),
+      ...tagsFromTaskProfile(parsedPromptProfile),
+    ]),
+    rubric: normalizeTags([
+      ...tagsFromRubricObject(rubric),
+      ...tagsFromCoverageText(rubricText),
+    ]),
+    changed_files: normalizeTags(classifyChangedFiles(changedFiles)),
+    test_commands: normalizeTags(tagsFromCoverageText((testCommands || []).join("\n"))),
+  };
+
+  const inferred = [];
+  for (const key of ["issue_labels", "task_profile", "rubric", "changed_files", "test_commands"]) {
+    pushUnique(inferred, sourceTags[key]);
+  }
+
+  if (sourceTags.cli.length) {
+    return {
+      source_tags: sourceTags,
+      effective_source: "cli",
+      effective_tags: sourceTags.cli,
+    };
+  }
+
+  return {
+    source_tags: sourceTags,
+    effective_source: inferred.length ? "inferred" : "none",
+    effective_tags: inferred,
+  };
+}
+
+function normalizeRuleName(rule, index) {
+  return nonEmptyString(rule?.name) || `routing_rules[${index}]`;
+}
+
+function normalizeMatch(rule) {
+  const match = isPlainObject(rule.match) ? rule.match : {};
+  return {
+    any_tags: normalizeTags(match.any_tags || match.tags || rule.tags || rule.match_tags),
+    all_tags: normalizeTags(match.all_tags),
+  };
+}
+
+function normalizeSelection(value, fieldName, index, warnings) {
+  if (value === undefined || value === null) return null;
+  if (!isPlainObject(value)) {
+    warnings.push({
+      code: "invalid_selection",
+      field: fieldName,
+      index,
+      reason: "expected_object",
+    });
+    return null;
+  }
+
+  const normalized = {};
+  for (const [field, fieldValue] of Object.entries(value)) {
+    if (fieldValue === null || fieldValue === undefined) continue;
+    const text = nonEmptyString(fieldValue);
+    if (!text) {
+      warnings.push({
+        code: "invalid_selection_field",
+        field: `${fieldName}.${field}`,
+        index,
+        reason: "expected_non_empty_string",
+      });
+      continue;
+    }
+    normalized[field] = text;
+  }
+  return Object.keys(normalized).length ? normalized : null;
+}
+
+function validateRoutingRules(routingRules = []) {
+  const warnings = [];
+  const normalizedRules = [];
+  const firstNameIndex = new Map();
+
+  if (!Array.isArray(routingRules)) {
+    return {
+      rules: [],
+      warnings: [{ code: "invalid_routing_rules", reason: "expected_array" }],
+    };
+  }
+
+  routingRules.forEach((rule, index) => {
+    if (!isPlainObject(rule)) {
+      warnings.push({ code: "invalid_rule", index, reason: "expected_object" });
+      return;
+    }
+
+    const name = normalizeRuleName(rule, index);
+    if (firstNameIndex.has(name)) {
+      warnings.push({
+        code: "duplicate_rule_name",
+        name,
+        first_index: firstNameIndex.get(name),
+        duplicate_index: index,
+      });
+    } else {
+      firstNameIndex.set(name, index);
+    }
+
+    const match = normalizeMatch(rule);
+    if (!match.any_tags.length && !match.all_tags.length) {
+      warnings.push({ code: "rule_without_tag_match", name, index });
+    }
+
+    const defaults = isPlainObject(rule.defaults) ? rule.defaults : {};
+    normalizedRules.push({
+      name,
+      index,
+      match,
+      advisory_review: normalizeSelection(rule.advisory_review ?? defaults.advisory_review, "advisory_review", index, warnings),
+      sidecar: normalizeSelection(rule.sidecar ?? defaults.sidecar, "sidecar", index, warnings),
+      ignored_primary_review: normalizeSelection(rule.review ?? defaults.review, "review", index, warnings),
+    });
+  });
+
+  return { rules: normalizedRules, warnings };
+}
+
+function ruleMatches(rule, effectiveTags) {
+  const tagSet = new Set(effectiveTags || []);
+  if (rule.match.all_tags.length && !rule.match.all_tags.every((tag) => tagSet.has(tag))) {
+    return false;
+  }
+  if (rule.match.any_tags.length) {
+    return rule.match.any_tags.some((tag) => tagSet.has(tag));
+  }
+  return rule.match.all_tags.length > 0;
+}
+
+function resolveRoutingDecision({
+  policy = {},
+  cliTags = [],
+  issueLabels = [],
+  labels = [],
+  taskProfile = null,
+  promptText = null,
+  rubric = null,
+  rubricText = null,
+  changedFiles = [],
+  testCommands = [],
+} = {}) {
+  const tagSources = collectRoutingTagSources({
+    cliTags,
+    issueLabels,
+    labels,
+    taskProfile,
+    promptText,
+    rubric,
+    rubricText,
+    changedFiles,
+    testCommands,
+  });
+  const { rules, warnings } = validateRoutingRules(policy?.routing_rules || []);
+  const matchedRule = rules.find((rule) => ruleMatches(rule, tagSources.effective_tags)) || null;
+
+  const base = {
+    version: 1,
+    source_tags: tagSources.source_tags,
+    effective_source: tagSources.effective_source,
+    effective_tags: tagSources.effective_tags,
+    warnings,
+    selected: {
+      advisory_review: null,
+      sidecar: null,
+    },
+    ignored_primary_review: null,
+  };
+
+  if (!matchedRule) {
+    return {
+      ...base,
+      matched: false,
+      matched_rule: null,
+      no_match_reason: "no_routing_rule_matched",
+    };
+  }
+
+  return {
+    ...base,
+    matched: true,
+    matched_rule: {
+      name: matchedRule.name,
+      index: matchedRule.index,
+      match: cloneJson(matchedRule.match),
+    },
+    selected: {
+      advisory_review: cloneJson(matchedRule.advisory_review) || null,
+      sidecar: cloneJson(matchedRule.sidecar) || null,
+    },
+    ignored_primary_review: cloneJson(matchedRule.ignored_primary_review) || null,
+    no_match_reason: null,
+  };
+}
+
+module.exports = {
+  classifyChangedFiles,
+  collectRoutingTagSources,
+  normalizeTags,
+  resolveRoutingDecision,
+  validateRoutingRules,
+};

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -38,6 +38,7 @@ function formatDispatchDryRun({
   doneCriteriaFile = null,
   reviewAssurance = null,
   policyDecision = null,
+  routingDecision = null,
   worktreePlan,
 }) {
   const lines = [
@@ -85,6 +86,28 @@ function formatDispatchDryRun({
       `phase=${policyDecision.phase} ${actorField}=${actorValue} ` +
       `model=${policyDecision.model || "(none)"} reason=${policyDecision.reason}${route}`
     );
+  }
+  if (routingDecision) {
+    const matched = routingDecision.matched_rule
+      ? `matched ${routingDecision.matched_rule.name} (#${routingDecision.matched_rule.index})`
+      : `no match${routingDecision.no_match_reason ? ` (${routingDecision.no_match_reason})` : ""}`;
+    const sourceTags = routingDecision.source_tags || {};
+    const sourceParts = Object.entries(sourceTags)
+      .filter(([, tags]) => Array.isArray(tags) && tags.length)
+      .map(([source, tags]) => `${source.replace(/_/g, "-")}=${tags.join(",")}`);
+    const effective = (routingDecision.effective_tags || []).join(",") || "(none)";
+    const advisory = routingDecision.selected?.advisory_review
+      ? Object.values(routingDecision.selected.advisory_review).join("/")
+      : "(none)";
+    const sidecar = routingDecision.selected?.sidecar
+      ? Object.values(routingDecision.selected.sidecar).join("/")
+      : "(none)";
+    lines.push(`  Routing: ${matched}`);
+    lines.push(`  Tags:    ${[...sourceParts, `effective=${effective}`].join(" ")}`);
+    lines.push(`  Selected: advisory_review=${advisory} sidecar=${sidecar}`);
+    if (routingDecision.warnings?.length) {
+      lines.push(`  Routing warnings: ${routingDecision.warnings.map((warning) => warning.code).join(", ")}`);
+    }
   }
   if (worktreePlan.worktreeinclude.length) {
     lines.push(`  .worktreeinclude: ${worktreePlan.worktreeinclude.join(", ")}`);

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1998,6 +1998,69 @@ test("dispatch dry-run includes managed default policy decision details", () => 
   });
 });
 
+test("dispatch routing dry-run JSON explains CLI tags and selected advisory sidecar defaults", () => {
+  const { repoRoot, relayHome, rubricFile, env } = setupDryRunFixtureRepo();
+  writeRelayPolicy(relayHome, {
+    profile: "routing-dry-run",
+    routing_rules: [
+      {
+        name: "docs",
+        match: { tags: ["docs"] },
+        advisory_review: { reviewer: "claude", profile: "blindspot" },
+        sidecar: { kind: "docs-sync", executor: "opencode" },
+      },
+    ],
+  });
+
+  const stdout = runDispatch(repoRoot, [
+    "-b", "issue-routing-dry-run",
+    "--prompt", "dry run routing decision",
+    "--rubric-file", rubricFile,
+    "--tags", "docs",
+    "--dry-run",
+    "--json",
+  ], env);
+  const result = JSON.parse(stdout);
+
+  assert.equal(result.routing_decision.effective_source, "cli");
+  assert.deepEqual(result.routing_decision.source_tags.cli, ["docs"]);
+  assert.equal(result.routing_decision.matched_rule.name, "docs");
+  assert.deepEqual(result.routing_decision.selected.advisory_review, {
+    reviewer: "claude",
+    profile: "blindspot",
+  });
+  assert.deepEqual(result.routing_decision.selected.sidecar, {
+    kind: "docs-sync",
+    executor: "opencode",
+  });
+});
+
+test("dispatch routing dry-run text explains no-match decisions", () => {
+  const { repoRoot, relayHome, rubricFile, env } = setupDryRunFixtureRepo();
+  writeRelayPolicy(relayHome, {
+    profile: "routing-no-match",
+    routing_rules: [
+      {
+        name: "docs",
+        match: { tags: ["docs"] },
+        sidecar: { kind: "docs-sync", executor: "opencode" },
+      },
+    ],
+  });
+
+  const stdout = runDispatch(repoRoot, [
+    "-b", "issue-routing-no-match",
+    "--prompt", "dry run routing no match",
+    "--rubric-file", rubricFile,
+    "--tags", "security",
+    "--dry-run",
+  ], env);
+
+  assert.match(stdout, /Routing:\s+no match/);
+  assert.match(stdout, /Tags:\s+cli=security .*effective=security/);
+  assert.match(stdout, /Selected:\s+advisory_review=\(none\) sidecar=\(none\)/);
+});
+
 test("dispatch resume --dry-run with new --model-hints reports the new hint in effective_dispatch_model and does NOT write the manifest or emit events", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/tests/relay-dispatch/scripts/relay-routing.test.js
+++ b/tests/relay-dispatch/scripts/relay-routing.test.js
@@ -1,0 +1,184 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  classifyChangedFiles,
+  collectRoutingTagSources,
+  normalizeTags,
+  resolveRoutingDecision,
+  validateRoutingRules,
+} = require("../../../skills/relay-dispatch/scripts/relay-routing");
+
+function policy(routingRules = []) {
+  return {
+    defaults: {
+      review: { reviewer: "codex" },
+      advisory_review: null,
+      sidecar: null,
+    },
+    routing_rules: routingRules,
+  };
+}
+
+test("routing normalizes tags from CSV and arrays deterministically", () => {
+  assert.deepEqual(
+    normalizeTags([" Docs ", "docs", "TEST-GAP", "", null, "test-gap"]),
+    ["docs", "test-gap"]
+  );
+  assert.deepEqual(normalizeTags(" Docs, 'test-gap' ,, \"SECURITY\" "), ["docs", "test-gap", "security"]);
+});
+
+test("routing CLI tags override inferred labels, profile, rubric, and file tags", () => {
+  const decision = resolveRoutingDecision({
+    policy: policy([
+      {
+        name: "docs",
+        match: { tags: ["docs-only"] },
+        sidecar: { kind: "docs-sync", executor: "opencode" },
+      },
+      {
+        name: "security",
+        match: { tags: ["security"] },
+        advisory_review: { reviewer: "claude", profile: "blindspot" },
+      },
+    ]),
+    cliTags: "security",
+    issueLabels: ["docs-only"],
+    taskProfile: { risk_tags: ["docs-only"], domains: ["docs"] },
+    rubric: { tags: ["docs-only"] },
+    changedFiles: ["README.md"],
+  });
+
+  assert.equal(decision.effective_source, "cli");
+  assert.deepEqual(decision.effective_tags, ["security"]);
+  assert.equal(decision.matched, true);
+  assert.equal(decision.matched_rule.name, "security");
+  assert.deepEqual(decision.selected.advisory_review, { reviewer: "claude", profile: "blindspot" });
+  assert.equal(decision.selected.sidecar, null);
+});
+
+test("routing collects label, task_profile, rubric, and test-command tags when CLI tags are absent", () => {
+  const sources = collectRoutingTagSources({
+    issueLabels: ["needs-review", "Docs"],
+    taskProfile: {
+      domains: ["relay-dispatch"],
+      risk_tags: ["trust-boundary"],
+      guidance_packs: ["verification-evidence"],
+    },
+    rubric: {
+      tags: ["rubric-tag"],
+      task_profile: { risk_tags: ["profile-rubric"] },
+    },
+    testCommands: ["node --test tests/relay-dispatch/scripts/relay-routing.test.js"],
+  });
+
+  assert.deepEqual(sources.effective_tags, [
+    "needs-review",
+    "docs",
+    "relay-dispatch",
+    "trust-boundary",
+    "verification-evidence",
+    "rubric-tag",
+    "profile-rubric",
+    "test-gap",
+  ]);
+  assert.equal(sources.effective_source, "inferred");
+});
+
+test("routing changed-file classifier recognizes docs-only and test-gap candidates", () => {
+  assert.deepEqual(
+    classifyChangedFiles(["README.md", "docs/usage.md", "skills/relay/SKILL.md"]),
+    ["docs", "docs-only"]
+  );
+  assert.deepEqual(classifyChangedFiles(["tests/relay-dispatch/scripts/relay-routing.test.js"]), [
+    "tests",
+    "test-gap",
+  ]);
+  assert.deepEqual(classifyChangedFiles(["skills/relay-dispatch/scripts/dispatch.js"]), []);
+});
+
+test("routing first matching rule selects advisory and sidecar defaults only", () => {
+  const originalPolicy = policy([
+    {
+      name: "first",
+      match: { tags: ["docs"] },
+      review: { reviewer: "opencode" },
+      advisory_review: { reviewer: "claude", profile: "blindspot" },
+      sidecar: { kind: "docs-sync", executor: "opencode" },
+    },
+    {
+      name: "second",
+      match: { tags: ["docs"] },
+      advisory_review: { reviewer: "opencode" },
+    },
+  ]);
+
+  const decision = resolveRoutingDecision({
+    policy: originalPolicy,
+    issueLabels: ["docs"],
+  });
+
+  assert.equal(decision.matched, true);
+  assert.equal(decision.matched_rule.name, "first");
+  assert.deepEqual(decision.selected, {
+    advisory_review: { reviewer: "claude", profile: "blindspot" },
+    sidecar: { kind: "docs-sync", executor: "opencode" },
+  });
+  assert.deepEqual(originalPolicy.defaults.review, { reviewer: "codex" });
+  assert.deepEqual(decision.ignored_primary_review, { reviewer: "opencode" });
+});
+
+test("routing reports no match with null advisory and sidecar selections", () => {
+  const decision = resolveRoutingDecision({
+    policy: policy([
+      {
+        name: "docs",
+        match: { tags: ["docs"] },
+        sidecar: { kind: "docs-sync" },
+      },
+    ]),
+    issueLabels: ["security"],
+  });
+
+  assert.equal(decision.matched, false);
+  assert.equal(decision.matched_rule, null);
+  assert.deepEqual(decision.selected, { advisory_review: null, sidecar: null });
+  assert.equal(decision.no_match_reason, "no_routing_rule_matched");
+});
+
+test("routing duplicate rule names warn but preserve first-match order", () => {
+  const rules = [
+    {
+      name: "dup",
+      match: { tags: ["docs"] },
+      sidecar: { kind: "docs-sync" },
+    },
+    {
+      name: "dup",
+      match: { tags: ["docs"] },
+      sidecar: { kind: "test-gap" },
+    },
+  ];
+
+  assert.deepEqual(validateRoutingRules(rules).warnings, [
+    {
+      code: "duplicate_rule_name",
+      name: "dup",
+      first_index: 0,
+      duplicate_index: 1,
+    },
+  ]);
+
+  const decision = resolveRoutingDecision({ policy: policy(rules), issueLabels: ["docs"] });
+  assert.equal(decision.matched_rule.name, "dup");
+  assert.equal(decision.matched_rule.index, 0);
+  assert.deepEqual(decision.selected.sidecar, { kind: "docs-sync" });
+  assert.deepEqual(decision.warnings, [
+    {
+      code: "duplicate_rule_name",
+      name: "dup",
+      first_index: 0,
+      duplicate_index: 1,
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

- Added `relay-routing.js` for deterministic tag normalization, source collection, changed-file classification, routing-rule warnings, and first-match advisory/sidecar selection.
- Wired `dispatch.js --tags <csv>` into dry-run JSON/text output and persisted the routing decision in live manifests for later #556 handoff.
- Kept routing selection advisory-only: primary merge-gating `review.reviewer` is not mutated or replaced.

## Verification

```text
$ node --test tests/relay-dispatch/scripts/relay-routing.test.js
✔ routing normalizes tags from CSV and arrays deterministically (1.92775ms)
✔ routing CLI tags override inferred labels, profile, rubric, and file tags (0.822542ms)
✔ routing collects label, task_profile, rubric, and test-command tags when CLI tags are absent (0.265ms)
✔ routing changed-file classifier recognizes docs-only and test-gap candidates (0.226ms)
✔ routing first matching rule selects advisory and sidecar defaults only (0.178791ms)
✔ routing reports no match with null advisory and sidecar selections (0.113083ms)
✔ routing duplicate rule names warn but preserve first-match order (0.152958ms)
ℹ tests 7
ℹ suites 0
ℹ pass 7
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 118.276209
```

```text
$ node --test --test-name-pattern 'routing' tests/relay-dispatch/scripts/dispatch.test.js
✔ dispatch routing dry-run JSON explains CLI tags and selected advisory sidecar defaults (4433.994166ms)
✔ dispatch routing dry-run text explains no-match decisions (3295.912791ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 7924.379
```

```text
$ node --test tests/relay-dispatch/scripts/cli-schema.test.js tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
✔ every registered command flag has an explicit parsed/verbatim mode (2.494083ms)
✔ unregistered flag reads fail closed (0.537375ms)
✔ --artifact-path verbatim mode preserves adversarial values through argv (1710.4975ms)
✔ --branch verbatim mode preserves adversarial values through argv (1631.11175ms)
✔ --contract-file verbatim mode preserves adversarial values through argv (1310.560458ms)
✔ --copy verbatim mode preserves adversarial values through argv (1524.22025ms)
✔ --diff-file verbatim mode preserves adversarial values through argv (1786.108375ms)
✔ --done-criteria-file verbatim mode preserves adversarial values through argv (2005.0985ms)
✔ --file verbatim mode preserves adversarial values through argv (2167.290292ms)
✔ --independent-review-reason verbatim mode preserves adversarial values through argv (1331.630667ms)
✔ --manifest verbatim mode preserves adversarial values through argv (1277.556833ms)
✔ --next-action verbatim mode preserves adversarial values through argv (1134.133ms)
✔ --out-dir verbatim mode preserves adversarial values through argv (1156.586917ms)
✔ --pr-body-file verbatim mode preserves adversarial values through argv (1260.334791ms)
✔ --pr-title verbatim mode preserves adversarial values through argv (1398.109208ms)
✔ --prompt verbatim mode preserves adversarial values through argv (1790.603333ms)
✔ --prompt-file verbatim mode preserves adversarial values through argv (2060.072208ms)
✔ --reason verbatim mode preserves adversarial values through argv (1664.611791ms)
✔ --repo verbatim mode preserves adversarial values through argv (1580.913459ms)
✔ --review-file verbatim mode preserves adversarial values through argv (1379.140208ms)
✔ --manual-review-reason verbatim mode preserves adversarial values through argv (1358.721333ms)
✔ --reviewer-script verbatim mode preserves adversarial values through argv (1623.119875ms)
✔ --rubric-file verbatim mode preserves adversarial values through argv (2329.233625ms)
✔ --runs-dir verbatim mode preserves adversarial values through argv (2038.355459ms)
✔ --skip verbatim mode preserves adversarial values through argv (2053.009458ms)
✔ --skip-review verbatim mode preserves adversarial values through argv (2052.6185ms)
✔ --test-command verbatim mode preserves adversarial values through argv (2106.926416ms)
✔ --text verbatim mode preserves adversarial values through argv (2055.938208ms)
✔ --title verbatim mode preserves adversarial values through argv (1875.291791ms)
✔ --topic verbatim mode preserves adversarial values through argv (1999.366042ms)
✔ --worktree-path verbatim mode preserves adversarial values through argv (2310.684583ms)
✔ verbatim values that look like flags do not activate sibling flags (1.519ms)
✔ --advisory-profile parsed mode treats --prefix input as missing through argv (332.162208ms)
✔ --advisory-reviewer parsed mode treats --prefix input as missing through argv (362.088125ms)
✔ --advisory-reviewer-model parsed mode treats --prefix input as missing through argv (319.574458ms)
✔ --advisory-timeout parsed mode treats --prefix input as missing through argv (340.538ms)
✔ --executor parsed mode treats --prefix input as missing through argv (344.268834ms)
✔ --fleet-id parsed mode treats --prefix input as missing through argv (342.919583ms)
✔ --head-sha parsed mode treats --prefix input as missing through argv (338.395708ms)
✔ --issue parsed mode treats --prefix input as missing through argv (326.074042ms)
✔ --last-reviewed-sha parsed mode treats --prefix input as missing through argv (324.963209ms)
✔ --leaf-id parsed mode treats --prefix input as missing through argv (326.770084ms)
✔ --max-rounds parsed mode treats --prefix input as missing through argv (309.011167ms)
✔ --merge-method parsed mode treats --prefix input as missing through argv (263.486541ms)
✔ --model parsed mode treats --prefix input as missing through argv (228.993166ms)
✔ --model-hints parsed mode treats --prefix input as missing through argv (224.876042ms)
✔ --network-access parsed mode treats --prefix input as missing through argv (229.921375ms)
✔ --older-than parsed mode treats --prefix input as missing through argv (229.315917ms)
✔ --phase parsed mode treats --prefix input as missing through argv (225.285292ms)
✔ --pr parsed mode treats --prefix input as missing through argv (228.543667ms)
✔ --pr-number parsed mode treats --prefix input as missing through argv (227.269375ms)
✔ --profile parsed mode treats --prefix input as missing through argv (230.989916ms)
✔ --reasoning parsed mode treats --prefix input as missing through argv (282.549042ms)
✔ --repeated-issue-count parsed mode treats --prefix input as missing through argv (329.493708ms)
✔ --request-id parsed mode treats --prefix input as missing through argv (323.858833ms)
✔ --review-assurance parsed mode treats --prefix input as missing through argv (332.464875ms)
✔ --reviewer parsed mode treats --prefix input as missing through argv (336.409792ms)
✔ --reviewer-model parsed mode treats --prefix input as missing through argv (325.491375ms)
✔ --rounds parsed mode treats --prefix input as missing through argv (323.064375ms)
✔ --run-id parsed mode treats --prefix input as missing through argv (335.321125ms)
✔ --sandbox parsed mode treats --prefix input as missing through argv (327.879041ms)
✔ --stale-hours parsed mode treats --prefix input as missing through argv (337.166416ms)
✔ --state parsed mode treats --prefix input as missing through argv (389.645875ms)
✔ --tags parsed mode treats --prefix input as missing through argv (425.533916ms)
✔ --timeout parsed mode treats --prefix input as missing through argv (364.169042ms)
✔ --to parsed mode treats --prefix input as missing through argv (418.229584ms)
✔ --verdict parsed mode treats --prefix input as missing through argv (352.307959ms)
✔ --window-days parsed mode treats --prefix input as missing through argv (414.208792ms)
✔ --writer-pr parsed mode treats --prefix input as missing through argv (377.871416ms)
✔ --flag value and --flag=value forms both work (0.729709ms)
✔ flag audit markdown enumerates every migrated flag (18.243875ms)
✔ recover-commit flags are registered with explicit required modes (0.442792ms)
✔ analyze-flip-flop-pattern help cites parsed/verbatim mode for listed flags (196.614208ms)
✔ cleanup-worktrees help cites parsed/verbatim mode for listed flags (222.187125ms)
✔ close-run help cites parsed/verbatim mode for listed flags (213.844542ms)
✔ create-worktree help cites parsed/verbatim mode for listed flags (311.298625ms)
✔ dispatch help cites parsed/verbatim mode for listed flags (245.037625ms)
✔ finalize-run help cites parsed/verbatim mode for listed flags (253.392667ms)
✔ gate-check help cites parsed/verbatim mode for listed flags (251.541833ms)
✔ invoke-reviewer-claude help cites parsed/verbatim mode for listed flags (224.275625ms)
✔ invoke-reviewer-codex help cites parsed/verbatim mode for listed flags (225.562708ms)
✔ persist-request help cites parsed/verbatim mode for listed flags (214.191291ms)
✔ probe-executor-env help cites parsed/verbatim mode for listed flags (245.932959ms)
✔ recover-commit help cites parsed/verbatim mode for listed flags (225.308583ms)
✔ relay-config help cites parsed/verbatim mode for listed flags (189.736875ms)
✔ rebrand-evidence help cites parsed/verbatim mode for listed flags (220.390083ms)
✔ recover-state help cites parsed/verbatim mode for listed flags (235.246417ms)
✔ reliability-report help cites parsed/verbatim mode for listed flags (222.759ms)
✔ review-runner help cites parsed/verbatim mode for listed flags (225.867083ms)
✔ update-manifest-state help cites parsed/verbatim mode for listed flags (193.975958ms)
✔ relay-merge: finalize-run.js rejects unknown flag --no-merge (141.03525ms)
✔ relay-merge: gate-check.js rejects unknown flag --no-merge (140.918833ms)
✔ relay-dispatch: dispatch.js rejects unknown flag --no-merge (164.470125ms)
✔ relay-dispatch: close-run.js rejects unknown flag --no-merge (165.594ms)
✔ relay-dispatch: cleanup-worktrees.js rejects unknown flag --no-merge (186.040834ms)
✔ relay-dispatch: relay-config.js rejects unknown flag --no-merge (175.146375ms)
✔ relay-dispatch: recover-state.js rejects unknown flag --no-merge (199.730375ms)
✔ relay-review: review-runner.js rejects unknown flag --no-merge (227.095209ms)
ℹ tests 98
ℹ suites 0
ℹ pass 98
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 66086.83525
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 디스패치 명령어에 `--tags` 플래그를 추가하여 라우팅 결정 제어 가능
  * 라우팅 정책 기반의 리뷰 선택 로직 구현으로 드라이런 시 라우팅 결과 포함

* **테스트**
  * 라우팅 결정 및 태그 처리 로직에 대한 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->