### PR TITLE
Add relay-fleet review single-pass mode

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/fleet.js
+++ b/skills/relay-dispatch/scripts/manifest/fleet.js
@@ -21,13 +21,15 @@ const STATES = Object.freeze({
   DRAFT: "draft",
   DISPATCHING: "dispatching",
   DISPATCHED: "dispatched",
+  REVIEWING: "reviewing",
   CLOSED: "closed",
 });
 
 const ALLOWED_TRANSITIONS = Object.freeze({
   [STATES.DRAFT]: new Set([STATES.DISPATCHING]),
   [STATES.DISPATCHING]: new Set([STATES.DISPATCHED]),
-  [STATES.DISPATCHED]: new Set([STATES.CLOSED]),
+  [STATES.DISPATCHED]: new Set([STATES.REVIEWING, STATES.CLOSED]),
+  [STATES.REVIEWING]: new Set([STATES.REVIEWING, STATES.CLOSED]),
   [STATES.CLOSED]: new Set(),
 });
 

--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: relay-fleet
-description: Fan out already-planned relay leaves into parallel child dispatches, resume crashed fleet dispatch, and print fleet status.
+description: Fan out already-planned relay leaves into parallel child dispatches, review child runs, resume crashed fleet dispatch, and print fleet status.
 compatibility: Requires git, Node.js 18+, and the sibling relay-dispatch skill.
 argument-hint: --fleet-id <id> --leaves-file <path>
 metadata:
@@ -10,13 +10,14 @@ metadata:
 ## Inputs
 - Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
 - Files: leaves JSON passed by `--leaves-file`, child prompt/rubric/Done Criteria files, and fleet/child run manifests under `~/.relay/runs/`.
-- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`, `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js`.
 
 # relay-fleet
 
 ## Use when
 
 - Fanning out already planned relay leaves into parallel child dispatches
+- Running one foreground review pass per review-ready child in a dispatched fleet
 - Resuming a crashed fleet dispatch from persisted child/fleet state
 - Printing read-only aggregate status for a fleet
 
@@ -25,7 +26,7 @@ metadata:
 - Decomposing raw or ambiguous requests into leaves — use `relay-ready`
 - Authoring per-leaf rubrics or dispatch prompts — use `relay-plan`
 - Dispatching a single task or run — use `relay-dispatch`
-- Reviewing child PRs — use `relay-review`
+- Reviewing one standalone child PR — use `relay-review`
 
 Run Phase 1 multi-leaf orchestration after `relay-ready` and `relay-plan` have already produced leaf artifacts. It only fans out prepared leaf contracts to `relay-dispatch`, records crash-safe fleet progress, and reports aggregate status.
 
@@ -63,6 +64,15 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --resume
 ```
 
+Run one review pass for each child currently in `review_pending`:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
+  --repo . \
+  --fleet-id fleet-481 \
+  --review
+```
+
 Read-only aggregate status:
 
 ```bash
@@ -86,6 +96,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 ## Behavior
 
 - The fleet script invokes `skills/relay-dispatch/scripts/dispatch.js` as a subprocess once per leaf and always passes `--fleet-id`.
+- `--review` invokes `skills/relay-review/scripts/review-runner.js` as foreground subprocesses for children already in `review_pending`; terminal children are skipped.
 - Each child dispatch owns worktree creation, in-flight run checks, executor invocation, and child run manifest writes.
 - Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
 - `--resume` reconciles both directions: it re-adopts child run manifests whose `fleet_id` points back to this fleet, and it marks no-manifest interrupted children as `dispatch_failed_pre_manifest` so they can be retried from the persisted leaf store.

