### PR TITLE
OpenCode advisory reviewer should handle fenced JSON from live CLI output (#591)

### DIFF
--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -1,4 +1,7 @@
-const { parseJsonObject } = require("../../relay-dispatch/scripts/agent-adapters/transport");
+const {
+  formatAdapterPhase,
+  parseJsonObject,
+} = require("../../relay-dispatch/scripts/agent-adapters/transport");
 
 const ADVISORY_PROFILES = Object.freeze(["blindspot"]);
 const ADVISORY_SEVERITIES = new Set(["P1", "P2", "P3"]);
@@ -67,32 +70,53 @@ function validateAdvisoryProfile(profile) {
   return normalized;
 }
 
+function normalizeAdvisoryJsonText(text) {
+  const raw = String(text);
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```[ \t]*json[ \t]*\r?\n([\s\S]*)\r?\n```[ \t]*$/i);
+  return fenced ? fenced[1].trim() : raw;
+}
+
+function rethrowWithContext(error, context) {
+  const message = error?.message || String(error);
+  if (message.startsWith(`${context} `)) {
+    throw error;
+  }
+  throw new Error(`${context} ${message}`);
+}
+
 function parseAdvisoryReview(text, {
   adapter = "advisory",
   phase = "advisory_review",
   profile = "blindspot",
 } = {}) {
   const expectedProfile = validateAdvisoryProfile(profile);
-  const parsed = parseJsonObject(text, {
-    adapter,
-    phase,
-    description: "advisory review",
-  });
-  const actualProfile = requireString(parsed.profile, "profile");
-  if (actualProfile !== expectedProfile) {
-    throw new Error(`profile must be '${expectedProfile}', got '${actualProfile}'`);
+  const context = formatAdapterPhase({ adapter, phase });
+  try {
+    const parsed = parseJsonObject(normalizeAdvisoryJsonText(text), {
+      adapter,
+      phase,
+      description: "advisory review",
+    });
+    const actualProfile = requireString(parsed.profile, "profile");
+    if (actualProfile !== expectedProfile) {
+      throw new Error(`profile must be '${expectedProfile}', got '${actualProfile}'`);
+    }
+    return {
+      profile: actualProfile,
+      summary: requireString(parsed.summary, "summary"),
+      required_findings: normalizeFindingArray(parsed.required_findings, "required_findings"),
+      advisory_findings: normalizeFindingArray(parsed.advisory_findings, "advisory_findings"),
+      duplicate_or_low_confidence: normalizeFindingArray(parsed.duplicate_or_low_confidence, "duplicate_or_low_confidence"),
+    };
+  } catch (error) {
+    rethrowWithContext(error, context);
   }
-  return {
-    profile: actualProfile,
-    summary: requireString(parsed.summary, "summary"),
-    required_findings: normalizeFindingArray(parsed.required_findings, "required_findings"),
-    advisory_findings: normalizeFindingArray(parsed.advisory_findings, "advisory_findings"),
-    duplicate_or_low_confidence: normalizeFindingArray(parsed.duplicate_or_low_confidence, "duplicate_or_low_confidence"),
-  };
 }
 
 module.exports = {
   ADVISORY_PROFILES,
+  normalizeAdvisoryJsonText,
   parseAdvisoryReview,
   validateAdvisoryProfile,
 };

--- a/skills/relay-review/scripts/invoke-reviewer-opencode.js
+++ b/skills/relay-review/scripts/invoke-reviewer-opencode.js
@@ -11,10 +11,10 @@ const {
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 const {
-  parseReviewerJsonObject,
   recoverExecStdout,
   summarizeFailure,
 } = require("./reviewer-helpers");
+const { parseAdvisoryReview } = require("./advisory-review-schema");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
@@ -76,16 +76,17 @@ function main() {
   if (!result) {
     throw new Error("opencode advisory reviewer did not produce a structured result");
   }
-  parseReviewerJsonObject(result, {
+  const parsed = parseAdvisoryReview(result, {
     adapter: "opencode",
     phase: "advisory_review",
-    description: "advisory review",
+    profile: "blindspot",
   });
+  const output = JSON.stringify(parsed);
 
   if (cliArgs.hasFlag("--json")) {
-    console.log(result);
+    console.log(output);
   } else {
-    process.stdout.write(result);
+    process.stdout.write(output);
   }
 }
 

--- a/tests/relay-review/scripts/advisory-review-schema.test.js
+++ b/tests/relay-review/scripts/advisory-review-schema.test.js
@@ -28,6 +28,41 @@ test("advisory schema accepts normalized blindspot payloads", () => {
   assert.equal(parsed.advisory_findings[0].category, "test-gap");
 });
 
+test("advisory schema accepts a single json fenced payload with surrounding whitespace", () => {
+  const text = `\n\n  \`\`\`json\n${JSON.stringify(advisoryPayload())}\n\`\`\`\n\n`;
+
+  const parsed = parseAdvisoryReview(text, {
+    adapter: "opencode",
+    phase: "advisory_review",
+    profile: "blindspot",
+  });
+
+  assert.equal(parsed.profile, "blindspot");
+  assert.equal(parsed.advisory_findings[0].title, "Exercise timeout path");
+});
+
+test("advisory schema fails closed for ambiguous fenced or prose-wrapped output", () => {
+  const payload = JSON.stringify(advisoryPayload());
+  const context = {
+    adapter: "opencode",
+    phase: "advisory_review",
+    profile: "blindspot",
+  };
+
+  for (const text of [
+    `Here is the JSON:\n${payload}`,
+    `\`\`\`json\n${payload}\n\`\`\`\nThanks.`,
+    `\`\`\`json\n${payload}\n\`\`\`\n\n\`\`\`json\n${payload}\n\`\`\``,
+    `\`\`\`json\n${payload}\n${payload}\n\`\`\``,
+    `\`\`\`json\n{"profile":\n\`\`\``,
+  ]) {
+    assert.throws(
+      () => parseAdvisoryReview(text, context),
+      /adapter=opencode phase=advisory_review advisory review must be valid JSON:/
+    );
+  }
+});
+
 test("advisory schema rejects unsupported profiles and invalid confidences", () => {
   assert.throws(() => validateAdvisoryProfile("cost"), /Unknown advisory profile/);
   assert.throws(

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -326,6 +326,36 @@ process.stdout.write(JSON.stringify({
   assert.match(loggedArgs, /Return a passing review\./);
 });
 
+test("opencode adapter accepts live-style json fenced advisory output", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-fenced-"));
+  const fakeOpencode = writeExecutable(fakeDir, "fake-opencode.js", `#!/usr/bin/env node
+process.stdout.write("\`\`\`json\\n" + JSON.stringify({
+  profile: "blindspot",
+  summary: "No blocking blind spots.",
+  required_findings: [],
+  advisory_findings: [],
+  duplicate_or_low_confidence: [],
+}) + "\\n\`\`\`\\n");
+`);
+
+  const stdout = execFileSync("node", [
+    OPENCODE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode },
+  });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.profile, "blindspot");
+  assert.equal(result.summary, "No blocking blind spots.");
+});
+
 test("pi adapter forwards read-only tools, model, and preserves primary review prompt", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-pi-"));


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-591-20260525080441991-9f5625b4
- Branch: issue-591
- Reason: codex completed implementation without committing; auto recovery hit repo-root validation mismatch
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-591-20260525080441991-9f5625b4.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-05-25T08:12:24.636Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * JSON 펜스 블록(```json ... ```) 형식 지원 추가
  * 오류 메시지에 어댑터 및 단계 정보 포함으로 문제 추적 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->