### PR TITLE
[codex] Document relay-plan scout signals

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 ---
 ## Inputs
 - Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; Step 7/8 examples use `RUN_ID`.
-- Files: relay-ready handoff, task file, issue/user text, optional `/tmp/done-criteria-<N>.md`, `/tmp/dispatch-<N>.md`, and `/tmp/rubric-<N>.yaml`.
+- Files: relay-ready handoff, task file, issue/user text, optional local harness context (`AGENTS.md`, `CLAUDE.md`, `CHARTER.md`, `spec/capabilities.md`, active sprint notes), optional `/tmp/done-criteria-<N>.md`, `/tmp/dispatch-<N>.md`, and `/tmp/rubric-<N>.yaml`.
 - Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/reliability-report.js`, `${RELAY_SKILL_ROOT:-skills}/relay-plan/scripts/probe-executor-env.js`, `${RELAY_SKILL_ROOT:-skills}/relay-plan/scripts/persist-done-criteria.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`.
 
 # Relay Plan
@@ -51,11 +51,11 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/reliability-report.js" 
 node "${RELAY_SKILL_ROOT:-skills}/relay-plan/scripts/probe-executor-env.js" . --project-only --json
 ```
 
-Read historical relay signal and repo-local quality signal as weak inputs only. They inform wording, prerequisites, and commands; they do not gate dispatch or override the task. Empty/failure cases render as `no historical data available` or `no quality infra detected`; field meanings: `references/signals.md`.
+Read historical relay signal, repo-local quality signal, and task-relevant local harness context as weak inputs only. They inform wording, prerequisites, commands, and where to look; they do not gate dispatch or override the task. Empty/failure cases render as `no historical data available` or `no quality infra detected`; field meanings and authority hierarchy: `references/signals.md`.
 
 ### 3. Normalize planning inputs
 
-Keep explicit AC, inferred Done Criteria, repo signal, historical signal, and task risk as separate evidence channels until the review anchor is written.
+Keep explicit AC, inferred Done Criteria, relay-ready handoff, project harness context, repo signal, historical signal, optional subsystem scout notes, and task risk as separate evidence channels until the review anchor is written.
 
 ### 4. Recover Done Criteria
 
@@ -144,5 +144,6 @@ Use these only when their trigger applies:
 | Edit scope is narrower than the repo | Apply `references/rubric-patterns.md#rubric-pattern--explicit-forbidden-zones`. |
 | Event schema evolves | Apply `references/rubric-patterns.md#rubric-pattern--event-shape-changes`. |
 | Red-first factor is useful | Apply `references/rubric-patterns.md#rubric-pattern--tdd-factor-flavor`; emit the optional Step 0a only when a factor has `tdd_anchor`. |
+| Task is L/XL, high ambiguity, or subsystem boundaries are unclear before Done Criteria recovery | Consider a read-only subsystem scout per `references/subsystem-scout.md`; skip for S/M tasks with clear scope. |
 | Done Criteria are novel, vague, high-risk, or easy to game | Run one stress-test round per `references/rubric-stress-test.md`; S/M usually skip, but ambiguity or risk can opt any size into stress-test. |
 | Re-dispatch after review feedback | Previous Score Log and reviewer feedback are automatically prepended; keep the original anchor fixed. |

--- a/skills/relay-plan/references/signals.md
+++ b/skills/relay-plan/references/signals.md
@@ -1,6 +1,39 @@
 # Planner Input Signals
 
