### PR TITLE
Add relay-fleet review redispatch loop

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -17,8 +17,8 @@ metadata:
 ## Use when
 
 - Fanning out already planned relay leaves into parallel child dispatches
-- Running one foreground review pass per review-ready child in a dispatched fleet
-- Resuming a crashed fleet dispatch from persisted child/fleet state
+- Driving foreground review/redispatch loops for review-ready children in a dispatched fleet
+- Resuming a crashed fleet dispatch or review loop from persisted child/fleet state
 - Printing read-only aggregate status for a fleet
 
 ## Do not use when
@@ -64,7 +64,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --resume
 ```
 
-Run one review pass for each child currently in `review_pending`:
+Drive review for each child currently in `review_pending` or `changes_requested` until it reaches `ready_to_merge` or `escalated`:
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
@@ -96,10 +96,10 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 ## Behavior
 
 - The fleet script invokes `skills/relay-dispatch/scripts/dispatch.js` as a subprocess once per leaf and always passes `--fleet-id`.
-- `--review` invokes `skills/relay-review/scripts/review-runner.js` as foreground subprocesses for children already in `review_pending`; terminal children are skipped.
+- `--review` invokes `skills/relay-review/scripts/review-runner.js` as foreground subprocesses for children in `review_pending`; when review returns `changes_requested`, it invokes `dispatch.js --manifest <child-manifest>` and re-enters review until the child reaches `ready_to_merge` or `escalated`.
 - Each child dispatch owns worktree creation, in-flight run checks, executor invocation, and child run manifest writes.
 - Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
-- `--resume` reconciles both directions: it re-adopts child run manifests whose `fleet_id` points back to this fleet, and it marks no-manifest interrupted children as `dispatch_failed_pre_manifest` so they can be retried from the persisted leaf store.
+- `--resume` reconciles both directions: it re-adopts child run manifests whose `fleet_id` points back to this fleet, marks no-manifest interrupted children as `dispatch_failed_pre_manifest`, skips still-running child subprocesses, and re-enters the review/redispatch loop for children in `review_pending` or `changes_requested`.
 - `--status` is read-only and uses the relay-dispatch fleet summary derivation rules.
 
 ## SPOF

--- a/skills/relay-fleet/references/design.md
+++ b/skills/relay-fleet/references/design.md
@@ -141,11 +141,14 @@ with existing per-run tools until Phase 2/3 land.
 Run `relay-review` per child until each reaches `ready_to_merge` or escalates.
 Adds `reviewing` to `fleet_state`.
 
-Sub-PR A implements `relay-fleet --review` as a single foreground review pass
+Sub-PR A implemented `relay-fleet --review` as a single foreground review pass
 over children currently in `review_pending`. It invokes `review-runner.js` as
 subprocesses, skips terminal children, and fails closed if a review subprocess
-exits without advancing the child manifest. Redispatch from
-`changes_requested` remains Sub-PR B.
+exits without advancing the child manifest. Sub-PR B extends that path into the
+full Phase 2 loop: `changes_requested` triggers `dispatch.js --manifest`, then
+review re-runs until the child reaches `ready_to_merge` or `escalated`. `--resume`
+uses the same loop after reconciling child manifests and still-running subprocess
+PID guards.
 
 > **Status (2026-05-15):** Phase 2 (#479) scoped without waiting for a Phase 1
 > dogfood gate. The original "scoped from Phase 1 dogfood" framing assumed

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -291,11 +291,18 @@ function writeRuntime(repoRoot, fleetId, runtime) {
 }
 
 function upsertRuntimeChild(repoRoot, fleetId, leaf, child) {
-  const runtime = readRuntime(repoRoot, fleetId);
-  runtime.children[leaf.leaf_ref] = {
-    pid: child.pid || null,
+  upsertRuntimeProcess(repoRoot, fleetId, leaf.leaf_ref, child, {
+    phase: "dispatch",
     branch: leaf.branch,
     issue_number: leaf.issue_number,
+  });
+}
+
+function upsertRuntimeProcess(repoRoot, fleetId, leafRef, child, metadata = {}) {
+  const runtime = readRuntime(repoRoot, fleetId);
+  runtime.children[leafRef] = {
+    pid: child.pid || null,
+    ...metadata,
     started_at: new Date().toISOString(),
   };
   writeRuntime(repoRoot, fleetId, runtime);
@@ -340,7 +347,12 @@ function maybeFinalizeFleet(repoRoot, fleetId) {
   const current = readFleetManifest(repoRoot, fleetId).data;
   const allDispatched = current.children.length > 0
     && current.children.every((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCHED && child.run_id);
-  if (!allDispatched || current.fleet_state === STATES.DISPATCHED || current.fleet_state === STATES.CLOSED) {
+  if (
+    !allDispatched
+    || current.fleet_state === STATES.DISPATCHED
+    || current.fleet_state === STATES.REVIEWING
+    || current.fleet_state === STATES.CLOSED
+  ) {
     return current;
   }
   return updateFleetManifest(repoRoot, fleetId, (fleet) => updateFleetState(fleet, STATES.DISPATCHED)).data;
@@ -493,6 +505,33 @@ function buildReviewArgs({ repoRoot, runId, options }) {
   return args;
 }
 
+function buildRedispatchArgs({ repoRoot, runId, options }) {
+  const args = [
+    options.dispatchScript,
+    repoRoot,
+    "--manifest", getManifestPath(repoRoot, runId),
+    "--json",
+  ];
+  const valueFlags = [
+    ["--executor", options.executor],
+    ["--model", options.model],
+    ["--model-hints", options.modelHints],
+    ["--sandbox", options.sandbox],
+    ["--network-access", options.networkAccess],
+    ["--timeout", options.timeout],
+    ["--reasoning", options.reasoning],
+    ["--copy", options.copy],
+    ["--test-command", options.testCommand],
+  ];
+  for (const [flag, value] of valueFlags) {
+    if (value !== undefined && value !== null && String(value).trim() !== "") {
+      args.push(flag, String(value));
+    }
+  }
+  if (options.register) args.push("--register");
+  return args;
+}
+
 function childReviewSnapshot(repoRoot, runId) {
   const record = readManifest(getManifestPath(repoRoot, runId));
   return {
@@ -523,10 +562,23 @@ function childNeedsReview(summaryChild) {
     && summaryChild.run_state === RUN_STATES.REVIEW_PENDING;
 }
 
-function spawnReviewForChild({ repoRoot, child, options, activeChildren, isInterrupted }) {
+function childNeedsReviewLoop(summaryChild) {
+  return summaryChild.dispatch_status === DISPATCH_STATUS.DISPATCHED
+    && summaryChild.run_id
+    && [
+      RUN_STATES.REVIEW_PENDING,
+      RUN_STATES.CHANGES_REQUESTED,
+    ].includes(summaryChild.run_state);
+}
+
+function spawnReviewForChild({ repoRoot, fleetId, child, options, activeChildren, isInterrupted }) {
   return new Promise((resolve) => {
     if (isInterrupted()) {
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_interrupted" });
+      return;
+    }
+    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) {
+      resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_running", run_state: child.run_state });
       return;
     }
     if (!child.run_id || terminalForFleetReview(child.run_state) || !childNeedsReview(child)) {
@@ -563,12 +615,14 @@ function spawnReviewForChild({ repoRoot, child, options, activeChildren, isInter
     let stderr = "";
     let settled = false;
     activeChildren.set(child.leaf_ref, review);
+    upsertRuntimeProcess(repoRoot, fleetId, child.leaf_ref, review, { phase: "review", run_id: child.run_id });
     review.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
     review.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
     review.once("error", (error) => {
       if (settled) return;
       settled = true;
       activeChildren.delete(child.leaf_ref);
+      removeRuntimeChild(repoRoot, fleetId, child.leaf_ref);
       resolve({
         leaf_ref: child.leaf_ref,
         run_id: child.run_id,
@@ -580,6 +634,7 @@ function spawnReviewForChild({ repoRoot, child, options, activeChildren, isInter
       if (settled) return;
       settled = true;
       activeChildren.delete(child.leaf_ref);
+      removeRuntimeChild(repoRoot, fleetId, child.leaf_ref);
 
       let after = null;
       try {
@@ -617,6 +672,91 @@ function spawnReviewForChild({ repoRoot, child, options, activeChildren, isInter
         status: code === 0 ? "reviewed" : "reviewed_with_child_failure",
         exit_code: code,
         signal,
+        stderr,
+        before,
+        after,
+      });
+    });
+  });
+}
+
+function spawnRedispatchForChild({ repoRoot, fleetId, child, options, activeChildren, isInterrupted }) {
+  return new Promise((resolve) => {
+    if (isInterrupted()) {
+      resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_interrupted" });
+      return;
+    }
+    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) {
+      resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_running", run_state: child.run_state });
+      return;
+    }
+
+    const before = childReviewSnapshot(repoRoot, child.run_id);
+    const args = buildRedispatchArgs({ repoRoot, runId: child.run_id, options });
+    const dispatch = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      env: process.env,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    activeChildren.set(child.leaf_ref, dispatch);
+    upsertRuntimeProcess(repoRoot, fleetId, child.leaf_ref, dispatch, { phase: "redispatch", run_id: child.run_id });
+    dispatch.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
+    dispatch.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
+    dispatch.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(child.leaf_ref);
+      removeRuntimeChild(repoRoot, fleetId, child.leaf_ref);
+      resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "redispatch_failed", error: error.message });
+    });
+    dispatch.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      activeChildren.delete(child.leaf_ref);
+      removeRuntimeChild(repoRoot, fleetId, child.leaf_ref);
+
+      let after = null;
+      try {
+        after = childReviewSnapshot(repoRoot, child.run_id);
+      } catch (error) {
+        resolve({
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: "redispatch_failed",
+          exit_code: code,
+          signal,
+          stderr,
+          error: `failed to read child manifest after redispatch: ${error.message}`,
+        });
+        return;
+      }
+
+      if (after.state === before.state) {
+        resolve({
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: "redispatch_stalled",
+          exit_code: code,
+          signal,
+          stderr,
+          before,
+          after,
+        });
+        return;
+      }
+
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: code === 0 ? "redispatched" : "redispatched_with_child_failure",
+        exit_code: code,
+        signal,
+        payload: parseDispatchJson(stdout),
         stderr,
         before,
         after,
@@ -842,13 +982,99 @@ async function statusFleet({ repoRoot, fleetId }) {
   return { summary, operator_attention: buildOperatorAttention(summary) };
 }
 
+function findSummaryChild(repoRoot, fleetId, leafRef) {
+  const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
+  return summary.children.find((child) => child.leaf_ref === leafRef) || null;
+}
+
+function loopStepFailed(step) {
+  return [
+    "review_failed",
+    "review_stalled",
+    "reviewed_with_child_failure",
+    "redispatch_failed",
+    "redispatch_stalled",
+    "redispatched_with_child_failure",
+    "skipped_interrupted",
+  ].includes(step?.status);
+}
+
+async function driveChildReviewLoop({ repoRoot, fleetId, child, options, activeChildren, isInterrupted }) {
+  const steps = [];
+  let current = child;
+
+  while (!isInterrupted()) {
+    if (!current || !childNeedsReviewLoop(current)) {
+      return {
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: terminalForFleetReview(current?.run_state) ? "complete" : "skipped",
+        run_state: current?.run_state || null,
+        steps,
+      };
+    }
+
+    if (current.run_state === RUN_STATES.REVIEW_PENDING) {
+      const review = await spawnReviewForChild({
+        repoRoot,
+        fleetId,
+        child: current,
+        options,
+        activeChildren,
+        isInterrupted,
+      });
+      steps.push({ phase: "review", ...review });
+      if (loopStepFailed(review) || review.status === "skipped_running") {
+        return {
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: review.status,
+          run_state: review.after?.state || current.run_state,
+          steps,
+        };
+      }
+    } else if (current.run_state === RUN_STATES.CHANGES_REQUESTED) {
+      const redispatch = await spawnRedispatchForChild({
+        repoRoot,
+        fleetId,
+        child: current,
+        options,
+        activeChildren,
+        isInterrupted,
+      });
+      steps.push({ phase: "redispatch", ...redispatch });
+      if (loopStepFailed(redispatch) || redispatch.status === "skipped_running") {
+        return {
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: redispatch.status,
+          run_state: redispatch.after?.state || current.run_state,
+          steps,
+        };
+      }
+    }
+
+    current = findSummaryChild(repoRoot, fleetId, child.leaf_ref);
+  }
+
+  return {
+    leaf_ref: child.leaf_ref,
+    run_id: child.run_id,
+    status: "skipped_interrupted",
+    run_state: current?.run_state || child.run_state,
+    steps,
+  };
+}
+
 async function reviewFleet({ repoRoot, fleetId, options, activeChildren = new Map(), isInterrupted = () => false }) {
   transitionFleetToReviewing(repoRoot, fleetId);
+  cleanupDeadRuntimeChildren(repoRoot, fleetId);
   const starting = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
-  const reviewableChildren = starting.children.filter(childNeedsReview);
+  const reviewableChildren = starting.children.filter(childNeedsReviewLoop);
   const children = await runPool(reviewableChildren, options.parallel, (child) => {
-    return spawnReviewForChild({
+    return driveChildReviewLoop({
       repoRoot,
+      fleetId,
       child,
       options,
       activeChildren,
@@ -858,7 +1084,7 @@ async function reviewFleet({ repoRoot, fleetId, options, activeChildren = new Ma
   const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
   const operatorAttention = buildOperatorAttention(summary);
   const failures = children.some((child) => {
-    return child.status !== "reviewed" && child.status !== "skipped";
+    return !["complete", "skipped"].includes(child.status);
   });
   return {
     ok: !isInterrupted() && !failures,
@@ -866,7 +1092,7 @@ async function reviewFleet({ repoRoot, fleetId, options, activeChildren = new Ma
     fleet_id: fleetId,
     reviewed_children: children,
     skipped_children: starting.children
-      .filter((child) => !childNeedsReview(child))
+      .filter((child) => !childNeedsReviewLoop(child))
       .map((child) => ({
         leaf_ref: child.leaf_ref,
         run_id: child.run_id,
@@ -1007,6 +1233,23 @@ async function runFleet(options) {
     const operatorAttention = buildOperatorAttention(summary);
     const preManifestFailures = summary.children
       .some((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+    if (options.resume && summary.children.some(childNeedsReviewLoop)) {
+      const reviewResult = await reviewFleet({
+        repoRoot,
+        fleetId,
+        options,
+        activeChildren,
+        isInterrupted: () => interrupted,
+      });
+      const reviewPreManifestFailures = reviewResult.summary.children
+        .some((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+      return {
+        ...reviewResult,
+        ok: reviewResult.ok && !reviewPreManifestFailures,
+        fleetManifestPath: manifestPath,
+        dispatch_children: children,
+      };
+    }
     return {
       ok: !interrupted && !preManifestFailures,
       interrupted,
@@ -1074,6 +1317,7 @@ module.exports = {
   FleetInputError,
   buildDispatchArgs,
   buildOperatorAttention,
+  buildRedispatchArgs,
   buildReviewArgs,
   formatStatusText,
   getFleetLeavesStorePath,

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -180,6 +180,7 @@ const {
 } = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "paths"));
 const {
   createManifestSkeleton,
+  readManifest,
   writeManifest,
 } = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "store"));
 const {
@@ -216,6 +217,7 @@ function appendLog(record) {
   fs.appendFileSync(process.env.FAKE_DISPATCH_LOG, JSON.stringify(record) + "\\n", "utf-8");
 }
 async function main() {
+  const manifestInput = get("--manifest");
   const branch = get(["--branch", "-b"]);
   const leafId = get("--leaf-id");
   const fleetId = get("--fleet-id");
@@ -223,6 +225,31 @@ async function main() {
   const config = process.env.FAKE_DISPATCH_CONFIG
     ? JSON.parse(fs.readFileSync(process.env.FAKE_DISPATCH_CONFIG, "utf-8"))
     : {};
+  if (manifestInput) {
+    const record = readManifest(manifestInput);
+    const runId = record.data.run_id;
+    const plan = config[runId] || {};
+    appendLog({ event: "spawn", runId, manifest: manifestInput, dryRun, args });
+    if (plan.delay_after_manifest_ms) {
+      await sleep(plan.delay_after_manifest_ms);
+    }
+    if (plan.exit_code && plan.exit_code !== 0) {
+      process.stderr.write("fake resume dispatch failure\\n");
+      process.exit(plan.exit_code);
+    }
+    let manifest = updateManifestState(record.data, STATES.DISPATCHED, "fleet_fake_redispatch");
+    if (plan.run_state !== "dispatched") {
+      manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "await_review");
+    }
+    writeManifest(manifestInput, manifest, record.body);
+    process.stdout.write(JSON.stringify({
+      status: "ok",
+      runId,
+      manifestPath: manifestInput,
+      fleetId: record.data.fleet_id || null,
+    }) + "\\n");
+    return;
+  }
   const plan = config[branch] || {};
   const issueNumber = issueFromBranch(branch);
   appendLog({ event: "spawn", branch, leafId, fleetId, dryRun, args });
@@ -316,16 +343,32 @@ function appendLog(record) {
   if (!process.env.FAKE_REVIEW_LOG) return;
   fs.appendFileSync(process.env.FAKE_REVIEW_LOG, JSON.stringify(record) + "\\n", "utf-8");
 }
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function nextPlan(basePlan, runId) {
+  if (!Array.isArray(basePlan.sequence)) return basePlan;
+  const countDir = process.env.FAKE_REVIEW_COUNT_DIR || path.dirname(process.env.FAKE_REVIEW_CONFIG || ".");
+  fs.mkdirSync(countDir, { recursive: true });
+  const countPath = path.join(countDir, runId + ".count");
+  const index = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, "utf-8")) : 0;
+  fs.writeFileSync(countPath, String(index + 1), "utf-8");
+  return { ...basePlan, ...(basePlan.sequence[index] || basePlan.sequence[basePlan.sequence.length - 1] || {}) };
+}
 const repoRoot = get("--repo");
 const runId = get("--run-id");
 const config = process.env.FAKE_REVIEW_CONFIG
   ? JSON.parse(fs.readFileSync(process.env.FAKE_REVIEW_CONFIG, "utf-8"))
   : {};
-const plan = config[runId] || {};
+const plan = nextPlan(config[runId] || {}, runId);
 appendLog({ event: "spawn", runId, args });
 const manifestPath = getManifestPath(repoRoot, runId);
 const record = readManifest(manifestPath);
 let manifest = record.data;
+async function main() {
+if (plan.delay_ms) {
+  await sleep(plan.delay_ms);
+}
 if (!plan.stall) {
   const verdict = plan.verdict || "lgtm";
   if (!plan.omit_review_fields) {
@@ -349,6 +392,11 @@ if (!plan.stall) {
 }
 process.stdout.write(JSON.stringify({ ok: true, runId, stalled: Boolean(plan.stall) }) + "\\n");
 process.exit(plan.exit_code || 0);
+}
+main().catch((error) => {
+  process.stderr.write(String(error.stack || error.message || error) + "\\n");
+  process.exit(1);
+});
 `, "utf-8");
   fs.chmodSync(scriptPath, 0o755);
   return scriptPath;
