### PR TITLE
Validate fleet leaf contracts and surface operational debt (#724)

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/fleet.js
+++ b/skills/relay-dispatch/scripts/manifest/fleet.js
@@ -267,6 +267,10 @@ function increment(map, key) {
 // - Review and merge facts are never copied into the fleet manifest. Any mixed
 //   picture, such as dispatched + escalated + pre-manifest-failed children, is
 //   normal and must be derived on read.
+// - pr_number, base_branch, and review_round are read-time pass-throughs of the
+//   child manifest's git.pr_number, git.base_branch, and review.rounds. They are
+//   nullable and only populated when the child manifest is readable; they carry
+//   no independent semantics beyond what the child manifest already states.
 function deriveFleetSummary(repoRoot, fleet) {
   const normalized = normalizeFleetManifest(fleet);
   const byDispatchStatus = {};
@@ -281,6 +285,9 @@ function deriveFleetSummary(repoRoot, fleet) {
       dispatch_status: child.dispatch_status,
       run_state: null,
       manifest_path: null,
+      pr_number: null,
+      base_branch: null,
+      review_round: null,
       error: null,
     };
 
@@ -296,6 +303,9 @@ function deriveFleetSummary(repoRoot, fleet) {
     try {
       const childRecord = readManifest(childManifestPath);
       summaryChild.run_state = childRecord.data?.state || "unknown";
+      summaryChild.pr_number = childRecord.data?.git?.pr_number ?? null;
+      summaryChild.base_branch = childRecord.data?.git?.base_branch ?? null;
+      summaryChild.review_round = childRecord.data?.review?.rounds ?? null;
     } catch (error) {
       summaryChild.run_state = "missing_manifest";
       summaryChild.error = String(error.message || error);

--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -44,7 +44,9 @@ Use a JSON file containing a non-empty `leaves[]` array. Each leaf must include:
 - `rubric_file`: prepared relay-plan rubric
 - `done_criteria_file`: frozen Done Criteria snapshot
 
-Optional per-leaf fields are passed through to `dispatch.js`: `request_id`, `leaf_id`, `executor`, `model`, `model_hints`, `sandbox`, `network_access`, `timeout`, `reasoning`, `copy`, `test_command`, and `register`.
+relay-fleet only fans out already-decomposed leaf contracts; it never splits a raw or ambiguous request itself — route that intake through `relay-ready` first and pass its leaf output here.
+
+Optional per-leaf fields are passed through to `dispatch.js`: `request_id`, `leaf_id`, `executor`, `model`, `model_hints`, `sandbox`, `network_access`, `timeout`, `reasoning`, `copy`, `test_command`, and `register`. An optional `depends_on` array of `leaf_ref` strings records ordering intent: a reference to another leaf in the *same* leaves file fails closed at load time (dispatch that leaf in an earlier wave and drop the reference here); a reference to a `leaf_ref` outside this file is accepted silently and assumed already satisfied.
 
 ## Commands
 

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -20,6 +20,7 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/paths");
 const { STATES: RUN_STATES } = require("../../relay-dispatch/scripts/manifest/lifecycle");
 const { readManifest } = require("../../relay-dispatch/scripts/manifest/store");
+const { execGh } = require("../../relay-dispatch/scripts/exec");
 const {
   DISPATCH_STATUS,
   FleetIssueLockError,
@@ -33,6 +34,7 @@ const {
   updateFleetState,
   upsertFleetChild,
 } = require("../../relay-dispatch/scripts/manifest/fleet");
+const { getRequestPath, readRequestArtifact } = require("../../relay-ready/scripts/relay-request");
 
 const DEFAULT_PARALLEL = 4;
 const DEFAULT_DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
@@ -161,6 +163,19 @@ function resolveInputPath(value, baseDir, label) {
   return path.resolve(baseDir, raw);
 }
 
+function normalizeDependsOn(rawValue, index) {
+  if (rawValue === undefined || rawValue === null) return undefined;
+  if (!Array.isArray(rawValue)) {
+    throw new FleetInputError(`leaves[${index}].depends_on must be an array of leaf_ref strings`);
+  }
+  return rawValue.map((entry, entryIndex) => {
+    if (typeof entry !== "string" || entry.trim() === "") {
+      throw new FleetInputError(`leaves[${index}].depends_on[${entryIndex}] must be a non-empty string`);
+    }
+    return entry.trim();
+  });
+}
+
 function normalizeLeaf(rawLeaf, index, baseDir) {
   if (!rawLeaf || typeof rawLeaf !== "object" || Array.isArray(rawLeaf)) {
     throw new FleetInputError(`leaves[${index}] must be an object`);
@@ -181,6 +196,7 @@ function normalizeLeaf(rawLeaf, index, baseDir) {
     ),
     request_id: optionalString(rawLeaf.request_id || rawLeaf.requestId),
     leaf_id: optionalString(rawLeaf.leaf_id || rawLeaf.leafId) || leafRef,
+    depends_on: normalizeDependsOn(rawLeaf.depends_on ?? rawLeaf.dependsOn, index),
     executor: optionalString(rawLeaf.executor),
     model: optionalString(rawLeaf.model),
     model_hints: optionalString(rawLeaf.model_hints || rawLeaf.modelHints),
@@ -218,6 +234,86 @@ function validateUniqueIssues(leaves) {
   }
 }
 
+// Fail-closed same-wave dependency guard. A leaf's depends_on entry that names
+// another leaf in THIS SAME leaves file cannot be satisfied by fan-out, since
+// fan-out dispatches every leaf in the file concurrently — that dependency must
+// be dispatched in an earlier wave (a separate --leaves-file/--fleet-id run)
+// first, then dropped from this file. A depends_on entry naming a leaf_ref that
+// is not present in this file is accepted silently: it is assumed to already be
+// satisfied by an earlier wave or external dispatch (see SKILL.md).
+function validateLeafDependencies(leaves) {
+  const refsInFile = new Set(leaves.map((leaf) => leaf.leaf_ref));
+  for (const leaf of leaves) {
+    if (!Array.isArray(leaf.depends_on)) continue;
+    for (const dependency of leaf.depends_on) {
+      if (dependency === leaf.leaf_ref) {
+        throw new FleetInputError(
+          `leaf '${leaf.leaf_ref}' has a depends_on entry that references itself`
+        );
+      }
+      if (refsInFile.has(dependency)) {
+        throw new FleetInputError(
+          `leaf '${leaf.leaf_ref}' depends_on '${dependency}', which is also in this leaves file (same-wave dependency); ` +
+          `dispatch '${dependency}' in an earlier wave (a separate fleet run) and remove it from this leaves file before fanning out '${leaf.leaf_ref}'.`
+        );
+      }
+      // Else: dependency is external to this leaves file and assumed already satisfied.
+    }
+  }
+}
+
+// Reads decomposition.leaf_order (multi-leaf requests) or the top-level
+// leaf_id (single-leaf requests) from a persisted relay-ready request
+// artifact's data, per the shapes written by relay-request.js's
+// buildRequestArtifactData. Returns [] when neither is present.
+function collectRequestLeafIds(requestData) {
+  if (requestData?.decomposition && Array.isArray(requestData.decomposition.leaf_order)) {
+    return requestData.decomposition.leaf_order;
+  }
+  if (typeof requestData?.leaf_id === "string" && requestData.leaf_id.trim() !== "") {
+    return [requestData.leaf_id];
+  }
+  return [];
+}
+
+// Fail-closed relay-ready lineage check: a leaf that claims a request_id must
+// point at a request artifact that actually exists and parses, and if it also
+// names a leaf_id, that leaf_id must be one of the leaf handoffs persisted for
+// that request. Leaves without a request_id are exempt (see SKILL.md). This is
+// separate from loadLeavesFile because it needs repoRoot, which loadLeavesFile
+// does not have in scope.
+function validateLeafLineage(repoRoot, leaves) {
+  for (const leaf of leaves) {
+    if (!leaf.request_id) continue;
+
+    const requestPath = getRequestPath(repoRoot, leaf.request_id);
+    if (!fs.existsSync(requestPath)) {
+      throw new FleetInputError(
+        `leaf '${leaf.leaf_ref}' request_id '${leaf.request_id}' does not resolve to a relay-ready request artifact: ${requestPath}`
+      );
+    }
+
+    let artifact;
+    try {
+      artifact = readRequestArtifact(requestPath);
+    } catch (error) {
+      throw new FleetInputError(
+        `leaf '${leaf.leaf_ref}' request_id '${leaf.request_id}' request artifact is unreadable at ${requestPath}: ${error.message}`
+      );
+    }
+
+    if (leaf.leaf_id) {
+      const knownLeafIds = collectRequestLeafIds(artifact.data);
+      if (!knownLeafIds.includes(leaf.leaf_id)) {
+        throw new FleetInputError(
+          `leaf '${leaf.leaf_ref}' leaf_id '${leaf.leaf_id}' is not among the leaf handoffs persisted for request '${leaf.request_id}' ` +
+          `(known: ${knownLeafIds.length ? knownLeafIds.join(", ") : "none"})`
+        );
+      }
+    }
+  }
+}
+
 function loadLeavesFile(leavesFile) {
   const resolved = path.resolve(requireNonEmptyString(leavesFile, "--leaves-file"));
   const payload = JSON.parse(fs.readFileSync(resolved, "utf-8"));
@@ -227,6 +323,7 @@ function loadLeavesFile(leavesFile) {
   }
   const leaves = rawLeaves.map((leaf, index) => normalizeLeaf(leaf, index, path.dirname(resolved)));
   validateUniqueIssues(leaves);
+  validateLeafDependencies(leaves);
   validateLeafFiles(leaves);
   return leaves;
 }
@@ -1036,21 +1133,90 @@ async function runPool(items, limit, worker) {
   return results;
 }
 
-function buildOperatorAttention(summary) {
-  return summary.children
-    .filter((child) => {
-      return child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
-        || child.run_state === "missing_manifest"
-        || child.run_state === "escalated"
-        || child.run_state === "changes_requested";
-    })
-    .map((child) => ({
-      leaf_ref: child.leaf_ref,
-      run_id: child.run_id,
-      reason: child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
-        ? DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
-        : child.run_state,
-    }));
+// Mirrors skills/relay-merge/scripts/finalize-run.js's fetchDefaultBranchName
+// (gh repo view --json defaultBranchRef) without importing from relay-merge,
+// which is frozen for this change. Returns null on any failure (no remote, gh
+// unavailable, offline) so callers must treat a null default branch as
+// "unknown" rather than a mismatch.
+function resolveFleetDefaultBranch(repoRoot) {
+  try {
+    const raw = execGh(repoRoot, ["repo", "view", "--json", "defaultBranchRef"]);
+    const parsed = JSON.parse(raw);
+    return parsed?.defaultBranchRef?.name || null;
+  } catch {
+    return null;
+  }
+}
+
+const MISSING_PR_RUN_STATES = new Set([
+  RUN_STATES.REVIEW_PENDING,
+  RUN_STATES.READY_TO_MERGE,
+  RUN_STATES.MERGE_BLOCKED,
+]);
+const KNOWN_RUN_STATES = new Set(Object.values(RUN_STATES));
+
+// The four original reasons, preserved byte-identical: at most one of these
+// ever applies to a given child (dispatch_failed_pre_manifest requires
+// run_id:null, which forces run_state to "no_run_manifest" and so can never
+// co-occur with missing_manifest/escalated/changes_requested).
+function legacyAttentionReason(child) {
+  if (child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST) {
+    return DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST;
+  }
+  if (child.run_state === "missing_manifest") return "missing_manifest";
+  if (child.run_state === "escalated") return "escalated";
+  if (child.run_state === "changes_requested") return "changes_requested";
+  return null;
+}
+
+// New reasons are independent of each other and of the legacy reason above, so
+// a single child can surface more than one attention item.
+function additionalAttentionReasons(child, { repoRoot, fleetId, defaultBranchName }) {
+  const reasons = [];
+
+  if (MISSING_PR_RUN_STATES.has(child.run_state) && !child.pr_number) {
+    reasons.push("missing_pr");
+  }
+  if (child.run_state === RUN_STATES.MERGE_BLOCKED) {
+    reasons.push("merge_blocked");
+  }
+  if (Number(child.review_round) >= 3) {
+    reasons.push("high_review_rounds");
+  }
+  if (child.base_branch && defaultBranchName && child.base_branch !== defaultBranchName) {
+    reasons.push("stale_base");
+  }
+  if (
+    child.dispatch_status === DISPATCH_STATUS.DISPATCHED
+    && KNOWN_RUN_STATES.has(child.run_state)
+    && !terminalForFleetReview(child.run_state)
+    && repoRoot
+    && fleetId
+    && !runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)
+  ) {
+    reasons.push("stuck_child");
+  }
+
+  return reasons;
+}
+
+function buildOperatorAttention(summary, context = {}) {
+  const { repoRoot, fleetId } = context;
+  const needsDefaultBranch = summary.children.some((child) => child.base_branch);
+  const defaultBranchName = needsDefaultBranch && repoRoot ? resolveFleetDefaultBranch(repoRoot) : null;
+  const resolvedContext = { repoRoot, fleetId, defaultBranchName };
+
+  const items = [];
+  for (const child of summary.children) {
+    const legacyReason = legacyAttentionReason(child);
+    if (legacyReason) {
+      items.push({ leaf_ref: child.leaf_ref, run_id: child.run_id, reason: legacyReason });
+    }
+    for (const reason of additionalAttentionReasons(child, resolvedContext)) {
+      items.push({ leaf_ref: child.leaf_ref, run_id: child.run_id, reason });
+    }
+  }
+  return items;
 }
 
 function formatStatusText(summary, operatorAttention) {
@@ -1086,7 +1252,7 @@ function formatStatusText(summary, operatorAttention) {
 async function statusFleet({ repoRoot, fleetId }) {
   const fleet = readFleetManifest(repoRoot, fleetId).data;
   const summary = deriveFleetSummary(repoRoot, fleet);
-  return { summary, operator_attention: buildOperatorAttention(summary) };
+  return { summary, operator_attention: buildOperatorAttention(summary, { repoRoot, fleetId }) };
 }
 
 function findSummaryChild(repoRoot, fleetId, leafRef) {
@@ -1212,7 +1378,7 @@ async function reviewFleet({ repoRoot, fleetId, options, activeChildren = new Ma
     });
   });
   const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
-  const operatorAttention = buildOperatorAttention(summary);
+  const operatorAttention = buildOperatorAttention(summary, { repoRoot, fleetId });
   const failures = children.some((child) => {
     return !["complete", "skipped"].includes(child.status);
   });
@@ -1284,6 +1450,7 @@ async function runFleet(options) {
   const leaves = options.leavesFile
     ? loadLeavesFile(options.leavesFile)
     : (options.resume ? readPersistedLeaves(repoRoot, fleetId) : []);
+  validateLeafLineage(repoRoot, leaves);
 
   if (!options.resume && !options.dryRun && fs.existsSync(manifestPath)) {
     throw new FleetInputError(`fleet manifest already exists: ${manifestPath}; use --resume`);
@@ -1360,7 +1527,7 @@ async function runFleet(options) {
     reconcileFleet(repoRoot, fleetId, leaves);
     const fleet = maybeFinalizeFleet(repoRoot, fleetId);
     const summary = deriveFleetSummary(repoRoot, fleet);
-    const operatorAttention = buildOperatorAttention(summary);
+    const operatorAttention = buildOperatorAttention(summary, { repoRoot, fleetId });
     const preManifestFailures = summary.children
       .some((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
     if (options.resume && summary.children.some(childNeedsReviewLoop)) {

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -33,6 +33,10 @@ const {
   releaseIssueLock,
   writeFleetManifest,
 } = require("../../../skills/relay-dispatch/scripts/manifest/fleet");
+const {
+  getRequestPath,
+  persistRequestContract,
+} = require("../../../skills/relay-ready/scripts/relay-request");
 
 function initGitRepo(repoRoot) {
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -71,10 +75,29 @@ function makeLeaf(repoRoot, index, overrides = {}) {
     prompt_file: promptFile,
     rubric_file: rubricFile,
     done_criteria_file: doneCriteriaFile,
-    request_id: overrides.request_id || "req-20260514010101000",
+    // No default request_id: leaves without one are exempt from the
+    // relay-ready lineage check (validateLeafLineage). Tests that exercise
+    // lineage pass their own request_id explicitly, backed by a real
+    // persisted request artifact via persistFixtureRequest below.
     leaf_id: overrides.leaf_id || leafRef,
     ...overrides,
   };
+}
+
+// Persists a real single-leaf relay-ready request artifact so fleet leaves can
+// reference a request_id/leaf_id pair that validateLeafLineage will resolve.
+function persistFixtureRequest(repoRoot, requestId, leafId) {
+  persistRequestContract(repoRoot, {
+    source: { kind: "manual" },
+    request_text: `Fixture request for ${leafId}`,
+    handoff: {
+      leaf_id: leafId,
+      title: `Fixture leaf ${leafId}`,
+      goal: `Implement ${leafId}`,
+      done_criteria_markdown: `- ${leafId} is done`,
+    },
+  }, { requestId });
+  return getRequestPath(repoRoot, requestId);
 }
 
 function writeLeavesFile(repoRoot, leaves) {
@@ -1207,4 +1230,327 @@ test("relay-fleet --status prints derived summary without writing the fleet mani
   assert.match(textResult.stdout, /Needs operator attention:/);
   assert.match(textResult.stdout, new RegExp(`leaf-escalated: escalated \\(${escalatedRun}\\)`));
   assert.equal(fs.readFileSync(created.manifestPath, "utf-8"), before);
+});
+
+function writeFakeGhDefaultBranch(tmpDir, defaultBranchName) {
+  const ghPath = path.join(tmpDir, "fake-gh-default-branch.js");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "repo" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({ defaultBranchRef: { name: ${JSON.stringify(defaultBranchName)} } }));
+  process.exit(0);
+}
+process.stderr.write("unsupported fake gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return ghPath;
+}
+
+test("relay-fleet rejects a depends_on entry that names another leaf in the same leaves file", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dep-same-wave-");
+  const dispatchScript = writeFakeDispatchScript(fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-")));
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, { issue_number: 540, leaf_ref: "leaf-a", leaf_id: "leaf-a" }),
+    makeLeaf(repoRoot, 2, { issue_number: 541, leaf_ref: "leaf-b", leaf_id: "leaf-b", depends_on: ["leaf-a"] }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-dep-same-wave",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /same-wave dependency/);
+  assert.equal(fs.existsSync(getFleetManifestPath(repoRoot, "fleet-dep-same-wave")), false);
+});
+
+test("relay-fleet rejects a depends_on entry that references the leaf itself", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dep-self-");
+  const dispatchScript = writeFakeDispatchScript(fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-")));
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, { issue_number: 542, leaf_ref: "leaf-a", leaf_id: "leaf-a", depends_on: ["leaf-a"] }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-dep-self",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /references itself/);
+  assert.equal(fs.existsSync(getFleetManifestPath(repoRoot, "fleet-dep-self")), false);
+});
+
+test("relay-fleet accepts a depends_on entry that references a leaf outside this leaves file", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-dep-external-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const logPath = path.join(tmpDir, "dispatch.log");
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, {
+      issue_number: 543,
+      leaf_ref: "leaf-c",
+      leaf_id: "leaf-c",
+      depends_on: ["leaf-dispatched-in-an-earlier-wave"],
+    }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-dep-external",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--dry-run",
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_LOG: logPath },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.dryRun, true);
+  assert.equal(payload.children.length, 1);
+  assert.equal(payload.children[0].status, "dry_run");
+});
+
+test("relay-fleet --dry-run fails closed when request_id does not resolve to a relay-ready request artifact", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-lineage-missing-");
+  const dispatchScript = writeFakeDispatchScript(fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-")));
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, {
+      issue_number: 544,
+      leaf_ref: "leaf-d",
+      leaf_id: "leaf-d",
+      request_id: "req-does-not-exist-000",
+    }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-lineage-missing",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--dry-run",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not resolve to a relay-ready request artifact/);
+  assert.equal(fs.existsSync(getFleetManifestPath(repoRoot, "fleet-lineage-missing")), false);
+});
+
+test("relay-fleet --dry-run fails closed when leaf_id is not among the request's leaf handoffs", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-lineage-mismatch-");
+  const dispatchScript = writeFakeDispatchScript(fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-")));
+  persistFixtureRequest(repoRoot, "req-lineage-mismatch", "leaf-real");
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, {
+      issue_number: 545,
+      leaf_ref: "leaf-e",
+      leaf_id: "leaf-not-in-request",
+      request_id: "req-lineage-mismatch",
+    }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-lineage-mismatch",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--dry-run",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /is not among the leaf handoffs persisted for request/);
+});
+
+test("relay-fleet --dry-run succeeds when request_id and leaf_id resolve to a persisted request artifact", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-lineage-ok-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const logPath = path.join(tmpDir, "dispatch.log");
+  persistFixtureRequest(repoRoot, "req-lineage-ok", "leaf-f");
+  const leavesFile = writeLeavesFile(repoRoot, [
+    makeLeaf(repoRoot, 1, {
+      issue_number: 546,
+      leaf_ref: "leaf-f",
+      leaf_id: "leaf-f",
+      request_id: "req-lineage-ok",
+    }),
+  ]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-lineage-ok",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--dry-run",
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_LOG: logPath },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.dryRun, true);
+  assert.equal(payload.children[0].status, "dry_run");
+});
+
+test("relay-fleet --status surfaces missing_pr, merge_blocked, high_review_rounds, stale_base, and stuck_child alongside the existing reasons, with a healthy child producing none", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-status-debt-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-status-debt-fake-"));
+  const fleetId = "fleet-status-debt";
+
+  // Existing reasons, reused from the fixtures above: dispatch_failed_pre_manifest
+  // (no run_id) and escalated/changes_requested/missing_manifest need a run_id.
+  const escalatedRun = "issue-550-20260601010101000-a1b2c3d4";
+  const changesRequestedRun = "issue-551-20260601010101000-a1b2c3d4";
+  const missingManifestRun = "issue-552-20260601010101000-a1b2c3d4";
+  // New reasons.
+  const missingPrRun = "issue-553-20260601010101000-a1b2c3d4";
+  const mergeBlockedRun = "issue-554-20260601010101000-a1b2c3d4";
+  const highReviewRoundsRun = "issue-555-20260601010101000-a1b2c3d4";
+  const staleBaseRun = "issue-556-20260601010101000-a1b2c3d4";
+  const stuckChildRun = "issue-557-20260601010101000-a1b2c3d4";
+  const healthyRun = "issue-558-20260601010101000-a1b2c3d4";
+
+  function makeChildManifest(runId, leafId, { patch = (manifest) => manifest } = {}) {
+    fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+    let manifest = createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch: `${leafId}-branch`,
+      baseBranch: "main",
+      issueNumber: Number(runId.slice(6, 9)),
+      worktreePath: path.join(repoRoot, "wt", runId),
+      fleetId,
+      leafId,
+    });
+    // Any transition into review_pending requires a satisfied rubric anchor
+    // (see lifecycle.js validateTransitionInvariants); write one up front so
+    // every fixture below can freely reach review_pending regardless of which
+    // attention reason it exercises.
+    fs.writeFileSync(path.join(getRunDir(repoRoot, runId), "rubric.yaml"), "rubric:\n  size_class: S\n", "utf-8");
+    manifest = { ...manifest, anchor: { ...(manifest.anchor || {}), rubric_path: "rubric.yaml" } };
+    manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+    manifest = patch(manifest);
+    writeManifest(getManifestPath(repoRoot, runId), manifest);
+    return runId;
+  }
+
+  makeChildManifest(escalatedRun, "leaf-escalated", {
+    patch: (manifest) => updateManifestState(manifest, RUN_STATES.ESCALATED, "inspect_dispatch_failure"),
+  });
+  makeChildManifest(changesRequestedRun, "leaf-changes-requested", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      return updateManifestState(manifest, RUN_STATES.CHANGES_REQUESTED, "retry");
+    },
+  });
+  // missing-manifest: fleet child references a run_id whose manifest file was never written.
+
+  makeChildManifest(missingPrRun, "leaf-missing-pr", {
+    patch: (manifest) => updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review"),
+  });
+  makeChildManifest(mergeBlockedRun, "leaf-merge-blocked", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      manifest = updateManifestState(manifest, RUN_STATES.READY_TO_MERGE, "ready");
+      manifest = updateManifestState(manifest, RUN_STATES.MERGE_BLOCKED, "merge_failed");
+      return { ...manifest, git: { ...manifest.git, pr_number: 601 } };
+    },
+  });
+  makeChildManifest(highReviewRoundsRun, "leaf-high-review-rounds", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      return {
+        ...manifest,
+        git: { ...manifest.git, pr_number: 602 },
+        review: { ...manifest.review, rounds: 3 },
+      };
+    },
+  });
+  makeChildManifest(staleBaseRun, "leaf-stale-base", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      return {
+        ...manifest,
+        git: { ...manifest.git, pr_number: 603, base_branch: "develop" },
+      };
+    },
+  });
+  makeChildManifest(stuckChildRun, "leaf-stuck-child", {
+    patch: (manifest) => ({
+      ...manifest,
+      git: { ...manifest.git, pr_number: 604 },
+    }),
+  });
+  makeChildManifest(healthyRun, "leaf-healthy", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      manifest = updateManifestState(manifest, RUN_STATES.READY_TO_MERGE, "ready");
+      manifest = updateManifestState(manifest, RUN_STATES.MERGED, "merged");
+      return { ...manifest, git: { ...manifest.git, pr_number: 605 } };
+    },
+  });
+
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [
+      { leaf_ref: "leaf-dispatch-failed", run_id: null, dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST },
+      { leaf_ref: "leaf-escalated", run_id: escalatedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-changes-requested", run_id: changesRequestedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-missing-manifest", run_id: missingManifestRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-missing-pr", run_id: missingPrRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-merge-blocked", run_id: mergeBlockedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-high-review-rounds", run_id: highReviewRoundsRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-stale-base", run_id: staleBaseRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-stuck-child", run_id: stuckChildRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-healthy", run_id: healthyRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    ],
+  });
+
+  const fakeGh = writeFakeGhDefaultBranch(tmpDir, "main");
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--status",
+    "--json",
+  ], { relayHome, env: { RELAY_GH_BIN: fakeGh } });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  const attention = payload.operator_attention;
+
+  function has(leafRef, reason) {
+    return attention.some((item) => item.leaf_ref === leafRef && item.reason === reason);
+  }
+
+  // Existing reasons still fire, byte-identical.
+  assert.equal(has("leaf-dispatch-failed", DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST), true);
+  assert.equal(has("leaf-escalated", "escalated"), true);
+  assert.equal(has("leaf-changes-requested", "changes_requested"), true);
+  assert.equal(has("leaf-missing-manifest", "missing_manifest"), true);
+
+  // New reasons.
+  assert.equal(has("leaf-missing-pr", "missing_pr"), true);
+  assert.equal(has("leaf-merge-blocked", "merge_blocked"), true);
+  assert.equal(has("leaf-high-review-rounds", "high_review_rounds"), true);
+  assert.equal(has("leaf-stale-base", "stale_base"), true);
+  assert.equal(has("leaf-stuck-child", "stuck_child"), true);
+
+  // The healthy child (terminal, PR stamped, rounds below threshold, base
+  // branch matches default, not eligible for stuck_child) produces zero items.
+  assert.equal(attention.some((item) => item.leaf_ref === "leaf-healthy"), false);
 });


