### PR TITLE
Generalize OpenCode route examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Adapter minimum versions, binary overrides, timeouts, capability gates, and prov
 
 ## Configure Routes
 
-Relay distinguishes CLI harnesses from provider/model routes. Names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` describe how relay invokes an agent. The compliance boundary is the provider/model route, for example `example/opencode-model-fast`, `opencode-go/glm-5.2`, `example/pi-model-fast`, or `google/antigravity-cli`.
+Relay distinguishes CLI harnesses from provider/model routes. Names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` describe how relay invokes an agent. The compliance boundary is the provider/model route, for example `example/opencode-model-fast`, `example/pi-model-fast`, or `google/antigravity-cli`.
 
 Without a policy file, relay stays conservative: managed Codex and Claude CLIs are allowed by default, while OpenCode, Pi, Antigravity, and advisory reviewers require explicit route approval.
 
@@ -91,18 +91,6 @@ Common starting points:
 | Approved OpenCode route | `/relay-config Only allow OpenCode through the example/opencode-model-* route at work` |
 | Personal advisory review | `$relay-config Use example/opencode-model-fast for personal advisory review` |
 | Managed only | `/relay-config Keep the default Codex/Claude-only setup` |
-
-For a current personal OpenCode Go GLM-5.2 trial, opt in explicitly instead of relying on bundled defaults:
-
-```bash
-node skills/relay-config/scripts/relay-config.js allow-route 'opencode-go/glm-5.2' \
-  --phase dispatch,review,advisory_review \
-  --executor opencode \
-  --reviewer opencode
-
-node skills/relay-config/scripts/relay-config.js check review opencode opencode-go/glm-5.2
-node skills/relay-config/scripts/relay-config.js check advisory_review opencode opencode-go/glm-5.2
-```
 
 For the full policy model and precedence order, see [docs/model-route-policy.md](docs/model-route-policy.md).
 

--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -2,7 +2,7 @@
 
 Route policy answers one operational question: which provider/model route is allowed to run in each relay phase?
 
-Executor and reviewer names such as `codex`, `claude`, `opencode`, and `pi` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `example/opencode-model-fast`, `opencode-go/glm-5.2`, `example/pi-model-fast`, `example/pi-model-deep`, or `ollama/qwen3`.
+Executor and reviewer names such as `codex`, `claude`, `opencode`, and `pi` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `example/opencode-model-fast`, `example/pi-model-fast`, `example/pi-model-deep`, or `ollama/qwen3`.
 
 Codex and Claude are the managed CLI defaults. In the default managed profile, a model-less Codex or Claude invocation is allowed because the CLI account and its managed default model are the boundary. Generated company defaults should not pin Codex or Claude model names just to make policy explicit. OpenCode, Pi, and Antigravity are routing harnesses, so managed/company profiles must require an explicit provider/model route and an allow rule before they can run.
 
@@ -183,17 +183,17 @@ node skills/relay-config/scripts/relay-config.js allow-route 'ollama/*' \
   --reviewer opencode
 ```
 
-For a current personal OpenCode Go GLM-5.2 trial, keep the route explicit and scoped to the phases you intend to dogfood:
+For any current OpenCode route you want to dogfood, keep the provider/model string explicit and scoped to the phases you intend to enable:
 
 ```bash
-node skills/relay-config/scripts/relay-config.js allow-route 'opencode-go/glm-5.2' \
+node skills/relay-config/scripts/relay-config.js allow-route '<opencode-provider>/<opencode-model>' \
   --phase dispatch,review,advisory_review \
   --executor opencode \
   --reviewer opencode
 
-node skills/relay-config/scripts/relay-config.js check dispatch opencode opencode-go/glm-5.2
-node skills/relay-config/scripts/relay-config.js check review opencode opencode-go/glm-5.2
-node skills/relay-config/scripts/relay-config.js check advisory_review opencode opencode-go/glm-5.2
+node skills/relay-config/scripts/relay-config.js check dispatch opencode '<opencode-provider>/<opencode-model>'
+node skills/relay-config/scripts/relay-config.js check review opencode '<opencode-provider>/<opencode-model>'
+node skills/relay-config/scripts/relay-config.js check advisory_review opencode '<opencode-provider>/<opencode-model>'
 ```
 
 For Pi, use the provider/model route your installed Pi CLI account exposes. Relay does not bundle a Pi route default:
@@ -245,7 +245,7 @@ node skills/relay-config/scripts/relay-config.js check dispatch opencode example
 
 node skills/relay-config/scripts/relay-config.js check dispatch pi example/pi-model-fast
 
-node skills/relay-config/scripts/relay-config.js check review opencode opencode-go/glm-5.2
+node skills/relay-config/scripts/relay-config.js check review opencode example/opencode-model-fast
 
 node skills/relay-config/scripts/relay-config.js check advisory_review opencode example/opencode-model-fast
 ```

--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -29,7 +29,7 @@ Use `/relay-config` to set route policy rather than editing JSON by hand:
 /relay-config Set up relay for my company environment
 /relay-config Only allow OpenCode through example/opencode-model-* at work
 $relay-config Use example/opencode-model-fast for personal advisory review
