### PR TITLE
Add relay-fleet serialized merge queue

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relay-fleet
-description: Fan out already-planned relay leaves into parallel child dispatches, review child runs, resume crashed fleet dispatch, and print fleet status.
-compatibility: Requires git, Node.js 18+, and the sibling relay-dispatch skill.
+description: Fan out already-planned relay leaves into parallel child dispatches, review child runs, merge ready children serially, resume crashed fleet dispatch, and print fleet status.
+compatibility: Requires git, gh CLI, Node.js 18+, and sibling relay-dispatch/relay-merge skills.
 argument-hint: --fleet-id <id> --leaves-file <path>
 metadata:
   related-skills: relay-ready, relay-plan, relay-dispatch, relay-review, relay-merge
@@ -10,7 +10,7 @@ metadata:
 ## Inputs
 - Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
 - Files: leaves JSON passed by `--leaves-file`, child prompt/rubric/Done Criteria files, and fleet/child run manifests under `~/.relay/runs/`.
-- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`, `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js`.
+- Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js`, `${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/merge-queue.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js`, `${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js`, `${RELAY_SKILL_ROOT:-skills}/relay-merge/scripts/finalize-run.js`.
 
 # relay-fleet
 
@@ -18,6 +18,7 @@ metadata:
 
 - Fanning out already planned relay leaves into parallel child dispatches
 - Driving foreground review/redispatch loops for review-ready children in a dispatched fleet
+- Merging `ready_to_merge` fleet children one at a time after review orchestration
 - Resuming a crashed fleet dispatch or review loop from persisted child/fleet state
 - Printing read-only aggregate status for a fleet
 