### PR DESCRIPTION
## Summary

Implements #724: validate accepted leaf contracts before fan-out, and surface operational debt in fleet status.

### A. Leaf-contract validation at load time (applies to both `--dry-run` and real fan-out, since it lives in `loadLeavesFile` / the `runFleet` entry point)
- New optional leaf field `depends_on` (array of `leaf_ref` strings, `dependsOn` alias accepted), parsed/validated in `normalizeLeaf`.
- New `validateLeafDependencies(leaves)`, called from `loadLeavesFile`:
  - `depends_on` entry referencing another leaf in the *same* leaves file → `FleetInputError` naming both leaves ("same-wave dependency"), telling the operator to dispatch the dependency in an earlier wave.
  - `depends_on` entry equal to the leaf's own `leaf_ref` → `FleetInputError` (self-dependency).
  - `depends_on` entry referencing a `leaf_ref` not in this file → accepted silently (external dependency assumed already satisfied). Documented in SKILL.md.
- New `validateLeafLineage(repoRoot, leaves)`, called from `runFleet` right after `leaves` is computed (needs `repoRoot`, which `loadLeavesFile` doesn't have — its signature is unchanged): for each leaf with a `request_id`, the request artifact must resolve via `getRequestPath` + exist + parse via `readRequestArtifact`; if `leaf_id` is also set (it always is, since `normalizeLeaf` defaults it to `leaf_ref`), it must be among that request's leaf handoffs (`decomposition.leaf_order` for multi-leaf requests, or the top-level `leaf_id` for single-leaf requests). Missing/unresolvable → `FleetInputError` naming the leaf and the broken pointer. Leaves without `request_id` are exempt.

### B. Status operational debt
- `deriveFleetSummary` (`skills/relay-dispatch/scripts/manifest/fleet.js`) extended additively: each child summary gains nullable `pr_number`, `base_branch`, `review_round`, read from the child manifest's `git.pr_number`, `git.base_branch`, `review.rounds` when readable. No existing fields/semantics changed.
- `buildOperatorAttention` now emits **one item per (leaf, reason)** — a child can appear multiple times. The four existing reasons (`dispatch_failed_pre_manifest`, `missing_manifest`, `escalated`, `changes_requested`) are preserved byte-identical (they were already mutually exclusive per child, so this is a pure refactor for those). Five new reasons:
  - `missing_pr`: run_state in `review_pending`/`ready_to_merge`/`merge_blocked` and `pr_number` is null.
  - `merge_blocked`: run_state is `merge_blocked`.
  - `high_review_rounds`: `review_round >= 3`.
  - `stale_base`: `base_branch` is set and differs from the repo's resolved default branch (`gh repo view --json defaultBranchRef`, mirroring `relay-merge/scripts/finalize-run.js`'s `fetchDefaultBranchName` without importing from the frozen `relay-merge` tree; resolved lazily, only when at least one child has a `base_branch`, and treated as "unknown" — no flag — if `gh` fails).
  - `stuck_child`: dispatch_status is `dispatched`, run_state is a real non-terminal state, and `runtimeChildIsAlive` is false for that leaf.
