### PR TITLE
Fix post-741 relay followups

### DIFF
--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -50,6 +50,17 @@ When applying a verdict, the runner:
 
 Reviewer adapter capabilities are shared with dispatch adapter metadata. See `../../relay-dispatch/references/agent-adapter-platform.md` for the supported adapter matrix, including primary vs advisory review support, read-only enforcement, structured-output shape, and the new-adapter checklist. Antigravity review support is for the `agy` CLI only, not GUI/IDE/Desktop flows.
 
+## External Review Triggers
+
+Delayed-publication runs should spend external review quota only after the internal relay review has converged:
+
+1. While the run is `internal_review_pending`, use relay-review against the retained worktree and do not request CodeRabbit, GitHub PR review, or other public PR reviewers.
+2. After internal PASS moves the run to `publish_pending`, run `publish-run.js`; the first post-publication relay-review round is the normal point to evaluate CI/actions, CodeRabbit, Codex PR review, and review-thread signals.
+3. After publication, trigger external reviewers only for the initial public review or for a meaningful new commit that could change their findings. Do not re-trigger `@coderabbitai review` for comment-only updates, metadata edits, audit-comment rewrites, or small cleanup commits when CI is green and active review threads are resolved.
+4. During final closeout, verify the latest CI/checks, unresolved non-outdated review threads, and latest applicable external review status. Do not spend another external review round merely to restate already-clean signals.
+
+This repository does not currently carry a repo-local CodeRabbit auto-review config. If one is added, prefer an opt-in policy for delayed-publication branches, such as manual review requests after publication or a label convention that enables review only after internal LGTM. On rate-limit responses, wait for quota recovery, push a meaningful code commit if one exists, and request manual review only when the new diff needs it; otherwise continue with the available CI and thread evidence.
+
 ## Execution Evidence Preflight
 
 Execution evidence preflight is script territory, not AI reviewer judgment. The script can verify file type, JSON schema, reviewed HEAD vs evidence HEAD, strict command/hash/exit fields, and `verification_runs[]` records deterministically before spending a reviewer round. The reviewer still handles semantic code review against Done Criteria and rubric anchors after that mechanical proof is valid.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -144,4 +144,4 @@ When multiple independent tasks are ready, dispatch in parallel instead of runni
 
 ## Summary Checklist
 
-Verify Done Criteria, relay-review LGTM/audit comment, `ready_to_merge` state, and any sprint/follow-up updates.
+Verify Done Criteria fully implemented, relay-review LGTM/audit comment, `ready_to_merge` state, and any sprint/follow-up updates.

