### PR TITLE
Add agent adapter descriptor registry

### DIFF
--- a/skills/relay-dispatch/scripts/agent-adapters/index.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/index.js
@@ -1,0 +1,333 @@
+const codex = require("../executors/codex");
+const claude = require("../executors/claude");
+const opencode = require("../executors/opencode");
+const bundledModels = require("../../references/executor-models.json");
+
+const ADAPTER_PHASES = Object.freeze({
+  DISPATCH: "dispatch",
+  PRIMARY_REVIEW: "primary_review",
+  ADVISORY_REVIEW: "advisory_review",
+});
+
+const PHASES = Object.freeze(Object.values(ADAPTER_PHASES));
+
+function bundledDefaultModel(name) {
+  const value = bundledModels.executors?.[name]?.default_model;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function freezeCapability(value) {
+  if (!value || typeof value !== "object") return value;
+  for (const child of Object.values(value)) {
+    freezeCapability(child);
+  }
+  return Object.freeze(value);
+}
+
+function buildDescriptor({
+  name,
+  displayName,
+  executor,
+  phases,
+  capabilities,
+  reviewer,
+}) {
+  return Object.freeze({
+    name,
+    displayName,
+    cliBinary: executor.cliBinary,
+    executor,
+    phases: freezeCapability(phases),
+    capabilities: freezeCapability(capabilities),
+    reviewer: reviewer ? freezeCapability(reviewer) : null,
+  });
+}
+
+const DESCRIPTORS = Object.freeze({
+  claude: buildDescriptor({
+    name: "claude",
+    displayName: "Claude Code",
+    executor: claude,
+    phases: {
+      [ADAPTER_PHASES.DISPATCH]: {
+        supported: true,
+        trust: "executor",
+      },
+      [ADAPTER_PHASES.PRIMARY_REVIEW]: {
+        supported: true,
+        trust: "trusted",
+      },
+      [ADAPTER_PHASES.ADVISORY_REVIEW]: {
+        supported: false,
+        trust: "unsupported",
+      },
+    },
+    capabilities: {
+      sandbox: {
+        dispatch: {
+          modes: ["workspace-write"],
+          enforced: false,
+        },
+        primaryReview: {
+          mode: "read-only",
+          enforced: true,
+        },
+        advisoryReview: null,
+      },
+      network: {
+        dispatch: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+        primaryReview: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+        advisoryReview: null,
+      },
+      readOnly: {
+        dispatch: false,
+        primaryReview: true,
+        advisoryReview: false,
+      },
+      transport: {
+        dispatch: "claude-cli",
+        primaryReview: "claude-cli",
+        advisoryReview: null,
+      },
+      structuredOutput: {
+        dispatch: "stdout-copied-result-file",
+        primaryReview: "json-schema-argv",
+        advisoryReview: null,
+      },
+      appRegistration: {
+        supported: true,
+        transport: "claude-app",
+      },
+      modelDefaults: {
+        provider: claude.providerDefault,
+        dispatch: {
+          configKey: "claude",
+          defaultModel: null,
+        },
+        primaryReview: {
+          configKey: "claude",
+          defaultModel: null,
+        },
+        advisoryReview: null,
+      },
+    },
+    reviewer: {
+      primaryReviewScript: "invoke-reviewer-claude.js",
+      advisoryReviewScript: null,
+    },
+  }),
+  codex: buildDescriptor({
+    name: "codex",
+    displayName: "Codex CLI",
+    executor: codex,
+    phases: {
+      [ADAPTER_PHASES.DISPATCH]: {
+        supported: true,
+        trust: "executor",
+      },
+      [ADAPTER_PHASES.PRIMARY_REVIEW]: {
+        supported: true,
+        trust: "trusted",
+      },
+      [ADAPTER_PHASES.ADVISORY_REVIEW]: {
+        supported: false,
+        trust: "unsupported",
+      },
+    },
+    capabilities: {
+      sandbox: {
+        dispatch: {
+          modes: ["read-only", "workspace-write"],
+          enforced: true,
+        },
+        primaryReview: {
+          mode: "read-only",
+          enforced: true,
+        },
+        advisoryReview: null,
+      },
+      network: {
+        dispatch: {
+          configurable: true,
+          default: "disabled",
+        },
+        primaryReview: {
+          configurable: false,
+          default: "disabled",
+        },
+        advisoryReview: null,
+      },
+      readOnly: {
+        dispatch: false,
+        primaryReview: true,
+        advisoryReview: false,
+      },
+      transport: {
+        dispatch: "codex-cli",
+        primaryReview: "codex-cli",
+        advisoryReview: null,
+      },
+      structuredOutput: {
+        dispatch: "result-file",
+        primaryReview: "json-schema-file",
+        advisoryReview: null,
+      },
+      appRegistration: {
+        supported: true,
+        transport: "codex-app",
+      },
+      modelDefaults: {
+        provider: codex.providerDefault,
+        dispatch: {
+          configKey: "codex",
+          defaultModel: null,
+        },
+        primaryReview: {
+          configKey: "codex",
+          defaultModel: null,
+        },
+        advisoryReview: null,
+      },
+    },
+    reviewer: {
+      primaryReviewScript: "invoke-reviewer-codex.js",
+      advisoryReviewScript: null,
+    },
+  }),
+  opencode: buildDescriptor({
+    name: "opencode",
+    displayName: "OpenCode",
+    executor: opencode,
+    phases: {
+      [ADAPTER_PHASES.DISPATCH]: {
+        supported: true,
+        trust: "executor",
+      },
+      [ADAPTER_PHASES.PRIMARY_REVIEW]: {
+        supported: false,
+        trust: "unsupported",
+      },
+      [ADAPTER_PHASES.ADVISORY_REVIEW]: {
+        supported: true,
+        trust: "advisory",
+      },
+    },
+    capabilities: {
+      sandbox: {
+        dispatch: {
+          modes: ["workspace-write"],
+          enforced: false,
+        },
+        primaryReview: null,
+        advisoryReview: {
+          mode: "read-only",
+          enforced: false,
+          guard: "worktree-status",
+        },
+      },
+      network: {
+        dispatch: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+        primaryReview: null,
+        advisoryReview: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+      },
+      readOnly: {
+        dispatch: false,
+        primaryReview: false,
+        advisoryReview: true,
+      },
+      transport: {
+        dispatch: "opencode-cli",
+        primaryReview: null,
+        advisoryReview: "opencode-cli",
+      },
+      structuredOutput: {
+        dispatch: "stdout-copied-result-file",
+        primaryReview: null,
+        advisoryReview: "json-text",
+      },
+      appRegistration: {
+        supported: false,
+        transport: null,
+      },
+      modelDefaults: {
+        provider: opencode.providerDefault || "opencode-go",
+        dispatch: {
+          configKey: "opencode",
+          defaultModel: bundledDefaultModel("opencode"),
+        },
+        primaryReview: null,
+        advisoryReview: {
+          configKey: "opencode",
+          defaultModel: bundledDefaultModel("opencode"),
+        },
+      },
+    },
+    reviewer: {
+      primaryReviewScript: null,
+      advisoryReviewScript: "invoke-reviewer-opencode.js",
+    },
+  }),
+});
+
+function listAgentAdapterNames() {
+  return Object.keys(DESCRIPTORS);
+}
+
+function supportedNamesMessage() {
+  return listAgentAdapterNames().join(", ");
+}
+
+function getAgentAdapterDescriptor(name) {
+  if (!Object.prototype.hasOwnProperty.call(DESCRIPTORS, name)) {
+    throw new Error(`unknown agent adapter '${name}'. Supported: ${supportedNamesMessage()}`);
+  }
+  return DESCRIPTORS[name];
+}
+
+function listAgentAdapters() {
+  return listAgentAdapterNames().map((name) => getAgentAdapterDescriptor(name));
+}
+
+function assertKnownPhase(phase) {
+  if (!PHASES.includes(phase)) {
+    throw new Error(`unknown agent adapter phase '${phase}'. Supported: ${PHASES.join(", ")}`);
+  }
+}
+
+function supportsAgentAdapterPhase(name, phase) {
+  assertKnownPhase(phase);
+  return getAgentAdapterDescriptor(name).phases[phase]?.supported === true;
+}
+
+function assertAgentAdapterSupportsPhase(name, phase) {
+  assertKnownPhase(phase);
+  if (!supportsAgentAdapterPhase(name, phase)) {
+    throw new Error(
+      `agent adapter '${name}' does not support phase '${phase}'. Supported phases: ${
+        PHASES.filter((candidate) => supportsAgentAdapterPhase(name, candidate)).join(", ") || "(none)"
+      }`
+    );
+  }
+  return getAgentAdapterDescriptor(name);
+}
+
+module.exports = {
+  ADAPTER_PHASES,
+  assertAgentAdapterSupportsPhase,
+  getAgentAdapterDescriptor,
+  listAgentAdapterNames,
+  listAgentAdapters,
+  supportsAgentAdapterPhase,
+};

--- a/skills/relay-dispatch/scripts/executors/index.js
+++ b/skills/relay-dispatch/scripts/executors/index.js
@@ -1,18 +1,31 @@
-const codex = require("./codex");
-const claude = require("./claude");
-const opencode = require("./opencode");
+const {
+  ADAPTER_PHASES,
+  getAgentAdapterDescriptor,
+  listAgentAdapterNames,
+  supportsAgentAdapterPhase,
+} = require("../agent-adapters");
 
-const EXECUTORS = { codex, claude, opencode };
-
-function getExecutor(name) {
-  if (!Object.prototype.hasOwnProperty.call(EXECUTORS, name)) {
-    throw new Error(`unknown executor '${name}'. Supported: ${Object.keys(EXECUTORS).join(", ")}`);
-  }
-  return EXECUTORS[name];
-}
+const EXECUTOR_COMPAT_ORDER = ["codex", "claude", "opencode"];
 
 function listExecutors() {
-  return Object.keys(EXECUTORS);
+  const names = listAgentAdapterNames();
+  return [
+    ...EXECUTOR_COMPAT_ORDER.filter((name) => (
+      names.includes(name) && supportsAgentAdapterPhase(name, ADAPTER_PHASES.DISPATCH)
+    )),
+    ...names.filter((name) => (
+      !EXECUTOR_COMPAT_ORDER.includes(name)
+      && supportsAgentAdapterPhase(name, ADAPTER_PHASES.DISPATCH)
+    )),
+  ];
+}
+
+function getExecutor(name) {
+  const executors = listExecutors();
+  if (!executors.includes(name)) {
+    throw new Error(`unknown executor '${name}'. Supported: ${executors.join(", ")}`);
+  }
+  return getAgentAdapterDescriptor(name).executor;
 }
 
 module.exports = { getExecutor, listExecutors };

--- a/tests/relay-dispatch/scripts/agent-adapters.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapters.test.js
@@ -1,0 +1,79 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  ADAPTER_PHASES,
+  getAgentAdapterDescriptor,
+  listAgentAdapterNames,
+  listAgentAdapters,
+  supportsAgentAdapterPhase,
+} = require("../../../skills/relay-dispatch/scripts/agent-adapters");
+
+test("agent adapter registry exposes the current built-in adapters", () => {
+  assert.deepEqual(listAgentAdapterNames(), ["claude", "codex", "opencode"]);
+  assert.deepEqual(listAgentAdapters().map((descriptor) => descriptor.name), ["claude", "codex", "opencode"]);
+});
+
+test("agent adapter registry reports dispatch, primary review, and advisory review independently", () => {
+  assert.equal(supportsAgentAdapterPhase("codex", ADAPTER_PHASES.DISPATCH), true);
+  assert.equal(supportsAgentAdapterPhase("codex", ADAPTER_PHASES.PRIMARY_REVIEW), true);
+  assert.equal(supportsAgentAdapterPhase("codex", ADAPTER_PHASES.ADVISORY_REVIEW), false);
+
+  assert.equal(supportsAgentAdapterPhase("claude", ADAPTER_PHASES.DISPATCH), true);
+  assert.equal(supportsAgentAdapterPhase("claude", ADAPTER_PHASES.PRIMARY_REVIEW), true);
+  assert.equal(supportsAgentAdapterPhase("claude", ADAPTER_PHASES.ADVISORY_REVIEW), false);
+
+  assert.equal(supportsAgentAdapterPhase("opencode", ADAPTER_PHASES.DISPATCH), true);
+  assert.equal(supportsAgentAdapterPhase("opencode", ADAPTER_PHASES.PRIMARY_REVIEW), false);
+  assert.equal(supportsAgentAdapterPhase("opencode", ADAPTER_PHASES.ADVISORY_REVIEW), true);
+});
+
+test("agent adapter descriptors expose structured capabilities and the executor contract", () => {
+  const codex = getAgentAdapterDescriptor("codex");
+  assert.equal(codex.executor.cliBinary, "codex");
+  assert.equal(codex.capabilities.appRegistration.supported, true);
+  assert.equal(codex.capabilities.appRegistration.transport, "codex-app");
+  assert.equal(codex.capabilities.modelDefaults.provider, "openai");
+  assert.equal(codex.capabilities.modelDefaults.dispatch.configKey, "codex");
+  assert.deepEqual(codex.capabilities.sandbox.dispatch.modes, ["read-only", "workspace-write"]);
+  assert.equal(codex.capabilities.network.dispatch.configurable, true);
+  assert.equal(codex.capabilities.readOnly.primaryReview, true);
+  assert.equal(codex.capabilities.transport.primaryReview, "codex-cli");
+  assert.equal(codex.capabilities.structuredOutput.primaryReview, "json-schema-file");
+
+  const claude = getAgentAdapterDescriptor("claude");
+  assert.equal(claude.executor.cliBinary, "claude");
+  assert.equal(claude.capabilities.appRegistration.transport, "claude-app");
+  assert.equal(claude.capabilities.modelDefaults.provider, "anthropic");
+  assert.equal(claude.capabilities.network.dispatch.configurable, false);
+  assert.equal(claude.capabilities.readOnly.primaryReview, true);
+  assert.equal(claude.capabilities.transport.primaryReview, "claude-cli");
+  assert.equal(claude.capabilities.structuredOutput.primaryReview, "json-schema-argv");
+
+  const opencode = getAgentAdapterDescriptor("opencode");
+  assert.equal(opencode.executor.cliBinary, "opencode");
+  assert.equal(opencode.capabilities.appRegistration.supported, false);
+  assert.equal(opencode.capabilities.modelDefaults.provider, "opencode-go");
+  assert.equal(opencode.capabilities.modelDefaults.dispatch.defaultModel, "opencode-go/deepseek-v4-pro");
+  assert.deepEqual(opencode.capabilities.sandbox.dispatch.modes, ["workspace-write"]);
+  assert.equal(opencode.capabilities.sandbox.dispatch.enforced, false);
+  assert.equal(opencode.capabilities.network.dispatch.configurable, false);
+  assert.equal(opencode.capabilities.readOnly.advisoryReview, true);
+  assert.equal(opencode.capabilities.transport.advisoryReview, "opencode-cli");
+  assert.equal(opencode.capabilities.structuredOutput.advisoryReview, "json-text");
+});
+
+test("agent adapter registry fails closed for unknown adapters and phases", () => {
+  assert.throws(
+    () => getAgentAdapterDescriptor("pi"),
+    /unknown agent adapter 'pi'\. Supported: claude, codex, opencode/
+  );
+  assert.throws(
+    () => supportsAgentAdapterPhase("pi", ADAPTER_PHASES.DISPATCH),
+    /unknown agent adapter 'pi'\. Supported: claude, codex, opencode/
+  );
+  assert.throws(
+    () => supportsAgentAdapterPhase("codex", "sidecar"),
+    /unknown agent adapter phase 'sidecar'\. Supported: dispatch, primary_review, advisory_review/
+  );
+});

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -31,6 +31,7 @@ after(() => {
 });
 
 test("registry exposes codex, claude, and opencode", () => {
+  assert.deepEqual(listExecutors(), ["codex", "claude", "opencode"]);
   assert.deepEqual(listExecutors().sort(), ["claude", "codex", "opencode"]);
   assert.throws(() => getExecutor("nonexistent"), /unknown executor/);
 });

