### PR TITLE
Document relay-ready decomposition contract

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -40,6 +40,9 @@ Read the normalized task source (try in order, use first that succeeds):
 - User-provided description
 
 If `relay-ready` produced a handoff brief, treat it as the source of truth instead of re-reading the raw request.
+For a shaped leaf, consume that persisted `relay-ready/<leaf-id>.md` plus its frozen Done Criteria path; the
+raw request is historical context only and must not be silently reinterpreted into a different task.
+If the relay-ready anchor is incomplete, surface the ambiguity or persist planner-authored Done Criteria under Step 7.
 
 ### 2. Gather planning signals
 

--- a/skills/relay-ready/SKILL.md
+++ b/skills/relay-ready/SKILL.md
@@ -54,6 +54,10 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-ready/scripts/persist-request.js" --repo
 
 Readiness is optional, but if supplied, all readiness dimensions are required; see schema enum domains.
 
+## Decomposition Boundary
+
+Readiness scripts emit deterministic signals and persist validated handoffs; they do not infer semantic leaf boundaries. When strong decomposition signals appear, use AI proposal-first shaping to decide whether the request is one high-risk leaf or multiple ordered leaves, then persist the accepted shape. Detailed operator contract and oversized product-foundation example: [`references/decomposition-contract.md`](references/decomposition-contract.md).
+
 Preflight shaping stays append-only in `events.jsonl`. Use the portable readiness event types:
 - `proposal_presented`
 - `question_asked`

--- a/skills/relay-ready/references/decomposition-contract.md
+++ b/skills/relay-ready/references/decomposition-contract.md
@@ -17,11 +17,13 @@ The deterministic scripts may say "this looks multi-task" from text-shape signal
 When strong decomposition signals appear, relay-ready uses proposal-first shaping: first propose a bounded shape instead of persisting immediately.
 
 1. Present whether the request should remain one high-risk leaf or split into named leaves.
-2. Include short AI-authored leaf proposals with order and dependency intent.
+2. Include short AI-authored leaf proposals with enough reviewable contract shape for the operator to accept boundaries: leaf title, goal, dependency intent, in-scope items, out-of-scope items, and leaf-level Done Criteria.
 3. Offer bounded response options: accept the proposal, keep one leaf, or edit boundaries with free text.
 4. Persist only after the proposal is accepted or edited into a stable handoff contract.
 
 Ask one bounded clarification question only when the proposed leaf boundary cannot be made reviewable from the request text. The question should choose between concrete alternatives, include a free-text escape hatch, and target the minimum ambiguity blocking a frozen Done Criteria snapshot. Do not ask an open-ended discovery interview.
+
+Sprint-batch bypass: if the requester already supplies a batch with leaf-level Done Criteria, dispatch prompt, rubric, and smoke/replay scenario for each leaf, do not repeat proposal-first shaping. Treat the batch as already shaped, validate and persist the existing leaf contracts, and surface schema or dependency gaps instead of reinterpreting the raw batch.
 
 ## Persistence Contract
 
@@ -54,9 +56,24 @@ Deterministic signals:
 
 AI-authored proposal:
 
-- Leaf 1: create tenant onboarding shell.
-- Leaf 2: add billing gate skeleton, `depends_on: [tenant onboarding shell]`.
-- Leaf 3: document product foundation operation, `depends_on: [tenant onboarding shell, billing gate skeleton]`.
+- Leaf 1: Create tenant onboarding shell.
+  - Goal: add the minimum tenant onboarding flow needed before gated features can exist.
+  - Dependencies: none.
+  - In scope: tenant onboarding entry points; persisted tenant setup status.
+  - Out of scope: billing enforcement; analytics dashboards.
+  - Done Criteria: tenant onboarding status is stored and visible to the app shell; existing unauthenticated access behavior remains unchanged.
+- Leaf 2: Add billing gate skeleton.
+  - Goal: introduce a billing gate that can block premium tenant actions after onboarding exists.
+  - Dependencies: depends on Leaf 1.
+  - In scope: billing gate decision point; coverage for allowed and blocked tenant states.
+  - Out of scope: payment provider integration; admin analytics.
+  - Done Criteria: premium tenant actions consult a billing gate; tests cover allowed and blocked billing states.
+- Leaf 3: Document product foundation operation.
+  - Goal: document the operator workflow after onboarding and billing gate contracts are frozen.
+  - Dependencies: depends on Leaves 1 and 2.
+  - In scope: onboarding and billing gate operational checks.
+  - Out of scope: changing product behavior; analytics dashboard implementation.
+  - Done Criteria: operator docs describe onboarding status checks; operator docs describe billing gate troubleshooting.
 
 If the request does not identify whether admin analytics or billing is the first production dependency, ask one bounded clarification question such as:
 