@@ -806,7 +854,232 @@ test("relay-fleet --review treats child state transitions as manifest progress",
 
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.reviewed_children[0].status, "reviewed");
+  assert.equal(payload.reviewed_children[0].status, "complete");
+  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
+});
+
+test("relay-fleet --review redispatches changes_requested children and re-reviews to ready_to_merge", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-loop-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-loop-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const reviewLog = path.join(tmpDir, "review.log");
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runId = "issue-524-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId,
+    branch: "issue-524-leaf-a",
+    issueNumber: 524,
+    leafId: "leaf-a",
+    fleetId: "fleet-review-loop",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  writeJson(configPath, {
+    [runId]: {
+      sequence: [
+        { to_state: "changes_requested", verdict: "changes_requested" },
+        { to_state: "ready_to_merge", verdict: "lgtm" },
+      ],
+    },
+  });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review-loop",
+    children: [{ leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review-loop").data;
+  fleet.fleet_state = FLEET_STATES.DISPATCHED;
+  writeFleetManifest(repoRoot, fleet);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-loop",
+    "--review",
+    "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_DISPATCH_LOG: dispatchLog,
+      FAKE_REVIEW_CONFIG: configPath,
+      FAKE_REVIEW_LOG: reviewLog,
+      FAKE_REVIEW_COUNT_DIR: tmpDir,
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.reviewed_children[0].status, "complete");
+  assert.deepEqual(payload.reviewed_children[0].steps.map((step) => step.phase), ["review", "redispatch", "review"]);
+  assert.equal(readJsonLines(dispatchLog).length, 1);
+  assert.match(readJsonLines(dispatchLog)[0].args.join(" "), /--manifest/);
+  assert.equal(readJsonLines(reviewLog).length, 2);
+  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
+});
+
+test("relay-fleet --resume re-enters the review loop for changes_requested children", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-resume-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-resume-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const reviewLog = path.join(tmpDir, "review.log");
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runId = "issue-525-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId,
+    branch: "issue-525-leaf-a",
+    issueNumber: 525,
+    leafId: "leaf-a",
+    fleetId: "fleet-review-resume",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  const record = readManifest(getManifestPath(repoRoot, runId));
+  writeManifest(getManifestPath(repoRoot, runId), updateManifestState(record.data, RUN_STATES.CHANGES_REQUESTED, "retry"), record.body);
+  writeJson(configPath, { [runId]: { to_state: "ready_to_merge", verdict: "lgtm" } });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review-resume",
+    children: [{ leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review-resume").data;
+  fleet.fleet_state = FLEET_STATES.REVIEWING;
+  writeFleetManifest(repoRoot, fleet);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-resume",
+    "--resume",
+    "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_DISPATCH_LOG: dispatchLog,
+      FAKE_REVIEW_CONFIG: configPath,
+      FAKE_REVIEW_LOG: reviewLog,
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.reviewed_children[0].status, "complete");
+  assert.deepEqual(payload.reviewed_children[0].steps.map((step) => step.phase), ["redispatch", "review"]);
+  assert.equal(readJsonLines(dispatchLog).length, 1);
+  assert.equal(readJsonLines(reviewLog).length, 1);
+  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
+});
+
+test("relay-fleet --resume keeps pre-manifest dispatch failures visible during review resume", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-resume-failure-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-resume-failure-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runId = "issue-527-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId,
+    branch: "issue-527-leaf-a",
+    issueNumber: 527,
+    leafId: "leaf-a",
+    fleetId: "fleet-review-resume-failure",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  const record = readManifest(getManifestPath(repoRoot, runId));
+  writeManifest(getManifestPath(repoRoot, runId), updateManifestState(record.data, RUN_STATES.CHANGES_REQUESTED, "retry"), record.body);
+  writeJson(configPath, { [runId]: { to_state: "ready_to_merge", verdict: "lgtm" } });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review-resume-failure",
+    children: [
+      { leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-b", run_id: null, dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST },
+    ],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review-resume-failure").data;
+  fleet.fleet_state = FLEET_STATES.REVIEWING;
+  writeFleetManifest(repoRoot, fleet);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-resume-failure",
+    "--resume",
+    "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_REVIEW_CONFIG: configPath },
+  });
+
+  assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.reviewed_children[0].status, "complete");
+  assert.equal(payload.operator_attention.some((item) => item.leaf_ref === "leaf-b"), true);
+});
+
+test("relay-fleet --resume skips a still-running review subprocess", async () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-review-running-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-running-fake-"));
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const reviewLog = path.join(tmpDir, "review.log");
+  const configPath = path.join(tmpDir, "review-config.json");
+  const runId = "issue-526-20260515010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId,
+    branch: "issue-526-leaf-a",
+    issueNumber: 526,
+    leafId: "leaf-a",
+    fleetId: "fleet-review-running",
+    state: RUN_STATES.REVIEW_PENDING,
+  });
+  writeJson(configPath, { [runId]: { to_state: "ready_to_merge", delay_ms: 1000 } });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-review-running",
+    children: [{ leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  let fleet = readFleetManifest(repoRoot, "fleet-review-running").data;
+  fleet.fleet_state = FLEET_STATES.DISPATCHED;
+  writeFleetManifest(repoRoot, fleet);
+
+  const first = spawn(process.execPath, [
+    RELAY_FLEET_SCRIPT,
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-running",
+    "--review",
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      FAKE_REVIEW_CONFIG: configPath,
+      FAKE_REVIEW_LOG: reviewLog,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await waitFor(() => readJsonLines(reviewLog).length === 1);
+  const resumed = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-review-running",
+    "--resume",
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_REVIEW_CONFIG: configPath,
+      FAKE_REVIEW_LOG: reviewLog,
+    },
+  });
+
+  assert.equal(resumed.status, 1);
+  const payload = JSON.parse(resumed.stdout);
+  assert.equal(payload.reviewed_children[0].status, "skipped_running");
+  assert.equal(readJsonLines(reviewLog).length, 1);
+  await new Promise((resolve) => first.on("close", resolve));
   assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
 });
 
