### PR TITLE
Enforce ready-light rubric factor bounds

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -119,6 +119,7 @@ const {
   buildGuidanceMetadata,
   extractGuidanceFromPrompt,
   extractReviewAssuranceFromPrompt,
+  extractTaskProfileSummaryFromPrompt,
   GUIDANCE_METADATA_FILENAME,
   persistGuidanceMetadata,
 } = require("./manifest/guidance");
@@ -729,24 +730,42 @@ function enforceRubricPersistence(manifest, runDir) {
 }
 
 function readyLightTaskProfileForDispatch({ promptText, manifest }) {
-  const extractedGuidance = extractGuidanceFromPrompt(promptText);
-  const taskProfile = extractedGuidance?.task_profile_summary
+  // Trust only structured task_profile metadata, not arbitrary examples embedded in the prompt body.
+  const promptProfile = extractTaskProfileSummaryFromPrompt(promptText);
+  const extractedGuidance = promptProfile ? null : extractGuidanceFromPrompt(promptText);
+  return promptProfile
+    || extractedGuidance?.task_profile_summary
     || manifest?.advisory?.guidance?.task_profile_summary
     || null;
-  const promptDeclaresReadyLight = /\b(?:planning_profile|route_decision):\s*["']?ready_light\b/i.test(String(promptText || ""));
-  if (!taskProfile && !promptDeclaresReadyLight) return null;
-  return {
-    ...(taskProfile || {}),
-    ...(promptDeclaresReadyLight ? { planning_profile: "ready_light" } : {}),
-  };
 }
 
-function enforceReadyLightRubricValidation({ rubricFile, promptText, manifest }) {
-  if (!rubricFile) return;
+function readRubricForReadyLightValidation({ rubricFile, manifest, runDir }) {
+  if (rubricFile) {
+    try {
+      return fs.readFileSync(path.resolve(rubricFile), "utf-8");
+    } catch (error) {
+      failEarly(`Failed to read rubric file: ${error.message}`, {
+        error_code: "rubric_file_read_failed",
+        rubric_file: rubricFile,
+      });
+    }
+  }
+
+  if (!hasRubricPath(manifest)) return null;
+  const rubricAnchor = getRubricAnchorStatus(manifest, { runDir, includeContent: true });
+  if (!rubricAnchor.satisfied) {
+    failRubricPersistence(rubricAnchor.error);
+  }
+  return rubricAnchor.content;
+}
+
+function enforceReadyLightRubricValidation({ rubricFile, promptText, manifest, runDir }) {
   const taskProfile = readyLightTaskProfileForDispatch({ promptText, manifest });
   if (!taskProfile) return;
+  const rubricYaml = readRubricForReadyLightValidation({ rubricFile, manifest, runDir });
+  if (!rubricYaml) return;
   const result = validateReadyLightRubric({
-    rubricYaml: fs.readFileSync(path.resolve(rubricFile), "utf-8"),
+    rubricYaml,
     taskProfile,
   });
   if (result.action !== "block") return;
@@ -1184,6 +1203,7 @@ async function main() {
     rubricFile: RUBRIC_FILE,
     promptText: taskPrompt,
     manifest,
+    runDir: manifestRunDir,
   });
 
   const effectiveDispatchModel = resolveEffectiveDispatchModel({

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -117,6 +117,7 @@ const { findUnknownFlags, getPositionals, modeLabel, readArg, schemaHasFlag } = 
 const { formatAttemptsForPrompt, readPreviousAttempts } = require("./manifest/attempts");
 const {
   buildGuidanceMetadata,
+  extractGuidanceFromPrompt,
   extractReviewAssuranceFromPrompt,
   GUIDANCE_METADATA_FILENAME,
   persistGuidanceMetadata,
@@ -135,6 +136,9 @@ const {
 } = require("./agent-adapters/policy");
 const { execGit } = require("./exec");
 const { resolveReasoningEffort } = require("./rubric-size");
+const {
+  validateReadyLightRubric,
+} = require("../../relay-plan/scripts/rubric-validation");
 const {
   assertRelayPolicyGate,
   buildPolicyGateFailureEnvelope,
@@ -724,6 +728,35 @@ function enforceRubricPersistence(manifest, runDir) {
   }
 }
 
+function readyLightTaskProfileForDispatch({ promptText, manifest }) {
+  const extractedGuidance = extractGuidanceFromPrompt(promptText);
+  const taskProfile = extractedGuidance?.task_profile_summary
+    || manifest?.advisory?.guidance?.task_profile_summary
+    || null;
+  const promptDeclaresReadyLight = /\b(?:planning_profile|route_decision):\s*["']?ready_light\b/i.test(String(promptText || ""));
+  if (!taskProfile && !promptDeclaresReadyLight) return null;
+  return {
+    ...(taskProfile || {}),
+    ...(promptDeclaresReadyLight ? { planning_profile: "ready_light" } : {}),
+  };
+}
+
+function enforceReadyLightRubricValidation({ rubricFile, promptText, manifest }) {
+  if (!rubricFile) return;
+  const taskProfile = readyLightTaskProfileForDispatch({ promptText, manifest });
+  if (!taskProfile) return;
+  const result = validateReadyLightRubric({
+    rubricYaml: fs.readFileSync(path.resolve(rubricFile), "utf-8"),
+    taskProfile,
+  });
+  if (result.action !== "block") return;
+  const firstError = result.errors[0] || { code: "ready_light_rubric_invalid", message: "Ready-light rubric validation failed." };
+  failEarly(firstError.message, {
+    error_code: firstError.code,
+    ready_light_rubric_validation: result,
+  });
+}
+
 function validateExecutorCli() {
   let adapter;
   try {
@@ -1146,6 +1179,12 @@ async function main() {
       });
     }
   }
+
+  enforceReadyLightRubricValidation({
+    rubricFile: RUBRIC_FILE,
+    promptText: taskPrompt,
+    manifest,
+  });
 
   const effectiveDispatchModel = resolveEffectiveDispatchModel({
     cliModel: MODEL,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -731,8 +731,16 @@ function enforceRubricPersistence(manifest, runDir) {
 
 function readyLightTaskProfileForDispatch({ promptText, manifest }) {
   // Trust only structured task_profile metadata, not arbitrary examples embedded in the prompt body.
-  const promptProfile = extractTaskProfileSummaryFromPrompt(promptText);
-  const extractedGuidance = promptProfile ? null : extractGuidanceFromPrompt(promptText);
+  let promptProfile = null;
+  let extractedGuidance = null;
+  try {
+    promptProfile = extractTaskProfileSummaryFromPrompt(promptText);
+    extractedGuidance = promptProfile ? null : extractGuidanceFromPrompt(promptText);
+  } catch (error) {
+    failEarly(`Invalid task_profile metadata in prompt: ${error.message}`, {
+      error_code: "task_profile_parse_failed",
+    });
+  }
   const manifestProfile = manifest?.advisory?.guidance?.task_profile_summary || null;
   const taskProfile = promptProfile
     || extractedGuidance?.task_profile_summary
@@ -1170,8 +1178,9 @@ async function main() {
     try {
       REVIEW_ASSURANCE = extractReviewAssuranceFromPrompt(taskPrompt) || REVIEW_ASSURANCE;
     } catch (error) {
-      console.error(`Error: ${error.message}`);
-      process.exit(1);
+      failEarly(`Invalid task_profile metadata in prompt: ${error.message}`, {
+        error_code: "task_profile_parse_failed",
+      });
     }
   }
   if (taskPromptResult.source === "auto-discovered-redispatch" && !JSON_OUT) {

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -733,10 +733,18 @@ function readyLightTaskProfileForDispatch({ promptText, manifest }) {
   // Trust only structured task_profile metadata, not arbitrary examples embedded in the prompt body.
   const promptProfile = extractTaskProfileSummaryFromPrompt(promptText);
   const extractedGuidance = promptProfile ? null : extractGuidanceFromPrompt(promptText);
-  return promptProfile
+  const manifestProfile = manifest?.advisory?.guidance?.task_profile_summary || null;
+  const taskProfile = promptProfile
     || extractedGuidance?.task_profile_summary
-    || manifest?.advisory?.guidance?.task_profile_summary
+    || manifestProfile
     || null;
+  if (!taskProfile) return null;
+
+  const manifestMarker = manifestProfile?.planning_profile || manifestProfile?.route_decision || manifestProfile?.routeDecision || null;
+  if (manifestMarker && !taskProfile.planning_profile && !taskProfile.route_decision && !taskProfile.routeDecision) {
+    return { ...taskProfile, route_decision: manifestMarker };
+  }
+  return taskProfile;
 }
 
 function readRubricForReadyLightValidation({ rubricFile, manifest, runDir }) {

--- a/skills/relay-dispatch/scripts/manifest/guidance.js
+++ b/skills/relay-dispatch/scripts/manifest/guidance.js
@@ -7,7 +7,7 @@ const { normalizeReviewAssurance } = require("./review-assurance");
 const GUIDANCE_METADATA_FILENAME = "guidance-metadata.json";
 const DISPATCH_PROMPT_FILENAME = "dispatch-prompt.md";
 
-const SCALAR_FIELDS = new Set(["size", "change_type", "execution_mode", "review_assurance", "planning_profile"]);
+const SCALAR_FIELDS = new Set(["size", "change_type", "execution_mode", "review_assurance", "planning_profile", "route_decision"]);
 const ARRAY_FIELDS = new Set(["domains", "risk_tags", "guidance_packs", "derivation_inputs"]);
 
 function stripYamlScalar(value) {
@@ -102,10 +102,21 @@ function buildTaskProfileSummary(profile) {
   if (profile.planning_profile) {
     summary.planning_profile = profile.planning_profile;
   }
+  if (profile.route_decision) {
+    summary.route_decision = profile.route_decision;
+  }
   if (profile.review_assurance) {
     summary.review_assurance = normalizeReviewAssurance(profile.review_assurance);
   }
   return summary;
+}
+
+function extractTaskProfileSummaryFromPrompt(promptText) {
+  const block = extractTaskProfileBlock(promptText);
+  if (!block) return null;
+  const profile = parseTaskProfileYaml(block);
+  if (!profile) return null;
+  return buildTaskProfileSummary(profile);
 }
 
 function extractReviewAssuranceFromPrompt(promptText) {
@@ -193,6 +204,7 @@ module.exports = {
   buildGuidanceMetadata,
   DISPATCH_PROMPT_FILENAME,
   extractGuidanceFromPrompt,
+  extractTaskProfileSummaryFromPrompt,
   extractReviewAssuranceFromPrompt,
   GUIDANCE_METADATA_FILENAME,
   persistGuidanceMetadata,

--- a/skills/relay-dispatch/scripts/manifest/guidance.js
+++ b/skills/relay-dispatch/scripts/manifest/guidance.js
@@ -79,8 +79,16 @@ function parseTaskProfileYaml(blockText) {
 
 function extractTaskProfileBlock(promptText) {
   const text = String(promptText || "").replace(/\r\n/g, "\n");
+  const sectionMatch = /^## Task Profile\s*$/m.exec(text);
+  if (!sectionMatch) return null;
+
+  const sectionStart = sectionMatch.index + sectionMatch[0].length;
+  const nextHeadingMatch = /^##\s+/m.exec(text.slice(sectionStart));
+  const sectionText = nextHeadingMatch
+    ? text.slice(sectionStart, sectionStart + nextHeadingMatch.index)
+    : text.slice(sectionStart);
   const fencePattern = /```(?:yaml|yml)?\s*\n([\s\S]*?)```/g;
-  for (const match of text.matchAll(fencePattern)) {
+  for (const match of sectionText.matchAll(fencePattern)) {
     if (/^task_profile:\s*$/m.test(match[1])) {
       return match[1];
     }

--- a/skills/relay-dispatch/scripts/manifest/guidance.js
+++ b/skills/relay-dispatch/scripts/manifest/guidance.js
@@ -7,7 +7,7 @@ const { normalizeReviewAssurance } = require("./review-assurance");
 const GUIDANCE_METADATA_FILENAME = "guidance-metadata.json";
 const DISPATCH_PROMPT_FILENAME = "dispatch-prompt.md";
 
-const SCALAR_FIELDS = new Set(["size", "change_type", "execution_mode", "review_assurance"]);
+const SCALAR_FIELDS = new Set(["size", "change_type", "execution_mode", "review_assurance", "planning_profile"]);
 const ARRAY_FIELDS = new Set(["domains", "risk_tags", "guidance_packs", "derivation_inputs"]);
 
 function stripYamlScalar(value) {
@@ -99,6 +99,9 @@ function buildTaskProfileSummary(profile) {
       ? { derivation_inputs: uniqueStrings(profile.derivation_inputs) }
       : {}),
   };
+  if (profile.planning_profile) {
+    summary.planning_profile = profile.planning_profile;
+  }
   if (profile.review_assurance) {
     summary.review_assurance = normalizeReviewAssurance(profile.review_assurance);
   }

--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -34,6 +34,8 @@ If any Done Criteria check fails, revise or persist clearer planner-authored Don
 
 Prerequisites (hygiene): as many as needed, uncounted. Factors (contract + quality): no hard cap, warning at 8+.
 
+Ready-light is stricter because its purpose is keeping small tasks small. Ready-light S mechanical rubrics default to 1-2 substantive factors. More than 2 substantive factors must warn or block unless an explicit risk or design-bearing rationale is present. Repo-wide lint, typecheck, and test commands stay in prerequisites and do not count as task-specific factors. Unsupported helper, dependency, config, or abstraction requirements are over-engineering risk unless the Done Criteria explicitly require them.
+
 | Size | Contract min | Quality min | Substantive total | Recommended |
 |------|--------------|-------------|-------------------|-------------|
 | S (narrow mechanical outcome, low ambiguity/risk) | ≥ 1 | 0 | 1+ | 1-2 |
@@ -71,8 +73,8 @@ probe_signal.scripts: no quality infra detected
 Grade: B
 Action: dispatch allowed
 
-Ready-light compact example
----------------------------
+Ready-light S mechanical compact example
+----------------------------------------
 Planning profile: ready_light
 Prerequisites count: 1
 Contract factors: 1
@@ -83,7 +85,23 @@ Auto coverage: 1 / 2 checks automated across prerequisites + factors
 Calibration status: skipped (ready-light)
 Risk signals: none
 Rationale: Readiness already returned proceed, but no bypass anchor exists; use one observable contract factor plus the smallest verification path.
-Over-engineering check: Unsupported helper, dependency, or config requirements are over-engineering risk.
+Over-engineering check: Unsupported helper, dependency, config, or abstraction requirements are over-engineering risk.
+Grade: B
+Action: dispatch allowed
+
+Ready-light S design-bearing example
+------------------------------------
+Planning profile: ready_light
+Prerequisites count: 1
+Contract factors: 1
+Quality factors: 1
+Substantive total: 2
+Quality ratio: 50%
+Auto coverage: 1 / 3 checks automated across prerequisites + factors
+Calibration status: compact (ready-light design-bearing)
+Risk signals: design-bearing
+Design-bearing rationale: The task is still S-size, but user-visible copy or prompt wording can be correct in shape while poor in judgment, so one quality factor is justified.
+Over-engineering check: no unsupported helper, dependency, config, or abstraction requirements.
 Grade: B
 Action: dispatch allowed
 
@@ -183,6 +201,9 @@ Grade D means stop and revise the rubric first. Grade C means warn before dispat
 | `vague_criteria` | Criteria contain "good", "proper", "clean", or "appropriate" |
 | `proxy_metric` | Automated checks measure effort or process instead of outcome |
 | `high_factor_count` | 8+ substantive factors |
+| `ready_light_factor_count` | Ready-light S rubric has more than 2 substantive factors without explicit risk or design-bearing rationale |
+| `repo_hygiene_in_factor` | Repo-wide lint, typecheck, or test command is placed in `factors` instead of `prerequisites` |
+| `over_engineering_risk` | Ready-light factor asks for unsupported helper, dependency, config, or abstraction work |
 | `all_contract` | Zero quality coverage on a design-bearing task |
 | `weak_done_criteria` | Done Criteria are not observable, bounded, reviewable, risk-aware, or verifiable |
 

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -2,9 +2,41 @@ const { extractAllFactors } = require("./tdd-flavor");
 
 const SUBSTANTIVE_TIERS = new Set(["contract", "quality"]);
 // Ready-light factors should prove the narrow task contract; broad repo hygiene belongs in prerequisites.
-const REPO_HYGIENE_COMMAND = /^(?:\s*(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\s*|\s*tsc\s+--noEmit\s*|\s*eslint\s*|\s*prettier\s*|\s*node\s+--test\s*|\s*node\s+--test\s+tests(?:\s*$|\/\S*\*\S*)|\s*(?:python\s+-m\s+)?pytest\s*|\s*go\s+test\s+\.\/\.\.\.\s*)$/i;
+const PACKAGE_HYGIENE_COMMAND = /^\s*(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)(?:\s+-{1,2}\S+)*\s*$/i;
+const SIMPLE_HYGIENE_COMMAND = /^\s*(?:tsc\s+--noEmit|eslint|prettier)\s*$/i;
 // Only warn on explicitly unsupported extra structure, not ordinary mentions of helpers/config.
 const OVER_ENGINEERING_TEXT = /\bunsupported\s+(?:helper|dependency|config|configuration|abstraction)\b/i;
+
+function commandTokens(command) {
+  return String(command || "").trim().split(/\s+/).filter(Boolean);
+}
+
+function isRepoWideTarget(token) {
+  return token === "tests" || token.includes("*");
+}
+
+function isRepoWideNodeTest(command) {
+  const tokens = commandTokens(command);
+  const testIndex = tokens.findIndex((token, index) => token === "--test" && index > 0 && tokens[index - 1] === "node");
+  if (testIndex === -1) return false;
+  const targets = tokens.slice(testIndex + 1).filter((token) => !token.startsWith("-"));
+  return targets.length === 0 || targets.some(isRepoWideTarget);
+}
+
+function isRepoWidePytest(command) {
+  const tokens = commandTokens(command);
+  const pytestIndex = tokens[0] === "pytest"
+    ? 0
+    : (tokens[0] === "python" && tokens[1] === "-m" && tokens[2] === "pytest" ? 2 : -1);
+  if (pytestIndex === -1) return false;
+  const targets = tokens.slice(pytestIndex + 1).filter((token) => !token.startsWith("-"));
+  return targets.length === 0 || targets.some(isRepoWideTarget);
+}
+
+function isRepoWideGoTest(command) {
+  const tokens = commandTokens(command);
+  return tokens[0] === "go" && tokens[1] === "test" && tokens[2] === "./...";
+}
 
 function normalizeTaskProfile(taskProfile = {}) {
   return {
@@ -40,7 +72,12 @@ function factorText(factor) {
 }
 
 function isRepoHygieneFactor(factor) {
-  return REPO_HYGIENE_COMMAND.test(String(factor.command || ""));
+  const command = String(factor.command || "");
+  return PACKAGE_HYGIENE_COMMAND.test(command)
+    || SIMPLE_HYGIENE_COMMAND.test(command)
+    || isRepoWideNodeTest(command)
+    || isRepoWidePytest(command)
+    || isRepoWideGoTest(command);
 }
 
 function isOverEngineeringRisk(factor) {

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -1,7 +1,7 @@
 const { extractAllFactors } = require("./tdd-flavor");
 
 const SUBSTANTIVE_TIERS = new Set(["contract", "quality"]);
-const REPO_HYGIENE_COMMAND = /\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b|\btsc\s+--noEmit\b|\beslint\b|\bprettier\b|(?:^|\s)node\s+--test\s*$|\bnode\s+--test\s+(?:tests(?:\s|$)|tests\/\S*\*)|\b(?:python\s+-m\s+)?pytest\b|\bgo\s+test\s+\.\/\.\.\./i;
+const REPO_HYGIENE_COMMAND = /\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b|\btsc\s+--noEmit\b|\beslint\b|\bprettier\b|(?:^|\s)node\s+--test\s*$|\bnode\s+--test\s+(?:tests(?:\s|$)|tests\/\S*\*)|(?:^|\s)(?:python\s+-m\s+)?pytest\s*$|\bgo\s+test\s+\.\/\.\.\./i;
 const OVER_ENGINEERING_TEXT = /\b(?:unsupported\s+)?(?:helper|dependency|config|configuration|abstraction)\b/i;
 
 function normalizeTaskProfile(taskProfile = {}) {

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -12,7 +12,8 @@ function commandTokens(command) {
 }
 
 function isRepoWideTarget(token) {
-  return token === "tests" || token.includes("*");
+  const normalized = String(token || "").replace(/\/+$/, "");
+  return normalized === "tests" || normalized.includes("*");
 }
 
 function isRepoWideNodeTest(command) {

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -27,6 +27,24 @@ const PYTEST_OPTIONS_WITH_VALUE = new Set([
   "--tb",
 ]);
 const PYTEST_SHORT_OPTIONS_WITH_VALUE = new Set(["-c", "-k", "-m", "-o", "-p", "-W"]);
+const TSC_OPTIONS_WITH_VALUE = new Set(["--build", "--module", "--outDir", "--pretty", "--project", "--target"]);
+const TSC_SHORT_OPTIONS_WITH_VALUE = new Set(["-b", "-m", "-p", "-t"]);
+const ESLINT_OPTIONS_WITH_VALUE = new Set([
+  "--config",
+  "--ext",
+  "--format",
+  "--ignore-pattern",
+  "--max-warnings",
+  "--parser",
+  "--parser-options",
+]);
+const ESLINT_SHORT_OPTIONS_WITH_VALUE = new Set(["-c", "-f"]);
+const PRETTIER_OPTIONS_WITH_VALUE = new Set([
+  "--config",
+  "--ignore-path",
+  "--parser",
+  "--plugin",
+]);
 
 function commandTokens(command) {
   return String(command || "").trim().split(/\s+/).filter(Boolean);
@@ -34,7 +52,7 @@ function commandTokens(command) {
 
 function isRepoWideTarget(token) {
   const normalized = String(token || "").replace(/\/+$/, "");
-  return normalized === "tests" || normalized.includes("*");
+  return normalized === "." || normalized === "tests" || normalized.includes("*");
 }
 
 function positionalTargets(tokens, {
@@ -87,7 +105,38 @@ function isRepoWidePytest(command) {
 
 function isRepoWideGoTest(command) {
   const tokens = commandTokens(command);
-  return tokens[0] === "go" && tokens[1] === "test" && tokens[2] === "./...";
+  if (tokens[0] !== "go" || tokens[1] !== "test") return false;
+  const targets = positionalTargets(tokens.slice(2));
+  return targets.length === 0 || targets.some((target) => target === "./..." || isRepoWideTarget(target));
+}
+
+function isRepoWideTypecheck(command) {
+  const tokens = commandTokens(command);
+  if (tokens[0] !== "tsc" || !tokens.some((token) => token === "--noEmit" || token.startsWith("--noEmit="))) return false;
+  const targets = positionalTargets(tokens.slice(1), {
+    longOptionsWithValue: TSC_OPTIONS_WITH_VALUE,
+    shortOptionsWithValue: TSC_SHORT_OPTIONS_WITH_VALUE,
+  });
+  return targets.length === 0 || targets.some(isRepoWideTarget);
+}
+
+function isRepoWideEslint(command) {
+  const tokens = commandTokens(command);
+  if (tokens[0] !== "eslint") return false;
+  const targets = positionalTargets(tokens.slice(1), {
+    longOptionsWithValue: ESLINT_OPTIONS_WITH_VALUE,
+    shortOptionsWithValue: ESLINT_SHORT_OPTIONS_WITH_VALUE,
+  });
+  return targets.length === 0 || targets.some(isRepoWideTarget);
+}
+
+function isRepoWidePrettier(command) {
+  const tokens = commandTokens(command);
+  if (tokens[0] !== "prettier") return false;
+  const targets = positionalTargets(tokens.slice(1), {
+    longOptionsWithValue: PRETTIER_OPTIONS_WITH_VALUE,
+  });
+  return targets.length === 0 || targets.some(isRepoWideTarget);
 }
 
 function normalizeTaskProfile(taskProfile = {}) {
@@ -127,6 +176,9 @@ function isRepoHygieneFactor(factor) {
   const command = String(factor.command || "");
   return PACKAGE_HYGIENE_COMMAND.test(command)
     || SIMPLE_HYGIENE_COMMAND.test(command)
+    || isRepoWideTypecheck(command)
+    || isRepoWideEslint(command)
+    || isRepoWidePrettier(command)
     || isRepoWideNodeTest(command)
     || isRepoWidePytest(command)
     || isRepoWideGoTest(command);

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -79,12 +79,12 @@ function validateReadyLightRubric({ rubricYaml, taskProfile = {} } = {}) {
     ));
   }
 
-  if (substantiveFactors.length > 2) {
+  if (substantiveFactors.length < 1 || substantiveFactors.length > 2) {
     const countIssue = issue(
       "ready_light_factor_count",
-      "Ready-light S rubrics default to 1-2 substantive factors; more requires explicit risk or design-bearing rationale."
+      "Ready-light S rubrics require 1-2 substantive factors by default; more requires explicit risk or design-bearing rationale."
     );
-    if (hasExplicitRiskOrDesignRationale(taskProfile)) {
+    if (substantiveFactors.length > 2 && hasExplicitRiskOrDesignRationale(taskProfile)) {
       warnings.push(countIssue);
     } else {
       errors.push(countIssue);

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -1,0 +1,104 @@
+const { extractAllFactors } = require("./tdd-flavor");
+
+const SUBSTANTIVE_TIERS = new Set(["contract", "quality"]);
+const REPO_HYGIENE_COMMAND = /\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b|\btsc\s+--noEmit\b|\beslint\b|\bprettier\b|\bnode\s+--test\s+(?:tests(?:\s|$)|tests\/\S*\*)/i;
+const OVER_ENGINEERING_TEXT = /\b(?:unsupported\s+)?(?:helper|dependency|config|configuration|abstraction)\b/i;
+
+function normalizeTaskProfile(taskProfile = {}) {
+  return {
+    planning_profile: taskProfile.planning_profile || taskProfile.route_decision || taskProfile.routeDecision || "standard",
+    size: String(taskProfile.size || "M").toUpperCase(),
+    risk_rationale: String(taskProfile.risk_rationale || taskProfile.riskRationale || ""),
+    design_rationale: String(taskProfile.design_rationale || taskProfile.designRationale || ""),
+    risk_tags: Array.isArray(taskProfile.risk_tags) ? taskProfile.risk_tags.map(String) : [],
+  };
+}
+
+function isReadyLightProfile(taskProfile) {
+  const profile = normalizeTaskProfile(taskProfile);
+  return profile.planning_profile === "ready_light";
+}
+
+function hasExplicitRiskOrDesignRationale(taskProfile) {
+  const profile = normalizeTaskProfile(taskProfile);
+  return Boolean(
+    profile.risk_rationale.trim() ||
+    profile.design_rationale.trim() ||
+    profile.risk_tags.includes("design-bearing") ||
+    profile.risk_tags.includes("risk-bearing")
+  );
+}
+
+function isSubstantiveFactor(factor) {
+  return SUBSTANTIVE_TIERS.has(String(factor.tier || "").toLowerCase());
+}
+
+function factorText(factor) {
+  return [factor.name, factor.command, factor.criteria, factor.target].filter(Boolean).join("\n");
+}
+
+function isRepoHygieneFactor(factor) {
+  return REPO_HYGIENE_COMMAND.test(String(factor.command || ""));
+}
+
+function isOverEngineeringRisk(factor) {
+  return OVER_ENGINEERING_TEXT.test(factorText(factor));
+}
+
+function issue(code, message) {
+  return { code, message };
+}
+
+function validateReadyLightRubric({ rubricYaml, taskProfile = {} } = {}) {
+  const factors = extractAllFactors(rubricYaml);
+  const substantiveFactors = factors.filter(isSubstantiveFactor);
+  const errors = [];
+  const warnings = [];
+
+  if (!isReadyLightProfile(taskProfile)) {
+    return {
+      action: "allow",
+      substantive_total: substantiveFactors.length,
+      errors,
+      warnings,
+    };
+  }
+
+  const hygieneFactors = substantiveFactors.filter(isRepoHygieneFactor);
+  if (hygieneFactors.length > 0) {
+    errors.push(issue(
+      "repo_hygiene_in_factor",
+      "Repo-wide lint, typecheck, or test commands belong in prerequisites, not ready-light factors."
+    ));
+  }
+
+  if (substantiveFactors.some(isOverEngineeringRisk)) {
+    warnings.push(issue(
+      "over_engineering_risk",
+      "Unsupported helper, dependency, config, or abstraction requirements are over-engineering risk for ready-light rubrics."
+    ));
+  }
+
+  if (substantiveFactors.length > 2) {
+    const countIssue = issue(
+      "ready_light_factor_count",
+      "Ready-light S rubrics default to 1-2 substantive factors; more requires explicit risk or design-bearing rationale."
+    );
+    if (hasExplicitRiskOrDesignRationale(taskProfile)) {
+      warnings.push(countIssue);
+    } else {
+      errors.push(countIssue);
+    }
+  }
+
+  return {
+    action: errors.length > 0 ? "block" : "allow",
+    substantive_total: substantiveFactors.length,
+    errors,
+    warnings,
+  };
+}
+
+module.exports = {
+  validateReadyLightRubric,
+};

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -6,6 +6,27 @@ const PACKAGE_HYGIENE_COMMAND = /^\s*(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint
 const SIMPLE_HYGIENE_COMMAND = /^\s*(?:tsc\s+--noEmit|eslint|prettier)\s*$/i;
 // Only warn on explicitly unsupported extra structure, not ordinary mentions of helpers/config.
 const OVER_ENGINEERING_TEXT = /\bunsupported\s+(?:helper|dependency|config|configuration|abstraction)\b/i;
+const NODE_TEST_OPTIONS_WITH_VALUE = new Set([
+  "--test-concurrency",
+  "--test-name-pattern",
+  "--test-reporter",
+  "--test-reporter-destination",
+  "--test-shard",
+  "--test-timeout",
+]);
+const PYTEST_OPTIONS_WITH_VALUE = new Set([
+  "--capture",
+  "--confcutdir",
+  "--cov",
+  "--cov-report",
+  "--import-mode",
+  "--junit-xml",
+  "--junitxml",
+  "--maxfail",
+  "--rootdir",
+  "--tb",
+]);
+const PYTEST_SHORT_OPTIONS_WITH_VALUE = new Set(["-c", "-k", "-m", "-o", "-p", "-W"]);
 
 function commandTokens(command) {
   return String(command || "").trim().split(/\s+/).filter(Boolean);
@@ -16,11 +37,38 @@ function isRepoWideTarget(token) {
   return normalized === "tests" || normalized.includes("*");
 }
 
+function positionalTargets(tokens, {
+  longOptionsWithValue = new Set(),
+  shortOptionsWithValue = new Set(),
+} = {}) {
+  const targets = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.startsWith("--")) {
+      const [optionName] = token.split("=", 1);
+      if (!token.includes("=") && longOptionsWithValue.has(optionName)) {
+        index += 1;
+      }
+      continue;
+    }
+    if (/^-[A-Za-z]+$/.test(token)) {
+      if (shortOptionsWithValue.has(token)) {
+        index += 1;
+      }
+      continue;
+    }
+    targets.push(token);
+  }
+  return targets;
+}
+
 function isRepoWideNodeTest(command) {
   const tokens = commandTokens(command);
   const testIndex = tokens.findIndex((token, index) => token === "--test" && index > 0 && tokens[index - 1] === "node");
   if (testIndex === -1) return false;
-  const targets = tokens.slice(testIndex + 1).filter((token) => !token.startsWith("-"));
+  const targets = positionalTargets(tokens.slice(testIndex + 1), {
+    longOptionsWithValue: NODE_TEST_OPTIONS_WITH_VALUE,
+  });
   return targets.length === 0 || targets.some(isRepoWideTarget);
 }
 
@@ -30,7 +78,10 @@ function isRepoWidePytest(command) {
     ? 0
     : (tokens[0] === "python" && tokens[1] === "-m" && tokens[2] === "pytest" ? 2 : -1);
   if (pytestIndex === -1) return false;
-  const targets = tokens.slice(pytestIndex + 1).filter((token) => !token.startsWith("-"));
+  const targets = positionalTargets(tokens.slice(pytestIndex + 1), {
+    longOptionsWithValue: PYTEST_OPTIONS_WITH_VALUE,
+    shortOptionsWithValue: PYTEST_SHORT_OPTIONS_WITH_VALUE,
+  });
   return targets.length === 0 || targets.some(isRepoWideTarget);
 }
 

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -1,7 +1,7 @@
 const { extractAllFactors } = require("./tdd-flavor");
 
 const SUBSTANTIVE_TIERS = new Set(["contract", "quality"]);
-const REPO_HYGIENE_COMMAND = /\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b|\btsc\s+--noEmit\b|\beslint\b|\bprettier\b|\bnode\s+--test\s+(?:tests(?:\s|$)|tests\/\S*\*)/i;
+const REPO_HYGIENE_COMMAND = /\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b|\btsc\s+--noEmit\b|\beslint\b|\bprettier\b|(?:^|\s)node\s+--test\s*$|\bnode\s+--test\s+(?:tests(?:\s|$)|tests\/\S*\*)|\b(?:python\s+-m\s+)?pytest\b|\bgo\s+test\s+\.\/\.\.\./i;
 const OVER_ENGINEERING_TEXT = /\b(?:unsupported\s+)?(?:helper|dependency|config|configuration|abstraction)\b/i;
 
 function normalizeTaskProfile(taskProfile = {}) {

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -1,8 +1,10 @@
 const { extractAllFactors } = require("./tdd-flavor");
 
 const SUBSTANTIVE_TIERS = new Set(["contract", "quality"]);
-const REPO_HYGIENE_COMMAND = /\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b|\btsc\s+--noEmit\b|\beslint\b|\bprettier\b|(?:^|\s)node\s+--test\s*$|\bnode\s+--test\s+(?:tests(?:\s|$)|tests\/\S*\*)|(?:^|\s)(?:python\s+-m\s+)?pytest\s*$|\bgo\s+test\s+\.\/\.\.\./i;
-const OVER_ENGINEERING_TEXT = /\b(?:unsupported\s+)?(?:helper|dependency|config|configuration|abstraction)\b/i;
+// Ready-light factors should prove the narrow task contract; broad repo hygiene belongs in prerequisites.
+const REPO_HYGIENE_COMMAND = /^(?:\s*(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|lint|typecheck|check)\s*|\s*tsc\s+--noEmit\s*|\s*eslint\s*|\s*prettier\s*|\s*node\s+--test\s*|\s*node\s+--test\s+tests(?:\s*$|\/\S*\*\S*)|\s*(?:python\s+-m\s+)?pytest\s*|\s*go\s+test\s+\.\/\.\.\.\s*)$/i;
+// Only warn on explicitly unsupported extra structure, not ordinary mentions of helpers/config.
+const OVER_ENGINEERING_TEXT = /\bunsupported\s+(?:helper|dependency|config|configuration|abstraction)\b/i;
 
 function normalizeTaskProfile(taskProfile = {}) {
   return {
@@ -79,6 +81,7 @@ function validateReadyLightRubric({ rubricYaml, taskProfile = {} } = {}) {
     ));
   }
 
+  // A compact ready-light rubric needs at least one reviewable contract and should stay at two by default.
   if (substantiveFactors.length < 1 || substantiveFactors.length > 2) {
     const countIssue = issue(
       "ready_light_factor_count",

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -156,8 +156,10 @@ function normalizeTaskProfile(profile) {
   const change_type = CHANGE_TYPES.has(profile?.change_type) ? profile.change_type : "feature";
   const execution_mode = EXECUTION_MODES.has(profile?.execution_mode) ? profile.execution_mode : "standard";
   const review_assurance = normalizeReviewAssurance(profile?.review_assurance);
+  const route_decision = profile?.route_decision || profile?.routeDecision || profile?.planning_profile || null;
   return {
     size: normalizeSize(profile?.size),
+    ...(route_decision ? { route_decision: String(route_decision) } : {}),
     change_type,
     domains: asStringArray(profile?.domains),
     risk_tags: asStringArray(profile?.risk_tags),
@@ -199,6 +201,7 @@ function deriveTaskProfile({
 
   return {
     size: normalizedSize,
+    ...(routeDecision ? { route_decision: String(routeDecision) } : {}),
     change_type,
     domains,
     risk_tags,
@@ -231,6 +234,7 @@ function renderTaskProfileBlock(taskProfile) {
     "```yaml",
     "task_profile:",
     `  size: ${yamlScalar(profile.size)}`,
+    ...(profile.route_decision ? [`  route_decision: ${yamlScalar(profile.route_decision)}`] : []),
     `  change_type: ${yamlScalar(profile.change_type)}`,
     renderYamlArray("domains", profile.domains, 2),
     renderYamlArray("risk_tags", profile.risk_tags, 2),

--- a/skills/relay-plan/scripts/task-profile.js
+++ b/skills/relay-plan/scripts/task-profile.js
@@ -180,7 +180,7 @@ function deriveTaskProfile({
   const probe = parseJsonish(probeSignal);
   const historical = parseJsonish(historicalSignal);
   const risk = parseJsonish(taskRisk);
-  const routeDecision = risk.route_decision || risk.routeDecision;
+  const routeDecision = risk.route_decision || risk.routeDecision || risk.planning_profile;
   const normalizedSize = normalizeSize(size || (routeDecision === "ready_light" ? "S" : "M"));
   const intentText = normalizeText(doneCriteria, taskRisk);
   const signalText = normalizeText(doneCriteria, probeSignal, historicalSignal, taskRisk);

--- a/skills/relay-plan/scripts/tdd-flavor.js
+++ b/skills/relay-plan/scripts/tdd-flavor.js
@@ -64,9 +64,14 @@ function extractAllFactors(rubricYaml) {
       blockScalar = null;
       return;
     }
+    const nonEmpty = blockScalar.lines.filter((line) => line.trim() !== "");
+    const minIndent = nonEmpty.length
+      ? Math.min(...nonEmpty.map((line) => line.match(/^\s*/)[0].length))
+      : 0;
+    const normalized = blockScalar.lines.map((line) => line.slice(minIndent));
     current[blockScalar.field] = blockScalar.style === "|"
-      ? blockScalar.lines.join("\n").trim()
-      : blockScalar.lines.map((line) => line.trim()).join(" ").trim();
+      ? normalized.join("\n").trimEnd()
+      : normalized.map((line) => line.trim()).join(" ").trim();
     blockScalar = null;
   }
 
@@ -89,14 +94,17 @@ function extractAllFactors(rubricYaml) {
   for (const line of String(rubricYaml || "").split(/\r?\n/)) {
     if (blockScalar) {
       const indent = line.match(/^\s*/)[0].length;
+      // Blank lines are part of the scalar body and should not end the block.
       if (/^\s*$/.test(line)) {
         blockScalar.lines.push("");
         continue;
       }
+      // YAML block scalar content is indented deeper than the field that opened it.
       if (indent > blockScalar.indent) {
         blockScalar.lines.push(line);
         continue;
       }
+      // Returning to the field indentation closes the scalar before normal parsing resumes.
       finishBlockScalar();
     }
 

--- a/skills/relay-plan/scripts/tdd-flavor.js
+++ b/skills/relay-plan/scripts/tdd-flavor.js
@@ -30,11 +30,26 @@ function createFactor() {
     name: null,
     tier: null,
     type: null,
+    command: null,
+    criteria: null,
+    target: null,
     tdd_anchor: null,
     tdd_runner: null,
     fix_hint: null,
   };
 }
+
+const FACTOR_FIELDS = new Set([
+  "name",
+  "tier",
+  "type",
+  "command",
+  "criteria",
+  "target",
+  "tdd_anchor",
+  "tdd_runner",
+  "fix_hint",
+]);
 
 function extractAllFactors(rubricYaml) {
   const factors = [];
@@ -74,14 +89,14 @@ function extractAllFactors(rubricYaml) {
       pushCurrent();
       current = createFactor();
       currentIndent = factorStart[1].length;
-      if (["name", "tier", "type", "tdd_anchor", "tdd_runner", "fix_hint"].includes(factorStart[2])) {
+      if (FACTOR_FIELDS.has(factorStart[2])) {
         current[factorStart[2]] = unquoteYamlScalar(factorStart[3]);
       }
       continue;
     }
 
     if (!current || indent <= currentIndent) continue;
-    const field = line.match(/^\s*(name|tier|type|tdd_anchor|tdd_runner|fix_hint):\s*(.*?)\s*$/);
+    const field = line.match(/^\s*(name|tier|type|command|criteria|target|tdd_anchor|tdd_runner|fix_hint):\s*(.*?)\s*$/);
     if (field) {
       current[field[1]] = unquoteYamlScalar(field[2]);
     }

--- a/skills/relay-plan/scripts/tdd-flavor.js
+++ b/skills/relay-plan/scripts/tdd-flavor.js
@@ -57,14 +57,40 @@ function extractAllFactors(rubricYaml) {
   let factorsIndent = null;
   let current = null;
   let currentIndent = null;
+  let blockScalar = null;
+
+  function finishBlockScalar() {
+    if (!blockScalar || !current) {
+      blockScalar = null;
+      return;
+    }
+    current[blockScalar.field] = blockScalar.style === "|"
+      ? blockScalar.lines.join("\n").trim()
+      : blockScalar.lines.map((line) => line.trim()).join(" ").trim();
+    blockScalar = null;
+  }
 
   function pushCurrent() {
+    finishBlockScalar();
     if (current) factors.push(current);
     current = null;
     currentIndent = null;
   }
 
   for (const line of String(rubricYaml || "").split(/\r?\n/)) {
+    if (blockScalar) {
+      const indent = line.match(/^\s*/)[0].length;
+      if (/^\s*$/.test(line)) {
+        blockScalar.lines.push("");
+        continue;
+      }
+      if (indent > blockScalar.indent) {
+        blockScalar.lines.push(line);
+        continue;
+      }
+      finishBlockScalar();
+    }
+
     if (/^\s*(#.*)?$/.test(line)) continue;
 
     const section = line.match(/^(\s*)([A-Za-z_][\w.-]*):\s*(.*?)\s*$/);
@@ -98,7 +124,17 @@ function extractAllFactors(rubricYaml) {
     if (!current || indent <= currentIndent) continue;
     const field = line.match(/^\s*(name|tier|type|command|criteria|target|tdd_anchor|tdd_runner|fix_hint):\s*(.*?)\s*$/);
     if (field) {
-      current[field[1]] = unquoteYamlScalar(field[2]);
+      const value = unquoteYamlScalar(field[2]);
+      if (value === ">" || value === "|") {
+        blockScalar = {
+          field: field[1],
+          style: value,
+          indent,
+          lines: [],
+        };
+      } else {
+        current[field[1]] = value;
+      }
     }
   }
 

--- a/skills/relay-plan/scripts/tdd-flavor.js
+++ b/skills/relay-plan/scripts/tdd-flavor.js
@@ -70,6 +70,15 @@ function extractAllFactors(rubricYaml) {
     blockScalar = null;
   }
 
+  function startBlockScalar(field, style, indent) {
+    blockScalar = {
+      field,
+      style,
+      indent,
+      lines: [],
+    };
+  }
+
   function pushCurrent() {
     finishBlockScalar();
     if (current) factors.push(current);
@@ -116,7 +125,12 @@ function extractAllFactors(rubricYaml) {
       current = createFactor();
       currentIndent = factorStart[1].length;
       if (FACTOR_FIELDS.has(factorStart[2])) {
-        current[factorStart[2]] = unquoteYamlScalar(factorStart[3]);
+        const value = unquoteYamlScalar(factorStart[3]);
+        if (value === ">" || value === "|") {
+          startBlockScalar(factorStart[2], value, currentIndent + 2);
+        } else {
+          current[factorStart[2]] = value;
+        }
       }
       continue;
     }
@@ -126,12 +140,7 @@ function extractAllFactors(rubricYaml) {
     if (field) {
       const value = unquoteYamlScalar(field[2]);
       if (value === ">" || value === "|") {
-        blockScalar = {
-          field: field[1],
-          style: value,
-          indent,
-          lines: [],
-        };
+        startBlockScalar(field[1], value, indent);
       } else {
         current[field[1]] = value;
       }

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -891,6 +891,40 @@ function standardPromptWithReadyLightExample() {
   ].join("\n");
 }
 
+function standardPromptWithTaskProfileExampleBeforeActiveProfile() {
+  return [
+    "# Dispatch: Standard docs task",
+    "",
+    "Update docs that include this example metadata:",
+    "",
+    "```yaml",
+    "task_profile:",
+    "  planning_profile: ready_light",
+    "  size: S",
+    "  guidance_packs:",
+    "    - surgical-change",
+    "```",
+    "",
+    "The example above is content, not the active task profile.",
+    "",
+    "## Task Profile",
+    "",
+    "```yaml",
+    "task_profile:",
+    "  planning_profile: standard",
+    "  size: M",
+    "  change_type: docs",
+    "  domains:",
+    "    - docs",
+    "  risk_tags: []",
+    "  execution_mode: standard",
+    "  review_assurance: standard",
+    "  guidance_packs:",
+    "    - docs-reader-success",
+    "```",
+  ].join("\n");
+}
+
 function readyLightRubricYaml() {
   return [
     "rubric:",
@@ -4218,6 +4252,34 @@ test("dispatch ignores ready-light examples outside structured task profile meta
   const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
     "-b", "issue-standard-ready-light-example",
     "--prompt", standardPromptWithReadyLightExample(),
+    "--rubric-file", rubricFile,
+    "--dry-run", "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(proc.status, 0, proc.stderr || proc.stdout);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.mode, "new");
+
+  fs.unlinkSync(rubricFile);
+});
+
+test("dispatch ignores task_profile examples before active Task Profile metadata", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const rubricFile = path.join(os.tmpdir(), `rubric-standard-task-profile-example-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricFile, threeFactorRubricYaml(), "utf-8");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-standard-task-profile-example",
+    "--prompt", standardPromptWithTaskProfileExampleBeforeActiveProfile(),
     "--rubric-file", rubricFile,
     "--dry-run", "--json",
   ])], {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -827,6 +827,31 @@ function guidancePrompt({ task = "guidance test task", reviewAssurance = null } 
   ].join("\n");
 }
 
+function readyLightPrompt({ task = "ready-light dispatch validation" } = {}) {
+  return [
+    "# Dispatch: Ready-light validation",
+    "",
+    task,
+    "",
+    "## Task Profile",
+    "",
+    "```yaml",
+    "task_profile:",
+    "  planning_profile: ready_light",
+    "  size: S",
+    "  change_type: feature",
+    "  domains:",
+    "    - relay-plan",
+    "  risk_tags: []",
+    "  execution_mode: quick",
+    "  review_assurance: standard",
+    "  guidance_packs:",
+    "    - surgical-change",
+    "    - verification-evidence",
+    "```",
+  ].join("\n");
+}
+
 function setupDryRunFixtureRepo() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-dry-run-"));
   const repoRoot = path.join(root, "repo");
@@ -4074,6 +4099,36 @@ test("dispatch dry-run includes rubric file info", () => {
   ], env));
 
   assert.equal(result.rubricFile, rubricFile);
+
+  fs.unlinkSync(rubricFile);
+});
+
+test("dispatch rejects invalid ready-light rubric before accepting rubric file", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const rubricFile = path.join(os.tmpdir(), `rubric-ready-light-invalid-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricFile, "rubric:\n  factors: []\n", "utf-8");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-ready-light-invalid-rubric",
+    "--prompt", readyLightPrompt(),
+    "--rubric-file", rubricFile,
+    "--dry-run", "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.error_code, "ready_light_factor_count");
+  assert.match(result.error, /Ready-light S rubrics require 1-2 substantive factors/);
 
   fs.unlinkSync(rubricFile);
 });

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -852,6 +852,28 @@ function readyLightPrompt({ task = "ready-light dispatch validation" } = {}) {
   ].join("\n");
 }
 
+function invalidReviewAssuranceTaskProfilePrompt() {
+  return [
+    "# Dispatch: Invalid task profile metadata",
+    "",
+    "## Task Profile",
+    "",
+    "```yaml",
+    "task_profile:",
+    "  planning_profile: ready_light",
+    "  size: S",
+    "  change_type: feature",
+    "  domains:",
+    "    - relay-plan",
+    "  risk_tags: []",
+    "  execution_mode: quick",
+    "  review_assurance: hardend",
+    "  guidance_packs:",
+    "    - surgical-change",
+    "```",
+  ].join("\n");
+}
+
 function plannerReadyLightPromptWithoutExplicitMarker() {
   return [
     "# Dispatch: Planner ready-light validation",
@@ -4235,6 +4257,36 @@ test("dispatch rejects invalid ready-light rubric before accepting rubric file",
   assert.equal(result.status, "failed");
   assert.equal(result.error_code, "ready_light_factor_count");
   assert.match(result.error, /Ready-light S rubrics require 1-2 substantive factors/);
+
+  fs.unlinkSync(rubricFile);
+});
+
+test("dispatch reports invalid task_profile metadata through failEarly", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const rubricFile = path.join(os.tmpdir(), `rubric-invalid-task-profile-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricFile, readyLightRubricYaml(), "utf-8");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-invalid-task-profile",
+    "--prompt", invalidReviewAssuranceTaskProfilePrompt(),
+    "--rubric-file", rubricFile,
+    "--dry-run", "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.error_code, "task_profile_parse_failed");
+  assert.match(result.error, /Invalid task_profile metadata/);
 
   fs.unlinkSync(rubricFile);
 });

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -852,6 +852,30 @@ function readyLightPrompt({ task = "ready-light dispatch validation" } = {}) {
   ].join("\n");
 }
 
+function plannerReadyLightPromptWithoutExplicitMarker() {
+  return [
+    "# Dispatch: Planner ready-light validation",
+    "",
+    "Planner-rendered prompt from an existing ready-light route.",
+    "",
+    "## Task Profile",
+    "",
+    "```yaml",
+    "task_profile:",
+    "  size: S",
+    "  change_type: feature",
+    "  domains:",
+    "    - relay-plan",
+    "  risk_tags: []",
+    "  execution_mode: quick",
+    "  review_assurance: standard",
+    "  guidance_packs:",
+    "    - surgical-change",
+    "    - verification-evidence",
+    "```",
+  ].join("\n");
+}
+
 function standardPromptWithReadyLightExample() {
   return [
     "# Dispatch: Standard docs task",
@@ -4244,6 +4268,58 @@ test("dispatch validates retained ready-light rubric on resume", () => {
   assert.notEqual(proc.status, 0);
   const result = JSON.parse(proc.stdout);
   assert.equal(result.status, "failed");
+  assert.equal(result.error_code, "ready_light_factor_count");
+
+  fs.unlinkSync(rubricFile);
+});
+
+test("dispatch preserves manifest ready-light marker when prompt profile omits it", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const rubricFile = path.join(os.tmpdir(), `rubric-ready-light-manifest-marker-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricFile, readyLightRubricYaml(), "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-ready-light-manifest-marker",
+    "--prompt", readyLightPrompt(),
+    "--rubric-file", rubricFile,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  const manifest = {
+    ...record.data,
+    advisory: {
+      ...(record.data.advisory || {}),
+      guidance: {
+        guidance_packs: ["surgical-change", "verification-evidence"],
+        task_profile_summary: {
+          route_decision: "ready_light",
+          size: "S",
+          guidance_packs: ["surgical-change", "verification-evidence"],
+        },
+      },
+    },
+  };
+  writeManifest(first.manifestPath, updateManifestState(manifest, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"), record.body);
+  fs.writeFileSync(rubricFile, "rubric:\n  factors: []\n", "utf-8");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", plannerReadyLightPromptWithoutExplicitMarker(),
+    "--rubric-file", rubricFile,
+    "--dry-run", "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
   assert.equal(result.error_code, "ready_light_factor_count");
 
   fs.unlinkSync(rubricFile);

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -852,6 +852,54 @@ function readyLightPrompt({ task = "ready-light dispatch validation" } = {}) {
   ].join("\n");
 }
 
+function standardPromptWithReadyLightExample() {
+  return [
+    "# Dispatch: Standard docs task",
+    "",
+    "Update docs that include this example metadata:",
+    "",
+    "```yaml",
+    "planning_profile: ready_light",
+    "route_decision: ready_light",
+    "```",
+    "",
+    "This example is content, not the active task profile.",
+  ].join("\n");
+}
+
+function readyLightRubricYaml() {
+  return [
+    "rubric:",
+    "  factors:",
+    "    - name: Task-specific check passes",
+    "      tier: contract",
+    "      type: automated",
+    "      command: \"node --test tests/task-specific.test.js\"",
+    "      target: \"exit 0\"",
+  ].join("\n");
+}
+
+function threeFactorRubricYaml() {
+  return [
+    "rubric:",
+    "  factors:",
+    "    - name: Parser path passes",
+    "      tier: contract",
+    "      type: automated",
+    "      command: \"node --test tests/parser.test.js\"",
+    "      target: \"exit 0\"",
+    "    - name: CLI path passes",
+    "      tier: contract",
+    "      type: automated",
+    "      command: \"node --test tests/cli.test.js\"",
+    "      target: \"exit 0\"",
+    "    - name: Error copy remains actionable",
+    "      tier: quality",
+    "      type: evaluated",
+    "      target: \">= 8/10\"",
+  ].join("\n");
+}
+
 function setupDryRunFixtureRepo() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-dry-run-"));
   const repoRoot = path.join(root, "repo");
@@ -4129,6 +4177,74 @@ test("dispatch rejects invalid ready-light rubric before accepting rubric file",
   assert.equal(result.status, "failed");
   assert.equal(result.error_code, "ready_light_factor_count");
   assert.match(result.error, /Ready-light S rubrics require 1-2 substantive factors/);
+
+  fs.unlinkSync(rubricFile);
+});
+
+test("dispatch ignores ready-light examples outside structured task profile metadata", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const rubricFile = path.join(os.tmpdir(), `rubric-standard-example-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricFile, threeFactorRubricYaml(), "utf-8");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-standard-ready-light-example",
+    "--prompt", standardPromptWithReadyLightExample(),
+    "--rubric-file", rubricFile,
+    "--dry-run", "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(proc.status, 0, proc.stderr || proc.stdout);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.mode, "new");
+
+  fs.unlinkSync(rubricFile);
+});
+
+test("dispatch validates retained ready-light rubric on resume", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+
+  const rubricFile = path.join(os.tmpdir(), `rubric-ready-light-valid-${Date.now()}.yaml`);
+  fs.writeFileSync(rubricFile, readyLightRubricYaml(), "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-ready-light-resume-invalid-retained",
+    "--prompt", readyLightPrompt(),
+    "--rubric-file", rubricFile,
+    "--json",
+  ], env));
+
+  const record = readManifest(first.manifestPath);
+  const updated = updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes");
+  writeManifest(first.manifestPath, updated, record.body);
+  fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "rubric.yaml"), "rubric:\n  factors: []\n", "utf-8");
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", readyLightPrompt({ task: "resume ready-light validation" }),
+    "--dry-run", "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.error_code, "ready_light_factor_count");
 
   fs.unlinkSync(rubricFile);
 });

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -127,8 +127,12 @@ test("blocks repo-wide hygiene block scalars when command starts the factor item
 test("blocks bare repo-wide test runners in ready-light factors", () => {
   const commands = [
     "node --test",
+    "node --test --test-reporter=spec",
+    "node --test tests/**/*.test.js --test-reporter=spec",
     "pytest",
+    "pytest -q",
     "go test ./...",
+    "go test ./... -race",
   ];
 
   for (const command of commands) {

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -128,9 +128,13 @@ test("blocks bare repo-wide test runners in ready-light factors", () => {
   const commands = [
     "node --test",
     "node --test --test-reporter=spec",
+    "node --test --test-reporter spec",
     "node --test tests/**/*.test.js --test-reporter=spec",
+    "node --test tests/**/*.test.js --test-reporter spec",
     "pytest",
     "pytest -q",
+    "pytest -k smoke",
+    "pytest --maxfail 1",
     "pytest tests/",
     "python -m pytest tests/",
     "go test ./...",
@@ -161,7 +165,10 @@ test("allows path-scoped pytest commands in ready-light factors", () => {
     "npm test tests/foo.test.js",
     "pnpm test tests/foo.test.js",
     "yarn test tests/foo.test.js",
+    "node --test tests/foo.test.js --test-reporter spec",
     "pytest tests/foo_test.py",
+    "pytest tests/foo_test.py -k smoke",
+    "pytest tests/foo_test.py --maxfail 1",
     "python -m pytest tests/foo_test.py::test_case",
   ];
 

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -124,6 +124,32 @@ test("blocks repo-wide hygiene block scalars when command starts the factor item
   assert.ok(result.errors.some((error) => error.code === "repo_hygiene_in_factor"));
 });
 
+test("blocks bare repo-wide test runners in ready-light factors", () => {
+  const commands = [
+    "node --test",
+    "pytest",
+    "go test ./...",
+  ];
+
+  for (const command of commands) {
+    const result = validateReadyLightRubric({
+      rubricYaml: rubricWithFactors([
+        {
+          name: "Repo suite remains green",
+          command,
+        },
+      ]),
+      taskProfile: { planning_profile: "ready_light", size: "S" },
+    });
+
+    assert.equal(result.action, "block", command);
+    assert.ok(
+      result.errors.some((error) => error.code === "repo_hygiene_in_factor"),
+      command
+    );
+  }
+});
+
 test("allows a three-factor ready-light rubric as a warning when explicit design rationale exists", () => {
   const result = validateReadyLightRubric({
     rubricYaml: rubricWithFactors([

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -39,6 +39,25 @@ test("allows a one-factor ready-light S mechanical rubric", () => {
   assert.deepEqual(result.errors, []);
 });
 
+test("blocks a ready-light S rubric with no substantive factors", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: [
+      "rubric:",
+      "  factors:",
+      "    - name: Repo suite remains green",
+      "      tier: hygiene",
+      "      type: automated",
+      "      command: \"node --test tests/relay-plan/scripts/*.test.js\"",
+      "      target: \"exit 0\"",
+    ].join("\n"),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "block");
+  assert.equal(result.substantive_total, 0);
+  assert.ok(result.errors.some((error) => error.code === "ready_light_factor_count"));
+});
+
 test("blocks a three-factor ready-light S mechanical rubric without explicit risk rationale", () => {
   const result = validateReadyLightRubric({
     rubricYaml: rubricWithFactors([
@@ -65,6 +84,25 @@ test("blocks a three-factor ready-light S mechanical rubric without explicit ris
   assert.ok(result.errors.some((error) => error.code === "ready_light_factor_count"));
   assert.ok(result.errors.some((error) => error.code === "repo_hygiene_in_factor"));
   assert.ok(result.warnings.some((warning) => warning.code === "over_engineering_risk"));
+});
+
+test("blocks repo-wide hygiene commands written as block scalars in ready-light factors", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: [
+      "rubric:",
+      "  factors:",
+      "    - name: Repo suite remains green",
+      "      tier: contract",
+      "      type: automated",
+      "      command: >",
+      "        node --test tests/relay-plan/scripts/*.test.js",
+      "      target: \"exit 0\"",
+    ].join("\n"),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "block");
+  assert.ok(result.errors.some((error) => error.code === "repo_hygiene_in_factor"));
 });
 
 test("allows a three-factor ready-light rubric as a warning when explicit design rationale exists", () => {

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -135,10 +135,17 @@ test("blocks bare repo-wide test runners in ready-light factors", () => {
     "pytest -q",
     "pytest -k smoke",
     "pytest --maxfail 1",
+    "pytest .",
+    "python -m pytest .",
     "pytest tests/",
     "python -m pytest tests/",
     "go test ./...",
     "go test ./... -race",
+    "go test -race ./...",
+    "go test -count=1 ./...",
+    "eslint .",
+    "prettier --check .",
+    "tsc --noEmit --pretty false",
   ];
 
   for (const command of commands) {
@@ -170,6 +177,9 @@ test("allows path-scoped pytest commands in ready-light factors", () => {
     "pytest tests/foo_test.py -k smoke",
     "pytest tests/foo_test.py --maxfail 1",
     "python -m pytest tests/foo_test.py::test_case",
+    "eslint src/foo.js",
+    "prettier --check src/foo.js",
+    "tsc --noEmit src/foo.ts",
   ];
 
   for (const command of commands) {

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -131,6 +131,8 @@ test("blocks bare repo-wide test runners in ready-light factors", () => {
     "node --test tests/**/*.test.js --test-reporter=spec",
     "pytest",
     "pytest -q",
+    "pytest tests/",
+    "python -m pytest tests/",
     "go test ./...",
     "go test ./... -race",
   ];

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  validateReadyLightRubric,
+} = require("../../../skills/relay-plan/scripts/rubric-validation");
+
+function rubricWithFactors(factors) {
+  return [
+    "rubric:",
+    "  prerequisites:",
+    "    - command: \"node --test tests/relay-plan/scripts/ready-light-rubric-validation.test.js\"",
+    "      target: \"exit 0\"",
+    "  factors:",
+    ...factors.flatMap((factor) => [
+      `    - name: ${factor.name}`,
+      `      tier: ${factor.tier || "contract"}`,
+      `      type: ${factor.type || "automated"}`,
+      ...(factor.command ? [`      command: "${factor.command}"`] : []),
+      ...(factor.criteria ? [`      criteria: "${factor.criteria}"`] : []),
+      `      target: "${factor.target || "exit 0"}"`,
+    ]),
+  ].join("\n");
+}
+
+test("allows a one-factor ready-light S mechanical rubric", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Preflight proceeds without Q&A",
+        command: "node --test tests/relay/scripts/run-preflight.test.js",
+      },
+    ]),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "allow");
+  assert.equal(result.substantive_total, 1);
+  assert.deepEqual(result.errors, []);
+});
+
+test("blocks a three-factor ready-light S mechanical rubric without explicit risk rationale", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Route decision is preserved",
+        command: "node --test tests/relay/scripts/run-preflight.test.js",
+      },
+      {
+        name: "New helper abstraction covers route shape",
+        type: "evaluated",
+        criteria: "Requires a new helper abstraction for route shape even though Done Criteria do not ask for it.",
+        target: ">= 8/10",
+      },
+      {
+        name: "Repo suite remains green",
+        command: "node --test tests/relay-plan/scripts/*.test.js",
+      },
+    ]),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "block");
+  assert.equal(result.substantive_total, 3);
+  assert.ok(result.errors.some((error) => error.code === "ready_light_factor_count"));
+  assert.ok(result.errors.some((error) => error.code === "repo_hygiene_in_factor"));
+  assert.ok(result.warnings.some((warning) => warning.code === "over_engineering_risk"));
+});
+
+test("allows a three-factor ready-light rubric as a warning when explicit design rationale exists", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: rubricWithFactors([
+      { name: "Prompt chooses the compact route", command: "node --test tests/relay/scripts/run-preflight.test.js" },
+      {
+        name: "Operator-facing copy is reviewable",
+        type: "evaluated",
+        criteria: "Inspect the changed prompt copy and confirm the user-visible guidance remains concrete.",
+        target: ">= 8/10",
+      },
+      {
+        name: "Design rationale is recorded",
+        type: "evaluated",
+        criteria: "Inspect the quality card rationale for the design-bearing exception.",
+        target: ">= 8/10",
+      },
+    ]),
+    taskProfile: {
+      planning_profile: "ready_light",
+      size: "S",
+      design_rationale: "User-visible prompt guidance can be structurally correct but misleading.",
+    },
+  });
+
+  assert.equal(result.action, "allow");
+  assert.equal(result.substantive_total, 3);
+  assert.deepEqual(result.errors, []);
+  assert.ok(result.warnings.some((warning) => warning.code === "ready_light_factor_count"));
+});
+
+test("allows a three-factor non-ready-light rubric without ready-light compact warnings", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: rubricWithFactors([
+      { name: "Parser accepts new field", command: "node --test tests/parser.test.js" },
+      { name: "CLI renders new field", command: "node --test tests/cli.test.js" },
+      {
+        name: "Error copy remains actionable",
+        type: "evaluated",
+        criteria: "Inspect CLI error paths for clear next actions.",
+        target: ">= 8/10",
+      },
+    ]),
+    taskProfile: { planning_profile: "standard", size: "M" },
+  });
+
+  assert.equal(result.action, "allow");
+  assert.equal(result.substantive_total, 3);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.warnings, []);
+});

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -105,6 +105,25 @@ test("blocks repo-wide hygiene commands written as block scalars in ready-light 
   assert.ok(result.errors.some((error) => error.code === "repo_hygiene_in_factor"));
 });
 
+test("blocks repo-wide hygiene block scalars when command starts the factor item", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: [
+      "rubric:",
+      "  factors:",
+      "    - command: >",
+      "        node --test tests/relay-plan/scripts/*.test.js",
+      "      name: Repo suite remains green",
+      "      tier: contract",
+      "      type: automated",
+      "      target: \"exit 0\"",
+    ].join("\n"),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "block");
+  assert.ok(result.errors.some((error) => error.code === "repo_hygiene_in_factor"));
+});
+
 test("allows a three-factor ready-light rubric as a warning when explicit design rationale exists", () => {
   const result = validateReadyLightRubric({
     rubricYaml: rubricWithFactors([

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -150,6 +150,28 @@ test("blocks bare repo-wide test runners in ready-light factors", () => {
   }
 });
 
+test("allows path-scoped pytest commands in ready-light factors", () => {
+  const commands = [
+    "pytest tests/foo_test.py",
+    "python -m pytest tests/foo_test.py::test_case",
+  ];
+
+  for (const command of commands) {
+    const result = validateReadyLightRubric({
+      rubricYaml: rubricWithFactors([
+        {
+          name: "Task-specific pytest coverage passes",
+          command,
+        },
+      ]),
+      taskProfile: { planning_profile: "ready_light", size: "S" },
+    });
+
+    assert.equal(result.action, "allow", command);
+    assert.deepEqual(result.errors, [], command);
+  }
+});
+
 test("allows a three-factor ready-light rubric as a warning when explicit design rationale exists", () => {
   const result = validateReadyLightRubric({
     rubricYaml: rubricWithFactors([

--- a/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
+++ b/tests/relay-plan/scripts/ready-light-rubric-validation.test.js
@@ -66,9 +66,9 @@ test("blocks a three-factor ready-light S mechanical rubric without explicit ris
         command: "node --test tests/relay/scripts/run-preflight.test.js",
       },
       {
-        name: "New helper abstraction covers route shape",
+        name: "New unsupported helper abstraction covers route shape",
         type: "evaluated",
-        criteria: "Requires a new helper abstraction for route shape even though Done Criteria do not ask for it.",
+        criteria: "Requires a new unsupported helper abstraction for route shape even though Done Criteria do not ask for it.",
         target: ">= 8/10",
       },
       {
@@ -152,6 +152,9 @@ test("blocks bare repo-wide test runners in ready-light factors", () => {
 
 test("allows path-scoped pytest commands in ready-light factors", () => {
   const commands = [
+    "npm test tests/foo.test.js",
+    "pnpm test tests/foo.test.js",
+    "yarn test tests/foo.test.js",
     "pytest tests/foo_test.py",
     "python -m pytest tests/foo_test.py::test_case",
   ];
@@ -170,6 +173,41 @@ test("allows path-scoped pytest commands in ready-light factors", () => {
     assert.equal(result.action, "allow", command);
     assert.deepEqual(result.errors, [], command);
   }
+});
+
+test("does not flag ordinary helper text as over-engineering", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Helper output stays stable",
+        type: "evaluated",
+        criteria: "Inspect the changed helper output and confirm the existing behavior is preserved.",
+        target: ">= 8/10",
+      },
+    ]),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "allow");
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("warns on explicitly unsupported helper requirements", () => {
+  const result = validateReadyLightRubric({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Unsupported helper requirement is visible",
+        type: "evaluated",
+        criteria: "Requires an unsupported helper abstraction beyond the Done Criteria.",
+        target: ">= 8/10",
+      },
+    ]),
+    taskProfile: { planning_profile: "ready_light", size: "S" },
+  });
+
+  assert.equal(result.action, "allow");
+  assert.ok(result.warnings.some((warning) => warning.code === "over_engineering_risk"));
 });
 
 test("allows a three-factor ready-light rubric as a warning when explicit design rationale exists", () => {

--- a/tests/relay-plan/scripts/rubric-reference-contract.test.js
+++ b/tests/relay-plan/scripts/rubric-reference-contract.test.js
@@ -87,11 +87,25 @@ test("rubric validation preserves the S mechanical quality-card example", () => 
 test("rubric validation documents the ready-light compact rubric boundary", () => {
   const text = readReference("rubric-validation.md");
 
-  assert.match(text, /Ready-light compact example/);
+  assert.match(text, /Ready-light S mechanical compact example/);
   assert.match(text, /Planning profile: ready_light/);
   assert.match(text, /Contract factors: 1/);
   assert.match(text, /Quality factors: 0/);
-  assert.match(text, /Unsupported helper, dependency, or config requirements are over-engineering risk/);
+  assert.match(text, /Ready-light S mechanical rubrics default to 1-2 substantive factors/);
+  assert.match(text, /Repo-wide lint, typecheck, and test commands stay in prerequisites/);
+  assert.match(text, /Unsupported helper, dependency, config, or abstraction requirements are over-engineering risk/);
+  assert.match(text, /Action: dispatch allowed/);
+});
+
+test("rubric validation documents the ready-light design-bearing exception", () => {
+  const text = readReference("rubric-validation.md");
+
+  assert.match(text, /Ready-light S design-bearing example/);
+  assert.match(text, /Planning profile: ready_light/);
+  assert.match(text, /Contract factors: 1/);
+  assert.match(text, /Quality factors: 1/);
+  assert.match(text, /Substantive total: 2/);
+  assert.match(text, /Design-bearing rationale:/);
   assert.match(text, /Action: dispatch allowed/);
 });
 

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -89,6 +89,7 @@ test("ready-light task profile defaults to S-size quick execution", () => {
   });
 
   assert.equal(profile.size, "S");
+  assert.equal(profile.route_decision, "ready_light");
   assert.equal(profile.execution_mode, "quick");
   assert.equal(profile.review_assurance, "standard");
   assert.ok(profile.guidance_packs.includes("surgical-change"));
@@ -107,6 +108,7 @@ test("ready-light task profile does not downshift risk-bearing tasks", () => {
   });
 
   assert.equal(profile.size, "S");
+  assert.equal(profile.route_decision, "ready_light");
   assert.ok(profile.risk_tags.includes("state-machine"));
   assert.equal(profile.execution_mode, "fresh-context");
   assert.equal(profile.review_assurance, "hardened");
@@ -311,6 +313,21 @@ test("selected task_profile renders metadata and working guidance in dispatch pr
   assert.match(rendered, /These instructions guide execution style\. They do not override Done Criteria, rubric commands, or scope boundaries\./);
   assert.match(rendered, /### surgical-change/);
   assert.doesNotMatch(fs.readFileSync(REVIEW_SCHEMA_PATH, "utf-8"), /task_profile|guidance_packs|execution_mode/);
+});
+
+test("ready-light task_profile renders route decision for dispatch validation", () => {
+  const baseline = fs.readFileSync(BASELINE_PROMPT_PATH, "utf-8");
+  const profile = deriveTaskProfile({
+    doneCriteria: "Update run-preflight so proceed readiness skips Q&A.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: { route_decision: "ready_light" },
+  });
+
+  const rendered = applyTaskProfileToDispatchPrompt({ dispatchPrompt: baseline, taskProfile: profile });
+
+  assert.match(rendered, /task_profile:/);
+  assert.match(rendered, /route_decision: ready_light/);
 });
 
 test("empty guidance_packs leaves existing non-guidance prompt byte-identical", () => {

--- a/tests/relay-plan/scripts/task-profile.test.js
+++ b/tests/relay-plan/scripts/task-profile.test.js
@@ -96,6 +96,19 @@ test("ready-light task profile defaults to S-size quick execution", () => {
   assert.ok(profile.guidance_packs.includes("verification-evidence"));
 });
 
+test("ready-light task profile accepts planning_profile alias", () => {
+  const profile = deriveTaskProfile({
+    doneCriteria: "Update skills/relay/scripts/run-preflight.js so proceed readiness skips Q&A.",
+    probeSignal: PROBE_SIGNAL,
+    historicalSignal: HISTORICAL_SIGNAL,
+    taskRisk: { planning_profile: "ready_light" },
+  });
+
+  assert.equal(profile.size, "S");
+  assert.equal(profile.route_decision, "ready_light");
+  assert.equal(profile.execution_mode, "quick");
+});
+
 test("ready-light task profile does not downshift risk-bearing tasks", () => {
   const profile = deriveTaskProfile({
     doneCriteria: "Validate manifest state before applying review gate decisions.",

--- a/tests/relay-plan/scripts/tdd-flavor.test.js
+++ b/tests/relay-plan/scripts/tdd-flavor.test.js
@@ -211,6 +211,28 @@ test("extractAllFactors carries fix_hint additively without changing TDD project
   ]);
 });
 
+test("extractAllFactors normalizes common indentation in literal block scalars", () => {
+  const rubric = [
+    "rubric:",
+    "  factors:",
+    "    - name: Multiline criteria",
+    "      tier: quality",
+    "      type: evaluated",
+    "      criteria: |",
+    "        Verify:",
+    "          - nested detail remains indented",
+    "        Done.",
+  ].join("\n");
+
+  const [factor] = extractAllFactors(rubric);
+
+  assert.equal(factor.criteria, [
+    "Verify:",
+    "  - nested detail remains indented",
+    "Done.",
+  ].join("\n"));
+});
+
 test("tdd_runner falls back to first probe test_infra entry", () => {
   const rubric = TDD_RUBRIC.replace("      tdd_runner: \"node:test\"\n", "");
 


### PR DESCRIPTION
Closes #728

## Summary
- add a focused ready-light rubric validator that keeps non-ready-light rubrics unchanged
- enforce 1-2 substantive factors for ready-light S rubrics, with explicit design/risk rationale producing a warning instead of a block
- flag repo-wide hygiene commands in factors and unsupported helper/dependency/config/abstraction requirements as over-engineering risk
- document S mechanical and S design-bearing ready-light quality-card examples

## Validation
- PASS: node --test tests/relay-plan/scripts/ready-light-rubric-validation.test.js tests/relay-plan/scripts/rubric-reference-contract.test.js tests/relay-plan/scripts/tdd-suggestion.test.js
- PASS: git diff --check
- KNOWN FAIL: node --test tests/relay-plan/scripts/*.test.js currently fails only in tests/relay-plan/scripts/tdd-flavor.test.js mixed TDD finalize path with finalize-run.js --json: Unexpected end of JSON input; unrelated to this ready-light rubric change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Ready-light 루브릭 검증이 작업 실행 전 단계에 추가되어, 블로킹 위반을 즉시 차단합니다.
  * 작업 프로필에서 `planning_profile` 및 `route_decision` 정보를 더 정확히 지원하고, dispatch 프롬프트에도 반영합니다.
* **Documentation**
  * Ready-light(특히 S) 기준과 리스크 신호 문구가 더 구체화되었습니다.
* **Tests**
  * Ready-light 루브릭 검증/프롬프트 렌더링/마커 처리 동작을 시나리오별로 확대 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->