--- a/skills/relay-fleet/references/design.md
+++ b/skills/relay-fleet/references/design.md
@@ -86,8 +86,9 @@ invisible to both `children[]` and any back-pointer scan. (Codex #5.)
 Every per-child *runtime* fact (state, review status) is still read through the
 child run manifest in `~/.relay/runs/` — the fleet manifest never duplicates it.
 
-- `fleet_state`: `draft → dispatching → dispatched → closed`. Deliberately simple.
-  Phase 1 has no `reviewing`/`merging` because Phase 1 does not review or merge.
+- `fleet_state`: `draft → dispatching → dispatched → reviewing → closed`.
+  Phase 1 shipped through `dispatched`; Phase 2 Sub-PR A adds `reviewing`.
+  `merging` remains deferred to Phase 3.
 - **Fleet summary is computed, not stored.** `fleet_state` is a coarse lifecycle
   marker; the real picture (3 children dispatched, 1 escalated, 1
   pre-manifest-failed) is a *derived summary* over `children[]` + child manifests.
@@ -139,6 +140,12 @@ with existing per-run tools until Phase 2/3 land.
 
 Run `relay-review` per child until each reaches `ready_to_merge` or escalates.
 Adds `reviewing` to `fleet_state`.
+
+Sub-PR A implements `relay-fleet --review` as a single foreground review pass
+over children currently in `review_pending`. It invokes `review-runner.js` as
+subprocesses, skips terminal children, and fails closed if a review subprocess
+exits without advancing the child manifest. Redispatch from
+`changes_requested` remains Sub-PR B.
 
 > **Status (2026-05-15):** Phase 2 (#479) scoped without waiting for a Phase 1
 > dogfood gate. The original "scoped from Phase 1 dogfood" framing assumed

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -14,9 +14,11 @@ const {
   getCanonicalRepoRoot,
   getFleetManifestPath,
   getFleetsDir,
+  getManifestPath,
   listManifestPaths,
   requireValidFleetId,
 } = require("../../relay-dispatch/scripts/manifest/paths");
+const { STATES: RUN_STATES } = require("../../relay-dispatch/scripts/manifest/lifecycle");
 const { readManifest } = require("../../relay-dispatch/scripts/manifest/store");
 const {
   DISPATCH_STATUS,
@@ -34,11 +36,12 @@ const {
 
 const DEFAULT_PARALLEL = 4;
 const DEFAULT_DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
+const DEFAULT_REVIEW_SCRIPT = path.join(__dirname, "..", "..", "relay-review", "scripts", "review-runner.js");
 const KNOWN_FLAGS = [
-  "--repo", "--fleet-id", "--leaves-file", "--resume", "--status", "--parallel",
-  "--dispatch-script", "--executor", "--model", "--model-hints", "--sandbox",
+  "--repo", "--fleet-id", "--leaves-file", "--resume", "--status", "--review", "--parallel",
+  "--dispatch-script", "--review-script", "--executor", "--model", "--model-hints", "--sandbox",
   "--network-access", "--timeout", "--reasoning", "--copy", "--test-command",
-  "--register", "--dry-run", "--json", "--help", "-h",
+  "--register", "--reviewer", "--reviewer-model", "--dry-run", "--json", "--help", "-h",
 ];
 const CLI_ARG_OPTIONS = { commandName: "relay-fleet", reservedFlags: KNOWN_FLAGS };
 const MODE_PARSED_LABEL = "[parsed]";
@@ -55,6 +58,7 @@ function usage() {
   return [
     "Usage: relay-fleet.js --repo <path> --fleet-id <id> --leaves-file <path> [options]",
     "       relay-fleet.js --repo <path> --fleet-id <id> --resume [options]",
+    "       relay-fleet.js --repo <path> --fleet-id <id> --review [options]",
     "       relay-fleet.js --repo <path> --fleet-id <id> --status [--json]",
     "",
     "Options:",
@@ -62,9 +66,11 @@ function usage() {
     `  --fleet-id <id>       ${modeLabel("--fleet-id")} Fleet manifest id (required)`,
     `  --leaves-file <path>  ${MODE_VERBATIM_LABEL} JSON file with already-planned leaf contracts`,
     `  --resume             ${MODE_PARSED_LABEL} Reconcile and continue pending/pre-manifest children`,
+    `  --review             ${MODE_PARSED_LABEL} Fan out one foreground review-runner.js pass per review_pending child`,
     `  --status             ${MODE_PARSED_LABEL} Print derived fleet summary without writing`,
     `  --parallel <n>       ${MODE_PARSED_LABEL} Maximum concurrent child dispatches (default: ${DEFAULT_PARALLEL})`,
     `  --dispatch-script <path>  ${MODE_VERBATIM_LABEL} Dispatch entrypoint (default: relay-dispatch/scripts/dispatch.js)`,
+    `  --review-script <path>    ${MODE_VERBATIM_LABEL} Review entrypoint (default: relay-review/scripts/review-runner.js)`,
     `  --executor <name>     ${modeLabel("--executor")} Child executor passed to dispatch.js`,
     `  --model <name>        ${modeLabel("--model")} Child model override passed to dispatch.js`,
     `  --model-hints <spec>  ${modeLabel("--model-hints")} Child model hints passed to dispatch.js`,
@@ -75,6 +81,8 @@ function usage() {
     `  --copy <files>        ${modeLabel("--copy")} Child copy list passed to dispatch.js`,
     `  --test-command <cmd>  ${modeLabel("--test-command")} Child test command evidence passed to dispatch.js`,
     `  --register           ${modeLabel("--register")} Pass --register to child dispatches`,
+    `  --reviewer <name>    ${modeLabel("--reviewer")} Reviewer override passed to review-runner.js`,
+    `  --reviewer-model <model>  ${modeLabel("--reviewer-model")} Reviewer model override passed to review-runner.js`,
     `  --dry-run            ${modeLabel("--dry-run")} Fan out dispatch.js --dry-run without writing fleet state`,
     `  --json               ${modeLabel("--json")} Print JSON output`,
     `  --help, -h           ${modeLabel("--help")} Show this help`,
@@ -101,9 +109,11 @@ function parseArgs(argv) {
     fleetId: getArg("--fleet-id"),
     leavesFile: getArg("--leaves-file"),
     resume: hasFlag("--resume"),
+    review: hasFlag("--review"),
     status: hasFlag("--status"),
     parallel,
     dispatchScript: path.resolve(getArg("--dispatch-script", DEFAULT_DISPATCH_SCRIPT)),
+    reviewScript: path.resolve(getArg("--review-script", DEFAULT_REVIEW_SCRIPT)),
     executor: getArg("--executor"),
     model: getArg("--model"),
     modelHints: getArg("--model-hints"),
@@ -114,6 +124,8 @@ function parseArgs(argv) {
     copy: getArg("--copy"),
     testCommand: getArg("--test-command"),
     register: hasFlag("--register"),
+    reviewer: getArg("--reviewer"),
+    reviewerModel: getArg("--reviewer-model"),
     dryRun: hasFlag("--dry-run"),
     json: hasFlag("--json"),
     help: hasFlag(["--help", "-h"]),
@@ -334,6 +346,12 @@ function maybeFinalizeFleet(repoRoot, fleetId) {
   return updateFleetManifest(repoRoot, fleetId, (fleet) => updateFleetState(fleet, STATES.DISPATCHED)).data;
 }
 
+function transitionFleetToReviewing(repoRoot, fleetId) {
+  const current = readFleetManifest(repoRoot, fleetId).data;
+  if (current.fleet_state === STATES.REVIEWING) return current;
+  return updateFleetManifest(repoRoot, fleetId, (fleet) => updateFleetState(fleet, STATES.REVIEWING)).data;
+}
+
 function listFleetRunRecords(repoRoot, fleetId) {
   return listManifestPaths(repoRoot)
     .map((manifestPath) => {
@@ -454,6 +472,157 @@ function parseDispatchJson(stdout) {
     } catch {}
   }
   return null;
+}
+
+function buildReviewArgs({ repoRoot, runId, options }) {
+  const args = [
+    options.reviewScript,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--json",
+  ];
+  const valueFlags = [
+    ["--reviewer", options.reviewer],
+    ["--reviewer-model", options.reviewerModel],
+  ];
+  for (const [flag, value] of valueFlags) {
+    if (value !== undefined && value !== null && String(value).trim() !== "") {
+      args.push(flag, String(value));
+    }
+  }
+  return args;
+}
+
+function childReviewSnapshot(repoRoot, runId) {
+  const record = readManifest(getManifestPath(repoRoot, runId));
+  return {
+    state: record.data?.state || null,
+    rounds: Number(record.data?.review?.rounds || 0),
+    latest_verdict: record.data?.review?.latest_verdict || null,
+  };
+}
+
+function reviewSnapshotAdvanced(before, after) {
+  return after.state !== before.state
+    || Number(after.rounds || 0) > Number(before.rounds || 0)
+    || after.latest_verdict !== before.latest_verdict;
+}
+
+function terminalForFleetReview(state) {
+  return [
+    RUN_STATES.READY_TO_MERGE,
+    RUN_STATES.ESCALATED,
+    RUN_STATES.MERGED,
+    RUN_STATES.CLOSED,
+  ].includes(state);
+}
+
+function childNeedsReview(summaryChild) {
+  return summaryChild.dispatch_status === DISPATCH_STATUS.DISPATCHED
+    && summaryChild.run_id
+    && summaryChild.run_state === RUN_STATES.REVIEW_PENDING;
+}
+
+function spawnReviewForChild({ repoRoot, child, options, activeChildren, isInterrupted }) {
+  return new Promise((resolve) => {
+    if (isInterrupted()) {
+      resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_interrupted" });
+      return;
+    }
+    if (!child.run_id || terminalForFleetReview(child.run_state) || !childNeedsReview(child)) {
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: "skipped",
+        run_state: child.run_state,
+      });
+      return;
+    }
+
+    let before;
+    try {
+      before = childReviewSnapshot(repoRoot, child.run_id);
+    } catch (error) {
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: "review_failed",
+        error: `failed to read child manifest before review: ${error.message}`,
+      });
+      return;
+    }
+
+    const args = buildReviewArgs({ repoRoot, runId: child.run_id, options });
+    const review = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    activeChildren.set(child.leaf_ref, review);
+    review.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
+    review.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
+    review.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(child.leaf_ref);
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: "review_failed",
+        error: error.message,
+      });
+    });
+    review.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(child.leaf_ref);
+
+      let after = null;
+      try {
+        after = childReviewSnapshot(repoRoot, child.run_id);
+      } catch (error) {
+        resolve({
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: "review_failed",
+          exit_code: code,
+          signal,
+          stderr,
+          error: `failed to read child manifest after review: ${error.message}`,
+        });
+        return;
+      }
+
+      if (!reviewSnapshotAdvanced(before, after)) {
+        resolve({
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: "review_stalled",
+          exit_code: code,
+          signal,
+          stderr,
+          before,
+          after,
+        });
+        return;
+      }
+
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: code === 0 ? "reviewed" : "reviewed_with_child_failure",
+        exit_code: code,
+        signal,
+        stderr,
+        before,
+        after,
+      });
+    });
+  });
 }
 
 function terminateChild(child) {
@@ -673,6 +842,42 @@ async function statusFleet({ repoRoot, fleetId }) {
   return { summary, operator_attention: buildOperatorAttention(summary) };
 }
 
+async function reviewFleet({ repoRoot, fleetId, options, activeChildren = new Map(), isInterrupted = () => false }) {
+  transitionFleetToReviewing(repoRoot, fleetId);
+  const starting = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
+  const reviewableChildren = starting.children.filter(childNeedsReview);
+  const children = await runPool(reviewableChildren, options.parallel, (child) => {
+    return spawnReviewForChild({
+      repoRoot,
+      child,
+      options,
+      activeChildren,
+      isInterrupted,
+    });
+  });
+  const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
+  const operatorAttention = buildOperatorAttention(summary);
+  const failures = children.some((child) => {
+    return child.status !== "reviewed" && child.status !== "skipped";
+  });
+  return {
+    ok: !isInterrupted() && !failures,
+    interrupted: isInterrupted(),
+    fleet_id: fleetId,
+    reviewed_children: children,
+    skipped_children: starting.children
+      .filter((child) => !childNeedsReview(child))
+      .map((child) => ({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: "skipped",
+        run_state: child.run_state,
+      })),
+    summary,
+    operator_attention: operatorAttention,
+  };
+}
+
 async function runFleet(options) {
   const repoRoot = getCanonicalRepoRoot(options.repo || ".");
   const fleetId = requireValidFleetId(options.fleetId);
@@ -685,6 +890,39 @@ async function runFleet(options) {
       fleetManifestPath: manifestPath,
       ...(await statusFleet({ repoRoot, fleetId })),
     };
+  }
+
+  if (options.review) {
+    if (!fs.existsSync(manifestPath)) {
+      throw new FleetInputError(`fleet manifest does not exist: ${manifestPath}`);
+    }
+    let interrupted = false;
+    const activeChildren = new Map();
+    const interrupt = () => {
+      interrupted = true;
+      for (const child of activeChildren.values()) terminateChild(child);
+    };
+    if (options.installSignalHandlers) {
+      process.once("SIGINT", interrupt);
+      process.once("SIGTERM", interrupt);
+    }
+    try {
+      return {
+        fleetManifestPath: manifestPath,
+        ...(await reviewFleet({
+          repoRoot,
+          fleetId,
+          options,
+          activeChildren,
+          isInterrupted: () => interrupted,
+        })),
+      };
+    } finally {
+      if (options.installSignalHandlers) {
+        process.removeListener("SIGINT", interrupt);
+        process.removeListener("SIGTERM", interrupt);
+      }
+    }
   }
 
   const leaves = options.leavesFile
@@ -800,6 +1038,9 @@ async function main(argv = process.argv.slice(2)) {
     if (options.status && (options.resume || options.leavesFile || options.dryRun)) {
       throw new FleetInputError("--status is read-only and cannot be combined with --resume, --leaves-file, or --dry-run");
     }
+    if (options.review && (options.resume || options.leavesFile || options.dryRun || options.status)) {
+      throw new FleetInputError("--review cannot be combined with --resume, --leaves-file, --dry-run, or --status");
+    }
     const result = await runFleet({ ...options, installSignalHandlers: true });
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -833,6 +1074,7 @@ module.exports = {
   FleetInputError,
   buildDispatchArgs,
   buildOperatorAttention,
+  buildReviewArgs,
   formatStatusText,
   getFleetLeavesStorePath,
   getFleetRuntimePath,
@@ -840,6 +1082,7 @@ module.exports = {
   main,
   parseArgs,
   reconcileFleet,
+  reviewFleet,
   runFleet,
   statusFleet,
 };

--- a/tests/relay-fleet/scripts/fleet.test.js
+++ b/tests/relay-fleet/scripts/fleet.test.js
@@ -158,12 +158,16 @@ test("fleet state machine accepts every valid pair and rejects every invalid pai
   assert.throws(() => validateTransition(STATES.DRAFT, "bad"), /Unknown relay fleet state/);
 });
 
-test("updateFleetState applies the draft-dispatching-dispatched-closed chain", () => {
+test("updateFleetState applies the draft-dispatching-dispatched-reviewing-closed chain", () => {
   let fleet = createFleetManifestSkeleton({ fleetId: "fleet-state-chain" });
   fleet = updateFleetState(fleet, STATES.DISPATCHING);
   assert.equal(fleet.fleet_state, STATES.DISPATCHING);
   fleet = updateFleetState(fleet, STATES.DISPATCHED);
   assert.equal(fleet.fleet_state, STATES.DISPATCHED);
+  fleet = updateFleetState(fleet, STATES.REVIEWING);
+  assert.equal(fleet.fleet_state, STATES.REVIEWING);
+  fleet = updateFleetState(fleet, STATES.REVIEWING);
+  assert.equal(fleet.fleet_state, STATES.REVIEWING);
   fleet = updateFleetState(fleet, STATES.CLOSED);
   assert.equal(fleet.fleet_state, STATES.CLOSED);
   assert.throws(() => updateFleetState(fleet, STATES.DRAFT), /Invalid relay fleet state transition/);

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -90,6 +90,49 @@ function readJsonLines(filePath) {
     .map((line) => JSON.parse(line));
 }
 
+function writeChildRun(repoRoot, {
+  runId,
+  branch,
+  issueNumber,
+  leafId,
+  fleetId,
+  state = RUN_STATES.REVIEW_PENDING,
+}) {
+  fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber,
+    worktreePath: path.join(repoRoot, "wt", runId),
+    fleetId,
+    leafId,
+  });
+  const rubricPath = path.join(getRunDir(repoRoot, runId), "rubric.yaml");
+  fs.writeFileSync(rubricPath, "rubric:\n  size_class: S\n", "utf-8");
+  manifest = {
+    ...manifest,
+    anchor: {
+      ...(manifest.anchor || {}),
+      rubric_path: "rubric.yaml",
+    },
+  };
+  manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+  if (state === RUN_STATES.REVIEW_PENDING) {
+    manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+  } else if (state === RUN_STATES.READY_TO_MERGE) {
+    manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+    manifest = updateManifestState(manifest, RUN_STATES.READY_TO_MERGE, "ready");
+  } else if (state === RUN_STATES.ESCALATED) {
+    manifest = updateManifestState(manifest, RUN_STATES.ESCALATED, "escalated");
+  } else if (state === RUN_STATES.CLOSED) {
+    manifest = updateManifestState(manifest, RUN_STATES.CLOSED, "closed");
+  }
+  writeManifest(getManifestPath(repoRoot, runId), manifest);
+  return runId;
+}
+
 function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
   const started = Date.now();
   return new Promise((resolve, reject) => {
@@ -240,6 +283,72 @@ main().catch((error) => {
   process.stderr.write(String(error.stack || error.message || error) + "\\n");
   process.exit(1);
 });
+`, "utf-8");
+  fs.chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+function writeFakeReviewScript(tmpDir) {
+  const scriptPath = path.join(tmpDir, "fake-review.js");
+  fs.writeFileSync(scriptPath, `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sourceRoot = process.env.RELAY_SOURCE_ROOT;
+const {
+  getManifestPath,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "paths"));
+const {
+  readManifest,
+  writeManifest,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "store"));
+const {
+  STATES,
+  updateManifestState,
+} = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "lifecycle"));
+
+const args = process.argv.slice(2);
+function get(flag, fallback = null) {
+  const index = args.indexOf(flag);
+  return index === -1 ? fallback : (args[index + 1] || fallback);
+}
+function appendLog(record) {
+  if (!process.env.FAKE_REVIEW_LOG) return;
+  fs.appendFileSync(process.env.FAKE_REVIEW_LOG, JSON.stringify(record) + "\\n", "utf-8");
+}
+const repoRoot = get("--repo");
+const runId = get("--run-id");
+const config = process.env.FAKE_REVIEW_CONFIG
+  ? JSON.parse(fs.readFileSync(process.env.FAKE_REVIEW_CONFIG, "utf-8"))
+  : {};
+const plan = config[runId] || {};
+appendLog({ event: "spawn", runId, args });
+const manifestPath = getManifestPath(repoRoot, runId);
+const record = readManifest(manifestPath);
+let manifest = record.data;
+if (!plan.stall) {
+  const verdict = plan.verdict || "lgtm";
+  if (!plan.omit_review_fields) {
+    manifest = {
+      ...manifest,
+      review: {
+        ...(manifest.review || {}),
+        rounds: Number(manifest.review?.rounds || 0) + 1,
+        latest_verdict: verdict,
+      },
+    };
+  }
+  if (plan.to_state === "ready_to_merge") {
+    manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "fleet_fake_review_pass");
+  } else if (plan.to_state === "escalated") {
+    manifest = updateManifestState(manifest, STATES.ESCALATED, "fleet_fake_review_escalated");
+  } else if (plan.to_state === "changes_requested") {
+    manifest = updateManifestState(manifest, STATES.CHANGES_REQUESTED, "fleet_fake_review_changes_requested");
+  }
+  writeManifest(manifestPath, manifest, record.body);
+}
+process.stdout.write(JSON.stringify({ ok: true, runId, stalled: Boolean(plan.stall) }) + "\\n");
+process.exit(plan.exit_code || 0);
 `, "utf-8");
   fs.chmodSync(scriptPath, 0o755);
   return scriptPath;
@@ -417,7 +526,7 @@ test("relay-fleet resume re-adopts orphan child via fleet_id back-pointer", () =
     "--json",
   ], { relayHome });
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const child = readFleetManifest(repoRoot, "fleet-orphan").data.children[0];
   assert.equal(child.run_id, runId);
   assert.equal(child.dispatch_status, DISPATCH_STATUS.DISPATCHED);
@@ -553,12 +662,152 @@ test("relay-fleet --dry-run fans out to dispatch dry-run without writing a fleet
     env: { FAKE_DISPATCH_LOG: logPath },
   });
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.dryRun, true);
   assert.equal(payload.children.length, 2);
   assert.equal(fs.existsSync(getFleetManifestPath(repoRoot, "fleet-dry")), false);
   assert.equal(readJsonLines(logPath).every((entry) => entry.dryRun && entry.fleetId === "fleet-dry"), true);
+});
+
+test("relay-fleet --review fans out foreground review-runner once per review_pending child", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-fake-"));
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const logPath = path.join(tmpDir, "review.log");
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runA = "issue-520-20260515010101000-a1b2c3d4";
+  const runB = "issue-521-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId: runA,
+    branch: "issue-520-leaf-a",
+    issueNumber: 520,
+    leafId: "leaf-a",
+    fleetId: "fleet-review",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  writeChildRun(repoRoot, {
+    runId: runB,
+    branch: "issue-521-leaf-b",
+    issueNumber: 521,
+    leafId: "leaf-b",
+    fleetId: "fleet-review",
+    state: RUN_STATES.READY_TO_MERGE,
+  });
+  writeJson(configPath, { [runA]: { to_state: "ready_to_merge" } });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review",
+    children: [
+      { leaf_ref: "leaf-a", run_id: runA, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-b", run_id: runB, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    ],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review").data;
+  fleet.fleet_state = FLEET_STATES.DISPATCHED;
+  writeFleetManifest(repoRoot, fleet);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review",
+    "--review",
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_REVIEW_CONFIG: configPath,
+      FAKE_REVIEW_LOG: logPath,
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.summary.fleet_state, FLEET_STATES.REVIEWING);
+  assert.equal(payload.reviewed_children.length, 1);
+  assert.equal(payload.reviewed_children[0].run_id, runA);
+  assert.equal(payload.skipped_children.some((child) => child.run_id === runB && child.run_state === RUN_STATES.READY_TO_MERGE), true);
+  assert.equal(readJsonLines(logPath).length, 1);
+  assert.equal(readManifest(getManifestPath(repoRoot, runA)).data.state, RUN_STATES.READY_TO_MERGE);
+});
+
+test("relay-fleet --review fails closed when review-runner exits without advancing manifest", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-stall-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-stall-fake-"));
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runId = "issue-522-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId,
+    branch: "issue-522-leaf-a",
+    issueNumber: 522,
+    leafId: "leaf-a",
+    fleetId: "fleet-review-stall",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  writeJson(configPath, { [runId]: { stall: true } });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review-stall",
+    children: [{ leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review-stall").data;
+  fleet.fleet_state = FLEET_STATES.DISPATCHED;
+  writeFleetManifest(repoRoot, fleet);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-stall",
+    "--review",
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_REVIEW_CONFIG: configPath },
+  });
+
+  assert.notEqual(result.status, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.reviewed_children[0].status, "review_stalled");
+  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.REVIEW_PENDING);
+});
+
+test("relay-fleet --review treats child state transitions as manifest progress", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-state-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-state-fake-"));
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runId = "issue-523-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId,
+    branch: "issue-523-leaf-a",
+    issueNumber: 523,
+    leafId: "leaf-a",
+    fleetId: "fleet-review-state",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  writeJson(configPath, { [runId]: { to_state: "ready_to_merge", omit_review_fields: true } });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review-state",
+    children: [{ leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review-state").data;
+  fleet.fleet_state = FLEET_STATES.DISPATCHED;
+  writeFleetManifest(repoRoot, fleet);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-state",
+    "--review",
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_REVIEW_CONFIG: configPath },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.reviewed_children[0].status, "reviewed");
+  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
 });
 
 test("relay-fleet --status prints derived summary without writing the fleet manifest", () => {


### PR DESCRIPTION
Part of #479.

## Summary
- add the fleet `reviewing` state and dispatch -> reviewing transitions
- add `relay-fleet --review` to run one foreground `review-runner.js` pass per `review_pending` child
- skip terminal child states and fail closed when a child review exits without manifest progress
- document the Phase 2 Sub-PR A boundary; redispatch loop/resume extensions remain deferred

## Validation
- `node --test tests/relay-fleet/scripts/*.test.js`
- `node --test tests/relay-dispatch/scripts/manifest/fleet.test.js`
- `node --test tests/relay-dispatch/scripts/*.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`