### PR TITLE
[codex] Tighten operator surface follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,12 @@ npx skills add . -g -y
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/code) or [Codex](https://chatgpt.com/codex)
-- Optional: OpenCode CLI for `--executor opencode`, `--reviewer opencode`, or `--advisory-reviewer opencode`; route policy must allow the selected provider/model route.
-- Optional: Pi CLI 0.72.1+ for `--executor pi`, `--reviewer pi`, or `--advisory-reviewer pi` (`RELAY_PI_BIN` may point review to a non-PATH binary; `RELAY_PI_REVIEW_TIMEOUT` sets the primary review parent timeout, default `1800s`)
-- Optional: Google Antigravity CLI `agy` 1.0.2+ for `--executor antigravity`, `--reviewer antigravity`, or `--advisory-reviewer antigravity`. Relay targets the `agy` CLI version track separately from any Antigravity IDE/Desktop app version; reviewer tests may use `RELAY_ANTIGRAVITY_BIN` to point at a non-PATH binary.
-- Optional: Cursor Agent CLI `agent` for `--executor cursor` or `--reviewer cursor` (`RELAY_CURSOR_AGENT_BIN` may point to a non-PATH binary; `RELAY_CURSOR_REVIEW_TIMEOUT` sets the primary review parent timeout, default `1800s`). Add `cursor` to route policy `managed_cli` for slug-only models such as `composer-2.5`.
+- Optional agent harness CLIs for `opencode`, `pi`, `antigravity`, or `cursor` when selecting those adapters; route policy must allow the selected provider/model route.
 - [`gh` CLI](https://cli.github.com/) authenticated with `gh auth login`
 - Git 2.20+
 - Node.js 18+
+
+Adapter minimum versions, binary overrides, timeouts, capability gates, and provider-specific limits live in [skills/relay-dispatch/references/agent-adapter-platform.md](skills/relay-dispatch/references/agent-adapter-platform.md).
 
 ## Configure Routes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Repo-local design notes, operator workflow docs, audit ledgers, and archived iss
 | [external-tool-workflow.md](./external-tool-workflow.md) | gstack, superpowers, CE around relay (optional) |
 | [direct-read-relay-operator-note.md](./direct-read-relay-operator-note.md) | Operate relay from a repo checkout without installed skills |
 | [relay-operator-guide.md](./relay-operator-guide.md) | Operator workflow for `/relay`, setup, manual phases, sidecars, batch dispatch, recovery, and extension points |
+| [references/operator-surface.md](../references/operator-surface.md) | Public/internal/optional skill tiers and placement rules for stable command surfaces |
 | [model-route-policy.md](./model-route-policy.md) | Provider/model route policy via `relay-config` (`~/.relay/policy.json`) — company defaults, personal opt-in, routing rules, advisory reviewers, sidecars |
 | [reviewer-policy-opencode.md](./reviewer-policy-opencode.md) | OpenCode trust boundary and review policy |
 | [script-inventory-and-cleanup.md](./script-inventory-and-cleanup.md) | Runtime script classification and cleanup backlog |

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -2,7 +2,7 @@
 
 Deep-dive into the manifest contract, state machine, and extension points. For overview, see [CLAUDE.md](../CLAUDE.md).
 
-This reference centers on the manifest-backed run lifecycle, plus the readiness boundary that may sit ahead of `relay-plan`. For the full relay-ready control-flow contract, see [docs/relay-ready-routing-and-handoff-design.md](../docs/relay-ready-routing-and-handoff-design.md). For provider/model route policy setup and operator examples, see [docs/model-route-policy.md](../docs/model-route-policy.md).
+This reference centers on the manifest-backed run lifecycle, plus the readiness boundary that may sit ahead of `relay-plan`. For the full relay-ready control-flow contract, see [docs/relay-ready-routing-and-handoff-design.md](../docs/relay-ready-routing-and-handoff-design.md). For provider/model route policy setup and operator examples, see [docs/model-route-policy.md](../docs/model-route-policy.md). For the public/internal/optional skill tiers, see [operator-surface.md](operator-surface.md).
 
 ## Readiness Boundary
 

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -22,16 +22,11 @@ const { buildPrimaryReviewerPreflight, loadReviewText, loadRunRoutePlan, resolve
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { resolveAdvisoryConfig, settleAdvisoryForVerdict, startConfiguredAdvisory } = require("./review-runner/advisory-orchestration");
 const { printResult, printUsage } = require("./review-runner/output");
-const { bindCliArgs, findUnknownFlags } = require("../../relay-dispatch/scripts/cli-args");
+const { assertKnownReviewRunnerFlags, parseReviewRunnerCliArgs } = require("./review-runner/cli");
 const { buildPolicyGateFailureEnvelope, isRelayPolicyGateError } = require("../../relay-dispatch/scripts/relay-policy-gate");
 const { buildAdapterCapabilityFailureEnvelope, isAdapterCapabilityError } = require("../../relay-dispatch/scripts/agent-adapters/policy");
 
-const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
-const cliArgs = bindCliArgs(args, {
-  commandName: "review-runner",
-  reservedFlags: KNOWN_FLAGS,
-});
+const { args, cliArgs, options } = parseReviewRunnerCliArgs(process.argv.slice(2));
 
 if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]))) {
   printUsage();
@@ -39,32 +34,13 @@ if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]
 }
 
 async function run() {
-  const unknownFlags = findUnknownFlags(args, "review-runner");
-  if (unknownFlags.length) {
-    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
-  }
-
-  const repoArg = cliArgs.getArg("--repo");
-  const repoPath = path.resolve(repoArg || ".");
-  const manifestPathArg = cliArgs.getArg("--manifest");
-  const runIdArg = cliArgs.getArg("--run-id");
-  const branchArg = cliArgs.getArg("--branch");
-  const prArg = cliArgs.getArg("--pr");
-  const doneCriteriaFile = cliArgs.getArg("--done-criteria-file");
-  const diffFile = cliArgs.getArg("--diff-file");
-  const reviewFile = cliArgs.getArg("--review-file");
-  const manualReviewReason = cliArgs.getArg("--manual-review-reason");
-  const reviewerArg = cliArgs.getArg("--reviewer");
-  const reviewerScriptArg = cliArgs.getArg("--reviewer-script");
-  const reviewerModel = cliArgs.getArg("--reviewer-model");
-  const independentReviewReason = cliArgs.getArg("--independent-review-reason");
-  const advisoryReviewerArg = cliArgs.getArg("--advisory-reviewer");
-  const advisoryProfileArg = cliArgs.getArg("--advisory-profile");
-  const advisoryReviewerModel = cliArgs.getArg("--advisory-reviewer-model");
-  const advisoryTimeoutArg = cliArgs.getArg("--advisory-timeout"), advisoryGraceArg = cliArgs.getArg("--advisory-grace");
-  const prepareOnly = cliArgs.hasFlag("--prepare-only");
-  const noComment = cliArgs.hasFlag("--no-comment");
-  const jsonOut = cliArgs.hasFlag("--json");
+  assertKnownReviewRunnerFlags(args);
+  const {
+    advisoryGraceArg, advisoryProfileArg, advisoryReviewerArg, advisoryReviewerModel,
+    advisoryTimeoutArg, branchArg, diffFile, doneCriteriaFile, independentReviewReason,
+    jsonOut, manifestPathArg, manualReviewReason, noComment, prArg, prepareOnly, repoArg,
+    repoPath, reviewFile, reviewerArg, reviewerModel, reviewerScriptArg, runIdArg,
+  } = options;
   if (manualReviewReason && !reviewFile) {
     throw new Error("--manual-review-reason requires --review-file");
   }
@@ -217,8 +193,6 @@ async function run() {
     branch, config: advisoryConfig, data, diffText, doneCriteria, doneCriteriaSource,
     issueNumber, prNumber, reviewedHeadSha, reviewRepoPath, round, rubricLoad, runDir, runRepoPath,
   }));
