### PR TITLE
[codex] docs: add model route policy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ For repo-local design notes, issue evidence, and documentation retention rules, 
 - Git 2.20+
 - Node.js 18+
 
+### Route Policy Setup
+
+Relay policy treats executor and reviewer names as CLI harnesses. The compliance boundary is the provider/model route. Missing policy config defaults to Codex/Claude managed CLI only; OpenCode, Pi, advisory reviewers, and sidecars need explicit route approval such as `kakao/opencode-glm-*` before they run.
+
+Use `relay-config doctor` and `relay-config check` to verify policy before enabling advisory reviewers or sidecars. See [docs/model-route-policy.md](docs/model-route-policy.md) for company/internal defaults, personal opt-in examples, and the final precedence order: `CLI flags -> routing rules -> defaults -> existing relay defaults -> policy gate`.
+
 ## Quick Start
 
 ### One command, full cycle

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory keeps repo-local design notes, issue evidence, operator workflow 
 - `workflow-lanes.md` — when to use relay, direct implementation, or planning lanes.
 - `external-tool-workflow.md` — external review and learning-capture workflow.
 - `direct-read-relay-operator-note.md` — operator note for direct relay reads.
+- `model-route-policy.md` — provider/model route policy setup for company defaults, personal opt-in, routing rules, advisory reviewers, and sidecars.
 
 ## Rubric And Review History
 