--- a/skills/relay-ready/references/decomposition-contract.md
+++ b/skills/relay-ready/references/decomposition-contract.md
@@ -1,0 +1,70 @@
+# Relay-Ready Decomposition Contract
+
+This contract defines the boundary between deterministic readiness scripts, AI relay-ready shaping, and downstream planning for oversized or semantically ambiguous requests.
+
+## Boundary
+
+- Scripts emit deterministic signals and persist validated artifacts.
+- Scripts must not infer semantic leaf boundaries.
+- AI relay-ready shaping decides whether the request is one high-risk leaf or multiple leaves.
+- `relay-plan` consumes the persisted `relay-ready/<leaf-id>.md` handoff and frozen Done Criteria for that leaf; it must not silently reinterpret the raw request after relay-ready has frozen a handoff.
+- #431 remains the older readiness epic for broader readiness-gate scope. Do not duplicate that scope here.
+
+The deterministic scripts may say "this looks multi-task" from text-shape signals such as a top-level `and`, a multi-verb opener, or bullets across modules. They may not decide that "auth setup", "billing gate", and "operator docs" are the correct leaves. That semantic boundary belongs to the AI shaping step and the operator/requester acceptance path.
+
+## Proposal-First Shaping
+
+When strong decomposition signals appear, relay-ready uses proposal-first shaping: first propose a bounded shape instead of persisting immediately.
+
+1. Present whether the request should remain one high-risk leaf or split into named leaves.
+2. Include short AI-authored leaf proposals with order and dependency intent.
+3. Offer bounded response options: accept the proposal, keep one leaf, or edit boundaries with free text.
+4. Persist only after the proposal is accepted or edited into a stable handoff contract.
+
+Ask one bounded clarification question only when the proposed leaf boundary cannot be made reviewable from the request text. The question should choose between concrete alternatives, include a free-text escape hatch, and target the minimum ambiguity blocking a frozen Done Criteria snapshot. Do not ask an open-ended discovery interview.
+
+## Persistence Contract
+
+After shaping is accepted, write the existing persistence contract:
+
+- one `handoff` for a single leaf, or ordered `handoffs[]` for multiple leaves
+- per leaf: `leaf_id`, `title`, `goal`, `order`, and `done_criteria_markdown`
+- optional per leaf: `depends_on`, `in_scope`, `out_of_scope`, `assumptions`, and `escalation_conditions`
+
+The persister validates schema shape, ordering, unique leaf ids, and `depends_on` references. It records the resulting request artifact, `relay-ready/<leaf-id>.md` handoff(s), frozen `done-criteria/<leaf-id>.md` snapshot(s), and append-only events. It does not create or revise semantic decomposition.
+
+## Planner Consumption
+
+For each accepted leaf, `relay-plan` reads the persisted handoff and its frozen Done Criteria path. The raw request remains historical context only. If planning finds the handoff or frozen Done Criteria incomplete, it must surface that as an ambiguity or persist a planner-authored Done Criteria anchor according to the relay-plan workflow; it must not quietly recover a different task from the original raw request.
+
+## Oversized Product-Foundation Example
+
+Raw request:
+
+```text
+Build the initial product foundation: tenant onboarding, billing gates,
+admin analytics, and operator documentation.
+```
+
+Deterministic signals:
+
+- multi-task granularity
+- cross-domain bullets or clauses
+- high implementation/review risk
+
+AI-authored proposal:
+
+- Leaf 1: create tenant onboarding shell.
+- Leaf 2: add billing gate skeleton, `depends_on: [tenant onboarding shell]`.
+- Leaf 3: document product foundation operation, `depends_on: [tenant onboarding shell, billing gate skeleton]`.
+
+If the request does not identify whether admin analytics or billing is the first production dependency, ask one bounded clarification question such as:
+
+```text
+Which foundation branch should be first?
+A. Onboarding then billing, analytics later
+B. Onboarding then analytics, billing later
+C. Other + free text
+```
+
+Once accepted, persist those AI-authored leaves through `handoffs[]`; do not ask `score-readiness.js` or `probe-readiness.js` to split the request.

