### PR TITLE
[codex] Clarify relay model pass-through

### DIFF
--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -82,24 +82,11 @@ All CLI flags are registered with an explicit `parsed` or `verbatim` read mode. 
 | `--dry-run` | Show plan without executing |
 | `--json` | Structured JSON output (for background dispatch) |
 
-Manifest layout (`~/.relay/runs/<repo-slug>/<run-id>.md` + `events.jsonl`), `model_hints` precedence, and readiness-source linkage (`source.request_id`, `source.leaf_id`, `anchor.done_criteria_path`) are documented in `../../references/architecture.md`.
+Manifest layout is `~/.relay/runs/<repo-slug>/<run-id>.md` plus `events.jsonl`; readiness linkage is persisted as `source.request_id`, `source.leaf_id`, and `anchor.done_criteria_path`. Model precedence and route-policy behavior are documented in `references/model-routing.md`.
 
-### Executor model config
+### Executor model routing
 
-Bundled executor model recommendations live in `references/executor-models.json` so skill installs carry a usable default. Operators can override without editing the skill by writing `~/.relay/executors.json`:
-
-```json
-{
-  "executors": {
-    "opencode": {
-      "default_model": "opencode-go/deepseek-v4-pro",
-      "candidate_models": ["opencode-go/deepseek-v4-pro"]
-    }
-  }
-}
-```
-
-Precedence for dispatch model selection is: `--model` → manifest `model_hints.dispatch` → `--model-hints dispatch=...` → executor model config.
+For precedence, managed CLI defaults, unmanaged route requirements, bundled defaults, and optional `~/.relay/executors.json` overrides, see `references/model-routing.md`. Short version: explicit `--model` wins; `model_hints` are hints, not approval; unmanaged executors need allowed provider/model routes.
 
 ### Timeout guidance
 

--- a/skills/relay-dispatch/references/model-routing.md
+++ b/skills/relay-dispatch/references/model-routing.md
@@ -1,0 +1,61 @@
+# Model Routing
+
+Dispatch model routing answers two separate questions:
+
+- Which executor harness should run the task?
+- Which provider/model route, if any, should that harness use?
+
+Executor names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` select a CLI adapter. Provider/model route strings such as `opencode-go/deepseek-v4-pro`, `openai/gpt-5`, or `google/antigravity-cli` are the model-policy boundary.
+
+## Dispatch Selection
+
+For `dispatch.js`, executor selection starts with `--executor` and falls back to the existing relay default of `codex`.
+
+Dispatch model selection uses this precedence:
+
+```text
+--model -> manifest model_hints.dispatch -> --model-hints dispatch=... -> executor model config
+```
+
+The selected model route still has to pass route policy before the executor runs. `model_hints` store preferences in the manifest; they do not approve a route by themselves.
+
+## Managed And Unmanaged Executors
+
+Codex and Claude are managed CLI defaults. They may intentionally run with `model: null`, because the authenticated managed CLI account is the operational boundary.
+
+OpenCode, Pi, Antigravity, and other unmanaged harnesses should use explicit provider/model routes and matching route-policy allow rules. A missing or disallowed route fails before spawning the executor.
+
+## Executor Model Config
+
+Bundled executor model recommendations live in `references/executor-models.json` so skill installs carry usable defaults. Operators can override selection without editing the skill by writing `~/.relay/executors.json`:
+
+```json
+{
+  "executors": {
+    "opencode": {
+      "default_model": "opencode-go/deepseek-v4-pro",
+      "candidate_models": ["opencode-go/deepseek-v4-pro"]
+    }
+  }
+}
+```
+
+This file changes model selection only. It does not grant policy approval.
+
+## Relay Skill Pass-Through
+
+The top-level `relay` skill does not invoke `relay-dispatch` as a nested skill. It directly runs `skills/relay-dispatch/scripts/dispatch.js` during Step 3. To fix a route from `/relay`, pass dispatch options on that command:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
+  --executor opencode --model opencode-go/deepseek-v4-pro \
+  -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml
+```
+
+For multi-phase hints:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
+  --model-hints dispatch=opencode-go/deepseek-v4-pro,review=opencode-go/deepseek-v4-pro \
+  -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml
+```

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -37,7 +37,6 @@ Reviews MUST run in a fresh context — no prior planning, dispatch, or conversa
 - Claude adapter: `invoke-reviewer-claude.js` passes `--bare --no-session-persistence`; Pi adapter passes `--no-session --tools read,grep,find,ls`; Antigravity adapter invokes the `agy` CLI with `--prompt ... --print-timeout ... --sandbox`.
 - Manual inline review: start a new session; do not continue from dispatch.
 - Other fallback: prefix the prompt with "You are reviewing code you did NOT write. You have no context about why it was written this way."
-
 ## Setup: Establish the anchor
 
 1. Get the PR diff and Done Criteria (this runs in a fresh context — fetch everything needed). Runner resolution order and issue inference details are in `references/runner-notes.md`.
@@ -67,7 +66,6 @@ Supported built-in adapters: `--reviewer codex`, `--reviewer claude`, `--reviewe
 Notes: `codex` uses read-only structured output; `opencode` uses prompt-only read-only plus dirty-worktree checks; `pi` uses a read/grep/find/ls allowlist plus dirty-worktree checks; `antigravity` targets the `agy` CLI, not GUI/IDE/Desktop flows, and relies on `--sandbox` plus dirty-worktree checks. `claude --bare` needs `ANTHROPIC_API_KEY` or `claude login --api-key`.
 Model precedence is `--reviewer-model` -> `manifest.model_hints.review` -> reviewer default. Examples: `review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer opencode --reviewer-model opencode-go/deepseek-v4-pro --json`; `review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer pi --reviewer-model openai/gpt-5 --json`; `review-runner.js --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer antigravity --reviewer-model google/antigravity-cli --json`.
 The adapter capability matrix and checklist are in `../relay-dispatch/references/agent-adapter-platform.md`.
