### PR TITLE
Scrub internal route examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Adapter minimum versions, binary overrides, timeouts, capability gates, and prov
 
 ## Configure Routes
 
-Relay distinguishes CLI harnesses from provider/model routes. Names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` describe how relay invokes an agent. The compliance boundary is the provider/model route, for example `kakao/opencode-glm-5-fp8`, `opencode-go/deepseek-v4-pro`, or `google/antigravity-cli`.
+Relay distinguishes CLI harnesses from provider/model routes. Names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` describe how relay invokes an agent. The compliance boundary is the provider/model route, for example `example/opencode-model-fast`, `opencode-go/deepseek-v4-pro`, or `google/antigravity-cli`.
 
 Without a policy file, relay stays conservative: managed Codex and Claude CLIs are allowed by default, while OpenCode, Pi, Antigravity, advisory reviewers, and sidecars require explicit route approval.
 
 After installing skills, ask for setup in plain language:
 
 ```text
-/relay-config Set up relay for my company environment. Only allow OpenCode through kakao/opencode-glm-*.
+/relay-config Set up relay for my company environment. Only allow OpenCode through example/opencode-model-*.
 $relay-config For my personal setup, use opencode-go/deepseek-v4-pro for sidecar and advisory review.
 ```
 
@@ -88,7 +88,7 @@ Common starting points:
 | Setup | Recommended request |
 | --- | --- |
 | Company default | `/relay-config Set up relay for my company environment` |
-| Company internal OpenCode | `/relay-config Only allow OpenCode through the kakao/opencode-glm-* route at work` |
+| Approved OpenCode route | `/relay-config Only allow OpenCode through the example/opencode-model-* route at work` |
 | Personal sidecars | `$relay-config Use opencode-go/deepseek-v4-pro for personal sidecar and advisory review` |
 | Managed only | `/relay-config Keep the default Codex/Claude-only setup` |
 

--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -2,7 +2,7 @@
 
 Route policy answers one operational question: which provider/model route is allowed to run in each relay phase?
 
-Executor and reviewer names such as `codex`, `claude`, `opencode`, and `pi` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `kakao/opencode-glm-5-fp8`, `opencode-go/deepseek-v4-pro`, `deepseek/r1`, or `ollama/qwen3`.
+Executor and reviewer names such as `codex`, `claude`, `opencode`, and `pi` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `example/opencode-model-fast`, `opencode-go/deepseek-v4-pro`, `deepseek/r1`, or `ollama/qwen3`.
 
 Codex and Claude are the managed CLI defaults. In the default managed profile, a model-less Codex or Claude invocation is allowed because the CLI account and its managed default model are the boundary. Generated company defaults should not pin Codex or Claude model names just to make policy explicit. OpenCode, Pi, and Antigravity are routing harnesses, so managed/company profiles must require an explicit provider/model route and an allow rule before they can run.
 
@@ -54,12 +54,12 @@ Policy `defaults` describe configured actor defaults for auditing and future-saf
 
 `model_hints` are route hints, not route approval. They can carry provider/model routes for unmanaged harnesses, especially advisory review. They should not be used to pin Codex or Claude defaults in generated company config.
 
-## Company/Internal Setup
+## Organization Setup
 
 After installing skills, prefer the interactive setup skill. Ask in natural language and let it inspect the current policy before writing:
 
 ```text
-/relay-config 회사 환경으로 relay 설정해줘. opencode는 kakao/opencode-glm-*만 허용해줘.
+/relay-config 회사 환경으로 relay 설정해줘. opencode는 example/opencode-model-*만 허용해줘.
 ```
 
 The skill should show the proposed policy, ask for confirmation, apply it, then run `doctor` and representative `check` commands.