--- a/tests/relay-plan/scripts/tdd-flavor.test.js
+++ b/tests/relay-plan/scripts/tdd-flavor.test.js
@@ -26,6 +26,7 @@ const {
 const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 const { createEnforcementFixture } = require("../../../skills/relay-dispatch/scripts/test-support");
 const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+const { writeFakeGhScript } = require("../../relay-review/fixtures/fake-gh");
 
 const BASELINE_PROMPT_PATH = path.join(__dirname, "..", "fixtures", "dispatch-prompt-baseline", "non-tdd.md");
 const REVIEW_RUNNER_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
@@ -407,55 +408,25 @@ function writeFakeGh({ repoRoot, branch, headSha }) {
   const statePath = path.join(repoRoot, "fake-gh-mixed-tdd-state.json");
   const logPath = path.join(repoRoot, "fake-gh-mixed-tdd.log");
   fs.writeFileSync(statePath, JSON.stringify({ state: "OPEN", mergeCommit: null }), "utf-8");
-  fs.writeFileSync(ghPath, `#!/usr/bin/env node
-const { execFileSync } = require("child_process");
-const fs = require("fs");
-const args = process.argv.slice(2);
-const repoRoot = ${JSON.stringify(repoRoot)};
-const branch = ${JSON.stringify(branch)};
-const statePath = ${JSON.stringify(statePath)};
-fs.appendFileSync(${JSON.stringify(logPath)}, args.join(" ") + "\\n", "utf-8");
-function loadState() { return JSON.parse(fs.readFileSync(statePath, "utf-8")); }
-function saveState(next) { fs.writeFileSync(statePath, JSON.stringify(next), "utf-8"); }
-if (args[0] === "pr" && args[1] === "view") {
-  const state = loadState();
-  const jsonArg = args[args.indexOf("--json") + 1] || "";
-  if (jsonArg === "headRefName") {
-    process.stdout.write(JSON.stringify({ headRefName: branch }));
-    process.exit(0);
-  }
-  if (jsonArg === "comments,commits,mergeable,statusCheckRollup" || jsonArg === "baseRefName,comments,commits,mergeable,statusCheckRollup") {
-    process.stdout.write(JSON.stringify({
+  writeFakeGhScript({
+    ghPath,
+    logPath,
+    statePath,
+    fixture: {
+      headRefName: branch,
       baseRefName: "main",
-      comments: [{ body: "<!-- relay-review -->\\n## Relay Review\\nVerdict: PASS\\nRounds: 1", createdAt: ${JSON.stringify(REVIEW_COMMENT_DATE)} }],
-      commits: [{ oid: ${JSON.stringify(headSha)}, committedDate: ${JSON.stringify(REVIEW_COMMENT_DATE)} }],
+      comments: [{ body: "<!-- relay-review -->\n## Relay Review\nVerdict: PASS\nRounds: 1", createdAt: REVIEW_COMMENT_DATE }],
+      commits: [{ oid: headSha, committedDate: REVIEW_COMMENT_DATE }],
       mergeable: "MERGEABLE",
-      statusCheckRollup: []
-    }));
-    process.exit(0);
-  }
-  if (jsonArg === "state,mergeCommit") {
-    process.stdout.write(JSON.stringify({ state: state.state, mergeCommit: state.mergeCommit }));
-    process.exit(0);
-  }
-}
-if (args[0] === "pr" && args[1] === "merge") {
-  execFileSync("git", ["-C", repoRoot, "checkout", "main"], { stdio: "pipe" });
-  execFileSync("git", ["-C", repoRoot, "merge", "--squash", branch], { stdio: "pipe" });
-  execFileSync("git", ["-C", repoRoot, "commit", "-m", "Squash mixed TDD branch"], { stdio: "pipe" });
-  const sha = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim();
-  saveState({ state: "MERGED", mergeCommit: { oid: sha } });
-  process.exit(0);
-}
-if (args[0] === "repo" && args[1] === "view") {
-  process.stdout.write(JSON.stringify({ defaultBranchRef: { name: "main" } }));
-  process.exit(0);
-}
-if (args[0] === "issue" && args[1] === "close") process.exit(0);
-process.stderr.write("unexpected fake gh invocation: " + args.join(" ") + "\\n");
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(ghPath, 0o755);
+      statusCheckRollup: [],
+    },
+    merge: {
+      repoRoot,
+      branch,
+      baseBranch: "main",
+      message: "Squash mixed TDD branch",
+    },
+  });
   return { ghPath, logPath };
 }
 
@@ -561,6 +532,7 @@ test("mixed TDD rubric drives red to green to reviewer pass and squash finalize"
     ],
     scope_drift: { creep: [], missing: [] },
   }, null, 2)}\n`, "utf-8");
+  const { ghPath, logPath } = writeFakeGh({ repoRoot: fixture.repoRoot, branch: fixture.branch, headSha });
 
   const reviewResult = JSON.parse(execFileSync("node", [
     REVIEW_RUNNER_SCRIPT,
@@ -572,7 +544,11 @@ test("mixed TDD rubric drives red to green to reviewer pass and squash finalize"
     "--review-file", reviewFile,
     "--no-comment",
     "--json",
-  ], { encoding: "utf-8", stdio: "pipe" }));
+  ], {
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: ghPath },
+  }));
   const promptText = fs.readFileSync(path.join(fixture.runDir, "review-round-1-prompt.md"), "utf-8");
   const appliedVerdict = JSON.parse(fs.readFileSync(path.join(fixture.runDir, "review-round-1-verdict.json"), "utf-8"));
   const scoreEvent = readRunEvents(fixture.repoRoot, fixture.runId).find((event) => event.event === "iteration_score");
