### PR TITLE
Normalize adapter policy audit metadata

### DIFF
--- a/skills/relay-dispatch/scripts/agent-adapters/index.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/index.js
@@ -90,6 +90,67 @@ const DESCRIPTORS = Object.freeze({
         primaryReview: true,
         advisoryReview: false,
       },
+      policy: {
+        dispatch: {
+          sandbox: {
+            "workspace-write": {
+              enforcement_level: "permission-mode",
+              mechanism: "claude-dangerously-skip-permissions",
+              flags: ["--dangerously-skip-permissions"],
+              warnings: ["Claude dispatch does not provide OS-level sandbox containment."],
+            },
+          },
+          network: {
+            ambient: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Claude dispatch does not gate network access at the executor level."],
+            },
+            disabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Claude dispatch does not gate network access at the executor level."],
+            },
+            enabled: {
+              enforcement_level: "unsupported",
+              mechanism: null,
+              fail_closed_reason: "Claude dispatch cannot represent requested network-access=enabled safely.",
+            },
+          },
+          read_only: {
+            false: {
+              enforcement_level: "unsupported",
+              mechanism: "write-capable-dispatch",
+            },
+          },
+        },
+        primary_review: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "tool-allowlist",
+              mechanism: "claude-allowed-tools",
+              flags: ["--allowedTools=Read"],
+              warnings: ["Claude reviewer read-only is a tool allowlist, not OS-level containment."],
+            },
+          },
+          network: {
+            ambient: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Claude reviewer does not gate network access at the CLI level."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "tool-allowlist",
+              mechanism: "claude-allowed-tools",
+              flags: ["--allowedTools=Read"],
+              warnings: ["Claude reviewer read-only is a tool allowlist, not OS-level containment."],
+            },
+          },
+        },
+        advisory_review: null,
+      },
       transport: {
         dispatch: "claude-cli",
         primaryReview: "claude-cli",
@@ -167,6 +228,67 @@ const DESCRIPTORS = Object.freeze({
         dispatch: false,
         primaryReview: true,
         advisoryReview: false,
+      },
+      policy: {
+        dispatch: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "native",
+              mechanism: "codex-cli-sandbox",
+              flags: ["--sandbox read-only"],
+            },
+            "workspace-write": {
+              enforcement_level: "native",
+              mechanism: "codex-cli-sandbox",
+              flags: ["--sandbox workspace-write"],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "native",
+              mechanism: "codex-default-network-disabled",
+            },
+            enabled: {
+              enforcement_level: "native",
+              mechanism: "codex-workspace-network-config",
+              flags: ["-c sandbox_workspace_write.network_access=true"],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "native",
+              mechanism: "codex-cli-sandbox",
+              flags: ["--sandbox read-only"],
+            },
+            false: {
+              enforcement_level: "unsupported",
+              mechanism: "write-capable-dispatch",
+            },
+          },
+        },
+        primary_review: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "native",
+              mechanism: "codex-cli-sandbox",
+              flags: ["--sandbox read-only"],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "native",
+              mechanism: "codex-default-network-disabled",
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "native",
+              mechanism: "codex-cli-sandbox",
+              flags: ["--sandbox read-only"],
+            },
+          },
+        },
+        advisory_review: null,
       },
       transport: {
         dispatch: "codex-cli",
@@ -246,6 +368,70 @@ const DESCRIPTORS = Object.freeze({
         dispatch: false,
         primaryReview: false,
         advisoryReview: true,
+      },
+      policy: {
+        dispatch: {
+          sandbox: {
+            "workspace-write": {
+              enforcement_level: "informational",
+              mechanism: "opencode-cli",
+              warnings: ["OpenCode does not provide native sandbox containment."],
+            },
+            "read-only": {
+              enforcement_level: "informational",
+              mechanism: "opencode-cli",
+              warnings: ["OpenCode does not provide native sandbox containment; read-only is not enforced for dispatch."],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["OpenCode does not gate network access at the executor level."],
+            },
+            enabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["OpenCode does not gate network access at the executor level."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "informational",
+              mechanism: "opencode-cli",
+              warnings: ["OpenCode dispatch read-only intent is informational only and does not prevent writes."],
+            },
+            false: {
+              enforcement_level: "unsupported",
+              mechanism: "write-capable-dispatch",
+            },
+          },
+        },
+        primary_review: null,
+        advisory_review: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "informational",
+              mechanism: "detached-worktree-status-guard",
+              warnings: ["OpenCode advisory review runs in a detached worktree with post-run status checks; this is not OS-level containment."],
+            },
+          },
+          network: {
+            ambient: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["OpenCode advisory review does not gate network access at the CLI level."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "prompt-only",
+              mechanism: "prompt-instruction-with-worktree-status-guard",
+              flags: ["prompt:do-not-modify-files", "git-status-before-after"],
+              warnings: ["OpenCode advisory read-only instructions do not prevent writes; relay records post-run worktree mutation as a policy violation."],
+            },
+          },
+        },
       },
       transport: {
         dispatch: "opencode-cli",

--- a/skills/relay-dispatch/scripts/agent-adapters/policy.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/policy.js
@@ -1,0 +1,153 @@
+const ENFORCEMENT_LEVELS = Object.freeze([
+  "native",
+  "tool-allowlist",
+  "permission-mode",
+  "prompt-only",
+  "informational",
+  "unsupported",
+]);
+
+const ENFORCEMENT_LEVEL_SET = new Set(ENFORCEMENT_LEVELS);
+
+function normalizeString(value, fallback = null) {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function normalizeBoolean(value, fallback = false) {
+  if (value === true || value === false) return value;
+  return fallback;
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeString(entry))
+    .filter(Boolean);
+}
+
+function normalizeRequested(requested = {}) {
+  const sandbox = normalizeString(requested.sandbox, "workspace-write");
+  const network = normalizeString(requested.networkAccess ?? requested.network, "disabled");
+  const readOnly = normalizeBoolean(
+    requested.readOnly ?? requested.read_only,
+    sandbox === "read-only"
+  );
+  return {
+    sandbox,
+    network,
+    read_only: readOnly,
+  };
+}
+
+function phasePolicyFor(descriptor, phase) {
+  return descriptor?.capabilities?.policy?.[phase] || null;
+}
+
+function lookupPolicy(policy, field, requestedValue) {
+  const values = policy?.[field];
+  if (!values || typeof values !== "object") return null;
+  return values[String(requestedValue)] || values.default || null;
+}
+
+function unsupportedPolicy({ adapter, field, phase, requestedValue, failClosed }) {
+  const reason = `${adapter} cannot represent ${phase} ${field}=${String(requestedValue)} safely`;
+  return {
+    enforcement_level: "unsupported",
+    mechanism: null,
+    flags: [],
+    warnings: [],
+    fail_closed_reason: failClosed ? reason : null,
+  };
+}
+
+function normalizePolicyEntry(entry, {
+  adapter,
+  field,
+  phase,
+  requestedValue,
+  failClosedWhenMissing,
+}) {
+  const raw = entry || unsupportedPolicy({
+    adapter,
+    field,
+    phase,
+    requestedValue,
+    failClosed: failClosedWhenMissing,
+  });
+  const level = normalizeString(raw.enforcement_level || raw.level, "unsupported");
+  if (!ENFORCEMENT_LEVEL_SET.has(level)) {
+    throw new Error(
+      `adapter policy ${adapter}.${phase}.${field}.${String(requestedValue)} has unknown enforcement_level '${level}'`
+    );
+  }
+  const failClosedReason = normalizeString(raw.fail_closed_reason || raw.failClosedReason);
+  return {
+    requested: requestedValue,
+    enforcement_level: level,
+    mechanism: normalizeString(raw.mechanism),
+    flags: normalizeStringArray(raw.flags),
+    warnings: normalizeStringArray(raw.warnings),
+    fail_closed_reason: failClosedReason,
+  };
+}
+
+function buildAgentPolicyAudit({ descriptor, phase, requested }) {
+  const adapter = normalizeString(descriptor?.name, "unknown");
+  const normalizedRequested = normalizeRequested(requested);
+  const policy = phasePolicyFor(descriptor, phase);
+
+  const sandbox = normalizePolicyEntry(lookupPolicy(policy, "sandbox", normalizedRequested.sandbox), {
+    adapter,
+    field: "sandbox",
+    phase,
+    requestedValue: normalizedRequested.sandbox,
+    failClosedWhenMissing: true,
+  });
+  const network = normalizePolicyEntry(lookupPolicy(policy, "network", normalizedRequested.network), {
+    adapter,
+    field: "network",
+    phase,
+    requestedValue: normalizedRequested.network,
+    failClosedWhenMissing: true,
+  });
+  const readOnly = normalizePolicyEntry(lookupPolicy(policy, "read_only", normalizedRequested.read_only), {
+    adapter,
+    field: "read_only",
+    phase,
+    requestedValue: normalizedRequested.read_only,
+    failClosedWhenMissing: normalizedRequested.read_only === true,
+  });
+
+  const components = [sandbox, network, readOnly];
+  const failClosedReasons = components
+    .map((component) => component.fail_closed_reason)
+    .filter(Boolean);
+  const warnings = components.flatMap((component) => component.warnings);
+
+  return {
+    adapter,
+    phase,
+    requested: normalizedRequested,
+    sandbox,
+    network,
+    read_only: readOnly,
+    warnings,
+    fail_closed_reasons: failClosedReasons,
+    safe: failClosedReasons.length === 0,
+  };
+}
+
+function assertPolicyRepresentable(audit) {
+  if (!audit?.safe) {
+    throw new Error(`agent policy is not safely representable: ${(audit?.fail_closed_reasons || []).join("; ")}`);
+  }
+  return audit;
+}
+
+module.exports = {
+  ENFORCEMENT_LEVELS,
+  assertPolicyRepresentable,
+  buildAgentPolicyAudit,
+};

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -123,6 +123,14 @@ const {
 const { STATES, updateManifestState } = require("./manifest/lifecycle");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
+const {
+  ADAPTER_PHASES,
+  getAgentAdapterDescriptor,
+} = require("./agent-adapters");
+const {
+  assertPolicyRepresentable,
+  buildAgentPolicyAudit,
+} = require("./agent-adapters/policy");
 const { execGit } = require("./exec");
 const { resolveReasoningEffort } = require("./rubric-size");
 const {
@@ -202,8 +210,10 @@ const PROMPT = readArg(args, ["--prompt", "-p"], undefined, CLI_ARG_OPTIONS);
 const PROMPT_FILE = readArg(args, "--prompt-file", undefined, CLI_ARG_OPTIONS);
 const EXECUTOR = readArg(args, ["--executor", "-e"], "codex", CLI_ARG_OPTIONS);
 let adapter;
+let adapterDescriptor;
 try {
   adapter = getExecutor(EXECUTOR);
+  adapterDescriptor = getAgentAdapterDescriptor(EXECUTOR);
 } catch (error) {
   console.error(`Error: ${error.message}`);
   process.exit(1);
@@ -246,6 +256,25 @@ if (!modeValidation.ok) {
   process.exit(1);
 }
 for (const warn of (modeValidation.warnings || [])) {
+  console.error(`Warning: ${warn}`);
+}
+
+let executorPolicy;
+try {
+  executorPolicy = assertPolicyRepresentable(buildAgentPolicyAudit({
+    descriptor: adapterDescriptor,
+    phase: ADAPTER_PHASES.DISPATCH,
+    requested: {
+      sandbox: SANDBOX,
+      networkAccess: NETWORK_ACCESS,
+      readOnly: SANDBOX === "read-only",
+    },
+  }));
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}
+for (const warn of executorPolicy.warnings || []) {
   console.error(`Warning: ${warn}`);
 }
 
@@ -1167,6 +1196,7 @@ async function main() {
       policy: {
         ...(manifest.policy || {}),
         executor_network: executorNetworkPolicy,
+        executor_policy: executorPolicy,
       },
       routing: routingDecision,
     };
@@ -1178,6 +1208,7 @@ async function main() {
       policy: {
         ...(manifest.policy || {}),
         executor_network: executorNetworkPolicy,
+        executor_policy: executorPolicy,
       },
       routing: routingDecision,
     };
@@ -1322,6 +1353,7 @@ async function main() {
     model: effectiveDispatchModel,
     provider,
     executor_network: executorNetworkPolicy,
+    executor_policy: executorPolicy,
   });
 
   // Redirect stdout/stderr to files. Using spawn with detached: true gives us
@@ -1523,6 +1555,7 @@ async function main() {
       ? `${RESUME_MODE ? "same_run_resume" : "new_dispatch"}:${error || "dispatch_failed"}`
       : `${RESUME_MODE ? "same_run_resume" : "new_dispatch"}:${status}`,
     executor_network: executorNetworkPolicy,
+    executor_policy: executorPolicy,
     failure_class: networkFailure,
     execution_evidence_path: executionEvidencePath,
     execution_evidence_hash: executionEvidencePath ? hashFileSha256(executionEvidencePath) : null,
@@ -1606,6 +1639,7 @@ async function main() {
     commitMode,
     executor: EXECUTOR,
     executorNetwork: executorNetworkPolicy,
+    executorPolicy,
     policyDecision,
     routingDecision,
     routedSidecar,

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -202,6 +202,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.executor_network !== undefined
       ? { executor_network: normalizeEventValue(eventData.executor_network) }
       : {}),
+    ...(eventData.executor_policy !== undefined
+      ? { executor_policy: normalizeEventValue(eventData.executor_policy) }
+      : {}),
+    ...(eventData.reviewer_policy !== undefined
+      ? { reviewer_policy: normalizeEventValue(eventData.reviewer_policy) }
+      : {}),
     ...(eventData.failure_class !== undefined
       ? { failure_class: normalizeEventValue(eventData.failure_class) }
       : {}),

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -2,6 +2,14 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { buildArtifactTimingFields } = require("../../../relay-dispatch/scripts/advisory-timing");
+const {
+  ADAPTER_PHASES,
+  getAgentAdapterDescriptor,
+} = require("../../../relay-dispatch/scripts/agent-adapters");
+const {
+  assertPolicyRepresentable,
+  buildAgentPolicyAudit,
+} = require("../../../relay-dispatch/scripts/agent-adapters/policy");
 const { resolveExecutorDefaultModel } = require("../../../relay-dispatch/scripts/executor-model-config");
 const { hashFileSha256 } = require("../../../relay-dispatch/scripts/execution-evidence");
 const { appendRunEvent, EVENTS, readRunEvents } = require("../../../relay-dispatch/scripts/relay-events");
@@ -73,6 +81,24 @@ function advisoryPaths(runDir, round, reviewerName) {
   };
 }
 
+function buildAdvisoryReviewerPolicy(reviewerName) {
+  let descriptor;
+  try {
+    descriptor = getAgentAdapterDescriptor(reviewerName);
+  } catch {
+    return null;
+  }
+  return assertPolicyRepresentable(buildAgentPolicyAudit({
+    descriptor,
+    phase: ADAPTER_PHASES.ADVISORY_REVIEW,
+    requested: {
+      sandbox: "read-only",
+      networkAccess: "ambient",
+      readOnly: true,
+    },
+  }));
+}
+
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
@@ -114,6 +140,7 @@ function startAdvisoryReview({
   writeText(promptPath, `${promptText}\n`);
   const reviewerScript = resolveReviewerScript(reviewerName, null);
   const startedAt = Date.now();
+  const reviewerPolicy = buildAdvisoryReviewerPolicy(reviewerName);
   const request = {
     decisionPath: paths.decisionPath,
     headSha,
@@ -123,6 +150,7 @@ function startAdvisoryReview({
     resultPath: paths.resultPath,
     reviewerModel,
     reviewerName,
+    reviewerPolicy,
     reviewerScript,
     reviewRepoPath,
     round,
@@ -420,6 +448,7 @@ function executeAdvisoryRequest(request) {
       round: request.round,
       reviewer: request.reviewerName,
       model: request.reviewerModel,
+      reviewer_policy: request.reviewerPolicy,
       profile: request.profile,
       status,
       artifact_path: artifactPath,
@@ -446,6 +475,7 @@ module.exports = {
   DEFAULT_ADVISORY_GRACE_SECONDS,
   executeAdvisoryRequest,
   finishAdvisoryReview,
+  buildAdvisoryReviewerPolicy,
   parseNonNegativeSeconds,
   parsePositiveSeconds,
   resolveAdvisoryModel,

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -3,6 +3,14 @@ const fs = require("fs");
 const path = require("path");
 const { STATES } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
 const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
+const {
+  ADAPTER_PHASES,
+  getAgentAdapterDescriptor,
+} = require("../../../relay-dispatch/scripts/agent-adapters");
+const {
+  assertPolicyRepresentable,
+  buildAgentPolicyAudit,
+} = require("../../../relay-dispatch/scripts/agent-adapters/policy");
 const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { assertRelayPolicyGate } = require("../../../relay-dispatch/scripts/relay-policy-gate");
 const { applyPolicyViolationToManifest } = require("./manifest-apply");
@@ -71,6 +79,25 @@ function resolveReviewerModel(data, reviewerModel) {
   return typeof hintedModel === "string" && hintedModel.trim() ? hintedModel : null;
 }
 
+function buildPrimaryReviewerPolicy(reviewerName) {
+  let descriptor;
+  try {
+    descriptor = getAgentAdapterDescriptor(reviewerName);
+  } catch {
+    return null;
+  }
+  const networkAccess = reviewerName === "claude" ? "ambient" : "disabled";
+  return assertPolicyRepresentable(buildAgentPolicyAudit({
+    descriptor,
+    phase: ADAPTER_PHASES.PRIMARY_REVIEW,
+    requested: {
+      sandbox: "read-only",
+      networkAccess,
+      readOnly: true,
+    },
+  }));
+}
+
 function captureGitStatus(repoPath) {
   return git(repoPath, "status", "--short", "--untracked-files=all").trim();
 }
@@ -87,6 +114,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
     reviewer: reviewerName,
     model: effectiveReviewerModel,
   });
+  const reviewerPolicy = buildPrimaryReviewerPolicy(reviewerName);
   appendRunEvent(runRepoPath, data.run_id, {
     event: EVENTS.REVIEW_INVOKE,
     state_from: data.state,
@@ -95,6 +123,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
     round,
     reason: reviewerName,
     model: effectiveReviewerModel,
+    reviewer_policy: reviewerPolicy,
   });
 
   const statusBeforeReviewer = captureGitStatus(reviewRepoPath);
@@ -158,6 +187,7 @@ module.exports = {
   captureGitStatus,
   invokeReviewer,
   loadReviewText,
+  buildPrimaryReviewerPolicy,
   resolveReviewerName,
   resolveReviewerModel,
   resolveReviewerScript,

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -98,6 +98,50 @@ function buildPrimaryReviewerPolicy(reviewerName) {
   }));
 }
 
+function isAdapterManagedReviewerScript(reviewerName, reviewerScript) {
+  try {
+    return path.resolve(reviewerScript) === path.resolve(resolveReviewerScript(reviewerName, null));
+  } catch {
+    return false;
+  }
+}
+
+function buildCustomReviewerScriptPolicy({ reviewerName, reviewerScript }) {
+  const warning = "Custom reviewer scripts are invoked outside adapter-managed containment; read-only is checked after invocation with git status.";
+  const informational = (requested) => ({
+    requested,
+    enforcement_level: "informational",
+    mechanism: "git-status-after-invocation",
+    flags: [],
+    warnings: [warning],
+    fail_closed_reason: null,
+  });
+  return {
+    adapter: "custom-reviewer-script",
+    phase: ADAPTER_PHASES.PRIMARY_REVIEW,
+    reviewer: reviewerName,
+    script: reviewerScript,
+    requested: {
+      sandbox: "read-only",
+      network: "disabled",
+      read_only: true,
+    },
+    sandbox: informational("read-only"),
+    network: informational("disabled"),
+    read_only: informational(true),
+    warnings: [warning],
+    fail_closed_reasons: [],
+    safe: true,
+  };
+}
+
+function buildReviewerPolicy({ reviewerName, reviewerScript }) {
+  if (isAdapterManagedReviewerScript(reviewerName, reviewerScript)) {
+    return buildPrimaryReviewerPolicy(reviewerName);
+  }
+  return buildCustomReviewerScriptPolicy({ reviewerName, reviewerScript });
+}
+
 function captureGitStatus(repoPath) {
   return git(repoPath, "status", "--short", "--untracked-files=all").trim();
 }
@@ -114,7 +158,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
     reviewer: reviewerName,
     model: effectiveReviewerModel,
   });
-  const reviewerPolicy = buildPrimaryReviewerPolicy(reviewerName);
+  const reviewerPolicy = buildReviewerPolicy({ reviewerName, reviewerScript });
   appendRunEvent(runRepoPath, data.run_id, {
     event: EVENTS.REVIEW_INVOKE,
     state_from: data.state,
@@ -188,6 +232,7 @@ module.exports = {
   invokeReviewer,
   loadReviewText,
   buildPrimaryReviewerPolicy,
+  buildReviewerPolicy,
   resolveReviewerName,
   resolveReviewerModel,
   resolveReviewerScript,

--- a/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
@@ -1,0 +1,203 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  ADAPTER_PHASES,
+  getAgentAdapterDescriptor,
+} = require("../../../skills/relay-dispatch/scripts/agent-adapters");
+const {
+  assertPolicyRepresentable,
+  buildAgentPolicyAudit,
+} = require("../../../skills/relay-dispatch/scripts/agent-adapters/policy");
+
+test("policy audit records Codex native sandbox and network enforcement", () => {
+  const audit = buildAgentPolicyAudit({
+    descriptor: getAgentAdapterDescriptor("codex"),
+    phase: ADAPTER_PHASES.DISPATCH,
+    requested: {
+      sandbox: "workspace-write",
+      networkAccess: "enabled",
+      readOnly: false,
+    },
+  });
+
+  assert.equal(audit.safe, true);
+  assert.deepEqual(audit.requested, {
+    sandbox: "workspace-write",
+    network: "enabled",
+    read_only: false,
+  });
+  assert.equal(audit.sandbox.enforcement_level, "native");
+  assert.equal(audit.sandbox.mechanism, "codex-cli-sandbox");
+  assert.deepEqual(audit.sandbox.flags, ["--sandbox workspace-write"]);
+  assert.equal(audit.network.enforcement_level, "native");
+  assert.equal(audit.network.mechanism, "codex-workspace-network-config");
+  assert.deepEqual(audit.network.flags, ["-c sandbox_workspace_write.network_access=true"]);
+  assert.equal(audit.read_only.enforcement_level, "unsupported");
+  assert.deepEqual(audit.fail_closed_reasons, []);
+});
+
+test("policy audit keeps OpenCode sandbox and network informational", () => {
+  const audit = buildAgentPolicyAudit({
+    descriptor: getAgentAdapterDescriptor("opencode"),
+    phase: ADAPTER_PHASES.DISPATCH,
+    requested: {
+      sandbox: "read-only",
+      networkAccess: "enabled",
+      readOnly: true,
+    },
+  });
+
+  assert.equal(audit.safe, true);
+  assert.equal(audit.sandbox.enforcement_level, "informational");
+  assert.equal(audit.network.enforcement_level, "informational");
+  assert.match(audit.sandbox.warnings.join("\n"), /does not provide native sandbox containment/i);
+  assert.match(audit.network.warnings.join("\n"), /does not gate network access/i);
+  assert.deepEqual(audit.fail_closed_reasons, []);
+});
+
+test("policy audit supports synthetic Pi read-only tool allowlist mapping", () => {
+  const piDescriptor = {
+    name: "pi",
+    capabilities: {
+      policy: {
+        primary_review: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "tool-allowlist",
+              mechanism: "pi-tool-policy",
+              flags: ["allow:read", "deny:write"],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "tool-allowlist",
+              mechanism: "pi-tool-policy",
+              flags: ["deny:network"],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "tool-allowlist",
+              mechanism: "pi-tool-policy",
+              flags: ["allow:Read", "deny:Write"],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const audit = buildAgentPolicyAudit({
+    descriptor: piDescriptor,
+    phase: ADAPTER_PHASES.PRIMARY_REVIEW,
+    requested: {
+      sandbox: "read-only",
+      networkAccess: "disabled",
+      readOnly: true,
+    },
+  });
+
+  assert.equal(audit.safe, true);
+  assert.equal(audit.read_only.enforcement_level, "tool-allowlist");
+  assert.deepEqual(audit.read_only.flags, ["allow:Read", "deny:Write"]);
+});
+
+test("policy audit supports synthetic Antigravity native sandbox mapping", () => {
+  const antigravityDescriptor = {
+    name: "antigravity",
+    capabilities: {
+      policy: {
+        dispatch: {
+          sandbox: {
+            "workspace-write": {
+              enforcement_level: "native",
+              mechanism: "antigravity-sandbox-profile",
+              flags: ["--sandbox-profile workspace-write"],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "native",
+              mechanism: "antigravity-network-policy",
+              flags: ["--network disabled"],
+            },
+          },
+          read_only: {
+            false: {
+              enforcement_level: "unsupported",
+              mechanism: "write-capable-dispatch",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const audit = buildAgentPolicyAudit({
+    descriptor: antigravityDescriptor,
+    phase: ADAPTER_PHASES.DISPATCH,
+    requested: {
+      sandbox: "workspace-write",
+      networkAccess: "disabled",
+      readOnly: false,
+    },
+  });
+
+  assert.equal(audit.safe, true);
+  assert.equal(audit.sandbox.enforcement_level, "native");
+  assert.equal(audit.sandbox.mechanism, "antigravity-sandbox-profile");
+  assert.deepEqual(audit.sandbox.flags, ["--sandbox-profile workspace-write"]);
+});
+
+test("policy audit fails closed when a requested policy cannot be represented safely", () => {
+  const unsupportedDescriptor = {
+    name: "future-agent",
+    capabilities: {
+      policy: {
+        dispatch: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "unsupported",
+              mechanism: null,
+              fail_closed_reason: "future-agent cannot represent read-only sandbox safely",
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "native",
+              mechanism: "future-agent-network",
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "unsupported",
+              mechanism: null,
+              fail_closed_reason: "future-agent has no read-only execution mode",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const audit = buildAgentPolicyAudit({
+    descriptor: unsupportedDescriptor,
+    phase: ADAPTER_PHASES.DISPATCH,
+    requested: {
+      sandbox: "read-only",
+      networkAccess: "disabled",
+      readOnly: true,
+    },
+  });
+
+  assert.equal(audit.safe, false);
+  assert.deepEqual(audit.fail_closed_reasons, [
+    "future-agent cannot represent read-only sandbox safely",
+    "future-agent has no read-only execution mode",
+  ]);
+  assert.throws(
+    () => assertPolicyRepresentable(audit),
+    /future-agent cannot represent read-only sandbox safely.*future-agent has no read-only execution mode/s
+  );
+});

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1336,6 +1336,9 @@ test("dispatch network-access enabled adds codex workspace-write network overrid
   assert.equal(result.codexGitCommonDir, commonGitDir);
   assert.equal(result.executorNetwork.access, "enabled");
   assert.equal(result.executorNetwork.mechanism, "sandbox_workspace_write.network_access");
+  assert.equal(result.executorPolicy.sandbox.enforcement_level, "native");
+  assert.equal(result.executorPolicy.network.enforcement_level, "native");
+  assert.deepEqual(result.executorPolicy.network.flags, ["-c sandbox_workspace_write.network_access=true"]);
 
   const manifest = readManifest(result.manifestPath).data;
   assert.deepEqual(manifest.policy.executor_network, {
@@ -1343,12 +1346,18 @@ test("dispatch network-access enabled adds codex workspace-write network overrid
     mechanism: "sandbox_workspace_write.network_access",
     domains: null,
   });
+  assert.equal(manifest.policy.executor_policy.sandbox.enforcement_level, "native");
+  assert.equal(manifest.policy.executor_policy.network.enforcement_level, "native");
 
   const events = readJsonLines(getEventsPath(repoRoot, result.runId));
   const dispatchStart = events.find((event) => event.event === "dispatch_start");
   const dispatchResult = events.find((event) => event.event === "dispatch_result");
   assert.equal(dispatchStart.executor_network.access, "enabled");
   assert.equal(dispatchResult.executor_network.access, "enabled");
+  assert.equal(dispatchStart.executor_policy.sandbox.enforcement_level, "native");
+  assert.equal(dispatchStart.executor_policy.network.enforcement_level, "native");
+  assert.equal(dispatchResult.executor_policy.sandbox.enforcement_level, "native");
+  assert.equal(dispatchResult.executor_policy.network.enforcement_level, "native");
 });
 
 test("dispatch widens codex sandbox via --add-dir <common-git-dir> for worktree (#389 sandbox-widening)", () => {

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -259,6 +259,8 @@ test("review-runner records successful opencode advisory review without gating p
   assert.equal(event.status, "success");
   assert.equal(event.profile, "blindspot");
   assert.equal(event.advisory_artifact_hash, hashFile(path.join(runDir, "review-round-1-advisory-opencode.json")));
+  assert.equal(event.reviewer_policy.read_only.enforcement_level, "prompt-only");
+  assert.match(event.reviewer_policy.read_only.warnings.join("\n"), /not prevent writes/i);
 });
 
 test("review-runner uses manifest routing advisory defaults without changing the primary reviewer", () => {

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -323,6 +323,8 @@ test("reviewer-invoke precedence R3 regression: manifest hint supplies the effec
   const reviewInvokeEvent = JSON.parse(eventLines.at(-1));
   assert.equal(reviewInvokeEvent.event, "review_invoke");
   assert.equal(reviewInvokeEvent.model, "haiku");
+  assert.equal(reviewInvokeEvent.reviewer_policy.read_only.enforcement_level, "native");
+  assert.deepEqual(reviewInvokeEvent.reviewer_policy.read_only.flags, ["--sandbox read-only"]);
 });
 
 test("reviewer-invoke/loadReviewText denies disallowed reviewer model before adapter invocation", (t) => {

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -329,6 +329,74 @@ test("reviewer-invoke precedence R3 regression: manifest hint supplies the effec
   assert.match(reviewInvokeEvent.reviewer_policy.read_only.warnings.join("\n"), /outside adapter-managed containment/i);
 });
 
+test("reviewer-invoke/loadReviewText records adapter-managed primary reviewer read-only policy", (t) => {
+  const originalRelayHome = process.env.RELAY_HOME;
+  const originalCodexBin = process.env.RELAY_CODEX_BIN;
+  const { relayHome, repoRoot, runDir, manifestPath, manifest, promptPath, runId } = setupReviewRun();
+  t.after(() => {
+    if (originalRelayHome === undefined) {
+      delete process.env.RELAY_HOME;
+    } else {
+      process.env.RELAY_HOME = originalRelayHome;
+    }
+    if (originalCodexBin === undefined) {
+      delete process.env.RELAY_CODEX_BIN;
+    } else {
+      process.env.RELAY_CODEX_BIN = originalCodexBin;
+    }
+  });
+  process.env.RELAY_HOME = relayHome;
+
+  const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
+  process.env.RELAY_CODEX_BIN = writeExecutable(helperDir, "fake-codex.js", `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("-o");
+if (outputIndex === -1 || !args[outputIndex + 1]) {
+  process.stderr.write("missing -o result path\\n");
+  process.exit(2);
+}
+fs.writeFileSync(args[outputIndex + 1], JSON.stringify({
+  verdict: "pass",
+  summary: "ok",
+  contract_status: "pass",
+  quality_review_status: "pass",
+  next_action: "ready_to_merge",
+  issues: [],
+  rubric_scores: [],
+  scope_drift: { creep: [], missing: [] }
+}) + "\\n", "utf-8");
+`);
+
+  const reviewerScript = resolveReviewerScript("codex");
+  const { reviewText } = loadReviewText({
+    body: "# Notes\n",
+    data: manifest,
+    manifestPath,
+    prNumber: 11,
+    promptPath,
+    reviewFile: null,
+    reviewRepoPath: repoRoot,
+    reviewedHeadSha: "abc123",
+    reviewerModel: null,
+    reviewerName: "codex",
+    reviewerScript,
+    round: 1,
+    runDir,
+    runRepoPath: repoRoot,
+  });
+
+  assert.equal(JSON.parse(reviewText).verdict, "pass");
+  const eventLines = fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8").trim().split("\n").filter(Boolean);
+  const reviewInvokeEvent = JSON.parse(eventLines.at(-1));
+  assert.equal(reviewInvokeEvent.event, "review_invoke");
+  assert.equal(reviewInvokeEvent.reviewer_policy.adapter, "codex");
+  assert.equal(reviewInvokeEvent.reviewer_policy.phase, "primary_review");
+  assert.equal(reviewInvokeEvent.reviewer_policy.read_only.enforcement_level, "native");
+  assert.deepEqual(reviewInvokeEvent.reviewer_policy.read_only.flags, ["--sandbox read-only"]);
+  assert.equal(reviewInvokeEvent.reviewer_policy.safe, true);
+});
+
 test("reviewer-invoke/loadReviewText denies disallowed reviewer model before adapter invocation", (t) => {
   const originalRelayHome = process.env.RELAY_HOME;
   const { relayHome, repoRoot, runDir, manifestPath, manifest, promptPath, runId } = setupReviewRun();

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -323,8 +323,10 @@ test("reviewer-invoke precedence R3 regression: manifest hint supplies the effec
   const reviewInvokeEvent = JSON.parse(eventLines.at(-1));
   assert.equal(reviewInvokeEvent.event, "review_invoke");
   assert.equal(reviewInvokeEvent.model, "haiku");
-  assert.equal(reviewInvokeEvent.reviewer_policy.read_only.enforcement_level, "native");
-  assert.deepEqual(reviewInvokeEvent.reviewer_policy.read_only.flags, ["--sandbox read-only"]);
+  assert.equal(reviewInvokeEvent.reviewer_policy.adapter, "custom-reviewer-script");
+  assert.equal(reviewInvokeEvent.reviewer_policy.read_only.enforcement_level, "informational");
+  assert.deepEqual(reviewInvokeEvent.reviewer_policy.read_only.flags, []);
+  assert.match(reviewInvokeEvent.reviewer_policy.read_only.warnings.join("\n"), /outside adapter-managed containment/i);
 });
 
 test("reviewer-invoke/loadReviewText denies disallowed reviewer model before adapter invocation", (t) => {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋까지 만들었습니다.

커밋: `7c81c94 Normalize adapter policy audit metadata`

변경 요약:
- `agent-adapters/policy.js` 추가: sandbox/network/read-only 요청을 `native`, `tool-allowlist`, `permission-mode`, `prompt-only`, `informational`, `unsupported`로 정규화하고 fail-closed 사유를 집계합니다.
- Codex/Claude/OpenCode descriptor에 policy audit metadata 추가.
- dispatch manifest/event/result에 `executor_policy` 기록.
- primary review/advisory review 이벤트에 adapter-managed reviewer의 `reviewer_policy` 기록.
- Pi read-only allowlist, 
```

## Score Log

- Run: issue-569-20260525023213228-eec00839
- Executor: codex
- Branch: issue-569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive policy audit system for agent execution across dispatch, primary review, and advisory review phases, including sandbox, network, and read-only enforcement configurations.
  * Introduced policy validation and representability checks for each execution stage.
  * Enhanced event recording to include executor and reviewer policy details.

* **Tests**
  * Added policy audit validation tests covering multiple adapter scenarios.
  * Extended dispatch and review tests to verify policy enforcement levels and audit stamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->