### PR TITLE
Table-drive live adapter dogfood scenarios

### DIFF
--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -634,6 +634,33 @@ function buildSteps({ repo, relayHome, prompts, options }) {
     });
 }
 
+function scenarioMetadata(scenario) {
+  return {
+    name: scenario.name,
+    adapter: scenario.adapter,
+    phase: scenario.phase,
+    category: scenario.category,
+    defaultEnabled: scenario.defaultEnabled === true,
+    requiresDispatchCanary: scenario.requiresDispatchCanary === true,
+    healthyPromotion: scenario.healthyPromotion === true,
+  };
+}
+
+function readinessExemptionMetadata(exemption) {
+  return {
+    adapter: exemption.adapter,
+    phase: exemption.phase,
+    reason: exemption.reason,
+  };
+}
+
+function buildCoverageMetadata() {
+  return {
+    scenarios: LIVE_DOGFOOD_SCENARIOS.map(scenarioMetadata),
+    readiness_exemptions: LIVE_DOGFOOD_READINESS_EXEMPTIONS.map(readinessExemptionMetadata),
+  };
+}
+
 function runDogfood(options = {}, deps = {}) {
   const spawnImpl = deps.spawnSync || spawnSync;
   const repo = path.resolve(options.repo || ".");
@@ -672,13 +699,17 @@ function runDogfood(options = {}, deps = {}) {
     };
   });
 
