### PR TITLE
adapter: add Pi executor and primary reviewer support (#571)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npx skills add . -g -y
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/code) or [Codex](https://chatgpt.com/codex)
+- Optional: Pi CLI 0.72.1+ for `--executor pi` or `--reviewer pi` (`RELAY_PI_BIN` may point review to a non-PATH binary)
 - [`gh` CLI](https://cli.github.com/) authenticated with `gh auth login`
 - Git 2.20+
 - Node.js 18+

--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -89,8 +89,8 @@ Useful dispatch flags:
 
 | Flag | Purpose |
 | --- | --- |
-| `--executor` | Select `codex`, `claude`, or `opencode` |
-| `--model` | Pass a model override when the harness supports it |
+| `--executor` | Select `codex`, `claude`, `opencode`, or `pi` |
+| `--model` | Pass a model override when the harness supports it; Pi should use an explicit provider/model route |
 | `--network-access enabled` | Enable Codex workspace-write network access for supported runs |
 | `--copy` | Copy extra gitignored files into the worktree |
 | `--register` | Register a Codex app thread or Claude relay-side receipt |
@@ -104,6 +104,16 @@ Manual review command:
 
 ```bash
 node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --pr <number> --reviewer codex --json
+```
+
+Pi can be used as dispatch executor or trusted primary reviewer when `pi` is on `PATH` (or `RELAY_PI_BIN` is set for review), authenticated for the selected provider, and route policy allows the model route:
+
+```bash
+node skills/relay-dispatch/scripts/dispatch.js . -e pi -m openai/gpt-5 \
+  -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml
+
+node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --pr <number> \
+  --reviewer pi --reviewer-model openai/gpt-5 --json
 ```
 
 Advisory review can run alongside the primary reviewer when route policy allows it:

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -305,7 +305,7 @@ Do not "simplify" the facade by collapsing submodules back into it or by force-m
 4. `review-runner.js` auto-discovers adapters via `resolveReviewerScript()` by naming convention: `invoke-reviewer-<name>.js`. The `<name>` must match `/^[a-z0-9-]+$/`.
 5. Existing adapters share small utilities (`getArg`, `hasFlag`, `summarizeFailure`, `ensureJsonText`) but NOT full execution logic — each adapter encodes its own execution contract (e.g. Claude uses `--json-schema` + stdout recovery; Codex uses temp-file exchange + `--ephemeral` + sandbox). New adapters should extract only the small utilities.
 
-`invoke-reviewer-opencode.js` is currently advisory-only: `review-runner --advisory-reviewer opencode` invokes it with a separate blind-spot prompt and validates output through `advisory-review-schema.js`, not the trusted verdict schema. Do not use opencode as the primary `--reviewer` until a trusted verdict adapter exists for it.
+`invoke-reviewer-opencode.js` is currently advisory-only: `review-runner --advisory-reviewer opencode` invokes it with a separate blind-spot prompt and validates output through `advisory-review-schema.js`, not the trusted verdict schema. Do not use opencode as the primary `--reviewer` until a trusted verdict adapter exists for it. `invoke-reviewer-pi.js` is a trusted primary reviewer adapter; it invokes `pi --no-session --tools read,grep,find,ls --print <prompt>` and relies on review-runner's before/after dirty-worktree check for write detection.
 
 ### Shared utilities (cross-skill)
 
@@ -320,8 +320,8 @@ Current shared helpers:
 
 | Module | Owner | Consumers |
 |--------|-------|-----------|
-| `skills/relay-dispatch/scripts/cli-args.js` | relay-dispatch | `review-runner.js`, `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `invoke-reviewer-opencode.js`, `finalize-run.js`, `persist-request.js`, `probe-executor-env.js` |
-| `skills/relay-review/scripts/reviewer-helpers.js` | relay-review | `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `invoke-reviewer-opencode.js` |
+| `skills/relay-dispatch/scripts/cli-args.js` | relay-dispatch | `review-runner.js`, `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `invoke-reviewer-opencode.js`, `invoke-reviewer-pi.js`, `finalize-run.js`, `persist-request.js`, `probe-executor-env.js` |
+| `skills/relay-review/scripts/reviewer-helpers.js` | relay-review | `invoke-reviewer-claude.js`, `invoke-reviewer-codex.js`, `invoke-reviewer-opencode.js`, `invoke-reviewer-pi.js` |
 
 `reviewer-helpers.js` is scoped to `summarizeFailure` and `ensureJsonText`. Reviewer adapters intentionally keep divergent execution contracts (Claude uses `--json-schema` + stdout recovery; Codex uses temp schema/result files + `--ephemeral` + sandbox; opencode is advisory-only with prompt-enforced read-only behavior), so a full adapter factory would hide meaningful differences. See item 5 under "Adding a new reviewer adapter" above.
 

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 ## Use when
 
-- Delegating implementation to an executor (`codex`, `claude`, `opencode`) via worktree isolation
+- Delegating implementation to an executor (`codex`, `claude`, `opencode`, `pi`) via worktree isolation
 - Resuming a same-run after a `changes_requested` review
 - Running background or parallel dispatches for independent tasks
 
@@ -43,6 +43,9 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -e claud
 
 # Experimental opencode executor (uses bundled/default model config unless --model is set)
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -e opencode -b feature-auth -p "..." --rubric-file rubric.yaml
+
+# Pi executor (requires pi CLI and an explicit allowed provider/model route)
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -e pi -m openai/gpt-5 -b feature-auth -p "..." --rubric-file rubric.yaml
 ```
 
 For background and parallel dispatch, see `../relay/SKILL.md` § Batch Mode (single source of truth for the parallel-fork flow).
@@ -58,8 +61,8 @@ All CLI flags are registered with an explicit `parsed` or `verbatim` read mode. 
 | `--manifest` | Resume an existing retained relay run by manifest path |
 | `--prompt, -p` | Task prompt (include Context + Done Criteria + self-review) |
 | `--prompt-file` | Read prompt from file (for large prompts) |
-| `--executor, -e` | Executor: `codex` (default), `claude`, `opencode` |
-| `--model, -m` | Model override; for `opencode`, falls back to bundled `references/executor-models.json`, then optional `~/.relay/executors.json` override |
+| `--executor, -e` | Executor: `codex` (default), `claude`, `opencode`, `pi` |
+| `--model, -m` | Model override; for `opencode`, falls back to bundled `references/executor-models.json`, then optional `~/.relay/executors.json` override; Pi should pass an explicit route such as `openai/gpt-5` |
 | `--model-hints` | Persist per-phase model hints as `phase=model[,phase=model...]` |
 | `--sandbox` | `workspace-write` (default) or `read-only` |
 | `--copy <files>` | Additional files to copy |
@@ -97,7 +100,7 @@ Precedence for dispatch model selection is: `--model` → manifest `model_hints.
 
 | Task type | Timeout | Rationale |
 |---|---|---|
-| Simple implementation | Default (`codex: 2400`, `claude/opencode: 1800`) | No self-review needed |
+| Simple implementation | Default (`codex: 2400`, `claude/opencode/pi: 1800`) | No self-review needed |
 | With self-review loop | `3600` | Executor iterates 2-3 times |
 | Complex / multi-file | `5400` | Deep implementation + thorough self-review |
 

--- a/skills/relay-dispatch/scripts/agent-adapters/index.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/index.js
@@ -1,6 +1,7 @@
 const codex = require("../executors/codex");
 const claude = require("../executors/claude");
 const opencode = require("../executors/opencode");
+const pi = require("../executors/pi");
 const bundledModels = require("../../references/executor-models.json");
 
 const ADAPTER_PHASES = Object.freeze({
@@ -463,6 +464,151 @@ const DESCRIPTORS = Object.freeze({
     reviewer: {
       primaryReviewScript: null,
       advisoryReviewScript: "invoke-reviewer-opencode.js",
+    },
+  }),
+  pi: buildDescriptor({
+    name: "pi",
+    displayName: "Pi CLI",
+    executor: pi,
+    phases: {
+      [ADAPTER_PHASES.DISPATCH]: {
+        supported: true,
+        trust: "executor",
+      },
+      [ADAPTER_PHASES.PRIMARY_REVIEW]: {
+        supported: true,
+        trust: "trusted",
+      },
+      [ADAPTER_PHASES.ADVISORY_REVIEW]: {
+        supported: false,
+        trust: "unsupported",
+      },
+    },
+    capabilities: {
+      sandbox: {
+        dispatch: {
+          modes: ["workspace-write"],
+          enforced: false,
+        },
+        primaryReview: {
+          mode: "read-only",
+          enforced: false,
+          guard: "worktree-status",
+        },
+        advisoryReview: null,
+      },
+      network: {
+        dispatch: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+        primaryReview: {
+          configurable: false,
+          default: "disabled",
+        },
+        advisoryReview: null,
+      },
+      readOnly: {
+        dispatch: false,
+        primaryReview: true,
+        advisoryReview: false,
+      },
+      policy: {
+        dispatch: {
+          sandbox: {
+            "workspace-write": {
+              enforcement_level: "informational",
+              mechanism: "pi-cli",
+              warnings: ["Pi dispatch does not provide native sandbox containment."],
+            },
+            "read-only": {
+              enforcement_level: "informational",
+              mechanism: "pi-cli",
+              warnings: ["Pi dispatch read-only intent is informational only and does not prevent writes."],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Pi dispatch does not gate network access at the executor level."],
+            },
+            enabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Pi dispatch does not gate network access at the executor level."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "informational",
+              mechanism: "pi-cli",
+              warnings: ["Pi dispatch read-only intent is informational only and does not prevent writes."],
+            },
+            false: {
+              enforcement_level: "unsupported",
+              mechanism: "write-capable-dispatch",
+            },
+          },
+        },
+        primary_review: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "tool-allowlist",
+              mechanism: "pi-tools-allowlist",
+              flags: ["--tools read,grep,find,ls"],
+              warnings: ["Pi reviewer read-only is a tool allowlist, not OS-level containment; relay still checks dirty worktree status after invocation."],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "tool-allowlist",
+              mechanism: "pi-tools-allowlist",
+              flags: ["--tools read,grep,find,ls"],
+              warnings: ["Pi reviewer has no network tool in the relay allowlist; dirty worktree detection remains active."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "tool-allowlist",
+              mechanism: "pi-tools-allowlist",
+              flags: ["--tools read,grep,find,ls"],
+              warnings: ["Pi reviewer read-only is a tool allowlist, not OS-level containment; dirty worktree detection remains active."],
+            },
+          },
+        },
+        advisory_review: null,
+      },
+      transport: {
+        dispatch: "pi-cli",
+        primaryReview: "pi-cli",
+        advisoryReview: null,
+      },
+      structuredOutput: {
+        dispatch: "stdout-copied-result-file",
+        primaryReview: "json-text",
+        advisoryReview: null,
+      },
+      appRegistration: {
+        supported: false,
+        transport: null,
+      },
+      modelDefaults: {
+        provider: pi.providerDefault,
+        dispatch: {
+          configKey: "pi",
+          defaultModel: bundledDefaultModel("pi"),
+        },
+        primaryReview: {
+          configKey: "pi",
+          defaultModel: bundledDefaultModel("pi"),
+        },
+        advisoryReview: null,
+      },
+    },
+    reviewer: {
+      primaryReviewScript: "invoke-reviewer-pi.js",
+      advisoryReviewScript: null,
     },
   }),
 });

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -151,6 +151,9 @@ const COMMAND_FLAGS = {
   "invoke-reviewer-opencode": [
     "--repo", "--prompt-file", "--model", "--json", "--help",
   ],
+  "invoke-reviewer-pi": [
+    "--repo", "--prompt-file", "--model", "--json", "--help",
+  ],
   "persist-done-criteria": [
     "--repo", "--run-id", "--text", "--file", "--json", "--help",
   ],

--- a/skills/relay-dispatch/scripts/executors/index.js
+++ b/skills/relay-dispatch/scripts/executors/index.js
@@ -5,7 +5,7 @@ const {
   supportsAgentAdapterPhase,
 } = require("../agent-adapters");
 
-const EXECUTOR_COMPAT_ORDER = ["codex", "claude", "opencode"];
+const EXECUTOR_COMPAT_ORDER = ["codex", "claude", "opencode", "pi"];
 
 function listExecutors() {
   const names = listAgentAdapterNames();

--- a/skills/relay-dispatch/scripts/executors/pi.js
+++ b/skills/relay-dispatch/scripts/executors/pi.js
@@ -1,0 +1,107 @@
+const { execFileSync } = require("child_process");
+const {
+  copyStdoutToResultFile,
+} = require("../agent-adapters/transport");
+
+const PROBE_FLAGS = [
+  "--print",
+  "--no-session",
+  "--mode",
+  "--tools",
+  "--model",
+  "--provider",
+  "--thinking",
+  "--no-context-files",
+];
+
+function normalizeThinking(reasoning) {
+  if (reasoning === "low" || reasoning === "medium" || reasoning === "high") return reasoning;
+  if (reasoning === "xhigh") return "high";
+  return null;
+}
+
+function parseProvider(model) {
+  if (typeof model !== "string" || !model) return null;
+  const idx = model.indexOf("/");
+  if (idx <= 0) return null;
+  return model.slice(0, idx);
+}
+
+function validateExecutionMode({ sandbox, networkAccess }) {
+  const warnings = [];
+  if (sandbox !== "workspace-write") {
+    warnings.push(
+      `pi executor: --sandbox '${sandbox}' is not enforced by pi; proceeding with workspace-write semantics.`
+    );
+  }
+  if (networkAccess === "enabled") {
+    warnings.push(
+      "pi executor: --network-access 'enabled' is informational only; pi does not gate network access at the executor level."
+    );
+  }
+  return { ok: true, warnings };
+}
+
+function buildExecCommand({ wtPath, prompt, model, reasoning }) {
+  const cmd = "pi";
+  const args = ["--no-session"];
+  if (model) args.push("--model", model);
+  const thinking = normalizeThinking(reasoning);
+  if (thinking) args.push("--thinking", thinking);
+  args.push("--print", prompt);
+  return { cmd, args, cwd: wtPath, codexGitCommonDir: null };
+}
+
+function finalizeResult({ stdoutLog, resultFile }) {
+  return copyStdoutToResultFile({ adapter: "pi", phase: "dispatch", stdoutLog, resultFile });
+}
+
+function register() {
+  return { threadId: null, raw: { provider: "pi", note: "no app registration surface" } };
+}
+
+function probe() {
+  const cmd = "pi";
+  let version;
+  try {
+    version = execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  } catch {
+    return { error: `${cmd} CLI not found`, raw: null };
+  }
+
+  let help = "";
+  const warnings = [];
+  try {
+    help = execFileSync(cmd, ["--help"], { encoding: "utf-8", stdio: "pipe" });
+  } catch (error) {
+    warnings.push(`pi --help failed: ${error.message}`);
+  }
+
+  const supportedFlags = PROBE_FLAGS.filter((flag) => help.includes(flag));
+  const missingFlags = PROBE_FLAGS.filter((flag) => !supportedFlags.includes(flag));
+  if (missingFlags.length) {
+    warnings.push(`pi --help does not mention expected flags: ${missingFlags.join(", ")}`);
+  }
+
+  return {
+    error: null,
+    raw: JSON.stringify({
+      version,
+      supported_flags: supportedFlags,
+      missing_flags: missingFlags,
+      warnings,
+    }),
+  };
+}
+
+module.exports = {
+  cliBinary: "pi",
+  providerDefault: "pi",
+  defaultTimeout: 1800,
+  validateExecutionMode,
+  buildExecCommand,
+  finalizeResult,
+  register,
+  probe,
+  parseProvider,
+};

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   keywords: "리뷰, 검토, review, gate, fresh context"
 ---
 ## Inputs
-- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; examples use `PR_NUM`, `BRANCH`, `ISSUE_NUM`, and `RUN_ID`; `ANTHROPIC_API_KEY` is required only for `--reviewer claude`.
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; examples use `PR_NUM`, `BRANCH`, `ISSUE_NUM`, and `RUN_ID`; `ANTHROPIC_API_KEY` is required only for `--reviewer claude`; `RELAY_PI_BIN` can override the Pi binary path.
 - Files: PR diff (`/tmp/pr-diff.txt`), Done Criteria anchor, Score Log/rubric artifacts, run manifest, and optional `/tmp/review-verdict.json`.
 - Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/resolve-issue-number.sh`, `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js`.
 
@@ -34,7 +34,7 @@ Reviews MUST run in a fresh context — no prior planning, dispatch, or conversa
 
 - Claude Code: `context: fork` frontmatter triggers isolation.
 - Codex adapter: `invoke-reviewer-codex.js` passes `--ephemeral --sandbox read-only`.
-- Claude adapter: `invoke-reviewer-claude.js` passes `--bare --no-session-persistence`.
+- Claude adapter: `invoke-reviewer-claude.js` passes `--bare --no-session-persistence`; Pi adapter passes `--no-session --tools read,grep,find,ls`.
 - Manual inline review: start a new session; do not continue from dispatch.
 - Other fallback: prefix the prompt with "You are reviewing code you did NOT write. You have no context about why it was written this way."
 
@@ -62,9 +62,9 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo 
 
 Run the runner in the foreground. Do NOT background it, detach it, or return with "I'll wait for the background runner." The relay-review result is the runner's verdict; do not return until the runner exits and the new `review-round-N-verdict.json` exists.
 
-Supported built-in adapters: `--reviewer codex`, `--reviewer claude`.
+Supported built-in adapters: `--reviewer codex`, `--reviewer claude`, `--reviewer pi`.
 
-Notes: `codex` uses a read-only structured-output adapter and must return a full two-phase verdict. `claude --bare` uses a separate token from interactive Claude OAuth; for `--reviewer claude`, set `ANTHROPIC_API_KEY` or run `claude login --api-key`.
+Notes: `codex` uses a read-only structured-output adapter and must return a full two-phase verdict. `pi` uses a read/grep/find/ls tool allowlist and the runner still checks dirty worktree status. `claude --bare` uses a separate token from interactive Claude OAuth; for `--reviewer claude`, set `ANTHROPIC_API_KEY` or run `claude login --api-key`.
 Model precedence is `--reviewer-model` -> `manifest.model_hints.review` -> reviewer default. Runner invocation records a `review_invoke` event with the effective `model` value (or `null`).
 
 Optional advisory path: add an opencode blind-spot lane alongside the primary reviewer:

--- a/skills/relay-review/scripts/invoke-reviewer-pi.js
+++ b/skills/relay-review/scripts/invoke-reviewer-pi.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Invoke Pi as an isolated structured primary reviewer.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { REVIEWER_VERDICT_JSON_SCHEMA } = require("./review-schema");
+const {
+  bindCliArgs,
+  modeLabel,
+} = require("../../relay-dispatch/scripts/cli-args");
+const {
+  parseReviewerJsonObject,
+  recoverExecStdout,
+  summarizeFailure,
+} = require("./reviewer-helpers");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
+const cliArgs = bindCliArgs(args, {
+  commandName: "invoke-reviewer-pi",
+  reservedFlags: KNOWN_FLAGS,
+});
+
+if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
+  console.log("Usage: invoke-reviewer-pi.js --repo <path> --prompt-file <path> [--model <name>] [--json]");
+  console.log("\nOptions:");
+  console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
+  console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
+  console.log(`  --model <name>       ${modeLabel("--model")} Model override`);
+  console.log(`  --json               ${modeLabel("--json")} Output JSON`);
+  process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
+}
+
+function main() {
+  const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
+  const promptFile = cliArgs.getArg("--prompt-file");
+  const model = cliArgs.getArg("--model");
+  const piBin = process.env.RELAY_PI_BIN || "pi";
+
+  if (!promptFile) {
+    throw new Error("--prompt-file is required");
+  }
+
+  const promptText = fs.readFileSync(promptFile, "utf-8").trim();
+  const fullPrompt = [
+    "[NON-INTERACTIVE REVIEW]",
+    "Review the provided bundle and return only JSON matching this schema:",
+    JSON.stringify(REVIEWER_VERDICT_JSON_SCHEMA),
+    "Do not wrap the response in markdown fences.",
+    "Start with the diff for overview. Then read callers/imports of changed functions to verify integration.",
+    "You have read-only access to the full codebase via read, grep, find, and ls tools.",
+    "Do not modify files, create commits, or write comments. Treat the checkout as read-only.",
+    "",
+    promptText,
+  ].join("\n");
+
+  const execArgs = [
+    "--no-session",
+    "--tools", "read,grep,find,ls",
+  ];
+  if (model) execArgs.push("--model", model);
+  execArgs.push("--print", fullPrompt);
+
+  let result;
+  try {
+    result = execFileSync(piBin, execArgs, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      stdio: "pipe",
+      maxBuffer: 10 * 1024 * 1024,
+    }).trim();
+  } catch (error) {
+    const recovered = recoverExecStdout(error);
+    if (!recovered) {
+      throw new Error(`Pi reviewer failed: ${summarizeFailure(error)}`);
+    }
+    result = recovered;
+  }
+
+  if (!result) {
+    throw new Error("Pi reviewer did not produce a structured result");
+  }
+  parseReviewerJsonObject(result, {
+    adapter: "pi",
+    phase: "primary_review",
+    description: "review verdict",
+  });
+
+  if (cliArgs.hasFlag("--json")) {
+    console.log(result);
+  } else {
+    process.stdout.write(result);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
@@ -56,40 +56,9 @@ test("policy audit keeps OpenCode sandbox and network informational", () => {
   assert.deepEqual(audit.fail_closed_reasons, []);
 });
 
-test("policy audit supports synthetic Pi read-only tool allowlist mapping", () => {
-  const piDescriptor = {
-    name: "pi",
-    capabilities: {
-      policy: {
-        primary_review: {
-          sandbox: {
-            "read-only": {
-              enforcement_level: "tool-allowlist",
-              mechanism: "pi-tool-policy",
-              flags: ["allow:read", "deny:write"],
-            },
-          },
-          network: {
-            disabled: {
-              enforcement_level: "tool-allowlist",
-              mechanism: "pi-tool-policy",
-              flags: ["deny:network"],
-            },
-          },
-          read_only: {
-            true: {
-              enforcement_level: "tool-allowlist",
-              mechanism: "pi-tool-policy",
-              flags: ["allow:Read", "deny:Write"],
-            },
-          },
-        },
-      },
-    },
-  };
-
+test("policy audit records Pi primary review read-only tool allowlist metadata", () => {
   const audit = buildAgentPolicyAudit({
-    descriptor: piDescriptor,
+    descriptor: getAgentAdapterDescriptor("pi"),
     phase: ADAPTER_PHASES.PRIMARY_REVIEW,
     requested: {
       sandbox: "read-only",
@@ -99,8 +68,11 @@ test("policy audit supports synthetic Pi read-only tool allowlist mapping", () =
   });
 
   assert.equal(audit.safe, true);
+  assert.equal(audit.sandbox.enforcement_level, "tool-allowlist");
+  assert.equal(audit.network.enforcement_level, "tool-allowlist");
   assert.equal(audit.read_only.enforcement_level, "tool-allowlist");
-  assert.deepEqual(audit.read_only.flags, ["allow:Read", "deny:Write"]);
+  assert.deepEqual(audit.read_only.flags, ["--tools read,grep,find,ls"]);
+  assert.match(audit.warnings.join("\n"), /dirty worktree/i);
 });
 
 test("policy audit supports synthetic Antigravity native sandbox mapping", () => {

--- a/tests/relay-dispatch/scripts/agent-adapters.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapters.test.js
@@ -10,8 +10,8 @@ const {
 } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
 
 test("agent adapter registry exposes the current built-in adapters", () => {
-  assert.deepEqual(listAgentAdapterNames(), ["claude", "codex", "opencode"]);
-  assert.deepEqual(listAgentAdapters().map((descriptor) => descriptor.name), ["claude", "codex", "opencode"]);
+  assert.deepEqual(listAgentAdapterNames(), ["claude", "codex", "opencode", "pi"]);
+  assert.deepEqual(listAgentAdapters().map((descriptor) => descriptor.name), ["claude", "codex", "opencode", "pi"]);
 });
 
 test("agent adapter registry reports dispatch, primary review, and advisory review independently", () => {
@@ -26,6 +26,10 @@ test("agent adapter registry reports dispatch, primary review, and advisory revi
   assert.equal(supportsAgentAdapterPhase("opencode", ADAPTER_PHASES.DISPATCH), true);
   assert.equal(supportsAgentAdapterPhase("opencode", ADAPTER_PHASES.PRIMARY_REVIEW), false);
   assert.equal(supportsAgentAdapterPhase("opencode", ADAPTER_PHASES.ADVISORY_REVIEW), true);
+
+  assert.equal(supportsAgentAdapterPhase("pi", ADAPTER_PHASES.DISPATCH), true);
+  assert.equal(supportsAgentAdapterPhase("pi", ADAPTER_PHASES.PRIMARY_REVIEW), true);
+  assert.equal(supportsAgentAdapterPhase("pi", ADAPTER_PHASES.ADVISORY_REVIEW), false);
 });
 
 test("agent adapter descriptors expose structured capabilities and the executor contract", () => {
@@ -61,16 +65,28 @@ test("agent adapter descriptors expose structured capabilities and the executor 
   assert.equal(opencode.capabilities.readOnly.advisoryReview, true);
   assert.equal(opencode.capabilities.transport.advisoryReview, "opencode-cli");
   assert.equal(opencode.capabilities.structuredOutput.advisoryReview, "json-text");
+
+  const pi = getAgentAdapterDescriptor("pi");
+  assert.equal(pi.executor.cliBinary, "pi");
+  assert.equal(pi.capabilities.appRegistration.supported, false);
+  assert.equal(pi.capabilities.modelDefaults.provider, "pi");
+  assert.deepEqual(pi.capabilities.sandbox.dispatch.modes, ["workspace-write"]);
+  assert.equal(pi.capabilities.sandbox.dispatch.enforced, false);
+  assert.equal(pi.capabilities.network.dispatch.configurable, false);
+  assert.equal(pi.capabilities.readOnly.primaryReview, true);
+  assert.equal(pi.capabilities.transport.primaryReview, "pi-cli");
+  assert.equal(pi.capabilities.structuredOutput.primaryReview, "json-text");
+  assert.deepEqual(pi.capabilities.policy.primary_review.read_only.true.flags, ["--tools read,grep,find,ls"]);
 });
 
 test("agent adapter registry fails closed for unknown adapters and phases", () => {
   assert.throws(
-    () => getAgentAdapterDescriptor("pi"),
-    /unknown agent adapter 'pi'\. Supported: claude, codex, opencode/
+    () => getAgentAdapterDescriptor("antigravity"),
+    /unknown agent adapter 'antigravity'\. Supported: claude, codex, opencode, pi/
   );
   assert.throws(
-    () => supportsAgentAdapterPhase("pi", ADAPTER_PHASES.DISPATCH),
-    /unknown agent adapter 'pi'\. Supported: claude, codex, opencode/
+    () => supportsAgentAdapterPhase("antigravity", ADAPTER_PHASES.DISPATCH),
+    /unknown agent adapter 'antigravity'\. Supported: claude, codex, opencode, pi/
   );
   assert.throws(
     () => supportsAgentAdapterPhase("codex", "sidecar"),

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -152,6 +152,7 @@ const HELP_COMMANDS = [
   ["gate-check", path.join(__dirname, "..", "..", "..", "skills", "relay-merge", "scripts", "gate-check.js")],
   ["invoke-reviewer-claude", path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-claude.js")],
   ["invoke-reviewer-codex", path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-codex.js")],
+  ["invoke-reviewer-pi", path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-pi.js")],
   ["persist-request", path.join(__dirname, "..", "..", "..", "skills", "relay-ready", "scripts", "persist-request.js")],
   ["probe-executor-env", path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "scripts", "probe-executor-env.js")],
   ["recover-commit", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-commit.js")],

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -244,6 +244,27 @@ process.stdout.write("ok\\n");
   return oc;
 }
 
+function writeArgCapturePi(binDir, capturePath) {
+  ensureDefaultFakeGh(binDir);
+  const piPath = path.join(binDir, "pi");
+  fs.writeFileSync(piPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("pi 0.72.1\\n"); process.exit(0); }
+if (!args.includes("--print")) { process.stderr.write("unsupported fake pi invocation"); process.exit(1); }
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(args), "utf-8");
+const cwd = process.cwd();
+const fileName = "captured-pi.txt";
+fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
+process.stdout.write("pi completed\\n");
+`, "utf-8");
+  fs.chmodSync(piPath, 0o755);
+  return piPath;
+}
+
 function writeNoOpCodex(binDir) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -2499,6 +2520,45 @@ test("dispatch with --executor claude creates worktree and collects result", () 
   assert.ok(fs.existsSync(result.resultFile));
   const resultText = fs.readFileSync(result.resultFile, "utf-8");
   assert.match(resultText, /ok/);
+});
+
+test("dispatch with --executor pi invokes Pi and copies stdout into the result file", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-pi-dispatch",
+    allowed_model_routes: [{ route: "openai/*", phases: ["dispatch"], executors: ["pi"] }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-pi-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-pi.json`);
+  writeArgCapturePi(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const taskPrompt = "test pi task";
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "pi-test",
+    "-e", "pi",
+    "--model", "openai/gpt-5",
+    "--prompt", taskPrompt,
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.executor, "pi");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.ok(result.commits);
+  assert.equal(fs.readFileSync(result.resultFile, "utf-8"), "pi completed\n");
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
+    "--no-session",
+    "--model", "openai/gpt-5",
+    "--thinking", "high",
+    "--print", buildDispatchExecPrompt(taskPrompt),
+  ]);
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.dispatch.last_executor, "pi");
+  assert.equal(manifest.dispatch.last_model, "openai/gpt-5");
+  assert.equal(manifest.dispatch.last_provider, "openai");
 });
 
 test("dispatch artifacts are persisted in the run directory", () => {

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -30,9 +30,9 @@ after(() => {
   if (TMP_ROOT) fs.rmSync(TMP_ROOT, { recursive: true, force: true });
 });
 
-test("registry exposes codex, claude, and opencode", () => {
-  assert.deepEqual(listExecutors(), ["codex", "claude", "opencode"]);
-  assert.deepEqual(listExecutors().sort(), ["claude", "codex", "opencode"]);
+test("registry exposes codex, claude, opencode, and pi", () => {
+  assert.deepEqual(listExecutors(), ["codex", "claude", "opencode", "pi"]);
+  assert.deepEqual(listExecutors().sort(), ["claude", "codex", "opencode", "pi"]);
   assert.throws(() => getExecutor("nonexistent"), /unknown executor/);
 });
 
@@ -42,6 +42,14 @@ test("opencode adapter exposes the same 7 fields", () => {
     assert.ok(typeof o[k] !== "undefined", `missing field: ${k}`);
   }
   assert.equal(o.cliBinary, "opencode");
+});
+
+test("pi adapter exposes the same 7 fields", () => {
+  const pi = getExecutor("pi");
+  for (const k of ["cliBinary", "defaultTimeout", "validateExecutionMode", "buildExecCommand", "finalizeResult", "register", "probe"]) {
+    assert.ok(typeof pi[k] !== "undefined", `missing field: ${k}`);
+  }
+  assert.equal(pi.cliBinary, "pi");
 });
 
 test("opencode validateExecutionMode accepts workspace-write+disabled with experimental warning", () => {
@@ -90,6 +98,48 @@ test("opencode buildExecCommand: model passthrough via -m", () => {
   assert.deepEqual(r.args, ["run", "-m", "openai/gpt-5", "P"]);
 });
 
+test("pi buildExecCommand: explicit non-interactive argv with thinking", () => {
+  const pi = getExecutor("pi");
+  const r = pi.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "high",
+  });
+  assert.equal(r.cmd, "pi");
+  assert.deepEqual(r.args, ["--no-session", "--thinking", "high", "--print", "P"]);
+  assert.equal(r.cwd, "/tmp/wt");
+  assert.equal(r.codexGitCommonDir, null);
+});
+
+test("pi buildExecCommand: model passthrough via --model", () => {
+  const pi = getExecutor("pi");
+  const r = pi.buildExecCommand({
+    wtPath: "/tmp/wt",
+    resultFile: "/tmp/r",
+    prompt: "P",
+    model: "openai/gpt-5",
+    sandbox: "workspace-write",
+    networkAccess: "disabled",
+    reasoning: "xhigh",
+  });
+  assert.deepEqual(r.args, ["--no-session", "--model", "openai/gpt-5", "--thinking", "high", "--print", "P"]);
+});
+
+test("pi finalizeResult copies stdout into the relay result file", () => {
+  const pi = getExecutor("pi");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "relay-pi-finalize-"));
+  const stdoutLog = path.join(tmp, "stdout.log");
+  const resultFile = path.join(tmp, "result.txt");
+  fs.writeFileSync(stdoutLog, "pi result\n", "utf-8");
+  const copied = pi.finalizeResult({ stdoutLog, resultFile });
+  assert.deepEqual(copied, { copied: true, status: "copied", bytes: "pi result\n".length });
+  assert.equal(fs.readFileSync(resultFile, "utf-8"), "pi result\n");
+});
+
 test("opencode register stub returns null thread id", () => {
   const o = getExecutor("opencode");
   const r = o.register({ wtPath: "/tmp/wt", repoPath: "/repo", branch: "b", title: "T" });
@@ -132,6 +182,57 @@ test("opencode probe returns {error: 'opencode CLI not found', raw: null} when b
     const result = o.probe({ timeout: 5 });
     assert.equal(result.raw, null);
     assert.match(result.error, /opencode CLI not found/);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
+test("pi probe returns {error: 'pi CLI not found', raw: null} when binary missing", () => {
+  const emptyBin = path.join(TMP_ROOT, "empty-pi-bin");
+  fs.mkdirSync(emptyBin, { recursive: true });
+  const originalPath = process.env.PATH;
+  process.env.PATH = emptyBin;
+  try {
+    const pi = getExecutor("pi");
+    const result = pi.probe({ timeout: 5 });
+    assert.equal(result.raw, null);
+    assert.match(result.error, /pi CLI not found/);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
+test("pi probe payload exposes version and supported flags without live API call", () => {
+  const fakeBin = path.join(TMP_ROOT, "fake-pi-bin");
+  const fakePi = path.join(fakeBin, "pi");
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(fakePi, `#!/bin/sh
+case "$1" in
+  --version) echo "pi 0.72.1" ;;
+  --help) echo "Usage: pi --print --no-session --mode text|json|rpc --tools read,grep,find,ls --model --provider --thinking --no-context-files" ;;
+  *) exit 2 ;;
+esac
+`);
+  fs.chmodSync(fakePi, 0o755);
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${fakeBin}${path.delimiter}${originalPath || ""}`;
+  try {
+    const pi = getExecutor("pi");
+    const result = pi.probe({ timeout: 5 });
+    assert.equal(result.error, null);
+    const parsed = JSON.parse(result.raw);
+    assert.equal(parsed.version, "pi 0.72.1");
+    assert.deepEqual(parsed.supported_flags, [
+      "--print",
+      "--no-session",
+      "--mode",
+      "--tools",
+      "--model",
+      "--provider",
+      "--thinking",
+      "--no-context-files",
+    ]);
   } finally {
     process.env.PATH = originalPath;
   }
@@ -329,4 +430,5 @@ test("validateExecutionMode: claude warns on non-workspace-write sandbox", () =>
 test("default timeouts match pre-refactor values", () => {
   assert.equal(getExecutor("codex").defaultTimeout, 2400);
   assert.equal(getExecutor("claude").defaultTimeout, 1800);
+  assert.equal(getExecutor("pi").defaultTimeout, 1800);
 });

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -8,6 +8,7 @@ const path = require("path");
 const CODEX_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-codex.js");
 const CLAUDE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-claude.js");
 const OPENCODE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-opencode.js");
+const PI_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-pi.js");
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-adapter-"));
@@ -322,4 +323,77 @@ process.stdout.write(JSON.stringify({
   assert.match(loggedArgs, /^run\n-m\nopencode-go\/deepseek-v4-pro\n/);
   assert.match(loggedArgs, /NON-INTERACTIVE ADVISORY REVIEW/);
   assert.match(loggedArgs, /Return a passing review\./);
+});
+
+test("pi adapter forwards read-only tools, model, and preserves primary review prompt", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-pi-"));
+  const logPath = path.join(fakeDir, "pi-args.log");
+  const fakePi = writeExecutable(fakeDir, "fake-pi.js", `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(logPath)}, args.join("\\n") + "\\n", "utf-8");
+process.stdout.write(JSON.stringify({
+  verdict: "pass",
+  summary: "Looks good.",
+  contract_status: "pass",
+  quality_review_status: "pass",
+  next_action: "ready_to_merge",
+  issues: [],
+  rubric_scores: [],
+  scope_drift: { creep: [], missing: [] },
+}));
+`);
+
+  const stdout = execFileSync("node", [
+    PI_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--model", "openai/gpt-5",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_PI_BIN: fakePi },
+  });
+
+  const result = JSON.parse(stdout);
+  const loggedArgs = fs.readFileSync(logPath, "utf-8");
+  assert.equal(result.verdict, "pass");
+  assert.match(loggedArgs, /^--no-session\n--tools\nread,grep,find,ls\n--model\nopenai\/gpt-5\n--print\n/);
+  assert.match(loggedArgs, /NON-INTERACTIVE REVIEW/);
+  assert.match(loggedArgs, /Return a passing review\./);
+});
+
+test("pi adapter reports adapter and phase when stdout is invalid JSON", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-pi-invalid-"));
+  const fakePi = writeExecutable(fakeDir, "fake-pi.js", `#!/usr/bin/env node
+process.stdout.write("not-json\\n");
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      PI_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_PI_BIN: fakePi },
+    });
+    assert.fail("expected invoke-reviewer-pi.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  assert.notEqual(error.status, 0);
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /adapter=pi phase=primary_review/);
+  assert.match(stderr, /review verdict must be valid JSON/);
 });

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -11,6 +11,7 @@ const { createManifestSkeleton, readManifest, writeManifest } = require("../../.
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const { ADAPTER_PHASES } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
 const {
+  buildPrimaryReviewerPolicy,
   captureGitStatus,
   loadReviewText,
   resolveReviewerName,
@@ -119,6 +120,8 @@ test("reviewer-invoke/resolveReviewerName preserves arg, manifest, env precedenc
 test("reviewer-invoke/resolveReviewerScript resolves built-in adapters and rejects invalid names", () => {
   const script = resolveReviewerScript("codex");
   assert.match(script, /invoke-reviewer-codex\.js$/);
+  const piScript = resolveReviewerScript("pi");
+  assert.match(piScript, /invoke-reviewer-pi\.js$/);
   assert.throws(() => resolveReviewerScript("../bad"), /Invalid reviewer name/);
 });
 
@@ -143,8 +146,17 @@ test("reviewer-invoke/resolveReviewerScript allows advisory-only adapters for ad
 test("reviewer-invoke/resolveReviewerScript rejects unknown adapter names without falling back to files", () => {
   assert.throws(
     () => resolveReviewerScript("not-an-adapter"),
-    /Unknown reviewer adapter 'not-an-adapter'.*Supported adapters:.*codex.*opencode.*--reviewer-script/s
+    /Unknown reviewer adapter 'not-an-adapter'.*Supported adapters:.*codex.*opencode.*pi.*--reviewer-script/s
   );
+});
+
+test("reviewer-invoke/buildPrimaryReviewerPolicy records Pi tool allowlist metadata", () => {
+  const policy = buildPrimaryReviewerPolicy("pi");
+  assert.equal(policy.adapter, "pi");
+  assert.equal(policy.phase, ADAPTER_PHASES.PRIMARY_REVIEW);
+  assert.equal(policy.safe, true);
+  assert.equal(policy.read_only.enforcement_level, "tool-allowlist");
+  assert.deepEqual(policy.read_only.flags, ["--tools read,grep,find,ls"]);
 });
 
 test("reviewer-invoke/resolveReviewerScript preserves manual reviewer-script overrides", () => {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-571-20260525034350475-1d3a16da
- Branch: issue-571
- Reason: Executor completed issue #571 implementation but final verification hung because --test-name-pattern was placed after the file path. Targeted verification was rerun manually with correct option ordering and passed before recovery.
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-571-20260525034350475-1d3a16da.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-25T04:02:20.098Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Pi CLI를 새로운 실행기 및 신뢰할 수 있는 주요 리뷰어로 지원
  * RELAY_PI_BIN 환경 변수로 커스텀 Pi 바이너리 경로 지정 가능
  * --model 플래그를 통한 Pi 모델 지정 지원

* **Documentation**
  * Pi 실행기 및 리뷰어 사용법 가이드 업데이트
  * Pi 통합을 위한 구성 예시 및 타임아웃 안내 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->