-Two informational signals feed into rubric design during `relay-plan` steps 2 and 3. Both are read-only inputs; neither gates dispatch, alters state transitions, or modifies rubric structure. They inform factor wording, prerequisite naming, and Available Tools context only.
+Planner input signals feed into rubric design during `relay-plan` steps 2 and 3. They are read-only inputs; none gates dispatch, alters state transitions, or modifies rubric structure by itself. They inform factor wording, prerequisite naming, where to look, and Available Tools context only.
+
+## Signal authority hierarchy
+
+Use this order when inputs disagree:
+
+1. Frozen Done Criteria once persisted or otherwise selected as the review anchor.
+2. Explicit issue/task AC and relay-ready handoff while recovering Done Criteria.
+3. Task-specific risk discovered during planning.
+4. Project harness context, probe signal, historical signal, and optional subsystem scout notes.
+
+The fourth group is weak planning context. It can suggest files, commands, terminology, and likely risk areas, but it cannot add product requirements, narrow explicit AC, or replace Done Criteria. If weak context appears to conflict with the task source, resolve the conflict before freezing Done Criteria and persist the planner-authored anchor when the final anchor differs from the task source.
+
+## Project harness context
+
+Task-relevant local harness/context files may include `AGENTS.md`, `CLAUDE.md`, `CHARTER.md`, `spec/capabilities.md`, and active sprint notes. Read them when they are present and plausibly relevant to the task, but treat them as execution and planning context unless the task explicitly names them as the product surface being changed.
+
+Field mapping (planner-authored, no required producer):
+
+| `harness_context.*` field | Read from | Planning use |
+|---------------------------|-----------|--------------|
+| `instructions` | Repo-local agent or contributor instructions such as `AGENTS.md` or `CLAUDE.md` | Preserve local workflow, style, and safety boundaries without treating them as product acceptance criteria |
+| `charter` | `CHARTER.md`, product charter, or equivalent project intent document | Clarify terminology and user-facing intent when it helps recover observable Done Criteria |
+| `capabilities` | `spec/capabilities.md` or equivalent capability map | Locate relevant subsystems and existing behavior contracts |
+| `sprint_context` | Active sprint or backlog execution notes | Understand sequencing, dependencies, and nearby work; GitHub issues or relay-ready artifacts remain the source of truth for what to build |
+
+Case handling:
+
+| Case | Planner handling |
+|------|------------------|
+| Harness file absent | Proceed without harness context; do not create a placeholder artifact. |
+| Harness file present but unrelated | Ignore it or mention it only as skipped context; do not let it broaden scope. |
+| Harness context conflicts with explicit AC or relay-ready handoff | Treat the conflict as an ambiguity to resolve before freezing Done Criteria. |
+| Task explicitly asks to edit a harness file | Treat that file as the task target for that change, while still keeping its general guidance non-authoritative over unrelated product requirements. |
 
 ## Historical signal — `reliability-report.js`
 

--- a/skills/relay-plan/references/subsystem-scout.md
+++ b/skills/relay-plan/references/subsystem-scout.md
@@ -1,0 +1,52 @@
+# Optional Subsystem Scout
+
+The subsystem scout is an optional read-only planning aid for L/XL or high-ambiguity tasks. It belongs in `relay-plan` as a risk-triggered add-on, not in the existing `relay-sidecar` runner. Existing `relay-sidecar` artifacts are for an already-created relay run and PR/diff context; the scout runs before Done Criteria are frozen and must not create a new lifecycle state.
+
+## Trigger criteria
+
+Run a scout only when at least one condition applies:
+
+- Task size is L or XL and the likely subsystem boundary is unclear.
+- The task spans multiple packages, skills, state machines, trust boundaries, or public surfaces.
+- The issue asks for planning, architecture, migration, or ambiguous behavioral design before implementation.
+- A planner cannot name likely files, tests, and review risks without broad code search.
+
+Skip the scout when:
+
+- The task is S/M with clear target files or an existing relay-ready handoff.
+- The task is documentation-only and the target docs are named.
+- Existing probe/historical/harness signals already identify the right commands and directories.
+- Running the scout would only duplicate Done Criteria recovery or rubric design.
+
+## Output shape
+
+A scout artifact should be concise and artifact-only:
+
+```md
+# Subsystem Scout
+
+## Relevant files and directories
+- `path`: why it matters
+
+## Existing tests and commands
+- command or test path: why it is relevant
+
+## Harness context read
+- `AGENTS.md`: relevant boundary or instruction
+
+## Risk areas
+- risk: why it may affect Done Criteria or rubric factors
+
+## Recommended planning anchor
+One sentence naming the best starting anchor for Done Criteria recovery.
+```
+
+## Consumption boundary
+
+The scout is a weak planning signal. It may help the planner decide where to look, which commands to consider, and which risks deserve questions. It does not supply acceptance criteria, freeze Done Criteria, select rubric factors automatically, gate dispatch, or alter relay manifest state.
+
+When the scout reveals a requirement not present in the task source, treat it as an ambiguity or inferred Done Criteria candidate. Resolve the conflict before freezing the review anchor, then persist planner-authored Done Criteria if the final anchor differs from the issue body or relay-ready handoff.
+
+## Storage
+
+Until a dedicated runner exists, keep scout output as planner-local handoff material such as `/tmp/relay-scout-<issue-or-run>.md` or inline planning notes. Do not write scout artifacts into `~/.relay/runs/` before dispatch allocates a run. If a future runner is added, it should preserve the same read-only, non-authoritative contract and test both the skip path and artifact path.

