### PR TITLE
Add interactive relay config setup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Roles are bound at manifest creation time and remain the run's assigned role bin
 npx skills add sungjunlee/dev-relay
 ```
 
-Installs all 6 skills as [Claude Code custom slash commands](https://docs.anthropic.com/en/docs/claude-code/skills). Add `-g -y` for global install without prompts:
+Installs the relay skills as [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills). Add `-g -y` for global install without prompts:
 
 ```bash
 npx skills add sungjunlee/dev-relay -g -y
@@ -75,7 +75,14 @@ For repo-local design notes, issue evidence, and documentation retention rules, 
 
 Relay policy treats executor and reviewer names as CLI harnesses. The compliance boundary is the provider/model route. Missing policy config defaults to Codex/Claude managed CLI only; OpenCode, Pi, advisory reviewers, and sidecars need explicit route approval such as `kakao/opencode-glm-*` before they run.
 
-Use `relay-config doctor` and `relay-config check` to verify policy before enabling advisory reviewers or sidecars. See [docs/model-route-policy.md](docs/model-route-policy.md) for company/internal defaults, personal opt-in examples, and the final precedence order: `CLI flags -> routing rules -> defaults -> existing relay defaults -> policy gate`.
+After installing skills, ask for setup in plain language:
+
+```text
+/relay-config 회사 환경으로 relay 설정해줘. opencode는 kakao/opencode-glm-*만 허용해줘.
+$relay-config 집에서는 opencode-go/deepseek-v4-pro를 sidecar/advisory에 쓰게 설정해줘.
+```
+
+`relay-config` inspects the current policy and installed harnesses, asks only for missing decisions, shows the proposed policy before writing, then runs `doctor` and representative `check` commands. From a direct checkout, use `node skills/relay-config/scripts/relay-config.js inspect` or the lower-level `node skills/relay-dispatch/scripts/relay-config.js ...` fallback. See [docs/model-route-policy.md](docs/model-route-policy.md) for company/internal defaults, personal opt-in examples, and the final precedence order: `CLI flags -> routing rules -> defaults -> existing relay defaults -> policy gate`.
 
 ## Quick Start
 

--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -52,20 +52,28 @@ Policy `defaults` describe configured actor defaults for auditing and future-saf
 
 ## Company/Internal Setup
 
-Initialize a company policy:
+After installing skills, prefer the interactive setup skill. Ask in natural language and let it inspect the current policy before writing:
+
+```text
+/relay-config 회사 환경으로 relay 설정해줘. opencode는 kakao/opencode-glm-*만 허용해줘.
+```
+
+The skill should show the proposed policy, ask for confirmation, apply it, then run `doctor` and representative `check` commands.
+
+From a direct checkout, initialize a company policy with the wrapper:
 
 ```bash
-node skills/relay-dispatch/scripts/relay-config.js init --profile company
+node skills/relay-config/scripts/relay-config.js init company
 ```
 
 The generated company policy intentionally keeps Codex and Claude as managed CLI defaults with no pinned model names. Add internal OpenCode or Pi routes explicitly:
 
 ```bash
-node skills/relay-dispatch/scripts/relay-config.js allow-route 'kakao/opencode-glm-*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'kakao/opencode-glm-*' \
   --phase dispatch,advisory_review,sidecar \
   --executor opencode
 
-node skills/relay-dispatch/scripts/relay-config.js allow-route 'kakao/pi-*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'kakao/pi-*' \
   --phase dispatch,review,advisory_review,sidecar \
   --executor pi \
   --reviewer pi
@@ -117,24 +125,30 @@ Repo-local `.relay/policy.json` files may narrow the global policy but may not w
 
 ## Personal Opt-In Setup
 
-Initialize a personal policy:
+After installing skills, prefer natural-language setup:
+
+```text
+$relay-config 집에서는 opencode-go/deepseek-v4-pro를 sidecar/advisory에 쓰게 설정해줘.
+```
+
+From a direct checkout, initialize a personal policy:
 
 ```bash
