### PR TITLE
Constrain OpenCode dispatch to relay worktrees

### DIFF
--- a/skills/relay-dispatch/scripts/executors/opencode.js
+++ b/skills/relay-dispatch/scripts/executors/opencode.js
@@ -37,9 +37,17 @@ function validateExecutionMode({ sandbox, networkAccess }) {
 
 function buildExecCommand({ wtPath, prompt, model }) {
   const cmd = "opencode";
-  const args = ["run"];
+  const args = ["run", "--dir", wtPath];
   if (model) args.push("-m", model);
-  args.push(prompt);
+  args.push([
+    "[RELAY WORKTREE BOUNDARY]",
+    `Repository worktree: ${wtPath}`,
+    "Run every shell command from that repository worktree.",
+    "Do not read, write, git add, git commit, or create files outside that repository worktree.",
+    "If a tool starts elsewhere, first change directory to the repository worktree before touching files.",
+    "",
+    prompt,
+  ].join("\n"));
   return { cmd, args, cwd: wtPath, codexGitCommonDir: null };
 }
 

--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -6,6 +6,8 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
+const SCRIPT_REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
 const OUTCOMES = Object.freeze({
   PASS: "pass",
   FAIL_SAFE_PASS: "fail-safe-pass",
@@ -560,7 +562,7 @@ function classifyAntigravityDispatch(result) {
 function buildDispatchCommand({ node, repo, branch, executor, model, routeIntentFile, promptFile, rubricFile, timeoutSeconds }) {
   const command = [
     node,
-    "skills/relay-dispatch/scripts/dispatch.js",
+    path.join(SCRIPT_REPO_ROOT, "skills/relay-dispatch/scripts/dispatch.js"),
     repo,
     "-b", branch,
     "--prompt-file", promptFile,
@@ -615,7 +617,7 @@ function buildScenarioEnv(scenario, options) {
 function buildProbeScenarioCommand({ node, repo, options, scenario }) {
   return [
     node,
-    "skills/relay-plan/scripts/probe-executor-env.js",
+    path.join(SCRIPT_REPO_ROOT, "skills/relay-plan/scripts/probe-executor-env.js"),
     repo,
     "--executor", scenario.adapter,
     "--model", modelForAdapter(options, scenario.adapter),
@@ -632,7 +634,7 @@ function buildReviewScenarioCommand({ node, repo, prompts, options, scenario }) 
     : prompts.primaryPrompt;
   const command = [
     node,
-    `skills/relay-review/scripts/${script}`,
+    path.join(SCRIPT_REPO_ROOT, "skills/relay-review/scripts", script),
     "--repo", repo,
     "--prompt-file", promptFile,
     "--model", modelForAdapter(options, scenario.adapter),
@@ -647,7 +649,7 @@ function buildReviewScenarioCommand({ node, repo, prompts, options, scenario }) 
 function buildFailSafeDispatchCommand({ node, repo, prompts, options, branch }) {
   return [
     node,
-    "skills/relay-dispatch/scripts/dispatch.js",
+    path.join(SCRIPT_REPO_ROOT, "skills/relay-dispatch/scripts/dispatch.js"),
     repo,
     "-b", branch,
     "--prompt", "Live dogfood fail-safe no-op canary: do not modify repository files, do not commit, and do not create a PR-ready change.",

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -896,6 +896,22 @@ function buildDispatchExecPrompt(taskPrompt) {
     + taskPrompt;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function assertOpencodeDispatchCommand(capturedArgs, { model, taskPrompt }) {
+  assert.deepEqual(capturedArgs.slice(0, 2), ["run", "--dir"]);
+  assert.ok(path.isAbsolute(capturedArgs[2]), `expected absolute worktree path, got ${capturedArgs[2]}`);
+  assert.deepEqual(capturedArgs.slice(3, 5), ["-m", model]);
+  assert.equal(capturedArgs.length, 6);
+  assert.match(capturedArgs[5], /^\[RELAY WORKTREE BOUNDARY\]\n/);
+  assert.match(capturedArgs[5], new RegExp(`Repository worktree: ${escapeRegExp(capturedArgs[2])}`));
+  assert.match(capturedArgs[5], /Run every shell command from that repository worktree\./);
+  assert.match(capturedArgs[5], /Do not read, write, git add, git commit, or create files outside that repository worktree\./);
+  assert.ok(capturedArgs[5].endsWith(buildDispatchExecPrompt(taskPrompt)));
+}
+
 function worktreeCommonGitDir(worktree) {
   const raw = execFileSync("git", ["-C", worktree, "rev-parse", "--git-common-dir"], {
     encoding: "utf-8",
@@ -1621,11 +1637,10 @@ test("dispatch opencode executor records provider metadata", () => {
   assert.match(proc.stderr, /reviewer-policy-opencode\.md/);
   const result = JSON.parse(proc.stdout);
 
-  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
-    "run",
-    "-m", "openai/gpt-5",
-    buildDispatchExecPrompt(taskPrompt),
-  ]);
+  assertOpencodeDispatchCommand(JSON.parse(fs.readFileSync(capturePath, "utf-8")), {
+    model: "openai/gpt-5",
+    taskPrompt,
+  });
 
   const events = readJsonLines(path.join(result.runDir, "events.jsonl"));
   const dispatchStart = events.find((event) => event.event === "dispatch_start");
@@ -1747,11 +1762,10 @@ test("dispatch opencode executor uses bundled default model when no override is 
     "--json",
   ], env));
 
-  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
-    "run",
-    "-m", "opencode-go/deepseek-v4-pro",
-    buildDispatchExecPrompt(taskPrompt),
-  ]);
+  assertOpencodeDispatchCommand(JSON.parse(fs.readFileSync(capturePath, "utf-8")), {
+    model: "opencode-go/deepseek-v4-pro",
+    taskPrompt,
+  });
 
   const dispatchStart = readJsonLines(path.join(result.runDir, "events.jsonl"))
     .find((event) => event.event === "dispatch_start");
@@ -1791,11 +1805,10 @@ test("dispatch opencode executor lets RELAY_HOME executors config override bundl
     "--json",
   ], env));
 
-  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
-    "run",
-    "-m", "opencode-go/qwen3.6-plus",
-    buildDispatchExecPrompt(taskPrompt),
-  ]);
+  assertOpencodeDispatchCommand(JSON.parse(fs.readFileSync(capturePath, "utf-8")), {
+    model: "opencode-go/qwen3.6-plus",
+    taskPrompt,
+  });
 
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.dispatch.last_model, "opencode-go/qwen3.6-plus");
@@ -1896,11 +1909,10 @@ test("dispatch opencode default model falls back to bundled config when local co
   assert.equal(proc.status, 0, proc.stderr);
   assert.match(proc.stderr, /Warning: ignoring optional executor model config/);
   assert.match(proc.stderr, /default_model must be a non-empty string/);
-  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
-    "run",
-    "-m", "opencode-go/deepseek-v4-pro",
-    buildDispatchExecPrompt(taskPrompt),
-  ]);
+  assertOpencodeDispatchCommand(JSON.parse(fs.readFileSync(capturePath, "utf-8")), {
+    model: "opencode-go/deepseek-v4-pro",
+    taskPrompt,
+  });
 });
 
 test("dispatch opencode explicit --model skips malformed local executor model config", () => {
@@ -1930,11 +1942,10 @@ test("dispatch opencode explicit --model skips malformed local executor model co
   ], env));
 
   assert.equal(result.status, "completed");
-  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
-    "run",
-    "-m", "opencode-go/qwen3.6-plus",
-    buildDispatchExecPrompt(taskPrompt),
-  ]);
+  assertOpencodeDispatchCommand(JSON.parse(fs.readFileSync(capturePath, "utf-8")), {
+    model: "opencode-go/qwen3.6-plus",
+    taskPrompt,
+  });
 });
 
 test("dispatch opencode default model falls back to bundled config when local config is malformed", () => {
@@ -1968,11 +1979,10 @@ test("dispatch opencode default model falls back to bundled config when local co
 
   assert.equal(proc.status, 0, proc.stderr);
   assert.match(proc.stderr, /Warning: ignoring optional executor model config/);
-  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, "utf-8")), [
-    "run",
-    "-m", "opencode-go/deepseek-v4-pro",
-    buildDispatchExecPrompt(taskPrompt),
-  ]);
+  assertOpencodeDispatchCommand(JSON.parse(fs.readFileSync(capturePath, "utf-8")), {
+    model: "opencode-go/deepseek-v4-pro",
+    taskPrompt,
+  });
 });
 
 function reasoningArgValue(args) {

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -95,7 +95,11 @@ test("opencode buildExecCommand: happy path", () => {
     reasoning: "high",
   });
   assert.equal(r.cmd, "opencode");
-  assert.deepEqual(r.args, ["run", "P"]);
+  assert.deepEqual(r.args.slice(0, 3), ["run", "--dir", "/tmp/wt"]);
+  assert.match(r.args[3], /RELAY WORKTREE BOUNDARY/);
+  assert.match(r.args[3], /Repository worktree: \/tmp\/wt/);
+  assert.match(r.args[3], /Run every shell command from that repository worktree/);
+  assert.match(r.args[3], /\nP$/);
   assert.equal(r.cwd, "/tmp/wt");
   assert.equal(r.codexGitCommonDir, null);
 });