--- a/skills/relay-sidecar/SKILL.md
+++ b/skills/relay-sidecar/SKILL.md
@@ -27,6 +27,7 @@ metadata:
 - Reviewing a PR for the relay gate — use `relay-review`
 - Dispatching implementation work — use `relay-dispatch`
 - Authoring rubrics or dispatch prompts — use `relay-plan`
+- Scouting a subsystem before a run exists or before Done Criteria are frozen — use `relay-plan`'s optional subsystem scout guidance
 - Merging or finalizing a PR — use `relay-merge`
 
 The runner resolves the run manifest, sends run context and PR diff text to the configured sidecar executor, and stores captured stdout under the run's `sidecars/<id>/` directory.

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -118,6 +118,41 @@ test("relay-plan frames AC as one input signal, not the whole rubric source", ()
   assert.doesNotMatch(skill, /Build a scoring rubric from task Acceptance Criteria/);
 });
 
+test("planner input signals document harness context as weak planning context", () => {
+  const skill = readSkill();
+  const signals = readReference("signals.md");
+
+  assert.match(skill, /task-relevant local harness context as weak inputs only/);
+  assert.match(skill, /authority hierarchy/);
+  assert.match(signals, /## Signal authority hierarchy/);
+  assert.match(signals, /Project harness context, probe signal, historical signal, and optional subsystem scout notes/);
+  assert.match(signals, /weak planning context/);
+  assert.match(signals, /AGENTS\.md/);
+  assert.match(signals, /CLAUDE\.md/);
+  assert.match(signals, /CHARTER\.md/);
+  assert.match(signals, /spec\/capabilities\.md/);
+  assert.match(signals, /GitHub issues or relay-ready artifacts remain the source of truth/);
+  assert.match(signals, /cannot add product requirements, narrow explicit AC, or replace Done Criteria/);
+});
+
+test("optional subsystem scout is a relay-plan add-on, not a sidecar lifecycle step", () => {
+  const skill = readSkill();
+  const scout = readReference("subsystem-scout.md");
+  const sidecarSkill = fs.readFileSync(path.join(__dirname, "..", "..", "..", "skills", "relay-sidecar", "SKILL.md"), "utf-8");
+
+  assert.match(skill, /references\/subsystem-scout\.md/);
+  assert.match(skill, /skip for S\/M tasks with clear scope/);
+  assert.match(scout, /belongs in `relay-plan` as a risk-triggered add-on/);
+  assert.match(scout, /not in the existing `relay-sidecar` runner/);
+  assert.match(scout, /must not create a new lifecycle state/);
+  assert.match(scout, /## Trigger criteria/);
+  assert.match(scout, /## Consumption boundary/);
+  assert.match(scout, /weak planning signal/);
+  assert.match(scout, /Do not write scout artifacts into `~\/\.relay\/runs\/` before dispatch allocates a run/);
+  assert.match(scout, /test both the skip path and artifact path/);
+  assert.match(sidecarSkill, /Scouting a subsystem before a run exists/);
+});
+
 test("rubric validation gates Done Criteria quality before dispatch", () => {
   const text = readReference("rubric-validation.md");
 


### PR DESCRIPTION
## Summary

- document project harness context as a weak relay-plan signal with an explicit authority hierarchy
- add optional subsystem scout guidance for L/XL or ambiguous planning without extending relay-sidecar runtime
- add contract tests covering the new planning boundaries

## Validation

- `node --test tests/relay-plan/scripts/*.test.js`
- `node --test tests/relay-sidecar/scripts/*.test.js`

## Issues

- Addresses #605
- Addresses #606