### PR TITLE
Add healthy unmanaged dispatch dogfood canaries (#611)

### DIFF
--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -143,9 +143,14 @@ For repeatable multi-executor dogfood, use the harness:
 
 ```bash
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --json --markdown
+node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --json
 ```
 
 By default the harness creates a temporary `RELAY_HOME`, writes a scoped route policy there, and runs Pi, OpenCode, and Antigravity probes plus bounded live canaries. Antigravity primary review uses a realistic healthy timeout by default, while `--antigravity-fail-safe-timeout` controls the intentionally short fail-safe timeout canary. Use `--dry-run` to print `not-run` planned steps without invoking live CLIs, or `--probe-only` to skip review/dispatch canaries.
+
+Add `--dispatch-canary` from a clean worktree to run healthy dispatch canaries for Pi, OpenCode, and Antigravity. Each canary asks for a unique minimal repository change and passes only when dispatch returns `review_pending` with a PR number. The default healthy dispatch timeout is bounded at 180 seconds via `--dispatch-timeout`, and branches use `--dispatch-branch-prefix` with the default `dogfood-dispatch`.
+
+The harness still keeps a separate Antigravity no-op/fail-safe dispatch canary. That no-op path is successful only when it avoids a reviewable false success; a PR from the no-op path is a failure, not proof of live dispatch health.
 
 Run the dispatch timeout canary only after route policy allows `google/antigravity-cli` for Antigravity dispatch:
 

--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -46,7 +46,7 @@ The healthy-path criteria are exact:
 - Dispatch: minimal repository change to recoverable/reviewable state.
 - Limitation path: documented CLI limitation, recorded as a limitation rather than success.
 
-Use the operator canaries in `docs/relay-operator-guide.md#antigravity-live-canary`. A `failed/escalated` result means relay failed safely or encountered a live CLI limitation; keep the adapter marked experimental. `ready_to_merge` is healthy only when the dispatch canary produced the minimal PR and the Antigravity primary reviewer returned strict verdict JSON inside the configured timeout. The fail-safe timeout canary is not healthy success; it verifies that a bounded timeout does not become a reviewable false positive.
+Use the operator canaries in `docs/relay-operator-guide.md#antigravity-live-canary`, including `live-dogfood.js --dispatch-canary` for controlled healthy dispatch evidence. A `failed/escalated` result means relay failed safely or encountered a live CLI limitation; keep the adapter marked experimental. Healthy dispatch canaries pass only when they produce the minimal PR, and `ready_to_merge` is healthy only after the Antigravity primary reviewer returns strict verdict JSON inside the configured timeout. The Antigravity no-op/fail-safe dispatch canary is separate; a PR from that no-op path is failure, not healthy dispatch success. The fail-safe timeout canary is not healthy success; it verifies that a bounded timeout does not become a reviewable false positive.
 
 ## New Adapter Checklist
 

--- a/skills/relay-dispatch/references/operator-utilities.md
+++ b/skills/relay-dispatch/references/operator-utilities.md
@@ -35,8 +35,13 @@ Use `live-dogfood.js` when you need repeatable evidence for Pi, OpenCode, and An
 
 ```bash
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --json --markdown
+node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --json
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --probe-only --json
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dry-run --markdown
 ```
 
-The harness creates a temporary `RELAY_HOME` by default and writes a scoped route policy there instead of mutating the operator's default `~/.relay/policy.json`. Healthy reviewer canaries use realistic default timeouts, while the Antigravity fail-safe timeout canary has its own intentionally short `--antigravity-fail-safe-timeout` setting. Output separates `pass`, `fail-safe-pass`, `timeout`, `fail`, and `not-run` so fake-bin regressions and live canary evidence are not conflated; the fail-safe timeout canary is not healthy success.
+The harness creates a temporary `RELAY_HOME` by default and writes a scoped route policy there instead of mutating the operator's default `~/.relay/policy.json`. Healthy reviewer canaries use realistic default timeouts, while the Antigravity fail-safe timeout canary has its own intentionally short `--antigravity-fail-safe-timeout` setting.
+
+Use `--dispatch-canary` from a clean worktree for healthy dispatch canaries across Pi, OpenCode, and Antigravity. Those steps request unique minimal repository changes and pass only when dispatch returns `review_pending` with a PR number. `--dispatch-timeout` defaults to 180 seconds, and `--dispatch-branch-prefix` defaults to `dogfood-dispatch`.
+
+The Antigravity no-op/fail-safe dispatch canary remains separate: a no-op PR is failure/false success, not healthy dispatch evidence. Output separates `pass`, `fail-safe-pass`, `timeout`, `fail`, and `not-run` so fake-bin regressions and live canary evidence are not conflated; the fail-safe timeout canary is not healthy success.

--- a/skills/relay-dispatch/scripts/executors/antigravity.js
+++ b/skills/relay-dispatch/scripts/executors/antigravity.js
@@ -7,7 +7,6 @@ const {
 } = require("../agent-adapters/transport");
 
 const PROBE_FLAGS = [
-  "--print",
   "--prompt",
   "--print-timeout",
   "--sandbox",
@@ -69,14 +68,13 @@ function validateExecutionMode({ sandbox, networkAccess }) {
 
 function buildExecCommand({ wtPath, prompt, sandbox, timeoutSeconds }) {
   const cmd = "agy";
-  const args = ["--print", "--print-timeout", formatPrintTimeout(timeoutSeconds)];
+  const args = ["--prompt", prompt, "--print-timeout", formatPrintTimeout(timeoutSeconds)];
   let codexGitCommonDir = null;
   if (sandbox === "workspace-write") {
     args.push("--sandbox");
     codexGitCommonDir = resolveWorktreeCommonGitDir(wtPath);
     args.push("--add-dir", codexGitCommonDir);
   }
-  args.push(prompt);
   return { cmd, args, cwd: wtPath, codexGitCommonDir };
 }
 

--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -23,6 +23,9 @@ const DEFAULTS = Object.freeze({
   antigravityReviewTimeout: "120s",
   antigravityFailSafeReviewTimeout: "5s",
   antigravityDispatchTimeoutSeconds: 45,
+  dispatchCanary: false,
+  dispatchTimeoutSeconds: 180,
+  dispatchBranchPrefix: "dogfood-dispatch",
 });
 
 function parseArgs(argv) {
@@ -42,6 +45,9 @@ function parseArgs(argv) {
     antigravityReviewTimeout: DEFAULTS.antigravityReviewTimeout,
     antigravityFailSafeReviewTimeout: DEFAULTS.antigravityFailSafeReviewTimeout,
     antigravityDispatchTimeoutSeconds: DEFAULTS.antigravityDispatchTimeoutSeconds,
+    dispatchCanary: DEFAULTS.dispatchCanary,
+    dispatchTimeoutSeconds: DEFAULTS.dispatchTimeoutSeconds,
+    dispatchBranchPrefix: DEFAULTS.dispatchBranchPrefix,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -55,6 +61,7 @@ function parseArgs(argv) {
     else if (arg === "--relay-home") parsed.relayHome = next();
     else if (arg === "--keep-relay-home") parsed.keepRelayHome = true;
     else if (arg === "--probe-only") parsed.probeOnly = true;
+    else if (arg === "--dispatch-canary") parsed.dispatchCanary = true;
     else if (arg === "--dry-run") parsed.dryRun = true;
     else if (arg === "--json") parsed.json = true;
     else if (arg === "--markdown") parsed.markdown = true;
@@ -66,6 +73,8 @@ function parseArgs(argv) {
     else if (arg === "--antigravity-review-timeout") parsed.antigravityReviewTimeout = next();
     else if (arg === "--antigravity-fail-safe-timeout") parsed.antigravityFailSafeReviewTimeout = next();
     else if (arg === "--antigravity-dispatch-timeout") parsed.antigravityDispatchTimeoutSeconds = Number(next());
+    else if (arg === "--dispatch-timeout") parsed.dispatchTimeoutSeconds = Number(next());
+    else if (arg === "--dispatch-branch-prefix") parsed.dispatchBranchPrefix = next();
     else if (arg === "--help" || arg === "-h") parsed.help = true;
     else throw new Error(`unknown argument: ${arg}`);
   }
@@ -75,6 +84,12 @@ function parseArgs(argv) {
   }
   if (!Number.isSafeInteger(parsed.antigravityDispatchTimeoutSeconds) || parsed.antigravityDispatchTimeoutSeconds <= 0) {
     throw new Error("--antigravity-dispatch-timeout must be a positive integer");
+  }
+  if (!Number.isSafeInteger(parsed.dispatchTimeoutSeconds) || parsed.dispatchTimeoutSeconds <= 0) {
+    throw new Error("--dispatch-timeout must be a positive integer");
+  }
+  if (!String(parsed.dispatchBranchPrefix || "").trim()) {
+    throw new Error("--dispatch-branch-prefix must be a non-empty string");
   }
   return parsed;
 }
@@ -133,12 +148,12 @@ function ensureRelayHome(relayHome, options = {}) {
   return resolved;
 }
 
-function writePromptFiles(relayHome) {
+function writePromptFiles(relayHome, options = {}) {
   const promptDir = path.join(relayHome, "dogfood-prompts");
   fs.mkdirSync(promptDir, { recursive: true });
   const advisoryPrompt = path.join(promptDir, "advisory-prompt.md");
   const primaryPrompt = path.join(promptDir, "primary-prompt.md");
-  const rubric = path.join(promptDir, "antigravity-dispatch-rubric.yaml");
+  const rubric = path.join(promptDir, "antigravity-dispatch-noop-rubric.yaml");
   fs.writeFileSync(advisoryPrompt, [
     "Return exactly one advisory JSON object for a relay live dogfood canary.",
     "The object must contain profile, summary, required_findings, advisory_findings, and duplicate_or_low_confidence.",
@@ -154,11 +169,35 @@ function writePromptFiles(relayHome) {
     "  - name: live_dogfood_noop",
     "    target: 3",
     "    criteria:",
-    "      3: Live dogfood canary returns a safe no-op classification.",
-    "      0: Live dogfood canary incorrectly creates reviewable output.",
+    "      3: Live dogfood no-op canary returns a safe no-op or failed/escalated classification without a PR.",
+    "      0: Live dogfood no-op canary incorrectly creates reviewable output or a PR.",
     "",
   ].join("\n"), "utf-8");
-  return { advisoryPrompt, primaryPrompt, rubric };
+
+  const dispatchStamp = String(options.dispatchStamp || Date.now());
+  const dispatchCanaries = {};
+  for (const executor of ["pi", "opencode", "antigravity"]) {
+    const canaryFile = `relay-live-dogfood-${executor}-${dispatchStamp}.txt`;
+    const canaryLine = `relay live dogfood dispatch canary ${executor} ${dispatchStamp}`;
+    const promptFile = path.join(promptDir, `${executor}-dispatch-canary-prompt.md`);
+    const rubricFile = path.join(promptDir, `${executor}-dispatch-canary-rubric.yaml`);
+    fs.writeFileSync(promptFile, [
+      `Create or update ${canaryFile} with exactly one line:`,
+      canaryLine,
+      "Commit that file and do not change anything else.",
+      "",
+    ].join("\n"), "utf-8");
+    fs.writeFileSync(rubricFile, [
+      "criteria:",
+      "  - id: minimal-intentional-change",
+      `    description: Creates or updates only ${canaryFile} with the requested single line.`,
+      "    weight: 1",
+      "",
+    ].join("\n"), "utf-8");
+    dispatchCanaries[executor] = { promptFile, rubricFile, canaryFile, canaryLine };
+  }
+
+  return { advisoryPrompt, primaryPrompt, rubric, dispatchCanaries, dispatchStamp };
 }
 
 function plannedStep(name, command, notes = "") {
@@ -174,6 +213,29 @@ function spawnCommand({ spawnImpl, cwd, env, command, args, timeoutMs }) {
     timeout: timeoutMs,
     maxBuffer: 10 * 1024 * 1024,
   });
+}
+
+function assertCleanDispatchCanaryRepo(repo, spawnImpl = spawnSync) {
+  const result = spawnImpl("git", ["status", "--porcelain"], {
+    cwd: repo,
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: 30_000,
+  });
+  if (result.error) {
+    throw new Error(`--dispatch-canary requires git status to succeed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const details = summarizeOutput(result) || `git status exited ${result.status}`;
+    throw new Error(`--dispatch-canary requires git status to succeed: ${details}`);
+  }
+  const dirty = String(result.stdout || "").trim();
+  if (dirty) {
+    throw new Error(
+      "--dispatch-canary requires a clean worktree because live dispatch canaries create branches, commits, and PRs. " +
+      `Current dirty status:\n${dirty}`
+    );
+  }
 }
 
 function parseJson(text) {
@@ -235,23 +297,68 @@ function classifyAntigravityFailSafeTimeout(result) {
   return standard;
 }
 
-function classifyAntigravityDispatch(result) {
+function hasPrNumber(parsed) {
+  return parsed?.prNumber !== null && typeof parsed?.prNumber !== "undefined";
+}
+
+function classifyHealthyDispatch(result) {
   if (result.error?.code === "ETIMEDOUT") return { outcome: OUTCOMES.TIMEOUT, notes: "harness command timeout" };
   const parsed = parseJson(result.stdout);
   if (!parsed) return { outcome: OUTCOMES.FAIL, notes: summarizeOutput(result) || "dispatch did not return JSON" };
-  if (result.status === 0 && parsed.runState === "review_pending" && parsed.prNumber) {
+  if (result.status === 0 && parsed.runState === "review_pending" && hasPrNumber(parsed)) {
     return { outcome: OUTCOMES.PASS, parsed, notes: "dispatch produced reviewable PR" };
   }
-  if (parsed.runState === "escalated" && parsed.status === "failed" && parsed.prNumber === null) {
-    return { outcome: OUTCOMES.FAIL_SAFE_PASS, parsed, notes: parsed.error || "dispatch failed safely without PR" };
+  const notes = parsed.error || summarizeOutput(result) || `unexpected dispatch state ${parsed.runState || "(unknown)"}`;
+  if (/timed out|timeout/i.test(notes)) return { outcome: OUTCOMES.TIMEOUT, parsed, notes };
+  return { outcome: OUTCOMES.FAIL, parsed, notes };
+}
+
+function classifyAntigravityNoOpDispatch(result) {
+  if (result.error?.code === "ETIMEDOUT") return { outcome: OUTCOMES.TIMEOUT, notes: "harness command timeout" };
+  const parsed = parseJson(result.stdout);
+  if (!parsed) return { outcome: OUTCOMES.FAIL, notes: summarizeOutput(result) || "dispatch did not return JSON" };
+  if (hasPrNumber(parsed)) {
+    return {
+      outcome: OUTCOMES.FAIL,
+      parsed,
+      notes: "no-op fail-safe canary produced a PR; treating as false success",
+    };
   }
-  return { outcome: OUTCOMES.FAIL, parsed, notes: parsed.error || `unexpected dispatch state ${parsed.runState || "(unknown)"}` };
+  if (parsed.status === "completed-no-op") {
+    return { outcome: OUTCOMES.FAIL_SAFE_PASS, parsed, notes: "no-op canary produced no PR" };
+  }
+  if (parsed.runState === "escalated" && parsed.status === "failed" && parsed.prNumber === null) {
+    const notes = parsed.error || "dispatch failed safely without PR";
+    if (/timed out|timeout|no reviewable repository changes|runtime metadata|silent failure|blocked on approval/i.test(notes)) {
+      return { outcome: OUTCOMES.FAIL_SAFE_PASS, parsed, notes };
+    }
+  }
+  return { outcome: OUTCOMES.FAIL, parsed, notes: parsed.error || `unexpected no-op dispatch state ${parsed.runState || "(unknown)"}` };
+}
+
+function classifyAntigravityDispatch(result) {
+  return classifyHealthyDispatch(result);
+}
+
+function buildDispatchCommand({ node, repo, branch, executor, model, promptFile, rubricFile, timeoutSeconds }) {
+  return [
+    node,
+    "skills/relay-dispatch/scripts/dispatch.js",
+    repo,
+    "-b", branch,
+    "--prompt-file", promptFile,
+    "--executor", executor,
+    "--model", model,
+    "--rubric-file", rubricFile,
+    "--timeout", String(timeoutSeconds),
+    "--json",
+  ];
 }
 
 function buildSteps({ repo, relayHome, prompts, options }) {
   const node = process.execPath;
   const dispatchBranch = `dogfood-antigravity-${Date.now()}`;
-  return [
+  const steps = [
     {
       name: "probe-pi",
       command: [node, "skills/relay-plan/scripts/probe-executor-env.js", repo, "--executor", "pi", "--model", options.piModel, "--json"],
@@ -291,22 +398,49 @@ function buildSteps({ repo, relayHome, prompts, options }) {
       classify: classifyAntigravityFailSafeTimeout,
     },
     {
-      name: "antigravity-dispatch",
+      name: "antigravity-dispatch-fail-safe-noop",
       command: [
         node,
         "skills/relay-dispatch/scripts/dispatch.js",
         repo,
         "-b", dispatchBranch,
-        "--prompt", "Live dogfood canary: do not modify repository files unless explicitly testing minimal dispatch output.",
+        "--prompt", "Live dogfood fail-safe no-op canary: do not modify repository files, do not commit, and do not create a PR-ready change.",
         "--executor", "antigravity",
         "--model", options.antigravityModel,
         "--rubric-file", prompts.rubric,
         "--timeout", String(options.antigravityDispatchTimeoutSeconds),
         "--json",
       ],
-      classify: classifyAntigravityDispatch,
+      classify: classifyAntigravityNoOpDispatch,
     },
-  ].filter((step) => !options.probeOnly || step.name.startsWith("probe-"))
+  ];
+
+  if (options.dispatchCanary) {
+    for (const executor of ["pi", "opencode", "antigravity"]) {
+      const model = executor === "pi"
+        ? options.piModel
+        : executor === "opencode"
+          ? options.opencodeModel
+          : options.antigravityModel;
+      const canary = prompts.dispatchCanaries[executor];
+      steps.push({
+        name: `${executor}-dispatch-canary`,
+        command: buildDispatchCommand({
+          node,
+          repo,
+          branch: `${options.dispatchBranchPrefix}-${executor}-${prompts.dispatchStamp}`,
+          executor,
+          model,
+          promptFile: canary.promptFile,
+          rubricFile: canary.rubricFile,
+          timeoutSeconds: options.dispatchTimeoutSeconds,
+        }),
+        classify: classifyHealthyDispatch,
+      });
+    }
+  }
+
+  return steps.filter((step) => !options.probeOnly || step.name.startsWith("probe-"))
     .map((step) => ({ ...step, relayHome }));
 }
 
@@ -314,8 +448,11 @@ function runDogfood(options = {}, deps = {}) {
   const spawnImpl = deps.spawnSync || spawnSync;
   const repo = path.resolve(options.repo || ".");
   const effectiveOptions = { ...DEFAULTS, ...options };
+  if (effectiveOptions.dispatchCanary && !effectiveOptions.dryRun) {
+    assertCleanDispatchCanaryRepo(repo, spawnImpl);
+  }
   const relayHome = ensureRelayHome(options.relayHome, effectiveOptions);
-  const prompts = writePromptFiles(relayHome);
+  const prompts = writePromptFiles(relayHome, effectiveOptions);
   const envBase = {
     ...process.env,
     RELAY_HOME: relayHome,
@@ -381,6 +518,7 @@ function printHelp() {
   console.log("  --repo <path>                         Repository root (default: .)");
   console.log("  --relay-home <path>                   Use an explicit RELAY_HOME instead of a temp directory");
   console.log("  --probe-only                          Run only Pi/OpenCode/Antigravity probes");
+  console.log("  --dispatch-canary                     Add healthy Pi/OpenCode/Antigravity dispatch canaries that must produce review_pending PRs");
   console.log("  --dry-run                             Print planned steps without invoking live CLIs");
   console.log("  --json                                Emit structured JSON");
   console.log("  --markdown                            Emit GitHub-comment-ready Markdown");
@@ -390,7 +528,9 @@ function printHelp() {
   console.log("  --pi-review-timeout <duration>        RELAY_PI_REVIEW_TIMEOUT for the Pi canary (default: 120s)");
   console.log("  --antigravity-review-timeout <duration>  RELAY_ANTIGRAVITY_REVIEW_TIMEOUT for the healthy Antigravity review canary (default: 120s)");
   console.log("  --antigravity-fail-safe-timeout <duration>  RELAY_ANTIGRAVITY_REVIEW_TIMEOUT for the intentional fail-safe timeout canary (default: 5s)");
-  console.log("  --antigravity-dispatch-timeout <sec>  Dispatch timeout seconds (default: 45)");
+  console.log("  --antigravity-dispatch-timeout <sec>  Antigravity no-op/fail-safe dispatch timeout seconds (default: 45)");
+  console.log("  --dispatch-timeout <sec>              Healthy dispatch canary timeout seconds (default: 180)");
+  console.log("  --dispatch-branch-prefix <prefix>     Healthy dispatch canary branch prefix (default: dogfood-dispatch)");
   console.log("  --command-timeout-ms <ms>             Harness per-command timeout (default: 300000)");
 }
 
@@ -424,7 +564,9 @@ module.exports = {
   buildAllowedModelRoutes,
   classifyAntigravityDispatch,
   classifyAntigravityFailSafeTimeout,
+  classifyAntigravityNoOpDispatch,
   classifyAntigravityPrimary,
+  classifyHealthyDispatch,
   classifyProbeJson,
   classifyStandardJson,
   ensureRelayHome,

--- a/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
@@ -58,7 +58,7 @@ test("policy audit keeps OpenCode sandbox and network informational", () => {
   assert.deepEqual(audit.fail_closed_reasons, []);
 });
 
-test("policy audit fails closed for OpenCode primary review because it is advisory-only", () => {
+test("policy audit records OpenCode primary review prompt-only read-only guards", () => {
   const audit = buildAgentPolicyAudit({
     descriptor: getAgentAdapterDescriptor("opencode"),
     phase: ADAPTER_PHASES.PRIMARY_REVIEW,
@@ -69,16 +69,18 @@ test("policy audit fails closed for OpenCode primary review because it is adviso
     },
   });
 
-  assert.equal(audit.safe, false);
-  assert.equal(audit.sandbox.enforcement_level, "unsupported");
-  assert.equal(audit.network.enforcement_level, "unsupported");
-  assert.equal(audit.read_only.enforcement_level, "unsupported");
-  assert.match(audit.fail_closed_reasons.join("\n"), /--advisory-reviewer opencode/i);
-  assert.match(audit.fail_closed_reasons.join("\n"), /--reviewer opencode/i);
-  assert.throws(
-    () => assertPolicyRepresentable(audit),
-    /OpenCode primary review is not implemented/
-  );
+  assert.equal(audit.safe, true);
+  assert.equal(audit.sandbox.enforcement_level, "informational");
+  assert.equal(audit.network.enforcement_level, "informational");
+  assert.equal(audit.read_only.enforcement_level, "prompt-only");
+  assert.deepEqual(audit.read_only.flags, [
+    "prompt:do-not-modify-files",
+    "git-status-before-after",
+  ]);
+  assert.match(audit.warnings.join("\n"), /post-run worktree mutation/i);
+  assert.match(audit.warnings.join("\n"), /does not gate network access/i);
+  assert.deepEqual(audit.fail_closed_reasons, []);
+  assert.doesNotThrow(() => assertPolicyRepresentable(audit));
 });
 
 test("policy audit records Pi primary review read-only tool allowlist metadata", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -273,7 +273,7 @@ const fs = require("fs");
 const { execFileSync } = require("child_process");
 const args = process.argv.slice(2);
 if (args[0] === "--version") { process.stdout.write("agy 1.0.2\\n"); process.exit(0); }
-if (!args.includes("--print")) { process.stderr.write("unsupported fake agy invocation"); process.exit(1); }
+if (args[0] !== "--prompt") { process.stderr.write("unsupported fake agy invocation"); process.exit(1); }
 fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(args), "utf-8");
 const cwd = process.cwd();
 const fileName = "captured-antigravity.txt";
@@ -425,7 +425,7 @@ if (args[0] === "--version") {
   process.stdout.write("agy 1.0.2\\n");
   process.exit(0);
 }
-if (!args.includes("--print")) {
+if (args[0] !== "--prompt") {
   process.stderr.write("unsupported fake agy invocation");
   process.exit(1);
 }
@@ -448,7 +448,7 @@ if (args[0] === "--version") {
   process.stdout.write("agy 1.0.2\\n");
   process.exit(0);
 }
-if (!args.includes("--print")) {
+if (args[0] !== "--prompt") {
   process.stderr.write("unsupported fake agy invocation");
   process.exit(1);
 }
@@ -2708,13 +2708,11 @@ test("dispatch with --executor antigravity invokes agy and copies stdout into th
   assert.equal(fs.readFileSync(result.resultFile, "utf-8"), "antigravity completed\n");
   const capturedArgs = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
   assert.deepEqual(capturedArgs.slice(0, 5), [
-    "--print",
+    "--prompt", buildDispatchExecPrompt(taskPrompt),
     "--print-timeout", "31s",
     "--sandbox",
-    "--add-dir",
   ]);
-  assert.equal(capturedArgs[5], worktreeCommonGitDir(result.worktree));
-  assert.equal(capturedArgs[6], buildDispatchExecPrompt(taskPrompt));
+  assert.deepEqual(capturedArgs.slice(5, 7), ["--add-dir", worktreeCommonGitDir(result.worktree)]);
 
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.dispatch.last_executor, "antigravity");

--- a/tests/relay-dispatch/scripts/docs-defaults.test.js
+++ b/tests/relay-dispatch/scripts/docs-defaults.test.js
@@ -206,8 +206,12 @@ test("operator docs publish the live dogfood harness and outcome meanings", () =
   ].join("\n");
 
   assert.match(docs, /live-dogfood\.js --repo \. --json --markdown/);
+  assert.match(docs, /live-dogfood\.js --repo \. --dispatch-canary --json/);
   assert.match(docs, /temporary `RELAY_HOME`/);
   assert.match(docs, /scoped route policy/);
+  assert.match(docs, /healthy dispatch canar(?:y|ies)[^.\n]*Pi[^.\n]*OpenCode[^.\n]*Antigravity/i);
+  assert.match(docs, /clean worktree/i);
+  assert.match(docs, /no-op[^.\n]*PR[^.\n]*(?:fail|failure|false success)/i);
   assert.match(docs, /fail-safe timeout canary[^.\n]*(?:not|never)[^.\n]*healthy/i);
   for (const outcome of ["pass", "fail-safe-pass", "timeout", "fail", "not-run"]) {
     assert.match(docs, new RegExp(`\`${outcome}\``));

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -137,7 +137,7 @@ test("pi buildExecCommand: model passthrough via --model", () => {
   assert.deepEqual(r.args, ["--no-session", "--model", "openai/gpt-5", "--thinking", "high", "--print", "P"]);
 });
 
-test("antigravity buildExecCommand: explicit print argv, timeout, sandbox, and git common dir", () => {
+test("antigravity buildExecCommand: prompt argv, timeout, sandbox, and git common dir", () => {
   const antigravity = getExecutor("antigravity");
   const r = antigravity.buildExecCommand({
     wtPath: WT,
@@ -151,11 +151,10 @@ test("antigravity buildExecCommand: explicit print argv, timeout, sandbox, and g
   });
   assert.equal(r.cmd, "agy");
   assert.deepEqual(r.args, [
-    "--print",
+    "--prompt", "P",
     "--print-timeout", "123s",
     "--sandbox",
     "--add-dir", COMMON_DIR,
-    "P",
   ]);
   assert.equal(r.cwd, WT);
   assert.equal(r.codexGitCommonDir, COMMON_DIR);
@@ -326,7 +325,6 @@ esac
     assert.equal(parsed.version, "agy 1.0.2");
     assert.equal(parsed.cli_path, fakeAgy);
     assert.deepEqual(parsed.supported_flags, [
-      "--print",
       "--prompt",
       "--print-timeout",
       "--sandbox",

--- a/tests/relay-dispatch/scripts/live-dogfood.test.js
+++ b/tests/relay-dispatch/scripts/live-dogfood.test.js
@@ -10,7 +10,9 @@ const {
   buildPolicy,
   classifyAntigravityDispatch,
   classifyAntigravityFailSafeTimeout,
+  classifyAntigravityNoOpDispatch,
   classifyAntigravityPrimary,
+  classifyHealthyDispatch,
   classifyProbeJson,
   parseArgs,
   renderMarkdown,
@@ -67,7 +69,7 @@ test("live dogfood classifies mocked command outcomes and preserves markdown dis
     jsonResult({ verdict: "pass", summary: "Pi ok." }),
     jsonResult({ verdict: "pass", summary: "Antigravity ok." }),
     { status: 1, stdout: "", stderr: "Antigravity reviewer primary_review timed out after 2s (RELAY_ANTIGRAVITY_REVIEW_TIMEOUT)." },
-    jsonResult({ status: "failed", runState: "escalated", prNumber: null, error: "executor timed out after 45s" }, 1),
+    jsonResult({ status: "completed-no-op", runState: "review_pending", prNumber: null }),
   ];
   const calls = [];
   const previousPolicyPath = process.env.RELAY_POLICY_PATH;
@@ -101,7 +103,7 @@ test("live dogfood classifies mocked command outcomes and preserves markdown dis
     "pi-primary",
     "antigravity-primary",
     "antigravity-primary-fail-safe-timeout",
-    "antigravity-dispatch",
+    "antigravity-dispatch-fail-safe-noop",
   ]);
   assert.equal(calls[0].env.RELAY_HOME, relayHome);
   assert.equal(calls[0].env.RELAY_POLICY_PATH, path.join(relayHome, "policy.json"));
@@ -126,21 +128,114 @@ test("live dogfood classifies mocked command outcomes and preserves markdown dis
   assert.match(markdown, /not healthy success/);
   assert.match(markdown, /\| `antigravity-primary` \| `pass` \|/);
   assert.match(markdown, /\| `antigravity-primary-fail-safe-timeout` \| `fail-safe-pass` \|/);
-  assert.match(markdown, /\| `antigravity-dispatch` \| `fail-safe-pass` \|/);
+  assert.match(markdown, /\| `antigravity-dispatch-fail-safe-noop` \| `fail-safe-pass` \|/);
 });
 
-test("live dogfood defaults use realistic healthy reviewer timeouts and a separate fail-safe timeout", () => {
+test("live dogfood dispatch canary adds healthy Pi, OpenCode, and Antigravity dispatch steps", () => {
+  const repo = tempDir("relay-live-dogfood-repo-");
+  const relayHome = tempDir("relay-live-dogfood-home-");
+  const responses = [
+    { status: 0, stdout: "", stderr: "" },
+    jsonResult({ policy_decision: { allowed: true }, agent_tools_raw: "{\"version\":\"pi\"}" }),
+    jsonResult({ policy_decision: { allowed: true }, agent_tools_raw: "{\"version\":\"opencode\"}" }),
+    jsonResult({ policy_decision: { allowed: true }, agent_tools_raw: "{\"version\":\"agy\"}" }),
+    jsonResult({ profile: "blindspot", advisory_findings: [] }),
+    jsonResult({ verdict: "pass", summary: "Pi ok." }),
+    jsonResult({ verdict: "pass", summary: "Antigravity ok." }),
+    { status: 1, stdout: "", stderr: "Antigravity reviewer primary_review timed out after 2s (RELAY_ANTIGRAVITY_REVIEW_TIMEOUT)." },
+    jsonResult({ status: "completed-no-op", runState: "review_pending", prNumber: null }),
+    jsonResult({ status: "completed", runState: "review_pending", prNumber: 601 }),
+    jsonResult({ status: "completed", runState: "review_pending", prNumber: 602 }),
+    jsonResult({ status: "completed", runState: "review_pending", prNumber: 603 }),
+  ];
+  const calls = [];
+
+  const result = runDogfood({
+    repo,
+    relayHome,
+    dispatchCanary: true,
+    dispatchTimeoutSeconds: 222,
+    dispatchBranchPrefix: "healthy-dogfood",
+    commandTimeoutMs: 1000,
+  }, {
+    spawnSync: (command, args, options) => {
+      calls.push({ command, args, env: options.env });
+      return responses.shift();
+    },
+  });
+
+  assert.equal(calls.length, 12);
+  assert.equal(calls[0].command, "git");
+  assert.deepEqual(calls[0].args, ["status", "--porcelain"]);
+  assert.deepEqual(result.outcomes.map((step) => step.name), [
+    "probe-pi",
+    "probe-opencode",
+    "probe-antigravity",
+    "opencode-advisory",
+    "pi-primary",
+    "antigravity-primary",
+    "antigravity-primary-fail-safe-timeout",
+    "antigravity-dispatch-fail-safe-noop",
+    "pi-dispatch-canary",
+    "opencode-dispatch-canary",
+    "antigravity-dispatch-canary",
+  ]);
+  assert.deepEqual(result.outcomes.slice(8).map((step) => step.outcome), [
+    OUTCOMES.PASS,
+    OUTCOMES.PASS,
+    OUTCOMES.PASS,
+  ]);
+  assert.equal(calls[9].args[calls[9].args.indexOf("--executor") + 1], "pi");
+  assert.equal(calls[10].args[calls[10].args.indexOf("--executor") + 1], "opencode");
+  assert.equal(calls[11].args[calls[11].args.indexOf("--executor") + 1], "antigravity");
+  for (const call of calls.slice(9)) {
+    assert.match(call.args[call.args.indexOf("-b") + 1], /^healthy-dogfood-(pi|opencode|antigravity)-\d+$/);
+    assert.equal(call.args[call.args.indexOf("--timeout") + 1], "222");
+    assert.ok(call.args.includes("--prompt-file"));
+    assert.ok(call.args.includes("--rubric-file"));
+  }
+});
+
+test("live dogfood dispatch canary refuses dirty repositories before creating live branches", () => {
+  const repo = tempDir("relay-live-dogfood-repo-");
+  const calls = [];
+
+  assert.throws(() => runDogfood({
+    repo,
+    dispatchCanary: true,
+  }, {
+    spawnSync: (command, args) => {
+      calls.push({ command, args });
+      return { status: 0, stdout: " M docs/relay-operator-guide.md\n", stderr: "" };
+    },
+  }), /--dispatch-canary requires a clean worktree/);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "git");
+  assert.deepEqual(calls[0].args, ["status", "--porcelain"]);
+});
+
+test("live dogfood defaults use realistic healthy reviewer timeouts and bounded dispatch canary settings", () => {
   const defaults = parseArgs([]);
 
   assert.equal(defaults.commandTimeoutMs, 300_000);
   assert.equal(defaults.piReviewTimeout, "120s");
   assert.equal(defaults.antigravityReviewTimeout, "120s");
   assert.equal(defaults.antigravityFailSafeReviewTimeout, "5s");
+  assert.equal(defaults.dispatchCanary, false);
+  assert.equal(defaults.dispatchTimeoutSeconds, 180);
+  assert.equal(defaults.dispatchBranchPrefix, "dogfood-dispatch");
 
   const parsed = parseArgs([
+    "--dispatch-canary",
+    "--dispatch-timeout", "240",
+    "--dispatch-branch-prefix", "relay-healthy",
     "--antigravity-review-timeout", "180s",
     "--antigravity-fail-safe-timeout", "3s",
   ]);
+  assert.equal(parsed.dispatchCanary, true);
+  assert.equal(parsed.dispatchTimeoutSeconds, 240);
+  assert.equal(parsed.dispatchBranchPrefix, "relay-healthy");
   assert.equal(parsed.antigravityReviewTimeout, "180s");
   assert.equal(parsed.antigravityFailSafeReviewTimeout, "3s");
 });
@@ -213,12 +308,31 @@ test("classification helpers separate harness timeout from safe adapter timeout"
     stderr: "Antigravity reviewer primary_review timed out after 5s (RELAY_ANTIGRAVITY_REVIEW_TIMEOUT).",
   }).outcome, OUTCOMES.FAIL_SAFE_PASS);
   assert.equal(classifyAntigravityFailSafeTimeout(jsonResult({ verdict: "pass" })).outcome, OUTCOMES.FAIL);
-  assert.equal(classifyAntigravityDispatch(jsonResult({
+  assert.equal(classifyAntigravityNoOpDispatch(jsonResult({
     status: "failed",
     runState: "escalated",
     prNumber: null,
     error: "executor produced no reviewable repository changes",
   }, 1)).outcome, OUTCOMES.FAIL_SAFE_PASS);
+  assert.equal(classifyAntigravityNoOpDispatch(jsonResult({
+    status: "completed-no-op",
+    runState: "review_pending",
+    prNumber: null,
+  })).outcome, OUTCOMES.FAIL_SAFE_PASS);
+  assert.equal(classifyAntigravityNoOpDispatch(jsonResult({
+    runState: "review_pending",
+    prNumber: 123,
+  })).outcome, OUTCOMES.FAIL);
+  assert.equal(classifyHealthyDispatch(jsonResult({
+    runState: "review_pending",
+    prNumber: 123,
+  })).outcome, OUTCOMES.PASS);
+  assert.equal(classifyHealthyDispatch(jsonResult({
+    status: "failed",
+    runState: "escalated",
+    prNumber: null,
+    error: "executor timed out after 180s",
+  }, 1)).outcome, OUTCOMES.TIMEOUT);
   assert.equal(classifyAntigravityDispatch(jsonResult({
     runState: "review_pending",
     prNumber: 123,


### PR DESCRIPTION
## Summary
- switch Antigravity dispatch to the live-working `agy --prompt <prompt> --print-timeout <duration> --sandbox` invocation
- add `live-dogfood.js --dispatch-canary` for controlled Pi/OpenCode/Antigravity healthy dispatch canaries
- split Antigravity no-op/fail-safe dispatch classification so a no-op PR is treated as failure, not healthy success
- require a clean worktree before live dispatch canaries create branches/commits/PRs

## Verification
- `node --test tests/relay-dispatch/scripts/agent-adapter-policy.test.js tests/relay-dispatch/scripts/executors.test.js`
- `node --test tests/relay-dispatch/scripts/live-dogfood.test.js tests/relay-dispatch/scripts/docs-defaults.test.js`
- `node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --dry-run --json`
- `node --test tests/relay-dispatch/scripts/*.test.js`
- `git diff --check`

## Live dogfood
Temporary `RELAY_HOME` run on the implementation worktree exposed why the new clean-worktree guard is necessary: probes passed, Antigravity primary review passed, fail-safe timeout/no-op passed, Pi produced a commit but PR creation failed from a non-default implementation branch, OpenCode reported worktree dirt instead of a reviewable PR, and Antigravity wrote to its scratch repo rather than the relay worktree. The generated dogfood branch/worktree artifacts were cleaned up and the Pi remote dogfood branch was deleted. This is recorded as live blocker evidence, not healthy success.

Closes #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 디스패치 헬스 체크를 위한 `--dispatch-canary` 옵션 추가
  * 디스패치 타임아웃 및 브랜치 접두사 커스터마이징 옵션 추가

* **Bug Fixes**
  * OpenCode 정책 검증 로직 개선 (읽기 전용 가드 처리)

* **Documentation**
  * 디스패치 캐너리 사용 설명서 추가
  * Antigravity 라이브 지원 상태 문서 업데이트
  * 도그푸드 유틸리티 사용 예제 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->