### PR TITLE
Clarify Pi primary review dogfood timeout

### DIFF
--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -150,7 +150,7 @@ node skills/relay-config/scripts/relay-config.js plan-run --repo . \
   --dispatch pi:deepseek/deepseek-v4-flash --review codex --json
 ```
 
-Pi primary review uses a bounded parent-process timeout. Set `RELAY_PI_REVIEW_TIMEOUT` to a positive duration such as `120s`, `10m`, or `1h`; the default is `1800s`.
+Pi primary review uses a bounded parent-process timeout. Set `RELAY_PI_REVIEW_TIMEOUT` to a positive duration such as `120s`, `10m`, or `1h`; the default is `1800s`. Relay invokes Pi with prompt-template, skill, theme, extension, and context-file discovery disabled so non-interactive review does not hang on optional startup integrations. If a Pi review still times out, first validate the CLI/provider path with a minimal `pi --no-session --no-context-files --no-tools --no-extensions --no-skills --no-prompt-templates --no-themes --print` command before treating the route as healthy. If that minimal command succeeds while `pi-primary` still times out, record the result as a prompt/scope or route-latency blocker rather than parser failure or healthy evidence.
 
 Cursor can be used as dispatch executor or trusted primary reviewer when `agent` is on `PATH` (or `RELAY_CURSOR_AGENT_BIN` overrides the binary for dispatch and review), authenticated via `agent login` or `CURSOR_API_KEY`, and route policy allows the model route (add `cursor` to `managed_cli` for slug-only models such as `composer-2.5`):
 
@@ -192,7 +192,7 @@ node skills/relay-dispatch/scripts/live-dogfood.js --repo . --json --markdown
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --json
 ```
 
-By default the harness creates a temporary `RELAY_HOME`, writes a scoped route policy there, and runs Pi, OpenCode, and Antigravity probes plus bounded live canaries. Antigravity primary review uses a realistic healthy timeout by default, while `--antigravity-fail-safe-timeout` controls the intentionally short fail-safe timeout canary. Use `--dry-run` to print `not-run` planned steps without invoking live CLIs, or `--probe-only` to skip review/dispatch canaries.
+By default the harness creates a temporary `RELAY_HOME`, writes a scoped route policy there, and runs Pi, OpenCode, and Antigravity probes plus bounded live canaries. Antigravity primary review uses a realistic healthy timeout by default, while `--antigravity-fail-safe-timeout` controls the intentionally short fail-safe timeout canary. Use `--dry-run` to print `not-run` planned steps without invoking live CLIs, `--probe-only` to skip review/dispatch canaries, or repeated `--scenario <name>` filters such as `--scenario pi-primary` when one adapter needs isolated evidence without waiting on unrelated live canaries.
 
 Add `--dispatch-canary` from a clean worktree to run healthy dispatch canaries for Pi, OpenCode, and Antigravity. Each canary asks for a unique minimal repository change and passes only when dispatch returns `review_pending` with a PR number. The default healthy dispatch timeout is bounded at 180 seconds via `--dispatch-timeout`, and branches use `--dispatch-branch-prefix` with the default `dogfood-dispatch`.
 

