### PR TITLE
Split recovery-assisted pass metrics

### DIFF
--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -16,6 +16,11 @@ const CLI_ARG_OPTIONS = { commandName: "reliability-report", reservedFlags: ["-h
 const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
 const NO_GUIDANCE_DATA_TEXT = "no guidance data available";
 const LINEAGE_VALUES = ["deepening", "repeat", "stale", "new", "newly_scoreable", "unknown"];
+const HANDOFF_RECOVERY_EVENTS = new Set([
+  EVENTS.RECOVER_COMMIT,
+  EVENTS.EXECUTION_EVIDENCE_REBRANDED,
+  EVENTS.STATE_RECOVERY,
+]);
 
 if (hasCliFlag(["--help", "-h"])) {
   console.log(
@@ -71,6 +76,10 @@ function normalizeRoleName(value) {
 }
 
 const normalizeDispatchKey = normalizeRoleName;
+
+function isHandoffRecoveryEvent(event) {
+  return HANDOFF_RECOVERY_EVENTS.has(event?.event);
+}
 
 function normalizeGuidancePacks(value) {
   if (!Array.isArray(value)) return [];
@@ -1374,10 +1383,22 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
     event.failure_class === "timeout" || /timeout/i.test(String(event.reason || ""))
   ));
   const dispatchFailures = dispatchResults.filter((event) => event.state_to === STATES.ESCALATED);
-  const recoveredRunIds = new Set(
+  const recoverCommitRunIds = new Set(
     events
       .filter((event) => event.event === EVENTS.RECOVER_COMMIT && event.run_id)
       .map((event) => event.run_id)
+  );
+  const recoveredRunIds = new Set(
+    events
+      .filter((event) => isHandoffRecoveryEvent(event) && event.run_id)
+      .map((event) => event.run_id)
+  );
+  const passedRunIds = new Set(passedRuns.map(({ data }) => data.run_id).filter(Boolean));
+  const cleanPassedRunIds = new Set(
+    [...passedRunIds].filter((runId) => !recoveredRunIds.has(runId))
+  );
+  const recoveryAssistedPassedRunIds = new Set(
+    [...passedRunIds].filter((runId) => recoveredRunIds.has(runId))
   );
   const reviewLineage = buildReviewLineageSummary({ repoRoot, manifests });
 
@@ -1399,9 +1420,12 @@ function buildReport({ repoRoot, staleHours, now, manifests, events }) {
       median_rounds_to_ready: median(readyRounds),
       stale_open_runs_72h: staleOpenRuns.length,
       pass_rate: ratio(passedRuns.length, manifests.length),
+      clean_pass_rate: ratio(cleanPassedRunIds.size, manifests.length),
+      handoff_recovery_rate: ratio(recoveredRunIds.size, manifests.length),
+      recovery_assisted_pass_rate: ratio(recoveryAssistedPassedRunIds.size, manifests.length),
       dispatch_timeout_rate: ratio(dispatchTimeouts.length, dispatchResults.length),
       dispatch_failure_rate: ratio(dispatchFailures.length, dispatchResults.length),
-      recover_commit_rate: ratio(recoveredRunIds.size, manifests.length),
+      recover_commit_rate: ratio(recoverCommitRunIds.size, manifests.length),
     },
     factor_analysis: buildFactorAnalysis(events),
     rubric_insights: buildRubricInsights(events, manifests),
@@ -1629,6 +1653,11 @@ function main() {
   console.log(`  median_rounds_to_ready: ${report.metrics.median_rounds_to_ready ?? "n/a"}`);
   console.log(`  stale_open_runs_72h: ${report.metrics.stale_open_runs_72h}`);
   console.log(`  pass_rate: ${report.metrics.pass_rate ?? "n/a"}`);
+  console.log(
+    `  pass_breakdown: clean=${report.metrics.clean_pass_rate ?? "n/a"} ` +
+    `recovery_assisted=${report.metrics.recovery_assisted_pass_rate ?? "n/a"} ` +
+    `handoff_recovery=${report.metrics.handoff_recovery_rate ?? "n/a"}`
+  );
   console.log(`  dispatch_timeout_rate: ${report.metrics.dispatch_timeout_rate ?? "n/a"}`);
   console.log(`  dispatch_failure_rate: ${report.metrics.dispatch_failure_rate ?? "n/a"}`);
   console.log(`  recover_commit_rate: ${report.metrics.recover_commit_rate ?? "n/a"}`);

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -327,6 +327,66 @@ test("reliability-report derives the core scorecard from manifests and events", 
   assert.equal(report.bootstrap_exempt_runs, 1);
 });
 
+test("reliability-report splits clean and recovery-assisted pass metrics", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-recovery-pass-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const cleanPass = createRunId({ branch: "clean-pass", timestamp: new Date("2026-04-12T00:00:10.000Z") });
+  const recoveredPass = createRunId({ branch: "recovered-pass", timestamp: new Date("2026-04-12T00:00:11.000Z") });
+  const recoveredFail = createRunId({ branch: "recovered-fail", timestamp: new Date("2026-04-12T00:00:12.000Z") });
+
+  writeRun(repoRoot, {
+    runId: cleanPass,
+    state: STATES.READY_TO_MERGE,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: recoveredPass,
+    state: STATES.MERGED,
+    rounds: 2,
+    updatedAt: recentTs,
+  });
+  writeRun(repoRoot, {
+    runId: recoveredFail,
+    state: STATES.REVIEW_PENDING,
+    rounds: 1,
+    updatedAt: recentTs,
+  });
+
+  appendRunEvent(repoRoot, recoveredPass, {
+    event: "recover_commit",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    round: 1,
+    reason: "completed-uncommitted",
+  });
+  appendRunEvent(repoRoot, recoveredPass, {
+    event: "execution_evidence_rebranded",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.REVIEW_PENDING,
+    round: 1,
+    reason: "evidence rebound to recovery commit",
+  });
+  appendRunEvent(repoRoot, recoveredFail, {
+    event: "state_recovery",
+    state_from: STATES.READY_TO_MERGE,
+    state_to: STATES.REVIEW_PENDING,
+    round: 1,
+    reason: "stale reviewed head",
+  });
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--json"], { encoding: "utf-8" }));
+  const text = execFileSync("node", [SCRIPT, "--repo", repoRoot], { encoding: "utf-8" });
+
+  assert.equal(report.metrics.pass_rate, 0.6667);
+  assert.equal(report.metrics.clean_pass_rate, 0.3333);
+  assert.equal(report.metrics.handoff_recovery_rate, 0.6667);
+  assert.equal(report.metrics.recovery_assisted_pass_rate, 0.3333);
+  assert.equal(report.metrics.recover_commit_rate, 0.3333);
+  assert.match(text, /pass_breakdown: clean=0\.3333 recovery_assisted=0\.3333 handoff_recovery=0\.6667/);
+});
+
 test("reliability-report aggregates review lineage by run and round", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-lineage-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));


### PR DESCRIPTION
## Summary
- Adds clean, handoff-recovery, and recovery-assisted pass rates to `reliability-report --json` while preserving existing `pass_rate` and `recover_commit_rate`.
- Prints the new distinction as a compact `pass_breakdown` line in text output.
- Covers clean pass, recovered pass, and failed recovered run cases in reliability-report tests.

## Verification
- `node --test --test-name-pattern "splits clean" tests/relay-dispatch/scripts/reliability-report.test.js`
- `node --test tests/relay-dispatch/scripts/reliability-report.test.js`
- `git diff --check`

Closes #696