- `statusFleet`, the review-loop return path, and the fan-out return path all now pass `{ repoRoot, fleetId }` into `buildOperatorAttention`.

### C. Docs
- `skills/relay-fleet/SKILL.md` (117 → 119 lines, under the 150-line cap): documents `depends_on` (same-wave fails closed, external accepted) and adds one sentence stating relay-fleet never splits raw/ambiguous requests — that routes through `relay-ready` first.

### Test evidence
- `node --test tests/relay-fleet/scripts/relay-fleet.test.js`: **23/23 pass** (7 new tests: same-wave depends_on rejection, self-depends_on rejection, external depends_on acceptance, lineage-missing-request rejection, lineage-leaf_id-mismatch rejection, lineage-success, and one combined `--status` test exercising all 5 new attention reasons + all 4 existing reasons + one healthy child with zero attention items).
- `node --test tests/*/scripts/*.test.js` (full repo suite): **1681/1683 pass, 0 fail, 2 skipped** (pre-existing skips, unrelated to this change).

### Deviations from the design doc
- The design said "if `leaf_id` is also set" for the lineage leaf_id check — in practice `normalizeLeaf` always defaults `leaf_id` to `leaf_ref` when absent, so this check effectively always runs whenever `request_id` is present. This matches the SKILL.md's existing framing of `leaf_ref` as "usually the relay-ready `leaf_id`".
- The exact review-round field name is `review.rounds` (plural) on the child manifest — the design doc's anchor said "review.round"; confirmed via `skills/relay-dispatch/scripts/manifest/store.js` and existing usage in `review-runner.js`/`relay-fleet.js`'s `childReviewSnapshot`. The new fleet-summary field is named `review_round` (singular) to match the design's field name, sourced from `review.rounds`.
- `resolveFleetDefaultBranch` duplicates (rather than imports) `finalize-run.js`'s `fetchDefaultBranchName` logic, since `skills/relay-merge/` is frozen for this change and that helper isn't exported.
- Existing test fixture `makeLeaf` had a hardcoded default `request_id` ("req-20260514010101000") that never resolved to a real request artifact; with `validateLeafLineage` now fail-closed, this default was removed (leaves without an explicit `request_id` are simply exempt, matching the design's "leaves without request_id are exempt" clause) so pre-existing tests weren't broken. Verified via full-suite run before and after.

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXf39ULLc7R6v21A17YXfh