-node skills/relay-dispatch/scripts/relay-config.js init --profile personal
+node skills/relay-config/scripts/relay-config.js init personal
 ```
 
 Then opt in to the routes you personally allow:
 
 ```bash
-node skills/relay-dispatch/scripts/relay-config.js allow-route 'opencode-go/*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'opencode-go/*' \
   --phase dispatch,advisory_review,sidecar \
   --executor opencode
 
-node skills/relay-dispatch/scripts/relay-config.js allow-route 'deepseek/*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'deepseek/*' \
   --phase dispatch,advisory_review,sidecar \
   --executor opencode
 
-node skills/relay-dispatch/scripts/relay-config.js allow-route 'ollama/*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'ollama/*' \
   --phase dispatch,advisory_review,sidecar \
   --executor opencode
 ```
@@ -160,10 +174,10 @@ This file changes model selection only. It does not grant policy approval. The s
 
 ## Doctor And Check
 
-Run `relay-config doctor` after policy changes and before enabling advisory reviewers or sidecars:
+Run `relay-config doctor` after policy changes and before enabling advisory reviewers or sidecars. Installed operators should use the skill; direct-checkout users can run:
 
 ```bash
-node skills/relay-dispatch/scripts/relay-config.js doctor
+node skills/relay-config/scripts/relay-config.js doctor
 ```
 
 Doctor reports whether known CLIs are installed and how policy treats each harness. For OpenCode or Pi, `route-configured (provider_model_route_required)` is expected when an allow rule exists but a specific model was not supplied to doctor. That is a reminder that the harness name alone is not compliant.
@@ -171,21 +185,11 @@ Doctor reports whether known CLIs are installed and how policy treats each harne
 Run `relay-config check` for each actual tuple you plan to enable:
 
 ```bash
-node skills/relay-dispatch/scripts/relay-config.js check \
-  --phase dispatch \
-  --executor opencode \
-  --model kakao/opencode-glm-5-fp8
+node skills/relay-config/scripts/relay-config.js check dispatch opencode kakao/opencode-glm-5-fp8
 
-node skills/relay-dispatch/scripts/relay-config.js check \
-  --phase advisory_review \
-  --executor opencode \
-  --reviewer opencode \
-  --model kakao/opencode-glm-5-fp8
+node skills/relay-config/scripts/relay-config.js check advisory_review opencode kakao/opencode-glm-5-fp8
 
-node skills/relay-dispatch/scripts/relay-config.js check \
-  --phase sidecar \
-  --executor opencode \
-  --model kakao/opencode-glm-5-fp8
+node skills/relay-config/scripts/relay-config.js check sidecar opencode kakao/opencode-glm-5-fp8
 ```
 
 Check exits non-zero when the tuple would be denied at runtime. Run it before turning on routed advisory review or sidecar rules because those phases can start automatically after dispatch.
@@ -195,24 +199,18 @@ Check exits non-zero when the tuple would be denied at runtime. Run it before tu
 With the company policy above, an external OpenAI route through OpenCode is not allowed:
 
 ```bash
-$ node skills/relay-dispatch/scripts/relay-config.js check \
-  --phase dispatch \
-  --executor opencode \
-  --model openai/gpt-5
+$ node skills/relay-config/scripts/relay-config.js check dispatch opencode openai/gpt-5
 denied: unknown_model_route
 ```
 
 If the route is explicitly denied, the reason is stronger and the matched deny route is shown:
 
 ```bash
-$ node skills/relay-dispatch/scripts/relay-config.js deny-route 'openai/*' \
+$ node skills/relay-config/scripts/relay-config.js deny-route 'openai/*' \
   --phase dispatch \
   --executor opencode
 
-$ node skills/relay-dispatch/scripts/relay-config.js check \
-  --phase dispatch \
-  --executor opencode \
-  --model openai/gpt-5
+$ node skills/relay-config/scripts/relay-config.js check dispatch opencode openai/gpt-5
 denied: denied_model_route
 matched route: openai/*
 ```

--- a/references/install-graph.md
+++ b/references/install-graph.md
@@ -16,6 +16,7 @@ relay-review ---> relay-dispatch
 relay-merge ----> relay-dispatch
 relay-merge ----> relay-plan
 relay-merge ----> relay-review
+relay-config ---> relay-dispatch
 relay-sidecar --> relay-dispatch
 ```
 
@@ -29,6 +30,7 @@ The `relay-dispatch` -> `relay-plan` edge is a small JS-level cycle: `skills/rel
 | `relay-dispatch` | `relay-plan` | `scripts/reliability-report.js` requires `../../relay-plan/scripts/tdd-flavor`; running reliability reporting from a dispatch-only install fails when relay-plan is absent. This is the closest skill to a root, but it is not fully standalone today. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
 | `relay-review` | `relay-dispatch` | Review entrypoints and helpers import dispatch manifest/event modules: `scripts/review-runner.js` requires `../../relay-dispatch/scripts/manifest/lifecycle`, `manifest/paths`, `manifest/rubric`, `manifest/store`, `relay-events`, and `cli-args`; nested `scripts/review-runner/*` modules require `../../../relay-dispatch/scripts/...`; reviewer adapters require `../../relay-dispatch/scripts/cli-args`; `scripts/reviewer-helpers.js` and `scripts/analyze-flip-flop-pattern.js` also require dispatch modules. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
 | `relay-merge` | `relay-dispatch`, `relay-plan`, `relay-review` | Merge scripts import dispatch modules throughout: `scripts/finalize-run.js`, `scripts/gate-check.js`, `scripts/relay-reconcile-artifact.js`, and `scripts/review-gate.js` require `../../relay-dispatch/scripts/...`. `scripts/sprint-close-report.js` additionally requires `../../relay-review/scripts/review-runner/divergence` and `../../relay-plan/scripts/tdd-flavor`, plus dispatch modules. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
+| `relay-config` | `relay-dispatch` | The setup skill wrapper delegates all policy mutations and route decisions to `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/relay-config.js`; installing it alone leaves the policy engine missing. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
 | `relay-sidecar` | `relay-dispatch` | `scripts/relay-sidecar.js` requires `../../relay-dispatch/scripts/cli-args`, `manifest/paths`, `manifest/store`, `manifest/rubric`, and `sidecar-store`; sidecar execution fails without relay-dispatch installed adjacent. | Use `npx skills add sungjunlee/dev-relay` for the full bundle. Per-skill installs are not operator-supported. |
 
 Keep this file in sync when adding or removing cross-skill script calls. `CLAUDE.md` points users here instead of duplicating the graph.

--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: relay-config
+argument-hint: "[setup request or command]"
+description: Interactive setup for relay route policy. Use when the user asks to set up relay, configure company/personal relay policy, enable OpenCode or Pi, allow provider/model routes, check sidecar/advisory-review policy, or run relay-config doctor/check.
+compatibility: Requires Node.js 18+ and the sibling relay-dispatch skill.
+metadata:
+  related-skills: "relay, relay-dispatch, relay-review, relay-sidecar"
+  keywords: "relay setup, relay config, route policy, model route, opencode, pi, sidecar, advisory review, 릴레이 설정, 회사 설정, 개인 설정"
+  entry: scripts/relay-config.js
+---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; relay policy writes to `RELAY_POLICY_PATH` or `~/.relay/policy.json`.
+- Files: effective relay policy, optional repo `.relay/policy.json`, optional `~/.relay/executors.json`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/relay-config.js`.
+
+# Relay Config
+
+Set up relay route policy interactively. The user should not have to memorize command flags.
+
+## Use when
+
+- The user asks to set up or configure relay
+- The user wants company-safe defaults, personal OpenCode/Pi opt-in, or sidecar/advisory-review routing
+- The user asks whether a provider/model route such as `kakao/opencode-glm-*` is allowed
+- The user asks to run relay policy doctor/check
+
+## Do not use when
+
+- Dispatching implementation work — use `relay-dispatch`
+- Reviewing PRs — use `relay-review`
+- Running a sidecar for an existing run — use `relay-sidecar`
+
+## Workflow
+
+### 1. Inspect current state
+
+Always start with:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" inspect --json
+```
+
+Use the output to identify the effective policy, policy source paths, installed harnesses, and whether `~/.relay/executors.json` exists.
+
+### 2. Infer the setup intent
+
+Infer from the user's words before asking questions:
+
+- `company`, `work`, `회사` → company profile
+- `personal`, `home`, `집`, `개인` → personal profile
+- `managed only`, `codex/claude only` → no unmanaged route opt-in
+- routes containing `/`, such as `kakao/opencode-glm-*`, `opencode-go/*`, `deepseek/*`, or `ollama/*` → provider/model route patterns
+- `sidecar`, `advisory`, `reviewer`, `documentation`, `docs` → likely advisory-review or sidecar phases
+
+Ask only for missing decisions, one at a time. Use plain language and wait for the user's answer. Do not use host-specific question primitives as the only path; this skill must work in both Claude Code and Codex.
+
+### 3. Propose before writing
+
+Before mutating policy, show a concise proposal:
+
+- profile to initialize or keep
+- managed CLIs that remain model-less (`codex`, `claude`)
+- allowed provider/model routes to add
+- phases and actors for each route
+- default actors to set, if any
+
+Ask for confirmation. If the user already explicitly approved the exact policy in the same request, proceed and state what will be written.
+
+### 4. Apply with deterministic commands
+
+Use the wrapper for shorthand, or pass through full flags:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" init company
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" allow-route 'kakao/opencode-glm-*' --phase dispatch,advisory_review,sidecar --executor opencode
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
+```
+
+Generated company and personal profiles must not pin Codex or Claude model names. Do not hardcode company-specific route defaults; use the user's supplied provider/model route patterns.
+
+### 5. Verify
+
+After changes, run:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" doctor
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" check dispatch opencode kakao/opencode-glm-5-fp8
+```
+
+Adjust the `check` tuple to match the actual actor, phase, and route that was enabled. Report denied tuples clearly and do not treat a denied OpenCode/Pi route as configured.
+
+## Power-user shorthand
+
+The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/relay-config.js`:
+
+| User form | Core command |
+| --- | --- |
+| `init company` | `init --profile company` |
+| `init personal` | `init --profile personal` |
+| `show` | `show --effective` |
+| `doctor` | `doctor` |
+| `check dispatch opencode kakao/opencode-glm-5-fp8` | `check --phase dispatch --executor opencode --model kakao/opencode-glm-5-fp8` |
+
+Full flag forms continue to pass through. Policy semantics live in the sibling `relay-dispatch` script, not this wrapper.

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const CORE_SCRIPT = path.resolve(__dirname, "..", "..", "relay-dispatch", "scripts", "relay-config.js");
+const VALID_PROFILES = new Set(["company", "personal"]);
+const VALID_PHASES = new Set(["dispatch", "review", "advisory_review", "sidecar"]);
+const REVIEWER_PHASES = new Set(["review", "advisory_review"]);
+
+function hasFlag(args, flag) {
+  return args.includes(flag) || args.some((arg) => arg.startsWith(`${flag}=`));
+}
+
+function relayHome() {
+  return process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
+}
+
+function executorsConfigPath() {
+  return process.env.RELAY_EXECUTORS_PATH || path.join(relayHome(), "executors.json");
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function printHelp() {
+  console.log("Usage: relay-config <command> [options]");
+  console.log("");
+  console.log("Interactive relay route-policy setup helper. Use the skill for natural-language setup, or this wrapper for deterministic shorthand.");
+  console.log("");
+  console.log("Common setup requests:");
+  console.log('  "relay setup 해줘"');
+  console.log('  "회사 환경으로 relay 설정해줘"');
+  console.log('  "집에서는 opencode-go/deepseek-v4-pro를 sidecar에 쓰게 해줘"');
+  console.log("");
+  console.log("Commands:");
+  console.log("  inspect [--json]");
+  console.log("  init company|personal [--json]");
+  console.log("  show [--json]");
+  console.log("  doctor [--json]");
+  console.log("  check <phase> <actor> [provider/model] [--json]");
+  console.log("  allow-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");
+  console.log("  deny-route <pattern> [--phase <csv>] [--executor <name>] [--reviewer <name>] [--json]");
+  console.log("  set-default <path> <value> [--json]");
+  console.log("");
+  console.log("Policy boundary: executor/reviewer names are harnesses; provider/model route strings are the compliance boundary.");
+}
+
+function runCore(args, { capture = false } = {}) {
+  const result = spawnSync(process.execPath, [CORE_SCRIPT, ...args], {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: "utf-8",
+  });
+
+  if (!capture) {
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+  }
+  return result;
+}
+
+function parseJsonOutput(result, label) {
+  try {
+    return JSON.parse(result.stdout || "{}");
+  } catch (error) {
+    return {
+      ok: false,
+      error: `failed to parse ${label} JSON: ${error.message}`,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      status: result.status,
+    };
+  }
+}
+
+function inspect(jsonOut) {
+  const showResult = runCore(["show", "--effective", "--json"], { capture: true });
+  const doctorResult = runCore(["doctor", "--json"], { capture: true });
+  const policy = parseJsonOutput(showResult, "show");
+  const doctor = parseJsonOutput(doctorResult, "doctor");
+  const configPath = executorsConfigPath();
+  const ok = showResult.status === 0 && doctorResult.status === 0;
+
+  const output = {
+    ok,
+    policy,
+    doctor,
+    executorsConfig: {
+      path: configPath,
+      exists: fs.existsSync(configPath),
+    },
+  };
+
+  if (jsonOut) {
+    printJson(output);
+    return ok ? 0 : 1;
+  }
+
+  console.log(`relay-config inspect: ${output.ok ? "ok" : "failed"}`);
+  console.log(`policy status: ${policy.status || "unknown"}`);
+  if (policy.sources?.global) console.log(`global policy: ${policy.sources.global}`);
+  if (policy.sources?.repo) console.log(`repo policy: ${policy.sources.repo}`);
+  console.log(`executors config: ${output.executorsConfig.exists ? "present" : "missing"} at ${configPath}`);
+  if (Array.isArray(doctor.tools)) {
+    for (const tool of doctor.tools) {
+      const installed = tool.installed ? `installed at ${tool.path}` : "not installed on PATH";
+      console.log(`${tool.name}: ${installed}; ${tool.policy} (${tool.reason})`);
+    }
+  }
+  return ok ? 0 : 1;
+}
+
+function normalizeCheck(rest) {
+  if (rest.length < 2 || rest[0].startsWith("-")) return ["check", ...rest];
+  const [phase, actor, maybeModel, ...tail] = rest;
+  if (!VALID_PHASES.has(phase)) return ["check", ...rest];
+
+  const normalized = ["check", "--phase", phase, "--executor", actor];
+  if (REVIEWER_PHASES.has(phase)) normalized.push("--reviewer", actor);
+
+  if (maybeModel && !maybeModel.startsWith("-")) {
+    normalized.push("--model", maybeModel);
+    normalized.push(...tail);
+  } else {
+    if (maybeModel) normalized.push(maybeModel);
+    normalized.push(...tail);
+  }
+  return normalized;
+}
+
+function normalizeArgs(args) {
+  if (!args.length || hasFlag(args, "--help") || args.includes("-h")) return null;
+
+  const [command, ...rest] = args;
+  if (command === "inspect") {
+    const unsupported = rest.filter((arg) => arg !== "--json");
+    if (unsupported.length) {
+      return {
+        error: `unsupported arguments for inspect: ${[...new Set(unsupported)].join(", ")}`,
+      };
+    }
+    return { inspect: true, jsonOut: hasFlag(rest, "--json") };
+  }
+
+  if (command === "init" && VALID_PROFILES.has(rest[0]) && !hasFlag(rest, "--profile")) {
+    return { coreArgs: ["init", "--profile", rest[0], ...rest.slice(1)] };
+  }
+
+  if (command === "show" && !hasFlag(rest, "--effective")) {
+    return { coreArgs: ["show", "--effective", ...rest] };
+  }
+
+  if (command === "check") {
+    return { coreArgs: normalizeCheck(rest) };
+  }
+
+  return { coreArgs: args };
+}
+
+function main() {
+  const normalized = normalizeArgs(process.argv.slice(2));
+  if (normalized === null) {
+    printHelp();
+    return 0;
+  }
+
+  if (normalized.error) {
+    console.error(`Error: ${normalized.error}`);
+    return 1;
+  }
+
+  if (normalized.inspect) {
+    return inspect(normalized.jsonOut);
+  }
+
+  const result = runCore(normalized.coreArgs);
+  return result.status || 0;
+}
+
+process.exit(main());

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -1,0 +1,142 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const {
+  validateRelayPolicy,
+} = require("../../../skills/relay-dispatch/scripts/relay-policy");
+
+const REPO_ROOT = path.join(__dirname, "..", "..", "..");
+const SCRIPT = path.join(REPO_ROOT, "skills", "relay-config", "scripts", "relay-config.js");
+
+function tempDir(prefix = "relay-config-wrapper-") {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function envFor(relayHome, extra = {}) {
+  const env = {
+    ...process.env,
+    ...extra,
+    RELAY_HOME: relayHome,
+  };
+  if (!Object.prototype.hasOwnProperty.call(extra, "RELAY_POLICY_PATH")) {
+    delete env.RELAY_POLICY_PATH;
+  }
+  if (!Object.prototype.hasOwnProperty.call(extra, "RELAY_EXECUTORS_PATH")) {
+    delete env.RELAY_EXECUTORS_PATH;
+  }
+  return env;
+}
+
+function runConfig(args, { relayHome = tempDir(), cwd = REPO_ROOT, env = {} } = {}) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd,
+    env: envFor(relayHome, env),
+    encoding: "utf-8",
+  });
+  return {
+    ...result,
+    relayHome,
+    combined: `${result.stdout}\n${result.stderr}`,
+  };
+}
+
+function parseJson(result) {
+  assert.equal(result.stderr, "", result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+function readPolicy(relayHome) {
+  const policyPath = path.join(relayHome, "policy.json");
+  const policy = JSON.parse(fs.readFileSync(policyPath, "utf-8"));
+  return validateRelayPolicy(policy, policyPath);
+}
+
+test("init company shorthand delegates to core init --profile company", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig(["init", "company", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  assert.equal(parseJson(result).profile, "company");
+  const policy = readPolicy(relayHome);
+  assert.equal(policy.profile, "company");
+  assert.deepEqual(policy.managed_cli, ["codex", "claude"]);
+  assert.equal(Object.prototype.hasOwnProperty.call(policy.defaults.dispatch, "model"), false);
+});
+
+test("show shorthand adds --effective", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "personal", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig(["show", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.status, "ok");
+  assert.equal(output.policy.profile, "personal");
+});
+
+test("check shorthand maps reviewer phases to reviewer and executor scopes", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "company", "--json"], { relayHome }).status, 0);
+  assert.equal(runConfig([
+    "allow-route",
+    "kakao/opencode-glm-*",
+    "--phase",
+    "dispatch,advisory_review,sidecar",
+    "--executor",
+    "opencode",
+    "--json",
+  ], { relayHome }).status, 0);
+
+  const result = runConfig([
+    "check",
+    "advisory_review",
+    "opencode",
+    "kakao/opencode-glm-5-fp8",
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  assert.equal(parseJson(result).decision.reason, "allowed_model_route");
+});
+
+test("inspect reports effective policy, doctor output, and executors config state", () => {
+  const relayHome = tempDir();
+  const executorsPath = path.join(relayHome, "executors.json");
+  fs.writeFileSync(executorsPath, "{\"executors\":{}}\n", "utf-8");
+
+  const result = runConfig(["inspect", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.policy.status, "defaulted");
+  assert.equal(output.executorsConfig.path, executorsPath);
+  assert.equal(output.executorsConfig.exists, true);
+  assert.ok(output.doctor.tools.some((tool) => tool.name === "codex"));
+});
+
+test("help advertises natural-language setup and provider/model boundary", () => {
+  const result = runConfig(["--help"]);
+
+  assert.equal(result.status, 0, result.combined);
+  assert.match(result.stdout, /relay setup 해줘/);
+  assert.match(result.stdout, /provider\/model route strings are the compliance boundary/i);
+});
+
+test("inspect rejects unsupported arguments instead of ignoring them", () => {
+  const flag = runConfig(["inspect", "--bogus"]);
+
+  assert.notEqual(flag.status, 0, flag.combined);
+  assert.match(flag.combined, /unsupported arguments for inspect: --bogus/);
+
+  const positional = runConfig(["inspect", "extra"]);
+  assert.notEqual(positional.status, 0, positional.combined);
+  assert.match(positional.combined, /unsupported arguments for inspect: extra/);
+});

--- a/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.json
+++ b/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.json
@@ -40,5 +40,27 @@
         "repo": "/tmp/issue187-fixtures/repo/.relay/policy.json"
       }
     }
+  },
+  "routing_decision": {
+    "version": 1,
+    "source_tags": {
+      "cli": [],
+      "issue_labels": [],
+      "task_profile": [],
+      "rubric": [],
+      "changed_files": [],
+      "test_commands": []
+    },
+    "effective_source": "none",
+    "effective_tags": [],
+    "warnings": [],
+    "selected": {
+      "advisory_review": null,
+      "sidecar": null
+    },
+    "ignored_primary_review": null,
+    "matched": false,
+    "matched_rule": null,
+    "no_match_reason": "no_routing_rule_matched"
   }
 }

--- a/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.txt
+++ b/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.txt
@@ -17,3 +17,6 @@ Dry run:
   Rubric:   /tmp/issue187-fixtures/rubric.yaml
   Assurance: standard
   Policy:   allowed phase=dispatch executor=codex model=(none) reason=managed_cli
+  Routing: no match (no_routing_rule_matched)
+  Tags:    effective=(none)
+  Selected: advisory_review=(none) sidecar=(none)


### PR DESCRIPTION
Closes #564

## Summary
- add a new `relay-config` setup skill for natural-language company/personal route-policy setup
- add a deterministic wrapper for `inspect`, `init company|personal`, `show`, and shorthand `check` while delegating policy semantics to `relay-dispatch/scripts/relay-config.js`
- update route-policy docs/install graph and sync stale dispatch dry-run fixtures with current routing output

## Verification
- `node --test tests/relay-config/scripts/*.test.js tests/relay-dispatch/scripts/relay-config.test.js`
- `node --check skills/relay-config/scripts/relay-config.js && node --check tests/relay-config/scripts/relay-config.test.js`
- `git diff --cached --check`

## Notes
- A full relay test sweep was run before fixture sync and only failed on stale dispatch dry-run routing fixtures; those fixtures are updated in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 라우트 정책을 대화형으로 설정할 수 있는 relay-config 도구 추가

* **문서화**
  * 설치 및 Route Policy 설정 가이드 업데이트
  * relay-config 스킬 사용 설명서 추가
  * 교차-스킬 의존성 문서 개선

* **테스트**
  * relay-config 통합 테스트 스위트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->