--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -184,6 +184,7 @@ function parseArgs(argv) {
     dryRun: false,
     json: false,
     markdown: false,
+    scenarios: [],
     piModel: DEFAULTS.piModel,
     opencodeModel: DEFAULTS.opencodeModel,
     antigravityModel: DEFAULTS.antigravityModel,
@@ -208,6 +209,7 @@ function parseArgs(argv) {
     else if (arg === "--relay-home") parsed.relayHome = next();
     else if (arg === "--keep-relay-home") parsed.keepRelayHome = true;
     else if (arg === "--probe-only") parsed.probeOnly = true;
+    else if (arg === "--scenario") parsed.scenarios.push(next());
     else if (arg === "--dispatch-canary") parsed.dispatchCanary = true;
     else if (arg === "--dry-run") parsed.dryRun = true;
     else if (arg === "--json") parsed.json = true;
@@ -237,6 +239,14 @@ function parseArgs(argv) {
   }
   if (!String(parsed.dispatchBranchPrefix || "").trim()) {
     throw new Error("--dispatch-branch-prefix must be a non-empty string");
+  }
+  if (parsed.scenarios.length) {
+    const knownScenarios = new Set(LIVE_DOGFOOD_SCENARIOS.map((scenario) => scenario.name));
+    for (const scenario of parsed.scenarios) {
+      if (!knownScenarios.has(scenario)) {
+        throw new Error(`unknown --scenario ${JSON.stringify(scenario)}; expected one of: ${[...knownScenarios].join(", ")}`);
+      }
+    }
   }
   return parsed;
 }
@@ -527,9 +537,19 @@ function modelForAdapter(options, adapter) {
 }
 
 function isScenarioEnabled(scenario, options) {
+  if (options.scenarios?.length) return options.scenarios.includes(scenario.name);
   if (options.probeOnly) return scenario.category === "probe";
   if (scenario.requiresDispatchCanary) return options.dispatchCanary === true;
   return scenario.defaultEnabled === true;
+}
+
+function includesDispatchCanaryScenario(options = {}) {
+  if (options.dispatchCanary) return true;
+  if (!options.scenarios?.length) return false;
+  const selected = new Set(options.scenarios);
+  return LIVE_DOGFOOD_SCENARIOS.some((scenario) => (
+    scenario.requiresDispatchCanary === true && selected.has(scenario.name)
+  ));
 }
 
 function buildScenarioEnv(scenario, options) {
@@ -675,7 +695,7 @@ function runDogfood(options = {}, deps = {}) {
   const spawnImpl = deps.spawnSync || spawnSync;
   const repo = path.resolve(options.repo || ".");
   const effectiveOptions = { ...DEFAULTS, ...options };
-  if (effectiveOptions.dispatchCanary && !effectiveOptions.dryRun) {
+  if (includesDispatchCanaryScenario(effectiveOptions) && !effectiveOptions.dryRun) {
     assertCleanDispatchCanaryRepo(repo, spawnImpl);
   }
   const relayHome = ensureRelayHome(options.relayHome, effectiveOptions);
@@ -749,6 +769,7 @@ function printHelp() {
   console.log("  --repo <path>                         Repository root (default: .)");
   console.log("  --relay-home <path>                   Use an explicit RELAY_HOME instead of a temp directory");
   console.log("  --probe-only                          Run only Pi/OpenCode/Antigravity probes");
+  console.log("  --scenario <name>                     Run only a named scenario; repeat for multiple scenarios");
   console.log("  --dispatch-canary                     Add healthy Pi/OpenCode/Antigravity dispatch canaries that must produce review_pending PRs");
   console.log("  --dry-run                             Print planned steps without invoking live CLIs");
   console.log("  --json                                Emit structured JSON");

--- a/skills/relay-review/scripts/invoke-reviewer-pi.js
+++ b/skills/relay-review/scripts/invoke-reviewer-pi.js
@@ -71,6 +71,24 @@ function isExecTimeout(error) {
   return error?.code === "ETIMEDOUT" || (error?.signal === "SIGKILL" && error?.killed);
 }
 
+function buildTimeoutDiagnosticCommand({ piBin, reviewTimeout }) {
+  const duration = String(reviewTimeout || DEFAULT_REVIEW_TIMEOUT).trim() || DEFAULT_REVIEW_TIMEOUT;
+  return [
+    "timeout",
+    duration,
+    piBin || "pi",
+    "--no-session",
+    "--no-context-files",
+    "--no-tools",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--print",
+    "'Return exactly {\"ok\":true} and nothing else.'",
+  ].join(" ");
+}
+
 function buildPrompt(promptText, phase) {
   if (phase === "advisory_review") {
     return [
@@ -130,6 +148,11 @@ function main() {
 
   const execArgs = [
     "--no-session",
+    "--no-context-files",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
     "--tools", "read,grep,find,ls",
   ];
   if (model) execArgs.push("--model", model);
@@ -147,9 +170,12 @@ function main() {
     }).trim();
   } catch (error) {
     if (isExecTimeout(error)) {
+      const diagnosticCommand = buildTimeoutDiagnosticCommand({ piBin, reviewTimeout });
       throw new Error(
         `Pi reviewer ${phase} timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}). ` +
-        "The pi --print invocation did not return before the parent-process timeout; retry with a larger timeout or split the review scope."
+        "The pi --print invocation did not return before the parent-process timeout, so relay cannot treat this as healthy review evidence. " +
+        `First verify Pi non-interactive auth/provider health with: ${diagnosticCommand}. ` +
+        "If that minimal command also times out, record this as a Pi CLI/provider non-interactive blocker; otherwise retry with a larger review timeout or split the review scope."
       );
     }
     const recovered = recoverExecStdout(error);

--- a/tests/relay-dispatch/scripts/live-dogfood.test.js
+++ b/tests/relay-dispatch/scripts/live-dogfood.test.js
@@ -143,6 +143,39 @@ test("live dogfood dry-run plans default non-dispatch scenarios without invoking
   assert.ok(result.coverage.scenarios.every((scenario) => typeof scenario.healthyPromotion === "boolean"));
 });
 
+test("live dogfood can target named scenarios for isolated adapter evidence", () => {
+  const repo = tempDir("relay-live-dogfood-repo-");
+  const calls = [];
+  const result = runDogfood({
+    repo,
+    dryRun: true,
+    scenarios: ["pi-primary"],
+  }, {
+    spawnSync: (...args) => {
+      calls.push(args);
+      return jsonResult({});
+    },
+  });
+
+  assert.equal(calls.length, 0);
+  assert.deepEqual(result.outcomes.map((step) => step.name), ["pi-primary"]);
+  assert.match(result.outcomes[0].command, /invoke-reviewer-pi\.js/);
+  assert.doesNotMatch(result.outcomes[0].command, /invoke-reviewer-opencode\.js/);
+});
+
+test("live dogfood rejects unknown scenario filters", () => {
+  assert.throws(
+    () => parseArgs(["--scenario", "missing-scenario"]),
+    /unknown --scenario "missing-scenario"/
+  );
+});
+
+test("live dogfood parses repeated scenario filters", () => {
+  const parsed = parseArgs(["--scenario", "probe-pi", "--scenario", "pi-primary"]);
+
+  assert.deepEqual(parsed.scenarios, ["probe-pi", "pi-primary"]);
+});
+
 test("live dogfood classifies mocked command outcomes and preserves markdown distinctions", () => {
   const repo = tempDir("relay-live-dogfood-repo-");
   const relayHome = tempDir("relay-live-dogfood-home-");
@@ -302,6 +335,25 @@ test("live dogfood dispatch canary refuses dirty repositories before creating li
   assert.deepEqual(calls[0].args, ["status", "--porcelain"]);
 });
 
+test("live dogfood targeted dispatch canary also refuses dirty repositories", () => {
+  const repo = tempDir("relay-live-dogfood-repo-");
+  const calls = [];
+
+  assert.throws(() => runDogfood({
+    repo,
+    scenarios: ["pi-dispatch-canary"],
+  }, {
+    spawnSync: (command, args) => {
+      calls.push({ command, args });
+      return { status: 0, stdout: " M README.md\n", stderr: "" };
+    },
+  }), /--dispatch-canary requires a clean worktree/);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "git");
+  assert.deepEqual(calls[0].args, ["status", "--porcelain"]);
+});
+
 test("live dogfood defaults use realistic healthy reviewer timeouts and bounded dispatch canary settings", () => {
   const defaults = parseArgs([]);
 
@@ -384,6 +436,18 @@ test("classification helpers separate harness timeout from safe adapter timeout"
     agent_tools_raw: "{\"version\":\"1\"}",
   })).outcome, OUTCOMES.PASS);
   assert.equal(classifyAntigravityPrimary({ error: { code: "ETIMEDOUT" }, stdout: "", stderr: "" }).outcome, OUTCOMES.TIMEOUT);
+  const piTimeout = classifyProbeJson({
+    status: 1,
+    stdout: "",
+    stderr: [
+      "Pi reviewer primary_review timed out after 20s (RELAY_PI_REVIEW_TIMEOUT).",
+      "The pi --print invocation did not return before the parent-process timeout, so relay cannot treat this as healthy review evidence.",
+      "First verify Pi non-interactive auth/provider health with: timeout 20s pi --no-session --no-context-files --no-tools --print 'Return exactly {\"ok\":true} and nothing else.'.",
+    ].join(" "),
+  });
+  assert.equal(piTimeout.outcome, OUTCOMES.TIMEOUT);
+  assert.match(piTimeout.notes, /cannot treat this as healthy review evidence/);
+  assert.match(piTimeout.notes, /verify Pi non-interactive auth\/provider health/);
   assert.equal(classifyAntigravityPrimary({
     status: 1,
     stdout: "",

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -504,7 +504,7 @@ process.stdout.write(JSON.stringify({
   const result = JSON.parse(stdout);
   const loggedArgs = fs.readFileSync(logPath, "utf-8");
   assert.equal(result.verdict, "pass");
-  assert.match(loggedArgs, /^--no-session\n--tools\nread,grep,find,ls\n--model\nopenai\/gpt-5\n--print\n/);
+  assert.match(loggedArgs, /^--no-session\n--no-context-files\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--tools\nread,grep,find,ls\n--model\nopenai\/gpt-5\n--print\n/);
   assert.match(loggedArgs, /NON-INTERACTIVE REVIEW/);
   assert.match(loggedArgs, /Return a passing review\./);
 });
@@ -543,7 +543,7 @@ process.stdout.write(JSON.stringify({
   const result = JSON.parse(stdout);
   const loggedArgs = fs.readFileSync(logPath, "utf-8");
   assert.equal(result.profile, "blindspot");
-  assert.match(loggedArgs, /^--no-session\n--tools\nread,grep,find,ls\n--model\nopenai\/gpt-5\n--print\n/);
+  assert.match(loggedArgs, /^--no-session\n--no-context-files\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--tools\nread,grep,find,ls\n--model\nopenai\/gpt-5\n--print\n/);
   assert.match(loggedArgs, /NON-INTERACTIVE ADVISORY REVIEW/);
 });
 
@@ -667,10 +667,15 @@ setTimeout(() => {
 
   assert.ok(error, "expected invoke-reviewer-pi.js to fail on parent timeout");
   assert.notEqual(error.status, 0);
-  assert.ok(elapsedMs < 2000, `expected adapter timeout before fake pi completed, elapsed=${elapsedMs}ms`);
   const stderr = String(error.stderr || "");
   assert.match(stderr, /Pi reviewer primary_review timed out after 1s/);
   assert.match(stderr, /RELAY_PI_REVIEW_TIMEOUT/);
+  assert.doesNotMatch(String(error.stdout || ""), /Too late/);
+  assert.match(stderr, /cannot treat this as healthy review evidence/);
+  assert.match(stderr, /verify Pi non-interactive auth\/provider health/);
+  assert.match(stderr, /--no-context-files --no-tools --no-extensions --no-skills --no-prompt-templates --no-themes --print/);
+  assert.match(stderr, /Pi CLI\/provider non-interactive blocker/);
+  assert.ok(elapsedMs < 5000, `expected adapter to fail before the outer test timeout, elapsed=${elapsedMs}ms`);
 });
 
 test("pi adapter rejects invalid review timeout without invoking pi", () => {
@@ -862,11 +867,12 @@ setTimeout(() => {
 
   assert.ok(error, "expected invoke-reviewer-antigravity.js to fail on parent timeout");
   assert.notEqual(error.status, 0);
-  assert.ok(elapsedMs < 2000, `expected adapter timeout before fake agy completed, elapsed=${elapsedMs}ms`);
   const stderr = String(error.stderr || "");
   assert.match(stderr, /Antigravity reviewer primary_review timed out after 1s/);
   assert.match(stderr, /RELAY_ANTIGRAVITY_REVIEW_TIMEOUT/);
   assert.match(stderr, /agy --prompt invocation/);
+  assert.doesNotMatch(String(error.stdout || ""), /Too late/);
+  assert.ok(elapsedMs < 5000, `expected adapter to fail before the outer test timeout, elapsed=${elapsedMs}ms`);
 });
 
 test("antigravity adapter rejects invalid review timeout without invoking agy", () => {


### PR DESCRIPTION
## Summary
- run Pi primary review with optional Pi startup discovery disabled for non-interactive review
- add actionable timeout diagnostics so Pi timeouts cannot be mistaken for healthy review evidence
- add `live-dogfood --scenario <name>` for isolated adapter evidence, plus operator docs

Closes #617

## Live evidence
- `RELAY_HOME=$(mktemp -d) node skills/relay-dispatch/scripts/live-dogfood.js --repo . --scenario pi-primary --pi-review-timeout 120s --command-timeout-ms 180000 --json --markdown`
- Result: `pi-primary` -> `timeout`; notes say relay cannot treat it as healthy evidence and include the minimal Pi non-interactive auth/provider diagnostic command.
- Control: minimal Pi `--print` command with discovery disabled returned `{"ok":true}`, so the remaining blocker is prompt/scope or route latency, not basic CLI auth/provider startup.

## Validation
- `node --test tests/relay-review/scripts/invoke-reviewer.test.js`
- `node --test tests/relay-dispatch/scripts/live-dogfood.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `node --test tests/relay-plan/scripts/*.test.js`
- `node --test tests/relay-merge/scripts/*.test.js`
- `git diff --check`

## Notes
- `node --test tests/relay-ready/scripts/*.test.js` has an environment-sensitive existing performance assertion failure: `happy_path_bypass ... under 200ms`, observed `elapsed=794.2335ms`; functional tests in that suite passed.
- `node --test tests/relay-dispatch/scripts/*.test.js` was started, but the wildcard run was interrupted after `dispatch.test.js` stayed open without child work; focused changed dispatch coverage passed via `live-dogfood.test.js`.