-$relay-config Use opencode-go/glm-5.2 for personal OpenCode dispatch and review dogfood
+$relay-config Use my selected OpenCode provider/model route for personal dispatch and review dogfood
 ```
 
 Route policy is based on provider/model routes, not only harness names. Managed Codex and Claude CLIs work by default when no policy exists. OpenCode, Pi, and advisory reviewers require explicit route approval. See [model-route-policy.md](model-route-policy.md) for the full policy shape and precedence order.
@@ -139,20 +139,20 @@ OpenCode, Pi, and Antigravity can be used as reviewer roles only when the adapte
 
 OpenCode review uses a bounded parent-process timeout. Set `RELAY_OPENCODE_REVIEW_TIMEOUT` to a positive duration such as `120s`, `10m`, or `1h`; the default is `1800s`. If an OpenCode review returns empty stdout or times out, first validate the CLI/provider path with a minimal `opencode run -m <model> '<json prompt>'` command before treating the route as healthy.
 
-For a current personal OpenCode Go GLM-5.2 route, authorize and check each role explicitly:
+For an OpenCode provider/model route you want to dogfood, authorize and check each role explicitly. Relay does not special-case or bundle any OpenCode model route:
 
 ```bash
-node skills/relay-config/scripts/relay-config.js allow-route 'opencode-go/glm-5.2' \
+node skills/relay-config/scripts/relay-config.js allow-route '<opencode-provider>/<opencode-model>' \
   --phase dispatch,review,advisory_review \
   --executor opencode \
   --reviewer opencode
 
-node skills/relay-config/scripts/relay-config.js check dispatch opencode opencode-go/glm-5.2
-node skills/relay-config/scripts/relay-config.js check review opencode opencode-go/glm-5.2
-node skills/relay-config/scripts/relay-config.js check advisory_review opencode opencode-go/glm-5.2
+node skills/relay-config/scripts/relay-config.js check dispatch opencode '<opencode-provider>/<opencode-model>'
+node skills/relay-config/scripts/relay-config.js check review opencode '<opencode-provider>/<opencode-model>'
+node skills/relay-config/scripts/relay-config.js check advisory_review opencode '<opencode-provider>/<opencode-model>'
 
