### PR TITLE
Janitor v2: narrow reconcile to ready_to_merge merged drift

### DIFF
--- a/skills/relay-dispatch/references/operator-utilities.md
+++ b/skills/relay-dispatch/references/operator-utilities.md
@@ -20,8 +20,11 @@ Successful dispatches keep their worktree by default. Cleanup moves later in the
 
 `--no-cleanup` remains accepted as a compatibility alias. `--register` still matters because it also opens the retained worktree in the executor app.
 
-To prune stale retained worktrees safely from this repo:
+Janitor v2 adds git/PR health scoring and optional merged-drift reconciliation. See [worktree-janitor-v2.md](./worktree-janitor-v2.md).
+
 ```bash
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --json
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --reconcile-merged --dry-run --json
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo .              # clean terminal runs > 24h old
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --all         # ignore age threshold
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --dry-run     # show what would be removed

--- a/skills/relay-dispatch/references/operator-utilities.md
+++ b/skills/relay-dispatch/references/operator-utilities.md
@@ -20,11 +20,12 @@ Successful dispatches keep their worktree by default. Cleanup moves later in the
 
 `--no-cleanup` remains accepted as a compatibility alias. `--register` still matters because it also opens the retained worktree in the executor app.
 
-Janitor v2 adds git/PR health scoring and optional merged-drift reconciliation. See [worktree-janitor-v2.md](./worktree-janitor-v2.md).
+Janitor v2 adds git/PR health scoring and optional merged-drift reconciliation (`ready_to_merge` only). See [worktree-janitor-v2.md](./worktree-janitor-v2.md).
 
 ```bash
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --json
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --reconcile-merged --dry-run --json
+# Prefer finalize-run when review gate passes; reconcile is disk recovery for merged drift
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo .              # clean terminal runs > 24h old
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --all         # ignore age threshold
 node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --dry-run     # show what would be removed

--- a/skills/relay-dispatch/references/worktree-janitor-v2.md
+++ b/skills/relay-dispatch/references/worktree-janitor-v2.md
@@ -73,7 +73,7 @@ node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --sta
 | Flag | Default | Effect |
 | --- | --- | --- |
 | `--inspect` | off | Health inventory only; no cleanup, no shell sweep |
-| `--reconcile-merged` | off | For eligible non-terminal runs: transition to `merged`, then cleanup |
+| `--reconcile-merged` | off | For `ready_to_merge` merged drift: transition to `merged`, then cleanup |
 | `--stale-days` | 14 | Stale classification for health + stale-open reporting (days; reporting only) |
 | `--older-than` | 24 | Age gate for terminal cleanup only (hours) |
 | `--all` | off | Ignore age gate |

