### PR TITLE
Recover OpenCode review output diagnostics

### DIFF
--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -137,6 +137,8 @@ node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --pr <n
 
 OpenCode, Pi, and Antigravity can be used as reviewer roles only when the adapter can represent the phase and route policy allows the model route. OpenCode primary review uses prompt-only read-only plus a dirty-worktree guard; Pi uses a read/grep/find/ls allowlist; Antigravity targets the `agy` CLI and remains fail-safe experimental until healthy live canary evidence exists.
 
+OpenCode review uses a bounded parent-process timeout. Set `RELAY_OPENCODE_REVIEW_TIMEOUT` to a positive duration such as `120s`, `10m`, or `1h`; the default is `1800s`. If an OpenCode review returns empty stdout or times out, first validate the CLI/provider path with a minimal `opencode run -m <model> '<json prompt>'` command before treating the route as healthy.
+
 Pi can be used as dispatch executor or trusted primary reviewer when `pi` is on `PATH` (or `RELAY_PI_BIN` is set for review), authenticated for the selected provider, and route policy allows the model route:
 
 ```bash
@@ -192,7 +194,7 @@ node skills/relay-dispatch/scripts/live-dogfood.js --repo . --json --markdown
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --json
 ```
 
-By default the harness creates a temporary `RELAY_HOME`, writes a scoped route policy there, and runs Pi, OpenCode, and Antigravity probes plus bounded live canaries. Antigravity primary review uses a realistic healthy timeout by default, while `--antigravity-fail-safe-timeout` controls the intentionally short fail-safe timeout canary. Use `--dry-run` to print `not-run` planned steps without invoking live CLIs, `--probe-only` to skip review/dispatch canaries, or repeated `--scenario <name>` filters such as `--scenario pi-primary` or `--scenario pi-advisory` when one adapter needs isolated evidence without waiting on unrelated live canaries.
+By default the harness creates a temporary `RELAY_HOME`, writes a scoped route policy there, and runs Pi, OpenCode, and Antigravity probes plus bounded live canaries. OpenCode and Pi review canaries use realistic healthy timeouts by default; Antigravity primary review does too, while `--antigravity-fail-safe-timeout` controls the intentionally short fail-safe timeout canary. Use `--dry-run` to print `not-run` planned steps without invoking live CLIs, `--probe-only` to skip review/dispatch canaries, or repeated `--scenario <name>` filters such as `--scenario opencode-primary`, `--scenario pi-primary`, or `--scenario pi-advisory` when one adapter needs isolated evidence without waiting on unrelated live canaries.
 
 Add `--dispatch-canary` from a clean worktree to run healthy dispatch canaries for Pi, OpenCode, and Antigravity. Each canary asks for a unique minimal repository change and passes only when dispatch returns `review_pending` with a PR number. The default healthy dispatch timeout is bounded at 180 seconds via `--dispatch-timeout`, and branches use `--dispatch-branch-prefix` with the default `dogfood-dispatch`.
 

