### PR TITLE
Preflight execution evidence before review

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -44,6 +44,7 @@ const EVENTS = Object.freeze({
   READINESS_PROBE: "readiness_probe",
   RECOVER_COMMIT: "recover_commit",
   RECOVER_COMMIT_FAILED: "recover_commit_failed",
+  REVIEW_PREFLIGHT_FAILED: "review_preflight_failed",
   ROUTE_RESOLUTION: "route_resolution",
   REVIEW_APPLY: "review_apply",
   REVIEW_INVOKE: "review_invoke",
@@ -223,6 +224,18 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
     ...(eventData.failure_class !== undefined
       ? { failure_class: normalizeEventValue(eventData.failure_class) }
+      : {}),
+    ...(eventData.preflight_type !== undefined
+      ? { preflight_type: normalizeEventValue(eventData.preflight_type) }
+      : {}),
+    ...(eventData.quality_execution_status !== undefined
+      ? { quality_execution_status: normalizeEventValue(eventData.quality_execution_status) }
+      : {}),
+    ...(eventData.reviewer_rounds_avoided !== undefined
+      ? { reviewer_rounds_avoided: normalizeEventValue(eventData.reviewer_rounds_avoided) }
+      : {}),
+    ...(eventData.evidence_head_sha !== undefined
+      ? { evidence_head_sha: normalizeEventValue(eventData.evidence_head_sha) }
       : {}),
     ...(eventData.execution_evidence_path !== undefined
       ? { execution_evidence_path: normalizeEventValue(eventData.execution_evidence_path) }

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -41,6 +41,7 @@ When applying a verdict, the runner:
 
 - validates the JSON verdict
 - optionally invokes the reviewer adapter itself when `--reviewer <name>` is used
+- preflights `execution-evidence.json` before invoking a primary reviewer; missing, stale, invalid, symlinked, or strict-failing evidence exits with JSON status and leaves the manifest in `review_pending`
 - fails fast for `policy.review_assurance=hardened` unless `--advisory-reviewer <name>` is present, except in `--prepare-only` mode
 - computes and overrides `quality_execution_status` from `execution-evidence.json`; strict gates prefer `verification_runs[]` when present and otherwise use the legacy `test_*` fields
 - rejects the round if the reviewer mutates the repo and escalates the manifest
@@ -48,6 +49,12 @@ When applying a verdict, the runner:
 - updates the relay manifest to `ready_to_merge`, `changes_requested`, or `escalated`
 
 Reviewer adapter capabilities are shared with dispatch adapter metadata. See `../../relay-dispatch/references/agent-adapter-platform.md` for the supported adapter matrix, including primary vs advisory review support, read-only enforcement, structured-output shape, and the new-adapter checklist. Antigravity review support is for the `agy` CLI only, not GUI/IDE/Desktop flows.
+
+## Execution Evidence Preflight
+
+Execution evidence preflight is script territory, not AI reviewer judgment. The script can verify file type, JSON schema, reviewed HEAD vs evidence HEAD, strict command/hash/exit fields, and `verification_runs[]` records deterministically before spending a reviewer round. The reviewer still handles semantic code review against Done Criteria and rubric anchors after that mechanical proof is valid.
+
+When preflight blocks, JSON output includes `executionEvidencePreflight.status`, `reason`, `reviewedHeadSha`, `evidenceHeadSha` when a valid artifact exposed one, and `nextAction=repair_execution_evidence`. Repair or regenerate `execution-evidence.json` for the reviewed HEAD, then rerun the same review command. Manual `--review-file` fallback paths intentionally bypass the preflight and keep the older fail-closed verdict override so operators can apply an already-produced verdict without weakening the execution evidence gate.
 
 ## Codex-only Operation Regression
 

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -18,6 +18,7 @@ const { applyReviewAssurancePolicy } = require("./review-runner/assurance");
 const { buildRedispatchPrompt, buildRubricGateRedispatchPrompt, computeFactorStatusFlips, computeRepeatedIssueCount, decideFlipFlopEscalation, detectChurnGrowth, summarizeLineage, toEscalatedVerdict } = require("./review-runner/redispatch");
 const { applyPolicyViolationToManifest, applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { writePrBodySnapshot } = require("./review-runner/pr-body-snapshot");
+const { maybeBlockForExecutionEvidencePreflight } = require("./review-runner/preflight");
 const { buildPrimaryReviewerPreflight, loadReviewText, loadRunRoutePlan, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { resolveAdvisoryConfig, settleAdvisoryForVerdict, startConfiguredAdvisory } = require("./review-runner/advisory-orchestration");
@@ -80,13 +81,8 @@ async function run() {
     routePlan: runRoutePlan,
   });
   const advisoryConfig = resolvedAdvisoryConfig;
+  const hardenedAssurance = isHardenedReviewAssurance(data);
 
-  if (isHardenedReviewAssurance(data) && !prepareOnly && !advisoryConfig.reviewer) {
-    throw new Error(
-      "policy.review_assurance=hardened requires --advisory-reviewer <name>, route-plan advisory_review.reviewer, or manifest routing.selected.advisory_review.reviewer so the round produces advisory evidence. " +
-      "Run with a configured advisory reviewer, configure routing, or lower the manifest policy before review."
-    );
-  }
   let reviewedHeadSha = null;
   try {
     reviewedHeadSha = git(reviewRepoPath, "rev-parse", "HEAD").trim();
@@ -179,6 +175,13 @@ async function run() {
     printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath: null, result, updatedManifest: null, verdictPath: null });
     return;
   }
+  if (maybeBlockForExecutionEvidencePreflight({ data, jsonOut, result, reviewFile, reviewedHeadSha, round, runDir, strict: hardenedAssurance })) return;
+  if (hardenedAssurance && !advisoryConfig.reviewer) {
+    throw new Error(
+      "policy.review_assurance=hardened requires --advisory-reviewer <name>, route-plan advisory_review.reviewer, or manifest routing.selected.advisory_review.reviewer so the round produces advisory evidence. " +
+      "Run with a configured advisory reviewer, configure routing, or lower the manifest policy before review."
+    );
+  }
   if (!reviewFile) {
     primaryReviewerPreflight = buildPrimaryReviewerPreflight({
       data,
@@ -220,7 +223,6 @@ async function run() {
       "The reviewer must score every rubric factor."
     );
   }
-  const hardenedAssurance = isHardenedReviewAssurance(data);
   const executionStatus = computeQualityExecutionStatus({
     runDir,
     reviewedHead: reviewedHeadSha,

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -175,7 +175,7 @@ async function run() {
     printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath: null, result, updatedManifest: null, verdictPath: null });
     return;
   }
-  if (maybeBlockForExecutionEvidencePreflight({ data, jsonOut, result, reviewFile, reviewedHeadSha, round, runDir, strict: hardenedAssurance })) return;
+  if (maybeBlockForExecutionEvidencePreflight({ data, jsonOut, result, reviewFile, runRepoPath, reviewedHeadSha, round, runDir, strict: hardenedAssurance })) return;
   if (hardenedAssurance && !advisoryConfig.reviewer) {
     throw new Error(
       "policy.review_assurance=hardened requires --advisory-reviewer <name>, route-plan advisory_review.reviewer, or manifest routing.selected.advisory_review.reviewer so the round produces advisory evidence. " +

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -262,6 +262,21 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false })
   };
 }
 
+function buildExecutionEvidencePreflight({ runDir, reviewedHead, strict = false }) {
+  const artifactLoad = readExecutionEvidenceArtifact(runDir);
+  const executionStatus = computeQualityExecutionStatus({ runDir, reviewedHead, strict });
+  const status = executionStatus.status === "pass" ? "pass" : "blocked";
+  return {
+    status,
+    qualityExecutionStatus: executionStatus.status,
+    reason: executionStatus.reason || null,
+    reviewedHeadSha: reviewedHead || null,
+    evidenceHeadSha: artifactLoad.state === "loaded" ? artifactLoad.artifact.head_sha : null,
+    artifactPath: artifactLoad.artifactPath,
+    nextAction: status === "pass" ? "invoke_primary_reviewer" : "repair_execution_evidence",
+  };
+}
+
 function applyQualityExecutionStatus(verdict, executionStatus) {
   return {
     ...verdict,
@@ -276,6 +291,7 @@ module.exports = {
   REQUIRED_EXECUTION_EVIDENCE_FIELDS,
   applyQualityExecutionStatus,
   buildExecutionEvidenceFailureVerdict,
+  buildExecutionEvidencePreflight,
   buildMissingExecutionEvidenceVerdict,
   buildMissingExecutionEvidenceReason,
   computeQualityExecutionStatus,

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -1,10 +1,12 @@
 const { buildExecutionEvidencePreflight } = require("./execution-evidence");
+const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 
 function maybeBlockForExecutionEvidencePreflight({
   data,
   jsonOut,
   result,
   reviewFile,
+  runRepoPath,
   reviewedHeadSha,
   round,
   runDir,
@@ -20,6 +22,20 @@ function maybeBlockForExecutionEvidencePreflight({
   }
 
   result.nextState = data.state;
+  appendRunEvent(runRepoPath || data.paths?.repo_root || ".", data.run_id, {
+    event: EVENTS.REVIEW_PREFLIGHT_FAILED,
+    state_from: data.state,
+    state_to: data.state,
+    head_sha: reviewedHeadSha,
+    round,
+    reason: result.executionEvidencePreflight.reason,
+    preflight_type: `execution_evidence_${result.executionEvidencePreflight.qualityExecutionStatus}`,
+    failure_class: result.executionEvidencePreflight.qualityExecutionStatus,
+    quality_execution_status: result.executionEvidencePreflight.qualityExecutionStatus,
+    reviewer_rounds_avoided: 1,
+    evidence_head_sha: result.executionEvidencePreflight.evidenceHeadSha,
+    execution_evidence_path: result.executionEvidencePreflight.artifactPath,
+  });
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));
   } else {

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -1,0 +1,35 @@
+const { buildExecutionEvidencePreflight } = require("./execution-evidence");
+
+function maybeBlockForExecutionEvidencePreflight({
+  data,
+  jsonOut,
+  result,
+  reviewFile,
+  reviewedHeadSha,
+  round,
+  runDir,
+  strict,
+}) {
+  result.executionEvidencePreflight = buildExecutionEvidencePreflight({
+    runDir,
+    reviewedHead: reviewedHeadSha,
+    strict,
+  });
+  if (reviewFile || result.executionEvidencePreflight.status === "pass") {
+    return false;
+  }
+
+  result.nextState = data.state;
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Review preflight blocked round ${round}: ${result.executionEvidencePreflight.reason}`);
+    console.log(`  Next action: ${result.executionEvidencePreflight.nextAction}`);
+  }
+  process.exitCode = 2;
+  return true;
+}
+
+module.exports = {
+  maybeBlockForExecutionEvidencePreflight,
+};

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -9,6 +9,7 @@ const {
   applyQualityExecutionStatus,
   buildExecutionEvidenceFailureVerdict,
   buildMissingExecutionEvidenceVerdict,
+  buildExecutionEvidencePreflight,
   computeQualityExecutionStatus,
   parseExecutionEvidenceArtifact,
   readExecutionEvidenceArtifact,
@@ -239,6 +240,32 @@ test("execution-evidence returns missing when artifact file is absent", () => {
   const result = computeQualityExecutionStatus({ runDir, reviewedHead: "a".repeat(40) });
   assert.equal(result.status, "missing");
   assert.match(result.reason, /pre-261 run, no artifact/);
+});
+
+test("execution-evidence preflight reports actionable head-bound status", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-execution-preflight-"));
+  writeArtifact(runDir, makeArtifact("a".repeat(40)));
+
+  assert.deepEqual(
+    buildExecutionEvidencePreflight({ runDir, reviewedHead: "a".repeat(40) }),
+    {
+      status: "pass",
+      qualityExecutionStatus: "pass",
+      reason: null,
+      reviewedHeadSha: "a".repeat(40),
+      evidenceHeadSha: "a".repeat(40),
+      artifactPath: path.join(runDir, EXECUTION_EVIDENCE_FILENAME),
+      nextAction: "invoke_primary_reviewer",
+    }
+  );
+
+  const stale = buildExecutionEvidencePreflight({ runDir, reviewedHead: "b".repeat(40) });
+  assert.equal(stale.status, "blocked");
+  assert.equal(stale.qualityExecutionStatus, "fail");
+  assert.match(stale.reason, /stale artifact/);
+  assert.equal(stale.reviewedHeadSha, "b".repeat(40));
+  assert.equal(stale.evidenceHeadSha, "a".repeat(40));
+  assert.equal(stale.nextAction, "repair_execution_evidence");
 });
 
 test("execution-evidence rejects replay attack artifact from another head as stale", () => {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -258,6 +258,29 @@ process.stdout.write(${JSON.stringify(JSON.stringify(verdict))});
   return filePath;
 }
 
+function writeMarkerReviewerScript(repoRoot, name, markerPath) {
+  const filePath = path.join(repoRoot, name);
+  const verdict = {
+    verdict: "pass",
+    summary: "Automated reviewer passed the change.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "ready_to_merge",
+    issues: [],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  };
+  const body = `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, "invoked\\n", "utf-8");
+process.stdout.write(${JSON.stringify(JSON.stringify(verdict))});
+`;
+  fs.writeFileSync(filePath, body, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
 function writeMutatingReviewerScript(repoRoot, name, verdict) {
   const filePath = path.join(repoRoot, name);
   const body = `#!/usr/bin/env node
@@ -1721,6 +1744,108 @@ test("reviewer-script invocation can drive a round without --review-file", () =>
   assert.equal(manifest.state, STATES.READY_TO_MERGE);
   assert.equal(manifest.review.latest_verdict, "lgtm");
   assert.ok(manifest.review.last_reviewed_sha);
+});
+
+test("review-runner execution evidence preflight blocks primary reviewer invocation", async (t) => {
+  const cases = [
+    {
+      name: "missing",
+      mutate({ runDir }) {
+        fs.unlinkSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME));
+      },
+      reason: /pre-261 run, no artifact/,
+      qualityExecutionStatus: "missing",
+      evidenceHeadSha: null,
+    },
+    {
+      name: "stale",
+      mutate({ runDir }) {
+        writeExecutionEvidence(runDir, "0".repeat(40));
+      },
+      reason: /stale artifact/,
+      qualityExecutionStatus: "fail",
+      evidenceHeadSha: "0".repeat(40),
+    },
+    {
+      name: "schema-invalid",
+      mutate({ runDir, reviewedHead }) {
+        writeExecutionEvidence(runDir, reviewedHead, { schema_version: 2 });
+      },
+      reason: /unsupported execution evidence schema_version=2/,
+      qualityExecutionStatus: "fail",
+      evidenceHeadSha: null,
+    },
+    {
+      name: "symlink",
+      mutate({ runDir, reviewedHead }) {
+        fs.unlinkSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME));
+        const outside = path.join(os.tmpdir(), `relay-review-preflight-${process.pid}-${Date.now()}.json`);
+        fs.writeFileSync(outside, `${JSON.stringify(buildExecutionEvidence(reviewedHead))}\n`, "utf-8");
+        fs.symlinkSync(outside, path.join(runDir, EXECUTION_EVIDENCE_FILENAME));
+      },
+      reason: /regular file/,
+      qualityExecutionStatus: "fail",
+      evidenceHeadSha: null,
+    },
+    {
+      name: "strict-failing",
+      mutate({ manifestPath }) {
+        updateManifestRecord(manifestPath, (data) => ({
+          ...data,
+          policy: {
+            ...(data.policy || {}),
+            review_assurance: "hardened",
+          },
+        }));
+      },
+      reason: /strict execution evidence requires a non-empty test_command/,
+      qualityExecutionStatus: "fail",
+      evidenceHeadSha: ({ reviewedHead }) => reviewedHead,
+    },
+  ];
+
+  for (const entry of cases) {
+    await t.test(entry.name, () => {
+      const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+      const runDir = ensureRunLayout(repoRoot, runId).runDir;
+      const reviewedHead = readManifest(manifestPath).data.git.head_sha;
+      entry.mutate({ manifestPath, reviewedHead, runDir });
+      const markerPath = path.join(repoRoot, `${entry.name}-reviewer-invoked.txt`);
+      const reviewerScript = writeMarkerReviewerScript(repoRoot, `${entry.name}-reviewer.js`, markerPath);
+
+      const result = spawnSync("node", [
+        SCRIPT,
+        "--repo", repoRoot,
+        "--run-id", runId,
+        "--pr", "123",
+        "--done-criteria-file", doneCriteriaPath,
+        "--diff-file", diffPath,
+        "--reviewer-script", reviewerScript,
+        "--no-comment",
+        "--json",
+      ], { encoding: "utf-8" });
+
+      assert.equal(result.status, 2, result.stderr || result.stdout);
+      assert.equal(fs.existsSync(markerPath), false, `${entry.name} preflight should not invoke reviewer`);
+      const output = JSON.parse(result.stdout);
+      assert.equal(output.executionEvidencePreflight.status, "blocked");
+      assert.equal(output.executionEvidencePreflight.qualityExecutionStatus, entry.qualityExecutionStatus);
+      assert.match(output.executionEvidencePreflight.reason, entry.reason);
+      assert.equal(output.executionEvidencePreflight.reviewedHeadSha, reviewedHead);
+      const expectedEvidenceHeadSha = typeof entry.evidenceHeadSha === "function"
+        ? entry.evidenceHeadSha({ reviewedHead })
+        : entry.evidenceHeadSha;
+      assert.equal(output.executionEvidencePreflight.evidenceHeadSha, expectedEvidenceHeadSha);
+      assert.equal(output.executionEvidencePreflight.nextAction, "repair_execution_evidence");
+      assert.equal(output.state, STATES.REVIEW_PENDING);
+      assert.equal(output.nextState, STATES.REVIEW_PENDING);
+      assert.equal(output.rawResponsePath, null);
+
+      const manifest = readManifest(manifestPath).data;
+      assert.equal(manifest.state, STATES.REVIEW_PENDING);
+      assert.equal(manifest.review.rounds, 0);
+    });
+  }
 });
 
 test("invalid pass verdict is rejected", () => {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -1844,6 +1844,19 @@ test("review-runner execution evidence preflight blocks primary reviewer invocat
       const manifest = readManifest(manifestPath).data;
       assert.equal(manifest.state, STATES.REVIEW_PENDING);
       assert.equal(manifest.review.rounds, 0);
+      const events = readRunEvents(repoRoot, runId);
+      const preflightEvent = events.find((event) => event.event === "review_preflight_failed");
+      assert.ok(preflightEvent, `${entry.name} should append a review_preflight_failed event`);
+      assert.equal(preflightEvent.state_from, STATES.REVIEW_PENDING);
+      assert.equal(preflightEvent.state_to, STATES.REVIEW_PENDING);
+      assert.equal(preflightEvent.head_sha, reviewedHead);
+      assert.equal(preflightEvent.round, 1);
+      assert.equal(preflightEvent.quality_execution_status, entry.qualityExecutionStatus);
+      assert.equal(preflightEvent.failure_class, entry.qualityExecutionStatus);
+      assert.equal(preflightEvent.preflight_type, `execution_evidence_${entry.qualityExecutionStatus}`);
+      assert.equal(preflightEvent.reviewer_rounds_avoided, 1);
+      assert.equal(preflightEvent.evidence_head_sha, expectedEvidenceHeadSha);
+      assert.equal(preflightEvent.execution_evidence_path, path.join(runDir, EXECUTION_EVIDENCE_FILENAME));
     });
   }
 });