@@ -111,7 +115,9 @@ test("opencode buildExecCommand: model passthrough via -m", () => {
     networkAccess: "disabled",
     reasoning: "high",
   });
-  assert.deepEqual(r.args, ["run", "-m", "openai/gpt-5", "P"]);
+  assert.equal(r.args[0], "run");
+  assert.deepEqual(r.args.slice(1, 5), ["--dir", "/tmp/wt", "-m", "openai/gpt-5"]);
+  assert.match(r.args[5], /\nP$/);
 });
 
 test("pi buildExecCommand: explicit non-interactive argv with thinking", () => {


### PR DESCRIPTION
Closes #620.

## Summary
- Pass `--dir <relay-worktree>` to `opencode run` and prepend a worktree-boundary prompt so OpenCode dispatch operates inside the relay worktree.
- Run live dogfood helper scripts from absolute paths in this repository, so clean-base canaries execute current branch code against a temporary target checkout.
- Update OpenCode executor and dispatch integration tests for the new argv/worktree contract.

## Live dogfood evidence
- `RELAY_HOME=$(mktemp -d) node skills/relay-dispatch/scripts/live-dogfood.js --repo . --scenario opencode-dispatch-canary --dispatch-timeout 180 --command-timeout-ms 300000 --json --markdown`
- Outcome: `pass`
- Dispatch base: `origin/main`
- Run reached `review_pending` and produced PR #669 with `prCreatedByUs: true`.
- PR #669 was closed after validation because it was a canary evidence PR, not intended to land.

## Validation
- `node --test tests/relay-dispatch/scripts/executors.test.js tests/relay-dispatch/scripts/live-dogfood.test.js tests/relay-dispatch/scripts/docs-defaults.test.js`
- `node --test tests/relay-dispatch/scripts/dispatch.test.js`
- `node --test tests/relay-dispatch/scripts/*.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`