--- a/skills/relay-dispatch/references/worktree-janitor-v2.md
+++ b/skills/relay-dispatch/references/worktree-janitor-v2.md
@@ -1,0 +1,120 @@
+# Worktree Janitor v2
+
+Manifest-aware relay worktree cleanup with git/PR health signals (GSD-inspired) and finish-path guidance (Superpowers-inspired). The existing manifest state machine is unchanged; janitor v2 adds inspection, drift reconciliation, and richer operator output on top of `cleanup-worktrees.js`.
+
+## Problem
+
+Relay intentionally retains worktrees after dispatch for PR handoff and re-dispatch. Disk accumulates when:
+
+- runs stall in non-terminal states (`ready_to_merge`, `review_pending`, …)
+- GitHub PR merges but `finalize-run` never runs
+- manifest `paths.repo_root` / `paths.worktree` drift from the operator repo
+- terminal runs age out without a janitor pass
+
+v1 janitor (`cleanup-worktrees.js`) only deletes **terminal** runs past an age gate. v2 adds health scoring and optional reconcile for **merged-but-not-finalized** drift.
+
+## Design principles
+
+1. **Manifest state machine stays authoritative** — janitor does not invent new states; reconcile uses existing `forceUpdateManifestState` → `merged` when git/PR evidence is strong.
+2. **PR handoff retention is normal** — Superpowers Option 2/3 analogue: `ready_to_merge` + open PR → retain worktree.
+3. **Fail closed on dirty unknown worktrees** — same as `runCleanup()`.
+4. **Git graph beats manifest alone** — GSD-style `mergedIntoBase` / `safeToRemove` for drift detection.
+5. **Operator-first** — default remains dry-run friendly; destructive paths require explicit flags.
+
+## Health model
+
+`assessRunWorktreeHealth()` (`worktree-health.js`) computes:
+
+| Field | Meaning |
+| --- | --- |
+| `mergedIntoBase` | `git branch --merged <base>` or `git merge-base --is-ancestor <branch> <base>` |
+| `prMerged` | `gh pr view --json mergedAt` when `git.pr_number` set (covers squash merges on GitHub) |
+| `mergedIntoBaseOrPr` | either signal true |
+| `dirty` / `dirtyFileCount` | worktree `git status --short` |
+| `relayOwnedStrayOnly` | only `?? rubric.yaml` (relay-owned stray) |
+| `unpushedCommits` | informational; does not block removal when merged |
+| `lastCommitAgeDays` | branch tip age |
+| `stale` | not merged and age ≥ `--stale-days` (default 14) |
+| `safeToRemove` | merged + effectively clean |
+| `reconcileEligible` | non-terminal + merged + clean + eligible state |
+
+## Finish paths (Superpowers mapping)
+
+| `finishPath` | Relay situation | Superpowers analogue | Default janitor action |
+| --- | --- | --- | --- |
+| `cleanup_terminal` | `merged`/`closed`, safe | Option 1/4 merge/discard cleanup | `runCleanup()` (v1) |
+| `reconcile_merged` | branch/PR merged, manifest not terminal | skipped finalize after merge | `--reconcile-merged` |
+| `retain_pr_handoff` | `ready_to_merge` + PR | Option 2 PR path | retain |
+| `retain_active` | dispatched / in-review | active work | retain |
+| `stale_open` | non-terminal + stale age | Option 3 keep-as-is + operator nudge | report + `close-run` hint |
+| `manual_required` | dirty or path validation failure | manual cleanup | fail closed |
+
+## CLI (v2)
+
+```bash
+# Health report only (no mutations)
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --json
+
+# Terminal cleanup (v1 behavior) with health embedded in JSON
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --older-than 24 --json
+
+# Reconcile merged drift (dry-run lists candidates)
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --reconcile-merged --dry-run --json
+
+# Apply reconcile + cleanup (force manifest -> merged, then runCleanup)
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --reconcile-merged --json
+
+# Stale classification threshold (default 14 days)
+node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --stale-days 7 --json
+```
+
+### Flags
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--inspect` | off | Health inventory only; no cleanup, no shell sweep |
+| `--reconcile-merged` | off | For eligible non-terminal runs: transition to `merged`, then cleanup |
+| `--stale-days` | 14 | Stale classification for health + stale-open reporting |
+| `--older-than` | 24 | Age gate for terminal cleanup and reconcile (hours) |
+| `--all` | off | Ignore age gate |
+| `--dry-run` | off | No manifest/git writes |
+
+## Reconcile eligibility
+
+`--reconcile-merged` applies only when **all** hold:
+
+- manifest state ∈ `{ ready_to_merge, review_pending, changes_requested, escalated }`
+- `mergedIntoBaseOrPr` is true
+- worktree effectively clean (or relay-owned stray only)
+- age gate satisfied (unless `--all`)
+- path validation succeeds
+
+Transition: `forceUpdateManifestState(..., merged, manual_cleanup_required)` with audit reason `janitor_reconcile_merged`, then `runCleanup()` with `deleteMergedBranch: true`.
+
+Prefer `finalize-run --skip-merge` when review audit trail matters; janitor reconcile is a **disk recovery** path, not a merge substitute.
+
+## Out of scope (v2.1 candidates)
+
+- Global sweep across all repos under `~/.relay/runs/`
+- Auto `close-run` for stale non-terminal runs (still operator explicit)
+- Project-local worktree base (`.relay/worktrees/` per repo)
+- Scheduled daemon / launchd cron
+- `policy.isolation: branch` escape hatch (spec only; see GSD `use_worktrees: false`)
+
+## Bootstrap audit hook (planned)
+
+On `/relay`, `relay-dispatch`, or `relay-merge` entry, emit a one-line warning when:
+
+- disk worktrees >> open manifests for repo slug
+- `inspect` reports `reconcile_merged` count > 0
+- path validation failure rate > 0
+
+Implementation tracked separately to keep v2 CLI-only.
+
+## Related files
+
+- `scripts/worktree-health.js` — health + finish path
+- `scripts/cleanup-worktrees.js` — janitor CLI
+- `scripts/manifest/cleanup.js` — `runCleanup()`
+- `scripts/finalize-run.js` — preferred post-review merge path
+- `references/operator-utilities.md` — operator cheat sheet

--- a/skills/relay-dispatch/references/worktree-janitor-v2.md
+++ b/skills/relay-dispatch/references/worktree-janitor-v2.md
@@ -36,7 +36,7 @@ v1 janitor (`cleanup-worktrees.js`) only deletes **terminal** runs past an age g
 | `lastCommitAgeDays` | branch tip age |
 | `stale` | not merged and age ≥ `--stale-days` (default 14) |
 | `safeToRemove` | merged + effectively clean |
-| `reconcileEligible` | non-terminal + merged + clean + eligible state |
+| `reconcileEligible` | `ready_to_merge` + merged + effectively clean |
 
 ## Finish paths (Superpowers mapping)
 
@@ -74,8 +74,8 @@ node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --sta
 | --- | --- | --- |
 | `--inspect` | off | Health inventory only; no cleanup, no shell sweep |
 | `--reconcile-merged` | off | For eligible non-terminal runs: transition to `merged`, then cleanup |
-| `--stale-days` | 14 | Stale classification for health + stale-open reporting |
-| `--older-than` | 24 | Age gate for terminal cleanup and reconcile (hours) |
+| `--stale-days` | 14 | Stale classification for health + stale-open reporting (days; reporting only) |
+| `--older-than` | 24 | Age gate for terminal cleanup only (hours) |
 | `--all` | off | Ignore age gate |
 | `--dry-run` | off | No manifest/git writes |
 
@@ -83,15 +83,18 @@ node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo . --inspect --sta
 
 `--reconcile-merged` applies only when **all** hold:
 
-- manifest state ∈ `{ ready_to_merge, review_pending, changes_requested, escalated }`
+- manifest state is `ready_to_merge`
 - `mergedIntoBaseOrPr` is true
 - worktree effectively clean (or relay-owned stray only)
-- age gate satisfied (unless `--all`)
 - path validation succeeds
+
+Reconcile **does not** use `--older-than`; merge/PR evidence is the safety gate. Terminal cleanup still uses `--older-than` (or `--all`).
 
 Transition: `forceUpdateManifestState(..., merged, manual_cleanup_required)` with audit reason `janitor_reconcile_merged`, then `runCleanup()` with `deleteMergedBranch: true`.
 
-Prefer `finalize-run --skip-merge` when review audit trail matters; janitor reconcile is a **disk recovery** path, not a merge substitute.
+**Preferred path:** `finalize-run --repo <path> --run-id <id>` when the run is `ready_to_merge` and the review gate can pass (issues close, `MERGE_FINALIZE` event, learnings). Use `finalize-run --skip-merge` only when the manifest is already `merged` and you need cleanup-only.
+
+Janitor reconcile is a **disk recovery** escape hatch when finalize is blocked or skipped — not a substitute for merge finalization.
 
 ## Out of scope (v2.1 candidates)
 

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -53,6 +53,14 @@ function parseHours(value, label) {
   return parsed;
 }
 
+function parsePositiveNumber(value, label) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative number`);
+  }
+  return parsed;
+}
+
 function relayWorktreeChildPath(base, name) {
   const candidate = path.join(base, name);
   if (!isPathContainedWithin(base, candidate)) {
@@ -133,7 +141,7 @@ function run() {
   const jsonOut = hasCliFlag("--json");
   const inspectOnly = hasCliFlag("--inspect");
   const reconcileMerged = hasCliFlag("--reconcile-merged");
-  const staleDays = parseHours(readArg(args, "--stale-days", String(DEFAULT_STALE_DAYS), CLI_ARG_OPTIONS), "--stale-days");
+  const staleDays = parsePositiveNumber(readArg(args, "--stale-days", String(DEFAULT_STALE_DAYS), CLI_ARG_OPTIONS), "--stale-days");
   const olderThanHours = all ? 0 : parseHours(readArg(args, "--older-than", "24", CLI_ARG_OPTIONS), "--older-than");
   const now = Date.now();
   const cutoff = now - olderThanHours * 60 * 60 * 1000;
@@ -228,14 +236,8 @@ function run() {
       continue;
     }
 
-    if (!all && updatedAt && updatedAt > cutoff) {
-      result.skipped.push({ ...enrichedBaseInfo, reason: "recent" });
-      continue;
-    }
-
     if (
       reconcileMerged
-      && !isTerminalState(normalizedData.state)
       && health.reconcileEligible
     ) {
       let reconcileData = normalizedData;
@@ -299,6 +301,11 @@ function run() {
       } else {
         result.failed.push(item);
       }
+      continue;
+    }
+
+    if (!all && updatedAt && updatedAt > cutoff) {
+      result.skipped.push({ ...enrichedBaseInfo, reason: "recent" });
       continue;
     }
 

--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -10,11 +10,14 @@
  *   --all                  Ignore age threshold
  *   --dry-run              Show what would be cleaned without writing
  *   --json                 Output as JSON
+ *   --inspect              Health inventory only (no cleanup or shell sweep)
+ *   --reconcile-merged     Reconcile merged drift for eligible non-terminal runs
+ *   --stale-days <days>    Stale classification threshold (default: 14)
  */
 
 const path = require("path");
 const fs = require("fs");
-const { isTerminalState } = require("./manifest/lifecycle");
+const { forceUpdateManifestState, isTerminalState } = require("./manifest/lifecycle");
 const {
   CLEANUP_STATUSES,
   runCleanup,
@@ -32,6 +35,10 @@ const {
 const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { safeFormatRunId } = require("./relay-resolver");
+const {
+  DEFAULT_STALE_DAYS,
+  assessRunWorktreeHealth,
+} = require("./worktree-health");
 
 const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "cleanup-worktrees" };
@@ -108,6 +115,9 @@ if (hasCliFlag(["--help", "-h"])) {
   console.log(`  --all                  ${modeLabel("--all")} Ignore age threshold`);
   console.log(`  --dry-run              ${modeLabel("--dry-run")} Show what would be cleaned without writing`);
   console.log(`  --json                 ${modeLabel("--json")} Output as JSON`);
+  console.log(`  --inspect              ${modeLabel("--inspect")} Health inventory only (no cleanup or shell sweep)`);
+  console.log(`  --reconcile-merged     ${modeLabel("--reconcile-merged")} Reconcile merged drift for eligible non-terminal runs`);
+  console.log(`  --stale-days <days>    ${modeLabel("--stale-days")} Stale classification threshold (default: ${DEFAULT_STALE_DAYS})`);
   process.exit(0);
 }
 
@@ -121,6 +131,9 @@ function run() {
   const dryRun = hasCliFlag("--dry-run");
   const all = hasCliFlag("--all");
   const jsonOut = hasCliFlag("--json");
+  const inspectOnly = hasCliFlag("--inspect");
+  const reconcileMerged = hasCliFlag("--reconcile-merged");
+  const staleDays = parseHours(readArg(args, "--stale-days", String(DEFAULT_STALE_DAYS), CLI_ARG_OPTIONS), "--stale-days");
   const olderThanHours = all ? 0 : parseHours(readArg(args, "--older-than", "24", CLI_ARG_OPTIONS), "--older-than");
   const now = Date.now();
   const cutoff = now - olderThanHours * 60 * 60 * 1000;
@@ -128,12 +141,17 @@ function run() {
   const result = {
     repoRoot,
     olderThanHours,
+    staleDays,
     dryRun,
     all,
+    inspectOnly,
+    reconcileMerged,
     cleaned: [],
+    reconciled: [],
     failed: [],
     staleOpen: [],
     skipped: [],
+    inventory: [],
     reapedShells: [],
     skippedShells: [],
   };
@@ -153,6 +171,7 @@ function run() {
       state: data.state,
       branch: data.git?.working_branch || null,
       worktree: data.paths?.worktree || null,
+      prNumber: data.git?.pr_number || null,
       ageHours,
       cleanupStatus,
       closeCommand: `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} --run-id ${JSON.stringify(runId)} --reason ${JSON.stringify("stale_non_terminal_run")}`,
@@ -190,18 +209,110 @@ function run() {
       continue;
     }
 
+    const health = assessRunWorktreeHealth({
+      repoRoot,
+      data: normalizedData,
+      worktreePath: normalizedData.paths?.worktree || null,
+      staleDays,
+    });
+    const enrichedBaseInfo = {
+      ...baseInfo,
+      health,
+    };
+
+    if (inspectOnly) {
+      result.inventory.push({
+        ...enrichedBaseInfo,
+        reason: health.finishPath,
+      });
+      continue;
+    }
+
     if (!all && updatedAt && updatedAt > cutoff) {
-      result.skipped.push({ ...baseInfo, reason: "recent" });
+      result.skipped.push({ ...enrichedBaseInfo, reason: "recent" });
+      continue;
+    }
+
+    if (
+      reconcileMerged
+      && !isTerminalState(normalizedData.state)
+      && health.reconcileEligible
+    ) {
+      let reconcileData = normalizedData;
+      if (!dryRun) {
+        reconcileData = forceUpdateManifestState(
+          normalizedData,
+          "merged",
+          "manual_cleanup_required",
+          {
+            reason: "janitor_reconcile_merged",
+            operator: "cleanup-worktrees",
+          }
+        );
+        writeManifest(manifestPath, reconcileData, body);
+        appendRunEvent(repoRoot, reconcileData.run_id, {
+          event: EVENTS.STATE_RECOVERY,
+          state_from: normalizedData.state,
+          state_to: reconcileData.state,
+          head_sha: reconcileData.git?.head_sha || null,
+          round: reconcileData.review?.rounds || null,
+          reason: "janitor_reconcile_merged",
+        });
+      }
+
+      const cleanupResult = runCleanup({
+        repoRoot,
+        data: reconcileData,
+        dryRun,
+        deleteMergedBranch: true,
+        acceptPrunedRelayOwned: true,
+      });
+
+      const item = {
+        ...enrichedBaseInfo,
+        state: dryRun ? normalizedData.state : reconcileData.state,
+        cleanupStatus: cleanupResult.summary.cleanupStatus,
+        nextAction: cleanupResult.summary.nextAction,
+        worktreeRemoved: cleanupResult.summary.worktreeRemoved,
+        branchDeleted: cleanupResult.summary.branchDeleted,
+        pruneRan: cleanupResult.summary.pruneRan,
+        error: cleanupResult.summary.error,
+        reason: "reconcile_merged",
+      };
+
+      if (!dryRun) {
+        writeManifest(manifestPath, cleanupResult.updatedData, body);
+        appendRunEvent(repoRoot, cleanupResult.updatedData.run_id, {
+          event: EVENTS.CLEANUP_RESULT,
+          state_from: cleanupResult.updatedData.state,
+          state_to: cleanupResult.updatedData.state,
+          head_sha: cleanupResult.updatedData.git?.head_sha || null,
+          round: cleanupResult.updatedData.review?.rounds || null,
+          reason: cleanupResult.summary.cleanupStatus === CLEANUP_STATUSES.SUCCEEDED
+            ? "reconcile_cleanup_succeeded"
+            : cleanupResult.summary.error,
+        });
+      }
+
+      if (cleanupResult.summary.cleanupStatus === CLEANUP_STATUSES.SUCCEEDED) {
+        result.reconciled.push(item);
+      } else {
+        result.failed.push(item);
+      }
       continue;
     }
 
     if (!isTerminalState(normalizedData.state)) {
-      result.staleOpen.push({ ...baseInfo, reason: "non-terminal" });
+      const staleReason = health.stale ? "stale_non_terminal" : "non-terminal";
+      result.staleOpen.push({
+        ...enrichedBaseInfo,
+        reason: staleReason,
+      });
       continue;
     }
 
     if (cleanupStatus === CLEANUP_STATUSES.SUCCEEDED) {
-      result.skipped.push({ ...baseInfo, reason: "already_cleaned" });
+      result.skipped.push({ ...enrichedBaseInfo, reason: "already_cleaned" });
       continue;
     }
 
@@ -214,7 +325,7 @@ function run() {
     });
 
     const item = {
-      ...baseInfo,
+      ...enrichedBaseInfo,
       cleanupStatus: cleanupResult.summary.cleanupStatus,
       nextAction: cleanupResult.summary.nextAction,
       worktreeRemoved: cleanupResult.summary.worktreeRemoved,
@@ -244,15 +355,21 @@ function run() {
     }
   }
 
-  const shellSweep = sweepOrphanedWorktreeShells({ dryRun });
-  result.reapedShells = shellSweep.reaped;
-  result.skippedShells = shellSweep.skipped;
+  if (!inspectOnly) {
+    const shellSweep = sweepOrphanedWorktreeShells({ dryRun });
+    result.reapedShells = shellSweep.reaped;
+    result.skippedShells = shellSweep.skipped;
+  }
 
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));
   } else {
     console.log(`Relay janitor: ${repoRoot}`);
+    if (inspectOnly) {
+      console.log(`  inspect:    ${result.inventory.length} runs`);
+    }
     console.log(`  cleaned:    ${result.cleaned.length}`);
+    console.log(`  reconciled: ${result.reconciled.length}`);
     console.log(`  failed:     ${result.failed.length}`);
     console.log(`  stale open: ${result.staleOpen.length}`);
     console.log(`  skipped:    ${result.skipped.length}`);
@@ -262,7 +379,16 @@ function run() {
     }
     if (result.staleOpen.length) {
       console.log("  stale open runs:");
-      result.staleOpen.forEach((entry) => console.log(`    ${entry.runId} (${entry.state}, ${entry.ageHours ?? "?"}h old) -> ${entry.closeCommand}`));
+      result.staleOpen.forEach((entry) => {
+        const finishPath = entry.health?.finishPath || "unknown";
+        console.log(`    ${entry.runId} (${entry.state}, ${entry.ageHours ?? "?"}h old, ${finishPath}) -> ${entry.health?.recommendedAction || entry.closeCommand}`);
+      });
+    }
+    if (inspectOnly && result.inventory.length) {
+      console.log("  inventory:");
+      result.inventory.forEach((entry) => {
+        console.log(`    ${entry.runId} (${entry.state}, ${entry.health.finishPath}) -> ${entry.health.recommendedAction}`);
+      });
     }
     if (dryRun) {
       console.log("  dry-run: no changes written");

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -44,6 +44,7 @@ const FLAGS = [
   { flag: "--head-sha", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Structured SHA field; flag-like following tokens should mean the value is missing." },
   { flag: "--help", aliases: ["-h"], kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--independent-review-reason", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit reason for a same-adapter independent review attempt; preserve the operator-supplied text." },
+  { flag: "--inspect", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Health inventory only; no cleanup or shell sweep." },
   { flag: "--issue", kind: VALUE, mode: MODE_PARSED, valueName: "<N>", rationale: "Numeric selector; flag-like following tokens should mean the value is missing." },
   { flag: "--json", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--last-reviewed-sha", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Structured SHA field; flag-like following tokens should mean the value is missing." },
@@ -78,6 +79,7 @@ const FLAGS = [
   { flag: "--reasoning", kind: VALUE, mode: MODE_PARSED, valueName: "<level>",
     allowedValues: ["none", "minimal", "low", "medium", "high", "xhigh"],
     rationale: "Codex reasoning_effort override; closed selector over codex CLI levels." },
+  { flag: "--reconcile-merged", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Reconcile merged drift for eligible non-terminal runs." },
   { flag: "--register", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--repeated-issue-count", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Numeric review field; flag-like following tokens should mean the value is missing." },
   { flag: "--repo", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied repository path; keep the literal argv token." },
@@ -99,6 +101,7 @@ const FLAGS = [
   { flag: "--skip-merge", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--skip-review", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit skip reason must be recorded exactly and must not be blank." },
   { flag: "--stale-hours", kind: VALUE, mode: MODE_PARSED, valueName: "<hours>", rationale: "Numeric threshold; flag-like following tokens should mean the value is missing." },
+  { flag: "--stale-days", kind: VALUE, mode: MODE_PARSED, valueName: "<days>", rationale: "Stale classification threshold for worktree health." },
   { flag: "--state", kind: VALUE, mode: MODE_PARSED, valueName: "<state>", rationale: "Closed manifest state selector; flag-like following tokens should mean the value is missing." },
   { flag: "--tags", kind: VALUE, mode: MODE_PARSED, valueName: "<csv>", rationale: "Explicit routing tags; flag-like following tokens should mean the value is missing." },
   { flag: "--test-command", kind: VALUE, mode: MODE_VERBATIM, valueName: "<cmd>", rationale: "Execution evidence must preserve the operator-supplied command token exactly." },
@@ -118,7 +121,8 @@ const COMMAND_FLAGS = {
     "--print", "--post-comment", "--issue", "--window-days", "--runs-dir", "--help",
   ],
   "cleanup-worktrees": [
-    "--repo", "--older-than", "--all", "--dry-run", "--json", "--help",
+    "--repo", "--older-than", "--all", "--dry-run", "--json",
+    "--inspect", "--reconcile-merged", "--stale-days", "--help",
   ],
   "close-run": [
     "--repo", "--run-id", "--reason", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -79,7 +79,7 @@ const FLAGS = [
   { flag: "--reasoning", kind: VALUE, mode: MODE_PARSED, valueName: "<level>",
     allowedValues: ["none", "minimal", "low", "medium", "high", "xhigh"],
     rationale: "Codex reasoning_effort override; closed selector over codex CLI levels." },
-  { flag: "--reconcile-merged", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Reconcile merged drift for eligible non-terminal runs." },
+  { flag: "--reconcile-merged", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Reconcile merged drift for ready_to_merge runs with merge evidence." },
   { flag: "--register", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--repeated-issue-count", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Numeric review field; flag-like following tokens should mean the value is missing." },
   { flag: "--repo", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied repository path; keep the literal argv token." },

--- a/skills/relay-dispatch/scripts/worktree-health.js
+++ b/skills/relay-dispatch/scripts/worktree-health.js
@@ -170,7 +170,7 @@ function buildRecommendedAction({ finishPath, runId, repoRoot }) {
     case FINISH_PATHS.CLEANUP_TERMINAL:
       return "cleanup-worktrees (terminal run)";
     case FINISH_PATHS.RECONCILE_MERGED:
-      return `cleanup-worktrees --reconcile-merged --repo ${repoArg} (or finalize-run --skip-merge --run-id ${runArg})`;
+      return `finalize-run --repo ${repoArg} --run-id ${runArg} (preferred); or cleanup-worktrees --reconcile-merged --repo ${repoArg} --dry-run first (disk recovery only)`;
     case FINISH_PATHS.RETAIN_PR_HANDOFF:
       return `retain worktree until merge/finalize; then finalize-run --run-id ${runArg}`;
     case FINISH_PATHS.STALE_OPEN:
@@ -201,10 +201,9 @@ function assessRunWorktreeHealth({
     && lastCommitAgeDays >= staleDays;
   const effectivelyClean = !dirtyStatus.dirty || dirtyStatus.relayOwnedStrayOnly;
   const safeToRemove = mergedIntoBaseOrPr && effectivelyClean;
-  const reconcileEligible = !isTerminalState(data?.state)
+  const reconcileEligible = data?.state === "ready_to_merge"
     && mergedIntoBaseOrPr
-    && effectivelyClean
-    && ["ready_to_merge", "review_pending", "changes_requested", "escalated"].includes(data?.state);
+    && effectivelyClean;
 
   const health = {
     mergedIntoBase,

--- a/skills/relay-dispatch/scripts/worktree-health.js
+++ b/skills/relay-dispatch/scripts/worktree-health.js
@@ -147,16 +147,16 @@ function inferFinishPath({ state, prNumber, health }) {
     return FINISH_PATHS.RECONCILE_MERGED;
   }
 
+  if (health.dirty && !health.relayOwnedStrayOnly) {
+    return FINISH_PATHS.MANUAL_REQUIRED;
+  }
+
   if (state === "ready_to_merge" && prNumber) {
     return FINISH_PATHS.RETAIN_PR_HANDOFF;
   }
 
   if (health.stale) {
     return FINISH_PATHS.STALE_OPEN;
-  }
-
-  if (health.dirty && !health.relayOwnedStrayOnly) {
-    return FINISH_PATHS.MANUAL_REQUIRED;
   }
 
   return FINISH_PATHS.RETAIN_ACTIVE;

--- a/skills/relay-dispatch/scripts/worktree-health.js
+++ b/skills/relay-dispatch/scripts/worktree-health.js
@@ -1,0 +1,246 @@
+"use strict";
+
+const fs = require("fs");
+
+const { execGit, execGh } = require("./exec");
+const { isTerminalState } = require("./manifest/lifecycle");
+
+const DEFAULT_STALE_DAYS = 14;
+
+const RELAY_OWNED_STRAY_WORKTREE_STATUS_LINES = Object.freeze([
+  "?? rubric.yaml",
+]);
+
+const FINISH_PATHS = Object.freeze({
+  CLEANUP_TERMINAL: "cleanup_terminal",
+  RECONCILE_MERGED: "reconcile_merged",
+  RETAIN_PR_HANDOFF: "retain_pr_handoff",
+  RETAIN_ACTIVE: "retain_active",
+  STALE_OPEN: "stale_open",
+  MANUAL_REQUIRED: "manual_required",
+});
+
+function readWorktreeDirty(worktreePath) {
+  if (!worktreePath || !fs.existsSync(worktreePath)) {
+    return { exists: false, dirty: false, dirtyFileCount: 0, text: "", relayOwnedStrayOnly: false };
+  }
+  try {
+    const text = execGit(worktreePath, ["status", "--short", "--untracked-files=all"]);
+    const lines = String(text || "").split(/\r?\n/).filter(Boolean);
+    const relayOwnedStrayOnly = lines.length === 1
+      && RELAY_OWNED_STRAY_WORKTREE_STATUS_LINES.includes(lines[0]);
+    return {
+      exists: true,
+      dirty: text !== "",
+      dirtyFileCount: lines.length,
+      text,
+      relayOwnedStrayOnly,
+    };
+  } catch (error) {
+    return {
+      exists: true,
+      dirty: true,
+      dirtyFileCount: -1,
+      text: String(error.message || error),
+      relayOwnedStrayOnly: false,
+    };
+  }
+}
+
+function branchExists(repoRoot, branch) {
+  if (!branch) return false;
+  try {
+    execGit(repoRoot, ["rev-parse", "--verify", `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isBranchMergedIntoBase(repoRoot, branch, baseBranch) {
+  if (!branch || !baseBranch || branch === baseBranch) {
+    return branch === baseBranch;
+  }
+  if (!branchExists(repoRoot, branch)) {
+    return false;
+  }
+  try {
+    const mergedRaw = execGit(repoRoot, ["branch", "--merged", baseBranch]);
+    const mergedBranches = mergedRaw
+      .split(/\r?\n/)
+      .map((line) => line.trim().replace(/^\* /, ""))
+      .filter(Boolean);
+    if (mergedBranches.includes(branch)) {
+      return true;
+    }
+  } catch {
+    // fall through to ancestry check
+  }
+  try {
+    execGit(repoRoot, ["merge-base", "--is-ancestor", branch, baseBranch]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readLastCommitAgeDays(repoRoot, branch) {
+  if (!branch || !branchExists(repoRoot, branch)) {
+    return -1;
+  }
+  try {
+    const epochRaw = execGit(repoRoot, ["log", "-1", "--format=%ct", branch]);
+    const epoch = Number(epochRaw);
+    if (!Number.isFinite(epoch) || epoch <= 0) {
+      return -1;
+    }
+    return (Date.now() / 1000 - epoch) / 86400;
+  } catch {
+    return -1;
+  }
+}
+
+function readUnpushedCommits(repoRoot, branch) {
+  if (!branch || !branchExists(repoRoot, branch)) {
+    return 0;
+  }
+  try {
+    const raw = execGit(repoRoot, ["rev-list", "--count", `${branch}@{upstream}..${branch}`]);
+    const count = Number(raw);
+    return Number.isFinite(count) && count >= 0 ? count : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function readPrMergedAt(repoRoot, prNumber) {
+  if (!prNumber) {
+    return { prMerged: false, prState: null, prMergedAt: null };
+  }
+  try {
+    const raw = execGh(repoRoot, [
+      "pr",
+      "view",
+      String(prNumber),
+      "--json",
+      "mergedAt,state",
+    ]);
+    const parsed = JSON.parse(raw);
+    return {
+      prMerged: Boolean(parsed.mergedAt),
+      prState: parsed.state || null,
+      prMergedAt: parsed.mergedAt || null,
+    };
+  } catch {
+    return { prMerged: false, prState: null, prMergedAt: null };
+  }
+}
+
+function inferFinishPath({ state, prNumber, health }) {
+  const terminal = isTerminalState(state);
+
+  if (terminal) {
+    return health.safeToRemove ? FINISH_PATHS.CLEANUP_TERMINAL : FINISH_PATHS.MANUAL_REQUIRED;
+  }
+
+  if (health.reconcileEligible) {
+    return FINISH_PATHS.RECONCILE_MERGED;
+  }
+
+  if (state === "ready_to_merge" && prNumber) {
+    return FINISH_PATHS.RETAIN_PR_HANDOFF;
+  }
+
+  if (health.stale) {
+    return FINISH_PATHS.STALE_OPEN;
+  }
+
+  if (health.dirty && !health.relayOwnedStrayOnly) {
+    return FINISH_PATHS.MANUAL_REQUIRED;
+  }
+
+  return FINISH_PATHS.RETAIN_ACTIVE;
+}
+
+function buildRecommendedAction({ finishPath, runId, repoRoot }) {
+  const repoArg = JSON.stringify(repoRoot);
+  const runArg = JSON.stringify(runId);
+
+  switch (finishPath) {
+    case FINISH_PATHS.CLEANUP_TERMINAL:
+      return "cleanup-worktrees (terminal run)";
+    case FINISH_PATHS.RECONCILE_MERGED:
+      return `cleanup-worktrees --reconcile-merged --repo ${repoArg} (or finalize-run --skip-merge --run-id ${runArg})`;
+    case FINISH_PATHS.RETAIN_PR_HANDOFF:
+      return `retain worktree until merge/finalize; then finalize-run --run-id ${runArg}`;
+    case FINISH_PATHS.STALE_OPEN:
+      return `close-run.js --repo ${repoArg} --run-id ${runArg} --reason "stale_non_terminal_run"`;
+    case FINISH_PATHS.MANUAL_REQUIRED:
+      return "inspect dirty worktree or manifest paths before cleanup";
+    default:
+      return "no cleanup action";
+  }
+}
+
+function assessRunWorktreeHealth({
+  repoRoot,
+  data,
+  worktreePath = data?.paths?.worktree || null,
+  staleDays = DEFAULT_STALE_DAYS,
+}) {
+  const branch = data?.git?.working_branch || null;
+  const baseBranch = data?.git?.base_branch || "main";
+  const prNumber = data?.git?.pr_number || null;
+  const dirtyStatus = readWorktreeDirty(worktreePath);
+  const mergedIntoBase = isBranchMergedIntoBase(repoRoot, branch, baseBranch);
+  const prStatus = readPrMergedAt(repoRoot, prNumber);
+  const mergedIntoBaseOrPr = mergedIntoBase || prStatus.prMerged;
+  const lastCommitAgeDays = readLastCommitAgeDays(repoRoot, branch);
+  const unpushedCommits = readUnpushedCommits(repoRoot, branch);
+  const stale = !mergedIntoBaseOrPr
+    && lastCommitAgeDays >= staleDays;
+  const effectivelyClean = !dirtyStatus.dirty || dirtyStatus.relayOwnedStrayOnly;
+  const safeToRemove = mergedIntoBaseOrPr && effectivelyClean;
+  const reconcileEligible = !isTerminalState(data?.state)
+    && mergedIntoBaseOrPr
+    && effectivelyClean
+    && ["ready_to_merge", "review_pending", "changes_requested", "escalated"].includes(data?.state);
+
+  const health = {
+    mergedIntoBase,
+    prMerged: prStatus.prMerged,
+    prState: prStatus.prState,
+    prMergedAt: prStatus.prMergedAt,
+    mergedIntoBaseOrPr,
+    dirty: dirtyStatus.dirty,
+    dirtyFileCount: dirtyStatus.dirtyFileCount,
+    relayOwnedStrayOnly: dirtyStatus.relayOwnedStrayOnly,
+    unpushedCommits,
+    lastCommitAgeDays,
+    stale,
+    safeToRemove,
+    reconcileEligible,
+    worktreeExists: dirtyStatus.exists,
+  };
+
+  const finishPath = inferFinishPath({ state: data?.state, prNumber, health });
+  return {
+    ...health,
+    finishPath,
+    recommendedAction: buildRecommendedAction({
+      finishPath,
+      runId: data?.run_id,
+      repoRoot,
+    }),
+  };
+}
+
+module.exports = {
+  DEFAULT_STALE_DAYS,
+  FINISH_PATHS,
+  assessRunWorktreeHealth,
+  buildRecommendedAction,
+  inferFinishPath,
+  isBranchMergedIntoBase,
+  readWorktreeDirty,
+};

--- a/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -222,11 +222,95 @@ test("cleanup-worktrees reports stale open runs without deleting them", () => {
   assert.equal(result.failed.length, 0);
   assert.equal(result.staleOpen.length, 1);
   assert.equal(result.staleOpen[0].branch, "issue-77");
+  assert.ok(result.staleOpen[0].health);
+  assert.equal(result.staleOpen[0].health.finishPath, "retain_active");
+  assert.equal(result.staleOpen[0].reason, "non-terminal");
   assert.equal(fs.existsSync(worktreePath), true);
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.cleanup.status, "pending");
   assert.equal(manifest.next_action, "run_review");
+});
+
+test("cleanup-worktrees inspect mode returns inventory without side effects", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  writeRun(repoRoot, {
+    branch: "issue-inspect",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--inspect",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.inspectOnly, true);
+  assert.equal(result.inventory.length, 1);
+  assert.equal(result.cleaned.length, 0);
+  assert.equal(result.reconciled.length, 0);
+  assert.equal(result.reapedShells.length, 0);
+  assert.ok(result.inventory[0].health);
+});
+
+test("cleanup-worktrees reconciles merged drift for ready_to_merge runs", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const branch = "issue-reconcile-janitor";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, `${branch}.txt`), `${branch}\n`, "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", `${branch}.txt`], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", `Add ${branch}`], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["merge", branch, "-m", "merge reconcile janitor"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const runId = createRunId({ branch, timestamp: new Date(updatedAt) });
+  const layout = ensureRunLayout(repoRoot, runId);
+  const manifestPath = layout.manifestPath;
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 42,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: reconcile\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  writeManifest(manifestPath, manifest);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--reconcile-merged",
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.reconciled.length, 1);
+  assert.equal(result.failed.length, 0);
+  assert.equal(fs.existsSync(worktreePath), false);
+  assert.equal(branchExists(repoRoot, branch), false);
+
+  const updated = readManifest(manifestPath).data;
+  assert.equal(updated.state, "merged");
+  assert.equal(updated.cleanup.status, "succeeded");
+  assert.equal(updated.next_action, "done");
+  assert.equal(updated.last_force.reason, "janitor_reconcile_merged");
 });
 
 test("cleanup-worktrees does not echo tampered run_id into operator output (#176)", () => {

--- a/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -313,6 +313,55 @@ test("cleanup-worktrees reconciles merged drift for ready_to_merge runs", () => 
   assert.equal(updated.last_force.reason, "janitor_reconcile_merged");
 });
 
+test("cleanup-worktrees reconciles merged drift without --all when manifest is recent", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = new Date().toISOString();
+  const branch = "issue-reconcile-recent";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, `${branch}.txt`), `${branch}\n`, "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", `${branch}.txt`], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", `Add ${branch}`], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["merge", branch, "-m", "merge reconcile recent"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const runId = createRunId({ branch, timestamp: new Date(updatedAt) });
+  const layout = ensureRunLayout(repoRoot, runId);
+  const manifestPath = layout.manifestPath;
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 42,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: reconcile-recent\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  writeManifest(manifestPath, manifest);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--reconcile-merged",
+    "--older-than", "24",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.reconciled.length, 1);
+  assert.equal(result.skipped.length, 0);
+  assert.equal(fs.existsSync(worktreePath), false);
+});
+
 test("cleanup-worktrees does not echo tampered run_id into operator output (#176)", () => {
   // Anti-theater: without the #176 safeFormatRunId reuse at cleanup-worktrees.js:88/:94,
   // the tampered run_id leaks into result.staleOpen[*].runId and the closeCommand --run-id.

--- a/tests/relay-dispatch/scripts/worktree-health.test.js
+++ b/tests/relay-dispatch/scripts/worktree-health.test.js
@@ -1,0 +1,122 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  readManifest,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const {
+  assessRunWorktreeHealth,
+  FINISH_PATHS,
+  isBranchMergedIntoBase,
+} = require("../../../skills/relay-dispatch/scripts/worktree-health");
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-health-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-health-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Health Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-health@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return repoRoot;
+}
+
+function writeReadyRun(repoRoot, { branch, updatedAt }) {
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, `${branch}.txt`), `${branch}\n`, "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", `${branch}.txt`], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", `Add ${branch}`], { encoding: "utf-8", stdio: "pipe" });
+
+  const runId = createRunId({ branch, timestamp: new Date(updatedAt) });
+  const manifestPath = ensureRunLayout(repoRoot, runId).manifestPath;
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 42,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(ensureRunLayout(repoRoot, runId).runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: health\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  manifest.git.pr_number = 99;
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  writeManifest(manifestPath, manifest);
+  return { manifestPath, worktreePath, manifest };
+}
+
+test("isBranchMergedIntoBase detects merged branches", () => {
+  const repoRoot = setupRepo();
+  const branch = "issue-merge-detect";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, "feature.txt"), "feature\n", "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", "feature.txt"], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", "feature"], { encoding: "utf-8", stdio: "pipe" });
+
+  assert.equal(isBranchMergedIntoBase(repoRoot, branch, "main"), false);
+  execFileSync("git", ["merge", branch, "-m", "merge feature"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  assert.equal(isBranchMergedIntoBase(repoRoot, branch, "main"), true);
+});
+
+test("assessRunWorktreeHealth marks ready_to_merge PR handoff as retain_pr_handoff", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const { manifest } = writeReadyRun(repoRoot, { branch: "issue-handoff", updatedAt });
+
+  const health = assessRunWorktreeHealth({ repoRoot, data: manifest, staleDays: 14 });
+  assert.equal(health.finishPath, FINISH_PATHS.RETAIN_PR_HANDOFF);
+  assert.equal(health.reconcileEligible, false);
+  assert.equal(health.safeToRemove, false);
+});
+
+test("assessRunWorktreeHealth marks merged drift as reconcile_eligible", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const branch = "issue-reconcile";
+  const { manifest } = writeReadyRun(repoRoot, { branch, updatedAt });
+
+  execFileSync("git", ["merge", branch, "-m", "merge issue-reconcile"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const health = assessRunWorktreeHealth({ repoRoot, data: manifest, staleDays: 14 });
+  assert.equal(health.mergedIntoBase, true);
+  assert.equal(health.reconcileEligible, true);
+  assert.equal(health.safeToRemove, true);
+  assert.equal(health.finishPath, FINISH_PATHS.RECONCILE_MERGED);
+});
+
+test("assessRunWorktreeHealth treats relay-owned rubric.yaml stray as effectively clean", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const branch = "issue-stray";
+  const { manifest, worktreePath } = writeReadyRun(repoRoot, { branch, updatedAt });
+  fs.writeFileSync(path.join(worktreePath, "rubric.yaml"), "rubric:\n  factors: []\n", "utf-8");
+
+  execFileSync("git", ["merge", branch, "-m", "merge issue-stray"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const health = assessRunWorktreeHealth({ repoRoot, data: manifest, staleDays: 14 });
+  assert.equal(health.relayOwnedStrayOnly, true);
+  assert.equal(health.reconcileEligible, true);
+  assert.equal(health.safeToRemove, true);
+});

--- a/tests/relay-dispatch/scripts/worktree-health.test.js
+++ b/tests/relay-dispatch/scripts/worktree-health.test.js
@@ -120,3 +120,44 @@ test("assessRunWorktreeHealth treats relay-owned rubric.yaml stray as effectivel
   assert.equal(health.reconcileEligible, true);
   assert.equal(health.safeToRemove, true);
 });
+
+test("assessRunWorktreeHealth does not reconcile review_pending even when branch merged", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const branch = "issue-review-pending-merged";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, `${branch}.txt`), `${branch}\n`, "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", `${branch}.txt`], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", `Add ${branch}`], { encoding: "utf-8", stdio: "pipe" });
+
+  const runId = createRunId({ branch, timestamp: new Date(updatedAt) });
+  const layout = ensureRunLayout(repoRoot, runId);
+  const manifestPath = layout.manifestPath;
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 42,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: review-pending\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  writeManifest(manifestPath, manifest);
+
+  execFileSync("git", ["merge", branch, "-m", "merge review pending"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const health = assessRunWorktreeHealth({ repoRoot, data: manifest, staleDays: 14 });
+  assert.equal(health.mergedIntoBase, true);
+  assert.equal(health.reconcileEligible, false);
+  assert.notEqual(health.finishPath, FINISH_PATHS.RECONCILE_MERGED);
+});

--- a/tests/relay-dispatch/scripts/worktree-health.test.js
+++ b/tests/relay-dispatch/scripts/worktree-health.test.js
@@ -121,6 +121,20 @@ test("assessRunWorktreeHealth treats relay-owned rubric.yaml stray as effectivel
   assert.equal(health.safeToRemove, true);
 });
 
+test("assessRunWorktreeHealth marks dirty ready_to_merge PR handoff as manual_required", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const branch = "issue-dirty-handoff";
+  const { manifest, worktreePath } = writeReadyRun(repoRoot, { branch, updatedAt });
+  fs.writeFileSync(path.join(worktreePath, "wip.txt"), "wip\n", "utf-8");
+
+  const health = assessRunWorktreeHealth({ repoRoot, data: manifest, staleDays: 14 });
+  assert.equal(health.dirty, true);
+  assert.equal(health.reconcileEligible, false);
+  assert.equal(health.finishPath, FINISH_PATHS.MANUAL_REQUIRED);
+  assert.notEqual(health.finishPath, FINISH_PATHS.RETAIN_PR_HANDOFF);
+});
+
 test("assessRunWorktreeHealth does not reconcile review_pending even when branch merged", () => {
   const repoRoot = setupRepo();
   const updatedAt = "2026-04-01T00:00:00.000Z";


### PR DESCRIPTION
## Summary

- Limit `--reconcile-merged` to `ready_to_merge` runs where git/PR evidence shows the branch is already merged and the worktree is effectively clean (disk recovery, not bulk state cleanup).
- Keep `--older-than` as the age gate for terminal manifest cleanup only; reconcile bypasses that gate because merge evidence is the safety check.
- Keep `--stale-days` report-only for stale non-terminal inventory; prefer `finalize-run` in operator guidance over janitor reconcile.

## Test plan

- [x] `node --test tests/relay-dispatch/scripts/worktree-health.test.js tests/relay-dispatch/scripts/cleanup-worktrees.test.js` (18/18)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 워크트리 헬스 검사 기능 추가
  * `--inspect` 옵션으로 인벤토리만 조회하는 모드 추가
  * `--reconcile-merged` 옵션으로 병합된 드리프트 재조정 기능 추가
  * `--stale-days` 옵션으로 오래된 워크트리 판정 기준 커스터마이징 가능

* **Documentation**
  * Janitor v2의 git/PR 헬스 스코링 기능 문서화
  * CLI 동작 및 플래그 사용법 상세 설명

* **Tests**
  * 워크트리 헬스 평가 로직 테스트 추가
  * Inspect, reconcile-merged 모드 동작 검증 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-relay/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->