### PR TITLE
Implement ready-light relay routing

### DIFF
--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -71,6 +71,22 @@ probe_signal.scripts: no quality infra detected
 Grade: B
 Action: dispatch allowed
 
+Ready-light compact example
+---------------------------
+Planning profile: ready_light
+Prerequisites count: 1
+Contract factors: 1
+Quality factors: 0
+Substantive total: 1
+Quality ratio: N/A (ready-light S-size task)
+Auto coverage: 1 / 2 checks automated across prerequisites + factors
+Calibration status: skipped (ready-light)
+Risk signals: none
+Rationale: Readiness already returned proceed, but no bypass anchor exists; use one observable contract factor plus the smallest verification path.
+Over-engineering check: Unsupported helper, dependency, or config requirements are over-engineering risk.
+Grade: B
+Action: dispatch allowed
+
 Synthetic populated signal example
 ---------------------------------
 Prerequisites count: 2

--- a/skills/relay-plan/references/task-profile.md
+++ b/skills/relay-plan/references/task-profile.md
@@ -32,6 +32,7 @@ Build the profile from the same planning evidence used for the rubric:
 - probe signal: use available tests, CI, scripts, and detected project tools as evidence for domains and runnable verification, not as automatic commands.
 - historical signal: use stuck factors, divergence hotspots, and average rounds to choose stronger working-style guidance when quality convergence has historically taken more rounds.
 - task risk: surface trust boundaries, state machines, public APIs, migrations, data loss, prompt contracts, or backward-compatibility concerns as `risk_tags`.
+- readiness route: when task risk includes `route_decision: ready_light`, default to `size: S` and `execution_mode: quick` unless risk tags require stronger review or fresh context.
 
 ## Planner Boundary
 
@@ -42,6 +43,7 @@ When `guidance_packs` is non-empty, dispatch prompts render both the profile met
 ## Selection Hints
 
 - Code tasks normally select `surgical-change` and `verification-evidence`.
+- Ready-light code tasks should stay S-size, use one observable contract factor when possible, and avoid unsupported helper, dependency, or config requirements.
 - Documentation tasks select `docs-reader-success`.
 - User-visible product-flow tasks can select `user-replay-evidence` for concise replay notes.
 - Refactors and quality-risk M+ code tasks select `simplify-pass`.

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -173,12 +173,13 @@ function deriveTaskProfile({
   probeSignal = "",
   historicalSignal = "",
   taskRisk = {},
-  size = "M",
+  size,
 } = {}) {
   const probe = parseJsonish(probeSignal);
   const historical = parseJsonish(historicalSignal);
   const risk = parseJsonish(taskRisk);
-  const normalizedSize = normalizeSize(size);
+  const routeDecision = risk.route_decision || risk.routeDecision;
+  const normalizedSize = normalizeSize(size || (routeDecision === "ready_light" ? "S" : "M"));
   const intentText = normalizeText(doneCriteria, taskRisk);
   const signalText = normalizeText(doneCriteria, probeSignal, historicalSignal, taskRisk);
   const change_type = inferChangeType(intentText);

--- a/skills/relay-ready/scripts/probe-readiness.js
+++ b/skills/relay-ready/scripts/probe-readiness.js
@@ -106,6 +106,18 @@ function taskShapeEnvelope(taskShape) {
   };
 }
 