@@ -591,7 +567,6 @@ test("mixed TDD rubric drives red to green to reviewer pass and squash finalize"
   assert.ok(prereqLog.every((line) => line.includes("--test-skip-pattern=anchor\\.test\\.js")));
 
   const baseBefore = Number(git(fixture.repoRoot, "rev-list", "--count", "main"));
-  const { ghPath, logPath } = writeFakeGh({ repoRoot: fixture.repoRoot, branch: fixture.branch, headSha });
   const finalizeResult = JSON.parse(execFileSync("node", [
     FINALIZE_RUN_SCRIPT,
     "--repo", fixture.repoRoot,

--- a/tests/relay-ready/scripts/probe-readiness.test.js
+++ b/tests/relay-ready/scripts/probe-readiness.test.js
@@ -51,7 +51,7 @@ function deterministic5KbBypassBody() {
 
 - \`skills/relay-ready/scripts/probe-readiness.js\` prints deterministic JSON.
 - \`tests/relay-ready/scripts/probe-readiness.test.js\` passes.
-- p95 < 200ms over 50 runs.
+- p95 internal elapsed_ms < 200ms over 50 runs.
 
 `;
   const filler = "The probe uses deterministic regex scoring with bounded output for audit. ";
@@ -60,21 +60,19 @@ function deterministic5KbBypassBody() {
   return body;
 }
 
-test("happy_path_bypass emits proceed envelope under 200ms for a 5KB issue body", (t) => {
+test("happy_path_bypass emits proceed envelope and bounded internal elapsed_ms for a 5KB issue body", (t) => {
   const bodyPath = path.join(os.tmpdir(), `relay-437-happy-${process.pid}-${Date.now()}.md`);
   fs.writeFileSync(bodyPath, deterministic5KbBypassBody(), "utf-8");
   t.after(() => fs.rmSync(bodyPath, { force: true }));
 
-  const start = process.hrtime.bigint();
   const result = runProbe(["--json", "--body-file", bodyPath]);
-  const elapsedMs = Number(process.hrtime.bigint() - start) / 1_000_000;
 
   assert.equal(result.status, 0, result.stderr);
-  assert.ok(elapsedMs < 200, `elapsed=${elapsedMs}ms`);
   const envelope = parseJson(result.stdout);
   assertEnvelopeShape(envelope);
   assert.equal(envelope.bypass, true);
   assert.equal(envelope.next_action, "proceed");
+  assert.ok(envelope.elapsed_ms < 200, `elapsed_ms=${envelope.elapsed_ms}ms`);
 });
 
 test("non_bypass_emits_summary returns a bounded human summary for low scores", () => {
@@ -182,7 +180,7 @@ test("non_interactive_abort_signal exposes bypass and escalate action for orches
   assert.deepEqual(envelope.risk.signals, ["high_risk_keyword"]);
 });
 
-test("performance_microbenchmark keeps p95 elapsed_ms below 200ms over 50 CLI invocations", (t) => {
+test("performance_microbenchmark keeps internal p95 elapsed_ms below 200ms over 50 CLI invocations", (t) => {
   const bodyPath = path.join(os.tmpdir(), `relay-437-bench-${process.pid}-${Date.now()}.md`);
   fs.writeFileSync(bodyPath, deterministic5KbBypassBody(), "utf-8");
   t.after(() => fs.rmSync(bodyPath, { force: true }));

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -23,6 +23,11 @@ const capturePath = ${JSON.stringify(capturePath)};
 const logPath = ${JSON.stringify(logPath)};
 const statePath = ${JSON.stringify(statePath)};
 const merge = ${JSON.stringify(merge)};
+const prBodySnapshotFields = new Set([
+  "body",
+  "body,headRefOid,headRefName,closingIssuesReferences",
+  "headRefOid,headRefName,body,closingIssuesReferences",
+]);
 
 if (logPath) {
   fs.appendFileSync(logPath, args.join(" ") + "\\n", "utf-8");
@@ -57,11 +62,13 @@ if (args[0] === "pr" && args[1] === "view") {
   const jsonIndex = args.indexOf("--json");
   const fields = jsonIndex >= 0 ? args[jsonIndex + 1] : "";
 
+  // Snapshot callers use gh's jq path to read only the body as raw text.
   if (args.includes("-q") && args[args.indexOf("-q") + 1] === ".body") {
     process.stdout.write(fixture.body || "");
     process.exit(0);
   }
 
+  // loadPrReviewSignals asks for checks, reviews, and top-level comments in one call.
   if (fields === "statusCheckRollup,reviews,comments") {
     writeJson({
       statusCheckRollup: fixture.statusCheckRollup || [],
@@ -71,6 +78,7 @@ if (args[0] === "pr" && args[1] === "view") {
     process.exit(0);
   }
 
+  // Issue inference reads the PR body plus GitHub's closing issue references.
   if (fields === "closingIssuesReferences,body,headRefName") {
     writeJson({
       closingIssuesReferences: fixture.closingIssuesReferences || [],
@@ -80,6 +88,7 @@ if (args[0] === "pr" && args[1] === "view") {
     process.exit(0);
   }
 
+  // The manual PR fallback path mirrors gh issue view's title/body/number shape.
   if (fields === "title,body,number") {
     writeJson({
       number: fixture.number || 123,
@@ -89,17 +98,29 @@ if (args[0] === "pr" && args[1] === "view") {
     process.exit(0);
   }
 
+  // Merge and preflight checks need the branch name without loading heavier PR data.
   if (fields === "headRefName") {
     writeJson({ headRefName: fixture.headRefName || "" });
     process.exit(0);
   }
 
+  if (fields === "number,headRefName,headRefOid") {
+    writeJson({
+      number: fixture.number || 123,
+      headRefName: fixture.headRefName || "",
+      headRefOid: fixture.headRefOid || "a".repeat(40),
+    });
+    process.exit(0);
+  }
+
+  // finalize-run polls PR terminal state after merge attempts.
   if (fields === "state,mergeCommit") {
     const state = loadState();
     writeJson({ state: state.state, mergeCommit: state.mergeCommit });
     process.exit(0);
   }
 
+  // merge gates need the latest relay audit comment, commits, mergeability, and checks.
   if (
     fields === "comments,commits,mergeable,statusCheckRollup" ||
     fields === "baseRefName,comments,commits,mergeable,statusCheckRollup"
@@ -114,7 +135,8 @@ if (args[0] === "pr" && args[1] === "view") {
     process.exit(0);
   }
 
-  if (fields === "body" || fields.includes("body")) {
+  // Body snapshot calls must stay explicit so future field sets fail loudly.
+  if (prBodySnapshotFields.has(fields)) {
     writeJson({
       body: fixture.body || "",
       headRefOid: fixture.headRefOid || "a".repeat(40),
@@ -124,6 +146,7 @@ if (args[0] === "pr" && args[1] === "view") {
     process.exit(0);
   }
 
+  // Some tests only need gh pr view to succeed; unsupported data stays empty.
   writeJson({});
   process.exit(0);
 }
@@ -203,23 +226,29 @@ process.exit(1);
 function installFakeGhOnPath(fixture = {}, options = {}) {
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-gh-"));
   const ghPath = path.join(binDir, "gh");
+  const originalPath = process.env.PATH;
   writeFakeGhScript({ ghPath, fixture, ...options });
   process.env.PATH = `${binDir}:${process.env.PATH}`;
-  return { binDir, ghPath };
+  let restored = false;
+  const restore = () => {
+    if (restored) return;
+    process.env.PATH = originalPath;
+    restored = true;
+  };
+  return { binDir, ghPath, restore };
 }
 
 function withFakeGh(fixture, callback, options = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), options.repoPrefix || "relay-review-gh-repo-"));
-  const originalPath = process.env.PATH;
-  const { binDir, ghPath } = installFakeGhOnPath(fixture, {
+  const installed = installFakeGhOnPath(fixture, {
     prefix: options.binPrefix || "relay-review-gh-bin-",
     ...options,
   });
 
   try {
-    return callback(repoRoot, { binDir, ghPath });
+    return callback(repoRoot, installed);
   } finally {
-    process.env.PATH = originalPath;
+    installed.restore();
   }
 }
 

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -1,0 +1,230 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+function writeFakeGhScript({
+  ghPath,
+  fixture = {},
+  capturePath = null,
+  logPath = null,
+  statePath = null,
+  merge = null,
+} = {}) {
+  if (!ghPath) {
+    throw new Error("writeFakeGhScript requires ghPath");
+  }
+
+  const script = `#!/usr/bin/env node
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const args = process.argv.slice(2);
+const fixture = ${JSON.stringify(fixture)};
+const capturePath = ${JSON.stringify(capturePath)};
+const logPath = ${JSON.stringify(logPath)};
+const statePath = ${JSON.stringify(statePath)};
+const merge = ${JSON.stringify(merge)};
+
+if (logPath) {
+  fs.appendFileSync(logPath, args.join(" ") + "\\n", "utf-8");
+}
+
+function writeJson(value) {
+  process.stdout.write(JSON.stringify(value));
+}
+
+function loadState() {
+  if (statePath && fs.existsSync(statePath)) {
+    return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+  }
+  return {
+    state: fixture.state || "OPEN",
+    mergeCommit: fixture.mergeCommit || null,
+  };
+}
+
+function saveState(next) {
+  if (statePath) {
+    fs.writeFileSync(statePath, JSON.stringify(next), "utf-8");
+  }
+}
+
+if (fixture.failOnCall) {
+  process.stderr.write("gh should not have been called");
+  process.exit(91);
+}
+
+if (args[0] === "pr" && args[1] === "view") {
+  const jsonIndex = args.indexOf("--json");
+  const fields = jsonIndex >= 0 ? args[jsonIndex + 1] : "";
+
+  if (args.includes("-q") && args[args.indexOf("-q") + 1] === ".body") {
+    process.stdout.write(fixture.body || "");
+    process.exit(0);
+  }
+
+  if (fields === "statusCheckRollup,reviews,comments") {
+    writeJson({
+      statusCheckRollup: fixture.statusCheckRollup || [],
+      reviews: fixture.reviews || [],
+      comments: fixture.comments || [],
+    });
+    process.exit(0);
+  }
+
+  if (fields === "closingIssuesReferences,body,headRefName") {
+    writeJson({
+      closingIssuesReferences: fixture.closingIssuesReferences || [],
+      body: fixture.body || "",
+      headRefName: fixture.headRefName || "",
+    });
+    process.exit(0);
+  }
+
+  if (fields === "title,body,number") {
+    writeJson({
+      number: fixture.number || 123,
+      title: fixture.title || "Fixture PR",
+      body: fixture.body || "",
+    });
+    process.exit(0);
+  }
+
+  if (fields === "headRefName") {
+    writeJson({ headRefName: fixture.headRefName || "" });
+    process.exit(0);
+  }
+
+  if (fields === "state,mergeCommit") {
+    const state = loadState();
+    writeJson({ state: state.state, mergeCommit: state.mergeCommit });
+    process.exit(0);
+  }
+
+  if (
+    fields === "comments,commits,mergeable,statusCheckRollup" ||
+    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup"
+  ) {
+    writeJson({
+      baseRefName: fixture.baseRefName || "main",
+      comments: fixture.comments || [],
+      commits: fixture.commits || [],
+      mergeable: fixture.mergeable || "MERGEABLE",
+      statusCheckRollup: fixture.statusCheckRollup || [],
+    });
+    process.exit(0);
+  }
+
+  if (fields === "body" || fields.includes("body")) {
+    writeJson({
+      body: fixture.body || "",
+      headRefOid: fixture.headRefOid || "a".repeat(40),
+      headRefName: fixture.headRefName || "",
+      closingIssuesReferences: fixture.closingIssuesReferences || [],
+    });
+    process.exit(0);
+  }
+
+  writeJson({});
+  process.exit(0);
+}
+
+if (args[0] === "repo" && args[1] === "view") {
+  writeJson({
+    owner: { login: fixture.owner || "acme" },
+    name: fixture.name || "dev-relay",
+    defaultBranchRef: { name: fixture.defaultBranch || "main" },
+  });
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "graphql") {
+  const cursorArg = args.find((arg) => arg.startsWith("threadsCursor="));
+  const pageIndex = cursorArg ? Number(cursorArg.split("=")[1].replace("page-", "")) : 0;
+  const pages = fixture.reviewThreadPages || [{
+    nodes: fixture.reviewThreads || [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }];
+  const page = pages[pageIndex] || { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } };
+  const hasNextPage = pageIndex < pages.length - 1;
+  writeJson({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: {
+              hasNextPage,
+              endCursor: hasNextPage ? "page-" + (pageIndex + 1) : null,
+            },
+            nodes: page.nodes || [],
+          },
+        },
+      },
+    },
+  });
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "user") {
+  process.stdout.write((fixture.login || "fixture-reviewer") + "\\n");
+  process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "comment") {
+  if (capturePath) {
+    const bodyIndex = args.indexOf("--body");
+    const body = bodyIndex !== -1 ? args[bodyIndex + 1] : "";
+    fs.writeFileSync(capturePath, body, "utf-8");
+  }
+  process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "merge" && merge) {
+  execFileSync("git", ["-C", merge.repoRoot, "checkout", merge.baseBranch || "main"], { stdio: "pipe" });
+  execFileSync("git", ["-C", merge.repoRoot, "merge", "--squash", merge.branch], { stdio: "pipe" });
+  execFileSync("git", ["-C", merge.repoRoot, "commit", "-m", merge.message || "Squash fixture branch"], { stdio: "pipe" });
+  const sha = execFileSync("git", ["-C", merge.repoRoot, "rev-parse", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  saveState({ state: "MERGED", mergeCommit: { oid: sha } });
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "close") {
+  process.exit(0);
+}
+
+process.stderr.write("Unsupported fake gh invocation: " + args.join(" "));
+process.exit(1);
+`;
+
+  fs.writeFileSync(ghPath, script, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return ghPath;
+}
+
+function installFakeGhOnPath(fixture = {}, options = {}) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-gh-"));
+  const ghPath = path.join(binDir, "gh");
+  writeFakeGhScript({ ghPath, fixture, ...options });
+  process.env.PATH = `${binDir}:${process.env.PATH}`;
+  return { binDir, ghPath };
+}
+
+function withFakeGh(fixture, callback, options = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), options.repoPrefix || "relay-review-gh-repo-"));
+  const originalPath = process.env.PATH;
+  const { binDir, ghPath } = installFakeGhOnPath(fixture, {
+    prefix: options.binPrefix || "relay-review-gh-bin-",
+    ...options,
+  });
+
+  try {
+    return callback(repoRoot, { binDir, ghPath });
+  } finally {
+    process.env.PATH = originalPath;
+  }
+}
+
+module.exports = {
+  installFakeGhOnPath,
+  withFakeGh,
+  writeFakeGhScript,
+};

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -22,60 +22,17 @@ const {
 } = require("../../../skills/relay-dispatch/scripts/test-support");
 const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 const { finishAdvisoryReview } = require("../../../skills/relay-review/scripts/review-runner/advisory");
+const { installFakeGhOnPath } = require("../fixtures/fake-gh");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
 
 function installDefaultGhFixture() {
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-advisory-gh-"));
-  const ghPath = path.join(binDir, "gh");
-  fs.writeFileSync(ghPath, `#!/usr/bin/env node
-const args = process.argv.slice(2);
-function writeJson(value) {
-  process.stdout.write(JSON.stringify(value));
-}
-if (args[0] === "pr" && args[1] === "view") {
-  const jsonIndex = args.indexOf("--json");
-  const fields = jsonIndex >= 0 ? args[jsonIndex + 1] : "";
-  if (fields === "statusCheckRollup,reviews,comments") {
-    writeJson({
-      statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
-      reviews: [],
-      comments: []
-    });
-    process.exit(0);
-  }
-  if (fields === "body" || fields.includes("body")) {
-    writeJson({
-      body: "## Test PR\\n\\nFixture body.\\n",
-      headRefOid: "a".repeat(40),
-      headRefName: "issue-429",
-      closingIssuesReferences: []
-    });
-    process.exit(0);
-  }
-  writeJson({});
-  process.exit(0);
-}
-if (args[0] === "repo" && args[1] === "view") {
-  writeJson({ owner: { login: "acme" }, name: "dev-relay" });
-  process.exit(0);
-}
-if (args[0] === "api" && args[1] === "graphql") {
-  writeJson({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } });
-  process.exit(0);
-}
-if (args[0] === "api" && args[1] === "user") {
-  process.stdout.write("fixture-reviewer\\n");
-  process.exit(0);
-}
-if (args[0] === "pr" && args[1] === "comment") {
-  process.exit(0);
-}
-process.stderr.write("Unsupported default gh fixture invocation: " + args.join(" "));
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(ghPath, 0o755);
-  process.env.PATH = `${binDir}:${process.env.PATH}`;
+  installFakeGhOnPath({
+    body: "## Test PR\n\nFixture body.\n",
+    headRefOid: "a".repeat(40),
+    headRefName: "issue-429",
+    statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
+  }, { prefix: "relay-review-advisory-gh-" });
 }
 
 installDefaultGhFixture();

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -27,7 +27,7 @@ const { installFakeGhOnPath } = require("../fixtures/fake-gh");
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
 
 function installDefaultGhFixture() {
-  installFakeGhOnPath({
+  return installFakeGhOnPath({
     body: "## Test PR\n\nFixture body.\n",
     headRefOid: "a".repeat(40),
     headRefName: "issue-429",
@@ -35,7 +35,8 @@ function installDefaultGhFixture() {
   }, { prefix: "relay-review-advisory-gh-" });
 }
 
-installDefaultGhFixture();
+const defaultGhFixture = installDefaultGhFixture();
+test.after(() => defaultGhFixture.restore());
 
 function hashFile(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");

--- a/tests/relay-review/scripts/review-runner-context.test.js
+++ b/tests/relay-review/scripts/review-runner-context.test.js
@@ -21,6 +21,7 @@ const {
   loadRubricFromRunDir,
 } = require("../../../skills/relay-dispatch/scripts/manifest/rubric");
 const { buildPrompt } = require("../../../skills/relay-review/scripts/review-runner/prompt");
+const { withFakeGh } = require("../fixtures/fake-gh");
 
 function createRunFixture() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-context-"));
@@ -34,96 +35,6 @@ function createRunFixture() {
   const runId = "issue-189-20260418010101010";
   const { runDir } = ensureRunLayout(repoRoot, runId);
   return { repoRoot, runDir, runId };
-}
-
-function withFakeGh(fixture, callback) {
-  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-repo-"));
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-bin-"));
-  const ghPath = path.join(binDir, "gh");
-  fs.writeFileSync(ghPath, `#!/usr/bin/env node
-const fixture = JSON.parse(process.env.RELAY_REVIEW_FAKE_GH_FIXTURE || "{}");
-const args = process.argv.slice(2);
-
-if (fixture.failOnCall) {
-  process.stderr.write("gh should not have been called");
-  process.exit(91);
-}
-
-if (args[0] === "pr" && args[1] === "view") {
-  const jsonIndex = args.indexOf("--json");
-  const fields = jsonIndex === -1 ? "" : args[jsonIndex + 1];
-  if (fields === "closingIssuesReferences,body,headRefName") {
-    process.stdout.write(JSON.stringify({
-      closingIssuesReferences: fixture.closingIssuesReferences || [],
-      body: fixture.body || "",
-      headRefName: fixture.headRefName || "",
-    }));
-    process.exit(0);
-  }
-  if (fields === "statusCheckRollup,reviews,comments") {
-    process.stdout.write(JSON.stringify({
-      statusCheckRollup: fixture.statusCheckRollup || [],
-      reviews: fixture.reviews || [],
-      comments: fixture.comments || [],
-    }));
-    process.exit(0);
-  }
-}
-
-if (args[0] === "repo" && args[1] === "view") {
-  process.stdout.write(JSON.stringify({
-    owner: { login: fixture.owner || "acme" },
-    name: fixture.name || "dev-relay",
-  }));
-  process.exit(0);
-}
-
-if (args[0] === "api" && args[1] === "graphql") {
-  const cursorArg = args.find((arg) => arg.startsWith("threadsCursor="));
-  const pageIndex = cursorArg ? Number(cursorArg.split("=")[1].replace("page-", "")) : 0;
-  const pages = fixture.reviewThreadPages || [{
-    nodes: fixture.reviewThreads || [],
-    pageInfo: { hasNextPage: false, endCursor: null },
-  }];
-  const page = pages[pageIndex] || { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } };
-  const hasNextPage = pageIndex < pages.length - 1;
-  process.stdout.write(JSON.stringify({
-    data: {
-      repository: {
-        pullRequest: {
-          reviewThreads: {
-            pageInfo: {
-              hasNextPage,
-              endCursor: hasNextPage ? "page-" + (pageIndex + 1) : null,
-            },
-            nodes: page.nodes || [],
-          },
-        },
-      },
-    },
-  }));
-  process.exit(0);
-}
-
-process.stderr.write("Unsupported gh invocation: " + args.join(" "));
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(ghPath, 0o755);
-
-  const originalPath = process.env.PATH;
-  const originalFixture = process.env.RELAY_REVIEW_FAKE_GH_FIXTURE;
-  process.env.PATH = `${binDir}:${originalPath}`;
-  process.env.RELAY_REVIEW_FAKE_GH_FIXTURE = JSON.stringify(fixture);
-  try {
-    return callback(repoRoot);
-  } finally {
-    process.env.PATH = originalPath;
-    if (originalFixture === undefined) {
-      delete process.env.RELAY_REVIEW_FAKE_GH_FIXTURE;
-    } else {
-      process.env.RELAY_REVIEW_FAKE_GH_FIXTURE = originalFixture;
-    }
-  }
 }
 
 test("context/resolveIssueNumber prefers manifest issue before GitHub fallbacks", () => {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -26,6 +26,10 @@ const {
   EXECUTION_EVIDENCE_FILENAME,
   FORCE_FINALIZE_GUIDANCE,
 } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+const {
+  installFakeGhOnPath,
+  writeFakeGhScript: writeSharedFakeGhScript,
+} = require("../fixtures/fake-gh");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
@@ -34,56 +38,12 @@ const REVIEW_RUNNER_LINE_CAP = 390;
 const REVIEW_RUNNER_FUNCTION_CAP = 12;
 
 function installDefaultGhFixture() {
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-gh-"));
-  const ghPath = path.join(binDir, "gh");
-  fs.writeFileSync(ghPath, `#!/usr/bin/env node
-const args = process.argv.slice(2);
-function writeJson(value) {
-  process.stdout.write(JSON.stringify(value));
-}
-if (args[0] === "pr" && args[1] === "view") {
-  const jsonIndex = args.indexOf("--json");
-  const fields = jsonIndex >= 0 ? args[jsonIndex + 1] : "";
-  if (fields === "statusCheckRollup,reviews,comments") {
-    writeJson({
-      statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
-      reviews: [],
-      comments: []
-    });
-    process.exit(0);
-  }
-  if (fields === "body" || fields.includes("body")) {
-    writeJson({
-      body: "## Test PR\\n\\nFixture body.\\n",
-      headRefOid: "a".repeat(40),
-      headRefName: "issue-123",
-      closingIssuesReferences: []
-    });
-    process.exit(0);
-  }
-  writeJson({});
-  process.exit(0);
-}
-if (args[0] === "repo" && args[1] === "view") {
-  writeJson({ owner: { login: "acme" }, name: "dev-relay" });
-  process.exit(0);
-}
-if (args[0] === "api" && args[1] === "graphql") {
-  writeJson({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } });
-  process.exit(0);
-}
-if (args[0] === "api" && args[1] === "user") {
-  process.stdout.write("fixture-reviewer\\n");
-  process.exit(0);
-}
-if (args[0] === "pr" && args[1] === "comment") {
-  process.exit(0);
-}
-process.stderr.write("Unsupported default gh fixture invocation: " + args.join(" "));
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(ghPath, 0o755);
-  process.env.PATH = `${binDir}:${process.env.PATH}`;
+  installFakeGhOnPath({
+    body: "## Test PR\n\nFixture body.\n",
+    headRefOid: "a".repeat(40),
+    headRefName: "issue-123",
+    statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
+  }, { prefix: "relay-review-gh-" });
 }
 
 installDefaultGhFixture();
@@ -372,50 +332,18 @@ function countFileLines(text) {
 
 function writeFakeGhScript(repoRoot, { prBody, capturePath }) {
   const filePath = path.join(repoRoot, "gh");
-  fs.writeFileSync(filePath, `#!/usr/bin/env node
-const fs = require("fs");
-const args = process.argv.slice(2);
-if (args[0] === "pr" && args[1] === "view") {
-  const jsonIndex = args.indexOf("--json");
-  const fields = jsonIndex === -1 ? "" : args[jsonIndex + 1];
-  if (fields === "statusCheckRollup,reviews,comments") {
-    process.stdout.write(JSON.stringify({
+  return writeSharedFakeGhScript({
+    ghPath: filePath,
+    capturePath,
+    fixture: {
+      body: prBody,
+      headRefOid: "a".repeat(40),
+      headRefName: "issue-42",
+      number: 123,
+      title: "Manifest-selected PR",
       statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
-      reviews: [],
-      comments: []
-    }));
-    process.exit(0);
-  }
-  if (args.includes("-q") && args[args.indexOf("-q") + 1] === ".body") {
-    process.stdout.write(${JSON.stringify(prBody)});
-    process.exit(0);
-  }
-  process.stdout.write(JSON.stringify({ body: ${JSON.stringify(prBody)} }));
-  process.exit(0);
-}
-if (args[0] === "pr" && args[1] === "comment") {
-  const bodyIndex = args.indexOf("--body");
-  const body = bodyIndex !== -1 ? args[bodyIndex + 1] : "";
-  fs.writeFileSync(${JSON.stringify(capturePath)}, body, "utf-8");
-  process.exit(0);
-}
-if (args[0] === "repo" && args[1] === "view") {
-  process.stdout.write(JSON.stringify({ owner: { login: "acme" }, name: "dev-relay" }));
-  process.exit(0);
-}
-if (args[0] === "api" && args[1] === "graphql") {
-  process.stdout.write(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }));
-  process.exit(0);
-}
-if (args[0] === "api" && args[1] === "user") {
-  process.stdout.write("fixture-reviewer\\n");
-  process.exit(0);
-}
-process.stderr.write("Unsupported gh invocation: " + args.join(" "));
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(filePath, 0o755);
-  return filePath;
+    },
+  });
 }
 
 function writePrHeadGhScript(repoRoot, { headRefOid, number = 123, headRefName = "issue-42" }) {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -38,7 +38,7 @@ const REVIEW_RUNNER_LINE_CAP = 390;
 const REVIEW_RUNNER_FUNCTION_CAP = 12;
 
 function installDefaultGhFixture() {
-  installFakeGhOnPath({
+  return installFakeGhOnPath({
     body: "## Test PR\n\nFixture body.\n",
     headRefOid: "a".repeat(40),
     headRefName: "issue-123",
@@ -46,7 +46,8 @@ function installDefaultGhFixture() {
   }, { prefix: "relay-review-gh-" });
 }
 
-installDefaultGhFixture();
+const defaultGhFixture = installDefaultGhFixture();
+test.after(() => defaultGhFixture.restore());
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-runner-"));


### PR DESCRIPTION
## Summary

- Restore the relay wrapper Done Criteria outcome phrase expected by the rubric reference contract.
- Consolidate shared fake `gh` review-signal behavior for review-runner and mixed TDD relay-plan tests.
- Stabilize relay-ready readiness performance assertions by gating internal `elapsed_ms`, not subprocess wall-clock startup.
- Document delayed-publication external review trigger policy and CodeRabbit rate-limit recovery guidance.

Fixes #743
Fixes #742
Fixes #697
Fixes #744

## Verification

- `node --check tests/relay-review/fixtures/fake-gh.js`
- `node --test tests/relay-plan/scripts/rubric-reference-contract.test.js`
- `node --test tests/relay-plan/scripts/tdd-flavor.test.js`
- `node --test tests/relay-ready/scripts/probe-readiness.test.js`
- `node --test tests/relay-review/scripts/review-runner-context.test.js tests/relay-review/scripts/review-runner.test.js tests/relay-review/scripts/review-runner-advisory.test.js`
- `node --test tests/relay-plan/scripts/*.test.js`
- `node --test tests/relay-ready/scripts/*.test.js`
- `node --test tests/relay-review/scripts/*.test.js`
- `node --test tests/relay-merge/scripts/*.test.js`
- `node --test --test-name-pattern 'doctor includes project route provenance and best-effort model probes' tests/relay-dispatch/scripts/relay-config.test.js`
- `node --test tests/relay-dispatch/scripts/relay-config.test.js`
- `npx --yes skills add . -l`
- `git diff --check`

Note: `node --test tests/relay-dispatch/scripts/*.test.js` was also run. It produced one non-reproduced `relay-config.test.js` doctor model-probe failure in the full-suite run; the exact test and the full `relay-config.test.js` file both passed immediately afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 외부 리뷰 요청 시점과 재요청 기준이 더 명확해졌습니다. 불필요한 리뷰 재호출을 줄이고, 상태 확인과 최종 정리 기준이 강화되었습니다.

* **Bug Fixes**
  * 병합 준비 점검 기준에 완료 조건 충족 여부 확인이 추가되어, 최종 승인 전 검증이 더 엄격해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->