--- a/tests/relay-ready/scripts/request-store.test.js
+++ b/tests/relay-ready/scripts/request-store.test.js
@@ -24,6 +24,16 @@ const {
 const PERSIST_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-ready", "scripts", "persist-request.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
 const REVIEW_RUNNER_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+const DECOMPOSITION_CONTRACT_DOC = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "skills",
+  "relay-ready",
+  "references",
+  "decomposition-contract.md",
+);
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-ready-"));
@@ -87,6 +97,70 @@ function createMultiLeafContract(overrides = {}) {
         order: 1,
         depends_on: [],
         done_criteria_markdown: "# Done Criteria\n\n- Authenticated users stay off /login\n- Guests still reach /login\n",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createProductFoundationContract(overrides = {}) {
+  return {
+    source: { kind: "raw_text" },
+    request_text: [
+      "Build the initial product foundation: tenant onboarding, billing gates,",
+      "admin analytics, and operator documentation.",
+    ].join(" "),
+    handoffs: [
+      {
+        leaf_id: "foundation-auth-shell",
+        title: "Create tenant onboarding shell",
+        goal: "Add the minimum tenant onboarding flow needed before gated features can exist",
+        order: 1,
+        depends_on: [],
+        in_scope: ["Create tenant onboarding entry points", "Persist tenant setup status"],
+        out_of_scope: ["Billing enforcement", "Analytics dashboards"],
+        assumptions: ["Existing account records can own tenant setup state"],
+        done_criteria_markdown: [
+          "# Done Criteria",
+          "",
+          "- Tenant onboarding status is stored and visible to the app shell",
+          "- Existing unauthenticated access behavior remains unchanged",
+        ].join("\n"),
+        escalation_conditions: ["Tenant ownership is not represented in the data model"],
+      },
+      {
+        leaf_id: "foundation-billing-gate",
+        title: "Add billing gate skeleton",
+        goal: "Introduce a billing gate that can block premium tenant actions after onboarding exists",
+        order: 2,
+        depends_on: ["foundation-auth-shell"],
+        in_scope: ["Add the billing gate decision point", "Cover allowed and blocked tenant states"],
+        out_of_scope: ["Payment provider integration", "Admin analytics"],
+        assumptions: ["Billing state can be stubbed for tests"],
+        done_criteria_markdown: [
+          "# Done Criteria",
+          "",
+          "- Premium tenant actions consult a billing gate",
+          "- Tests cover allowed and blocked billing states",
+        ].join("\n"),
+        escalation_conditions: ["No stable premium-action boundary exists"],
+      },
+      {
+        leaf_id: "foundation-operator-docs",
+        title: "Document product foundation operation",
+        goal: "Document the operator workflow after onboarding and billing gate contracts are frozen",
+        order: 3,
+        depends_on: ["foundation-auth-shell", "foundation-billing-gate"],
+        in_scope: ["Document onboarding and billing gate operational checks"],
+        out_of_scope: ["Changing product behavior", "Analytics dashboard implementation"],
+        assumptions: ["The first two leaves define the stable operator contract"],
+        done_criteria_markdown: [
+          "# Done Criteria",
+          "",
+          "- Operator docs describe onboarding status checks",
+          "- Operator docs describe billing gate troubleshooting",
+        ].join("\n"),
+        escalation_conditions: ["Earlier foundation leaves change their public contract"],
       },
     ],
     ...overrides,
@@ -643,6 +717,91 @@ test("scenario: larger request decomposes into ordered child handoffs", () => {
       "relay_ready_handoff_persisted",
     ]
   );
+});
+
+test("scenario: oversized product-foundation request uses AI-authored leaf proposals before persistence", () => {
+  const { repoRoot } = setupRepo();
+  const requestId = "req-20260608010101000";
+  const contract = createProductFoundationContract();
+
+  structure(repoRoot, requestId, {
+    source_kind: "raw_text",
+    request_text: contract.request_text,
+    readiness: createReadiness({
+      clarity: "medium",
+      granularity: "multi_task",
+      dependency: "internal",
+      verifiability: "medium",
+      risk: "high",
+    }),
+    proposal_summary: "Strong decomposition signals: product foundation spans onboarding, billing, and docs.",
+    proposal_kind: "structure",
+    proposal_text: [
+      "Leaf 1: tenant onboarding shell.",
+      "Leaf 2: billing gate skeleton, depends on Leaf 1.",
+      "Leaf 3: operator docs, depends on Leaves 1 and 2.",
+    ].join("\n"),
+    response_options: [
+      "A. Accept proposed leaves",
+      "B. Keep one high-risk leaf",
+      "C. Edit boundaries + free text",
+    ],
+    structure_kind: "decompose",
+    reason: "Deterministic signals show multi-task scope; AI proposes semantic leaf boundaries.",
+  });
+  acceptProposal(repoRoot, requestId, {
+    proposal_summary: "Persist the three AI-authored product foundation leaves.",
+    acceptance_note: "Use the proposed dependency order.",
+  });
+
+  const result = persistRequestContract(repoRoot, contract, { requestId });
+  const requestArtifact = readRequestArtifact(result.requestPath);
+  const leafArtifacts = result.handoffPaths.map((artifactPath) => readRequestArtifact(artifactPath));
+
+  assert.equal(result.leafCount, 3);
+  assert.deepEqual(result.leafIds, [
+    "foundation-auth-shell",
+    "foundation-billing-gate",
+    "foundation-operator-docs",
+  ]);
+  assert.deepEqual(requestArtifact.data.decomposition.leaf_order, result.leafIds);
+  assert.deepEqual(requestArtifact.data.decomposition.dependencies, {
+    "foundation-billing-gate": ["foundation-auth-shell"],
+    "foundation-operator-docs": ["foundation-auth-shell", "foundation-billing-gate"],
+  });
+  assert.deepEqual(
+    leafArtifacts.map((artifact) => artifact.data.depends_on),
+    [
+      [],
+      ["foundation-auth-shell"],
+      ["foundation-auth-shell", "foundation-billing-gate"],
+    ]
+  );
+  assert.match(requestArtifact.body, /foundation-operator-docs \[order 3\]/);
+  assert.match(requestArtifact.body, /depends_on: foundation-auth-shell, foundation-billing-gate/);
+  assert.deepEqual(
+    readEventNames(repoRoot, requestId),
+    [
+      "request_persisted",
+      "proposal_presented",
+      "proposal_accepted",
+      "relay_ready_handoff_persisted",
+      "relay_ready_handoff_persisted",
+      "relay_ready_handoff_persisted",
+    ]
+  );
+});
+
+test("decomposition contract docs pin the script-vs-AI and planner handoff boundary", () => {
+  const doc = fs.readFileSync(DECOMPOSITION_CONTRACT_DOC, "utf-8");
+
+  assert.match(doc, /Scripts emit deterministic signals and persist validated artifacts/);
+  assert.match(doc, /Scripts must not infer semantic leaf boundaries/);
+  assert.match(doc, /proposal-first shaping/);
+  assert.match(doc, /one bounded clarification question/);
+  assert.match(doc, /relay-ready\/<leaf-id>\.md/);
+  assert.match(doc, /frozen Done Criteria/);
+  assert.match(doc, /#431/);
 });
 
 test("scenario: non-issue request freezes done criteria from the handoff rather than GitHub", () => {

--- a/tests/relay-ready/scripts/request-store.test.js
+++ b/tests/relay-ready/scripts/request-store.test.js
@@ -723,6 +723,28 @@ test("scenario: oversized product-foundation request uses AI-authored leaf propo
   const { repoRoot } = setupRepo();
   const requestId = "req-20260608010101000";
   const contract = createProductFoundationContract();
+  const proposalText = [
+    "Leaf 1: Create tenant onboarding shell",
+    "Goal: Add the minimum tenant onboarding flow needed before gated features can exist",
+    "Dependencies: none",
+    "In scope: Create tenant onboarding entry points; Persist tenant setup status",
+    "Out of scope: Billing enforcement; Analytics dashboards",
+    "Done Criteria: Tenant onboarding status is stored and visible to the app shell; Existing unauthenticated access behavior remains unchanged",
+    "",
+    "Leaf 2: Add billing gate skeleton",
+    "Goal: Introduce a billing gate that can block premium tenant actions after onboarding exists",
+    "Dependencies: depends on Leaf 1",
+    "In scope: Add the billing gate decision point; Cover allowed and blocked tenant states",
+    "Out of scope: Payment provider integration; Admin analytics",
+    "Done Criteria: Premium tenant actions consult a billing gate; Tests cover allowed and blocked billing states",
+    "",
+    "Leaf 3: Document product foundation operation",
+    "Goal: Document the operator workflow after onboarding and billing gate contracts are frozen",
+    "Dependencies: depends on Leaves 1 and 2",
+    "In scope: Document onboarding and billing gate operational checks",
+    "Out of scope: Changing product behavior; Analytics dashboard implementation",
+    "Done Criteria: Operator docs describe onboarding status checks; Operator docs describe billing gate troubleshooting",
+  ].join("\n");
 
   structure(repoRoot, requestId, {
     source_kind: "raw_text",
@@ -736,11 +758,7 @@ test("scenario: oversized product-foundation request uses AI-authored leaf propo
     }),
     proposal_summary: "Strong decomposition signals: product foundation spans onboarding, billing, and docs.",
     proposal_kind: "structure",
-    proposal_text: [
-      "Leaf 1: tenant onboarding shell.",
-      "Leaf 2: billing gate skeleton, depends on Leaf 1.",
-      "Leaf 3: operator docs, depends on Leaves 1 and 2.",
-    ].join("\n"),
+    proposal_text: proposalText,
     response_options: [
       "A. Accept proposed leaves",
       "B. Keep one high-risk leaf",
@@ -779,6 +797,13 @@ test("scenario: oversized product-foundation request uses AI-authored leaf propo
   );
   assert.match(requestArtifact.body, /foundation-operator-docs \[order 3\]/);
   assert.match(requestArtifact.body, /depends_on: foundation-auth-shell, foundation-billing-gate/);
+  const proposalEvent = readRequestEvents(repoRoot, requestId).find((event) => event.event === "proposal_presented");
+  assert.equal(proposalEvent.proposal_text, proposalText);
+  assert.match(proposalEvent.proposal_text, /Goal: Add the minimum tenant onboarding flow/);
+  assert.match(proposalEvent.proposal_text, /Dependencies: depends on Leaves 1 and 2/);
+  assert.match(proposalEvent.proposal_text, /In scope: Document onboarding and billing gate operational checks/);
+  assert.match(proposalEvent.proposal_text, /Out of scope: Changing product behavior; Analytics dashboard implementation/);
+  assert.match(proposalEvent.proposal_text, /Done Criteria: Operator docs describe onboarding status checks/);
   assert.deepEqual(
     readEventNames(repoRoot, requestId),
     [
@@ -798,7 +823,10 @@ test("decomposition contract docs pin the script-vs-AI and planner handoff bound
   assert.match(doc, /Scripts emit deterministic signals and persist validated artifacts/);
   assert.match(doc, /Scripts must not infer semantic leaf boundaries/);
   assert.match(doc, /proposal-first shaping/);
+  assert.match(doc, /leaf title, goal, dependency intent, in-scope items, out-of-scope items, and leaf-level Done Criteria/);
   assert.match(doc, /one bounded clarification question/);
+  assert.match(doc, /Sprint-batch bypass/);
+  assert.match(doc, /leaf-level Done Criteria, dispatch prompt, rubric, and smoke\/replay scenario/);
   assert.match(doc, /relay-ready\/<leaf-id>\.md/);
   assert.match(doc, /frozen Done Criteria/);
   assert.match(doc, /#431/);


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다.

변경 사항:
- [decomposition-contract.md](/Users/sjlee/.relay/worktrees/8a7b82fc/dev-relay/skills/relay-ready/references/decomposition-contract.md:1) 추가: script-vs-AI 경계, proposal-first shaping, bounded clarification, planner consumption, #431 범위 구분 문서화
- [relay-ready/SKILL.md](/Users/sjlee/.relay/worktrees/8a7b82fc/dev-relay/skills/relay-ready/SKILL.md:57)에 decomposition boundary 요약 추가
- [relay-plan/SKILL.md](/Users/sjlee/.relay/worktrees/8a7b82fc/dev-relay/skills/relay-plan/SKILL.md:42)에 p
```

## Score Log

- Run: issue-680-20260608003105658-ef963c5b
- Executor: codex
- Branch: issue-680-ai-decomposition-contract