### PR TITLE
Detect stale ready PR head drift

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -38,6 +38,10 @@ node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
   --to review_pending --allow-same-head --require-pr-body-change \
   --reason "PR body metadata fixed with gh pr edit"
 
+# PR advanced after ready_to_merge → return to review for the new live PR HEAD
+node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
+  --to review_pending --reason "PR head advanced after passing review"
+
 # No-op re-dispatch escalated the run → bring it back for a fresh review
 node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
   --to review_pending --force --reason "no-op-dispatch-recovery"
@@ -53,6 +57,7 @@ Whitelisted transitions (unlisted pairs are rejected — use the normal dispatch
 |---|---|---|---|
 | `changes_requested` | `review_pending` | no | fresh commit on branch (HEAD ≠ `review.last_reviewed_sha`) |
 | `changes_requested` | `review_pending` | no | same HEAD allowed only with `--allow-same-head --require-pr-body-change`, a manifest PR number (`git.pr_number` or `github.pr_number`), a prior `review-round-N-pr-body.md` snapshot, and a current GitHub PR body that differs from the latest numbered snapshot |
+| `ready_to_merge` | `review_pending` | no | live GitHub PR HEAD differs from `review.last_reviewed_sha` or `git.head_sha`; emits old/new SHA and PR number in `state_recovery` |
 | `escalated` | `review_pending` | yes | — |
 | `escalated` | `changes_requested` | no | — |
 | `dispatched` | `changes_requested` | yes | — |
@@ -88,6 +93,6 @@ If `--add-dir` is NOT supported or doesn't fix the failure: ship Path 2 and docu
 
 Use normal `dispatch.js --run-id <id>` when reviewer feedback requires code changes. That path re-dispatches implementation work and must produce a fresh code handoff before review.
 
-Use `recover-state.js --to review_pending` for external events that make a new review valid without redispatch. The normal path still requires `HEAD != review.last_reviewed_sha`. The same-HEAD exception is only for PR-body-only evidence changes and emits a `state_recovery` event with `pr_body_only: true`, `head_sha`, `last_reviewed_sha`, `pr_number`, and the operator `reason`.
+Use `recover-state.js --to review_pending` for external events that make a new review valid without redispatch. The normal changes-requested path still requires `HEAD != review.last_reviewed_sha`. The same-HEAD exception is only for PR-body-only evidence changes and emits a `state_recovery` event with `pr_body_only: true`, `head_sha`, `last_reviewed_sha`, `pr_number`, and the operator `reason`. The ready-to-merge stale path is stricter: it only opens when GitHub's live PR HEAD differs from the reviewed/manifest SHA, updates `git.head_sha` to the live SHA, and emits `previous_head_sha`, `new_head_sha`, and `pr_number`.
 
 Use `finalize-run.js --force-finalize-nonready --reason ...` only as a merge/finalization override for non-ready terminal cleanup. It is not a substitute for fresh review evidence and does not repair missing PR body metadata.

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -16,6 +16,7 @@ const VALUE = "value";
 
 const FLAGS = [
   { flag: "--all", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--allow-stacked-base-hazard", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit reason for overriding a non-default stacked PR base hazard." },
   { flag: "--allow-conflicting-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Operator override for the in-flight-run check; logs a conflicting_run_override event." },
   { flag: "--allow-same-head", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit same-HEAD recovery opt-in; no value is consumed." },
   { flag: "--advisory-profile", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed advisory review profile selector; flag-like following tokens should mean the value is missing." },
@@ -146,7 +147,7 @@ const COMMAND_FLAGS = {
   "finalize-run": [
     "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method",
     "--skip-review", "--force-finalize-nonready", "--reason", "--skip-merge",
-    "--no-issue-close", "--dry-run", "--json", "--help",
+    "--allow-stacked-base-hazard", "--no-issue-close", "--dry-run", "--json", "--help",
   ],
   "gate-check": [
     "--skip", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -45,6 +45,16 @@ const RECOVERY_TRANSITIONS = Object.freeze([
     description: "Operator pushed a fix commit directly to the branch instead of re-dispatching.",
   },
   {
+    from: STATES.READY_TO_MERGE,
+    to: STATES.REVIEW_PENDING,
+    nextAction: "run_review",
+    requireForce: false,
+    requireFreshCommit: false,
+    requireReadyHeadDrift: true,
+    resetLastReviewedSha: false,
+    description: "PR HEAD advanced after a passing review; recover to review_pending for a fresh review.",
+  },
+  {
     from: STATES.ESCALATED,
     to: STATES.REVIEW_PENDING,
     nextAction: "run_review",
@@ -95,7 +105,10 @@ function printUsage(stream = console.log) {
       const freshFlag = t.requireFreshCommit
         ? " (fresh commit required on branch; same-HEAD PR-body-only recovery requires both same-HEAD flags)"
         : "";
-      return `  ${t.from} -> ${t.to}${forceFlag}${freshFlag}`;
+      const driftFlag = t.requireReadyHeadDrift
+        ? " (live PR HEAD drift required)"
+        : "";
+      return `  ${t.from} -> ${t.to}${forceFlag}${freshFlag}${driftFlag}`;
     }).join("\n")
   );
 }
@@ -221,6 +234,80 @@ function fetchCurrentPrBody(repoRoot, prNumber) {
   }
 }
 
+function fetchLivePrHead(repoRoot, prNumber) {
+  try {
+    const ghBin = process.env.RELAY_GH_BIN || "gh";
+    const raw = execFileSync(
+      ghBin,
+      ["pr", "view", String(prNumber), "--json", "number,headRefName,headRefOid"],
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+        timeout: PR_BODY_FETCH_TIMEOUT_MS,
+      }
+    );
+    const parsed = JSON.parse(raw || "{}");
+    return {
+      prNumber: Number(parsed.number || prNumber),
+      headRefName: parsed.headRefName || null,
+      headSha: parsed.headRefOid || null,
+    };
+  } catch (error) {
+    throw new Error(
+      `Cannot fetch live PR HEAD for PR #${prNumber}: ${summarizeCommandFailure(error)}`
+    );
+  }
+}
+
+function requireReadyHeadDriftEvidence({ repoRoot, manifestData }) {
+  const prNumber = getManifestPrNumber(manifestData);
+  if (!prNumber) {
+    throw new Error(
+      "Refusing stale-ready recovery: manifest has no PR number " +
+      "(expected git.pr_number or github.pr_number)."
+    );
+  }
+
+  const live = fetchLivePrHead(repoRoot, prNumber);
+  if (!live.headSha) {
+    throw new Error(`Refusing stale-ready recovery: PR #${prNumber} live HEAD is missing.`);
+  }
+
+  const lastReviewedSha = manifestData?.review?.last_reviewed_sha || null;
+  const manifestHeadSha = manifestData?.git?.head_sha || null;
+  if (!lastReviewedSha && !manifestHeadSha) {
+    throw new Error(
+      "Refusing stale-ready recovery: manifest has neither review.last_reviewed_sha nor git.head_sha " +
+      "to compare against the live PR HEAD."
+    );
+  }
+
+  const differsFromReviewed = Boolean(lastReviewedSha && live.headSha !== lastReviewedSha);
+  const differsFromManifestHead = Boolean(manifestHeadSha && live.headSha !== manifestHeadSha);
+  if (!differsFromReviewed && !differsFromManifestHead) {
+    const equalTargets = [];
+    if (lastReviewedSha) equalTargets.push("review.last_reviewed_sha");
+    if (manifestHeadSha) equalTargets.push("git.head_sha");
+    throw new Error(
+      `Refusing stale-ready recovery: live PR HEAD for PR #${prNumber} (${live.headSha}) ` +
+      `equals ${equalTargets.join(" and ")}. Objective drift evidence requires the live PR HEAD ` +
+      "to differ from review.last_reviewed_sha or git.head_sha."
+    );
+  }
+
+  return {
+    prNumber: live.prNumber || prNumber,
+    headRefName: live.headRefName,
+    oldSha: differsFromReviewed ? lastReviewedSha : manifestHeadSha,
+    newSha: live.headSha,
+    lastReviewedSha,
+    manifestHeadSha,
+    differsFromReviewed,
+    differsFromManifestHead,
+  };
+}
+
 function requirePrBodyOnlyEvidence({ repoRoot, manifestData, currentHead, lastReviewedSha }) {
   const prNumber = getManifestPrNumber(manifestData);
   if (!prNumber) {
@@ -336,6 +423,7 @@ function main() {
 
   let commitContext = null;
   let prBodyOnlyContext = null;
+  let readyHeadDriftContext = null;
   if (recovery.requireFreshCommit) {
     const headContext = getBranchHeadContext({
       repoRoot: validatedPaths.repoRoot,
@@ -356,11 +444,27 @@ function main() {
       });
     }
   }
+  if (recovery.requireReadyHeadDrift) {
+    readyHeadDriftContext = requireReadyHeadDriftEvidence({
+      repoRoot: validatedPaths.repoRoot,
+      manifestData: safeData,
+    });
+  }
 
-  const updated = forceTransitionState(safeData, toState, recovery.nextAction);
+  let updated = forceTransitionState(safeData, toState, recovery.nextAction);
 
   if (recovery.resetLastReviewedSha) {
     updated.review = { ...(updated.review || {}), last_reviewed_sha: null };
+  }
+  if (readyHeadDriftContext) {
+    updated = {
+      ...updated,
+      git: {
+        ...(updated.git || {}),
+        pr_number: readyHeadDriftContext.prNumber,
+        head_sha: readyHeadDriftContext.newSha,
+      },
+    };
   }
 
   if (!dryRun) {
@@ -369,12 +473,24 @@ function main() {
       event: EVENTS.STATE_RECOVERY,
       state_from: fromState,
       state_to: toState,
-      head_sha: commitContext?.currentHead || prBodyOnlyContext?.currentHead || updated.git?.head_sha || null,
+      head_sha: readyHeadDriftContext?.newSha
+        || commitContext?.currentHead
+        || prBodyOnlyContext?.currentHead
+        || updated.git?.head_sha
+        || null,
       round: prBodyOnlyContext?.previousSnapshotRound || updated.review?.rounds || null,
       reason,
       last_reviewed_sha: commitContext?.lastReviewedSha
         ?? prBodyOnlyContext?.lastReviewedSha
+        ?? readyHeadDriftContext?.lastReviewedSha
         ?? (safeData.review?.last_reviewed_sha || null),
+      ...(readyHeadDriftContext
+        ? {
+            pr_number: readyHeadDriftContext.prNumber,
+            previous_head_sha: readyHeadDriftContext.oldSha,
+            new_head_sha: readyHeadDriftContext.newSha,
+          }
+        : {}),
       ...(prBodyOnlyContext
         ? {
             pr_body_only: true,
@@ -394,6 +510,7 @@ function main() {
     force,
     freshCommit: commitContext,
     prBodyOnly: prBodyOnlyContext,
+    readyHeadDrift: readyHeadDriftContext,
     dryRun,
   };
 
@@ -414,6 +531,12 @@ function main() {
       console.log(`  Prev reviewed: ${prBodyOnlyContext.lastReviewedSha || "(none)"}`);
       console.log(`  PR number:    ${prBodyOnlyContext.prNumber}`);
       console.log(`  Snapshot:     ${prBodyOnlyContext.previousSnapshotPath}`);
+    }
+    if (readyHeadDriftContext) {
+      console.log("  Ready drift:  true");
+      console.log(`  PR number:    ${readyHeadDriftContext.prNumber}`);
+      console.log(`  Prev HEAD:    ${readyHeadDriftContext.oldSha}`);
+      console.log(`  New HEAD:     ${readyHeadDriftContext.newSha}`);
     }
     if (dryRun) console.log("  dry-run:      no changes written");
   }

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -308,6 +308,47 @@ function requireReadyHeadDriftEvidence({ repoRoot, manifestData }) {
   };
 }
 
+function requireRetainedWorktreeAtLiveHead({ repoRoot, manifestData, readyHeadDrift }) {
+  const worktreePath = manifestData?.paths?.worktree;
+  const branch = manifestData?.git?.working_branch || readyHeadDrift?.headRefName || null;
+  if (!worktreePath) {
+    throw new Error(
+      "Refusing stale-ready recovery: manifest has no paths.worktree. " +
+      "Cannot verify the retained review checkout before returning to review_pending."
+    );
+  }
+  if (!branch) {
+    throw new Error(
+      "Refusing stale-ready recovery: manifest has no git.working_branch and the PR head branch is unknown. " +
+      "Cannot verify the retained review checkout before returning to review_pending."
+    );
+  }
+
+  let worktreeHead;
+  try {
+    worktreeHead = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch (error) {
+    throw new Error(
+      `Refusing stale-ready recovery: cannot read retained worktree HEAD at ${worktreePath}: ` +
+      `${summarizeCommandFailure(error)}`
+    );
+  }
+
+  if (worktreeHead !== readyHeadDrift.newSha) {
+    throw new Error(
+      `Refusing stale-ready recovery: retained worktree HEAD for '${branch}' is ${worktreeHead}, ` +
+      `but live PR HEAD is ${readyHeadDrift.newSha}. ` +
+      `Update the retained worktree first, for example: git -C ${worktreePath} fetch origin ${branch} && ` +
+      `git -C ${worktreePath} reset --hard ${readyHeadDrift.newSha}`
+    );
+  }
+
+  return { worktreePath, branch, worktreeHead };
+}
+
 function requirePrBodyOnlyEvidence({ repoRoot, manifestData, currentHead, lastReviewedSha }) {
   const prNumber = getManifestPrNumber(manifestData);
   if (!prNumber) {
@@ -448,6 +489,11 @@ function main() {
     readyHeadDriftContext = requireReadyHeadDriftEvidence({
       repoRoot: validatedPaths.repoRoot,
       manifestData: safeData,
+    });
+    requireRetainedWorktreeAtLiveHead({
+      repoRoot: validatedPaths.repoRoot,
+      manifestData: safeData,
+      readyHeadDrift: readyHeadDriftContext,
     });
   }
 

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -128,6 +128,38 @@ function mergeFlag(method) {
   }
 }
 
+function buildMergeFinalizeReason({
+  mergeMethod,
+  mergeRecovered,
+  skipReviewReason,
+  stackedBaseGuard,
+}) {
+  const mergeReason = skipReviewReason
+    ? `skip_review:${skipReviewReason}`
+    : (mergeRecovered ? "already_merged" : mergeMethod);
+
+  if (stackedBaseGuard?.status !== "overridden") {
+    return mergeReason;
+  }
+
+  return `stacked_base_override:${stackedBaseGuard.reason};${mergeReason}`;
+}
+
+function buildStackedBaseOverrideAuditFields(stackedBaseGuard, prNumber, headSha, priorState) {
+  if (stackedBaseGuard?.status !== "overridden") {
+    return {};
+  }
+
+  return {
+    override_class: "stacked_base_hazard",
+    affected_head_sha: headSha,
+    prior_state: priorState,
+    required_reason: stackedBaseGuard.overrideReason,
+    operator_initiated: true,
+    pr_number: prNumber,
+  };
+}
+
 function fetchPreMergeContext(repoPath, prNumber) {
   const raw = execGh(repoPath, ["pr", "view", String(prNumber),
     "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup"]);
@@ -896,9 +928,18 @@ function main() {
         state_to: STATES.MERGED,
         head_sha: updated.git?.head_sha || null,
         round: updated.review?.rounds || null,
-        reason: skipReviewReason
-          ? `skip_review:${skipReviewReason}`
-          : (mergeRecovered ? "already_merged" : mergeMethod),
+        reason: buildMergeFinalizeReason({
+          mergeMethod,
+          mergeRecovered,
+          skipReviewReason,
+          stackedBaseGuard,
+        }),
+        ...buildStackedBaseOverrideAuditFields(
+          stackedBaseGuard,
+          prNumber,
+          updated.git?.head_sha || currentHeadSha,
+          safeData.state
+        ),
       });
     }
   }

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -22,6 +22,8 @@
  *   --force-finalize-nonready
  *                          Operator-only: bypass non-ready state gate
  *   --reason <text>        Required with --force-finalize-nonready
+ *   --allow-stacked-base-hazard <reason>
+ *                          Override non-default stacked PR base hazard block
  *   --skip-merge           Skip the PR merge step and run cleanup only
  *   --no-issue-close       Skip linked issue close
  *   --dry-run              Print what would happen without writing
@@ -69,6 +71,7 @@ const args = process.argv.slice(2);
 const KNOWN_FLAGS = [
   "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method", "--skip-review",
   "--force-finalize-nonready", "--reason",
+  "--allow-stacked-base-hazard",
   "--skip-merge", "--no-issue-close", "--dry-run", "--json", "--help", "-h",
 ];
 const cliArgs = bindCliArgs(args, {
@@ -91,6 +94,7 @@ if (!args.length || helpRequested) {
   console.log(`  --force-finalize-nonready ${modeLabel("--force-finalize-nonready")}`);
   console.log("                         Operator-only: bypass non-ready state gate");
   console.log(`  --reason <text>        ${modeLabel("--reason")} Required with --force-finalize-nonready`);
+  console.log(`  --allow-stacked-base-hazard <reason> ${modeLabel("--allow-stacked-base-hazard")} Override non-default stacked PR base hazard block`);
   console.log(`  --skip-merge           ${modeLabel("--skip-merge")} Skip the PR merge step and run cleanup only`);
   console.log(`  --no-issue-close       ${modeLabel("--no-issue-close")} Skip linked issue close`);
   console.log(`  --dry-run              ${modeLabel("--dry-run")} Print what would happen without writing`);
@@ -126,10 +130,11 @@ function mergeFlag(method) {
 
 function fetchPreMergeContext(repoPath, prNumber) {
   const raw = execGh(repoPath, ["pr", "view", String(prNumber),
-    "--json", "comments,commits,mergeable,statusCheckRollup"]);
+    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup"]);
   const parsed = JSON.parse(raw);
   const checks = parsed.statusCheckRollup || [];
   return {
+    baseRefName: parsed.baseRefName || null,
     comments: parsed.comments || [],
     commits: parsed.commits || [],
     mergeable: parsed.mergeable || null,
@@ -180,6 +185,124 @@ function fetchPrMergeState(repoPath, prNumber) {
     state: parsed.state || null,
     mergeCommitSha: parsed.mergeCommit?.oid || null,
   };
+}
+
+function fetchDefaultBranchName(repoPath) {
+  try {
+    const raw = execGh(repoPath, ["repo", "view", "--json", "defaultBranchRef"]);
+    const parsed = JSON.parse(raw);
+    return parsed.defaultBranchRef?.name || null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchPrsForHeadBranch(repoPath, branchName) {
+  try {
+    const raw = execGh(repoPath, [
+      "pr",
+      "list",
+      "--head",
+      String(branchName),
+      "--state",
+      "all",
+      "--json",
+      "number,state,mergedAt,headRefName,url",
+    ]);
+    return JSON.parse(raw || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function normalizePrState(value) {
+  return String(value || "").trim().toUpperCase();
+}
+
+function buildStackedBaseGuard(repoPath, prNumber, baseRefName, overrideReason = null) {
+  if (!baseRefName) {
+    return {
+      status: "skipped",
+      reason: "missing_base_ref",
+      prNumber,
+      baseRefName: null,
+      defaultBranchName: null,
+      basePr: null,
+      overrideReason: null,
+    };
+  }
+
+  const defaultBranchName = fetchDefaultBranchName(repoPath);
+  if (!defaultBranchName || baseRefName === defaultBranchName) {
+    return {
+      status: "clear",
+      reason: defaultBranchName ? "default_branch_base" : "default_branch_unknown",
+      prNumber,
+      baseRefName,
+      defaultBranchName,
+      basePr: null,
+      overrideReason: null,
+    };
+  }
+
+  const candidates = fetchPrsForHeadBranch(repoPath, baseRefName)
+    .filter((entry) => !entry.headRefName || entry.headRefName === baseRefName);
+  const merged = candidates.find((entry) => normalizePrState(entry.state) === "MERGED" || Boolean(entry.mergedAt));
+  if (merged) {
+    return {
+      status: "clear",
+      reason: "base_pr_merged",
+      prNumber,
+      baseRefName,
+      defaultBranchName,
+      basePr: {
+        number: Number(merged.number),
+        state: merged.state || null,
+        mergedAt: merged.mergedAt || null,
+        url: merged.url || null,
+      },
+      overrideReason: null,
+    };
+  }
+
+  const selected = candidates.find((entry) => normalizePrState(entry.state) === "OPEN")
+    || candidates.find((entry) => normalizePrState(entry.state) === "CLOSED")
+    || candidates[0]
+    || null;
+  const selectedState = normalizePrState(selected?.state);
+  const reason = !selected
+    ? "base_pr_missing"
+    : selectedState === "CLOSED"
+      ? "base_pr_closed"
+      : "base_pr_unmerged";
+  return {
+    status: overrideReason ? "overridden" : "blocked",
+    reason,
+    prNumber,
+    baseRefName,
+    defaultBranchName,
+    basePr: selected
+      ? {
+          number: Number(selected.number),
+          state: selected.state || null,
+          mergedAt: selected.mergedAt || null,
+          url: selected.url || null,
+        }
+      : null,
+    overrideReason: overrideReason || null,
+  };
+}
+
+function assertStackedBaseGuard(guard, prNumber) {
+  if (!guard || guard.status !== "blocked") return;
+  const basePrText = guard.basePr?.number
+    ? `; base PR #${guard.basePr.number} is ${guard.basePr.state || "unmerged"}`
+    : "; no base PR was found";
+  throw new Error(
+    `Stacked PR base hazard: PR #${prNumber} targets non-default base '${guard.baseRefName}' ` +
+    `(default: '${guard.defaultBranchName || "unknown"}')${basePrText}. ` +
+    "Merge the base PR first or rerun with --allow-stacked-base-hazard <reason>."
+  );
 }
 
 function assertPreMergeSafety(preMerge, prNumber) {
@@ -422,6 +545,10 @@ function main() {
   const mergeMethod = cliArgs.getArg("--merge-method") || "squash";
   const skipReviewReason = cliArgs.getArg("--skip-review");
   const forceFinalizeNonready = cliArgs.hasFlag("--force-finalize-nonready");
+  const allowStackedBaseHazard = cliArgs.hasFlag("--allow-stacked-base-hazard");
+  const stackedBaseOverrideReason = allowStackedBaseHazard
+    ? cliArgs.getArg("--allow-stacked-base-hazard")
+    : null;
   let forceFinalizeReason;
   try {
     forceFinalizeReason = cliArgs.getArg("--reason");
@@ -438,6 +565,9 @@ function main() {
   const jsonOut = cliArgs.hasFlag("--json");
   if (forceFinalizeNonready && !String(forceFinalizeReason || "").trim()) {
     throw new Error("--force-finalize-nonready requires --reason <non-empty-text>");
+  }
+  if (allowStackedBaseHazard && !String(stackedBaseOverrideReason || "").trim()) {
+    throw new Error("--allow-stacked-base-hazard requires a non-empty reason");
   }
 
   let branch = cliArgs.getArg("--branch");
@@ -526,6 +656,7 @@ function main() {
   let issueClosed = false;
   let issueCloseWarning = null;
   let reviewGate = null;
+  let stackedBaseGuard = { status: "not_checked", reason: null };
   let currentHeadSha = safeData.git?.head_sha || null;
   const skipReviewRubricAudit = summarizeRubricAuditForSkip(safeData, {
     runDir: getRunDir(validatedPaths.repoRoot, safeData.run_id),
@@ -549,6 +680,24 @@ function main() {
         }
         throw new Error(`Fresh review gate failed: ${skipReviewFailure.status}`);
       }
+      const preMerge = fetchPreMergeContext(repoPath, prNumber);
+      stackedBaseGuard = buildStackedBaseGuard(
+        repoPath,
+        prNumber,
+        preMerge.baseRefName,
+        stackedBaseOverrideReason
+      );
+      if (stackedBaseGuard.status === "blocked" && !dryRun) {
+        appendRunEvent(repoPath, safeData.run_id, {
+          event: EVENTS.MERGE_BLOCKED,
+          state_from: safeData.state,
+          state_to: safeData.state,
+          head_sha: currentHeadSha,
+          round: safeData.review?.rounds || null,
+          reason: `stacked_base_hazard:${stackedBaseGuard.reason}`,
+        });
+      }
+      assertStackedBaseGuard(stackedBaseGuard, prNumber);
       reviewGate = {
         status: "skipped",
         pr: prNumber,
@@ -592,9 +741,43 @@ function main() {
         }
         throw new Error(`Fresh review gate failed: ${reviewGate.status}`);
       }
+      stackedBaseGuard = buildStackedBaseGuard(
+        repoPath,
+        prNumber,
+        preMerge.baseRefName,
+        stackedBaseOverrideReason
+      );
+      if (stackedBaseGuard.status === "blocked" && !dryRun) {
+        appendRunEvent(repoPath, safeData.run_id, {
+          event: EVENTS.MERGE_BLOCKED,
+          state_from: safeData.state,
+          state_to: safeData.state,
+          head_sha: reviewGate.latestCommit || currentHeadSha,
+          round: safeData.review?.rounds || null,
+          reason: `stacked_base_hazard:${stackedBaseGuard.reason}`,
+        });
+      }
+      assertStackedBaseGuard(stackedBaseGuard, prNumber);
       assertPreMergeSafety(preMerge, prNumber);
     } else if (forceFinalizeNonready) {
       const preMerge = fetchPreMergeContext(repoPath, prNumber);
+      stackedBaseGuard = buildStackedBaseGuard(
+        repoPath,
+        prNumber,
+        preMerge.baseRefName,
+        stackedBaseOverrideReason
+      );
+      if (stackedBaseGuard.status === "blocked" && !dryRun) {
+        appendRunEvent(repoPath, safeData.run_id, {
+          event: EVENTS.MERGE_BLOCKED,
+          state_from: safeData.state,
+          state_to: safeData.state,
+          head_sha: currentHeadSha,
+          round: safeData.review?.rounds || null,
+          reason: `stacked_base_hazard:${stackedBaseGuard.reason}`,
+        });
+      }
+      assertStackedBaseGuard(stackedBaseGuard, prNumber);
       assertPreMergeSafety(preMerge, prNumber);
     }
   }
@@ -788,6 +971,7 @@ function main() {
     remoteBranchDeleted,
     remoteBranchDeleteWarning,
     reviewGate,
+    stackedBaseGuard,
     issueClosed,
     issueCloseWarning,
     cleanup: cleanupResult.summary,

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -98,6 +98,16 @@ REVIEW_BEFORE=$(node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js
   --stage review --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --json)
 ```
 
+If `REVIEW_BEFORE.ready_status.status == "stale_ready"`, do not invoke relay-review yet. Recover the audited stale-ready transition first, then review the recovered run:
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/recover-state.js" \
+  --repo . --run-id "$RUN_ID" --to review_pending \
+  --reason "PR HEAD advanced after ready_to_merge; rerun review for the live head" --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" \
+  --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --json
+```
+If `REVIEW_BEFORE.ready_status.status == "merge_ready"`, skip the review invocation and continue to Step 5.
+
 Invoke **relay-review** in an isolated context. It runs Spec Compliance then Code Quality, re-dispatches on issues, updates manifest state, and keeps the relay-plan rubric fixed as the review anchor. Safety cap: 20 rounds. Do NOT review inline.
 
 After review returns, compare against the snapshot:

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -59,14 +59,20 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage review
 ### Stale-review guard
 
 - Firing condition: Step 4 is about to invoke relay-review, then again immediately after relay-review returns.
-- Signals read: target manifest `review.rounds`, `review.latest_verdict`, `git.head_sha`, and `review.last_reviewed_sha`.
+- Signals read: target manifest `review.rounds`, `review.latest_verdict`, `git.head_sha`, and `review.last_reviewed_sha`; for `ready_to_merge` runs, live PR `headRefOid` from GitHub.
 - Events emitted: none by this guard; relay-review emits its normal review events.
 - Branch labels:
   - `snapshot`: before review, store `.snapshot.rounds` and `.snapshot.latest_verdict`.
   - `advanced`: after review, `.comparison.rounds_advanced` or `.comparison.verdict_changed` is true; proceed to Step 5.
   - `stale`: after review, neither value changed; treat the review as stalled and run `review-runner.js` directly in the foreground, then repeat the same comparison.
+  - `stale_ready`: when `.snapshot.state == "ready_to_merge"` and `.ready_status.status == "stale_ready"`, the PR advanced after the passing review; run `recover-state.js --to review_pending --reason <why>` and then run relay-review again.
+  - `merge_ready`: when `.snapshot.state == "ready_to_merge"` and `.ready_status.status == "merge_ready"`, the live PR HEAD still matches the reviewed/manifest SHA.
 
 The JSON also reports `.snapshot.sha_state` / `.comparison.sha_state` as
 `reviewed_current_head`, `stale_reviewed_sha`, `not_reviewed`, or
 `missing_head_sha` so operators can see whether the manifest's review SHA is
 current without changing the round/verdict advancement rule.
+
+For ready runs, `.ready_status` includes `pr_number`, `old_sha`, `new_sha`,
+`reviewed_sha`, `manifest_head_sha`, and `next_action` so recovery can be
+audited without manually editing the manifest.

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -88,7 +88,8 @@ function summarizeExecError(error) {
 }
 
 function execGhJson(repoRoot, args) {
-  const raw = execFileSync("gh", args, {
+  const ghBin = process.env.RELAY_GH_BIN || "gh";
+  const raw = execFileSync(ghBin, args, {
     cwd: repoRoot,
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -431,6 +432,101 @@ function snapshotReview(record) {
   };
 }
 
+function fetchLivePrHead(repoRoot, prNumber) {
+  if (!prNumber) {
+    return {
+      status: "skipped",
+      reason: "missing_pr_number",
+      pr_number: null,
+      head_ref_name: null,
+      head_sha: null,
+      command: null,
+    };
+  }
+
+  const args = [
+    "pr",
+    "view",
+    String(prNumber),
+    "--json",
+    "number,headRefName,headRefOid",
+  ];
+  try {
+    const parsed = execGhJson(repoRoot, args);
+    return {
+      status: "found",
+      reason: null,
+      pr_number: Number(parsed?.number || prNumber),
+      head_ref_name: parsed?.headRefName || null,
+      head_sha: parsed?.headRefOid || null,
+      command: ["gh", ...args],
+    };
+  } catch (error) {
+    return {
+      status: "unknown",
+      reason: summarizeExecError(error),
+      pr_number: prNumber,
+      head_ref_name: null,
+      head_sha: null,
+      command: ["gh", ...args],
+    };
+  }
+}
+
+function buildReadyStatus(snapshot, repoRoot) {
+  if (snapshot.state !== "ready_to_merge") {
+    return {
+      status: "not_ready",
+      reason: `state_${snapshot.state || "unknown"}`,
+      pr_number: snapshot.pr_number || null,
+      old_sha: snapshot.last_reviewed_sha || snapshot.head_sha || null,
+      new_sha: null,
+      reviewed_sha: snapshot.last_reviewed_sha || null,
+      manifest_head_sha: snapshot.head_sha || null,
+      next_action: "continue_review_flow",
+    };
+  }
+
+  const oldSha = snapshot.last_reviewed_sha || snapshot.head_sha || null;
+  const live = fetchLivePrHead(repoRoot, snapshot.pr_number);
+  if (live.status !== "found" || !live.head_sha) {
+    return {
+      status: "unknown",
+      reason: live.reason || live.status,
+      pr_number: live.pr_number || snapshot.pr_number || null,
+      old_sha: oldSha,
+      new_sha: live.head_sha || null,
+      reviewed_sha: snapshot.last_reviewed_sha || null,
+      manifest_head_sha: snapshot.head_sha || null,
+      head_ref_name: live.head_ref_name || snapshot.branch || null,
+      next_action: "inspect_pr_head_before_merge",
+    };
+  }
+
+  const differsFromReviewed = Boolean(snapshot.last_reviewed_sha && live.head_sha !== snapshot.last_reviewed_sha);
+  const differsFromManifestHead = Boolean(snapshot.head_sha && live.head_sha !== snapshot.head_sha);
+  const stale = differsFromReviewed || differsFromManifestHead;
+  const staleOldSha = differsFromReviewed
+    ? snapshot.last_reviewed_sha
+    : differsFromManifestHead
+      ? snapshot.head_sha
+      : oldSha;
+
+  return {
+    status: stale ? "stale_ready" : "merge_ready",
+    reason: stale ? "live_pr_head_drift" : null,
+    pr_number: live.pr_number || snapshot.pr_number || null,
+    old_sha: staleOldSha || null,
+    new_sha: live.head_sha,
+    reviewed_sha: snapshot.last_reviewed_sha || null,
+    manifest_head_sha: snapshot.head_sha || null,
+    head_ref_name: live.head_ref_name || snapshot.branch || null,
+    next_action: stale
+      ? "recover_ready_to_review_pending_then_rerun_review"
+      : "proceed_to_merge",
+  };
+}
+
 function compareReviewSnapshot(current, cliArgs) {
   const previousRounds = parsePositiveInteger(
     cliArgs.getArg("--previous-rounds"),
@@ -475,6 +571,7 @@ function runReviewStage(cliArgs) {
     stage: "review",
     repo: repoRoot,
     snapshot,
+    ready_status: buildReadyStatus(snapshot, repoRoot),
     comparison: compareReviewSnapshot(snapshot, cliArgs),
   };
 }

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -71,6 +71,9 @@ function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211", prN
     manifest = updateManifestState(manifest, STATES.CHANGES_REQUESTED, "await_redispatch");
   } else if (state === STATES.ESCALATED) {
     manifest = updateManifestState(manifest, STATES.ESCALATED, "inspect_review_failure");
+  } else if (state === STATES.READY_TO_MERGE) {
+    manifest.review = { ...manifest.review, latest_verdict: "lgtm" };
+    manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
   } else if (state === STATES.DISPATCHED) {
     manifest = { ...manifest, state: STATES.DISPATCHED, next_action: "await_dispatch_result" };
   }
@@ -120,6 +123,28 @@ process.exit(2);
   };
 }
 
+function writeGhPrHeadScript(headRefOid, { number = 334, headRefName = "issue-211" } = {}) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-head-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({
+    number: ${JSON.stringify(number)},
+    headRefName: ${JSON.stringify(headRefName)},
+    headRefOid: ${JSON.stringify(headRefOid)}
+  }));
+  process.exit(0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return {
+    PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+  };
+}
+
 test("changes_requested -> review_pending succeeds after a fresh commit", () => {
   const { repoRoot, manifestPath, runId, worktreePath, branch, initialHead } = setupRepo({ state: STATES.CHANGES_REQUESTED });
   const newHead = addCommitOnBranch(worktreePath, branch);
@@ -151,6 +176,69 @@ test("changes_requested -> review_pending succeeds after a fresh commit", () => 
   assert.match(events, new RegExp(`"state_to":"${STATES.REVIEW_PENDING}"`));
   assert.match(events, new RegExp(`"head_sha":"${newHead}"`));
   assert.match(events, new RegExp(`"last_reviewed_sha":"${initialHead}"`));
+});
+
+test("ready_to_merge -> review_pending succeeds when live PR HEAD drift is objective evidence", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.READY_TO_MERGE,
+    prNumber: 334,
+  });
+  const liveHead = "def4567890abcdef";
+  const env = { ...process.env, ...writeGhPrHeadScript(liveHead, { number: 334 }) };
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR head advanced after passing review",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.previousState, STATES.READY_TO_MERGE);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.nextAction, "run_review");
+  assert.equal(result.readyHeadDrift.prNumber, 334);
+  assert.equal(result.readyHeadDrift.oldSha, initialHead);
+  assert.equal(result.readyHeadDrift.newSha, liveHead);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.next_action, "run_review");
+  assert.equal(manifest.git.head_sha, liveHead);
+  assert.equal(manifest.review.last_reviewed_sha, initialHead);
+
+  const event = readRunEvents(repoRoot, runId).find((entry) => entry.event === "state_recovery");
+  assert.equal(event?.state_from, STATES.READY_TO_MERGE);
+  assert.equal(event?.state_to, STATES.REVIEW_PENDING);
+  assert.equal(event?.pr_number, 334);
+  assert.equal(event?.previous_head_sha, initialHead);
+  assert.equal(event?.new_head_sha, liveHead);
+  assert.equal(event?.head_sha, liveHead);
+  assert.equal(event?.last_reviewed_sha, initialHead);
+  assert.equal(event?.reason, "PR head advanced after passing review");
+});
+
+test("ready_to_merge -> review_pending fails when live PR HEAD has not drifted", () => {
+  const { repoRoot, runId, initialHead } = setupRepo({
+    state: STATES.READY_TO_MERGE,
+    prNumber: 334,
+  });
+  const env = { ...process.env, ...writeGhPrHeadScript(initialHead, { number: 334 }) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "retry review without objective drift",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Refusing stale-ready recovery/);
+  assert.match(result.stderr, /equals review\.last_reviewed_sha/);
 });
 
 test("changes_requested -> review_pending fails when HEAD equals last_reviewed_sha", () => {
@@ -376,8 +464,9 @@ test("unlisted transition (dispatched -> merged) rejected with allowed set liste
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, new RegExp(`Recovery transition '${STATES.DISPATCHED} -> ${STATES.MERGED}' is not whitelisted`));
   assert.match(result.stderr, /Allowed: /);
-  // All four whitelisted transitions must appear in the allowed list.
+  // All whitelisted transitions must appear in the allowed list.
   assert.match(result.stderr, new RegExp(`${STATES.CHANGES_REQUESTED} -> ${STATES.REVIEW_PENDING}`));
+  assert.match(result.stderr, new RegExp(`${STATES.READY_TO_MERGE} -> ${STATES.REVIEW_PENDING}`));
   assert.match(result.stderr, new RegExp(`${STATES.ESCALATED} -> ${STATES.REVIEW_PENDING}`));
   assert.match(result.stderr, new RegExp(`${STATES.ESCALATED} -> ${STATES.CHANGES_REQUESTED}`));
   assert.match(result.stderr, new RegExp(`${STATES.DISPATCHED} -> ${STATES.CHANGES_REQUESTED}`));

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -179,11 +179,11 @@ test("changes_requested -> review_pending succeeds after a fresh commit", () => 
 });
 
 test("ready_to_merge -> review_pending succeeds when live PR HEAD drift is objective evidence", () => {
-  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+  const { repoRoot, manifestPath, runId, worktreePath, branch, initialHead } = setupRepo({
     state: STATES.READY_TO_MERGE,
     prNumber: 334,
   });
-  const liveHead = "def4567890abcdef";
+  const liveHead = addCommitOnBranch(worktreePath, branch, "ready-drift.txt");
   const env = { ...process.env, ...writeGhPrHeadScript(liveHead, { number: 334 }) };
 
   const stdout = execFileSync("node", [
@@ -218,6 +218,31 @@ test("ready_to_merge -> review_pending succeeds when live PR HEAD drift is objec
   assert.equal(event?.head_sha, liveHead);
   assert.equal(event?.last_reviewed_sha, initialHead);
   assert.equal(event?.reason, "PR head advanced after passing review");
+});
+
+test("ready_to_merge -> review_pending fails when retained worktree is not at live PR HEAD", () => {
+  const { repoRoot, runId, initialHead } = setupRepo({
+    state: STATES.READY_TO_MERGE,
+    prNumber: 334,
+  });
+  const liveHead = "def4567890abcdefdef4567890abcdefdef45678";
+  const env = { ...process.env, ...writeGhPrHeadScript(liveHead, { number: 334 }) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR head advanced remotely after passing review",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /retained worktree HEAD/);
+  assert.match(result.stderr, new RegExp(initialHead));
+  assert.match(result.stderr, new RegExp(liveHead));
+  assert.match(result.stderr, /fetch origin issue-211/);
+  assert.match(result.stderr, /reset --hard/);
 });
 
 test("ready_to_merge -> review_pending fails when live PR HEAD has not drifted", () => {

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -226,6 +226,9 @@ function remoteBranchExists(repoRoot, branch) {
 }
 
 function writeFakeGh(logPath, {
+  basePrCandidates = [],
+  baseRefName = "main",
+  defaultBranchName = "main",
   headRefName = "issue-42",
   comments = [],
   commits = [],
@@ -242,6 +245,9 @@ function writeFakeGh(logPath, {
   const statePath = path.join(path.dirname(logPath), "fake-gh-state.json");
   fs.writeFileSync(statePath, JSON.stringify({
     headRefName,
+    baseRefName,
+    defaultBranchName,
+    basePrCandidates,
     comments,
     commits,
     state,
@@ -279,6 +285,7 @@ if (args[0] === "pr" && args[1] === "view") {
   const state = loadState();
   process.stdout.write(JSON.stringify({
     headRefName: state.headRefName,
+    baseRefName: state.baseRefName,
     state: state.state,
     mergeCommit: state.mergeCommit,
     comments: state.comments,
@@ -286,6 +293,20 @@ if (args[0] === "pr" && args[1] === "view") {
     mergeable: state.mergeable,
     statusCheckRollup: state.statusCheckRollup
   }));
+}
+if (args[0] === "pr" && args[1] === "list") {
+  const state = loadState();
+  process.stdout.write(JSON.stringify(state.basePrCandidates || []));
+  process.exit(0);
+}
+if (args[0] === "repo" && args[1] === "view") {
+  const state = loadState();
+  process.stdout.write(JSON.stringify({
+    defaultBranchRef: {
+      name: state.defaultBranchName
+    }
+  }));
+  process.exit(0);
 }
 `, "utf-8");
   fs.chmodSync(ghPath, 0o755);
@@ -794,7 +815,7 @@ test("finalize-run merges and cleans a ready run", () => {
   assert.equal(manifest.cleanup.branch_deleted, true);
 
   const ghLog = fs.readFileSync(logPath, "utf-8");
-  assert.match(ghLog, /pr view 123 --json comments,commits/);
+  assert.match(ghLog, /pr view 123 --json baseRefName,comments,commits,mergeable,statusCheckRollup/);
   assert.match(ghLog, /pr merge 123 --squash/);
   assert.match(ghLog, /issue close 42 --comment Resolved in PR #123/);
 });
@@ -1241,6 +1262,114 @@ test("finalize-run blocks merge when PR has merge conflicts", () => {
 
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.READY_TO_MERGE);
+});
+
+test("finalize-run blocks obvious stacked PR base hazards before merge", () => {
+  const fixture = setupRepo();
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    baseRefName: "issue-688",
+    comments: [DEFAULT_REVIEW_COMMENT],
+    commits: [
+      {
+        oid: fixture.headSha,
+        committedDate: DEFAULT_COMMIT_DATE,
+      },
+    ],
+    basePrCandidates: [
+      {
+        number: 688,
+        state: "CLOSED",
+        mergedAt: null,
+        headRefName: "issue-688",
+        url: "https://example.test/pulls/688",
+      },
+    ],
+  });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  }), /Stacked PR base hazard: PR #123 targets non-default base 'issue-688'/);
+
+  const manifest = readManifest(fixture.manifestPath).data;
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  assert.equal(events.find((event) => event.event === "merge_finalize"), undefined);
+  assert.equal(events.find((event) => event.event === "merge_blocked")?.reason, "stacked_base_hazard:base_pr_closed");
+});
+
+test("finalize-run allows stacked base hazard only with an explicit override reason", () => {
+  const fixture = setupRepo();
+  const result = execFinalize(fixture, {
+    extraArgs: ["--allow-stacked-base-hazard", "base PR was manually merged into the target branch"],
+    ghOptions: {
+      baseRefName: "issue-688",
+      comments: [DEFAULT_REVIEW_COMMENT],
+      commits: [
+        {
+          oid: fixture.headSha,
+          committedDate: DEFAULT_COMMIT_DATE,
+        },
+      ],
+      basePrCandidates: [
+        {
+          number: 688,
+          state: "OPEN",
+          mergedAt: null,
+          headRefName: "issue-688",
+          url: "https://example.test/pulls/688",
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.result.state, STATES.MERGED);
+  assert.equal(result.result.stackedBaseGuard.status, "overridden");
+  assert.equal(result.result.stackedBaseGuard.reason, "base_pr_unmerged");
+  assert.equal(result.result.stackedBaseGuard.overrideReason, "base PR was manually merged into the target branch");
+  assert.match(fs.readFileSync(result.logPath, "utf-8"), /pr list --head issue-688 --state all/);
+});
+
+test("finalize-run skip-review still blocks stacked base hazards", () => {
+  const fixture = setupRepo();
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    baseRefName: "issue-688",
+    commits: [
+      {
+        oid: fixture.headSha,
+        committedDate: DEFAULT_COMMIT_DATE,
+      },
+    ],
+    basePrCandidates: [],
+  });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--skip-review", "operator skip still checks base",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  }), /Stacked PR base hazard: PR #123 targets non-default base 'issue-688'/);
+
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  assert.equal(events.find((event) => event.event === "skip_review"), undefined);
+  assert.equal(events.find((event) => event.event === "merge_blocked")?.reason, "stacked_base_hazard:base_pr_missing");
 });
 
 test("finalize-run blocks merge when CI checks are not successful", () => {

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -1336,6 +1336,14 @@ test("finalize-run allows stacked base hazard only with an explicit override rea
   assert.equal(result.result.stackedBaseGuard.status, "overridden");
   assert.equal(result.result.stackedBaseGuard.reason, "base_pr_unmerged");
   assert.equal(result.result.stackedBaseGuard.overrideReason, "base PR was manually merged into the target branch");
+  const mergeEvent = result.events.find((event) => event.event === "merge_finalize");
+  assert.equal(mergeEvent?.override_class, "stacked_base_hazard");
+  assert.equal(mergeEvent?.affected_head_sha, fixture.headSha);
+  assert.equal(mergeEvent?.prior_state, STATES.READY_TO_MERGE);
+  assert.equal(mergeEvent?.required_reason, "base PR was manually merged into the target branch");
+  assert.equal(mergeEvent?.operator_initiated, true);
+  assert.equal(mergeEvent?.pr_number, 123);
+  assert.match(mergeEvent?.reason || "", /^stacked_base_override:base_pr_unmerged;/);
   assert.match(fs.readFileSync(result.logPath, "utf-8"), /pr list --head issue-688 --state all/);
 });
 

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -28,6 +28,7 @@ const {
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
+const RECOVER_STATE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-state.js");
 const REVIEW_RUNNER_LINE_CAP = 390;
 const REVIEW_RUNNER_FUNCTION_CAP = 12;
 
@@ -330,6 +331,25 @@ if (args[0] === "pr" && args[1] === "comment") {
   const bodyIndex = args.indexOf("--body");
   const body = bodyIndex !== -1 ? args[bodyIndex + 1] : "";
   fs.writeFileSync(${JSON.stringify(capturePath)}, body, "utf-8");
+  process.exit(0);
+}
+process.stderr.write("Unsupported gh invocation: " + args.join(" "));
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function writePrHeadGhScript(repoRoot, { headRefOid, number = 123, headRefName = "issue-42" }) {
+  const filePath = path.join(repoRoot, "gh-pr-head");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({
+    number: ${JSON.stringify(number)},
+    headRefName: ${JSON.stringify(headRefName)},
+    headRefOid: ${JSON.stringify(headRefOid)}
+  }));
   process.exit(0);
 }
 process.stderr.write("Unsupported gh invocation: " + args.join(" "));
@@ -852,6 +872,75 @@ test("pass verdict moves review_pending to ready_to_merge", () => {
   assert.equal(manifest.review.last_quality_review_status, "pass");
   assert.equal(manifest.review.last_quality_execution_status, "pass");
   assert.equal(manifest.review.last_quality_execution_reason, null);
+});
+
+test("review-runner proceeds after audited ready_to_merge HEAD-drift recovery", () => {
+  const { repoRoot, worktreePath, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const oldHead = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+
+  updateManifestRecord(manifestPath, (manifest) => {
+    const reviewed = {
+      ...manifest,
+      review: {
+        ...(manifest.review || {}),
+        rounds: 1,
+        latest_verdict: "lgtm",
+        last_reviewed_sha: oldHead,
+      },
+      git: {
+        ...(manifest.git || {}),
+        head_sha: oldHead,
+      },
+    };
+    return updateManifestState(reviewed, STATES.READY_TO_MERGE, "await_explicit_merge");
+  });
+
+  fs.writeFileSync(path.join(worktreePath, "after-ready.txt"), "advanced\n", "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", "after-ready.txt"], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", "Advance after ready review"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const newHead = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+  writeExecutionEvidence(ensureRunLayout(repoRoot, runId).runDir, newHead);
+  const ghPath = writePrHeadGhScript(repoRoot, { headRefOid: newHead });
+
+  const recovered = JSON.parse(execFileSync("node", [
+    RECOVER_STATE_SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "PR head advanced after ready review",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_GH_BIN: ghPath },
+  }));
+  assert.equal(recovered.previousState, STATES.READY_TO_MERGE);
+  assert.equal(recovered.state, STATES.REVIEW_PENDING);
+
+  const reviewFile = writePassVerdict(repoRoot, "pass-after-ready-drift.json");
+  const result = runPassReview({ repoRoot, runId, doneCriteriaPath, diffPath, reviewFile });
+  const manifest = readManifest(manifestPath).data;
+  const events = readRunEvents(repoRoot, runId);
+  const recoveryEvent = events.find((event) => event.event === "state_recovery");
+
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.round, 2);
+  assert.equal(result.reviewHeadSha, newHead);
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.equal(manifest.review.last_reviewed_sha, newHead);
+  assert.equal(manifest.git.head_sha, newHead);
+  assert.equal(recoveryEvent?.state_from, STATES.READY_TO_MERGE);
+  assert.equal(recoveryEvent?.state_to, STATES.REVIEW_PENDING);
+  assert.equal(recoveryEvent?.previous_head_sha, oldHead);
+  assert.equal(recoveryEvent?.new_head_sha, newHead);
 });
 
 test("mixed TDD rubric pass keeps non-TDD factor scoring unchanged", () => {

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay", "scripts", "run-preflight.js");
+
+function setupReadyRun({ liveHead = "abc123", reviewedSha = "abc123", manifestHead = "abc123" } = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-preflight-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+
+  const runId = createRunId({
+    branch: "issue-691",
+    timestamp: new Date("2026-06-08T00:00:00.000Z"),
+  });
+  const { manifestPath } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-691",
+    baseBranch: "main",
+    issueNumber: 691,
+    worktreePath: repoRoot,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest.git.pr_number = 691;
+  manifest.git.head_sha = manifestHead;
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(ensureRunLayout(repoRoot, runId).runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: ready drift\n", "utf-8");
+  manifest.review = {
+    ...(manifest.review || {}),
+    rounds: 1,
+    latest_verdict: "lgtm",
+    last_reviewed_sha: reviewedSha,
+  };
+  manifest = updateManifestState(
+    updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result"),
+    STATES.REVIEW_PENDING,
+    "run_review"
+  );
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  writeManifest(manifestPath, manifest);
+
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-preflight-gh-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({
+    number: 691,
+    headRefName: "issue-691",
+    headRefOid: ${JSON.stringify(liveHead)}
+  }));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+
+  return { repoRoot, runId, manifestPath, env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` } };
+}
+
+function runReviewPreflight(fixture) {
+  return JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--stage", "review",
+    "--repo", fixture.repoRoot,
+    "--run-id", fixture.runId,
+    "--pr", "691",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: fixture.env,
+  }));
+}
+
+test("review preflight reports unchanged ready_to_merge PR as merge-ready", () => {
+  const fixture = setupReadyRun({ liveHead: "abc123", reviewedSha: "abc123", manifestHead: "abc123" });
+
+  const result = runReviewPreflight(fixture);
+
+  assert.equal(result.snapshot.state, STATES.READY_TO_MERGE);
+  assert.equal(result.ready_status.status, "merge_ready");
+  assert.equal(result.ready_status.pr_number, 691);
+  assert.equal(result.ready_status.old_sha, "abc123");
+  assert.equal(result.ready_status.new_sha, "abc123");
+  assert.equal(result.ready_status.next_action, "proceed_to_merge");
+});
+
+test("review preflight reports ready_to_merge PR with live HEAD drift as stale-ready", () => {
+  const fixture = setupReadyRun({ liveHead: "def456", reviewedSha: "abc123", manifestHead: "abc123" });
+
+  const result = runReviewPreflight(fixture);
+
+  assert.equal(result.snapshot.state, STATES.READY_TO_MERGE);
+  assert.equal(result.ready_status.status, "stale_ready");
+  assert.equal(result.ready_status.pr_number, 691);
+  assert.equal(result.ready_status.old_sha, "abc123");
+  assert.equal(result.ready_status.new_sha, "def456");
+  assert.equal(result.ready_status.reviewed_sha, "abc123");
+  assert.equal(result.ready_status.manifest_head_sha, "abc123");
+  assert.equal(result.ready_status.next_action, "recover_ready_to_review_pending_then_rerun_review");
+});


### PR DESCRIPTION
Closes #691.

## Summary
- Add review preflight `ready_status` for `ready_to_merge` runs by comparing GitHub's live PR `headRefOid` with `review.last_reviewed_sha` / `git.head_sha`.
- Add guarded `recover-state` support for `ready_to_merge -> review_pending` only when live PR HEAD drift is objective evidence; the recovery updates `git.head_sha` and emits `state_recovery` with `pr_number`, `previous_head_sha`, `new_head_sha`, `last_reviewed_sha`, and the operator reason.
- Add a minimal finalize-time stacked-base guard for non-default PR bases, with `--allow-stacked-base-hazard <reason>` as the explicit override.

## Validation
- `node --test tests/relay/scripts/run-preflight.test.js tests/relay-dispatch/scripts/recover-state.test.js tests/relay-dispatch/scripts/relay-events.test.js tests/relay-dispatch/scripts/cli-schema.test.js tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js`
- `node --test tests/relay-review/scripts/review-runner*.test.js`
- `node --test tests/relay-merge/scripts/gate-check.test.js tests/relay-merge/scripts/finalize-run.test.js`
- `git diff --check`
- `git diff --cached --check`

## Deferred
- No semantic reviewer heuristics or PR dependency graph subsystem. The stacked-base check intentionally stays one-level and mechanical: if the PR base is not the default branch, it looks only for an associated PR whose head is that base branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * PR HEAD 변경 감지 시 자동 복구 메커니즘 추가
  * 병합 시 스태킹된 PR 베이스 위험 탐지 및 차단 기능
  * Ready-to-merge 상태에서 실시간 PR HEAD 추적 및 상태 리포팅 강화

* **문서**
  * 상태 복구 가이드 및 전이 조건 명확화
  * 병합 전 안전 검사 플로우 설명 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->