### PR TITLE
Prefer PR headRefOid in review-gate latest-commit resolution (#753)

### DIFF
--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -162,7 +162,7 @@ function buildStackedBaseOverrideAuditFields(stackedBaseGuard, prNumber, headSha
 
 function fetchPreMergeContext(repoPath, prNumber) {
   const raw = execGh(repoPath, ["pr", "view", String(prNumber),
-    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup"]);
+    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid"]);
   const parsed = JSON.parse(raw);
   const checks = parsed.statusCheckRollup || [];
   return {
@@ -170,6 +170,7 @@ function fetchPreMergeContext(repoPath, prNumber) {
     comments: parsed.comments || [],
     commits: parsed.commits || [],
     mergeable: parsed.mergeable || null,
+    headRefOid: parsed.headRefOid || null,
     checks,
     unsafeChecks: checks.filter(isUnsafeStatusCheck),
   };
@@ -759,6 +760,7 @@ function main() {
         manifestData: safeData,
         expectedReviewerLogin: safeData.review?.reviewer_login || null,
         runDir: getRunDir(validatedPaths.repoRoot, safeData.run_id),
+        headRefOid: preMerge.headRefOid,
       });
       if (!reviewGate.readyToMerge) {
         if (!dryRun) {

--- a/skills/relay-merge/scripts/gate-check.js
+++ b/skills/relay-merge/scripts/gate-check.js
@@ -338,6 +338,7 @@ function main() {
   let commits;
   let manifestData = null;
   let runDir = null;
+  let headRefOid = null;
   if (DRY_RUN) {
     // Dry-run: read JSON object/array from stdin, or plain text as single comment
     const stdin = require("fs").readFileSync(0, "utf-8").trim();
@@ -348,16 +349,18 @@ function main() {
       commits = Array.isArray(parsed.commits) ? parsed.commits : [];
       manifestData = parsed.manifest || null;
       runDir = typeof parsed.runDir === "string" ? parsed.runDir : null;
+      headRefOid = typeof parsed.headRefOid === "string" ? parsed.headRefOid : null;
     } catch {
       // Plain text: treat entire stdin as one comment body
       comments = [{ body: stdin, createdAt: null }];
       commits = [];
     }
   } else {
-    const raw = execGh(null, ["pr", "view", PR_NUM, "--json", "comments,commits,headRefName"]);
+    const raw = execGh(null, ["pr", "view", PR_NUM, "--json", "comments,commits,headRefName,headRefOid"]);
     const parsed = JSON.parse(raw);
     comments = parsed.comments || [];
     commits = parsed.commits || [];
+    headRefOid = parsed.headRefOid || null;
     const manifestRecord = tryResolveManifestForPr(PR_NUM, parsed.headRefName || null);
     if (manifestRecord.error || !manifestRecord.data) {
       output({
@@ -428,6 +431,7 @@ function main() {
     manifestData,
     expectedReviewerLogin,
     runDir,
+    headRefOid,
   });
   const reviewRunnerRubricGate = deriveReviewRunnerRubricGate(manifestData, runDir);
   const enrichedResult = reviewRunnerRubricGate

--- a/skills/relay-merge/scripts/review-gate.js
+++ b/skills/relay-merge/scripts/review-gate.js
@@ -112,12 +112,27 @@ function normalizeCommentRecords(comments) {
   ));
 }
 
-function extractLatestCommit(commits) {
+function extractLatestCommit(commits, headRefOid) {
+  const commitList = commits || [];
+
+  if (headRefOid) {
+    const headCommit = commitList.find((commit) => commit.oid === headRefOid);
+    if (headCommit) {
+      return {
+        latestCommit: headCommit.oid,
+        latestCommitAt: toIsoOrNull(headCommit.committedDate || headCommit.authoredDate),
+      };
+    }
+  }
+
+  // Fallback scan: use >= so that on committedDate ties (e.g. after a rebase
+  // collapses timestamps to the same second) the later array entry wins,
+  // which for `gh pr view --json commits` is the entry closer to HEAD.
   let latestCommit = null;
   let latestCommitAt = null;
-  for (const commit of commits || []) {
+  for (const commit of commitList) {
     const committedAt = toIsoOrNull(commit.committedDate || commit.authoredDate);
-    if (committedAt && (!latestCommitAt || committedAt > latestCommitAt)) {
+    if (committedAt && (!latestCommitAt || committedAt >= latestCommitAt)) {
       latestCommitAt = committedAt;
       latestCommit = commit.oid || null;
     }
@@ -342,9 +357,9 @@ function buildReviewAssuranceGateFailure({ prNumber, manifestData, runDir }) {
   return null;
 }
 
-function evaluateReviewGate({ prNumber, comments, commits, manifestData, expectedReviewerLogin, runDir }) {
+function evaluateReviewGate({ prNumber, comments, commits, manifestData, expectedReviewerLogin, runDir, headRefOid }) {
   const commentRecords = normalizeCommentRecords(comments);
-  const { latestCommit, latestCommitAt } = extractLatestCommit(commits);
+  const { latestCommit, latestCommitAt } = extractLatestCommit(commits, headRefOid);
   const rubricAnchor = manifestData
     ? getRubricAnchorStatus(manifestData, runDir ? { runDir } : undefined)
     : null;

--- a/tests/relay-merge/scripts/review-gate.test.js
+++ b/tests/relay-merge/scripts/review-gate.test.js
@@ -408,6 +408,56 @@ test("evaluateReviewGate rejects the legacy grandfather field matrix", async (t)
   }
 });
 
+function evaluateWithTiedCommits({ headRefOid } = {}) {
+  const { runDir, manifestData } = createRubricStateFixture("loaded");
+  // Two commits share the same committedDate (second-granularity tie, e.g. after
+  // a rebase). "commit-head" is first in array order but is the actual PR HEAD;
+  // "commit-other" is a non-HEAD commit sharing the same timestamp.
+  manifestData.review.last_reviewed_sha = "commit-head";
+  return evaluateReviewGate({
+    prNumber: 40,
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: PASS\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      { oid: "commit-head", committedDate: "2026-04-03T07:00:00Z" },
+      { oid: "commit-other", committedDate: "2026-04-03T07:00:00Z" },
+    ],
+    manifestData,
+    runDir,
+    headRefOid,
+  });
+}
+
+test("extractLatestCommit prefers headRefOid on committedDate ties", () => {
+  const result = evaluateWithTiedCommits({ headRefOid: "commit-head" });
+
+  assert.equal(result.status, "lgtm");
+  assert.equal(result.readyToMerge, true);
+  assert.equal(result.latestCommit, "commit-head");
+});
+
+test("extractLatestCommit falls back to the later array entry on ties when headRefOid is absent", () => {
+  const result = evaluateWithTiedCommits();
+
+  // Without headRefOid, the >= fallback scan lets the later array entry win
+  // the tie, which is stale relative to last_reviewed_sha="commit-head".
+  assert.equal(result.status, "stale");
+  assert.equal(result.readyToMerge, false);
+  assert.equal(result.latestCommit, "commit-other");
+});
+
+test("extractLatestCommit falls back to the scan when headRefOid is not among the commits", () => {
+  const result = evaluateWithTiedCommits({ headRefOid: "commit-not-in-list" });
+
+  assert.equal(result.status, "stale");
+  assert.equal(result.readyToMerge, false);
+  assert.equal(result.latestCommit, "commit-other");
+});
+
 test("buildSkipComment records only rubric_status after grandfather retirement", () => {
   const comment = buildSkipComment("hotfix", {
     rubricStatus: "legacy_grandfather_field",

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -123,7 +123,8 @@ if (args[0] === "pr" && args[1] === "view") {
   // merge gates need the latest relay audit comment, commits, mergeability, and checks.
   if (
     fields === "comments,commits,mergeable,statusCheckRollup" ||
-    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup"
+    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup" ||
+    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid"
   ) {
     writeJson({
       baseRefName: fixture.baseRefName || "main",
@@ -131,6 +132,7 @@ if (args[0] === "pr" && args[1] === "view") {
       commits: fixture.commits || [],
       mergeable: fixture.mergeable || "MERGEABLE",
       statusCheckRollup: fixture.statusCheckRollup || [],
+      headRefOid: fixture.headRefOid || "a".repeat(40),
     });
     process.exit(0);
   }


### PR DESCRIPTION
## Bug

`skills/relay-merge/scripts/review-gate.js` → `extractLatestCommit(commits)` picked the max `committedDate` with strict `>`. After a rebase, multiple PR commits can share the same `committedDate` (second granularity), and the tie was broken by array order — sometimes returning a non-HEAD commit. `gate-check.js` then reported a legitimate review as stale (`status: "stale"`) even though the reviewed SHA matched the PR's actual HEAD.

## Fix

- `extractLatestCommit(commits, headRefOid)`: if `headRefOid` is provided and matches a commit's `oid` in the list, that commit wins outright (its `committedDate`/`authoredDate` populate `latestCommitAt`). Otherwise falls back to the original scan, now using `>=` instead of `>` so committedDate ties are broken by later array position (closer to PR HEAD in `gh pr view --json commits` ordering). `headRefOid` absent or not present in `commits` ⇒ pure fallback, preserving dry-run stdin behavior with no `headRefOid`.
- `evaluateReviewGate({ ... })` gains a `headRefOid` option and threads it into `extractLatestCommit`.
- `gate-check.js`: the main `gh pr view --json comments,commits,headRefName` fetch that feeds `evaluateReviewGate` now also fetches `headRefOid` and passes it through (both the live path and the dry-run stdin payload accept an optional `headRefOid`). The separate small `resolveSkipAuditContext` fetch (`--json headRefName` only) is untouched since it never feeds `evaluateReviewGate`.
- `finalize-run.js`: `fetchPreMergeContext` now also fetches `headRefOid`, and the `evaluateReviewGate` call in the `ready_to_merge` branch passes it through.

## Tests

Added to `tests/relay-merge/scripts/review-gate.test.js`:
- Tie case with `headRefOid` set to the actual HEAD commit (first in array) ⇒ HEAD wins even though it's not the array-order "winner".
- Same tie, no `headRefOid` ⇒ `>=` fallback lets the later array entry win (documents the fallback behavior).
- `headRefOid` set to a commit not present in `commits` ⇒ falls back to the scan.

All existing `review-gate.test.js` / `gate-check.test.js` assertions are unchanged and still pass — no existing fixtures had committedDate ties, so the `>` → `>=` change doesn't alter any existing test's expected output.

Also updated the shared test fixture `tests/relay-review/fixtures/fake-gh.js` (used by `tests/relay-plan/scripts/tdd-flavor.test.js`) to answer the new `headRefOid`-augmented `gh pr view` field list used by `finalize-run.js`; without this the fixture's exact field-list match fell through to its empty-JSON branch and broke an unrelated finalize-run integration test.

## Test results

- `node --test tests/relay-merge/scripts/*.test.js`: 185 pass, 0 fail
- `node --test tests/*/scripts/*.test.js`: 1672 pass, 2 fail
  - `relay-fleet --resume skips a still-running review subprocess` — pre-existing known flake, tracked as #754 (tolerated per issue instructions)
  - `relay-config doctor includes project route provenance and best-effort model probes` — verified pre-existing/flaky independent of this change (reproduced failing intermittently on a clean `main` checkout with none of this PR's changes applied)

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXf39ULLc7R6v21A17YXfh