### PR DESCRIPTION
Fixes #681
Refs #678

## Summary

Adds execution-evidence preflight before primary reviewer invocation for mechanical evidence failures.

## Relay

- Run: `issue-681-20260607235606942-5c342363`
- Request: `req-20260607235336010`
- Leaf: `issue-681-execution-evidence-preflight`
- Commit: `bb24997d8dd8431bb199a2bc6c89aafae0aefab3`

## Completion Audit

- Missing `execution-evidence.json` blocks before primary reviewer invocation.
- Stale evidence blocks when artifact `head_sha` differs from reviewed HEAD.
- Invalid evidence, including schema-invalid and symlink artifact cases, blocks before primary reviewer invocation.
- Hardened/strict failure is covered by strict evidence preflight test coverage.
- Existing `--review-file` fallback/fail-closed behavior remains intact.
- `runner-notes.md` documents script-level mechanical proof vs semantic AI review.

## Verification

- `node --test tests/relay-review/scripts/review-runner-execution-evidence.test.js tests/relay-review/scripts/review-runner.test.js tests/relay-review/scripts/review-runner-verdict.test.js` -> 165/165 pass
- `execution-evidence.json` rebound by orchestrator recovery to HEAD `bb24997d8dd8431bb199a2bc6c89aafae0aefab3` with `test_exit_code=0` and `verification_runs[]`.

## Notes

The initial relay-dispatch publication failed because the dispatch prompt said to commit to `issue-681` while the manifest branch was `issue-681-preflight`. The implementation commit was preserved, `issue-681-preflight` was fast-forwarded to the implementation HEAD, and this PR was created as recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 코드 리뷰 이전에 실행 증거 파일을 기계적으로 검증하는 사전검사(Preflight) 단계 추가
  * 검증 실패 시 리뷰어 호출을 차단하고 검토 상태를 보류로 유지

* **행동/출력 변경**
  * 실패 시 JSON 출력에 상태, 사유, 관련 SHA 및 권장 다음 조치(nextAction)를 포함
  * 특정 파일 기반 옵션은 기존 동작(사전검사 우회)을 유지

* **테스트**
  * 다양한 증거 실패 모드를 검증하는 통합 테스트 추가

* **잡일**
  * 사전검사 실패 이벤트 기록 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->