-opencode run -m opencode-go/glm-5.2 \
-  'Do not edit files. Reply exactly OPENCODE_GLM52_OK and nothing else.'
+opencode run -m '<opencode-provider>/<opencode-model>' \
+  'Do not edit files. Reply exactly OPENCODE_ROUTE_OK and nothing else.'
 ```
 
 Pi can be used as dispatch executor or trusted primary reviewer when `pi` is on `PATH` (or `RELAY_PI_BIN` is set for review), authenticated for the selected provider, and route policy allows the model route:
@@ -224,7 +224,7 @@ For repeatable multi-executor dogfood, use the harness:
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --json --markdown
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . --dispatch-canary --json
 node skills/relay-dispatch/scripts/live-dogfood.js --repo . \
-  --opencode-model opencode-go/glm-5.2 \
+  --opencode-model '<opencode-provider>/<opencode-model>' \
   --pi-model '<pi-provider>/<pi-model>' \
   --scenario opencode-advisory \
   --scenario pi-primary \

--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -21,7 +21,7 @@ Set up relay route policy interactively. The user should not have to memorize co
 
 - The user asks to set up or configure relay
 - The user wants company-safe defaults, personal OpenCode/Pi opt-in, or advisory-review routing
-- The user asks whether a provider/model route such as `example/opencode-model-*` or `opencode-go/glm-5.2` is allowed
+- The user asks whether a provider/model route such as `example/opencode-model-*` or `openai/*` is allowed
 - The user asks to run relay policy doctor/check
 
 ## Do not use when
@@ -49,7 +49,7 @@ Infer from the user's words before asking questions:
 - `company`, `work`, `회사` → company profile
 - `personal`, `home`, `집`, `개인` → personal profile
 - `managed only`, `codex/claude only` → no unmanaged route opt-in
-- routes containing `/`, such as `example/opencode-model-*`, `opencode-go/glm-5.2`, `example/pi-*`, `openai/*`, or `ollama/*` → provider/model route patterns
+- routes containing `/`, such as `example/opencode-model-*`, `example/pi-*`, `openai/*`, or `ollama/*` → provider/model route patterns
 - `advisory`, `reviewer`, `documentation`, `docs` → likely advisory-review phases
 
 Ask only for missing decisions, one at a time. Use plain language and wait for the user's answer. Do not use host-specific question primitives as the only path; this skill must work in both Claude Code and Codex.
@@ -85,7 +85,7 @@ After changes, run:
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" doctor
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" check dispatch opencode example/opencode-model-fast
-node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" check review opencode opencode-go/glm-5.2
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" check review opencode example/opencode-model-fast
 ```
 
 Adjust the `check` tuple to match the actual actor, phase, and route that was enabled. Report denied tuples clearly and do not treat a denied OpenCode/Pi route as configured.
@@ -101,7 +101,7 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
 | `check dispatch opencode example/opencode-model-fast` | `check --phase dispatch --executor opencode --model example/opencode-model-fast` |
-| `check review opencode opencode-go/glm-5.2` | `check --phase review --reviewer opencode --model opencode-go/glm-5.2` |
+| `check review opencode example/opencode-model-fast` | `check --phase review --reviewer opencode --model example/opencode-model-fast` |
 | `check advisory_review pi example/pi-model-fast` | `check --phase advisory_review --reviewer pi --model example/pi-model-fast` |
 
 Full flag forms continue to pass through. Policy semantics live in the sibling `relay-dispatch` script, not this wrapper.

--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -87,9 +87,8 @@ node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --
 node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer codex --advisory-reviewer pi --advisory-reviewer-model openai/gpt-5 --json
 
 # OpenCode dispatch, primary review, or advisory review with an explicit route
-node skills/relay-dispatch/scripts/dispatch.js . --executor opencode --model opencode-go/glm-5.2 -b issue-42 -p "..." --rubric-file rubric.yaml
+node skills/relay-dispatch/scripts/dispatch.js . --executor opencode --model example/opencode-model-fast -b issue-42 -p "..." --rubric-file rubric.yaml
 node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer opencode --reviewer-model example/opencode-model-fast --json
-node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer opencode --reviewer-model opencode-go/glm-5.2 --json
 node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer codex --advisory-reviewer opencode --advisory-reviewer-model example/opencode-model-fast --json
 
 # Antigravity CLI dispatch and primary review

--- a/skills/relay-dispatch/references/model-routing.md
+++ b/skills/relay-dispatch/references/model-routing.md
@@ -5,7 +5,7 @@ Dispatch model routing answers two separate questions:
 - Which executor harness should run the task?
 - Which provider/model route, if any, should that harness use?
 
-Executor names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` select a CLI adapter. Provider/model route strings such as `example/opencode-model-fast`, `opencode-go/glm-5.2`, `openai/gpt-5`, or `google/antigravity-cli` are the model-policy boundary.
+Executor names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` select a CLI adapter. Provider/model route strings such as `example/opencode-model-fast`, `openai/gpt-5`, or `google/antigravity-cli` are the model-policy boundary.
 
 ## Dispatch Selection
 
@@ -27,7 +27,7 @@ OpenCode, Pi, Antigravity, and other unmanaged harnesses should use explicit pro
 
 ## Executor Model Config
 
-Bundled executor model config intentionally ships empty so installs do not select a provider/model route on an operator's behalf. Even current dogfood routes such as `opencode-go/glm-5.2` must be added by the operator or organization. Operators can add local defaults without editing the skill by writing `~/.relay/executors.json`:
+Bundled executor model config intentionally ships empty so installs do not select a provider/model route on an operator's behalf. Operators can add local defaults without editing the skill by writing `~/.relay/executors.json`:
 
 ```json
 {
@@ -50,10 +50,6 @@ The top-level `relay` skill does not invoke `relay-dispatch` as a nested skill. 
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
   --executor opencode --model example/opencode-model-fast \
   -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml
-
-node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
-  --executor opencode --model opencode-go/glm-5.2 \
-  -b glm52-canary --prompt-file /tmp/dispatch.md --rubric-file /tmp/rubric.yaml
 ```
 
 For multi-phase hints:

--- a/skills/relay-dispatch/scripts/live-dogfood.js
+++ b/skills/relay-dispatch/scripts/live-dogfood.js
@@ -864,7 +864,7 @@ function printHelp() {
   console.log("  --command-timeout-ms <ms>             Harness per-command timeout (default: 300000)");
   console.log("");
   console.log("Examples:");
-  console.log("  live-dogfood.js --repo . --opencode-model opencode-go/glm-5.2 --scenario opencode-advisory --json");
+  console.log("  live-dogfood.js --repo . --opencode-model <opencode-provider>/<opencode-model> --scenario opencode-advisory --json");
   console.log("  live-dogfood.js --repo . --pi-model <pi-provider>/<pi-model> --scenario pi-primary --json");
 }
 


### PR DESCRIPTION
## Summary

- Remove the concrete `opencode-go/glm-5.2` route from skill instructions, README, operator examples, and live-dogfood help.
- Keep OpenCode/Pi route setup explicit and flexible through `<provider>/<model>` placeholders and existing `example/*` policy examples.
- Preserve the important boundary: relay still does not bundle or bless provider/model defaults for unmanaged harnesses.

## Verification

- `rg -n "glm-5\\.2|OPENCODE_GLM52|opencode-go/" README.md docs skills tests || true`
- `git diff --check`
- `node --check skills/relay-dispatch/scripts/live-dogfood.js`
- `node --test tests/relay-dispatch/scripts/live-dogfood.test.js tests/relay-dispatch/scripts/docs-defaults.test.js`
- `wc -l skills/relay-config/SKILL.md` -> 107 lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 설정 가이드 및 예시 코드에서 특정 모델 라우트를 범용 형식으로 업데이트했습니다. 사용자는 이제 자신의 provider/model 조합을 더 유연하게 적용할 수 있으며, 설명서의 예시가 더 일반화되어 다양한 환경에 대응합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->