-
-  try {
   const { rawResponsePath, reviewText } = loadReviewText({
     body,
     data,
@@ -391,9 +365,6 @@ async function run() {
   result.verdictPath = verdictPath;
 
   printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath, result, updatedManifest, verdictPath });
-  } catch (error) {
-    throw error;
-  }
 }
 
 if (require.main === module) {
@@ -411,10 +382,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = {
-  applyVerdictToManifest, buildCommentBody, buildPrompt, buildRedispatchPrompt,
-  buildReviewRunnerRubricGateFailure, detectChurnGrowth, formatIssueList,
-  formatPriorVerdictSummary, formatScopeDrift, getGhLogin, loadRubricFromRunDir,
-  parseRemoteHost, parseReviewVerdict, parseScoreLog, resolveIssueNumber,
-  resolveRemoteHost, validateReviewVerdict, validateScopeDrift,
-};
+module.exports = { applyVerdictToManifest, buildCommentBody, buildPrompt, buildRedispatchPrompt, buildReviewRunnerRubricGateFailure, detectChurnGrowth, formatIssueList, formatPriorVerdictSummary, formatScopeDrift, getGhLogin, loadRubricFromRunDir, parseRemoteHost, parseReviewVerdict, parseScoreLog, resolveIssueNumber, resolveRemoteHost, validateReviewVerdict, validateScopeDrift };

--- a/skills/relay-review/scripts/review-runner/cli.js
+++ b/skills/relay-review/scripts/review-runner/cli.js
@@ -1,0 +1,52 @@
+const path = require("path");
+const { bindCliArgs, findUnknownFlags } = require("../../../relay-dispatch/scripts/cli-args");
+
+const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
+
+function parseReviewRunnerCliArgs(args) {
+  const cliArgs = bindCliArgs(args, {
+    commandName: "review-runner",
+    reservedFlags: KNOWN_FLAGS,
+  });
+  const repoArg = cliArgs.getArg("--repo");
+  return {
+    args,
+    cliArgs,
+    options: {
+      advisoryGraceArg: cliArgs.getArg("--advisory-grace"),
+      advisoryProfileArg: cliArgs.getArg("--advisory-profile"),
+      advisoryReviewerArg: cliArgs.getArg("--advisory-reviewer"),
+      advisoryReviewerModel: cliArgs.getArg("--advisory-reviewer-model"),
+      advisoryTimeoutArg: cliArgs.getArg("--advisory-timeout"),
+      branchArg: cliArgs.getArg("--branch"),
+      diffFile: cliArgs.getArg("--diff-file"),
+      doneCriteriaFile: cliArgs.getArg("--done-criteria-file"),
+      independentReviewReason: cliArgs.getArg("--independent-review-reason"),
+      jsonOut: cliArgs.hasFlag("--json"),
+      manifestPathArg: cliArgs.getArg("--manifest"),
+      manualReviewReason: cliArgs.getArg("--manual-review-reason"),
+      noComment: cliArgs.hasFlag("--no-comment"),
+      prArg: cliArgs.getArg("--pr"),
+      prepareOnly: cliArgs.hasFlag("--prepare-only"),
+      repoArg,
+      repoPath: path.resolve(repoArg || "."),
+      reviewFile: cliArgs.getArg("--review-file"),
+      reviewerArg: cliArgs.getArg("--reviewer"),
+      reviewerModel: cliArgs.getArg("--reviewer-model"),
+      reviewerScriptArg: cliArgs.getArg("--reviewer-script"),
+      runIdArg: cliArgs.getArg("--run-id"),
+    },
+  };
+}
+
+function assertKnownReviewRunnerFlags(args) {
+  const unknownFlags = findUnknownFlags(args, "review-runner");
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+}
+
+module.exports = {
+  assertKnownReviewRunnerFlags,
+  parseReviewRunnerCliArgs,
+};

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -28,7 +28,7 @@ const {
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
-const REVIEW_RUNNER_LINE_CAP = 420;
+const REVIEW_RUNNER_LINE_CAP = 390;
 const REVIEW_RUNNER_FUNCTION_CAP = 12;
 
 function setupRepo() {

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -16,6 +16,7 @@ const RELAY_READY_REQUEST_CONTRACT_SCHEMA = path.join(
   "request-contract.schema.json",
 );
 const OPERATOR_SURFACE_REFERENCE = path.join(REPO_ROOT, "references", "operator-surface.md");
+const README_PATH = path.join(REPO_ROOT, "README.md");
 
 const SURFACE_TIERS = {
   "public operator surface": ["relay-config", "relay", "relay-merge"],
@@ -238,6 +239,26 @@ function readSkillFiles() {
     }));
 }
 
+function extractOperatorSurfaceTierSkills(content) {
+  const tierNames = new Set(Object.keys(SURFACE_TIERS));
+  const entries = [];
+
+  splitLines(content).forEach((line) => {
+    const row = line.match(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|/);
+    if (!row) return;
+
+    const tier = row[1].trim().toLowerCase();
+    if (!tierNames.has(tier)) return;
+
+    const skillsCell = row[2];
+    for (const match of skillsCell.matchAll(/`([^`]+)`/g)) {
+      entries.push({ tier, skill: match[1] });
+    }
+  });
+
+  return entries;
+}
+
 function assertOperatorSurfacePolicy(content) {
   assert.match(
     content,
@@ -256,6 +277,21 @@ function assertOperatorSurfacePolicy(content) {
       assert.match(content, new RegExp(`\`${skill}\``), `operator surface reference must classify ${skill}`);
     });
   });