-  return {
+  const result = {
     schema_version: 1,
     relay_home: relayHome,
     repo,
     temp_relay_home: !options.relayHome,
     outcomes: results,
   };
+  if (effectiveOptions.dryRun) {
+    result.coverage = buildCoverageMetadata();
+  }
+  return result;
 }
 
 function renderMarkdown(result) {

--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -28,6 +28,153 @@ const DEFAULTS = Object.freeze({
   dispatchBranchPrefix: "dogfood-dispatch",
 });
 
+const MODEL_OPTION_BY_ADAPTER = Object.freeze({
+  pi: "piModel",
+  opencode: "opencodeModel",
+  antigravity: "antigravityModel",
+});
+
+const REVIEWER_SCRIPT_BY_ADAPTER = Object.freeze({
+  pi: "invoke-reviewer-pi.js",
+  opencode: "invoke-reviewer-opencode.js",
+  antigravity: "invoke-reviewer-antigravity.js",
+});
+
+const DEFAULT_REVIEW_PHASE_BY_ADAPTER = Object.freeze({
+  pi: "primary_review",
+  opencode: "advisory_review",
+  antigravity: "primary_review",
+});
+
+const LIVE_DOGFOOD_SCENARIOS = Object.freeze([
+  {
+    name: "probe-pi",
+    adapter: "pi",
+    phase: "probe",
+    category: "probe",
+    classifier: "probe-json",
+    defaultEnabled: true,
+    healthyPromotion: false,
+  },
+  {
+    name: "probe-opencode",
+    adapter: "opencode",
+    phase: "probe",
+    category: "probe",
+    classifier: "probe-json",
+    defaultEnabled: true,
+    healthyPromotion: false,
+  },
+  {
+    name: "probe-antigravity",
+    adapter: "antigravity",
+    phase: "probe",
+    category: "probe",
+    classifier: "probe-json",
+    defaultEnabled: true,
+    healthyPromotion: false,
+  },
+  {
+    name: "opencode-advisory",
+    adapter: "opencode",
+    phase: "advisory_review",
+    category: "healthy-review",
+    classifier: "standard-json",
+    defaultEnabled: true,
+    healthyPromotion: true,
+  },
+  {
+    name: "pi-primary",
+    adapter: "pi",
+    phase: "primary_review",
+    category: "healthy-review",
+    classifier: "standard-json",
+    defaultEnabled: true,
+    healthyPromotion: true,
+    env: { name: "RELAY_PI_REVIEW_TIMEOUT", option: "piReviewTimeout" },
+  },
+  {
+    name: "antigravity-primary",
+    adapter: "antigravity",
+    phase: "primary_review",
+    category: "healthy-review",
+    classifier: "antigravity-primary",
+    defaultEnabled: true,
+    healthyPromotion: true,
+    env: { name: "RELAY_ANTIGRAVITY_REVIEW_TIMEOUT", option: "antigravityReviewTimeout" },
+  },
+  {
+    name: "antigravity-primary-fail-safe-timeout",
+    adapter: "antigravity",
+    phase: "primary_review",
+    category: "fail-safe",
+    classifier: "antigravity-fail-safe-timeout",
+    defaultEnabled: true,
+    healthyPromotion: false,
+    env: { name: "RELAY_ANTIGRAVITY_REVIEW_TIMEOUT", option: "antigravityFailSafeReviewTimeout" },
+  },
+  {
+    name: "antigravity-dispatch-fail-safe-noop",
+    adapter: "antigravity",
+    phase: "dispatch",
+    category: "fail-safe",
+    classifier: "antigravity-noop-dispatch",
+    defaultEnabled: true,
+    healthyPromotion: false,
+  },
+  {
+    name: "pi-dispatch-canary",
+    adapter: "pi",
+    phase: "dispatch",
+    category: "healthy-dispatch",
+    classifier: "healthy-dispatch",
+    defaultEnabled: false,
+    requiresDispatchCanary: true,
+    healthyPromotion: true,
+  },
+  {
+    name: "opencode-dispatch-canary",
+    adapter: "opencode",
+    phase: "dispatch",
+    category: "healthy-dispatch",
+    classifier: "healthy-dispatch",
+    defaultEnabled: false,
+    requiresDispatchCanary: true,
+    healthyPromotion: true,
+  },
+  {
+    name: "antigravity-dispatch-canary",
+    adapter: "antigravity",
+    phase: "dispatch",
+    category: "healthy-dispatch",
+    classifier: "healthy-dispatch",
+    defaultEnabled: false,
+    requiresDispatchCanary: true,
+    healthyPromotion: true,
+  },
+]);
+
+const LIVE_DOGFOOD_READINESS_EXEMPTIONS = Object.freeze([
+  {
+    adapter: "opencode",
+    phase: "primary_review",
+    reason: "OpenCode primary review readiness is route-policy limited; the current harness keeps OpenCode live review dogfood on the advisory row.",
+    readinessTextPattern: /Live:\s*`limited`\s*by route policy and live reviewer evidence/i,
+  },
+  {
+    adapter: "pi",
+    phase: "advisory_review",
+    reason: "Pi advisory review readiness remains route-specific until dedicated advisory canaries are added.",
+    readinessTextPattern: /Live:\s*`limited`\s*by route-specific advisory canaries/i,
+  },
+  {
+    adapter: "antigravity",
+    phase: "advisory_review",
+    reason: "Antigravity advisory review is blocked until a healthy advisory dogfood scenario exists.",
+    readinessTextPattern: /Live:\s*`blocked`\s*until healthy advisory dogfood exists/i,
+  },
+]);
+
 function parseArgs(argv) {
   const parsed = {
     repo: ".",
@@ -355,93 +502,136 @@ function buildDispatchCommand({ node, repo, branch, executor, model, promptFile,
   ];
 }
 
+const CLASSIFIER_BY_ID = Object.freeze({
+  "probe-json": classifyProbeJson,
+  "standard-json": classifyStandardJson,
+  "antigravity-primary": classifyAntigravityPrimary,
+  "antigravity-fail-safe-timeout": classifyAntigravityFailSafeTimeout,
+  "antigravity-noop-dispatch": classifyAntigravityNoOpDispatch,
+  "healthy-dispatch": classifyHealthyDispatch,
+});
+
+function modelForAdapter(options, adapter) {
+  const optionName = MODEL_OPTION_BY_ADAPTER[adapter];
+  if (!optionName) throw new Error(`unknown dogfood adapter: ${adapter}`);
+  return options[optionName];
+}
+
+function isScenarioEnabled(scenario, options) {
+  if (options.probeOnly) return scenario.category === "probe";
+  if (scenario.requiresDispatchCanary) return options.dispatchCanary === true;
+  return scenario.defaultEnabled === true;
+}
+
+function buildScenarioEnv(scenario, options) {
+  if (!scenario.env) return {};
+  return { [scenario.env.name]: options[scenario.env.option] };
+}
+
+function buildProbeScenarioCommand({ node, repo, options, scenario }) {
+  return [
+    node,
+    "skills/relay-plan/scripts/probe-executor-env.js",
+    repo,
+    "--executor", scenario.adapter,
+    "--model", modelForAdapter(options, scenario.adapter),
+    "--json",
+  ];
+}
+
+function buildReviewScenarioCommand({ node, repo, prompts, options, scenario }) {
+  const script = REVIEWER_SCRIPT_BY_ADAPTER[scenario.adapter];
+  if (!script) throw new Error(`unknown reviewer dogfood adapter: ${scenario.adapter}`);
+
+  const promptFile = scenario.phase === "advisory_review"
+    ? prompts.advisoryPrompt
+    : prompts.primaryPrompt;
+  const command = [
+    node,
+    `skills/relay-review/scripts/${script}`,
+    "--repo", repo,
+    "--prompt-file", promptFile,
+    "--model", modelForAdapter(options, scenario.adapter),
+    "--json",
+  ];
+  if (scenario.phase !== DEFAULT_REVIEW_PHASE_BY_ADAPTER[scenario.adapter]) {
+    command.splice(command.length - 1, 0, "--phase", scenario.phase);
+  }
+  return command;
+}
+
+function buildFailSafeDispatchCommand({ node, repo, prompts, options, branch }) {
+  return [
+    node,
+    "skills/relay-dispatch/scripts/dispatch.js",
+    repo,
+    "-b", branch,
+    "--prompt", "Live dogfood fail-safe no-op canary: do not modify repository files, do not commit, and do not create a PR-ready change.",
+    "--executor", "antigravity",
+    "--model", options.antigravityModel,
+    "--rubric-file", prompts.rubric,
+    "--timeout", String(options.antigravityDispatchTimeoutSeconds),
+    "--json",
+  ];
+}
+
+function buildHealthyDispatchScenarioCommand({ node, repo, prompts, options, scenario }) {
+  const canary = prompts.dispatchCanaries[scenario.adapter];
+  return buildDispatchCommand({
+    node,
+    repo,
+    branch: `${options.dispatchBranchPrefix}-${scenario.adapter}-${prompts.dispatchStamp}`,
+    executor: scenario.adapter,
+    model: modelForAdapter(options, scenario.adapter),
+    promptFile: canary.promptFile,
+    rubricFile: canary.rubricFile,
+    timeoutSeconds: options.dispatchTimeoutSeconds,
+  });
+}
+
+function buildScenarioCommand(context, scenario) {
+  if (scenario.category === "probe") {
+    return buildProbeScenarioCommand({ ...context, scenario });
+  }
+  if (scenario.category === "healthy-review" || (scenario.category === "fail-safe" && scenario.phase !== "dispatch")) {
+    return buildReviewScenarioCommand({ ...context, scenario });
+  }
+  if (scenario.name === "antigravity-dispatch-fail-safe-noop") {
+    return buildFailSafeDispatchCommand({
+      ...context,
+      branch: context.failSafeDispatchBranch,
+    });
+  }
+  if (scenario.category === "healthy-dispatch") {
+    return buildHealthyDispatchScenarioCommand({ ...context, scenario });
+  }
+  throw new Error(`unknown dogfood scenario category: ${scenario.category}`);
+}
+
 function buildSteps({ repo, relayHome, prompts, options }) {
   const node = process.execPath;
-  const dispatchBranch = `dogfood-antigravity-${Date.now()}`;
-  const steps = [
-    {
-      name: "probe-pi",
-      command: [node, "skills/relay-plan/scripts/probe-executor-env.js", repo, "--executor", "pi", "--model", options.piModel, "--json"],
-      classify: classifyProbeJson,
-    },
-    {
-      name: "probe-opencode",
-      command: [node, "skills/relay-plan/scripts/probe-executor-env.js", repo, "--executor", "opencode", "--model", options.opencodeModel, "--json"],
-      classify: classifyProbeJson,
-    },
-    {
-      name: "probe-antigravity",
-      command: [node, "skills/relay-plan/scripts/probe-executor-env.js", repo, "--executor", "antigravity", "--model", options.antigravityModel, "--json"],
-      classify: classifyProbeJson,
-    },
-    {
-      name: "opencode-advisory",
-      command: [node, "skills/relay-review/scripts/invoke-reviewer-opencode.js", "--repo", repo, "--prompt-file", prompts.advisoryPrompt, "--model", options.opencodeModel, "--json"],
-      classify: classifyStandardJson,
-    },
-    {
-      name: "pi-primary",
-      command: [node, "skills/relay-review/scripts/invoke-reviewer-pi.js", "--repo", repo, "--prompt-file", prompts.primaryPrompt, "--model", options.piModel, "--json"],
-      env: { RELAY_PI_REVIEW_TIMEOUT: options.piReviewTimeout },
-      classify: classifyStandardJson,
-    },
-    {
-      name: "antigravity-primary",
-      command: [node, "skills/relay-review/scripts/invoke-reviewer-antigravity.js", "--repo", repo, "--prompt-file", prompts.primaryPrompt, "--model", options.antigravityModel, "--json"],
-      env: { RELAY_ANTIGRAVITY_REVIEW_TIMEOUT: options.antigravityReviewTimeout },
-      classify: classifyAntigravityPrimary,
-    },
-    {
-      name: "antigravity-primary-fail-safe-timeout",
-      command: [node, "skills/relay-review/scripts/invoke-reviewer-antigravity.js", "--repo", repo, "--prompt-file", prompts.primaryPrompt, "--model", options.antigravityModel, "--json"],
-      env: { RELAY_ANTIGRAVITY_REVIEW_TIMEOUT: options.antigravityFailSafeReviewTimeout },
-      classify: classifyAntigravityFailSafeTimeout,
-    },
-    {
-      name: "antigravity-dispatch-fail-safe-noop",
-      command: [
-        node,
-        "skills/relay-dispatch/scripts/dispatch.js",
-        repo,
-        "-b", dispatchBranch,
-        "--prompt", "Live dogfood fail-safe no-op canary: do not modify repository files, do not commit, and do not create a PR-ready change.",
-        "--executor", "antigravity",
-        "--model", options.antigravityModel,
-        "--rubric-file", prompts.rubric,
-        "--timeout", String(options.antigravityDispatchTimeoutSeconds),
-        "--json",
-      ],
-      classify: classifyAntigravityNoOpDispatch,
-    },
-  ];
+  const context = {
+    node,
+    repo,
+    relayHome,
+    prompts,
+    options,
+    failSafeDispatchBranch: `dogfood-antigravity-${Date.now()}`,
+  };
 
-  if (options.dispatchCanary) {
-    for (const executor of ["pi", "opencode", "antigravity"]) {
-      const model = executor === "pi"
-        ? options.piModel
-        : executor === "opencode"
-          ? options.opencodeModel
-          : options.antigravityModel;
-      const canary = prompts.dispatchCanaries[executor];
-      steps.push({
-        name: `${executor}-dispatch-canary`,
-        command: buildDispatchCommand({
-          node,
-          repo,
-          branch: `${options.dispatchBranchPrefix}-${executor}-${prompts.dispatchStamp}`,
-          executor,
-          model,
-          promptFile: canary.promptFile,
-          rubricFile: canary.rubricFile,
-          timeoutSeconds: options.dispatchTimeoutSeconds,
-        }),
-        classify: classifyHealthyDispatch,
-      });
-    }
-  }
-
-  return steps.filter((step) => !options.probeOnly || step.name.startsWith("probe-"))
-    .map((step) => ({ ...step, relayHome }));
+  return LIVE_DOGFOOD_SCENARIOS
+    .filter((scenario) => isScenarioEnabled(scenario, options))
+    .map((scenario) => {
+      const classify = CLASSIFIER_BY_ID[scenario.classifier];
+      if (!classify) throw new Error(`unknown dogfood classifier: ${scenario.classifier}`);
+      return {
+        ...scenario,
+        command: buildScenarioCommand(context, scenario),
+        env: buildScenarioEnv(scenario, options),
+        classify,
+        relayHome,
+      };
+    });
 }
 
 function runDogfood(options = {}, deps = {}) {
@@ -570,6 +760,8 @@ module.exports = {
   classifyProbeJson,
   classifyStandardJson,
   ensureRelayHome,
+  LIVE_DOGFOOD_READINESS_EXEMPTIONS,
+  LIVE_DOGFOOD_SCENARIOS,
   parseArgs,
   renderMarkdown,
   runDogfood,

--- a/tests/relay-dispatch/scripts/docs-defaults.test.js
+++ b/tests/relay-dispatch/scripts/docs-defaults.test.js
@@ -8,6 +8,10 @@ const {
   ADAPTER_PHASES,
   listAgentAdapters,
 } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
+const {
+  LIVE_DOGFOOD_READINESS_EXEMPTIONS,
+  LIVE_DOGFOOD_SCENARIOS,
+} = require("../../../skills/relay-dispatch/scripts/live-dogfood");
 
 const ROOT = path.join(__dirname, "..", "..", "..");
 const DISPATCH_SCRIPT = path.join(ROOT, "skills", "relay-dispatch", "scripts", "dispatch.js");
@@ -19,6 +23,12 @@ const READINESS_STATUSES = Object.freeze([
   "fail-safe-experimental",
   "blocked",
   "not-supported",
+]);
+const LIVE_DOGFOOD_ADAPTERS = Object.freeze(["opencode", "pi", "antigravity"]);
+const READINESS_ROLE_COLUMNS = Object.freeze([
+  [1, "dispatch", "dispatch"],
+  [2, "primary_review", "primary review"],
+  [3, "advisory_review", "advisory review"],
 ]);
 
 function readRepoFile(relativePath) {
@@ -264,6 +274,39 @@ test("operator guide separates implementation parity from live promotion criteri
   for (const adapter of ["pi", "opencode", "antigravity"]) {
     const row = rowsToText(operatorReadinessMatrix().rows.get(adapter));
     assert.match(row, /Live:\s*`(?!stable`)/i, `${adapter} live readiness is not published as stable without promotion evidence`);
+  }
+});
+
+test("live dogfood metadata covers readiness matrix roles or explains exemptions", () => {
+  const { rows } = operatorReadinessMatrix();
+  const healthyScenarios = new Set(LIVE_DOGFOOD_SCENARIOS
+    .filter((scenario) => scenario.healthyPromotion)
+    .map((scenario) => `${scenario.adapter}:${scenario.phase}`));
+  const exemptions = new Map(LIVE_DOGFOOD_READINESS_EXEMPTIONS
+    .map((exemption) => [`${exemption.adapter}:${exemption.phase}`, exemption]));
+
+  for (const adapter of LIVE_DOGFOOD_ADAPTERS) {
+    const row = rows.get(adapter);
+    assert.ok(row, `${adapter} readiness row`);
+
+    for (const [index, phase, label] of READINESS_ROLE_COLUMNS) {
+      const pair = readinessPair(row[index]);
+      if (pair.implementation === "not-supported" && pair.live === "not-supported") {
+        continue;
+      }
+
+      const key = `${adapter}:${phase}`;
+      if (healthyScenarios.has(key)) {
+        continue;
+      }
+
+      const exemption = exemptions.get(key);
+      assert.ok(exemption, `${key} must have a healthy dogfood scenario or explicit exemption`);
+      assert.equal(exemption.adapter, adapter);
+      assert.equal(exemption.phase, phase);
+      assert.ok(exemption.reason, `${key} exemption reason`);
+      assert.match(rowsToText(row), exemption.readinessTextPattern, `${key} exemption tied to readiness wording for ${label}`);
+    }
   }
 });
 

--- a/tests/relay-dispatch/scripts/live-dogfood.test.js
+++ b/tests/relay-dispatch/scripts/live-dogfood.test.js
@@ -110,6 +110,11 @@ test("live dogfood dry-run plans default non-dispatch scenarios without invoking
   assert.ok(result.outcomes.some((step) => step.name === "antigravity-primary-fail-safe-timeout"));
   assert.ok(result.outcomes.some((step) => step.name === "antigravity-dispatch-fail-safe-noop"));
   assert.ok(result.outcomes.every((step) => step.outcome === OUTCOMES.NOT_RUN));
+  assert.deepEqual(result.coverage.scenarios.map((scenario) => scenario.name), LIVE_DOGFOOD_SCENARIOS.map((scenario) => scenario.name));
+  assert.ok(result.coverage.readiness_exemptions.some((exemption) => (
+    exemption.adapter === "opencode" && exemption.phase === "primary_review"
+  )));
+  assert.ok(result.coverage.scenarios.every((scenario) => typeof scenario.healthyPromotion === "boolean"));
 });
 
 test("live dogfood classifies mocked command outcomes and preserves markdown distinctions", () => {

--- a/tests/relay-dispatch/scripts/live-dogfood.test.js
+++ b/tests/relay-dispatch/scripts/live-dogfood.test.js
@@ -14,6 +14,7 @@ const {
   classifyAntigravityPrimary,
   classifyHealthyDispatch,
   classifyProbeJson,
+  LIVE_DOGFOOD_SCENARIOS,
   parseArgs,
   renderMarkdown,
   runDogfood,
@@ -56,6 +57,59 @@ test("live dogfood uses temp RELAY_HOME by default and writes scoped policy", ()
   assert.deepEqual(policy.allowed_model_routes[0].reviewers, ["pi"]);
   assert.deepEqual(policy.allowed_model_routes[1].reviewers, ["opencode"]);
   assert.ok(!result.relay_home.startsWith(path.dirname(homeBefore)) || result.relay_home !== path.dirname(homeBefore));
+});
+
+test("live dogfood exposes explicit scenario metadata rows", () => {
+  assert.ok(Array.isArray(LIVE_DOGFOOD_SCENARIOS));
+  const rows = new Map(LIVE_DOGFOOD_SCENARIOS.map((scenario) => [scenario.name, scenario]));
+
+  for (const [name, adapter, phase, category] of [
+    ["probe-pi", "pi", "probe", "probe"],
+    ["probe-opencode", "opencode", "probe", "probe"],
+    ["probe-antigravity", "antigravity", "probe", "probe"],
+    ["opencode-advisory", "opencode", "advisory_review", "healthy-review"],
+    ["pi-primary", "pi", "primary_review", "healthy-review"],
+    ["antigravity-primary", "antigravity", "primary_review", "healthy-review"],
+    ["antigravity-primary-fail-safe-timeout", "antigravity", "primary_review", "fail-safe"],
+    ["antigravity-dispatch-fail-safe-noop", "antigravity", "dispatch", "fail-safe"],
+    ["pi-dispatch-canary", "pi", "dispatch", "healthy-dispatch"],
+    ["opencode-dispatch-canary", "opencode", "dispatch", "healthy-dispatch"],
+    ["antigravity-dispatch-canary", "antigravity", "dispatch", "healthy-dispatch"],
+  ]) {
+    const scenario = rows.get(name);
+    assert.ok(scenario, `${name} scenario row`);
+    assert.equal(scenario.adapter, adapter);
+    assert.equal(scenario.phase, phase);
+    assert.equal(scenario.category, category);
+  }
+
+  assert.equal(rows.get("antigravity-primary-fail-safe-timeout").healthyPromotion, false);
+  assert.equal(rows.get("antigravity-dispatch-fail-safe-noop").healthyPromotion, false);
+  assert.equal(rows.get("pi-dispatch-canary").healthyPromotion, true);
+  assert.equal(rows.get("opencode-dispatch-canary").healthyPromotion, true);
+  assert.equal(rows.get("antigravity-dispatch-canary").healthyPromotion, true);
+});
+
+test("live dogfood dry-run plans default non-dispatch scenarios without invoking CLIs", () => {
+  const repo = tempDir("relay-live-dogfood-repo-");
+  const calls = [];
+  const result = runDogfood({
+    repo,
+    dryRun: true,
+  }, {
+    spawnSync: (...args) => {
+      calls.push(args);
+      return jsonResult({});
+    },
+  });
+
+  assert.equal(calls.length, 0);
+  assert.deepEqual(result.outcomes.map((step) => step.name), LIVE_DOGFOOD_SCENARIOS
+    .filter((scenario) => scenario.defaultEnabled)
+    .map((scenario) => scenario.name));
+  assert.ok(result.outcomes.some((step) => step.name === "antigravity-primary-fail-safe-timeout"));
+  assert.ok(result.outcomes.some((step) => step.name === "antigravity-dispatch-fail-safe-noop"));
+  assert.ok(result.outcomes.every((step) => step.outcome === OUTCOMES.NOT_RUN));
 });
 
 test("live dogfood classifies mocked command outcomes and preserves markdown distinctions", () => {


### PR DESCRIPTION
## Summary
- Refactor live dogfood canaries into explicit scenario metadata consumed by the existing runner.
- Add readiness coverage guards so Pi/OpenCode/Antigravity documented roles require a healthy scenario or explicit exemption.
- Preserve fail-safe semantics and dry-run behavior while avoiding a new DSL/framework.

## Verification
- `node --test tests/relay-dispatch/scripts/live-dogfood.test.js tests/relay-dispatch/scripts/docs-defaults.test.js`
- `node --test tests/relay-review/scripts/invoke-reviewer.test.js`
- `node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dry-run --json`
- `node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --dry-run --json`
- `git diff --check`

Closes #622.
