### PR TITLE
relay-plan: allow unmanaged executor probe checks to carry explicit model route (#587)

### DIFF
--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -198,6 +198,19 @@ node skills/relay-config/scripts/relay-config.js check sidecar opencode kakao/op
 
 Check exits non-zero when the tuple would be denied at runtime. Run it before turning on routed advisory review or sidecar rules because those phases can start automatically after dispatch.
 
+For pre-planning dispatch probes, run the matching `probe-executor-env` command with the same unmanaged route. The probe evaluates `--executor` plus `--model` as a dispatch policy tuple before invoking the adapter:
+
+```bash
+node skills/relay-config/scripts/relay-config.js check dispatch pi opencode-go/deepseek-v4-pro
+
+node skills/relay-plan/scripts/probe-executor-env.js . \
+  --executor pi \
+  --model opencode-go/deepseek-v4-pro \
+  --json
+```
+
+If the route is allowed, the probe policy decision reports `reason=allowed_model_route`, `model=opencode-go/deepseek-v4-pro`, and then invokes the Pi adapter probe. If `--model` is omitted and no executor default supplies a provider/model route, unmanaged executors fail closed before adapter invocation: JSON output reports `policy_decision.reason=missing_model_route`, `policy_decision.model=null`, and `agent_tools_raw=null`. This is different from an explicit but unapproved route, which reports `unknown_model_route` with the rejected route in `policy_decision.model`.
+
 ## Denial Example
 
 With the company policy above, an external OpenAI route through OpenCode is not allowed:

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -164,7 +164,7 @@ const COMMAND_FLAGS = {
     "--repo", "--contract-file", "--json", "--help",
   ],
   "probe-executor-env": [
-    "--executor", "--timeout", "--project-only", "--json", "--help",
+    "--executor", "--model", "--timeout", "--project-only", "--json", "--help",
   ],
   "recover-state": [
     "--repo", "--run-id", "--manifest", "--to", "--reason", "--force", "--dry-run", "--json", "--help",

--- a/skills/relay-plan/scripts/probe-executor-env.js
+++ b/skills/relay-plan/scripts/probe-executor-env.js
@@ -8,6 +8,7 @@
  *
  * Options:
  *   --executor, -e <name>  Executor to probe (required)
+ *   --model, -m <route>    Provider/model route for unmanaged executor policy
  *   --timeout <seconds>    Probe timeout (default: 30)
  *   --project-only         Skip agent probe, only scan project tools
  *   --json                 Output as JSON (default: human-readable)
@@ -24,6 +25,9 @@ const { getExecutor, listExecutors } = require("../../relay-dispatch/scripts/exe
 const { resolveExecutorDefaultModel } = require("../../relay-dispatch/scripts/executor-model-config");
 const { evaluateRelayPolicyGate, formatRelayPolicyGateMessage } = require("../../relay-dispatch/scripts/relay-policy-gate");
 
+const MANAGED_MODELLESS_EXECUTORS = new Set(["codex", "claude"]);
+const PROBE_POLICY_PHASE = "dispatch";
+
 // ---------------------------------------------------------------------------
 // CLI (only when run directly)
 // ---------------------------------------------------------------------------
@@ -31,7 +35,7 @@ const { evaluateRelayPolicyGate, formatRelayPolicyGateMessage } = require("../..
 function parseCli(argv) {
   const args = argv.slice(2);
   const KNOWN_FLAGS = [
-    "--executor", "-e", "--timeout", "--project-only", "--json", "--help", "-h",
+    "--executor", "-e", "--model", "-m", "--timeout", "--project-only", "--json", "--help", "-h",
   ];
   const cliArgs = bindCliArgs(args, {
     commandName: "probe-executor-env",
@@ -42,6 +46,7 @@ function parseCli(argv) {
     console.log(`Usage: probe-executor-env.js <repo-path> --executor <${listExecutors().join("|")}> [options]`);
     console.log("\nOptions:");
     console.log(`  --executor, -e   ${modeLabel("--executor")} Executor to probe (${listExecutors().join(", ")})`);
+    console.log(`  --model, -m      ${modeLabel("--model")} Provider/model route for unmanaged executors; ignored for codex/claude`);
     console.log(`  --timeout        ${modeLabel("--timeout")} Probe timeout in seconds (default: 30)`);
     console.log(`  --project-only   ${modeLabel("--project-only")} Skip agent probe, only scan project tools`);
     console.log(`  --json           ${modeLabel("--json")} Output as JSON`);
@@ -53,6 +58,7 @@ function parseCli(argv) {
   return {
     repoPath: path.resolve(repoPathRaw || "."),
     executor: cliArgs.getArg(["--executor", "-e"], undefined),
+    model: cliArgs.getArg(["--model", "-m"], undefined),
     timeout: parseInt(cliArgs.getArg("--timeout", "30"), 10),
     projectOnly: cliArgs.hasFlag("--project-only"),
     jsonOut: cliArgs.hasFlag("--json"),
@@ -196,22 +202,32 @@ function probeAgent(executor, timeout) {
   return adapter.probe({ timeout });
 }
 
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function resolveEffectiveProbeModel(executor, model, { relayHome = process.env.RELAY_HOME } = {}) {
+  if (MANAGED_MODELLESS_EXECUTORS.has(executor)) return null;
+  return nonEmptyString(model) || resolveExecutorDefaultModel(executor, { relayHome });
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
-function run({ repoPath, executor, timeout, projectOnly, jsonOut }) {
+function run({ repoPath, executor, model, timeout, projectOnly, jsonOut }) {
   const projectTools = scanProjectTools(repoPath);
 
   let agentProbe = { error: null, raw: null };
   let policyDecision = null;
   if (!projectOnly) {
-    const effectiveProbeModel = ["codex", "claude"].includes(executor)
-      ? null
-      : resolveExecutorDefaultModel(executor, { relayHome: process.env.RELAY_HOME });
+    const effectiveProbeModel = resolveEffectiveProbeModel(executor, model);
+    // The probe checks whether the selected executor route is acceptable for
+    // dispatch. relay-config exposes dispatch/review policy phases, not a
+    // separate operator-facing probe phase.
     policyDecision = evaluateRelayPolicyGate({
       repoRoot: repoPath,
-      phase: "probe",
+      phase: PROBE_POLICY_PHASE,
       executor,
       model: effectiveProbeModel,
     });

--- a/tests/relay-plan/scripts/probe-executor-env.test.js
+++ b/tests/relay-plan/scripts/probe-executor-env.test.js
@@ -312,6 +312,48 @@ test("CLI probes pi when explicit model route is allowed for dispatch policy", (
   assert.equal(output.policy_decision.matched_route, "opencode-go/*");
 });
 
+test("CLI denied pi probe without model route fails closed before adapter probe", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-missing-model-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-missing-model-home-"));
+  writeRelayPolicy(relayHome, {
+    profile: "allow-pi-dispatch-probe-requires-route",
+    allowed_model_routes: [{
+      route: "opencode-go/*",
+      phases: ["dispatch"],
+      executors: ["pi"],
+    }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-missing-model-bin-"));
+  const markerPath = path.join(binDir, "pi-invoked.txt");
+  writeFakePi(binDir, markerPath);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    repoRoot,
+    "--executor", "pi",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: envForRelayHome(relayHome, {
+      PATH: `${binDir}:${process.env.PATH}`,
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(markerPath), false);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.agent_tools_raw, null);
+  assert.match(output.agent_probe_error, /policy disallowed/);
+  assert.match(output.agent_probe_error, /model=\(none\)/);
+  assert.equal(output.policy_decision.allowed, false);
+  assert.equal(output.policy_decision.phase, "dispatch");
+  assert.equal(output.policy_decision.actor_field, "executor");
+  assert.equal(output.policy_decision.executor, "pi");
+  assert.equal(output.policy_decision.model, null);
+  assert.equal(output.policy_decision.reason, "missing_model_route");
+});
+
 test("CLI denied pi probe reports the explicit unknown model route", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-denied-"));
   const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-denied-home-"));

--- a/tests/relay-plan/scripts/probe-executor-env.test.js
+++ b/tests/relay-plan/scripts/probe-executor-env.test.js
@@ -6,8 +6,48 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const { deriveTestInfra, scanProjectTools, probeAgent } = require("../../../skills/relay-plan/scripts/probe-executor-env");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "scripts", "probe-executor-env.js");
+
+function envForRelayHome(relayHome, extra = {}) {
+  const env = {
+    ...process.env,
+    ...extra,
+    RELAY_HOME: relayHome,
+  };
+  if (!Object.prototype.hasOwnProperty.call(extra, "RELAY_POLICY_PATH")) {
+    delete env.RELAY_POLICY_PATH;
+  }
+  return env;
+}
+
+function writeRelayPolicy(relayHome, overrides = {}) {
+  fs.mkdirSync(relayHome, { recursive: true });
+  fs.writeFileSync(path.join(relayHome, "policy.json"), JSON.stringify({
+    ...buildDefaultRelayPolicy(),
+    ...overrides,
+  }, null, 2), "utf-8");
+}
+
+function writeFakePi(binDir, markerPath) {
+  const piPath = path.join(binDir, "pi");
+  fs.writeFileSync(piPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(markerPath)}, args.join(" ") + "\\n", "utf-8");
+if (args[0] === "--version") {
+  process.stdout.write("pi-fake\\n");
+  process.exit(0);
+}
+if (args[0] === "--help") {
+  process.stdout.write("--print --no-session --mode --tools --model --provider --thinking --no-context-files\\n");
+  process.exit(0);
+}
+process.stdout.write("pi-fake\\n");
+`, "utf-8");
+  fs.chmodSync(piPath, 0o755);
+}
 
 // ---------------------------------------------------------------------------
 // scanProjectTools
@@ -219,7 +259,103 @@ test("CLI handles missing executor gracefully", () => {
   assert.equal(output.agent_tools_raw, null);
 });
 
-test("CLI reports policy-disallowed opencode without invoking adapter probe", () => {
+test("CLI help advertises unmanaged executor model route override", () => {
+  const result = spawnSync("node", [SCRIPT, "--help"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--model, -m/);
+  assert.match(result.stdout, /provider\/model/i);
+});
+
+test("CLI probes pi when explicit model route is allowed for dispatch policy", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-allowed-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-policy-home-"));
+  writeRelayPolicy(relayHome, {
+    profile: "allow-pi-dispatch-probe",
+    allowed_model_routes: [{
+      route: "opencode-go/*",
+      phases: ["dispatch"],
+      executors: ["pi"],
+    }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-bin-"));
+  const markerPath = path.join(binDir, "pi-invoked.txt");
+  writeFakePi(binDir, markerPath);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    repoRoot,
+    "-e", "pi",
+    "--model", "opencode-go/deepseek-v4-pro",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: envForRelayHome(relayHome, {
+      PATH: `${binDir}:${process.env.PATH}`,
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(markerPath), true);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.agent_probe_error, null);
+  assert.match(output.agent_tools_raw, /pi-fake/);
+  assert.equal(output.policy_decision.allowed, true);
+  assert.equal(output.policy_decision.phase, "dispatch");
+  assert.equal(output.policy_decision.actor_field, "executor");
+  assert.equal(output.policy_decision.executor, "pi");
+  assert.equal(output.policy_decision.model, "opencode-go/deepseek-v4-pro");
+  assert.equal(output.policy_decision.reason, "allowed_model_route");
+  assert.equal(output.policy_decision.matched_route, "opencode-go/*");
+});
+
+test("CLI denied pi probe reports the explicit unknown model route", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-denied-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-denied-home-"));
+  writeRelayPolicy(relayHome, {
+    profile: "deny-unknown-pi-dispatch-probe",
+    allowed_model_routes: [{
+      route: "openai/*",
+      phases: ["dispatch"],
+      executors: ["pi"],
+    }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-pi-denied-bin-"));
+  const markerPath = path.join(binDir, "pi-invoked.txt");
+  writeFakePi(binDir, markerPath);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    repoRoot,
+    "--executor", "pi",
+    "--model", "opencode-go/unknown",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: envForRelayHome(relayHome, {
+      PATH: `${binDir}:${process.env.PATH}`,
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(markerPath), false);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.agent_tools_raw, null);
+  assert.match(output.agent_probe_error, /policy disallowed/);
+  assert.match(output.agent_probe_error, /model=opencode-go\/unknown/);
+  assert.equal(output.policy_decision.allowed, false);
+  assert.equal(output.policy_decision.phase, "dispatch");
+  assert.equal(output.policy_decision.actor_field, "executor");
+  assert.equal(output.policy_decision.executor, "pi");
+  assert.equal(output.policy_decision.model, "opencode-go/unknown");
+  assert.equal(output.policy_decision.reason, "unknown_model_route");
+});
+
+test("CLI reports policy-disallowed opencode default model without invoking adapter probe", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "probe-policy-denied-"));
   const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "probe-policy-home-"));
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-policy-bin-"));
@@ -235,11 +371,9 @@ process.stdout.write("opencode-fake\\n");
   const result = spawnSync("node", [SCRIPT, repoRoot, "-e", "opencode", "--json"], {
     encoding: "utf-8",
     stdio: "pipe",
-    env: {
-      ...process.env,
+    env: envForRelayHome(relayHome, {
       PATH: `${binDir}:${process.env.PATH}`,
-      RELAY_HOME: relayHome,
-    },
+    }),
   });
 
   assert.equal(result.status, 0, result.stderr);
@@ -248,7 +382,7 @@ process.stdout.write("opencode-fake\\n");
   assert.equal(output.agent_tools_raw, null);
   assert.match(output.agent_probe_error, /policy disallowed/);
   assert.equal(output.policy_decision.allowed, false);
-  assert.equal(output.policy_decision.phase, "probe");
+  assert.equal(output.policy_decision.phase, "dispatch");
   assert.equal(output.policy_decision.actor_field, "executor");
   assert.equal(output.policy_decision.executor, "opencode");
   assert.equal(output.policy_decision.model, "opencode-go/deepseek-v4-pro");


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-587-20260525074456009-8ea3a677
- Branch: issue-587
- Reason: codex completed implementation without committing; auto recovery hit repo-root validation mismatch
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-587-20260525074456009-8ea3a677.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-25T07:53:14.346Z