### PR TITLE
Restore relay-plan prose contract sentence broken by #746

### DIFF
--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -72,7 +72,7 @@ If AC are missing, vague, or incomplete, write observable Done Criteria first. T
 
 ### 5. Build the rubric
 
-Use the guided interview in `references/rubric-design-guide.md` to synthesize factors from the recovered Done Criteria. Minimal shape:
+Synthesize task intent, explicit AC when present, repo signals, and task risk into a scored rubric — the recovered Done Criteria are the anchor, not the issue text alone. Use the guided interview in `references/rubric-design-guide.md` to synthesize factors from them. Minimal shape:
 
 ```yaml
 rubric:


### PR DESCRIPTION
PR #746's trigger-only description rewrite removed the sentence "Synthesize task intent, explicit AC when present, repo signals, and task risk" which `tests/relay-plan/scripts/rubric-reference-contract.test.js` line 137 pins as a prose contract. The sentence is restored in the '### 5. Build the rubric' body while keeping the new trigger-only frontmatter description.

## Test results

- `node --test tests/relay-plan/scripts/*.test.js`: **141 passed, 0 failed**
- `node --test tests/skills-lint/scripts/*.test.js`: **18 passed, 0 failed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 루브릭 작성 지침이 강화되어, 단순한 완료 기준 복원뿐 아니라 태스크 의도, 명시적 AC, 저장소 신호, 작업 리스크까지 함께 반영하도록 안내가 추가됐습니다.
  * 루브릭의 기준점은 복원된 완료 기준으로 유지하되, 이슈 텍스트만을 기준으로 삼지 않도록 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->