--- a/tests/relay-dispatch/scripts/worktree-runtime.test.js
+++ b/tests/relay-dispatch/scripts/worktree-runtime.test.js
@@ -41,6 +41,7 @@ test("formatPlan matches the frozen create-worktree text fixture", () => {
 });
 
 test("formatDispatchDryRun matches the frozen dispatch text fixture", () => {
+  const frozenJson = JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, "dispatch-dry-run.json"), "utf-8"));
   const actual = formatDispatchDryRun({
     runId: "test-branch-20260418005000000-22222222",
     mode: "new",
@@ -56,6 +57,8 @@ test("formatDispatchDryRun matches the frozen dispatch text fixture", () => {
     timeout: 2400,
     rubricFile: "/tmp/issue187-fixtures/rubric.yaml",
     reviewAssurance: "standard",
+    policyDecision: frozenJson.policy_decision,
+    routingDecision: frozenJson.routing_decision,
     worktreePlan: {
       worktree: "/tmp/issue187-fixtures/relay-home/worktrees/11111111/repo",
       branch: "test-branch",


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 만들었습니다.

커밋: `4a1382b Add agent adapter descriptor registry`

변경 요약:
- [agent-adapters/index.js](/Users/sjlee/.relay/worktrees/1c8e67c5/dev-relay/skills/relay-dispatch/scripts/agent-adapters/index.js:6)에 Codex/Claude/OpenCode capability descriptor registry 추가
- [executors/index.js](/Users/sjlee/.relay/worktrees/1c8e67c5/dev-relay/skills/relay-dispatch/scripts/executors/index.js:10)를 기존 `getExecutor()` / `listExecutors()` 호환 래퍼로 전환
- [agent-adapters.test.js](/Users/sjlee/.relay/workt
```

## Score Log

- Run: issue-567-20260525014517885-2888ca4d
- Executor: codex
- Branch: issue-567