### PR TITLE
Wire needs_split to proposal-first relay-ready shaping

### DIFF
--- a/docs/relay-ready-routing-and-handoff-design.md
+++ b/docs/relay-ready-routing-and-handoff-design.md
@@ -10,6 +10,8 @@
 
 Once a relay-ready leaf exists, `/relay` returns to the canonical lifecycle in [references/architecture.md](../references/architecture.md): plan, dispatch, review, stop at `ready_to_merge`; merge only on explicit request.
 
+Route preflight detects task-shape risk only; semantic leaf boundaries require operator-approved relay-ready handoffs before `/relay` may continue to planning or dispatch.
+
 ## Decision
 
 1. `relay-ready` is a standalone skill, not hidden state inside the run manifest lifecycle.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -44,7 +44,8 @@ Branch on the JSON using [preflight-guards.md](references/preflight-guards.md); 
 - `inflight.route == "inflight-run"` → resume or inspect that run; continue at its manifest state.
 - `readiness.decision.route_decision == "ready_single"` → proceed to Step 2.
 - `readiness.decision.route_decision == "ready_light"` → proceed to Step 2 with S-size quick planning and compact rubric guidance.
-- `readiness.decision.route_decision in ["readiness_prompt", "needs_split"]` and `.decision.prompt_allowed == true` → set `SUMMARY=.readiness.signals_summary` and issue exactly `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.
+- `readiness.decision.route_decision == "readiness_prompt"` and `.decision.prompt_allowed == true` → set `SUMMARY=.readiness.signals_summary` and issue exactly `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.
+- `readiness.decision.route_decision == "needs_split"` and `.decision.prompt_allowed == true` → run proposal-first relay-ready shaping; accepted handoffs become the relay-plan source of truth before any dispatch.
 - `chain-y` → invoke relay-ready Q&A, wait, persist the handoff, set `manifest.anchor.readiness`, then resume Step 2.
 - `chain-n` → emit `bypass_override_by_user` from `.decision.branch_labels["chain-n"].event_payload`, then proceed to Step 2.
 - `chain-abort` → emit `readiness_check_failed` from `.decision.branch_labels["chain-abort"].event_payload`, then close the run.

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -36,7 +36,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage route 
   - `bypass`: route decision is `ready_single`; probe returns `bypass=true`; proceed to Step 2.
   - `ready-light`: route decision is `ready_light`; readiness returned `next_action=proceed` without a bypass anchor; proceed to Step 2 using S-size quick planning and compact rubric guidance.
   - `chain-y`: probe returns `bypass=false`, prompt is allowed, user answers `y`; invoke relay-ready Q&A, persist the handoff, set `manifest.anchor.readiness`, then resume Step 2.
-  - `chain-n`: probe returns `bypass=false`, prompt is allowed, user answers `n`; emit `bypass_override_by_user` with the script's event payload and proceed to Step 2.
+  - `proposal-first`: route decision is `needs_split`, prompt is allowed, and the request must go through relay-ready proposal-first shaping before Step 2. The JSON branch label includes `relay_ready_mode=proposal_first`, `requires_accepted_handoff=true`, and `source_of_truth=accepted_relay_ready_handoff`.
+  - `chain-n`: probe returns `bypass=false`, prompt is allowed, user explicitly bypasses relay-ready; emit `bypass_override_by_user` with the script's event payload and proceed to Step 2. For `needs_split`, this remains an explicit operator override, not the default route.
   - `chain-abort`: probe returns `bypass=false`, prompt is allowed, user answers `abort`; emit `readiness_check_failed` with the script's event payload and close the run.
   - `noninteractive-fail`: route decision is `readiness_prompt` or `needs_split` and no prompt is allowed; emit `readiness_check_failed_nontty` with the script's event payload and close the run.
 
@@ -45,7 +46,7 @@ Route decisions are advisory labels, not lifecycle states:
 - `ready_single`: preserve the existing bypass fast path.
 - `ready_light`: keep the task on relay, but plan it as a small quick task with compact rubric guidance. This is only for non-bypass `next_action=proceed` results with no high-risk readiness signal.
 - `readiness_prompt`: preserve the existing `qa_needed` prompt or non-interactive failure behavior.