+
+  const installedSkills = readSkillFiles().map((skillFile) => path.basename(path.dirname(skillFile.path))).sort();
+  const classifiedSkills = extractOperatorSurfaceTierSkills(content);
+  const counts = new Map();
+  classifiedSkills.forEach(({ skill }) => counts.set(skill, (counts.get(skill) || 0) + 1));
+  const duplicates = [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([skill]) => skill)
+    .sort();
+  assert.deepEqual(duplicates, [], "operator surface reference must not classify a skill in multiple tiers");
+  assert.deepEqual(
+    [...counts.keys()].sort(),
+    installedSkills,
+    "operator surface reference must classify every installed skill exactly once",
+  );
 }
 
 function assertRelayStopsAtReadyToMerge(content) {
@@ -297,6 +333,26 @@ function assertRelayReviewAdapterDetailsStayReferenced(content) {
     /\.\.\/relay-dispatch\/references\/agent-adapter-platform\.md/,
     "relay-review/SKILL.md must point provider-specific adapter details to the adapter platform reference",
   );
+}
+
+function assertReadmeAdapterPrereqDetailsStayReferenced(content) {
+  assert.match(
+    content,
+    /skills\/relay-dispatch\/references\/agent-adapter-platform\.md/,
+    "README must point adapter-specific prerequisites to the adapter platform reference",
+  );
+  for (const pattern of [
+    /RELAY_(?:PI|CURSOR|ANTIGRAVITY)_[A-Z_]+/,
+    /Pi CLI \d/i,
+    /Antigravity CLI `agy` \d/i,
+    /Cursor Agent CLI `agent`/i,
+  ]) {
+    assert.doesNotMatch(
+      content,
+      pattern,
+      `README should not carry high-churn adapter prerequisite detail: ${pattern}`,
+    );
+  }
 }
 
 test("all skills/SKILL.md files satisfy the lint contract", () => {
@@ -341,6 +397,18 @@ test("operator surface policy classifies skill command tiers", () => {
   assertOperatorSurfacePolicy(content);
 });
 
+test("operator surface policy rejects missing or duplicate skill coverage", () => {
+  const content = fs.readFileSync(OPERATOR_SURFACE_REFERENCE, "utf-8");
+  assert.throws(
+    () => assertOperatorSurfacePolicy(content.replace("`relay-fleet`", "")),
+    /classify relay-fleet|classify every installed skill exactly once/,
+  );
+  assert.throws(
+    () => assertOperatorSurfacePolicy(content.replace("`relay-fleet`", "`relay`, `relay-fleet`")),
+    /must not classify a skill in multiple tiers/,
+  );
+});
+
 test("relay skill description preserves explicit ready_to_merge stop boundary", () => {
   const relaySkill = fs.readFileSync(path.join(SKILLS_DIR, "relay", "SKILL.md"), "utf-8");
   assertRelayStopsAtReadyToMerge(relaySkill);
@@ -349,6 +417,11 @@ test("relay skill description preserves explicit ready_to_merge stop boundary", 
 test("relay-review spine delegates provider-specific adapter details", () => {
   const relayReviewSkill = fs.readFileSync(path.join(SKILLS_DIR, "relay-review", "SKILL.md"), "utf-8");
   assertRelayReviewAdapterDetailsStayReferenced(relayReviewSkill);
+});
+
+test("README delegates adapter prerequisite churn to adapter references", () => {
+  const readme = fs.readFileSync(README_PATH, "utf-8");
+  assertReadmeAdapterPrereqDetailsStayReferenced(readme);
 });
 
 test("assertLineCount rejects SKILL.md files over 150 lines", () => {


### PR DESCRIPTION
## Summary
- Split review-runner CLI parsing into a helper so the main facade has line-cap headroom.
- Add operator-surface discovery links from the docs index and architecture reference.
- Strengthen skills-lint so every installed skill is classified exactly once in operator-surface tiers.
- Slim README adapter prerequisites and delegate provider-specific version/env/timeout details to the adapter platform reference.

## Validation
- `node --test tests/skills-lint/scripts/*.test.js`
- `node --test tests/relay-ready/scripts/*.test.js`
- `node --test tests/relay-plan/scripts/*.test.js`
- `node --test tests/relay-dispatch/scripts/*.test.js`
- `node --test tests/relay-review/scripts/*.test.js`
- `node --test tests/relay-merge/scripts/*.test.js`
- `node --test tests/relay-config/scripts/*.test.js`

Closes #657.
Closes #658.
Closes #659.
Closes #660.
