### PR TITLE
Dogfood: Pi adapter live relay canary (#589)

### DIFF
--- a/docs/adapter-dogfood.md
+++ b/docs/adapter-dogfood.md
@@ -1,0 +1,34 @@
+# Adapter Dogfood Log
+
+Live relay canary runs for executor and reviewer adapter validation. Each entry records
+the harnesses, model routes, and phases exercised during a live dispatch→review→merge
+cycle. The relay run itself is the arbiter — entries in this log record intent and
+configuration, not outcome.
+
+## Pi Adapter Live Relay Canary (Issue #589)
+
+- **Date**: 2026-05-25
+- **Issue**: [#589 — Dogfood: Pi adapter live relay canary](https://github.com/sungjunlee/dev-relay/issues/589)
+- **Intent**: End-to-end validation of the Pi CLI adapter through a full relay lifecycle
+  (plan → dispatch → review → merge) using a docs-only change.
+- **Dispatch executor**: `pi` via `opencode-go/deepseek-v4-pro`
+- **Primary reviewer**: `pi` via `opencode-go/deepseek-v4-pro`
+- **Advisory reviewer**: `opencode` via `opencode-go/deepseek-v4-pro` (OpenCode advisory review)
+
+### Validation Targets
+
+| Target | Description |
+| --- | --- |
+| CLI invocation | Pi harness launches and responds to the dispatch prompt without adapter errors |
+| Result capture | Executor output (commit, PR) is captured by the dispatch adapter contract |
+| PR handoff | The resulting PR is addressable by relay-review and relay-merge |
+| Review gating | Primary review (Pi) and advisory review (OpenCode) run without adapter failures; verdicts flow into the review manifest |
+
+### Notes
+
+- The change is docs-only (`docs/adapter-dogfood.md`) to keep the blast radius minimal.
+- Same-model review pairing (executor and reviewer both `pi` via `opencode-go/deepseek-v4-pro`)
+  carries the same-family reviewer warning documented in [reviewer-policy-opencode.md](reviewer-policy-opencode.md).
+  The advisory OpenCode reviewer on the same route provides a cross-harness signal.
+- Any adapter or runtime failures discovered during the run will be captured as follow-up issues
+  rather than hidden.


### PR DESCRIPTION
## Summary

Docs-only canary entry for the Pi adapter live relay dogfood (issue #589).

Records the dispatch and review configuration:
- **Executor**: `pi` via `opencode-go/deepseek-v4-pro`
- **Primary reviewer**: `pi` via `opencode-go/deepseek-v4-pro`
- **Advisory reviewer**: `opencode` via `opencode-go/deepseek-v4-pro`

## Change

- `docs/adapter-dogfood.md` — New file with the Pi adapter canary entry and validation target table.

## Done Criteria

- [x] PR contains only `docs/adapter-dogfood.md` (docs-only, no unrelated files)
- [x] Document is non-empty and references Pi executor, Pi reviewer, and OpenCode advisory review
- [x] No `.antigravitycli/` or generated cache files committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Adapter Dogfood Log 문서가 새로 추가되었으며, Pi Adapter Live Relay Canary 실행 기록을 추적하기 위한 템플릿이 포함되어 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->