-- `needs_split`: strong task-shape signals indicate decomposition should be considered before dispatch; use the same prompt/non-interactive failure mechanics as readiness gaps.
+- `needs_split`: strong task-shape signals indicate decomposition should be considered before dispatch. Prompt-allowed runs use `proposal-first`; non-interactive runs still fail closed before dispatch.
 
 Do not move the readiness prompt into the script. The exact prompt remains:
 `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -261,6 +261,8 @@ function buildReadinessDecision(envelope, { promptAllowed }) {
   let recommendedBranch = "bypass";
   if (routeDecision === "ready_light") {
     recommendedBranch = "ready-light";
+  } else if (routeDecision === "needs_split" && promptAllowed) {
+    recommendedBranch = "proposal-first";
   } else if (routeDecision !== "ready_single") {
     recommendedBranch = promptAllowed ? "prompt" : "noninteractive-fail";
   }
@@ -292,6 +294,14 @@ function buildReadinessDecision(envelope, { promptAllowed }) {
         label: "chain-y",
         [EVENT_FIELD]: EVENTS.READINESS_PROBE,
         action: "invoke_relay_ready_then_resume_step_2",
+      },
+      "proposal-first": {
+        label: "proposal-first",
+        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+        action: "invoke_relay_ready_proposal_first_then_resume_step_2",
+        relay_ready_mode: "proposal_first",
+        requires_accepted_handoff: true,
+        source_of_truth: "accepted_relay_ready_handoff",
       },
       "chain-n": {
         label: "chain-n",

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -118,6 +118,37 @@ test("route decision exposes needs_split for strong task-shape signals", () => {
   assert.equal(decision.branch_labels["noninteractive-fail"].event_payload.route_decision, "needs_split");
 });
 
+test("route decision directs prompt-allowed needs_split to proposal-first shaping", () => {
+  const decision = buildReadinessDecision({
+    readiness_score: { clarity: "medium", granularity: "low", verifiability: "high" },
+    bypass: false,
+    next_action: "qa_needed",
+    signals_summary: "Gaps: granularity=low, task-shape decomposition.",
+    task_shape: {
+      strength: "strong",
+      strong: true,
+      signals: [{ condition: "broad_scope_language", evidence: "foundation" }],
+    },
+  }, { promptAllowed: true });
+
+  assert.equal(decision.route_decision, "needs_split");
+  assert.equal(decision.recommended_branch, "proposal-first");
+  assert.equal(decision.prompt_summary, "Gaps: granularity=low, task-shape decomposition.");
+  assert.equal(
+    decision.branch_labels["proposal-first"].action,
+    "invoke_relay_ready_proposal_first_then_resume_step_2"
+  );
+  assert.equal(decision.branch_labels["proposal-first"].relay_ready_mode, "proposal_first");
+  assert.equal(decision.branch_labels["proposal-first"].requires_accepted_handoff, true);
+  assert.equal(decision.branch_labels["proposal-first"].source_of_truth, "accepted_relay_ready_handoff");
+  assert.equal(decision.branch_labels["chain-n"].event, "bypass_override_by_user");
+  assert.equal(decision.branch_labels["chain-n"].event_payload.route_decision, "needs_split");
+  assert.equal(
+    decision.branch_labels["chain-n"].event_payload.reason,
+    "operator_bypass_after_readiness_prompt"
+  );
+});
+
 function setupReadyRun({ liveHead = "abc123", reviewedSha = "abc123", manifestHead = "abc123" } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-preflight-"));
   process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -399,6 +399,24 @@ function assertProjectDocsPreserveExplicitMergeBoundary(docs) {
   );
 }
 
+function assertNeedsSplitProposalFirstBoundary(docs) {
+  assert.match(
+    docs.relaySkill,
+    /route_decision == "needs_split"[\s\S]*proposal-first relay-ready shaping/i,
+    "relay skill must route needs_split to proposal-first relay-ready shaping",
+  );
+  assert.match(
+    docs.preflightGuards,
+    /`proposal-first`[\s\S]*requires_accepted_handoff[\s\S]*`chain-n`[\s\S]*explicit operator override/i,
+    "preflight guard docs must expose the accepted-handoff default and explicit operator override for needs_split",
+  );
+  assert.match(
+    docs.relayReadyDesign,
+    /route preflight detects task-shape risk only[\s\S]*semantic leaf boundaries require operator-approved relay-ready handoffs/i,
+    "handoff design must separate task-shape detection from semantic leaf approval",
+  );
+}
+
 test("all skills/SKILL.md files satisfy the lint contract", () => {
   const skillFiles = readSkillFiles();
   assert.ok(skillFiles.length > 0, "expected at least one skills/*/SKILL.md file");
@@ -456,6 +474,14 @@ test("operator surface policy rejects missing or duplicate skill coverage", () =
 test("relay skill description preserves explicit ready_to_merge stop boundary", () => {
   const relaySkill = fs.readFileSync(path.join(SKILLS_DIR, "relay", "SKILL.md"), "utf-8");
   assertRelayStopsAtReadyToMerge(relaySkill);
+});
+
+test("needs_split route documents proposal-first relay-ready shaping boundary", () => {
+  assertNeedsSplitProposalFirstBoundary({
+    relaySkill: fs.readFileSync(path.join(SKILLS_DIR, "relay", "SKILL.md"), "utf-8"),
+    preflightGuards: fs.readFileSync(path.join(SKILLS_DIR, "relay", "references", "preflight-guards.md"), "utf-8"),
+    relayReadyDesign: fs.readFileSync(RELAY_READY_DESIGN_PATH, "utf-8"),
+  });
 });
 
 test("relay-review spine delegates provider-specific adapter details", () => {


### PR DESCRIPTION
Closes #729.

## Summary
- Route prompt-allowed `needs_split` to a `proposal-first` branch label instead of normal planning.
- Preserve non-interactive fail-closed behavior and existing bypass/qa-needed branch behavior.
- Document that preflight detects task-shape risk only, while semantic leaf boundaries require operator-approved relay-ready handoffs.
- Add focused route and docs-contract tests for proposal-first routing, accepted handoff source-of-truth metadata, non-interactive fail-closed coverage, and explicit bypass event behavior.

## Validation
- `node --test tests/relay/scripts/run-preflight.test.js tests/skills-lint/scripts/skills-lint.test.js`
- `node --test tests/relay-ready/scripts/probe-readiness.test.js`
- `node --test --test-name-pattern "dispatch stores request linkage|dispatch resume keeps the original intake linkage" tests/relay-dispatch/scripts/dispatch.test.js`
- `git diff --check`

## Review
- Pre-landing diff review: no unresolved findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 릴리 준비(relay-ready) 핸드오프 요구사항 및 라우팅 의사결정 흐름에 대한 설명서 업데이트
  * 프리플라이트 가드 조건 및 제어 경로에 대한 참고 문서 개선

* **테스트**
  * 제안 우선 라우팅 모드의 동작 검증 테스트 추가
  * 문서 내 라우팅 경계 조건 준수 여부를 자동 검사하는 린트 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->