--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -1,0 +1,220 @@
+# Model Route Policy
+
+Route policy answers one operational question: which provider/model route is allowed to run in each relay phase?
+
+Executor and reviewer names such as `codex`, `claude`, `opencode`, and `pi` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `kakao/opencode-glm-5-fp8`, `opencode-go/deepseek-v4-pro`, `deepseek/r1`, or `ollama/qwen3`.
+
+Codex and Claude are the managed CLI defaults. In the default managed profile, a model-less Codex or Claude invocation is allowed because the CLI account and its managed default model are the boundary. Generated company defaults should not pin Codex or Claude model names just to make policy explicit. OpenCode and Pi are routing harnesses, so managed/company profiles must require an explicit provider/model route and an allow rule before they can run.
+
+## Default Posture
+
+When no policy config exists, relay loads a fail-closed default policy:
+
+```json
+{
+  "profile": "managed-cli-default",
+  "defaults": {
+    "dispatch": { "executor": "codex" },
+    "review": { "reviewer": "codex" },
+    "advisory_review": null,
+    "sidecar": null
+  },
+  "managed_cli": ["codex", "claude"],
+  "allowed_model_routes": [],
+  "denied_model_routes": [],
+  "routing_rules": [],
+  "deny_unknown_model_routes": true
+}
+```
+
+That means missing policy config defaults to Codex/Claude managed CLI only. `codex` and `claude` pass the gate without a pinned model route. `opencode`, `pi`, and any other unmanaged harness fail unless the effective invocation includes a provider/model route and that route matches `allowed_model_routes`.
+
+## Precedence
+
+Use this final precedence order when reasoning about an invocation:
+
+`CLI flags -> routing rules -> defaults -> existing relay defaults -> policy gate`
+
+The policy gate is last and fail-closed. A route selected by a CLI flag, a routing rule, a model hint, an executor default, or an existing relay fallback still has to pass the policy gate. Deny rules win over allow rules, and unknown provider/model routes are denied when `deny_unknown_model_routes` is true.
+
+## Phase Interaction
+
+| Phase | Route selection before the gate | Policy gate tuple |
+| --- | --- | --- |
+| `dispatch` | `--executor` selects the harness. `--model` wins over `manifest.model_hints.dispatch`, then `--model-hints dispatch=...`, then executor model config such as `~/.relay/executors.json` or bundled OpenCode defaults. Primary dispatch routing rules are not used today; `--tags` only affects advisory and sidecar routing selected by dispatch. If no actor is supplied, the existing relay default is `codex`. | `phase=dispatch`, `executor=<name>`, `model=<effective route or null>` |
+| `review` | `--reviewer` wins over `RELAY_REVIEWER`, then `roles.reviewer`, then the existing relay default `codex`. `--reviewer-model` wins over `manifest.model_hints.review`; otherwise Codex/Claude normally run as managed CLI with no model route. | `phase=review`, `reviewer=<name>`, `model=<effective route or null>` |
+| `advisory_review` | `--advisory-reviewer` and `--advisory-reviewer-model` win. If absent, `routing.selected.advisory_review` from dispatch routing can supply the reviewer, profile, and model. If a reviewer is selected but no model is supplied, `manifest.model_hints.advisory_review` and then executor model config can supply the route. No advisory reviewer runs by default. | `phase=advisory_review`, `reviewer=<name>`, `model=<effective route or null>` |
+| `sidecar` | A direct `relay-sidecar` command uses `--executor` and `--model`; routed sidecars use `routing.selected.sidecar` persisted by dispatch. The direct sidecar runner defaults to `opencode`, which means it still needs an allowed OpenCode route unless `--executor none` is used for deterministic sidecars. | `phase=sidecar`, `executor=<name>`, `model=<effective route or null>` |
+
+Policy `defaults` describe configured actor defaults for auditing and future-safe profile shape. Where a current call site does not consume a policy default directly, the existing relay default in the table applies next. The policy gate still evaluates the final effective tuple.
+
+`model_hints` are route hints, not route approval. They can carry provider/model routes for unmanaged harnesses, especially advisory review. They should not be used to pin Codex or Claude defaults in generated company config.
+
+## Company/Internal Setup
+
+Initialize a company policy:
+
+```bash
+node skills/relay-dispatch/scripts/relay-config.js init --profile company
+```
+
+The generated company policy intentionally keeps Codex and Claude as managed CLI defaults with no pinned model names. Add internal OpenCode or Pi routes explicitly:
+
+```bash
+node skills/relay-dispatch/scripts/relay-config.js allow-route 'kakao/opencode-glm-*' \
+  --phase dispatch,advisory_review,sidecar \
+  --executor opencode
+
+node skills/relay-dispatch/scripts/relay-config.js allow-route 'kakao/pi-*' \
+  --phase dispatch,review,advisory_review,sidecar \
+  --executor pi \
+  --reviewer pi
+```
+
+For routed advisory reviewers or sidecars, add routing rules to the policy JSON so the selected route is internal:
+
+```json
+{
+  "version": 1,
+  "profile": "company",
+  "defaults": {
+    "dispatch": { "executor": "codex" },
+    "review": { "reviewer": "codex" },
+    "advisory_review": null,
+    "sidecar": null
+  },
+  "managed_cli": ["codex", "claude"],
+  "allowed_model_routes": [
+    {
+      "route": "kakao/opencode-glm-*",
+      "phases": ["dispatch", "advisory_review", "sidecar"],
+      "executors": ["opencode"],
+      "reviewers": ["opencode"]
+    }
+  ],
+  "denied_model_routes": [],
+  "routing_rules": [
+    {
+      "name": "docs-internal-sidecar",
+      "match": { "any_tags": ["docs", "docs-only"] },
+      "advisory_review": {
+        "reviewer": "opencode",
+        "profile": "blindspot",
+        "model": "kakao/opencode-glm-5-fp8"
+      },
+      "sidecar": {
+        "kind": "docs-sync",
+        "executor": "opencode",
+        "model": "kakao/opencode-glm-5-fp8"
+      }
+    }
+  ],
+  "deny_unknown_model_routes": true
+}
+```
+
+Repo-local `.relay/policy.json` files may narrow the global policy but may not widen it. For example, a repo policy can reduce `allowed_model_routes` from `kakao/*` to `kakao/opencode-glm-*`; it cannot add a new external provider that the global policy did not allow.
+
+## Personal Opt-In Setup
+
+Initialize a personal policy:
+
+```bash
+node skills/relay-dispatch/scripts/relay-config.js init --profile personal
+```
+
+Then opt in to the routes you personally allow:
+
+```bash
+node skills/relay-dispatch/scripts/relay-config.js allow-route 'opencode-go/*' \
+  --phase dispatch,advisory_review,sidecar \
+  --executor opencode
+
+node skills/relay-dispatch/scripts/relay-config.js allow-route 'deepseek/*' \
+  --phase dispatch,advisory_review,sidecar \
+  --executor opencode
+
+node skills/relay-dispatch/scripts/relay-config.js allow-route 'ollama/*' \
+  --phase dispatch,advisory_review,sidecar \
+  --executor opencode
+```
+
+If you want OpenCode to default to a personal route, set the executor model config and allow the matching route:
+
+```json
+{
+  "executors": {
+    "opencode": {
+      "default_model": "opencode-go/deepseek-v4-pro",
+      "candidate_models": [
+        "opencode-go/deepseek-v4-pro",
+        "deepseek/r1",
+        "ollama/qwen3"
+      ]
+    }
+  }
+}
+```
+
+This file changes model selection only. It does not grant policy approval. The selected provider/model route must still match `allowed_model_routes`.
+
+## Doctor And Check
+
+Run `relay-config doctor` after policy changes and before enabling advisory reviewers or sidecars:
+
+```bash
+node skills/relay-dispatch/scripts/relay-config.js doctor
+```
+
+Doctor reports whether known CLIs are installed and how policy treats each harness. For OpenCode or Pi, `route-configured (provider_model_route_required)` is expected when an allow rule exists but a specific model was not supplied to doctor. That is a reminder that the harness name alone is not compliant.
+
+Run `relay-config check` for each actual tuple you plan to enable:
+
+```bash
+node skills/relay-dispatch/scripts/relay-config.js check \
+  --phase dispatch \
+  --executor opencode \
+  --model kakao/opencode-glm-5-fp8
+
+node skills/relay-dispatch/scripts/relay-config.js check \
+  --phase advisory_review \
+  --executor opencode \
+  --reviewer opencode \
+  --model kakao/opencode-glm-5-fp8
+
+node skills/relay-dispatch/scripts/relay-config.js check \
+  --phase sidecar \
+  --executor opencode \
+  --model kakao/opencode-glm-5-fp8
+```
+
+Check exits non-zero when the tuple would be denied at runtime. Run it before turning on routed advisory review or sidecar rules because those phases can start automatically after dispatch.
+
+## Denial Example
+
+With the company policy above, an external OpenAI route through OpenCode is not allowed:
+
+```bash
+$ node skills/relay-dispatch/scripts/relay-config.js check \
+  --phase dispatch \
+  --executor opencode \
+  --model openai/gpt-5
+denied: unknown_model_route
+```
+
+If the route is explicitly denied, the reason is stronger and the matched deny route is shown:
+
+```bash
+$ node skills/relay-dispatch/scripts/relay-config.js deny-route 'openai/*' \
+  --phase dispatch \
+  --executor opencode
+
+$ node skills/relay-dispatch/scripts/relay-config.js check \
+  --phase dispatch \
+  --executor opencode \
+  --model openai/gpt-5
+denied: denied_model_route
+matched route: openai/*
+```
+
+Both failures happen before the harness runs. That is the intended safety property: the provider/model route must be approved before relay invokes an unmanaged CLI.

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -2,7 +2,7 @@
 
 Deep-dive into the manifest contract, state machine, and extension points. For overview, see [CLAUDE.md](../CLAUDE.md).
 
