### PR TITLE
Add relay-ready task-shape signals

### DIFF
--- a/skills/relay-ready/references/design-v1.md
+++ b/skills/relay-ready/references/design-v1.md
@@ -14,6 +14,12 @@ Decision: B - coexist with new `readiness_score` field: keep legacy `readiness.*
 
 Decision: A - regex+heuristic. Rationale: #437 needs a sub-200ms deterministic probe, and #435/#436 need repeatable scoring/defaults. Heuristics may be dumb, so they fail open: if no confident default exists, ask the Q&A question without a recommended answer rather than spending an LLM call or laundering guesswork.
 
+## Task-shape signals
+
+`score-readiness.js` and `probe-readiness.js` may emit additive `task_shape` metadata for obvious oversized request shapes: many criteria groups, sprint/epic/milestone/foundation language, many subsystem references, multi-stage user journeys, or broad product-foundation mixtures. These are deterministic soft signals for routing into relay-ready/planner shaping. They do not create leaf handoffs, infer semantic task boundaries, or replace AI judgment about decomposition.
+
+Strong task-shape signals prevent direct readiness bypass, but they are not a blanket ban on XL work. Operators should treat them as evidence that relay-ready needs to shape the request before dispatch.
+
 ## Schema migration plan
 
 Steps:

--- a/skills/relay-ready/scripts/probe-readiness.js
+++ b/skills/relay-ready/scripts/probe-readiness.js
@@ -32,6 +32,7 @@ const CONDITION_LABELS = Object.freeze({
   [READINESS_CONDITIONS.OBSERVABLE_ASSERTION]: "missing observable assertion",
   [READINESS_CONDITIONS.HIGH_RISK_KEYWORD]: "high-risk keyword",
   [READINESS_CONDITIONS.SINGLE_LEAF]: "not single-leaf",
+  [READINESS_CONDITIONS.STRONG_TASK_SHAPE]: "task-shape decomposition",
 });
 
 function elapsedMsSince(startedAt) {
@@ -83,6 +84,28 @@ function summarizeSignals(scoreResult) {
   return clipLine(`Gaps: ${[...new Set(parts)].join(", ")}.`);
 }
 
+function emptyTaskShape() {
+  return {
+    strength: "none",
+    strong: false,
+    signals: [],
+  };
+}
+
+function taskShapeEnvelope(taskShape) {
+  if (!taskShape || typeof taskShape !== "object") {
+    return emptyTaskShape();
+  }
+  return {
+    strength: taskShape.strength || "none",
+    strong: Boolean(taskShape.strong),
+    signals: Array.isArray(taskShape.signals) ? taskShape.signals.map((signal) => ({
+      condition: String(signal.condition || ""),
+      evidence: clipLine(signal.evidence, 80),
+    })) : [],
+  };
+}
+
 function buildEnvelope(scoreResult, elapsedMs) {
   return {
     readiness_score: {
@@ -93,6 +116,7 @@ function buildEnvelope(scoreResult, elapsedMs) {
     bypass: scoreResult.bypass,
     next_action: scoreResult.next_action,
     signals_summary: summarizeSignals(scoreResult),
+    task_shape: taskShapeEnvelope(scoreResult.task_shape),
     elapsed_ms: elapsedMs,
   };
 }
@@ -107,6 +131,7 @@ function buildDegradedEnvelope(error, elapsedMs) {
     bypass: true,
     next_action: "proceed",
     signals_summary: clipLine(`Readiness probe degraded; proceeding fail-open: ${error.message}`),
+    task_shape: emptyTaskShape(),
     elapsed_ms: elapsedMs,
   };
 }
@@ -133,6 +158,7 @@ function appendReadinessProbeEvent(manifestPath, envelope, issueNumber) {
     readiness_score: envelope.readiness_score,
     bypass: envelope.bypass,
     next_action: envelope.next_action,
+    task_shape: envelope.task_shape,
     elapsed_ms: envelope.elapsed_ms,
   };
   appendEventLineToPath(eventsPath, record);
@@ -144,6 +170,7 @@ function formatHuman(envelope) {
     `bypass=${envelope.bypass}`,
     `next_action=${envelope.next_action}`,
     `signals_summary="${envelope.signals_summary}"`,
+    `task_shape=${JSON.stringify(envelope.task_shape)}`,
     `elapsed_ms=${envelope.elapsed_ms.toFixed(3)}`,
   ].join(" ");
 }

--- a/skills/relay-ready/scripts/score-readiness.js
+++ b/skills/relay-ready/scripts/score-readiness.js
@@ -21,6 +21,12 @@ const READINESS_CONDITIONS = Object.freeze({
   OBSERVABLE_ASSERTION: "observable_assertion",
   HIGH_RISK_KEYWORD: "high_risk_keyword",
   SINGLE_LEAF: "single_leaf",
+  MANY_CRITERIA_GROUPS: "many_criteria_groups",
+  BROAD_SCOPE_LANGUAGE: "broad_scope_language",
+  MULTI_SUBSYSTEM_REFERENCES: "multi_subsystem_references",
+  MULTI_STAGE_JOURNEY: "multi_stage_journey",
+  PRODUCT_FOUNDATION_MIX: "product_foundation_mix",
+  STRONG_TASK_SHAPE: "strong_task_shape",
 });
 
 const VAGUE_VERB_RE = /\b(?:improve|enhance|clean up|polish)\b/i;
@@ -32,6 +38,13 @@ const TEST_PATH_RE = /`?(?:\.{0,2}\/)?(?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+(?:te
 const FUNCTION_RE = /`?[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\)`?/;
 const NUMERIC_THRESHOLD_RE = /\b(?:p\d{2}|latency|duration|coverage|count|runs?|size)?\s*(?:<=|>=|<|>|=|\u2264|\u2265)\s*\d+(?:\.\d+)?\s*(?:ms|s|kb|mb|gb|%|runs?)?\b/i;
 const LOG_LINE_RE = /\b(?:prints?|logs?|emits?|outputs?|stderr|stdout|console)\b.{0,50}`[^`\n]+`/i;
+const TASK_SCOPE_LANGUAGE_RE = /\b(?:sprints?|epics?|milestones?|foundations?|foundational|roadmaps?|initiatives?|platform\s+foundation)\b/i;
+const PRODUCT_SURFACE_RE = /\b(?:user[-\s]?facing|users?|ui|ux|onboarding|dashboard|editor|admin|mobile|web\s+app|product|sharing|review\s+handoff|account|workspace)\b/i;
+const FOUNDATION_SURFACE_RE = /\b(?:schema|database|api|backend|storage|queue|worker|observability|deployment|infra|platform|architecture|persistence|jobs?|runbook)\b/i;
+const JOURNEY_MARKER_RE = /\b(?:flow|journey|end[-\s]?to[-\s]?end|from\b[\s\S]{0,80}\bthrough\b|through\b[\s\S]{0,80}\bwhile\b)\b/i;
+const JOURNEY_STAGE_RE = /\b(?:signup|sign[-\s]?up|onboarding|setup|create|configure|draft|save|share|review|approve|handoff|export|notify|rollback)\b/ig;
+const CRITERIA_GROUP_HEADING_RE = /^#{3,6}\s+\S.+$/gm;
+const CRITERIA_BULLET_RE = /^\s*[-*]\s+(?!Do not\b|Don't\b)/gim;
 
 const ACTION_VERBS = Object.freeze([
   "add",
@@ -73,6 +86,7 @@ function scoreReadiness(input, metadata = {}) {
   const criteriaObservable = criteria.section ? findObservable(criteria.section) : null;
   const highRisk = findFirst(scanText, HIGH_RISK_RE);
   const granularitySignals = inspectGranularity(scanText);
+  const taskShape = inspectTaskShape(scanText, criteria);
   const signals = [];
 
   addBypassSignals(signals, {
@@ -80,10 +94,12 @@ function scoreReadiness(input, metadata = {}) {
     criteriaObservable,
     highRisk,
     granularitySignals,
+    taskShape,
   });
+  addTaskShapeSignals(signals, taskShape);
 
   const clarity = scoreClarity(signals, combinedText, scanText);
-  const granularity = scoreGranularity(signals, granularitySignals);
+  const granularity = scoreGranularity(signals, granularitySignals, taskShape);
   const verifiability = scoreVerifiability(signals, combinedText, scanText, criteria, criteriaObservable);
   const readiness = { clarity, granularity, verifiability };
   const bypass = Boolean(
@@ -91,12 +107,14 @@ function scoreReadiness(input, metadata = {}) {
       && criteriaObservable
       && !highRisk
       && granularitySignals.singleLeaf
+      && !taskShape.strong
   );
 
   return {
     readiness,
     bypass,
     signals,
+    task_shape: taskShape,
     next_action: determineNextAction(readiness, bypass, Boolean(highRisk)),
   };
 }
@@ -153,7 +171,7 @@ function extractCriteriaSection(body) {
   };
 }
 
-function addBypassSignals(signals, { criteria, criteriaObservable, highRisk, granularitySignals }) {
+function addBypassSignals(signals, { criteria, criteriaObservable, highRisk, granularitySignals, taskShape }) {
   pushSignal(
     signals,
     "bypass",
@@ -186,6 +204,20 @@ function addBypassSignals(signals, { criteria, criteriaObservable, highRisk, gra
       ? "pass: no top-level and, multi-verb opener, or cross-module bullets"
       : `fail: ${granularitySignals.singleLeafFailures.join(", ")}`
   );
+  pushSignal(
+    signals,
+    "bypass",
+    READINESS_CONDITIONS.STRONG_TASK_SHAPE,
+    taskShape.strong
+      ? `fail: ${taskShape.signals.map((signal) => signal.condition).join(", ")}`
+      : "pass: no strong task-shape signal"
+  );
+}
+
+function addTaskShapeSignals(signals, taskShape) {
+  for (const signal of taskShape.signals) {
+    pushSignal(signals, "task_shape", signal.condition, signal.evidence);
+  }
 }
 
 function scoreClarity(signals, combinedText, scanText) {
@@ -221,7 +253,7 @@ function scoreClarity(signals, combinedText, scanText) {
   return "medium";
 }
 
-function scoreGranularity(signals, granularitySignals) {
+function scoreGranularity(signals, granularitySignals, taskShape) {
   if (granularitySignals.topLevelAnd) {
     pushSignal(signals, "granularity", READINESS_CONDITIONS.TOP_LEVEL_AND, granularitySignals.topLevelAnd);
   }
@@ -243,6 +275,9 @@ function scoreGranularity(signals, granularitySignals) {
     pushSignal(signals, "granularity", READINESS_CONDITIONS.SINGLE_SUBSYSTEM, granularitySignals.singleSubsystem);
   }
 
+  if (taskShape.strong) {
+    return "low";
+  }
   if (
     granularitySignals.topLevelAnd
       || granularitySignals.bulletsAcrossModules
@@ -254,6 +289,109 @@ function scoreGranularity(signals, granularitySignals) {
     return "high";
   }
   return "medium";
+}
+
+function inspectTaskShape(text, criteria) {
+  const signals = [];
+  const manyCriteria = detectManyCriteriaGroups(criteria.section);
+  const broadScope = findFirst(text, TASK_SCOPE_LANGUAGE_RE);
+  const subsystems = extractTaskShapeSubsystems(text);
+  const multiStageJourney = detectMultiStageJourney(text);
+  const productFoundationMix = detectProductFoundationMix(text, {
+    broadScope,
+    manyCriteria,
+    subsystemCount: subsystems.length,
+  });
+
+  if (manyCriteria) {
+    pushTaskShapeSignal(signals, READINESS_CONDITIONS.MANY_CRITERIA_GROUPS, manyCriteria.evidence);
+  }
+  if (broadScope) {
+    pushTaskShapeSignal(signals, READINESS_CONDITIONS.BROAD_SCOPE_LANGUAGE, broadScope);
+  }
+  if (subsystems.length >= 3) {
+    pushTaskShapeSignal(
+      signals,
+      READINESS_CONDITIONS.MULTI_SUBSYSTEM_REFERENCES,
+      `${subsystems.length} subsystems: ${subsystems.slice(0, 5).join(", ")}`
+    );
+  }
+  if (multiStageJourney) {
+    pushTaskShapeSignal(signals, READINESS_CONDITIONS.MULTI_STAGE_JOURNEY, multiStageJourney);
+  }
+  if (productFoundationMix) {
+    pushTaskShapeSignal(signals, READINESS_CONDITIONS.PRODUCT_FOUNDATION_MIX, productFoundationMix);
+  }
+
+  const strong = signals.length >= 2
+    || Boolean(manyCriteria && manyCriteria.strong)
+    || subsystems.length >= 4;
+  return {
+    strength: signals.length === 0 ? "none" : (strong ? "strong" : "soft"),
+    strong,
+    signals,
+  };
+}
+
+function detectManyCriteriaGroups(criteriaSection) {
+  if (!criteriaSection) {
+    return null;
+  }
+
+  const groupCount = (criteriaSection.match(CRITERIA_GROUP_HEADING_RE) || []).length;
+  if (groupCount >= 4) {
+    return {
+      evidence: `${groupCount} criteria groups`,
+      strong: groupCount >= 6,
+    };
+  }
+
+  const bulletCount = (criteriaSection.match(CRITERIA_BULLET_RE) || []).length;
+  if (bulletCount >= 8) {
+    return {
+      evidence: `${bulletCount} criteria bullets`,
+      strong: true,
+    };
+  }
+  return null;
+}
+
+function extractTaskShapeSubsystems(text) {
+  const subsystems = new Set();
+  const pathMatches = text.match(new RegExp(FILE_PATH_RE.source, "ig")) || [];
+  for (const pathMatch of pathMatches) {
+    const subsystem = subsystemFromPath(pathMatch);
+    if (subsystem) {
+      subsystems.add(subsystem);
+    }
+  }
+
+  const domainMatches = text.match(/\b(?:frontend|backend|api|database|auth|billing|docs|cli|review|dispatch|ready|plan|worker|scheduler|renderer|storage|sync|notifications|onboarding|settings|admin|analytics|infra)\b/ig) || [];
+  for (const domainMatch of domainMatches) {
+    subsystems.add(domainMatch.toLowerCase());
+  }
+
+  return [...subsystems].sort();
+}
+
+function detectMultiStageJourney(text) {
+  if (!JOURNEY_MARKER_RE.test(text)) {
+    return null;
+  }
+
+  const matches = text.match(JOURNEY_STAGE_RE) || [];
+  const stages = [...new Set(matches.map((match) => match.toLowerCase().replace(/\s+/g, " ")))];
+  return stages.length >= 3 ? `journey stages: ${stages.slice(0, 5).join(", ")}` : null;
+}
+
+function detectProductFoundationMix(text, context) {
+  if (!PRODUCT_SURFACE_RE.test(text) || !FOUNDATION_SURFACE_RE.test(text)) {
+    return null;
+  }
+  if (!context.broadScope && !context.manyCriteria && context.subsystemCount < 3) {
+    return null;
+  }
+  return "product surface plus platform foundation terms";
 }
 
 function scoreVerifiability(signals, combinedText, scanText, criteria, criteriaObservable) {
@@ -454,6 +592,13 @@ function findFirst(text, regex) {
 function pushSignal(signals, dimension, condition, evidence) {
   signals.push({
     dimension,
+    condition,
+    evidence: clipEvidence(evidence),
+  });
+}
+
+function pushTaskShapeSignal(signals, condition, evidence) {
+  signals.push({
     condition,
     evidence: clipEvidence(evidence),
   });

--- a/tests/relay-ready/scripts/probe-readiness.test.js
+++ b/tests/relay-ready/scripts/probe-readiness.test.js
@@ -34,6 +34,10 @@ function assertEnvelopeShape(envelope) {
   assert.ok(["proceed", "qa_needed", "escalate"].includes(envelope.next_action));
   assert.equal(typeof envelope.signals_summary, "string");
   assert.ok(envelope.signals_summary.length <= 140, envelope.signals_summary);
+  assert.equal(typeof envelope.task_shape, "object");
+  assert.ok(["none", "soft", "strong"].includes(envelope.task_shape.strength));
+  assert.equal(typeof envelope.task_shape.strong, "boolean");
+  assert.ok(Array.isArray(envelope.task_shape.signals));
   assert.equal(typeof envelope.elapsed_ms, "number");
 }
 
@@ -85,6 +89,54 @@ test("non_bypass_emits_summary returns a bounded human summary for low scores", 
   assert.ok(envelope.signals_summary.length > 0);
   assert.ok(envelope.signals_summary.length <= 140);
   assert.equal(envelope.signals_summary, repeatedEnvelope.signals_summary);
+});
+
+test("task_shape_signals are emitted in JSON and human output without breaking envelope fields", () => {
+  const body = `Deliver a milestone foundation across onboarding, admin review, analytics, API, database, and worker operations.
+
+The request combines user-facing product flows with platform foundation work from signup through review approval and export.
+
+## Acceptance Criteria
+
+### Onboarding
+- \`apps/web/onboarding.tsx\` creates an account.
+
+### Admin Review
+- \`apps/admin/review.tsx\` approves submitted work.
+
+### Analytics
+- \`apps/analytics/dashboard.tsx\` reports usage.
+
+### API
+- \`services/api/routes.js\` exposes review endpoints.
+
+### Database
+- \`services/database/models.js\` stores account, review, and export records.
+
+### Worker
+- \`workers/export-worker.js\` emits \`export queued\`.
+
+## Done Criteria
+
+- \`tests/web/onboarding.test.js\` passes.
+- \`tests/admin/review.test.js\` passes.
+- p95 < 500ms over 50 runs.
+`;
+
+  const jsonResult = runProbe(["--json", "--body", body]);
+  const humanResult = runProbe(["--body", body]);
+
+  assert.equal(jsonResult.status, 0, jsonResult.stderr);
+  assert.equal(humanResult.status, 0, humanResult.stderr);
+  const envelope = parseJson(jsonResult.stdout);
+  assertEnvelopeShape(envelope);
+  assert.equal(envelope.task_shape.strength, "strong");
+  assert.equal(envelope.task_shape.strong, true);
+  assert.equal(envelope.bypass, false);
+  assert.equal(envelope.next_action, "qa_needed");
+  assert.match(envelope.signals_summary, /task-shape/i);
+  assert.match(humanResult.stdout, /task_shape=/);
+  assert.match(humanResult.stdout, /"strength":"strong"/);
 });
 
 test("manifest_event_appended writes one readiness_probe line with probe payload", (t) => {

--- a/tests/relay-ready/scripts/score-readiness.test.js
+++ b/tests/relay-ready/scripts/score-readiness.test.js
@@ -22,10 +22,22 @@ function signalEvidence(result, dimension, condition) {
 function assertSignalShape(result) {
   assert.ok(Array.isArray(result.signals));
   for (const signal of result.signals) {
-    assert.ok(["clarity", "granularity", "verifiability", "bypass"].includes(signal.dimension));
+    assert.ok(["clarity", "granularity", "verifiability", "bypass", "task_shape"].includes(signal.dimension));
     assert.equal(typeof signal.condition, "string");
     assert.equal(typeof signal.evidence, "string");
     assert.ok(signal.evidence.length <= 80, `oversized evidence: ${signal.evidence}`);
+  }
+}
+
+function assertTaskShapeShape(result) {
+  assert.equal(typeof result.task_shape, "object");
+  assert.ok(["none", "soft", "strong"].includes(result.task_shape.strength));
+  assert.equal(typeof result.task_shape.strong, "boolean");
+  assert.ok(Array.isArray(result.task_shape.signals));
+  for (const signal of result.task_shape.signals) {
+    assert.equal(typeof signal.condition, "string");
+    assert.equal(typeof signal.evidence, "string");
+    assert.ok(signal.evidence.length <= 80, `oversized task-shape evidence: ${signal.evidence}`);
   }
 }
 
@@ -157,7 +169,7 @@ test("bypass rejects opener with top-level and before non-verb target", () => {
   assertSignalShape(result);
 });
 
-test("bypass_true requires all four bypass checks to pass", () => {
+test("bypass_true requires bypass checks to pass", () => {
   const body = `Fix \`skills/relay-ready/scripts/relay-request.js\` request ID normalization.
 
 ## Done Criteria
@@ -176,11 +188,88 @@ test("bypass_true requires all four bypass checks to pass", () => {
     READINESS_CONDITIONS.OBSERVABLE_ASSERTION,
     READINESS_CONDITIONS.HIGH_RISK_KEYWORD,
     READINESS_CONDITIONS.SINGLE_LEAF,
+    READINESS_CONDITIONS.STRONG_TASK_SHAPE,
   ]) {
     assert.ok(hasSignal(result, "bypass", condition), `missing bypass signal: ${condition}`);
     assert.match(signalEvidence(result, "bypass", condition), /^pass:/);
   }
   assertSignalShape(result);
+  assertTaskShapeShape(result);
+});
+
+test("broad product foundation request emits task-shape signals and does not bypass", () => {
+  const body = `Build the first usable foundation for a scene collaboration product across onboarding, editor, sharing, and operations.
+
+The work should cover the user-facing flow from first project setup through review handoff while also laying the platform foundation for persistence, API boundaries, background jobs, and deployment observability.
+
+## Acceptance Criteria
+
+### Onboarding
+- New users can create a workspace and see an empty project in \`apps/web/onboarding.tsx\`.
+
+### Editor
+- The editor shell in \`apps/web/editor.tsx\` can save a draft scene.
+
+### Sharing
+- Review links use \`services/api/share-links.js\` and expose audit-friendly logs.
+
+### Data Model
+- \`services/database/models.js\` records projects, scenes, and review links.
+
+### Workers
+- \`workers/render-queue.js\` emits \`render queued\` for background jobs.
+
+### Observability
+- \`infra/deploy/observability.yml\` captures p95 < 500ms checks.
+
+### Documentation
+- \`docs/operator-runbook.md\` explains the release and rollback path.
+
+## Done Criteria
+
+- \`tests/web/onboarding.test.js\` passes.
+- \`tests/api/share-links.test.js\` passes.
+- \`tests/workers/render-queue.test.js\` passes.
+`;
+
+  const result = scoreReadiness(body);
+
+  assert.equal(result.task_shape.strength, "strong");
+  assert.equal(result.task_shape.strong, true);
+  assert.equal(result.bypass, false);
+  assert.equal(result.next_action, "qa_needed");
+  assert.ok(hasSignal(result, "task_shape", READINESS_CONDITIONS.MANY_CRITERIA_GROUPS));
+  assert.ok(hasSignal(result, "task_shape", READINESS_CONDITIONS.BROAD_SCOPE_LANGUAGE));
+  assert.ok(hasSignal(result, "task_shape", READINESS_CONDITIONS.MULTI_SUBSYSTEM_REFERENCES));
+  assert.ok(hasSignal(result, "task_shape", READINESS_CONDITIONS.PRODUCT_FOUNDATION_MIX));
+  assert.ok(hasSignal(result, "bypass", READINESS_CONDITIONS.STRONG_TASK_SHAPE));
+  assert.match(signalEvidence(result, "bypass", READINESS_CONDITIONS.STRONG_TASK_SHAPE), /^fail:/);
+  assertSignalShape(result);
+  assertTaskShapeShape(result);
+});
+
+test("narrow multi-verb single-subsystem request does not emit decomposition task-shape signals", () => {
+  const body = `Refactor and document \`skills/relay-ready/scripts/score-readiness.js\` task scoring helpers.
+
+Keep the change inside the relay-ready scorer. The work may rename local helper functions, add inline comments only where the task-shape regex rules are non-obvious, and update nearby tests that already exercise \`scoreReadiness()\`.
+
+## Done Criteria
+
+- \`skills/relay-ready/scripts/score-readiness.js\` keeps \`scoreReadiness()\` deterministic.
+- \`tests/relay-ready/scripts/score-readiness.test.js\` passes.
+- p95 < 50ms over 100 runs.
+`;
+
+  const result = scoreReadiness(body);
+
+  assert.equal(result.task_shape.strength, "none");
+  assert.equal(result.task_shape.strong, false);
+  assert.deepEqual(result.task_shape.signals, []);
+  assert.equal(result.readiness.granularity, "medium");
+  assert.equal(result.bypass, false);
+  assert.ok(!hasSignal(result, "task_shape", READINESS_CONDITIONS.MULTI_SUBSYSTEM_REFERENCES));
+  assertSignalShape(result);
+  assertTaskShapeShape(result);
 });
 
 test("maintenance refactor issue with explicit observable assertions is a single ready leaf", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료했고 커밋했습니다.

커밋: `e036e1a91e9a15de1755de81c0c12cec6ea07a63` (`Add relay-ready task-shape signals`)

변경 내용:
- `score-readiness.js`에 additive `task_shape` 신호 추가
- 강한 task-shape 신호는 direct bypass를 막고 granularity를 낮춰 relay-ready shaping으로 유도
- `probe-readiness.js` JSON/human output에 `task_shape` 추가
- broad foundation / narrow single-subsystem regression 테스트 추가
- 문서에 “신호만 emit, semantic decomposition/leaf 생성은 AI shaping 책임” 경계 명시

검증:
- 커밋된 HEAD에서 실행:
  `node --test tests/relay-ready/scripts/scor
```

## Score Log

- Run: issue-679-20260608002011820-c5b567e2
- Executor: codex
- Branch: issue-679-task-shape