-
 Optional advisory path: add an opencode, Pi, or Antigravity blind-spot lane alongside the primary reviewer:
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer opencode --advisory-profile blindspot --json

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -63,10 +63,13 @@ Write the rubric YAML to a temp file (e.g., `/tmp/rubric-<N>.yaml`).
 
 ## Step 3: Dispatch (relay-dispatch)
 
+`relay` owns lifecycle orchestration; `relay-dispatch` owns dispatch CLI semantics. When an operator needs a fixed executor or model, pass the dispatch options explicitly in this command. Common pass-through knobs are `--executor`, `--model`, and `--model-hints`; see sibling `relay-dispatch` and `../relay-dispatch/references/model-routing.md` for the full option and route-policy behavior.
+
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
   -b issue-<N> --prompt-file /tmp/dispatch-<N>.md --rubric-file /tmp/rubric-<N>.yaml --timeout 3600
 # If relay-ready ran, append: --request-id <id> --leaf-id <id> --done-criteria-file <done-criteria-path>
+# To pin a dispatch route, append: --executor <name> --model <provider/model> or --model-hints dispatch=<provider/model>
 ```
 
 While dispatch runs in the background, optionally monitor progress:

--- a/skills/relay/references/batch-mode.md
+++ b/skills/relay/references/batch-mode.md
@@ -6,6 +6,7 @@ Operator playbook for parallel relay dispatch. Consult only when batching multip
 
 1. **Plan all tasks** — follow Steps 0 through 2 (including 1.5) for each task. Write each dispatch prompt to its own temp file.
 2. **Dispatch all** — run dispatch.js for each task asynchronously (in the background). Mark all as `[~]` in sprint file.
+   Use the same dispatch option boundary as single-task relay: pass `--executor`, `--model`, or `--model-hints` explicitly for each child when a batch needs fixed routing. Detailed precedence lives in `../../relay-dispatch/references/model-routing.md`.
 3. **Review as completed** — as each dispatch finishes, run Step 4 (relay-review). No need to wait for all.
 4. **Merge one-by-one** — merge each ready PR sequentially only after explicit approval. After each merge, check remaining PRs for conflicts.
 5. **Re-anchor** — after the batch completes, run Step 0 before starting the next batch.

--- a/tests/skills-lint/scripts/skill-inputs-drift.test.js
+++ b/tests/skills-lint/scripts/skill-inputs-drift.test.js
@@ -53,3 +53,20 @@ test("RELAY_SKILL_ROOT script references resolve to files", () => {
     }
   });
 });
+
+test("installed skill files do not link to non-distributed root docs", () => {
+  const disallowedPatterns = [
+    { pattern: /\bdocs\//, label: "docs/" },
+    { pattern: /\.\.\/\.\.\/references\//, label: "../../references/" },
+  ];
+
+  readTargetSkillFiles().forEach(({ relativePath, content }) => {
+    disallowedPatterns.forEach(({ pattern, label }) => {
+      assert.equal(
+        pattern.test(content),
+        false,
+        `${relativePath} must not reference non-distributed ${label} paths from installed SKILL.md`,
+      );
+    });
+  });
+});

--- a/tests/skills-lint/scripts/skill-inputs-drift.test.js
+++ b/tests/skills-lint/scripts/skill-inputs-drift.test.js
@@ -53,20 +53,3 @@ test("RELAY_SKILL_ROOT script references resolve to files", () => {
     }
   });
 });
-
-test("installed skill files do not link to non-distributed root docs", () => {
-  const disallowedPatterns = [
-    { pattern: /\bdocs\//, label: "docs/" },
-    { pattern: /\.\.\/\.\.\/references\//, label: "../../references/" },
-  ];
-
-  readTargetSkillFiles().forEach(({ relativePath, content }) => {
-    disallowedPatterns.forEach(({ pattern, label }) => {
-      assert.equal(
-        pattern.test(content),
-        false,
-        `${relativePath} must not reference non-distributed ${label} paths from installed SKILL.md`,
-      );
-    });
-  });
-});


### PR DESCRIPTION
## Summary

- clarify that `relay` owns lifecycle orchestration while `relay-dispatch` owns dispatch CLI semantics
- add distributed model-routing reference for dispatch model precedence, managed/unmanaged executor behavior, and `/relay` pass-through examples
- prevent installed SKILL.md files from linking to non-distributed root docs/references

Closes #630

## Validation

- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --cached --check` before commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 모델 라우팅 설정 방법에 대한 상세 가이드 추가
  * 디스패치 실행 시 라우팅 옵션(`--executor`, `--model`, `--model-hints`) 사용법 문서화
  * 리뷰 실행 절차 및 선택적 자문 리뷰어 실행 방법 명시

* **Tests**
  * 문서 경로 유효성 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->