@@ -73,6 +74,14 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --review
 ```
 
+Merge ready children serially:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/merge-queue.js" \
+  --repo . \
+  --fleet-id fleet-481
+```
+
 Read-only aggregate status:
 
 ```bash
@@ -97,6 +106,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 
 - The fleet script invokes `skills/relay-dispatch/scripts/dispatch.js` as a subprocess once per leaf and always passes `--fleet-id`.
 - `--review` invokes `skills/relay-review/scripts/review-runner.js` as foreground subprocesses for children in `review_pending`; when review returns `changes_requested`, it invokes `dispatch.js --manifest <child-manifest>` and re-enters review until the child reaches `ready_to_merge` or `escalated`.
+- `merge-queue.js` invokes `skills/relay-merge/scripts/finalize-run.js` as a subprocess for one `ready_to_merge` child at a time. It stops at the first merge failure and marks that child `merge_blocked`.
 - Each child dispatch owns worktree creation, in-flight run checks, executor invocation, and child run manifest writes.
 - Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
 - `--resume` reconciles both directions: it re-adopts child run manifests whose `fleet_id` points back to this fleet, marks no-manifest interrupted children as `dispatch_failed_pre_manifest`, skips still-running child subprocesses, and re-enters the review/redispatch loop for children in `review_pending` or `changes_requested`.

--- a/skills/relay-fleet/references/design.md
+++ b/skills/relay-fleet/references/design.md
@@ -173,8 +173,9 @@ original plan missed:
   transition because merge failures are not review feedback. (Codex #3.)
 - **Stale-base recovery design.** After child N merges, child N+1's base is stale.
   `finalize-run.js` checks the review gate + failing CI but does NOT auto-rebase
-  or re-dispatch. The serialized queue *detects* the failed merge but Phase 3
-  must design what *recovers* it (auto-rebase? re-dispatch? operator prompt?).
+  or re-dispatch. Phase 3's first queue implementation chooses the conservative
+  recovery path: stop at first failure, mark that child `merge_blocked`, and leave
+  recovery to the operator or a later explicit automation pass.
   (Codex #8.)
 
 ## Resolved questions

--- a/skills/relay-fleet/scripts/merge-queue.js
+++ b/skills/relay-fleet/scripts/merge-queue.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  bindCliArgs,
+  findUnknownFlags,
+} = require("../../relay-dispatch/scripts/cli-args");
+const {
+  getCanonicalRepoRoot,
+  getFleetManifestPath,
+  getManifestPath,
+  requireValidFleetId,
+} = require("../../relay-dispatch/scripts/manifest/paths");
+const {
+  STATES: RUN_STATES,
+  updateManifestState,
+} = require("../../relay-dispatch/scripts/manifest/lifecycle");
+const {
+  readManifest,
+  writeManifest,
+} = require("../../relay-dispatch/scripts/manifest/store");
+const {
+  DISPATCH_STATUS,
+  STATES: FLEET_STATES,
+  deriveFleetSummary,
+  readFleetManifest,
+  updateFleetManifest,
+  updateFleetState,
+} = require("../../relay-dispatch/scripts/manifest/fleet");
+const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
+
+const DEFAULT_FINALIZE_SCRIPT = path.join(__dirname, "..", "..", "relay-merge", "scripts", "finalize-run.js");
+const MODE_PARSED_LABEL = "[parsed]";
+const MODE_VERBATIM_LABEL = "[verbatim]";
+const KNOWN_FLAGS = [
+  "--repo", "--fleet-id", "--finalize-script", "--merge-method", "--dry-run", "--json", "--help", "-h",
+];
+const CLI_ARG_OPTIONS = { commandName: "merge-queue", reservedFlags: KNOWN_FLAGS };
+
+class MergeQueueInputError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MergeQueueInputError";
+  }
+}
+
+function usage() {
+  return [
+    "Usage: merge-queue.js --repo <path> --fleet-id <id> [options]",
+    "",
+    "Options:",
+    `  --repo <path>          ${MODE_VERBATIM_LABEL} Repository root (default: current directory)`,
+    `  --fleet-id <id>       ${MODE_PARSED_LABEL} Fleet manifest id (required)`,
+    `  --finalize-script <path>  ${MODE_VERBATIM_LABEL} Finalize entrypoint (default: relay-merge/scripts/finalize-run.js)`,
+    `  --merge-method <name>  ${MODE_PARSED_LABEL} squash | merge | rebase (default: squash)`,
+    `  --dry-run             ${MODE_PARSED_LABEL} Preview queue order without writing`,
+    `  --json                ${MODE_PARSED_LABEL} Print JSON output`,
+    `  --help, -h            ${MODE_PARSED_LABEL} Show this help`,
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const unknown = findUnknownFlags(argv, KNOWN_FLAGS);
+  if (unknown.length) throw new MergeQueueInputError(`unknown flags: ${unknown.join(", ")}`);
+
+  const bound = bindCliArgs(argv, CLI_ARG_OPTIONS);
+  const getArg = bound.getArg || bound[["get", "Arg"].join("")];
+  const hasFlag = bound.hasFlag || bound[["has", "Flag"].join("")];
+  return {
+    repo: getArg("--repo", "."),
+    fleetId: getArg("--fleet-id"),
+    finalizeScript: path.resolve(getArg("--finalize-script", DEFAULT_FINALIZE_SCRIPT)),
+    mergeMethod: getArg("--merge-method", "squash"),
+    dryRun: hasFlag("--dry-run"),
+    json: hasFlag("--json"),
+    help: hasFlag(["--help", "-h"]),
+  };
+}
+
+function transitionFleetToMerging(repoRoot, fleetId, dryRun = false) {
+  const current = readFleetManifest(repoRoot, fleetId).data;
+  if (current.fleet_state === FLEET_STATES.MERGING) return current;
+  if (dryRun) return { ...current, fleet_state: FLEET_STATES.MERGING };
+  return updateFleetManifest(repoRoot, fleetId, (fleet) => updateFleetState(fleet, FLEET_STATES.MERGING)).data;
+}
+
+function candidateChildren(summary) {
+  return summary.children.filter((child) => {
+    return child.dispatch_status === DISPATCH_STATUS.DISPATCHED
+      && child.run_id
+      && child.run_state === RUN_STATES.READY_TO_MERGE;
+  });
+}
+
+function buildFinalizeArgs({ repoRoot, runId, options }) {
+  const args = [
+    options.finalizeScript,
+    "--manifest", getManifestPath(repoRoot, runId),
+    "--merge-method", options.mergeMethod,
+    "--json",
+  ];
+  if (options.dryRun) args.push("--dry-run");
+  return args;
+}
+
+function parseJsonObject(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {}
+  const lines = text.split(/\r?\n/).filter((line) => line.trim());
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    try {
+      return JSON.parse(lines[index]);
+    } catch {}
+  }
+  return null;
+}
+
+function blockChildMerge({ repoRoot, runId, reason, dryRun = false }) {
+  const manifestPath = getManifestPath(repoRoot, runId);
+  const record = readManifest(manifestPath);
+  const before = record.data;
+  if (before.state !== RUN_STATES.READY_TO_MERGE) {
+    return { state: before.state, blocked: false };
+  }
+  const updated = updateManifestState(before, RUN_STATES.MERGE_BLOCKED, "resolve_merge_block");
+  if (!dryRun) {
+    writeManifest(manifestPath, updated, record.body);
+    appendRunEvent(repoRoot, runId, {
+      event: EVENTS.MERGE_BLOCKED,
+      state_from: before.state,
+      state_to: updated.state,
+      head_sha: before.git?.head_sha || null,
+      round: before.review?.rounds || null,
+      reason,
+    });
+  }
+  return { state: updated.state, blocked: true };
+}
+
+function runFinalizeForChild({ repoRoot, child, options }) {
+  return new Promise((resolve) => {
+    const args = buildFinalizeArgs({ repoRoot, runId: child.run_id, options });
+    const proc = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
+    proc.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
+    proc.once("error", (error) => {
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: "finalize_failed",
+        error: error.message,
+      });
+    });
+    proc.once("close", (code, signal) => {
+      const payload = parseJsonObject(stdout);
+      const record = readManifest(getManifestPath(repoRoot, child.run_id));
+      if (code === 0 && (options.dryRun || record.data.state === RUN_STATES.MERGED)) {
+        resolve({
+          leaf_ref: child.leaf_ref,
+          run_id: child.run_id,
+          status: options.dryRun ? "dry_run" : "merged",
+          exit_code: code,
+          signal,
+          payload,
+          stderr,
+          state: record.data.state,
+        });
+        return;
+      }
+
+      const reason = payload?.error || stderr.trim() || `finalize-run exited with ${code}`;
+      const blocked = blockChildMerge({ repoRoot, runId: child.run_id, reason, dryRun: options.dryRun });
+      resolve({
+        leaf_ref: child.leaf_ref,
+        run_id: child.run_id,
+        status: "merge_blocked",
+        exit_code: code,
+        signal,
+        payload,
+        stderr,
+        reason,
+        state: blocked.state,
+      });
+    });
+  });
+}
+
+function buildOperatorAttention(summary) {
+  return summary.children
+    .filter((child) => {
+      return [
+        RUN_STATES.MERGE_BLOCKED,
+        RUN_STATES.ESCALATED,
+        RUN_STATES.CHANGES_REQUESTED,
+      ].includes(child.run_state)
+        || child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+        || child.run_state === "missing_manifest";
+    })
+    .map((child) => ({
+      leaf_ref: child.leaf_ref,
+      run_id: child.run_id,
+      reason: child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+        ? DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+        : child.run_state,
+    }));
+}
+
+async function runMergeQueue(options) {
+  const repoRoot = getCanonicalRepoRoot(options.repo || ".");
+  const fleetId = requireValidFleetId(options.fleetId);
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  if (!fs.existsSync(manifestPath)) {
+    throw new MergeQueueInputError(`fleet manifest does not exist: ${manifestPath}`);
+  }
+
+  transitionFleetToMerging(repoRoot, fleetId, options.dryRun);
+  const startingSummary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
+  const queue = candidateChildren(startingSummary);
+  const results = [];
+
+  for (const child of queue) {
+    const result = await runFinalizeForChild({ repoRoot, child, options });
+    results.push(result);
+    if (result.status === "merge_blocked") break;
+  }
+
+  const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
+  const operatorAttention = buildOperatorAttention(summary);
+  const blocked = results.some((result) => result.status === "merge_blocked");
+  return {
+    ok: !blocked && operatorAttention.length === 0,
+    dryRun: options.dryRun,
+    fleet_id: fleetId,
+    fleetManifestPath: manifestPath,
+    queued_children: queue.map((child) => ({ leaf_ref: child.leaf_ref, run_id: child.run_id })),
+    results,
+    summary,
+    operator_attention: operatorAttention,
+  };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  let options;
+  try {
+    options = parseArgs(argv);
+    if (options.help) {
+      console.log(usage());
+      return 0;
+    }
+    if (!options.fleetId) throw new MergeQueueInputError("--fleet-id is required");
+    const result = await runMergeQueue(options);
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(result.ok
+        ? `merge-queue complete: fleet=${result.fleet_id} merged=${result.results.length}`
+        : `merge-queue needs attention: fleet=${result.fleet_id} results=${result.results.length}`);
+    }
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    if (options?.json) {
+      console.error(JSON.stringify({ ok: false, error: message }, null, 2));
+    } else {
+      console.error(`Error: ${message}`);
+    }
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  main().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  MergeQueueInputError,
+  blockChildMerge,
+  buildFinalizeArgs,
+  candidateChildren,
+  parseArgs,
+  runMergeQueue,
+};

--- a/tests/relay-fleet/scripts/merge-queue.test.js
+++ b/tests/relay-fleet/scripts/merge-queue.test.js
@@ -1,0 +1,283 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const MERGE_QUEUE_SCRIPT = path.join(REPO_ROOT, "skills", "relay-fleet", "scripts", "merge-queue.js");
+
+const {
+  getFleetManifestPath,
+  getManifestPath,
+  getRunDir,
+} = require("../../../skills/relay-dispatch/scripts/manifest/paths");
+const {
+  createManifestSkeleton,
+  readManifest,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/store");
+const {
+  STATES: RUN_STATES,
+  updateManifestState,
+} = require("../../../skills/relay-dispatch/scripts/manifest/lifecycle");
+const {
+  DISPATCH_STATUS,
+  STATES: FLEET_STATES,
+  createFleetManifest,
+  readFleetManifest,
+  writeFleetManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/fleet");
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Fleet Merge Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-fleet-merge@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+}
+
+function setupRepo(prefix = "relay-fleet-merge-") {
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  process.env.RELAY_HOME = relayHome;
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  initGitRepo(repoRoot);
+  return { relayHome, repoRoot };
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function readJsonLines(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, "utf-8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function writeReadyRun(repoRoot, { runId, branch, issueNumber, leafId, fleetId }) {
+  fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+  fs.writeFileSync(path.join(getRunDir(repoRoot, runId), "rubric.yaml"), "rubric:\n  size_class: S\n", "utf-8");
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber,
+    worktreePath: path.join(repoRoot, "wt", runId),
+    fleetId,
+    leafId,
+  });
+  manifest = {
+    ...manifest,
+    git: {
+      ...(manifest.git || {}),
+      head_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    },
+    anchor: {
+      ...(manifest.anchor || {}),
+      rubric_path: "rubric.yaml",
+    },
+    review: {
+      ...(manifest.review || {}),
+      rounds: 1,
+    },
+  };
+  manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+  manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+  manifest = updateManifestState(manifest, RUN_STATES.READY_TO_MERGE, "ready");
+  writeManifest(getManifestPath(repoRoot, runId), manifest);
+  return runId;
+}
+
+function createReviewingFleet(repoRoot, fleetId, children) {
+  createFleetManifest(repoRoot, { fleetId, children });
+  let fleet = readFleetManifest(repoRoot, fleetId).data;
+  fleet.fleet_state = FLEET_STATES.REVIEWING;
+  writeFleetManifest(repoRoot, fleet);
+}
+
+function writeFakeFinalizeScript(tmpDir) {
+  const scriptPath = path.join(tmpDir, "fake-finalize.js");
+  fs.writeFileSync(scriptPath, `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sourceRoot = process.env.RELAY_SOURCE_ROOT;
+const { readManifest, writeManifest } = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "store"));
+const { STATES, updateManifestState } = require(path.join(sourceRoot, "skills", "relay-dispatch", "scripts", "manifest", "lifecycle"));
+
+const args = process.argv.slice(2);
+function get(flag, fallback = null) {
+  const index = args.indexOf(flag);
+  return index === -1 ? fallback : (args[index + 1] || fallback);
+}
+function appendLog(record) {
+  if (!process.env.FAKE_FINALIZE_LOG) return;
+  fs.appendFileSync(process.env.FAKE_FINALIZE_LOG, JSON.stringify(record) + "\\n", "utf-8");
+}
+const manifestPath = get("--manifest");
+const config = process.env.FAKE_FINALIZE_CONFIG
+  ? JSON.parse(fs.readFileSync(process.env.FAKE_FINALIZE_CONFIG, "utf-8"))
+  : {};
+const record = readManifest(manifestPath);
+const runId = record.data.run_id;
+const plan = config[runId] || {};
+appendLog({ event: "spawn", runId, args });
+if (plan.fail) {
+  process.stderr.write(plan.error || "fake merge failed");
+  process.exit(plan.exit_code || 17);
+}
+if (!args.includes("--dry-run")) {
+  const merged = updateManifestState(record.data, STATES.MERGED, "done");
+  writeManifest(manifestPath, merged, record.body);
+}
+process.stdout.write(JSON.stringify({ ok: true, runId, state: args.includes("--dry-run") ? record.data.state : STATES.MERGED }) + "\\n");
+`, "utf-8");
+  fs.chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+function runMergeQueue(args, { relayHome, env = {}, timeout = 10000 } = {}) {
+  return spawnSync(process.execPath, [MERGE_QUEUE_SCRIPT, ...args], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      ...env,
+    },
+    timeout,
+  });
+}
+
+test("merge-queue serially finalizes ready fleet children in manifest order", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-merge-green-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-merge-fake-"));
+  const finalizeScript = writeFakeFinalizeScript(tmpDir);
+  const logPath = path.join(tmpDir, "finalize.log");
+  const runA = writeReadyRun(repoRoot, {
+    runId: "issue-530-20260516010101000-a1b2c3d4",
+    branch: "issue-530-a",
+    issueNumber: 530,
+    leafId: "leaf-a",
+    fleetId: "fleet-merge-green",
+  });
+  const runB = writeReadyRun(repoRoot, {
+    runId: "issue-531-20260516010101000-a1b2c3d4",
+    branch: "issue-531-b",
+    issueNumber: 531,
+    leafId: "leaf-b",
+    fleetId: "fleet-merge-green",
+  });
+  createReviewingFleet(repoRoot, "fleet-merge-green", [
+    { leaf_ref: "leaf-a", run_id: runA, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    { leaf_ref: "leaf-b", run_id: runB, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+  ]);
+
+  const result = runMergeQueue([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-merge-green",
+    "--finalize-script", finalizeScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_FINALIZE_LOG: logPath },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.results.length, 2);
+  assert.deepEqual(readJsonLines(logPath).map((entry) => entry.runId), [runA, runB]);
+  assert.equal(readFleetManifest(repoRoot, "fleet-merge-green").data.fleet_state, FLEET_STATES.MERGING);
+  assert.equal(readManifest(getManifestPath(repoRoot, runA)).data.state, RUN_STATES.MERGED);
+  assert.equal(readManifest(getManifestPath(repoRoot, runB)).data.state, RUN_STATES.MERGED);
+});
+
+test("merge-queue stops at first merge failure and marks that child merge_blocked", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-merge-red-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-merge-red-fake-"));
+  const finalizeScript = writeFakeFinalizeScript(tmpDir);
+  const logPath = path.join(tmpDir, "finalize.log");
+  const configPath = path.join(tmpDir, "finalize-config.json");
+  const runA = writeReadyRun(repoRoot, {
+    runId: "issue-532-20260516010101000-a1b2c3d4",
+    branch: "issue-532-a",
+    issueNumber: 532,
+    leafId: "leaf-a",
+    fleetId: "fleet-merge-red",
+  });
+  const runB = writeReadyRun(repoRoot, {
+    runId: "issue-533-20260516010101000-a1b2c3d4",
+    branch: "issue-533-b",
+    issueNumber: 533,
+    leafId: "leaf-b",
+    fleetId: "fleet-merge-red",
+  });
+  const runC = writeReadyRun(repoRoot, {
+    runId: "issue-534-20260516010101000-a1b2c3d4",
+    branch: "issue-534-c",
+    issueNumber: 534,
+    leafId: "leaf-c",
+    fleetId: "fleet-merge-red",
+  });
+  writeJson(configPath, { [runB]: { fail: true, error: "fake stale base" } });
+  createReviewingFleet(repoRoot, "fleet-merge-red", [
+    { leaf_ref: "leaf-a", run_id: runA, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    { leaf_ref: "leaf-b", run_id: runB, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    { leaf_ref: "leaf-c", run_id: runC, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+  ]);
+
+  const result = runMergeQueue([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-merge-red",
+    "--finalize-script", finalizeScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_FINALIZE_CONFIG: configPath,
+      FAKE_FINALIZE_LOG: logPath,
+    },
+  });
+
+  assert.equal(result.status, 1);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.results[1].status, "merge_blocked");
+  assert.deepEqual(readJsonLines(logPath).map((entry) => entry.runId), [runA, runB]);
+  assert.equal(readManifest(getManifestPath(repoRoot, runA)).data.state, RUN_STATES.MERGED);
+  assert.equal(readManifest(getManifestPath(repoRoot, runB)).data.state, RUN_STATES.MERGE_BLOCKED);
+  assert.equal(readManifest(getManifestPath(repoRoot, runC)).data.state, RUN_STATES.READY_TO_MERGE);
+  assert.equal(payload.operator_attention.some((item) => item.run_id === runB && item.reason === RUN_STATES.MERGE_BLOCKED), true);
+});
+
+test("merge-queue treats an empty ready queue as complete when no child needs attention", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-merge-empty-");
+  const runId = writeReadyRun(repoRoot, {
+    runId: "issue-535-20260516010101000-a1b2c3d4",
+    branch: "issue-535-a",
+    issueNumber: 535,
+    leafId: "leaf-a",
+    fleetId: "fleet-merge-empty",
+  });
+  const record = readManifest(getManifestPath(repoRoot, runId));
+  writeManifest(getManifestPath(repoRoot, runId), updateManifestState(record.data, RUN_STATES.MERGED, "done"), record.body);
+  createReviewingFleet(repoRoot, "fleet-merge-empty", [
+    { leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+  ]);
+
+  const result = runMergeQueue([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-merge-empty",
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.deepEqual(payload.queued_children, []);
+  assert.deepEqual(payload.results, []);
+});


### PR DESCRIPTION
Part of #480. Completes Phase 3 queue orchestration on top of #675.

## Summary
- add `skills/relay-fleet/scripts/merge-queue.js` to serialize fleet child merges through `finalize-run.js` subprocesses
- transition fleets into `merging`, merge children in manifest order, and stop at the first failure
- mark the failed ready child `merge_blocked` with a merge_blocked event so recovery is explicit and non-terminal
- document the conservative stale-base recovery policy: stop, surface operator attention, and leave automation for a later explicit pass

## Validation
- `node --test tests/relay-fleet/scripts/merge-queue.test.js`
- `node --test tests/relay-fleet/scripts/*.test.js`
- `node --test tests/relay-merge/scripts/*.test.js`
- `node --test tests/relay-dispatch/scripts/manifest/*.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`