+function riskEnvelope(scoreResult) {
+  const highRisk = Array.isArray(scoreResult?.signals)
+    && scoreResult.signals.some((signal) => (
+      signal?.condition === READINESS_CONDITIONS.HIGH_RISK_KEYWORD
+        && /^fail:/i.test(String(signal.evidence || ""))
+    ));
+  return {
+    high: highRisk,
+    signals: highRisk ? [READINESS_CONDITIONS.HIGH_RISK_KEYWORD] : [],
+  };
+}
+
 function buildEnvelope(scoreResult, elapsedMs) {
   return {
     readiness_score: {
@@ -117,6 +129,7 @@ function buildEnvelope(scoreResult, elapsedMs) {
     next_action: scoreResult.next_action,
     signals_summary: summarizeSignals(scoreResult),
     task_shape: taskShapeEnvelope(scoreResult.task_shape),
+    risk: riskEnvelope(scoreResult),
     elapsed_ms: elapsedMs,
   };
 }
@@ -132,6 +145,7 @@ function buildDegradedEnvelope(error, elapsedMs) {
     next_action: "proceed",
     signals_summary: clipLine(`Readiness probe degraded; proceeding fail-open: ${error.message}`),
     task_shape: emptyTaskShape(),
+    risk: { high: false, signals: [] },
     elapsed_ms: elapsedMs,
   };
 }

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -42,8 +42,9 @@ Branch on the JSON using [preflight-guards.md](references/preflight-guards.md); 
 - `inflight.route == "existing-open-pr"` → set `PR_NUM`, skip Steps 2-3, and review the existing PR.
 - `inflight.route == "existing-merged-pr"` → update the sprint file to `[x]` if present and stop.
 - `inflight.route == "inflight-run"` → resume or inspect that run; continue at its manifest state.
-- `readiness.bypass == true` → proceed to Step 2.
-- `readiness.bypass == false` and `.decision.prompt_allowed == true` → set `SUMMARY=.readiness.signals_summary` and issue exactly `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.
+- `readiness.decision.route_decision == "ready_single"` → proceed to Step 2.
+- `readiness.decision.route_decision == "ready_light"` → proceed to Step 2 with S-size quick planning and compact rubric guidance.
+- `readiness.decision.route_decision in ["readiness_prompt", "needs_split"]` and `.decision.prompt_allowed == true` → set `SUMMARY=.readiness.signals_summary` and issue exactly `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.
 - `chain-y` → invoke relay-ready Q&A, wait, persist the handoff, set `manifest.anchor.readiness`, then resume Step 2.
 - `chain-n` → emit `bypass_override_by_user` from `.decision.branch_labels["chain-n"].event_payload`, then proceed to Step 2.
 - `chain-abort` → emit `readiness_check_failed` from `.decision.branch_labels["chain-abort"].event_payload`, then close the run.

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -33,11 +33,19 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage route 
   - `readiness_check_failed`: emitted by the skill decision layer for `chain-abort`.
   - `readiness_check_failed_nontty`: emitted by the skill decision layer for `noninteractive-fail`.
 - Branch labels:
-  - `bypass`: probe returns `bypass=true`; proceed to Step 2.
+  - `bypass`: route decision is `ready_single`; probe returns `bypass=true`; proceed to Step 2.
+  - `ready-light`: route decision is `ready_light`; readiness returned `next_action=proceed` without a bypass anchor; proceed to Step 2 using S-size quick planning and compact rubric guidance.
   - `chain-y`: probe returns `bypass=false`, prompt is allowed, user answers `y`; invoke relay-ready Q&A, persist the handoff, set `manifest.anchor.readiness`, then resume Step 2.
   - `chain-n`: probe returns `bypass=false`, prompt is allowed, user answers `n`; emit `bypass_override_by_user` with the script's event payload and proceed to Step 2.
   - `chain-abort`: probe returns `bypass=false`, prompt is allowed, user answers `abort`; emit `readiness_check_failed` with the script's event payload and close the run.
-  - `noninteractive-fail`: probe returns `bypass=false` and no prompt is allowed; emit `readiness_check_failed_nontty` with the script's event payload and close the run.
+  - `noninteractive-fail`: route decision is `readiness_prompt` or `needs_split` and no prompt is allowed; emit `readiness_check_failed_nontty` with the script's event payload and close the run.
+
+Route decisions are advisory labels, not lifecycle states:
+
+- `ready_single`: preserve the existing bypass fast path.
+- `ready_light`: keep the task on relay, but plan it as a small quick task with compact rubric guidance.
+- `readiness_prompt`: preserve the existing `qa_needed` prompt or non-interactive failure behavior.
+- `needs_split`: strong task-shape signals indicate decomposition should be considered before dispatch; use the same prompt/non-interactive failure mechanics as readiness gaps.
 
 Do not move the readiness prompt into the script. The exact prompt remains:
 `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -43,7 +43,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage route 
 Route decisions are advisory labels, not lifecycle states:
 
 - `ready_single`: preserve the existing bypass fast path.
-- `ready_light`: keep the task on relay, but plan it as a small quick task with compact rubric guidance.
+- `ready_light`: keep the task on relay, but plan it as a small quick task with compact rubric guidance. This is only for non-bypass `next_action=proceed` results with no high-risk readiness signal.
 - `readiness_prompt`: preserve the existing `qa_needed` prompt or non-interactive failure behavior.
 - `needs_split`: strong task-shape signals indicate decomposition should be considered before dispatch; use the same prompt/non-interactive failure mechanics as readiness gaps.
 

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -235,7 +235,7 @@ function routeDecisionFromReadiness(envelope) {
   if (!envelope) return "readiness_prompt";
   if (envelope.bypass === true) return "ready_single";
   if (envelope.task_shape?.strong === true) return "needs_split";
-  if (envelope.next_action === "proceed" && !hasHighRiskReadinessSignal(envelope)) return "ready_light";
+  if (envelope.bypass === false && envelope.next_action === "proceed" && !hasHighRiskReadinessSignal(envelope)) return "ready_light";
   return "readiness_prompt";
 }
 

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -235,8 +235,14 @@ function routeDecisionFromReadiness(envelope) {
   if (!envelope) return "readiness_prompt";
   if (envelope.bypass === true) return "ready_single";
   if (envelope.task_shape?.strong === true) return "needs_split";
-  if (envelope.next_action === "proceed") return "ready_light";
+  if (envelope.next_action === "proceed" && !hasHighRiskReadinessSignal(envelope)) return "ready_light";
   return "readiness_prompt";
+}
+
+function hasHighRiskReadinessSignal(envelope) {
+  if (envelope?.risk?.high === true) return true;
+  if (Array.isArray(envelope?.risk?.signals) && envelope.risk.signals.includes("high_risk_keyword")) return true;
+  return /\bhigh-risk keyword\b/i.test(String(envelope?.signals_summary || ""));
 }
 
 function buildReadinessDecision(envelope, { promptAllowed }) {
@@ -248,6 +254,7 @@ function buildReadinessDecision(envelope, { promptAllowed }) {
     next_action: envelope?.next_action || null,
     route_decision: routeDecision,
     task_shape: envelope?.task_shape || null,
+    risk: envelope?.risk || null,
     signals_summary: envelope?.signals_summary || null,
   };
 
@@ -645,6 +652,7 @@ module.exports = {
   checkInflightRuns,
   checkPullRequest,
   compareReviewSnapshot,
+  hasHighRiskReadinessSignal,
   main,
   routeDecisionFromReadiness,
   routeFromInflight,

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -231,31 +231,55 @@ function runReadinessProbe({ issueNumber, body, bodyFile, manifestPath }) {
   };
 }
 
+function routeDecisionFromReadiness(envelope) {
+  if (!envelope) return "readiness_prompt";
+  if (envelope.bypass === true) return "ready_single";
+  if (envelope.task_shape?.strong === true) return "needs_split";
+  if (envelope.next_action === "proceed") return "ready_light";
+  return "readiness_prompt";
+}
+
 function buildReadinessDecision(envelope, { promptAllowed }) {
+  const routeDecision = routeDecisionFromReadiness(envelope);
   const score = envelope?.readiness_score || null;
   const commonPayload = {
     readiness_score: score,
     bypass: envelope?.bypass ?? null,
     next_action: envelope?.next_action || null,
+    route_decision: routeDecision,
+    task_shape: envelope?.task_shape || null,
     signals_summary: envelope?.signals_summary || null,
   };
 
   let recommendedBranch = "bypass";
-  if (envelope && envelope.bypass !== true) {
+  if (routeDecision === "ready_light") {
+    recommendedBranch = "ready-light";
+  } else if (routeDecision !== "ready_single") {
     recommendedBranch = promptAllowed ? "prompt" : "noninteractive-fail";
   }
 
   return {
+    route_decision: routeDecision,
     recommended_branch: recommendedBranch,
     prompt_allowed: promptAllowed,
-    prompt_summary: envelope && envelope.bypass !== true && promptAllowed
-      ? envelope.signals_summary
+    prompt_summary: ["readiness_prompt", "needs_split"].includes(routeDecision) && promptAllowed
+      ? envelope?.signals_summary || null
       : null,
     branch_labels: {
       bypass: {
         label: "bypass",
         [EVENT_FIELD]: EVENTS.READINESS_PROBE,
         action: "proceed_to_step_2",
+      },
+      "ready-light": {
+        label: "ready-light",
+        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+        action: "proceed_to_step_2_light_planning",
+        planning_profile: "ready_light",
+        event_payload: {
+          [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+          ...commonPayload,
+        },
       },
       "chain-y": {
         label: "chain-y",
@@ -622,6 +646,7 @@ module.exports = {
   checkPullRequest,
   compareReviewSnapshot,
   main,
+  routeDecisionFromReadiness,
   routeFromInflight,
   snapshotReview,
 };

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -84,6 +84,17 @@ test("rubric validation preserves the S mechanical quality-card example", () => 
   assert.match(text, /Rationale: Recovered Done Criteria require one observable behavior change/);
 });
 
+test("rubric validation documents the ready-light compact rubric boundary", () => {
+  const text = readReference("rubric-validation.md");
+
+  assert.match(text, /Ready-light compact example/);
+  assert.match(text, /Planning profile: ready_light/);
+  assert.match(text, /Contract factors: 1/);
+  assert.match(text, /Quality factors: 0/);
+  assert.match(text, /Unsupported helper, dependency, or config requirements are over-engineering risk/);
+  assert.match(text, /Action: dispatch allowed/);
+});
+
 test("rubric stress-test is gated by ambiguity or risk signal", () => {
   const text = readReference("rubric-stress-test.md");
   const skill = readSkill();

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -80,6 +80,39 @@ test("docs task profile selects docs reader-success guidance", () => {
   assert.ok(!profile.guidance_packs.includes("user-replay-evidence"));
 });
 
+test("ready-light task profile defaults to S-size quick execution", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Update skills/relay/scripts/run-preflight.js so proceed readiness skips Q&A.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: { route_decision: "ready_light" },
+  });
+
+  assert.equal(profile.size, "S");
+  assert.equal(profile.execution_mode, "quick");
+  assert.equal(profile.review_assurance, "standard");
+  assert.ok(profile.guidance_packs.includes("surgical-change"));
+  assert.ok(profile.guidance_packs.includes("verification-evidence"));
+});
+
+test("ready-light task profile does not downshift risk-bearing tasks", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Validate manifest state before applying review gate decisions.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: {
+      route_decision: "ready_light",
+      risk_tags: ["state-machine"],
+    },
+  });
+
+  assert.equal(profile.size, "S");
+  assert.ok(profile.risk_tags.includes("state-machine"));
+  assert.equal(profile.execution_mode, "fresh-context");
+  assert.equal(profile.review_assurance, "hardened");
+  assert.ok(profile.guidance_packs.includes("trust-boundary"));
+});
+
 test("generic code and docs tasks do not select user replay evidence guidance", () => {
   const codeProfile = deriveTaskProfile({
     doneCriteria: "Add a relay-plan parser helper with unit tests and keep the public API backward compatible.",

--- a/tests/relay-ready/scripts/probe-readiness.test.js
+++ b/tests/relay-ready/scripts/probe-readiness.test.js
@@ -38,6 +38,9 @@ function assertEnvelopeShape(envelope) {
   assert.ok(["none", "soft", "strong"].includes(envelope.task_shape.strength));
   assert.equal(typeof envelope.task_shape.strong, "boolean");
   assert.ok(Array.isArray(envelope.task_shape.signals));
+  assert.equal(typeof envelope.risk, "object");
+  assert.equal(typeof envelope.risk.high, "boolean");
+  assert.ok(Array.isArray(envelope.risk.signals));
   assert.equal(typeof envelope.elapsed_ms, "number");
 }
 
@@ -175,6 +178,8 @@ test("non_interactive_abort_signal exposes bypass and escalate action for orches
   assertEnvelopeShape(envelope);
   assert.equal(envelope.bypass, false);
   assert.equal(envelope.next_action, "escalate");
+  assert.equal(envelope.risk.high, true);
+  assert.deepEqual(envelope.risk.signals, ["high_risk_keyword"]);
 });
 
 test("performance_microbenchmark keeps p95 elapsed_ms below 200ms over 50 CLI invocations", (t) => {

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -49,6 +49,21 @@ test("route decision treats proceed without bypass as ready_light in non-interac
   assert.equal(decision.branch_labels["ready-light"].action, "proceed_to_step_2_light_planning");
 });
 
+test("route decision keeps high-risk proceed without bypass on readiness prompt path", () => {
+  const decision = buildReadinessDecision({
+    readiness_score: { clarity: "high", granularity: "high", verifiability: "high" },
+    bypass: false,
+    next_action: "proceed",
+    signals_summary: "Gaps: high-risk keyword.",
+    task_shape: { strength: "none", strong: false, signals: [] },
+    risk: { high: true, signals: ["high_risk_keyword"] },
+  }, { promptAllowed: false });
+
+  assert.equal(decision.route_decision, "readiness_prompt");
+  assert.equal(decision.recommended_branch, "noninteractive-fail");
+  assert.equal(decision.branch_labels["noninteractive-fail"].event_payload.risk.high, true);
+});
+
 test("route decision keeps qa_needed on the existing prompt or noninteractive-fail path", () => {
   const interactive = buildReadinessDecision({
     readiness_score: { clarity: "medium", granularity: "medium", verifiability: "low" },

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -6,6 +6,10 @@ const os = require("os");
 const path = require("path");
 
 const {
+  buildReadinessDecision,
+} = require("../../../skills/relay/scripts/run-preflight");
+
+const {
   STATES,
   createManifestSkeleton,
   createRunId,
@@ -15,6 +19,76 @@ const {
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay", "scripts", "run-preflight.js");
+
+test("route decision treats bypass as ready_single without changing the bypass branch", () => {
+  const decision = buildReadinessDecision({
+    readiness_score: { clarity: "high", granularity: "high", verifiability: "high" },
+    bypass: true,
+    next_action: "proceed",
+    signals_summary: "Ready: bypass conditions passed.",
+    task_shape: { strength: "none", strong: false, signals: [] },
+  }, { promptAllowed: false });
+
+  assert.equal(decision.route_decision, "ready_single");
+  assert.equal(decision.recommended_branch, "bypass");
+  assert.equal(decision.branch_labels.bypass.action, "proceed_to_step_2");
+});
+
+test("route decision treats proceed without bypass as ready_light in non-interactive mode", () => {
+  const decision = buildReadinessDecision({
+    readiness_score: { clarity: "high", granularity: "high", verifiability: "high" },
+    bypass: false,
+    next_action: "proceed",
+    signals_summary: "Not bypassed: next action proceed.",
+    task_shape: { strength: "none", strong: false, signals: [] },
+  }, { promptAllowed: false });
+
+  assert.equal(decision.route_decision, "ready_light");
+  assert.equal(decision.recommended_branch, "ready-light");
+  assert.equal(decision.prompt_summary, null);
+  assert.equal(decision.branch_labels["ready-light"].action, "proceed_to_step_2_light_planning");
+});
+
+test("route decision keeps qa_needed on the existing prompt or noninteractive-fail path", () => {
+  const interactive = buildReadinessDecision({
+    readiness_score: { clarity: "medium", granularity: "medium", verifiability: "low" },
+    bypass: false,
+    next_action: "qa_needed",
+    signals_summary: "Gaps: verifiability=low.",
+    task_shape: { strength: "none", strong: false, signals: [] },
+  }, { promptAllowed: true });
+  const noninteractive = buildReadinessDecision({
+    readiness_score: { clarity: "medium", granularity: "medium", verifiability: "low" },
+    bypass: false,
+    next_action: "qa_needed",
+    signals_summary: "Gaps: verifiability=low.",
+    task_shape: { strength: "none", strong: false, signals: [] },
+  }, { promptAllowed: false });
+
+  assert.equal(interactive.route_decision, "readiness_prompt");
+  assert.equal(interactive.recommended_branch, "prompt");
+  assert.equal(interactive.prompt_summary, "Gaps: verifiability=low.");
+  assert.equal(noninteractive.route_decision, "readiness_prompt");
+  assert.equal(noninteractive.recommended_branch, "noninteractive-fail");
+});
+
+test("route decision exposes needs_split for strong task-shape signals", () => {
+  const decision = buildReadinessDecision({
+    readiness_score: { clarity: "medium", granularity: "low", verifiability: "high" },
+    bypass: false,
+    next_action: "qa_needed",
+    signals_summary: "Gaps: granularity=low, task-shape decomposition.",
+    task_shape: {
+      strength: "strong",
+      strong: true,
+      signals: [{ condition: "broad_scope_language", evidence: "foundation" }],
+    },
+  }, { promptAllowed: false });
+
+  assert.equal(decision.route_decision, "needs_split");
+  assert.equal(decision.recommended_branch, "noninteractive-fail");
+  assert.equal(decision.branch_labels["noninteractive-fail"].event_payload.route_decision, "needs_split");
+});
 
 function setupReadyRun({ liveHead = "abc123", reviewedSha = "abc123", manifestHead = "abc123" } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-preflight-"));

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -64,6 +64,19 @@ test("route decision keeps high-risk proceed without bypass on readiness prompt 
   assert.equal(decision.branch_labels["noninteractive-fail"].event_payload.risk.high, true);
 });
 
+test("route decision fails closed when bypass is missing from proceed envelope", () => {
+  const decision = buildReadinessDecision({
+    readiness_score: { clarity: "high", granularity: "high", verifiability: "high" },
+    next_action: "proceed",
+    signals_summary: "Not bypassed: next action proceed.",
+    task_shape: { strength: "none", strong: false, signals: [] },
+    risk: { high: false, signals: [] },
+  }, { promptAllowed: false });
+
+  assert.equal(decision.route_decision, "readiness_prompt");
+  assert.equal(decision.recommended_branch, "noninteractive-fail");
+});
+
 test("route decision keeps qa_needed on the existing prompt or noninteractive-fail path", () => {
   const interactive = buildReadinessDecision({
     readiness_score: { clarity: "medium", granularity: "medium", verifiability: "low" },


### PR DESCRIPTION
## Summary
- Add relay preflight route decisions for ready_single, ready_light, readiness_prompt, and needs_split without adding a new lifecycle state.
- Preserve existing bypass and qa_needed prompt/non-interactive behavior.
- Make relay-plan treat ready_light as S-size quick planning with compact rubric guidance, while keeping risk-bearing tasks hardened.

Closes #719.
Closes #720.
Closes #721.
Closes #722.
Refs #718.

## Validation
- `node --test tests/relay-ready/scripts/*.test.js` - 64/64 pass
- `node --test tests/relay/scripts/run-preflight.test.js tests/relay-plan/scripts/task-profile.test.js tests/relay-plan/scripts/rubric-reference-contract.test.js` - 38/38 pass
- Broader combined command observed an existing `tests/relay-plan/scripts/tdd-flavor.test.js` fixture failure in `finalize-run.js` (`Unexpected end of JSON input`); reran affected ready-light/readiness suites separately as above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Ready-light 라우팅 결정에 대한 예제 및 선택 가이드 추가
  * 라우팅 로직 및 readiness 라벨의 의미 명확화
  * 작업 프로필 설정 가이드 개선

* **Tests**
  * Ready-light 경계 조건에 대한 테스트 케이스 추가
  * 라우팅 의사결정 로직 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->