@@ -70,20 +70,20 @@ From a direct checkout, initialize a company policy with the wrapper:
 node skills/relay-config/scripts/relay-config.js init company
 ```
 
-The generated company policy intentionally keeps Codex and Claude as managed CLI defaults with no pinned model names. Add internal OpenCode or Pi routes explicitly:
+The generated company policy intentionally keeps Codex and Claude as managed CLI defaults with no pinned model names. Add organization-approved OpenCode or Pi routes explicitly:
 
 ```bash
-node skills/relay-config/scripts/relay-config.js allow-route 'kakao/opencode-glm-*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'example/opencode-model-*' \
   --phase dispatch,advisory_review,sidecar \
   --executor opencode
 
-node skills/relay-config/scripts/relay-config.js allow-route 'kakao/pi-*' \
+node skills/relay-config/scripts/relay-config.js allow-route 'example/pi-*' \
   --phase dispatch,review,advisory_review,sidecar \
   --executor pi \
   --reviewer pi
 ```
 
-For routed advisory reviewers or sidecars, add routing rules to the policy JSON so the selected route is internal:
+For routed advisory reviewers or sidecars, add routing rules to the policy JSON so the selected route is policy-approved:
 
 ```json
 {
@@ -98,7 +98,7 @@ For routed advisory reviewers or sidecars, add routing rules to the policy JSON 
   "managed_cli": ["codex", "claude"],
   "allowed_model_routes": [
     {
-      "route": "kakao/opencode-glm-*",
+      "route": "example/opencode-model-*",
       "phases": ["dispatch", "advisory_review", "sidecar"],
       "executors": ["opencode"],
       "reviewers": ["opencode"]
@@ -107,17 +107,17 @@ For routed advisory reviewers or sidecars, add routing rules to the policy JSON 
   "denied_model_routes": [],
   "routing_rules": [
     {
-      "name": "docs-internal-sidecar",
+      "name": "docs-approved-sidecar",
       "match": { "any_tags": ["docs", "docs-only"] },
       "advisory_review": {
         "reviewer": "opencode",
         "profile": "blindspot",
-        "model": "kakao/opencode-glm-5-fp8"
+        "model": "example/opencode-model-fast"
       },
       "sidecar": {
         "kind": "docs-sync",
         "executor": "opencode",
-        "model": "kakao/opencode-glm-5-fp8"
+        "model": "example/opencode-model-fast"
       }
     }
   ],
@@ -125,7 +125,7 @@ For routed advisory reviewers or sidecars, add routing rules to the policy JSON 
 }
 ```
 
-Repo-local `.relay/policy.json` files may narrow the global policy but may not widen it. For example, a repo policy can reduce `allowed_model_routes` from `kakao/*` to `kakao/opencode-glm-*`; it cannot add a new external provider that the global policy did not allow.
+Repo-local `.relay/policy.json` files may narrow the global policy but may not widen it. For example, a repo policy can reduce `allowed_model_routes` from `example/*` to `example/opencode-model-*`; it cannot add a new external provider that the global policy did not allow.
 
 Project-local `~/.relay/projects/<repo-slug>/policy.json` is an additional local narrow-only layer after global and repo policy. It is for company or personal machine restrictions that should not be committed. Policy is authorization; `~/.relay/projects/<repo-slug>/routes.json` is only preferences and cannot grant a route.
 
@@ -224,11 +224,11 @@ Doctor reports whether known CLIs are installed and how policy treats each harne
 Run `relay-config check` for each actual tuple you plan to enable:
 
 ```bash
-node skills/relay-config/scripts/relay-config.js check dispatch opencode kakao/opencode-glm-5-fp8
+node skills/relay-config/scripts/relay-config.js check dispatch opencode example/opencode-model-fast
 
-node skills/relay-config/scripts/relay-config.js check advisory_review opencode kakao/opencode-glm-5-fp8
+node skills/relay-config/scripts/relay-config.js check advisory_review opencode example/opencode-model-fast
 
-node skills/relay-config/scripts/relay-config.js check sidecar opencode kakao/opencode-glm-5-fp8
+node skills/relay-config/scripts/relay-config.js check sidecar opencode example/opencode-model-fast
 ```
 
 Check exits non-zero when the tuple would be denied at runtime. Run it before turning on routed advisory review or sidecar rules because those phases can start automatically after dispatch.

--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -27,7 +27,7 @@ Use `/relay-config` to set route policy rather than editing JSON by hand:
 
 ```text
 /relay-config Set up relay for my company environment
-/relay-config Only allow OpenCode through kakao/opencode-glm-* at work
+/relay-config Only allow OpenCode through example/opencode-model-* at work
 $relay-config Use opencode-go/deepseek-v4-pro for personal sidecar review
 ```
 

--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -21,7 +21,7 @@ Set up relay route policy interactively. The user should not have to memorize co
 
 - The user asks to set up or configure relay
 - The user wants company-safe defaults, personal OpenCode/Pi opt-in, or sidecar/advisory-review routing
-- The user asks whether a provider/model route such as `kakao/opencode-glm-*` is allowed
+- The user asks whether a provider/model route such as `example/opencode-model-*` is allowed
 - The user asks to run relay policy doctor/check
 
 ## Do not use when
@@ -49,7 +49,7 @@ Infer from the user's words before asking questions:
 - `company`, `work`, `회사` → company profile
 - `personal`, `home`, `집`, `개인` → personal profile
 - `managed only`, `codex/claude only` → no unmanaged route opt-in
-- routes containing `/`, such as `kakao/opencode-glm-*`, `opencode-go/*`, `deepseek/*`, or `ollama/*` → provider/model route patterns
+- routes containing `/`, such as `example/opencode-model-*`, `opencode-go/*`, `deepseek/*`, or `ollama/*` → provider/model route patterns
 - `sidecar`, `advisory`, `reviewer`, `documentation`, `docs` → likely advisory-review or sidecar phases
 
 Ask only for missing decisions, one at a time. Use plain language and wait for the user's answer. Do not use host-specific question primitives as the only path; this skill must work in both Claude Code and Codex.
@@ -72,7 +72,7 @@ Use the wrapper for shorthand, or pass through full flags:
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" init company
-node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" allow-route 'kakao/opencode-glm-*' --phase dispatch,advisory_review,sidecar --executor opencode
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" allow-route 'example/opencode-model-*' --phase dispatch,advisory_review,sidecar --executor opencode
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
 ```
 
@@ -84,7 +84,7 @@ After changes, run:
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" doctor
-node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" check dispatch opencode kakao/opencode-glm-5-fp8
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" check dispatch opencode example/opencode-model-fast
 ```
 
 Adjust the `check` tuple to match the actual actor, phase, and route that was enabled. Report denied tuples clearly and do not treat a denied OpenCode/Pi route as configured.
@@ -99,6 +99,6 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `init personal` | `init --profile personal` |
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
-| `check dispatch opencode kakao/opencode-glm-5-fp8` | `check --phase dispatch --executor opencode --model kakao/opencode-glm-5-fp8` |
+| `check dispatch opencode example/opencode-model-fast` | `check --phase dispatch --executor opencode --model example/opencode-model-fast` |
 
 Full flag forms continue to pass through. Policy semantics live in the sibling `relay-dispatch` script, not this wrapper.

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -86,7 +86,7 @@ test("check shorthand maps reviewer phases to reviewer and executor scopes", () 
   assert.equal(runConfig(["init", "company", "--json"], { relayHome }).status, 0);
   assert.equal(runConfig([
     "allow-route",
-    "kakao/opencode-glm-*",
+    "example/opencode-model-*",
     "--phase",
     "dispatch,advisory_review,sidecar",
     "--executor",
@@ -98,7 +98,7 @@ test("check shorthand maps reviewer phases to reviewer and executor scopes", () 
     "check",
     "advisory_review",
     "opencode",
-    "kakao/opencode-glm-5-fp8",
+    "example/opencode-model-fast",
     "--json",
   ], { relayHome });
 

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -220,7 +220,7 @@ test("check exits non-zero for missing and unknown OpenCode/Pi provider routes",
     "--executor",
     "opencode",
     "--model",
-    "kakao/opencode-glm-5-fp8",
+    "example/opencode-model-fast",
     "--json",
   ], { relayHome });
   assert.notEqual(unknown.status, 0, unknown.combined);
@@ -247,7 +247,7 @@ test("allow-route maps mixed executor phases to executors and reviewer phases to
 
   const mutation = runConfig([
     "allow-route",
-    "kakao/opencode-glm-*",
+    "example/opencode-model-*",
     "--executor",
     "opencode",
     "--phase",
@@ -257,7 +257,7 @@ test("allow-route maps mixed executor phases to executors and reviewer phases to
   assert.equal(mutation.status, 0, mutation.combined);
 
   const [entry] = readPolicy(relayHome).allowed_model_routes;
-  assert.equal(entry.route, "kakao/opencode-glm-*");
+  assert.equal(entry.route, "example/opencode-model-*");
   assert.deepEqual(new Set(entry.phases), new Set(["sidecar", "advisory_review", "dispatch"]));
   assert.deepEqual(entry.executors, ["opencode"]);
   assert.deepEqual(entry.reviewers, ["opencode"]);
@@ -269,7 +269,7 @@ test("allow-route maps mixed executor phases to executors and reviewer phases to
     "--executor",
     "opencode",
     "--model",
-    "kakao/opencode-glm-5-fp8",
+    "example/opencode-model-fast",
     "--json",
   ], { relayHome });
   assert.equal(dispatch.status, 0, dispatch.combined);
@@ -284,7 +284,7 @@ test("allow-route maps mixed executor phases to executors and reviewer phases to
     "--reviewer",
     "opencode",
     "--model",
-    "kakao/opencode-glm-5-fp8",
+    "example/opencode-model-fast",
     "--json",
   ], { relayHome });
   assert.equal(advisory.status, 0, advisory.combined);
@@ -296,7 +296,7 @@ test("deny-route preserves route scopes and denied routes win during check", () 
   assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
   assert.equal(runConfig([
     "allow-route",
-    "kakao/opencode-glm-*",
+    "example/opencode-model-*",
     "--executor",
     "opencode",
     "--phase",
@@ -306,7 +306,7 @@ test("deny-route preserves route scopes and denied routes win during check", () 
 
   const mutation = runConfig([
     "deny-route",
-    "kakao/opencode-glm-bad",
+    "example/opencode-model-bad",
     "--executor",
     "opencode",
     "--phase",
@@ -317,7 +317,7 @@ test("deny-route preserves route scopes and denied routes win during check", () 
 
   const [entry] = readPolicy(relayHome).denied_model_routes;
   assert.deepEqual(entry, {
-    route: "kakao/opencode-glm-bad",
+    route: "example/opencode-model-bad",
     phases: ["dispatch"],
     executors: ["opencode"],
   });
@@ -329,7 +329,7 @@ test("deny-route preserves route scopes and denied routes win during check", () 
     "--executor",
     "opencode",
     "--model",
-    "kakao/opencode-glm-bad",
+    "example/opencode-model-bad",
     "--json",
   ], { relayHome });
   assert.notEqual(denied.status, 0, denied.combined);

--- a/tests/relay-dispatch/scripts/relay-policy.test.js
+++ b/tests/relay-dispatch/scripts/relay-policy.test.js
@@ -103,7 +103,7 @@ test("validateRelayPolicy rejects invalid v1 schema shapes", () => {
       validateRelayPolicy(
         {
           ...buildDefaultRelayPolicy(),
-          allowed_model_routes: [{ route: "kakao/*", phases: "dispatch" }],
+          allowed_model_routes: [{ route: "example/*", phases: "dispatch" }],
         },
         "bad.json"
       ),
@@ -120,7 +120,7 @@ test("global-only policy allows matching model routes and denies unknown routes"
       managed_cli: ["codex"],
       allowed_model_routes: [
         {
-          route: "kakao/*",
+          route: "example/*",
           phases: ["dispatch"],
           executors: ["opencode"],
         },
@@ -136,7 +136,7 @@ test("global-only policy allows matching model routes and denies unknown routes"
     evaluateRelayRoute(result.policy, {
       phase: "dispatch",
       executor: "opencode",
-      model: "kakao/opencode-glm-5",
+      model: "example/opencode-model-5",
     }).reason,
     "allowed_model_route"
   );
@@ -193,7 +193,7 @@ test("repo-local policy can narrow managed CLIs, allowed routes, and unknown-rou
       deny_unknown_model_routes: false,
       allowed_model_routes: [
         {
-          route: "kakao/*",
+          route: "example/*",
           phases: ["dispatch", "review"],
           executors: ["opencode"],
           reviewers: ["opencode"],
@@ -209,12 +209,12 @@ test("repo-local policy can narrow managed CLIs, allowed routes, and unknown-rou
       deny_unknown_model_routes: true,
       allowed_model_routes: [
         {
-          route: "kakao/opencode-glm-*",
+          route: "example/opencode-model-*",
           phases: ["dispatch"],
           executors: ["opencode"],
         },
       ],
-      denied_model_routes: ["kakao/opencode-glm-bad"],
+      denied_model_routes: ["example/opencode-model-bad"],
     })
   );
 
@@ -227,7 +227,7 @@ test("repo-local policy can narrow managed CLIs, allowed routes, and unknown-rou
     evaluateRelayRoute(result.policy, {
       phase: "dispatch",
       executor: "opencode",
-      model: "kakao/opencode-glm-5",
+      model: "example/opencode-model-5",
     }).reason,
     "allowed_model_route"
   );
@@ -235,7 +235,7 @@ test("repo-local policy can narrow managed CLIs, allowed routes, and unknown-rou
     evaluateRelayRoute(result.policy, {
       phase: "review",
       reviewer: "opencode",
-      model: "kakao/opencode-glm-5",
+      model: "example/opencode-model-5",
     }).reason,
     "unknown_model_route"
   );
@@ -253,7 +253,7 @@ test("repo-local policy that widens global policy is rejected", () => {
     policy({
       profile: "global",
       managed_cli: ["codex"],
-      allowed_model_routes: [{ route: "kakao/opencode-glm-*", phases: ["dispatch"], executors: ["opencode"] }],
+      allowed_model_routes: [{ route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] }],
     })
   );
   writeJson(
@@ -261,7 +261,7 @@ test("repo-local policy that widens global policy is rejected", () => {
     policy({
       profile: "repo",
       managed_cli: ["codex", "claude"],
-      allowed_model_routes: [{ route: "kakao/*", phases: ["dispatch"], executors: ["opencode"] }],
+      allowed_model_routes: [{ route: "example/*", phases: ["dispatch"], executors: ["opencode"] }],
     })
   );
 
@@ -317,8 +317,8 @@ test("project-local policy cannot widen or remove inherited deny routes", () => 
     policy({
       profile: "global",
       managed_cli: ["codex"],
-      allowed_model_routes: [{ route: "kakao/opencode-glm-*", phases: ["dispatch"], executors: ["opencode"] }],
-      denied_model_routes: [{ route: "kakao/opencode-glm-bad", phases: ["dispatch"], executors: ["opencode"] }],
+      allowed_model_routes: [{ route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] }],
+      denied_model_routes: [{ route: "example/opencode-model-bad", phases: ["dispatch"], executors: ["opencode"] }],
     })
   );
 
@@ -327,7 +327,7 @@ test("project-local policy cannot widen or remove inherited deny routes", () => 
     policy({
       profile: "project",
       managed_cli: ["codex", "claude"],
-      allowed_model_routes: [{ route: "kakao/*", phases: ["dispatch"], executors: ["opencode"] }],
+      allowed_model_routes: [{ route: "example/*", phases: ["dispatch"], executors: ["opencode"] }],
       denied_model_routes: [],
     })
   );
@@ -341,31 +341,31 @@ test("project-local policy cannot widen or remove inherited deny routes", () => 
 
 test("denied model routes win over allowed model routes", () => {
   const currentPolicy = policy({
-    allowed_model_routes: ["kakao/*"],
-    denied_model_routes: ["kakao/opencode-glm-bad"],
+    allowed_model_routes: ["example/*"],
+    denied_model_routes: ["example/opencode-model-bad"],
   });
 
   const decision = evaluateRelayRoute(currentPolicy, {
     phase: "dispatch",
     executor: "opencode",
-    model: "kakao/opencode-glm-bad",
+    model: "example/opencode-model-bad",
   });
 
   assert.equal(decision.allowed, false);
   assert.equal(decision.reason, "denied_model_route");
-  assert.equal(decision.matchedRoute, "kakao/opencode-glm-bad");
+  assert.equal(decision.matchedRoute, "example/opencode-model-bad");
 });
 
 test("route actor scopes are bound to the evaluated phase", () => {
   const currentPolicy = policy({
     allowed_model_routes: [
       {
-        route: "kakao/*",
+        route: "example/*",
         phases: ["review"],
         executors: ["opencode"],
       },
       {
-        route: "kakao/*",
+        route: "example/*",
         phases: ["review"],
         reviewers: ["codex"],
       },
@@ -377,7 +377,7 @@ test("route actor scopes are bound to the evaluated phase", () => {
       phase: "review",
       executor: "opencode",
       reviewer: "opencode",
-      model: "kakao/opencode-glm-5",
+      model: "example/opencode-model-5",
     }).reason,
     "unknown_model_route"
   );
@@ -386,7 +386,7 @@ test("route actor scopes are bound to the evaluated phase", () => {
       phase: "review",
       executor: "opencode",
       reviewer: "codex",
-      model: "kakao/opencode-glm-5",
+      model: "example/opencode-model-5",
     }).reason,
     "allowed_model_route"
   );
@@ -412,7 +412,7 @@ test("unknown route denial can be explicitly disabled for non-managed executors"
 });
 
 test("matchRoutePattern supports simple star globs", () => {
-  assert.equal(matchRoutePattern("kakao/*", "kakao/opencode-glm-5"), true);
-  assert.equal(matchRoutePattern("kakao/opencode-glm-*", "kakao/opencode-glm-5"), true);
-  assert.equal(matchRoutePattern("kakao/opencode-glm-*", "kakao/opencode-qwen-3"), false);
+  assert.equal(matchRoutePattern("example/*", "example/opencode-model-5"), true);
+  assert.equal(matchRoutePattern("example/opencode-model-*", "example/opencode-model-5"), true);
+  assert.equal(matchRoutePattern("example/opencode-model-*", "example/opencode-qwen-3"), false);
 });


### PR DESCRIPTION
## Summary
- replace company-specific route examples with neutral `example/...` provider/model routes
- remove internal-route wording from route policy docs
- update config and policy tests to use the neutral fixtures

## Tests
- `node --test tests/relay-config/scripts/*.test.js`
- `node --test tests/relay-dispatch/scripts/relay-config.test.js tests/relay-dispatch/scripts/relay-policy.test.js tests/relay-dispatch/scripts/docs-defaults.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`
- `rg -n "kakao|opencode-glm" .` (no matches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 모델 라우트 설정 예시가 일관되게 업데이트되었습니다.
  * README, 정책 설명서, 운영자 가이드의 라우팅 구성 예시가 표준화되었습니다.
  * 설정 검증 명령어 및 라우팅 정책 예시가 최신 패턴으로 반영되었습니다.

* **Tests**
  * 설정 및 정책 검증 테스트의 모델 라우트 예시가 동기화되었습니다.
  * 테스트 시나리오의 예상 결과가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->