### PR TITLE
Add convergence budget operator summaries to relay-review (#725)

### DIFF
--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -16,6 +16,7 @@ const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog, toIterationScor
 const { applyQualityExecutionStatus, buildExecutionEvidenceFailureVerdict, buildMissingExecutionEvidenceVerdict, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
 const { applyReviewAssurancePolicy } = require("./review-runner/assurance");
 const { buildRedispatchPrompt, buildRubricGateRedispatchPrompt, computeFactorStatusFlips, computeRepeatedIssueCount, decideFlipFlopEscalation, detectChurnGrowth, summarizeLineage, toEscalatedVerdict } = require("./review-runner/redispatch");
+const { buildConvergenceSummary, formatConvergenceMarkdown } = require("./review-runner/convergence");
 const { applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { enforceRoundCap } = require("./review-runner/round-cap");
 const { passNextActionsFor, writeRoundArtifacts } = require("./review-runner/round-artifacts");
@@ -40,9 +41,7 @@ async function run() {
     jsonOut, manifestPathArg, manualReviewReason, noComment, prArg, prepareOnly, repoArg,
     repoPath, reviewFile, reviewerArg, reviewerModel, reviewerScriptArg, runIdArg,
   } = options;
-  if (manualReviewReason && !reviewFile) {
-    throw new Error("--manual-review-reason requires --review-file");
-  }
+  if (manualReviewReason && !reviewFile) throw new Error("--manual-review-reason requires --review-file");
 
   const { branch, issueNumber, manifest, prNumber, reviewRepoPath, runRepoPath } = resolveContext(
     repoPath,
@@ -152,8 +151,7 @@ async function run() {
     rubricStatus: rubricLoad.status,
     rubricWarning: rubricLoad.warning || null,
     runId: data.run_id,
-    state: data.state,
-    verdictPath: null,
+    state: data.state, convergenceSummary: null, verdictPath: null,
   };
   let advisoryRun = null;
   let advisoryResult = null;
@@ -249,9 +247,7 @@ async function run() {
     disallowPassReason: prSignalsPassBlockReason,
   });
 
-  const repeatedIssueCount = verdict.verdict === "changes_requested"
-    ? computeRepeatedIssueCount(runDir, round, verdict.issues)
-    : 0;
+  const repeatedIssueCount = verdict.verdict === "changes_requested" ? computeRepeatedIssueCount(runDir, round, verdict.issues) : 0;
   const lineageSummary = summarizeLineage(verdict.issues);
   let escalationDecision = { round, trigger: "none", factors: [], traces: [], lineage_summary: lineageSummary, decision: "continue", reason: "no_trigger" };
   if (verdict.verdict === "changes_requested" && repeatedIssueCount >= 3) {
@@ -271,6 +267,9 @@ async function run() {
       factorFlips.map(({ factor, trace }) => `Rubric factor '${factor}' status flipped across 3 rounds (trace: ${trace.join("→")}). Owner decision required — reviewer cannot converge autonomously.`).join("; ")
     );
   }
+  const convergenceSummary = buildConvergenceSummary({ runDir, round, verdict, factorFlips, repeatedIssueCount });
+  result.convergenceSummary = convergenceSummary;
+  if (convergenceSummary) writeText(path.join(runDir, `review-round-${round}-convergence.md`), `${formatConvergenceMarkdown(convergenceSummary)}\n`);
 
   const rubricGateRedispatchPath = path.join(runDir, `review-round-${round}-redispatch.md`);
   const rubricGateFailure = verdict.verdict === "pass"
@@ -299,8 +298,8 @@ async function run() {
       ? rubricGateRedispatchPath
       : path.join(runDir, `review-round-${round}-redispatch.md`);
     const redispatchPrompt = rubricGateFailure
-      ? buildRubricGateRedispatchPrompt(rubricGateFailure, doneCriteria, doneCriteriaSource)
-      : buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource, reviewedHeadSha);
+      ? buildRubricGateRedispatchPrompt(rubricGateFailure, doneCriteria, doneCriteriaSource, convergenceSummary)
+      : buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource, reviewedHeadSha, convergenceSummary);
     writeText(redispatchPath, `${redispatchPrompt}\n`);
   }
 

--- a/skills/relay-review/scripts/review-runner/convergence.js
+++ b/skills/relay-review/scripts/review-runner/convergence.js
@@ -1,0 +1,231 @@
+const {
+  computeFactorStatusFlips,
+  fingerprintIssue,
+  issueMatchesFactor,
+  normalizeFingerprintPart,
+  scanPriorVerdicts,
+  summarizeLineage,
+} = require("./redispatch");
+const { getRubricScoreNumber } = require("./score-utils");
+
+const LINEAGE_ORDER = ["deepening", "repeat", "stale", "new", "newly_scoreable", "unknown"];
+const SUMMARY_VERDICTS = new Set(["pass", "changes_requested", "escalated"]);
+
+function statusForRoundVerdict(round, verdict) {
+  if (round < 3 || !SUMMARY_VERDICTS.has(verdict?.verdict)) return null;
+  if (verdict.verdict === "pass") return "converged";
+  if (round >= 5) return "decision_recommended";
+  return "watch";
+}
+
+function getRubricScores(verdict) {
+  return Array.isArray(verdict?.rubric_scores) ? verdict.rubric_scores : [];
+}
+
+function collectPriorVerdicts(runDir, round) {
+  const entries = [];
+  if (!runDir || round <= 1) return entries;
+  scanPriorVerdicts(runDir, round, (verdict, verdictRound) => {
+    entries.push({ round: verdictRound, verdict });
+  });
+  entries.reverse();
+  return entries;
+}
+
+function buildScoreTrends(runDir, round, verdict) {
+  const scoreEntries = getRubricScores(verdict);
+  const trends = {};
+  const priorEntries = collectPriorVerdicts(runDir, round);
+
+  for (const scoreEntry of scoreEntries) {
+    const factor = scoreEntry.factor;
+    const factorKey = normalizeFingerprintPart(factor);
+    const trend = [];
+    for (const { verdict: priorVerdict } of priorEntries) {
+      const priorScore = getRubricScores(priorVerdict)
+        .find((entry) => normalizeFingerprintPart(entry.factor) === factorKey);
+      const numericScore = getRubricScoreNumber(priorScore);
+      if (numericScore !== null) trend.push(numericScore);
+    }
+    const currentScore = getRubricScoreNumber(scoreEntry);
+    if (currentScore !== null) trend.push(currentScore);
+    trends[factor] = trend;
+  }
+
+  return trends;
+}
+
+function findImmediatePriorChangesRequested(runDir, round) {
+  if (!runDir || round <= 1) return null;
+  let prior = null;
+  scanPriorVerdicts(runDir, round, (verdict) => {
+    prior = verdict;
+    return false;
+  });
+  return prior?.verdict === "changes_requested" && Array.isArray(prior.issues) ? prior : null;
+}
+
+function currentIssueFactors(issue, verdict) {
+  const factors = [];
+  for (const scoreEntry of getRubricScores(verdict)) {
+    if (issueMatchesFactor(issue, scoreEntry.factor)) factors.push(scoreEntry.factor);
+  }
+  if (factors.length) return factors;
+  if (issue?.factor) return [String(issue.factor)];
+  if (issue?.category) return [String(issue.category)];
+  return [];
+}
+
+function computeRepeatedFactors(runDir, round, verdict) {
+  const currentIssues = Array.isArray(verdict?.issues) ? verdict.issues : [];
+  if (!currentIssues.length) return [];
+  const prior = findImmediatePriorChangesRequested(runDir, round);
+  if (!prior) return [];
+
+  const priorFingerprints = new Set(prior.issues.map(fingerprintIssue));
+  const repeated = new Set();
+  for (const issue of currentIssues) {
+    if (!priorFingerprints.has(fingerprintIssue(issue))) continue;
+    for (const factor of currentIssueFactors(issue, verdict)) repeated.add(factor);
+  }
+  return [...repeated];
+}
+
+function tiedIssuesForFactor(issues, factor) {
+  return (Array.isArray(issues) ? issues : []).filter((issue) => issueMatchesFactor(issue, factor));
+}
+
+function isAllLineage(issues, lineage) {
+  return issues.length > 0 && issues.every((issue) => issue?.lineage === lineage);
+}
+
+function describeInstabilityReason(tiedIssues) {
+  if (!tiedIssues.length) return "Flipped factor has no current tied issues to explain the status change.";
+  const lineageCounts = summarizeLineage(tiedIssues);
+  const active = LINEAGE_ORDER
+    .filter((lineage) => lineageCounts[lineage] > 0)
+    .map((lineage) => `${lineage}=${lineageCounts[lineage]}`)
+    .join(", ");
+  return `Flipped factor has tied issues outside progressive deepening or newly scoreable lineage (${active}).`;
+}
+
+function computeSemanticInstability(verdict, factorFlips) {
+  const issues = Array.isArray(verdict?.issues) ? verdict.issues : [];
+  return (Array.isArray(factorFlips) ? factorFlips : []).flatMap(({ factor, trace }) => {
+    const tiedIssues = tiedIssuesForFactor(issues, factor);
+    if (isAllLineage(tiedIssues, "deepening") || isAllLineage(tiedIssues, "newly_scoreable")) return [];
+    if (verdict?.verdict === "pass" && tiedIssues.length === 0) return [];
+    return [{
+      factor,
+      trace,
+      reason: describeInstabilityReason(tiedIssues),
+    }];
+  });
+}
+
+function countFailingFactors(verdict) {
+  return getRubricScores(verdict).filter((entry) => entry.status === "fail").length;
+}
+
+function addRecommendation(summary, verdict, repeatedIssueCount) {
+  if (summary.status !== "decision_recommended") return summary;
+  if (summary.semantic_instability.length) {
+    return {
+      ...summary,
+      recommendation: "decide_semantics",
+      recommendation_reason: "semantic_instability non-empty",
+    };
+  }
+  if (repeatedIssueCount >= 2) {
+    return {
+      ...summary,
+      recommendation: "manual_pairing",
+      recommendation_reason: "repeatedIssueCount >= 2",
+    };
+  }
+  if (countFailingFactors(verdict) >= 3) {
+    return {
+      ...summary,
+      recommendation: "narrow_rubric",
+      recommendation_reason: "current verdict has at least 3 failing rubric factors",
+    };
+  }
+  if (summary.lineage_counts.new >= 2) {
+    return {
+      ...summary,
+      recommendation: "split_issue",
+      recommendation_reason: "lineage_counts.new >= 2",
+    };
+  }
+  return {
+    ...summary,
+    recommendation: "defer_follow_up",
+    recommendation_reason: "no earlier convergence-budget condition matched",
+  };
+}
+
+function buildConvergenceSummary({ runDir, round, verdict, factorFlips, repeatedIssueCount = 0 }) {
+  const status = statusForRoundVerdict(round, verdict);
+  if (!status) return null;
+
+  const flips = Array.isArray(factorFlips)
+    ? factorFlips
+    : computeFactorStatusFlips(runDir, round, verdict);
+  const summary = {
+    round,
+    status,
+    repeated_factors: computeRepeatedFactors(runDir, round, verdict),
+    lineage_counts: summarizeLineage(verdict?.issues || []),
+    score_trends: buildScoreTrends(runDir, round, verdict),
+    flip_candidates: flips,
+    semantic_instability: computeSemanticInstability(verdict, flips),
+  };
+
+  return addRecommendation(summary, verdict, repeatedIssueCount);
+}
+
+function formatScoreTrends(scoreTrends) {
+  const entries = Object.entries(scoreTrends || {});
+  if (!entries.length) return ["- Score trends: none"];
+  return [
+    "- Score trends:",
+    ...entries.map(([factor, trend]) => `  - ${factor}: ${Array.isArray(trend) && trend.length ? trend.join(" -> ") : "none"}`),
+  ];
+}
+
+function formatLineageCounts(lineageCounts) {
+  return LINEAGE_ORDER.map((lineage) => `${lineage}=${Number(lineageCounts?.[lineage] || 0)}`).join(", ");
+}
+
+function formatFactorTraces(label, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return [`- ${label}: none`];
+  return [
+    `- ${label}:`,
+    ...entries.map((entry) => `  - ${entry.factor}: ${(entry.trace || []).join(" -> ")}${entry.reason ? ` (${entry.reason})` : ""}`),
+  ];
+}
+
+function formatConvergenceMarkdown(summary) {
+  if (!summary) return "";
+  const lines = [
+    "## Convergence context",
+    "",
+    `- Round: ${summary.round}`,
+    `- Status: ${summary.status}`,
+    `- Repeated factors: ${summary.repeated_factors.length ? summary.repeated_factors.join(", ") : "none"}`,
+    `- Lineage counts: ${formatLineageCounts(summary.lineage_counts)}`,
+    ...formatScoreTrends(summary.score_trends),
+    ...formatFactorTraces("Flip candidates", summary.flip_candidates),
+    ...formatFactorTraces("Semantic instability", summary.semantic_instability),
+  ];
+  if (summary.recommendation) {
+    lines.push(`- Recommendation: ${summary.recommendation}`);
+    lines.push(`- Recommendation reason: ${summary.recommendation_reason}`);
+  }
+  return lines.join("\n");
+}
+
+module.exports = {
+  buildConvergenceSummary,
+  formatConvergenceMarkdown,
+};

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -7,7 +7,7 @@ const { getRubricScoreNumber, getRubricTargetNumber } = require("./score-utils")
 const FLIP_STATES = new Set(["pass", "fail"]);
 const LINEAGE_VALUES = ["deepening", "repeat", "stale", "new", "newly_scoreable", "unknown"];
 
-function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource, currentHeadSha) {
+function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth, doneCriteriaSource, currentHeadSha, convergenceSummary) {
   const sections = [
     `This is round ${round + 1}. Fix these review issues in the PR. Do not change anything else. Push to the same branch.`,
     "",
@@ -44,6 +44,8 @@ function buildRedispatchPrompt(verdict, doneCriteria, runDir, round, churnGrowth
   if (scoreTarget) {
     sections.push("", scoreTarget);
   }
+
+  appendConvergenceContext(sections, convergenceSummary);
 
   if (churnGrowth) {
     sections.push(
@@ -372,8 +374,15 @@ function toEscalatedVerdict(baseVerdict, summary) {
   };
 }
 
-function buildRubricGateRedispatchPrompt(gateFailure, doneCriteria, doneCriteriaSource) {
-  return [
+function appendConvergenceContext(sections, convergenceSummary) {
+  if (!convergenceSummary) return;
+  const { formatConvergenceMarkdown } = require("./convergence");
+  const convergenceMarkdown = formatConvergenceMarkdown(convergenceSummary);
+  if (convergenceMarkdown) sections.push("", convergenceMarkdown);
+}
+
+function buildRubricGateRedispatchPrompt(gateFailure, doneCriteria, doneCriteriaSource, convergenceSummary) {
+  const sections = [
     "Rubric recovery re-dispatch",
     "",
     "relay-review failed closed on the rubric anchor, not on the code diff.",
@@ -391,7 +400,9 @@ function buildRubricGateRedispatchPrompt(gateFailure, doneCriteria, doneCriteria
     `Done Criteria source: ${doneCriteriaSource}`,
     "Done Criteria:",
     doneCriteria,
-  ].join("\n");
+  ];
+  appendConvergenceContext(sections, convergenceSummary);
+  return sections.join("\n");
 }
 
 module.exports = {
@@ -404,6 +415,7 @@ module.exports = {
   detectChurnGrowth,
   fingerprintIssue,
   findWeakestBelowTargetQualityScore,
+  issueMatchesFactor,
   normalizeFingerprintPart,
   readPriorVerdicts,
   scanPriorVerdicts,

--- a/tests/relay-review/scripts/convergence.test.js
+++ b/tests/relay-review/scripts/convergence.test.js
@@ -1,0 +1,257 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  buildRedispatchPrompt,
+  computeFactorStatusFlips,
+} = require("../../../skills/relay-review/scripts/review-runner/redispatch");
+const {
+  buildConvergenceSummary,
+  formatConvergenceMarkdown,
+} = require("../../../skills/relay-review/scripts/review-runner/convergence");
+
+function tempRunDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-convergence-"));
+}
+
+function writeVerdict(runDir, round, verdict) {
+  fs.writeFileSync(
+    path.join(runDir, `review-round-${round}-verdict.json`),
+    `${JSON.stringify(verdict, null, 2)}\n`,
+    "utf-8"
+  );
+}
+
+function score(factor, scoreValue, status) {
+  return { factor, score: scoreValue, status };
+}
+
+function issue(overrides = {}) {
+  return {
+    file: "src/widget.js",
+    line: 12,
+    title: "Behavior breaks when state changes",
+    category: "Behavior",
+    lineage: "repeat",
+    ...overrides,
+  };
+}
+
+function buildSummary({ runDir = tempRunDir(), round, verdict, repeatedIssueCount = 0 }) {
+  return buildConvergenceSummary({
+    runDir,
+    round,
+    verdict,
+    factorFlips: computeFactorStatusFlips(runDir, round, verdict),
+    repeatedIssueCount,
+  });
+}
+
+test("rounds below 3 yield no convergence summary", () => {
+  const verdict = {
+    verdict: "changes_requested",
+    issues: [issue()],
+    rubric_scores: [score("Behavior", 6, "fail")],
+  };
+
+  assert.equal(buildSummary({ round: 1, verdict }), null);
+  assert.equal(buildSummary({ round: 2, verdict }), null);
+});
+
+test("round 3 summary lists repeated factors, lineage counts, score trends, and flip candidates", () => {
+  const runDir = tempRunDir();
+  writeVerdict(runDir, 1, {
+    verdict: "changes_requested",
+    issues: [issue({ line: 7 })],
+    rubric_scores: [score("Behavior", 7, "pass"), score("Coverage", 5, "fail")],
+  });
+  writeVerdict(runDir, 2, {
+    verdict: "changes_requested",
+    issues: [issue({ line: 9 })],
+    rubric_scores: [score("behavior", 5, "fail"), score("Coverage", 6, "fail")],
+  });
+  const verdict = {
+    verdict: "changes_requested",
+    issues: [issue({ line: 11, lineage: "repeat" })],
+    rubric_scores: [score("BEHAVIOR", 6, "pass"), score("Coverage", 7, "pass")],
+  };
+
+  const summary = buildSummary({ runDir, round: 3, verdict, repeatedIssueCount: 3 });
+
+  assert.equal(summary.status, "watch");
+  assert.deepEqual(summary.repeated_factors, ["BEHAVIOR"]);
+  assert.deepEqual(summary.lineage_counts, {
+    deepening: 0,
+    repeat: 1,
+    stale: 0,
+    new: 0,
+    newly_scoreable: 0,
+    unknown: 0,
+  });
+  assert.deepEqual(summary.score_trends, {
+    BEHAVIOR: [7, 5, 6],
+    Coverage: [5, 6, 7],
+  });
+  assert.deepEqual(summary.flip_candidates, [{ factor: "BEHAVIOR", trace: ["pass", "fail", "pass"] }]);
+});
+
+test("round 5 summary recommends an operator decision path", async (t) => {
+  await t.test("decide_semantics", () => {
+    const runDir = tempRunDir();
+    writeVerdict(runDir, 3, { rubric_scores: [score("Behavior", 8, "pass")] });
+    writeVerdict(runDir, 4, { rubric_scores: [score("Behavior", 5, "fail")] });
+    const verdict = {
+      verdict: "changes_requested",
+      issues: [issue({ lineage: "repeat" })],
+      rubric_scores: [score("Behavior", 6, "pass")],
+    };
+
+    const summary = buildSummary({ runDir, round: 5, verdict, repeatedIssueCount: 1 });
+    assert.equal(summary.status, "decision_recommended");
+    assert.equal(summary.recommendation, "decide_semantics");
+    assert.match(summary.recommendation_reason, /semantic_instability/);
+  });
+
+  await t.test("manual_pairing", () => {
+    const verdict = {
+      verdict: "changes_requested",
+      issues: [issue({ lineage: "deepening" })],
+      rubric_scores: [score("Behavior", 6, "fail")],
+    };
+
+    const summary = buildSummary({ round: 5, verdict, repeatedIssueCount: 2 });
+    assert.equal(summary.recommendation, "manual_pairing");
+    assert.match(summary.recommendation_reason, /repeatedIssueCount >= 2/);
+  });
+
+  await t.test("narrow_rubric", () => {
+    const verdict = {
+      verdict: "changes_requested",
+      issues: [issue({ lineage: "deepening" })],
+      rubric_scores: [
+        score("Behavior", 6, "fail"),
+        score("Coverage", 5, "fail"),
+        score("Scope", 4, "fail"),
+      ],
+    };
+
+    const summary = buildSummary({ round: 5, verdict, repeatedIssueCount: 1 });
+    assert.equal(summary.recommendation, "narrow_rubric");
+    assert.match(summary.recommendation_reason, /3 failing rubric factors/);
+  });
+
+  await t.test("split_issue", () => {
+    const verdict = {
+      verdict: "changes_requested",
+      issues: [
+        issue({ title: "First new finding", lineage: "new" }),
+        issue({ title: "Second new finding", lineage: "new" }),
+      ],
+      rubric_scores: [score("Behavior", 6, "fail")],
+    };
+
+    const summary = buildSummary({ round: 5, verdict, repeatedIssueCount: 1 });
+    assert.equal(summary.recommendation, "split_issue");
+    assert.match(summary.recommendation_reason, /lineage_counts.new >= 2/);
+  });
+
+  await t.test("defer_follow_up", () => {
+    const verdict = {
+      verdict: "changes_requested",
+      issues: [issue({ lineage: "deepening" })],
+      rubric_scores: [score("Behavior", 6, "fail")],
+    };
+
+    const summary = buildSummary({ round: 5, verdict, repeatedIssueCount: 1 });
+    assert.equal(summary.recommendation, "defer_follow_up");
+    assert.match(summary.recommendation_reason, /no earlier convergence-budget condition matched/);
+  });
+});
+
+test("progressive deepening flip is not semantic instability", () => {
+  const runDir = tempRunDir();
+  writeVerdict(runDir, 1, { rubric_scores: [score("Behavior", 8, "pass")] });
+  writeVerdict(runDir, 2, { rubric_scores: [score("Behavior", 5, "fail")] });
+  const verdict = {
+    verdict: "changes_requested",
+    issues: [issue({ lineage: "deepening" })],
+    rubric_scores: [score("Behavior", 7, "pass")],
+  };
+
+  const summary = buildSummary({ runDir, round: 3, verdict });
+
+  assert.deepEqual(summary.flip_candidates, [{ factor: "Behavior", trace: ["pass", "fail", "pass"] }]);
+  assert.deepEqual(summary.semantic_instability, []);
+});
+
+test("repeat and stale lineage issues surface in the round summary", () => {
+  const verdict = {
+    verdict: "changes_requested",
+    issues: [
+      issue({ title: "Behavior repeat", lineage: "repeat" }),
+      issue({ title: "Behavior stale", lineage: "stale" }),
+    ],
+    rubric_scores: [score("Behavior", 5, "fail")],
+  };
+
+  const summary = buildSummary({ round: 3, verdict });
+  const markdown = formatConvergenceMarkdown(summary);
+
+  assert.deepEqual(summary.lineage_counts, {
+    deepening: 0,
+    repeat: 1,
+    stale: 1,
+    new: 0,
+    newly_scoreable: 0,
+    unknown: 0,
+  });
+  assert.match(markdown, /repeat=1/);
+  assert.match(markdown, /stale=1/);
+});
+
+test("clean pass at round 3 yields converged status without recommendation", () => {
+  const verdict = {
+    verdict: "pass",
+    issues: [],
+    rubric_scores: [score("Behavior", 9, "pass")],
+  };
+
+  const summary = buildSummary({ round: 3, verdict });
+
+  assert.equal(summary.status, "converged");
+  assert.equal(Object.hasOwn(summary, "recommendation"), false);
+});
+
+test("redispatch prompt includes convergence context without new directives", () => {
+  const summary = {
+    round: 5,
+    status: "decision_recommended",
+    repeated_factors: ["Behavior"],
+    lineage_counts: { deepening: 0, repeat: 1, stale: 0, new: 0, newly_scoreable: 0, unknown: 0 },
+    score_trends: { Behavior: [7, 5, 6] },
+    flip_candidates: [{ factor: "Behavior", trace: ["pass", "fail", "pass"] }],
+    semantic_instability: [{
+      factor: "Behavior",
+      trace: ["pass", "fail", "pass"],
+      reason: "Flipped factor has tied issues with repeat lineage.",
+    }],
+    recommendation: "decide_semantics",
+    recommendation_reason: "semantic_instability non-empty",
+  };
+
+  const prompt = buildRedispatchPrompt({
+    verdict: "changes_requested",
+    issues: [issue()],
+    scope_drift: { creep: [], missing: [] },
+    rubric_scores: [score("Behavior", 6, "pass")],
+  }, "# Done Criteria\n\n- Keep redispatch targeted.", null, 5, null, "planner_decision", null, summary);
+
+  assert.match(prompt, /## Convergence context/);
+  assert.match(prompt, /Status: decision_recommended/);
+  assert.match(prompt, /Recommendation: decide_semantics/);
+  assert.doesNotMatch(prompt, /modify any file/i);
+  assert.doesNotMatch(prompt, /widen/i);
+});


### PR DESCRIPTION
## Summary

Adds operator-readable convergence summaries to the relay-review runner so long review loops surface actionable signals before churn gets expensive (issue #725, epic #718).

- New pure module `skills/relay-review/scripts/review-runner/convergence.js`: `buildConvergenceSummary` + `formatConvergenceMarkdown`, derive-on-read from `review-round-*-verdict.json` artifacts (no new event types).
- Round ≥3: summary written to `<run-dir>/review-round-<N>-convergence.md` and exposed as `result.convergenceSummary` in `--json` output (repeated factors, lineage counts, score trends, flip candidates, semantic instability).
- Round ≥5: deterministic first-match recommendation — `decide_semantics` / `manual_pairing` / `narrow_rubric` / `split_issue` / `defer_follow_up`.
- Semantic instability = factor status flips whose tied issues are not all `deepening` (progressive) and not all `newly_scoreable` (planner spec correction).
- Redispatch prompts gain an informational `## Convergence context` section; escalation logic, 20-round cap, and the reviewer verdict schema are unchanged.
- New `tests/relay-review/scripts/convergence.test.js` (7 cases per Done Criteria).

Closes #725