### PR TITLE
Canonicalize equivalent relay manifest repo roots

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -418,6 +418,13 @@ function getWorktreeGitCommonDir(worktreePath) {
   }
 }
 
+function sameGitCommonDir(leftPath, rightPath) {
+  const leftCommonDir = getWorktreeGitCommonDir(leftPath);
+  const rightCommonDir = getWorktreeGitCommonDir(rightPath);
+  if (!leftCommonDir || !rightCommonDir) return false;
+  return leftCommonDir === rightCommonDir || sameFilesystemLocation(leftCommonDir, rightCommonDir);
+}
+
 function validateManifestPaths(paths, {
   expectedRepoRoot,
   manifestPath,
@@ -439,6 +446,11 @@ function validateManifestPaths(paths, {
   const normalizedExpectedRepoRoot = typeof expectedRepoRoot === "string" && expectedRepoRoot.trim() !== ""
     ? path.resolve(expectedRepoRoot)
     : null;
+  const repoRootEquivalentToExpected = normalizedExpectedRepoRoot
+    && repoRoot !== normalizedExpectedRepoRoot
+    && !sameFilesystemLocation(repoRoot, normalizedExpectedRepoRoot)
+    && sameGitCommonDir(repoRoot, normalizedExpectedRepoRoot);
+  const effectiveRepoRoot = repoRootEquivalentToExpected ? normalizedExpectedRepoRoot : repoRoot;
   const normalizedManifestPath = typeof manifestPath === "string" && manifestPath.trim() !== ""
     ? path.resolve(manifestPath)
     : null;
@@ -452,6 +464,7 @@ function validateManifestPaths(paths, {
     normalizedExpectedRepoRoot
     && repoRoot !== normalizedExpectedRepoRoot
     && !sameFilesystemLocation(repoRoot, normalizedExpectedRepoRoot)
+    && !repoRootEquivalentToExpected
   ) {
     throw new Error(
       `${caller}: manifest paths.repo_root ${JSON.stringify(repoRoot)} does not match the expected repo root ` +
@@ -460,10 +473,10 @@ function validateManifestPaths(paths, {
   }
 
   if (normalizedManifestPath) {
-    const expectedManifestPath = getManifestPath(repoRoot, normalizedRunId);
+    const expectedManifestPath = getManifestPath(effectiveRepoRoot, normalizedRunId);
     if (normalizedManifestPath !== expectedManifestPath) {
       throw new Error(
-        `${caller}: manifest paths.repo_root ${JSON.stringify(repoRoot)} does not match the manifest storage path ` +
+        `${caller}: manifest paths.repo_root ${JSON.stringify(effectiveRepoRoot)} does not match the manifest storage path ` +
         `${JSON.stringify(normalizedManifestPath)} for run ${JSON.stringify(normalizedRunId)}. ` +
         `Expected ${JSON.stringify(expectedManifestPath)}.`
       );
@@ -481,7 +494,7 @@ function validateManifestPaths(paths, {
       throw new Error(`${caller}: manifest paths.worktree must be set`);
     }
     return {
-      repoRoot,
+      repoRoot: effectiveRepoRoot,
       worktree: null,
       worktreeLocation: "missing",
       relayWorktreeBase: getRelayWorktreeBase(),
@@ -490,10 +503,10 @@ function validateManifestPaths(paths, {
 
   const worktree = path.resolve(worktreeRaw);
   const relayWorktreeBase = getRelayWorktreeBase();
-  const repoContainedWorktree = isPathContainedWithin(repoRoot, worktree);
+  const repoContainedWorktree = isPathContainedWithin(effectiveRepoRoot, worktree);
   const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
-    && path.basename(worktree) === path.basename(repoRoot);
-  const expectedGitCommonDir = getWorktreeGitCommonDir(repoRoot) || path.join(repoRoot, ".git");
+    && path.basename(worktree) === path.basename(effectiveRepoRoot);
+  const expectedGitCommonDir = getWorktreeGitCommonDir(effectiveRepoRoot) || path.join(effectiveRepoRoot, ".git");
   const worktreeGitCommonDir = fs.existsSync(worktree)
     ? getWorktreeGitCommonDir(worktree)
     : null;
@@ -514,13 +527,13 @@ function validateManifestPaths(paths, {
   if (!repoContainedWorktree && !relayOwnedWorktree && !prunedRelayOwnedWorktreeForCleanup) {
     throw new Error(
       `${caller}: manifest paths.worktree ${JSON.stringify(worktree)} is not contained under the expected repo root ` +
-      `${JSON.stringify(repoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +
-      `that is bound to ${JSON.stringify(expectedGitCommonDir)} for repo ${JSON.stringify(path.basename(repoRoot))}.`
+      `${JSON.stringify(effectiveRepoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +
+      `that is bound to ${JSON.stringify(expectedGitCommonDir)} for repo ${JSON.stringify(path.basename(effectiveRepoRoot))}.`
     );
   }
 
   return {
-    repoRoot,
+    repoRoot: effectiveRepoRoot,
     worktree,
     worktreeLocation: repoContainedWorktree ? "repo_root" : "relay_worktree",
     prunedRelayOwnedForCleanup: prunedRelayOwnedWorktreeForCleanup,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -522,7 +522,7 @@ function validateManifestPaths(paths, {
   const prunedRelayOwnedWorktreeForCleanup = acceptPrunedRelayOwned
     && !relayOwnedWorktree
     && (!worktreeGitCommonDir || !fs.existsSync(worktreeGitCommonDir))
-    && isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot });
+    && isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot: effectiveRepoRoot });
 
   if (!repoContainedWorktree && !relayOwnedWorktree && !prunedRelayOwnedWorktreeForCleanup) {
     throw new Error(

--- a/skills/relay-dispatch/scripts/manifest/pr-number-stamp.js
+++ b/skills/relay-dispatch/scripts/manifest/pr-number-stamp.js
@@ -119,12 +119,24 @@ function stampPrNumberUnderLock(manifestRecord, numericPrNumber, options = {}) {
       return freshRecord;
     }
 
+    const freshValidatedPaths = validateManifestPaths(freshRecord.data?.paths, {
+      expectedRepoRoot: repoRoot,
+      manifestPath: manifestRecord.manifestPath,
+      runId: freshRecord.data?.run_id,
+      caller,
+    });
+
     if (freshRecord.data?.git?.pr_number !== undefined && freshRecord.data?.git?.pr_number !== null) {
       return freshRecord;
     }
 
     const updatedData = {
       ...freshRecord.data,
+      paths: {
+        ...(freshRecord.data?.paths || {}),
+        repo_root: freshValidatedPaths.repoRoot,
+        worktree: freshValidatedPaths.worktree,
+      },
       git: {
         ...(freshRecord.data?.git || {}),
         pr_number: numericPrNumber,

--- a/tests/relay-dispatch/scripts/manifest/paths.test.js
+++ b/tests/relay-dispatch/scripts/manifest/paths.test.js
@@ -48,6 +48,36 @@ test("manifest/paths validateManifestPaths rejects manifest-path mismatches", ()
   assert.match(getManifestPath(repoRoot, runId), /issue-188-20260418091011123-a1b2c3d4\.md$/);
 });
 
+test("manifest/paths validateManifestPaths canonicalizes same-git-common-dir repo roots", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-canonical-repo-"));
+  initGitRepo(repoRoot);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+
+  const linkedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-linked-root-"));
+  execFileSync("git", ["worktree", "add", linkedRoot, "-b", "linked-root"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  const runId = "issue-626-20260526131500000-a1b2c3d4";
+  const manifestPath = getManifestPath(repoRoot, runId);
+
+  const result = validateManifestPaths({
+    repo_root: linkedRoot,
+    worktree: path.join(repoRoot, "wt", "issue-626"),
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "manifest/paths.test same common dir",
+  });
+
+  assert.equal(result.repoRoot, path.resolve(repoRoot));
+  assert.equal(result.worktreeLocation, "repo_root");
+});
+
 test("manifest/paths cleanup mode accepts pruned and missing relay-owned worktrees", () => {
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-cleanup-repo-"));

--- a/tests/relay-dispatch/scripts/manifest/paths.test.js
+++ b/tests/relay-dispatch/scripts/manifest/paths.test.js
@@ -78,6 +78,46 @@ test("manifest/paths validateManifestPaths canonicalizes same-git-common-dir rep
   assert.equal(result.worktreeLocation, "repo_root");
 });
 
+test("manifest/paths cleanup mode uses canonical root for pruned same-git-common-dir worktrees", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-pruned-canonical-repo-"));
+  initGitRepo(repoRoot);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+
+  const linkedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-pruned-linked-root-"));
+  execFileSync("git", ["worktree", "add", linkedRoot, "-b", "linked-pruned-root"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  const runId = "issue-626-20260526131501000-a1b2c3d4";
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const relayWorktreeBase = path.join(process.env.RELAY_HOME, "worktrees");
+  const prunedWorktree = path.join(relayWorktreeBase, "pruned-canonical-binding", path.basename(repoRoot));
+  fs.mkdirSync(prunedWorktree, { recursive: true });
+  fs.writeFileSync(
+    path.join(prunedWorktree, ".git"),
+    `gitdir: ${path.join(relayWorktreeBase, "missing-admin-dir")}\n`,
+    "utf-8"
+  );
+
+  const result = validateManifestPaths({
+    repo_root: linkedRoot,
+    worktree: prunedWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    acceptPrunedRelayOwned: true,
+    caller: "manifest/paths.test cleanup canonical pruned",
+  });
+
+  assert.equal(result.repoRoot, path.resolve(repoRoot));
+  assert.equal(result.worktreeLocation, "relay_worktree");
+  assert.equal(result.prunedRelayOwnedForCleanup, true);
+});
+
 test("manifest/paths cleanup mode accepts pruned and missing relay-owned worktrees", () => {
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-cleanup-repo-"));

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -287,6 +287,37 @@ test("happy path commits dirty worktree, pushes, opens PR, stamps manifest, and 
   assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 1);
 });
 
+test("recover-commit canonicalizes manifest repo_root when it shares the expected git common dir", () => {
+  const fixture = setupRepo({ dirty: true });
+  const linkedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-recover-linked-root-"));
+  execFileSync("git", ["worktree", "add", linkedRoot, "-b", "equivalent-root-626"], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const beforeManifest = readManifest(fixture.manifestPath);
+  writeManifest(fixture.manifestPath, {
+    ...beforeManifest.data,
+    paths: {
+      ...beforeManifest.data.paths,
+      repo_root: linkedRoot,
+    },
+  }, beforeManifest.body);
+
+  const result = runRecover(fixture, ["--reason", "executor completed before commit", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, "recovered");
+  assert.equal(parsed.prNumber, 281);
+
+  const manifest = readManifest(fixture.manifestPath).data;
+  assert.equal(manifest.paths.repo_root, fixture.repoRoot);
+  assert.equal(manifest.paths.worktree, fixture.worktreePath);
+  assert.equal(manifest.git.pr_number, 281);
+  assert.ok(readRunEvents(fixture.repoRoot, fixture.runId).some((entry) => entry.event === "recover_commit"));
+});
+
 test("default PR title uses manifest issue title when available", () => {
   const fixture = setupRepo({ dirty: true });
   const result = runRecover(fixture, ["--reason", "executor completed before commit", "--json"]);


### PR DESCRIPTION
## Summary
- Allow manifest path validation to normalize `paths.repo_root` when the manifest root and expected root share the same Git common dir.
- Persist the normalized root during PR-number stamping while revalidating the freshly read manifest before writing.
- Add regression coverage for both low-level path validation and `recover-commit` lifecycle recovery.

Closes #626.

## Tests
- `node --test tests/relay-dispatch/scripts/manifest/paths.test.js`
- `node --test tests/relay-dispatch/scripts/recover-commit.test.js`
- `node --test tests/relay-dispatch/scripts/relay-manifest.test.js`
- `node --test tests/relay-review/scripts/review-runner.test.js`
- `node --test tests/relay-merge/scripts/finalize-run.test.js`
- `node --test tests/relay-dispatch/scripts/*.test.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git worktree 환경에서 저장소 경로를 더 정확히 검증·정규화하도록 개선. 서로 다른 경로라도 동일한 Git 공통 디렉터리를 공유하면 동등한 루트로 처리하고, 관련 워트리 판정 및 오류 메시지에 반영합니다.

* **Tests**
  * 공유 Git common dir 및 linked/pruned worktree 시나리오에서 경로 정규화와 복구 동작을 검증하는 새로운 테스트 케이스 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->