### PR TITLE
relay-review: fail closed on advisory-only adapters used as primary reviewers (#570)

### DIFF
--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -138,7 +138,7 @@ function startAdvisoryReview({
   const paths = advisoryPaths(runDir, round, reviewerName);
   const promptPath = path.join(runDir, `review-round-${round}-advisory-${reviewerName}-prompt.md`);
   writeText(promptPath, `${promptText}\n`);
-  const reviewerScript = resolveReviewerScript(reviewerName, null);
+  const reviewerScript = resolveReviewerScript(reviewerName, null, { phase: ADAPTER_PHASES.ADVISORY_REVIEW });
   const startedAt = Date.now();
   const reviewerPolicy = buildAdvisoryReviewerPolicy(reviewerName);
   const request = {

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -5,7 +5,9 @@ const { STATES } = require("../../../relay-dispatch/scripts/manifest/lifecycle")
 const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
 const {
   ADAPTER_PHASES,
+  listAgentAdapterNames,
   getAgentAdapterDescriptor,
+  supportsAgentAdapterPhase,
 } = require("../../../relay-dispatch/scripts/agent-adapters");
 const {
   assertPolicyRepresentable,
@@ -27,7 +29,39 @@ function resolveReviewerName(data, reviewerArg) {
   return "codex";
 }
 
-function resolveReviewerScript(reviewerName, reviewerScriptArg) {
+function supportedAdapterPhases(reviewerName) {
+  return Object.values(ADAPTER_PHASES)
+    .filter((phase) => supportsAgentAdapterPhase(reviewerName, phase));
+}
+
+function formatUnsupportedReviewerPhaseError(reviewerName, phase) {
+  const supported = supportedAdapterPhases(reviewerName);
+  if (
+    phase === ADAPTER_PHASES.PRIMARY_REVIEW &&
+    supported.includes(ADAPTER_PHASES.ADVISORY_REVIEW)
+  ) {
+    return (
+      `Reviewer adapter '${reviewerName}' supports advisory_review but not primary_review; ` +
+      `use --advisory-reviewer ${reviewerName} instead of --reviewer ${reviewerName} until primary review support is implemented. ` +
+      "Use --reviewer-script for an operator override."
+    );
+  }
+  if (
+    phase === ADAPTER_PHASES.ADVISORY_REVIEW &&
+    supported.includes(ADAPTER_PHASES.PRIMARY_REVIEW)
+  ) {
+    return (
+      `Reviewer adapter '${reviewerName}' supports primary_review but not advisory_review; ` +
+      `use --reviewer ${reviewerName} instead of --advisory-reviewer ${reviewerName}.`
+    );
+  }
+  return (
+    `Reviewer adapter '${reviewerName}' does not support ${phase}. ` +
+    `Supported phases: ${supported.join(", ") || "(none)"}. Use --reviewer-script for an operator override.`
+  );
+}
+
+function resolveReviewerScript(reviewerName, reviewerScriptArg, { phase = ADAPTER_PHASES.PRIMARY_REVIEW } = {}) {
   if (reviewerScriptArg) {
     return path.resolve(reviewerScriptArg);
   }
@@ -35,9 +69,28 @@ function resolveReviewerScript(reviewerName, reviewerScriptArg) {
   if (!/^[a-z0-9-]+$/.test(reviewerName)) {
     throw new Error(`Invalid reviewer name '${reviewerName}': must be lowercase alphanumeric/hyphens only. Use --reviewer-script for custom paths.`);
   }
-  const candidate = path.join(__dirname, "..", `invoke-reviewer-${reviewerName}.js`);
+  let descriptor;
+  try {
+    descriptor = getAgentAdapterDescriptor(reviewerName);
+  } catch {
+    throw new Error(
+      `Unknown reviewer adapter '${reviewerName}'. Supported adapters: ${listAgentAdapterNames().join(", ")}. ` +
+      "Use --reviewer-script for custom paths."
+    );
+  }
+  if (!supportsAgentAdapterPhase(reviewerName, phase)) {
+    throw new Error(formatUnsupportedReviewerPhaseError(reviewerName, phase));
+  }
+
+  const scriptName = phase === ADAPTER_PHASES.ADVISORY_REVIEW
+    ? descriptor.reviewer?.advisoryReviewScript
+    : descriptor.reviewer?.primaryReviewScript;
+  if (!scriptName) {
+    throw new Error(`Reviewer adapter '${reviewerName}' supports ${phase} but has no registered reviewer script.`);
+  }
+  const candidate = path.join(__dirname, "..", scriptName);
   if (!fs.existsSync(candidate)) {
-    throw new Error(`No reviewer adapter found for '${reviewerName}'. Provide --reviewer-script or --review-file.`);
+    throw new Error(`No reviewer adapter script found for '${reviewerName}' phase ${phase}. Provide --reviewer-script or --review-file.`);
   }
   return candidate;
 }

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -9,6 +9,7 @@ const { STATES, updateManifestState } = require("../../../skills/relay-dispatch/
 const { ensureRunLayout, getEventsPath } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 const { createManifestSkeleton, readManifest, writeManifest } = require("../../../skills/relay-dispatch/scripts/manifest/store");
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
+const { ADAPTER_PHASES } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
 const {
   captureGitStatus,
   loadReviewText,
@@ -119,6 +120,37 @@ test("reviewer-invoke/resolveReviewerScript resolves built-in adapters and rejec
   const script = resolveReviewerScript("codex");
   assert.match(script, /invoke-reviewer-codex\.js$/);
   assert.throws(() => resolveReviewerScript("../bad"), /Invalid reviewer name/);
+});
+
+test("reviewer-invoke/resolveReviewerScript fails closed for advisory-only adapters in primary review", () => {
+  assert.throws(
+    () => resolveReviewerScript("opencode"),
+    (error) => {
+      assert.match(error.message, /supports advisory_review but not primary_review/);
+      assert.match(error.message, /--advisory-reviewer opencode/);
+      assert.match(error.message, /--reviewer opencode/);
+      assert.match(error.message, /--reviewer-script/);
+      return true;
+    }
+  );
+});
+
+test("reviewer-invoke/resolveReviewerScript allows advisory-only adapters for advisory review", () => {
+  const script = resolveReviewerScript("opencode", null, { phase: ADAPTER_PHASES.ADVISORY_REVIEW });
+  assert.match(script, /invoke-reviewer-opencode\.js$/);
+});
+
+test("reviewer-invoke/resolveReviewerScript rejects unknown adapter names without falling back to files", () => {
+  assert.throws(
+    () => resolveReviewerScript("not-an-adapter"),
+    /Unknown reviewer adapter 'not-an-adapter'.*Supported adapters:.*codex.*opencode.*--reviewer-script/s
+  );
+});
+
+test("reviewer-invoke/resolveReviewerScript preserves manual reviewer-script overrides", () => {
+  const customScript = path.join(os.tmpdir(), "custom-reviewer.js");
+  assert.equal(resolveReviewerScript("opencode", customScript), customScript);
+  assert.equal(resolveReviewerScript("unknown", customScript, { phase: ADAPTER_PHASES.ADVISORY_REVIEW }), customScript);
 });
 
 test("reviewer-invoke/loadReviewText forwards promptPath to the adapter and persists the raw response", (t) => {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-570-20260525033557732-4962ab3f
- Branch: issue-570
- Reason: Executor completed issue #570 with uncommitted changes; automatic recover-commit failed because this Codex worktree canonicalizes to the primary checkout, so recovery is being run with an explicit manifest path.
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-570-20260525033557732-4962ab3f.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-25T03:39:32.722Z