--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -20,6 +20,7 @@ const DEFAULTS = Object.freeze({
   antigravityModel: "google/antigravity-cli",
   commandTimeoutMs: 300_000,
   piReviewTimeout: "120s",
+  opencodeReviewTimeout: "120s",
   antigravityReviewTimeout: "120s",
   antigravityFailSafeReviewTimeout: "5s",
   antigravityDispatchTimeoutSeconds: 45,
@@ -82,6 +83,17 @@ const LIVE_DOGFOOD_SCENARIOS = Object.freeze([
     classifier: "standard-json",
     defaultEnabled: true,
     healthyPromotion: true,
+    env: { name: "RELAY_OPENCODE_REVIEW_TIMEOUT", option: "opencodeReviewTimeout" },
+  },
+  {
+    name: "opencode-primary",
+    adapter: "opencode",
+    phase: "primary_review",
+    category: "healthy-review",
+    classifier: "standard-json",
+    defaultEnabled: false,
+    healthyPromotion: true,
+    env: { name: "RELAY_OPENCODE_REVIEW_TIMEOUT", option: "opencodeReviewTimeout" },
   },
   {
     name: "pi-advisory",
@@ -166,12 +178,6 @@ const LIVE_DOGFOOD_SCENARIOS = Object.freeze([
 
 const LIVE_DOGFOOD_READINESS_EXEMPTIONS = Object.freeze([
   {
-    adapter: "opencode",
-    phase: "primary_review",
-    reason: "OpenCode primary review readiness is route-policy limited; the current harness keeps OpenCode live review dogfood on the advisory row.",
-    readinessTextPattern: /Live:\s*`limited`\s*by route policy and live reviewer evidence/i,
-  },
-  {
     adapter: "antigravity",
     phase: "advisory_review",
     reason: "Antigravity advisory review is blocked until a healthy advisory dogfood scenario exists.",
@@ -194,6 +200,7 @@ function parseArgs(argv) {
     antigravityModel: DEFAULTS.antigravityModel,
     commandTimeoutMs: DEFAULTS.commandTimeoutMs,
     piReviewTimeout: DEFAULTS.piReviewTimeout,
+    opencodeReviewTimeout: DEFAULTS.opencodeReviewTimeout,
     antigravityReviewTimeout: DEFAULTS.antigravityReviewTimeout,
     antigravityFailSafeReviewTimeout: DEFAULTS.antigravityFailSafeReviewTimeout,
     antigravityDispatchTimeoutSeconds: DEFAULTS.antigravityDispatchTimeoutSeconds,
@@ -223,6 +230,7 @@ function parseArgs(argv) {
     else if (arg === "--antigravity-model") parsed.antigravityModel = next();
     else if (arg === "--command-timeout-ms") parsed.commandTimeoutMs = Number(next());
     else if (arg === "--pi-review-timeout") parsed.piReviewTimeout = next();
+    else if (arg === "--opencode-review-timeout") parsed.opencodeReviewTimeout = next();
     else if (arg === "--antigravity-review-timeout") parsed.antigravityReviewTimeout = next();
     else if (arg === "--antigravity-fail-safe-timeout") parsed.antigravityFailSafeReviewTimeout = next();
     else if (arg === "--antigravity-dispatch-timeout") parsed.antigravityDispatchTimeoutSeconds = Number(next());
@@ -782,6 +790,7 @@ function printHelp() {
   console.log("  --opencode-model <route>              OpenCode route (default: opencode-go/deepseek-v4-pro)");
   console.log("  --antigravity-model <route>           Antigravity route (default: google/antigravity-cli)");
   console.log("  --pi-review-timeout <duration>        RELAY_PI_REVIEW_TIMEOUT for the Pi canary (default: 120s)");
+  console.log("  --opencode-review-timeout <duration>  RELAY_OPENCODE_REVIEW_TIMEOUT for OpenCode review canaries (default: 120s)");
   console.log("  --antigravity-review-timeout <duration>  RELAY_ANTIGRAVITY_REVIEW_TIMEOUT for the healthy Antigravity review canary (default: 120s)");
   console.log("  --antigravity-fail-safe-timeout <duration>  RELAY_ANTIGRAVITY_REVIEW_TIMEOUT for the intentional fail-safe timeout canary (default: 5s)");
   console.log("  --antigravity-dispatch-timeout <sec>  Antigravity no-op/fail-safe dispatch timeout seconds (default: 45)");

--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -1,7 +1,7 @@
 const {
   formatAdapterPhase,
-  parseJsonObject,
 } = require("../../relay-dispatch/scripts/agent-adapters/transport");
+const { parsePossiblyWrappedReviewerJsonObject } = require("./reviewer-helpers");
 
 const ADVISORY_PROFILES = Object.freeze(["blindspot"]);
 const ADVISORY_SEVERITIES = new Set(["P1", "P2", "P3"]);
@@ -93,7 +93,7 @@ function parseAdvisoryReview(text, {
   const expectedProfile = validateAdvisoryProfile(profile);
   const context = formatAdapterPhase({ adapter, phase });
   try {
-    const parsed = parseJsonObject(normalizeAdvisoryJsonText(text), {
+    const parsed = parsePossiblyWrappedReviewerJsonObject(normalizeAdvisoryJsonText(text), {
       adapter,
       phase,
       description: "advisory review",

--- a/skills/relay-review/scripts/invoke-reviewer-opencode.js
+++ b/skills/relay-review/scripts/invoke-reviewer-opencode.js
@@ -24,6 +24,8 @@ const cliArgs = bindCliArgs(args, {
   commandName: "invoke-reviewer-opencode",
   reservedFlags: KNOWN_FLAGS,
 });
+const REVIEW_TIMEOUT_ENV = "RELAY_OPENCODE_REVIEW_TIMEOUT";
+const DEFAULT_REVIEW_TIMEOUT = "1800s";
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
   console.log("Usage: invoke-reviewer-opencode.js --repo <path> --prompt-file <path> [--phase <name>] [--model <name>] [--json]");
@@ -42,6 +44,31 @@ function resolvePhase(value) {
     throw new Error(`--phase must be primary_review or advisory_review, got ${JSON.stringify(value)}`);
   }
   return phase;
+}
+
+function parseReviewTimeoutMs(value) {
+  const raw = String(value || "").trim();
+  const match = raw.match(/^([1-9]\d*)(ms|s|m|h)$/);
+  if (!match) {
+    throw new Error(
+      `${REVIEW_TIMEOUT_ENV} must be a positive duration like 120s, got ${JSON.stringify(value)}`
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const multipliers = { ms: 1, s: 1000, m: 60 * 1000, h: 60 * 60 * 1000 };
+  const timeoutMs = amount * multipliers[unit];
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `${REVIEW_TIMEOUT_ENV} must resolve to a safe positive millisecond timeout, got ${JSON.stringify(value)}`
+    );
+  }
+  return timeoutMs;
+}
+
+function isExecTimeout(error) {
+  return error?.code === "ETIMEDOUT" || (error?.signal === "SIGKILL" && error?.killed);
 }
 
 function buildPrompt(promptText, phase) {
@@ -85,12 +112,24 @@ function parseResult(result, phase) {
   });
 }
 
+function buildEmptyOutputDiagnosticCommand({ opencodeBin, model, phase }) {
+  const prompt = phase === "primary_review"
+    ? "Return exactly {\"verdict\":\"pass\",\"summary\":\"ok\",\"contract_status\":\"pass\",\"quality_review_status\":\"pass\",\"next_action\":\"ready_to_merge\",\"issues\":[],\"rubric_scores\":[],\"scope_drift\":{\"creep\":[],\"missing\":[]}} and nothing else."
+    : "Return exactly {\"profile\":\"blindspot\",\"summary\":\"ok\",\"required_findings\":[],\"advisory_findings\":[],\"duplicate_or_low_confidence\":[]} and nothing else.";
+  const command = [opencodeBin || "opencode", "run"];
+  if (model) command.push("-m", model);
+  command.push(JSON.stringify(prompt));
+  return command.join(" ");
+}
+
 function main() {
   const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
   const promptFile = cliArgs.getArg("--prompt-file");
   const model = cliArgs.getArg("--model");
   const phase = resolvePhase(cliArgs.getArg("--phase", "advisory_review"));
   const opencodeBin = process.env.RELAY_OPENCODE_BIN || "opencode";
+  const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
+  const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
 
   if (!promptFile) {
     throw new Error("--prompt-file is required");
@@ -109,9 +148,20 @@ function main() {
       cwd: repoPath,
       encoding: "utf-8",
       stdio: "pipe",
+      timeout: parentTimeoutMs,
+      killSignal: "SIGKILL",
       maxBuffer: 10 * 1024 * 1024,
     }).trim();
   } catch (error) {
+    if (isExecTimeout(error)) {
+      const diagnosticCommand = buildEmptyOutputDiagnosticCommand({ opencodeBin, model, phase });
+      throw new Error(
+        `opencode ${phase} reviewer timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}). ` +
+        "The opencode run invocation did not return before the parent-process timeout, so relay cannot treat this as healthy review evidence. " +
+        `First verify OpenCode non-interactive model/provider output with: ${diagnosticCommand}. ` +
+        "If that minimal command also times out, record this as an OpenCode CLI/provider non-interactive blocker; otherwise retry with a larger review timeout or split the review scope."
+      );
+    }
     const recovered = recoverExecStdout(error);
     if (!recovered) {
       throw new Error(`opencode ${phase} reviewer failed: ${summarizeFailure(error)}`);
@@ -120,7 +170,12 @@ function main() {
   }
 
   if (!result) {
-    throw new Error(`opencode ${phase} reviewer did not produce a structured result`);
+    const diagnosticCommand = buildEmptyOutputDiagnosticCommand({ opencodeBin, model, phase });
+    throw new Error(
+      `opencode ${phase} reviewer produced empty stdout, so relay cannot treat this as healthy review evidence. ` +
+      `First verify OpenCode non-interactive model/provider output with: ${diagnosticCommand}. ` +
+      "If that minimal command is also empty, record this as an OpenCode CLI/provider non-interactive blocker; otherwise tighten the review prompt or increase the live dogfood command timeout."
+    );
   }
   const parsed = parseResult(result, phase);
   const output = JSON.stringify(parsed);

--- a/tests/relay-dispatch/scripts/live-dogfood.test.js
+++ b/tests/relay-dispatch/scripts/live-dogfood.test.js
@@ -68,6 +68,7 @@ test("live dogfood exposes explicit scenario metadata rows", () => {
     ["probe-opencode", "opencode", "probe", "probe"],
     ["probe-antigravity", "antigravity", "probe", "probe"],
     ["opencode-advisory", "opencode", "advisory_review", "healthy-review"],
+    ["opencode-primary", "opencode", "primary_review", "healthy-review"],
     ["pi-advisory", "pi", "advisory_review", "healthy-review"],
     ["pi-primary", "pi", "primary_review", "healthy-review"],
     ["antigravity-primary", "antigravity", "primary_review", "healthy-review"],
@@ -86,6 +87,8 @@ test("live dogfood exposes explicit scenario metadata rows", () => {
 
   assert.equal(rows.get("antigravity-primary-fail-safe-timeout").healthyPromotion, false);
   assert.equal(rows.get("antigravity-dispatch-fail-safe-noop").healthyPromotion, false);
+  assert.equal(rows.get("opencode-primary").defaultEnabled, false);
+  assert.equal(rows.get("opencode-primary").healthyPromotion, true);
   assert.equal(rows.get("pi-advisory").healthyPromotion, true);
   assert.equal(rows.get("pi-dispatch-canary").healthyPromotion, true);
   assert.equal(rows.get("opencode-dispatch-canary").healthyPromotion, true);
@@ -140,7 +143,7 @@ test("live dogfood dry-run plans default non-dispatch scenarios without invoking
   assert.ok(result.outcomes.every((step) => step.outcome === OUTCOMES.NOT_RUN));
   assert.deepEqual(result.coverage.scenarios.map((scenario) => scenario.name), LIVE_DOGFOOD_SCENARIOS.map((scenario) => scenario.name));
   assert.ok(result.coverage.readiness_exemptions.some((exemption) => (
-    exemption.adapter === "opencode" && exemption.phase === "primary_review"
+    exemption.adapter === "antigravity" && exemption.phase === "advisory_review"
   )));
   assert.ok(result.coverage.scenarios.every((scenario) => typeof scenario.healthyPromotion === "boolean"));
 });
@@ -178,6 +181,19 @@ test("live dogfood parses repeated scenario filters", () => {
   assert.deepEqual(parsed.scenarios, ["probe-pi", "pi-primary"]);
 });
 
+test("live dogfood can target OpenCode primary review without enabling it by default", () => {
+  const repo = tempDir("relay-live-dogfood-repo-");
+  const result = runDogfood({
+    repo,
+    dryRun: true,
+    scenarios: ["opencode-primary"],
+  });
+
+  assert.deepEqual(result.outcomes.map((step) => step.name), ["opencode-primary"]);
+  assert.match(result.outcomes[0].command, /invoke-reviewer-opencode\.js/);
+  assert.match(result.outcomes[0].command, /--phase primary_review/);
+});
+
 test("live dogfood classifies mocked command outcomes and preserves markdown distinctions", () => {
   const repo = tempDir("relay-live-dogfood-repo-");
   const relayHome = tempDir("relay-live-dogfood-home-");
@@ -202,6 +218,7 @@ test("live dogfood classifies mocked command outcomes and preserves markdown dis
       relayHome,
       commandTimeoutMs: 1000,
       piReviewTimeout: "1s",
+      opencodeReviewTimeout: "1s",
       antigravityReviewTimeout: "90s",
       antigravityFailSafeReviewTimeout: "2s",
     }, {
@@ -229,6 +246,7 @@ test("live dogfood classifies mocked command outcomes and preserves markdown dis
   ]);
   assert.equal(calls[0].env.RELAY_HOME, relayHome);
   assert.equal(calls[0].env.RELAY_POLICY_PATH, path.join(relayHome, "policy.json"));
+  assert.equal(calls[3].env.RELAY_OPENCODE_REVIEW_TIMEOUT, "1s");
   assert.equal(calls[4].env.RELAY_PI_REVIEW_TIMEOUT, "1s");
   assert.equal(calls[5].env.RELAY_PI_REVIEW_TIMEOUT, "1s");
   assert.equal(calls[6].env.RELAY_ANTIGRAVITY_REVIEW_TIMEOUT, "90s");
@@ -367,6 +385,7 @@ test("live dogfood defaults use realistic healthy reviewer timeouts and bounded 
 
   assert.equal(defaults.commandTimeoutMs, 300_000);
   assert.equal(defaults.piReviewTimeout, "120s");
+  assert.equal(defaults.opencodeReviewTimeout, "120s");
   assert.equal(defaults.antigravityReviewTimeout, "120s");
   assert.equal(defaults.antigravityFailSafeReviewTimeout, "5s");
   assert.equal(defaults.dispatchCanary, false);
@@ -377,12 +396,14 @@ test("live dogfood defaults use realistic healthy reviewer timeouts and bounded 
     "--dispatch-canary",
     "--dispatch-timeout", "240",
     "--dispatch-branch-prefix", "relay-healthy",
+    "--opencode-review-timeout", "150s",
     "--antigravity-review-timeout", "180s",
     "--antigravity-fail-safe-timeout", "3s",
   ]);
   assert.equal(parsed.dispatchCanary, true);
   assert.equal(parsed.dispatchTimeoutSeconds, 240);
   assert.equal(parsed.dispatchBranchPrefix, "relay-healthy");
+  assert.equal(parsed.opencodeReviewTimeout, "150s");
   assert.equal(parsed.antigravityReviewTimeout, "180s");
   assert.equal(parsed.antigravityFailSafeReviewTimeout, "3s");
 });

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -391,6 +391,110 @@ process.stdout.write("\`\`\`json\\n" + JSON.stringify({
   assert.equal(result.summary, "No blocking blind spots.");
 });
 
+test("opencode adapter recovers live-style prose-wrapped advisory JSON", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-prose-"));
+  const fakeOpencode = writeExecutable(fakeDir, "fake-opencode.js", `#!/usr/bin/env node
+process.stdout.write("Sure, here is the advisory result:\\n" + JSON.stringify({
+  profile: "blindspot",
+  summary: "Recovered from verbose live output.",
+  required_findings: [],
+  advisory_findings: [],
+  duplicate_or_low_confidence: [],
+}) + "\\n");
+`);
+
+  const stdout = execFileSync("node", [
+    OPENCODE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode },
+  });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.profile, "blindspot");
+  assert.equal(result.summary, "Recovered from verbose live output.");
+});
+
+test("opencode adapter reports actionable diagnostics for empty stdout", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-empty-"));
+  const fakeOpencode = writeExecutable(fakeDir, "fake-opencode.js", `#!/usr/bin/env node
+process.exit(0);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      OPENCODE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--model", "opencode-go/deepseek-v4-pro",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode },
+    });
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error, "expected empty stdout to fail closed");
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /opencode advisory_review reviewer produced empty stdout/);
+  assert.match(stderr, /cannot treat this as healthy review evidence/);
+  assert.match(stderr, /verify OpenCode non-interactive model\/provider output/);
+  assert.match(stderr, /OpenCode CLI\/provider non-interactive blocker/);
+});
+
+test("opencode adapter enforces parent timeout and reports timeout context", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-timeout-"));
+  const fakeOpencode = writeExecutable(fakeDir, "fake-opencode.js", `#!/usr/bin/env node
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    profile: "blindspot",
+    summary: "Too late.",
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  }));
+}, 2500);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      OPENCODE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 5000,
+      env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode, RELAY_OPENCODE_REVIEW_TIMEOUT: "1s" },
+    });
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error, "expected invoke-reviewer-opencode.js to fail on parent timeout");
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /opencode advisory_review reviewer timed out after 1s/);
+  assert.match(stderr, /RELAY_OPENCODE_REVIEW_TIMEOUT/);
+  assert.match(stderr, /cannot treat this as healthy review evidence/);
+  assert.doesNotMatch(String(error.stdout || ""), /Too late/);
+});
+
 test("opencode adapter supports primary review verdict parsing when phase is primary_review", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-primary-"));


### PR DESCRIPTION
## Summary
- let advisory review parsing recover one prose-wrapped JSON object, matching primary verdict recovery
- add opt-in `opencode-primary` live dogfood scenario and remove the stale primary-review exemption
- add OpenCode reviewer parent timeout and actionable empty-stdout/timeout diagnostics

Closes #618

## Live evidence
- `RELAY_HOME=$(mktemp -d) node skills/relay-dispatch/scripts/live-dogfood.js --repo . --scenario opencode-primary --command-timeout-ms 120000 --json --markdown`
  - Result: `opencode-primary` -> `pass`, valid strict verdict JSON returned.
- `RELAY_HOME=$(mktemp -d) node skills/relay-dispatch/scripts/live-dogfood.js --repo . --scenario opencode-advisory --opencode-review-timeout 30s --command-timeout-ms 70000 --json --markdown`
  - Result: `opencode-advisory` -> `timeout`, now with `RELAY_OPENCODE_REVIEW_TIMEOUT` diagnostics and no false promotion.

## Validation
- `node --test tests/relay-review/scripts/invoke-reviewer.test.js`
- `node --test tests/relay-dispatch/scripts/live-dogfood.test.js tests/relay-dispatch/scripts/docs-defaults.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`