-This reference centers on the manifest-backed run lifecycle, plus the readiness boundary that may sit ahead of `relay-plan`. For the full relay-ready control-flow contract, see [docs/relay-ready-routing-and-handoff-design.md](../docs/relay-ready-routing-and-handoff-design.md).
+This reference centers on the manifest-backed run lifecycle, plus the readiness boundary that may sit ahead of `relay-plan`. For the full relay-ready control-flow contract, see [docs/relay-ready-routing-and-handoff-design.md](../docs/relay-ready-routing-and-handoff-design.md). For provider/model route policy setup and operator examples, see [docs/model-route-policy.md](../docs/model-route-policy.md).
 
 ## Readiness Boundary
 
@@ -83,8 +83,8 @@ roles:
   reviewer: claude              # who reviews (isolated)
 
 model_hints:
-  dispatch: opus                # optional per-phase advisory model preference
-  review: haiku                 # optional per-phase advisory model preference
+  dispatch: null                # omit for Codex/Claude managed CLI defaults
+  review: null                  # omit for Codex/Claude managed CLI defaults
   advisory_review: opencode-go/deepseek-v4-pro  # optional non-gating advisory reviewer model
 
 paths:
@@ -146,8 +146,9 @@ bootstrap_exempt:
 | Field | Purpose |
 |-------|---------|
 | `roles.*` | Immutable per-run binding. Decouples who decides, who implements, who validates |
-| `model_hints.*` | Optional advisory per-phase model preference. Current runtime consumers: `dispatch`, `review`, `advisory_review` |
-| `dispatch.last_model` / executor config | Dispatch records the effective model. If no explicit model hint is present, executor defaults come from the skill-bundled `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json` overrides |
+| `model_hints.*` | Optional per-phase model preference. Current runtime consumers: `dispatch`, `review`, `advisory_review`. For unmanaged harnesses, values must resolve to approved provider/model routes. Do not add Codex/Claude model hints in generated company defaults just to pin their managed CLI model. |
+| `dispatch.last_model` / executor config | Dispatch records the effective model route when one exists. For unmanaged executors such as OpenCode, defaults come from the skill-bundled `skills/relay-dispatch/references/executor-models.json` plus optional `~/.relay/executors.json` overrides and still pass through the route policy gate. Codex/Claude managed CLI defaults normally record a null model route. |
+| Route policy | Stored outside the manifest in `~/.relay/policy.json` plus optional repo-local `.relay/policy.json`. Executor/reviewer names are harnesses; provider/model route strings are the policy boundary. Final operator precedence is `CLI flags -> routing rules -> defaults -> existing relay defaults -> policy gate`. |
 | `policy.merge` | `manual_after_lgtm` — orchestrator must explicitly merge |
 | `policy.reviewer_write` | `forbid` — review runner rejects rounds where reviewer mutated files |
 | `policy.review_assurance` | `standard` keeps current behavior; `hardened` requires stronger review/evidence gates without using agent identity heuristics. Hardened review commands must include an advisory reviewer, and passing verdicts require successful advisory artifacts plus strict execution evidence. When `execution-evidence.json` includes `verification_runs[]`, hardened gates prefer those actual command-run records; legacy evidence without that array still falls back to `test_exit_code=0` plus a SHA-bound result hash |
