### PR TITLE
[codex] Recognize scoped maintenance refactor readiness

### DIFF
--- a/skills/relay-ready/scripts/score-readiness.js
+++ b/skills/relay-ready/scripts/score-readiness.js
@@ -356,7 +356,7 @@ function detectTopLevelAnd(opener) {
 }
 
 function detectBulletsAcrossModules(text) {
-  const bulletLines = text.split("\n").filter((line) => /^\s*[-*]\s+/.test(line));
+  const bulletLines = extractGranularityBulletLines(text);
   if (bulletLines.length < 3) {
     return null;
   }
@@ -370,6 +370,20 @@ function detectBulletsAcrossModules(text) {
   }
 
   return modules.size >= 2 ? `${bulletLines.length} bullets across ${modules.size} modules` : null;
+}
+
+function extractGranularityBulletLines(text) {
+  const excludedHeadings = /^(?:non[-\s]?goals?|out of scope|suggested tests?|tests?|notes?)$/i;
+  let excludedSection = false;
+
+  return text.split("\n").filter((line) => {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      excludedSection = excludedHeadings.test(heading[1].trim());
+      return false;
+    }
+    return !excludedSection && /^\s*[-*]\s+/.test(line);
+  });
 }
 
 function extractSubsystems(text) {

--- a/tests/relay-ready/scripts/score-readiness.test.js
+++ b/tests/relay-ready/scripts/score-readiness.test.js
@@ -183,6 +183,66 @@ test("bypass_true requires all four bypass checks to pass", () => {
   assertSignalShape(result);
 });
 
+test("maintenance refactor issue with explicit observable assertions is a single ready leaf", () => {
+  const body = `Refactor relay-ready maintenance scoring for \`skills/relay-ready/scripts/score-readiness.js\`.
+
+## Single Leaf Scope
+
+- Update only \`skills/relay-ready/scripts/score-readiness.js\` so maintenance refactor issues with explicit observable assertions are recognized as one relay-ready leaf.
+
+## Non-goals
+
+- Do not change relay-plan scoring.
+- Do not add new runtime dependencies.
+
+## Observable Assertions
+
+- \`skills/relay-ready/scripts/score-readiness.js\` reports granularity above low for this issue shape.
+- \`tests/relay-ready/scripts/score-readiness.test.js\` passes.
+
+## Done Criteria
+
+- \`skills/relay-ready/scripts/score-readiness.js\` keeps genuinely broad, ambiguous, or multi-leaf requests below bypass.
+- \`tests/relay-ready/scripts/score-readiness.test.js\` passes.
+
+## Suggested Tests
+
+- \`node --test tests/relay-ready/scripts/*.test.js\`
+- \`node --test tests/relay-plan/scripts/*.test.js\`
+`;
+
+  const result = scoreReadiness(body);
+
+  assert.notEqual(result.readiness.granularity, "low");
+  assert.equal(result.bypass, true);
+  assert.equal(result.next_action, "proceed");
+  assert.match(signalEvidence(result, "bypass", READINESS_CONDITIONS.SINGLE_LEAF), /^pass:/);
+  assertSignalShape(result);
+});
+
+test("single leaf labels do not override cross-module done criteria", () => {
+  const body = `Refactor relay-ready and relay-plan maintenance behavior.
+
+## Single Leaf Scope
+
+- Keep this as one maintenance pass across relay-ready and relay-plan.
+
+## Done Criteria
+
+- \`skills/relay-ready/scripts/score-readiness.js\` changes readiness scoring.
+- \`skills/relay-plan/scripts/task-profile.js\` changes planning profile scoring.
+- \`tests/relay-plan/scripts/task-profile.test.js\` passes.
+`;
+
+  const result = scoreReadiness(body);
+
+  assert.equal(result.readiness.granularity, "low");
+  assert.equal(result.bypass, false);
+  assert.match(signalEvidence(result, "bypass", READINESS_CONDITIONS.SINGLE_LEAF), /^fail:/);
+  assert.ok(hasSignal(result, "granularity", READINESS_CONDITIONS.BULLETS_ACROSS_MODULES));
+  assertSignalShape(result);
+});
+
 test("minimal input marks clarity low and asks for QA", () => {
   const result = scoreReadiness("Polish the thing.");
 


### PR DESCRIPTION
## Summary
- Make relay-ready granularity scoring ignore `Non-goals`, `Suggested Tests`, and similar non-scope sections when detecting cross-module bullet sprawl.
- Add a regression fixture for maintenance refactor issues with explicit single-leaf scope, observable assertions, done criteria, and suggested tests.
- Add a guard that cross-module Done Criteria still fail single-leaf bypass.

## Validation
- `node --test tests/relay-ready/scripts/score-readiness.test.js` (red before implementation for the new maintenance-refactor fixture)
- `node --test tests/relay-ready/scripts/*.test.js`
- `node --test tests/relay-plan/scripts/*.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`

Closes #627.