@@ -878,5 +1151,7 @@ test("relay-fleet --status prints derived summary without writing the fleet mani
     textResult.stdout,
     /leaf-failed \| run_id=null \| dispatch_status=dispatch_failed_pre_manifest \| run_state=no_run_manifest/,
   );
+  assert.match(textResult.stdout, /Needs operator attention:/);
+  assert.match(textResult.stdout, new RegExp(`leaf-escalated: escalated \\(${escalatedRun}\\)`));
   assert.equal(fs.readFileSync(created.manifestPath, "utf-8"), before);
 });


### PR DESCRIPTION
Part of #479. Completes Phase 2 Sub-PR B.

## Summary
- extend `relay-fleet --review` from a single review pass into the review/redispatch loop
- redispatch children in `changes_requested` with `dispatch.js --manifest <child-manifest>` and re-enter review until `ready_to_merge` or `escalated`
- extend `--resume` to re-enter review orchestration and skip still-running child review/redispatch subprocesses via runtime PID guards
- keep reviewing fleet state stable during resume and document the Phase 2 loop behavior

## Validation
- `node --test tests/relay-fleet/scripts/*.test.js`
- `node --test tests/relay-dispatch/scripts/*.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`

## Broader suite note
- Attempted `node --test tests/relay-review/scripts/*.test.js`: 388/390 passed. Two failures are outside this PR's touched files: `advisory-review-schema.test.js` ambiguous prose/fenced-output assertion and `review-runner.test.js` PR body snapshot timeout (`spawnSync gh ETIMEDOUT`).