### PR TITLE
Emit route next-step instructions from run-preflight (#747)

### DIFF
--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -38,18 +38,7 @@ PREFLIGHT=$(node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" \
   --body-file "$ISSUE_BODY_FILE" --manifest "$RUN_MANIFEST" --json)
 ```
 
-Branch on the JSON using [preflight-guards.md](references/preflight-guards.md); only evaluate readiness when `inflight.route == "continue"`:
-- `inflight.route == "existing-open-pr"` → set `PR_NUM`, skip Steps 2-3, and review the existing PR.
-- `inflight.route == "existing-merged-pr"` → update the sprint file to `[x]` if present and stop.
-- `inflight.route == "inflight-run"` → resume or inspect that run; continue at its manifest state.
-- `readiness.decision.route_decision == "ready_single"` → proceed to Step 2.
-- `readiness.decision.route_decision == "ready_light"` → proceed to Step 2 with S-size quick planning and compact rubric guidance.
-- `readiness.decision.route_decision == "readiness_prompt"` and `.decision.prompt_allowed == true` → set `SUMMARY=.readiness.signals_summary` and issue exactly `AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.
-- `readiness.decision.route_decision == "needs_split"` and `.decision.prompt_allowed == true` → run proposal-first relay-ready shaping; accepted handoffs become the relay-plan source of truth before any dispatch.
-- `chain-y` → invoke relay-ready Q&A, wait, persist the handoff, set `manifest.anchor.readiness`, then resume Step 2.
-- `chain-n` → emit `bypass_override_by_user` from `.decision.branch_labels["chain-n"].event_payload`, then proceed to Step 2.
-- `chain-abort` → emit `readiness_check_failed` from `.decision.branch_labels["chain-abort"].event_payload`, then close the run.
-- `noninteractive-fail` → emit `readiness_check_failed_nontty` from `.decision.branch_labels["noninteractive-fail"].event_payload`, then close the run.
+Branch on the JSON: follow `inflight.instruction` when `inflight.route != "continue"`, otherwise follow `readiness.decision.instruction`. The full branch table lives in [preflight-guards.md](references/preflight-guards.md). When `readiness.decision.route_decision == "needs_split"`, the instruction routes through proposal-first relay-ready shaping; accepted handoffs become the relay-plan source of truth before any dispatch.
 
 Fast path: bypass relay-ready only for one relay-ready task with a stable review anchor and no clarification/decomposition needed. Otherwise run `relay-ready`; its handoff brief becomes the downstream source of truth.
 

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -1,8 +1,8 @@
 # Relay Preflight Guards
 
 `relay/scripts/run-preflight.js` keeps deterministic guard work outside the
-main `/relay` flow. It prints JSON only. The skill keeps the decision layer,
-including the readiness `AskUserQuestion(...)` branch.
+main `/relay` flow. It prints JSON only, including human-readable next-step
+instructions that the skill follows without carrying route prose inline.
 
 ## Route Stage
 
@@ -17,11 +17,12 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage route 
 - Firing condition: an issue-numbered task is entering Step 1 routing.
 - Signals read: `gh pr list --head <branch> --state all --json number,state,mergedAt,headRefName,url`; non-terminal manifests for the issue via relay-dispatch manifest storage.
 - Events emitted: none by this guard.
+- Instruction field: every in-flight route includes `inflight.instruction`, a one-sentence operator next action.
 - Branch labels:
-  - `existing-open-pr`: open PR found; skip plan/dispatch and review the existing PR.
-  - `existing-merged-pr`: merged PR found; update sprint completion if present and stop.
-  - `inflight-run`: non-terminal run manifest found; resume or inspect that run.
-  - `continue`: no in-flight work found; continue to readiness handling.
+  - `existing-open-pr`: `instruction` tells the operator to review the existing open PR instead of planning or dispatching a new run.
+  - `existing-merged-pr`: `instruction` tells the operator to mark the sprint item done if present and stop because the PR is already merged.
+  - `inflight-run`: `instruction` tells the operator to resume or inspect the existing inflight run and continue from its manifest state.
+  - `continue`: `instruction` tells the operator to continue to readiness handling before planning or dispatch.
 
 ### Readiness probe + chain prompt guard
 
@@ -32,14 +33,15 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage route 
   - `bypass_override_by_user`: emitted by the skill decision layer for `chain-n`.
   - `readiness_check_failed`: emitted by the skill decision layer for `chain-abort`.
   - `readiness_check_failed_nontty`: emitted by the skill decision layer for `noninteractive-fail`.
+- Instruction fields: every `readiness.decision.branch_labels.<label>.instruction` is a one-sentence operator next action, and `readiness.decision.instruction` copies the selected branch instruction, using the prompt instruction when the selected branch is the interactive prompt.
 - Branch labels:
-  - `bypass`: route decision is `ready_single`; probe returns `bypass=true`; proceed to Step 2.
-  - `ready-light`: route decision is `ready_light`; readiness returned `next_action=proceed` without a bypass anchor; proceed to Step 2 using S-size quick planning and compact rubric guidance.
-  - `chain-y`: probe returns `bypass=false`, prompt is allowed, user answers `y`; invoke relay-ready Q&A, persist the handoff, set `manifest.anchor.readiness`, then resume Step 2.
+  - `bypass`: route decision is `ready_single`; probe returns `bypass=true`; `instruction` names the `readiness_probe` event and tells the operator to proceed to Step 2.
+  - `ready-light`: route decision is `ready_light`; readiness returned `next_action=proceed` without a bypass anchor; `instruction` names the `readiness_probe` event and tells the operator to proceed to Step 2 using S-size quick planning and compact rubric guidance.
+  - `chain-y`: probe returns `bypass=false`, prompt is allowed, and the host should ask the operator in plain text to choose `y` to invoke relay-ready before Step 2, `n` to emit `bypass_override_by_user` and proceed to Step 2, or `abort` to emit `readiness_check_failed` and close the run after the `readiness_probe`.
   - `proposal-first`: route decision is `needs_split`, prompt is allowed, and the request must go through relay-ready proposal-first shaping before Step 2. The JSON branch label includes `relay_ready_mode=proposal_first`, `requires_accepted_handoff=true`, and `source_of_truth=accepted_relay_ready_handoff`.
   - `chain-n`: probe returns `bypass=false`, prompt is allowed, user explicitly bypasses relay-ready; emit `bypass_override_by_user` with the script's event payload and proceed to Step 2. For `needs_split`, this remains an explicit operator override, not the default route.
-  - `chain-abort`: probe returns `bypass=false`, prompt is allowed, user answers `abort`; emit `readiness_check_failed` with the script's event payload and close the run.
-  - `noninteractive-fail`: route decision is `readiness_prompt` or `needs_split` and no prompt is allowed; emit `readiness_check_failed_nontty` with the script's event payload and close the run.
+  - `chain-abort`: probe returns `bypass=false`, prompt is allowed, user answers `abort`; `instruction` names `readiness_check_failed` and tells the operator to close the run with the script's event payload.
+  - `noninteractive-fail`: route decision is `readiness_prompt` or `needs_split` and no prompt is allowed; `instruction` names `readiness_check_failed_nontty` and tells the operator to close the run with the script's event payload.
 
 Route decisions are advisory labels, not lifecycle states:
 
@@ -48,8 +50,7 @@ Route decisions are advisory labels, not lifecycle states:
 - `readiness_prompt`: preserve the existing `qa_needed` prompt or non-interactive failure behavior.
 - `needs_split`: strong task-shape signals indicate decomposition should be considered before dispatch. Prompt-allowed runs use `proposal-first`; non-interactive runs still fail closed before dispatch.
 
-Do not move the readiness prompt into the script. The exact prompt remains:
-`AskUserQuestion("Readiness gaps detected: ${SUMMARY}. Invoke relay-ready first? [y/n/abort]")`.
+The readiness prompt wording is host-neutral: ask the operator to choose `y` to invoke relay-ready first, `n` to bypass relay-ready and proceed, or `abort` to close the run.
 
 ## Review Stage
 

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -33,7 +33,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage route 
   - `bypass_override_by_user`: emitted by the skill decision layer for `chain-n`.
   - `readiness_check_failed`: emitted by the skill decision layer for `chain-abort`.
   - `readiness_check_failed_nontty`: emitted by the skill decision layer for `noninteractive-fail`.
-- Instruction fields: every `readiness.decision.branch_labels.<label>.instruction` is a one-sentence operator next action, and `readiness.decision.instruction` copies the selected branch instruction, using the prompt instruction when the selected branch is the interactive prompt.
+- Instruction fields: every `readiness.decision.branch_labels.<label>.instruction` is a one-sentence operator next action, and `readiness.decision.instruction` copies the selected branch instruction except for `recommended_branch == "prompt"`, where it emits the host-neutral readiness question because `prompt` is intentionally not a branch label.
 - Branch labels:
   - `bypass`: route decision is `ready_single`; probe returns `bypass=true`; `instruction` names the `readiness_probe` event and tells the operator to proceed to Step 2.
   - `ready-light`: route decision is `ready_light`; readiness returned `next_action=proceed` without a bypass anchor; `instruction` names the `readiness_probe` event and tells the operator to proceed to Step 2 using S-size quick planning and compact rubric guidance.
@@ -50,7 +50,7 @@ Route decisions are advisory labels, not lifecycle states:
 - `readiness_prompt`: preserve the existing `qa_needed` prompt or non-interactive failure behavior.
 - `needs_split`: strong task-shape signals indicate decomposition should be considered before dispatch. Prompt-allowed runs use `proposal-first`; non-interactive runs still fail closed before dispatch.
 
-The readiness prompt wording is host-neutral: ask the operator to choose `y` to invoke relay-ready first, `n` to bypass relay-ready and proceed, or `abort` to close the run.
+The readiness prompt wording is host-neutral: `Readiness gaps detected: <summary>. Invoke relay-ready first? Answer y, n, or abort?`
 
 ## Review Stage
 

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -28,6 +28,11 @@ const BRANCH_INSTRUCTIONS = {
   "chain-abort": "If the operator answers abort, emit readiness_check_failed with the supplied payload and close the run.",
   "noninteractive-fail": "Emit readiness_check_failed_nontty with the supplied payload and close the run because no prompt is allowed.",
 };
+
+function buildPromptInstruction(summary) {
+  const detail = summary || "readiness gaps require operator choice";
+  return `Readiness gaps detected: ${detail}. Invoke relay-ready first? Answer y, n, or abort?`;
+}
 const KNOWN_FLAGS = [
   "--stage",
   "--repo",
@@ -357,7 +362,9 @@ function buildReadinessDecision(envelope, { promptAllowed }) {
   return {
     route_decision: routeDecision,
     recommended_branch: recommendedBranch,
-    instruction: (branchLabels[recommendedBranch] || branchLabels["chain-y"]).instruction,
+    instruction: recommendedBranch === "prompt"
+      ? buildPromptInstruction(envelope?.signals_summary)
+      : branchLabels[recommendedBranch].instruction,
     prompt_allowed: promptAllowed,
     prompt_summary: ["readiness_prompt", "needs_split"].includes(routeDecision) && promptAllowed
       ? envelope?.signals_summary || null

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -403,6 +403,7 @@ function buildUnevaluatedReadinessForInflightRoute(inflight) {
     elapsed_ms: 0,
     decision: {
       recommended_branch: "not-evaluated",
+      instruction: inflight?.instruction || `Follow the ${route} inflight route before readiness handling.`,
       prompt_allowed: false,
       prompt_summary: null,
       branch_labels: {},

--- a/skills/relay/scripts/run-preflight.js
+++ b/skills/relay/scripts/run-preflight.js
@@ -13,6 +13,21 @@ const { resolveManifestRecord } = require("../../relay-dispatch/scripts/relay-re
 const { EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 
 const EVENT_FIELD = "event";
+const INFLIGHT_ROUTE_INSTRUCTIONS = {
+  "existing-open-pr": "Review the existing open PR instead of planning or dispatching a new run.",
+  "existing-merged-pr": "Mark the sprint item done if present and stop because the PR is already merged.",
+  "inflight-run": "Resume or inspect the existing inflight run and continue from its manifest state.",
+  continue: "Continue to readiness handling before planning or dispatch.",
+};
+const BRANCH_INSTRUCTIONS = {
+  bypass: "Proceed to Step 2 using the bypass route and keep the readiness_probe event as the readiness evidence.",
+  "ready-light": "Proceed to Step 2 with S-size quick planning and compact rubric guidance while preserving the readiness_probe event payload.",
+  "chain-y": "Ask the operator in plain text to choose y to invoke relay-ready before Step 2, n to emit bypass_override_by_user and proceed to Step 2, or abort to emit readiness_check_failed and close the run after the readiness_probe.",
+  "proposal-first": "Run proposal-first relay-ready shaping after the readiness_probe, require an accepted handoff, and use that handoff as the relay-plan source of truth before dispatch.",
+  "chain-n": "If the operator answers n, emit bypass_override_by_user with the supplied payload and proceed to Step 2.",
+  "chain-abort": "If the operator answers abort, emit readiness_check_failed with the supplied payload and close the run.",
+  "noninteractive-fail": "Emit readiness_check_failed_nontty with the supplied payload and close the run because no prompt is allowed.",
+};
 const KNOWN_FLAGS = [
   "--stage",
   "--repo",
@@ -181,6 +196,7 @@ function routeFromInflight({ prCheck, runCheck }) {
   if (prCheck.status === "open") {
     return {
       route: "existing-open-pr",
+      instruction: INFLIGHT_ROUTE_INSTRUCTIONS["existing-open-pr"],
       next_action: "skip_plan_dispatch_and_review_existing_pr",
       prNumber: prCheck.pr?.number || null,
       runId: runCheck.runs[0]?.runId || null,
@@ -189,6 +205,7 @@ function routeFromInflight({ prCheck, runCheck }) {
   if (prCheck.status === "merged") {
     return {
       route: "existing-merged-pr",
+      instruction: INFLIGHT_ROUTE_INSTRUCTIONS["existing-merged-pr"],
       next_action: "mark_sprint_done_if_present",
       prNumber: prCheck.pr?.number || null,
       runId: runCheck.runs[0]?.runId || null,
@@ -197,6 +214,7 @@ function routeFromInflight({ prCheck, runCheck }) {
   if (runCheck.runs.length > 0) {
     return {
       route: "inflight-run",
+      instruction: INFLIGHT_ROUTE_INSTRUCTIONS["inflight-run"],
       next_action: "resume_or_inspect_inflight_run",
       prNumber: prCheck.pr?.number || null,
       runId: runCheck.runs[0].runId,
@@ -204,6 +222,7 @@ function routeFromInflight({ prCheck, runCheck }) {
   }
   return {
     route: "continue",
+    instruction: INFLIGHT_ROUTE_INSTRUCTIONS.continue,
     next_action: "continue_to_readiness",
     prNumber: null,
     runId: null,
@@ -267,73 +286,83 @@ function buildReadinessDecision(envelope, { promptAllowed }) {
     recommendedBranch = promptAllowed ? "prompt" : "noninteractive-fail";
   }
 
+  const branchLabels = {
+    bypass: {
+      label: "bypass",
+      [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+      action: "proceed_to_step_2",
+      instruction: BRANCH_INSTRUCTIONS.bypass,
+    },
+    "ready-light": {
+      label: "ready-light",
+      [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+      action: "proceed_to_step_2_light_planning",
+      instruction: BRANCH_INSTRUCTIONS["ready-light"],
+      planning_profile: "ready_light",
+      event_payload: {
+        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+        ...commonPayload,
+      },
+    },
+    "chain-y": {
+      label: "chain-y",
+      [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+      action: "invoke_relay_ready_then_resume_step_2",
+      instruction: BRANCH_INSTRUCTIONS["chain-y"],
+    },
+    "proposal-first": {
+      label: "proposal-first",
+      [EVENT_FIELD]: EVENTS.READINESS_PROBE,
+      action: "invoke_relay_ready_proposal_first_then_resume_step_2",
+      instruction: BRANCH_INSTRUCTIONS["proposal-first"],
+      relay_ready_mode: "proposal_first",
+      requires_accepted_handoff: true,
+      source_of_truth: "accepted_relay_ready_handoff",
+    },
+    "chain-n": {
+      label: "chain-n",
+      [EVENT_FIELD]: EVENTS.BYPASS_OVERRIDE_BY_USER,
+      action: "proceed_to_step_2",
+      instruction: BRANCH_INSTRUCTIONS["chain-n"],
+      event_payload: {
+        [EVENT_FIELD]: EVENTS.BYPASS_OVERRIDE_BY_USER,
+        reason: "operator_bypass_after_readiness_prompt",
+        ...commonPayload,
+      },
+    },
+    "chain-abort": {
+      label: "chain-abort",
+      [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED,
+      action: "close_run",
+      instruction: BRANCH_INSTRUCTIONS["chain-abort"],
+      event_payload: {
+        [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED,
+        reason: "operator_aborted_after_readiness_prompt",
+        ...commonPayload,
+      },
+    },
+    "noninteractive-fail": {
+      label: "noninteractive-fail",
+      [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED_NONTTY,
+      action: "close_run",
+      instruction: BRANCH_INSTRUCTIONS["noninteractive-fail"],
+      event_payload: {
+        [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED_NONTTY,
+        reason: "readiness_gaps_without_prompt",
+        ...commonPayload,
+      },
+    },
+  };
+
   return {
     route_decision: routeDecision,
     recommended_branch: recommendedBranch,
+    instruction: (branchLabels[recommendedBranch] || branchLabels["chain-y"]).instruction,
     prompt_allowed: promptAllowed,
     prompt_summary: ["readiness_prompt", "needs_split"].includes(routeDecision) && promptAllowed
       ? envelope?.signals_summary || null
       : null,
-    branch_labels: {
-      bypass: {
-        label: "bypass",
-        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
-        action: "proceed_to_step_2",
-      },
-      "ready-light": {
-        label: "ready-light",
-        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
-        action: "proceed_to_step_2_light_planning",
-        planning_profile: "ready_light",
-        event_payload: {
-          [EVENT_FIELD]: EVENTS.READINESS_PROBE,
-          ...commonPayload,
-        },
-      },
-      "chain-y": {
-        label: "chain-y",
-        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
-        action: "invoke_relay_ready_then_resume_step_2",
-      },
-      "proposal-first": {
-        label: "proposal-first",
-        [EVENT_FIELD]: EVENTS.READINESS_PROBE,
-        action: "invoke_relay_ready_proposal_first_then_resume_step_2",
-        relay_ready_mode: "proposal_first",
-        requires_accepted_handoff: true,
-        source_of_truth: "accepted_relay_ready_handoff",
-      },
-      "chain-n": {
-        label: "chain-n",
-        [EVENT_FIELD]: EVENTS.BYPASS_OVERRIDE_BY_USER,
-        action: "proceed_to_step_2",
-        event_payload: {
-          [EVENT_FIELD]: EVENTS.BYPASS_OVERRIDE_BY_USER,
-          reason: "operator_bypass_after_readiness_prompt",
-          ...commonPayload,
-        },
-      },
-      "chain-abort": {
-        label: "chain-abort",
-        [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED,
-        action: "close_run",
-        event_payload: {
-          [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED,
-          reason: "operator_aborted_after_readiness_prompt",
-          ...commonPayload,
-        },
-      },
-      "noninteractive-fail": {
-        label: "noninteractive-fail",
-        [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED_NONTTY,
-        action: "close_run",
-        event_payload: {
-          [EVENT_FIELD]: EVENTS.READINESS_CHECK_FAILED_NONTTY,
-          reason: "readiness_gaps_without_prompt",
-          ...commonPayload,
-        },
-      },
-    },
+    branch_labels: branchLabels,
   };
 }
 

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -62,7 +62,7 @@ test("route branch_labels entries all carry non-empty instruction", () => {
   });
 });
 
-test("route readiness decision instruction follows the recommended branch instruction", () => {
+test("route readiness decision instruction follows the recommended branch instruction for branch routes", () => {
   const cases = [
     buildReadinessDecision(readyEnvelope(), { promptAllowed: false }),
     buildReadinessDecision(readyEnvelope({ bypass: false }), { promptAllowed: false }),
@@ -100,7 +100,9 @@ test("route prompt instruction offers host-neutral y n abort choices", () => {
   }), { promptAllowed: true });
 
   assert.equal(decision.recommended_branch, "prompt");
-  assert.equal(decision.instruction, EXPECTED_BRANCH_INSTRUCTIONS["chain-y"]);
+  assert.notEqual(decision.instruction, EXPECTED_BRANCH_INSTRUCTIONS["chain-y"]);
+  assert.match(decision.instruction, /^Readiness gaps detected: Gaps: verifiability=low\./);
+  assert.match(decision.instruction, /\?$/);
   assert.match(decision.instruction, /\by\b/);
   assert.match(decision.instruction, /\bn\b/);
   assert.match(decision.instruction, /\babort\b/);

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const {
   buildReadinessDecision,
+  routeFromInflight,
 } = require("../../../skills/relay/scripts/run-preflight");
 
 const {
@@ -20,14 +21,129 @@ const {
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay", "scripts", "run-preflight.js");
 
-test("route decision treats bypass as ready_single without changing the bypass branch", () => {
-  const decision = buildReadinessDecision({
+const EXPECTED_BRANCH_INSTRUCTIONS = {
+  bypass: "Proceed to Step 2 using the bypass route and keep the readiness_probe event as the readiness evidence.",
+  "ready-light": "Proceed to Step 2 with S-size quick planning and compact rubric guidance while preserving the readiness_probe event payload.",
+  "chain-y": "Ask the operator in plain text to choose y to invoke relay-ready before Step 2, n to emit bypass_override_by_user and proceed to Step 2, or abort to emit readiness_check_failed and close the run after the readiness_probe.",
+  "proposal-first": "Run proposal-first relay-ready shaping after the readiness_probe, require an accepted handoff, and use that handoff as the relay-plan source of truth before dispatch.",
+  "chain-n": "If the operator answers n, emit bypass_override_by_user with the supplied payload and proceed to Step 2.",
+  "chain-abort": "If the operator answers abort, emit readiness_check_failed with the supplied payload and close the run.",
+  "noninteractive-fail": "Emit readiness_check_failed_nontty with the supplied payload and close the run because no prompt is allowed.",
+};
+
+const EXPECTED_INFLIGHT_INSTRUCTIONS = {
+  "existing-open-pr": "Review the existing open PR instead of planning or dispatching a new run.",
+  "existing-merged-pr": "Mark the sprint item done if present and stop because the PR is already merged.",
+  "inflight-run": "Resume or inspect the existing inflight run and continue from its manifest state.",
+  continue: "Continue to readiness handling before planning or dispatch.",
+};
+
+function readyEnvelope(overrides = {}) {
+  return {
     readiness_score: { clarity: "high", granularity: "high", verifiability: "high" },
     bypass: true,
     next_action: "proceed",
     signals_summary: "Ready: bypass conditions passed.",
     task_shape: { strength: "none", strong: false, signals: [] },
-  }, { promptAllowed: false });
+    risk: { high: false, signals: [] },
+    ...overrides,
+  };
+}
+
+test("route branch_labels entries all carry non-empty instruction", () => {
+  const decision = buildReadinessDecision(readyEnvelope(), { promptAllowed: true });
+  const branchKeys = Object.keys(decision.branch_labels);
+
+  assert.deepEqual(branchKeys.sort(), Object.keys(EXPECTED_BRANCH_INSTRUCTIONS).sort());
+  branchKeys.forEach((key) => {
+    assert.equal(typeof decision.branch_labels[key].instruction, "string");
+    assert.ok(decision.branch_labels[key].instruction.length > 0);
+    assert.equal(decision.branch_labels[key].instruction, EXPECTED_BRANCH_INSTRUCTIONS[key]);
+  });
+});
+
+test("route readiness decision instruction follows the recommended branch instruction", () => {
+  const cases = [
+    buildReadinessDecision(readyEnvelope(), { promptAllowed: false }),
+    buildReadinessDecision(readyEnvelope({ bypass: false }), { promptAllowed: false }),
+    buildReadinessDecision(readyEnvelope({
+      bypass: false,
+      next_action: "qa_needed",
+      task_shape: {
+        strength: "strong",
+        strong: true,
+        signals: [{ condition: "broad_scope_language", evidence: "foundation" }],
+      },
+    }), { promptAllowed: true }),
+    buildReadinessDecision(readyEnvelope({
+      bypass: false,
+      next_action: "qa_needed",
+      signals_summary: "Gaps: verifiability=low.",
+      risk: { high: true, signals: ["high_risk_keyword"] },
+    }), { promptAllowed: false }),
+  ];
+
+  cases.forEach((decision) => {
+    assert.equal(
+      decision.instruction,
+      decision.branch_labels[decision.recommended_branch].instruction
+    );
+  });
+});
+
+test("route prompt instruction offers host-neutral y n abort choices", () => {
+  const decision = buildReadinessDecision(readyEnvelope({
+    bypass: false,
+    next_action: "qa_needed",
+    signals_summary: "Gaps: verifiability=low.",
+    risk: { high: true, signals: ["high_risk_keyword"] },
+  }), { promptAllowed: true });
+
+  assert.equal(decision.recommended_branch, "prompt");
+  assert.equal(decision.instruction, EXPECTED_BRANCH_INSTRUCTIONS["chain-y"]);
+  assert.match(decision.instruction, /\by\b/);
+  assert.match(decision.instruction, /\bn\b/);
+  assert.match(decision.instruction, /\babort\b/);
+});
+
+test("route inflight routes all carry next-step instruction", () => {
+  const cases = [
+    {
+      expectedRoute: "existing-open-pr",
+      prCheck: { status: "open", pr: { number: 12 } },
+      runCheck: { runs: [{ runId: "run-open" }] },
+    },
+    {
+      expectedRoute: "existing-merged-pr",
+      prCheck: { status: "merged", pr: { number: 13 } },
+      runCheck: { runs: [{ runId: "run-merged" }] },
+    },
+    {
+      expectedRoute: "inflight-run",
+      prCheck: { status: "not_found", pr: null },
+      runCheck: { runs: [{ runId: "run-active" }] },
+    },
+    {
+      expectedRoute: "continue",
+      prCheck: { status: "not_found", pr: null },
+      runCheck: { runs: [] },
+    },
+  ];
+
+  cases.forEach(({ expectedRoute, prCheck, runCheck }) => {
+    const result = routeFromInflight({ prCheck, runCheck });
+    assert.equal(result.route, expectedRoute);
+    assert.equal(result.instruction, EXPECTED_INFLIGHT_INSTRUCTIONS[expectedRoute]);
+  });
+});
+
+test("run-preflight source does not reference AskUserQuestion", () => {
+  const source = fs.readFileSync(SCRIPT, "utf-8");
+  assert.doesNotMatch(source, /AskUserQuestion/);
+});
+
+test("route decision treats bypass as ready_single without changing the bypass branch", () => {
+  const decision = buildReadinessDecision(readyEnvelope(), { promptAllowed: false });
 
   assert.equal(decision.route_decision, "ready_single");
   assert.equal(decision.recommended_branch, "bypass");

--- a/tests/relay/scripts/run-preflight.test.js
+++ b/tests/relay/scripts/run-preflight.test.js
@@ -139,6 +139,56 @@ test("route inflight routes all carry next-step instruction", () => {
   });
 });
 
+function setupRouteGhFixture({ prCandidates = [] } = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-route-preflight-"));
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-route-gh-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "list") {
+  process.stdout.write(${JSON.stringify(JSON.stringify(prCandidates))});
+  process.exit(0);
+}
+process.stderr.write("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+
+  return { repoRoot, env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` } };
+}
+
+function runRoutePreflight(fixture, args = []) {
+  return JSON.parse(execFileSync(process.execPath, [
+    SCRIPT,
+    "--stage", "route",
+    "--repo", fixture.repoRoot,
+    ...args,
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: fixture.env,
+  }));
+}
+
+test("route inflight readiness decision carries a non-empty instruction", () => {
+  const fixture = setupRouteGhFixture({
+    prCandidates: [{
+      number: 404,
+      state: "OPEN",
+      mergedAt: null,
+      headRefName: "issue-404",
+      url: "https://example.test/pull/404",
+    }],
+  });
+
+  const result = runRoutePreflight(fixture, ["--branch", "issue-404"]);
+
+  assert.equal(result.inflight.route, "existing-open-pr");
+  assert.equal(typeof result.readiness.decision.instruction, "string");
+  assert.ok(result.readiness.decision.instruction.length > 0);
+  assert.equal(result.readiness.decision.instruction, result.inflight.instruction);
+});
+
 test("run-preflight source does not reference AskUserQuestion", () => {
   const source = fs.readFileSync(SCRIPT, "utf-8");
   assert.doesNotMatch(source, /AskUserQuestion/);


### PR DESCRIPTION
Closes #747.

`run-preflight.js --stage route` now emits operator-readable `instruction` fields — on all 4 inflight routes, all 7 `readiness.decision.branch_labels` entries, and `readiness.decision.instruction` (the recommended branch's instruction; for the interactive prompt route, the host-neutral y/n/abort question itself). SKILL.md Step 1 collapses to follow-the-instruction with `references/preflight-guards.md` as the authoritative branch table; route semantics are byte-identical (additive-only output change).

Relay run `issue-747-20260703034220261-72e4f32b`: 3 dispatch rounds (R1 caught a planner DC defect — the `recommended_branch == "prompt"` invariant was unsatisfiable; anchor amended via persist-done-criteria as `planner_decision`), internal review R3 PASS, post-publication review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 사전 점검 결과에 다음 행동을 더 명확히 안내하는 문구가 추가되었습니다.
  * 인플라이트 상태와 준비성 분기에서 각 상황별 안내가 한눈에 보이도록 정리되었습니다.

* **문서**
  * 사전 점검 분기와 안내 문구를 설명하는 참고 문서가 더 구체적으로 업데이트되었습니다.

* **테스트**
  * 다양한 라우팅 및 준비성 분기에서 안내 문구가 올바르게 표시되는지 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->