@@ -184,9 +185,9 @@ Semantics:
 Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `pr_number`, `bootstrap_exempt`, `model`, `executor_network`, `failure_class`, `before`, `after`, `profile`, `status`, `artifact_path`, `raw_response_path`, `elapsed_ms`, `critical_path_wait_ms`, `consumed_by_phase`, `phase_decision_waited`, `frontier_step_replaced`, `failure_reason`, override audit fields):
 
 ```jsonl
-{"ts":"2026-04-18T12:00:00.000Z","event":"dispatch_start","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"draft","state_to":"dispatched","head_sha":"abc123","round":null,"reason":"new_dispatch","model":"gpt-5-codex","executor_network":{"access":"enabled","mechanism":"sandbox_workspace_write.network_access","domains":null}}
+{"ts":"2026-04-18T12:00:00.000Z","event":"dispatch_start","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"draft","state_to":"dispatched","head_sha":"abc123","round":null,"reason":"new_dispatch","model":null,"executor_network":{"access":"enabled","mechanism":"sandbox_workspace_write.network_access","domains":null}}
 {"ts":"2026-04-18T12:05:00.000Z","event":"dispatch_result","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"dispatched","state_to":"review_pending","head_sha":"def456","round":null,"reason":"new_dispatch:completed","executor_network":{"access":"enabled","mechanism":"sandbox_workspace_write.network_access","domains":null},"failure_class":null}
-{"ts":"2026-04-18T12:10:00.000Z","event":"review_invoke","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"review_pending","head_sha":"def456","round":1,"reason":"codex","model":"haiku"}
+{"ts":"2026-04-18T12:10:00.000Z","event":"review_invoke","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"review_pending","head_sha":"def456","round":1,"reason":"codex","model":null}
 {"ts":"2026-04-18T12:11:00.000Z","event":"advisory_review","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"review_pending","head_sha":"def456","round":1,"reason":null,"reviewer":"opencode","model":"opencode-go/deepseek-v4-pro","profile":"blindspot","status":"success","artifact_path":"~/.relay/runs/project-abcd1234/issue-42-20260418120000000/review-round-1-advisory-opencode.json","raw_response_path":"~/.relay/runs/project-abcd1234/issue-42-20260418120000000/review-round-1-advisory-opencode-raw-response.txt","required_count":0,"advisory_count":1,"duplicate_low_confidence_count":0,"elapsed_ms":42000,"advisory_elapsed_ms":42000,"critical_path_wait_ms":5000,"consumed_by_phase":"metrics","phase_decision_waited":true,"frontier_step_replaced":false,"failure_reason":null}
 {"ts":"2026-04-18T12:12:00.000Z","event":"review_apply","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"changes_requested","head_sha":"def456","round":1,"reviewer":"codex","reason":"changes_requested"}
 {"ts":"2026-04-18T12:40:00.000Z","event":"review_apply","actor":"claude","run_id":"issue-42-20260418120000000","state_from":"review_pending","state_to":"ready_to_merge","head_sha":"ghi789","round":2,"reviewer":"codex","reason":"pass"}


### PR DESCRIPTION
## Summary

- Add `docs/model-route-policy.md` as the primary operator guide for provider/model route policy.
- Link the guide from `README.md` and `docs/README.md`.
- Align `references/architecture.md` model hint examples with managed CLI defaults and route-policy language.

Closes #557.

## Verification

- `node --test tests/relay-dispatch/scripts/relay-config.test.js tests/relay-dispatch/scripts/relay-policy.test.js tests/relay-dispatch/scripts/relay-policy-gate.test.js tests/relay-dispatch/scripts/relay-routing.test.js` -> 33 tests passed.
- `rg -n "CLI flags -> routing rules -> defaults -> existing relay defaults -> policy gate|kakao/opencode-glm|relay-config doctor|relay-config check|managed CLI|provider/model route" README.md docs references` -> required route-policy terms found in README, docs, and references.
- `git diff --check` -> passed.
