### PR TITLE
relay-plan: show quality mix and TDD accountability in quality card (#730)

### DIFF
--- a/skills/relay-plan/references/rubric-validation.md
+++ b/skills/relay-plan/references/rubric-validation.md
@@ -59,6 +59,10 @@ Quality factors: 0
 Substantive total: 1
 Quality ratio: N/A (mechanical S-size task)
 Auto coverage: 2 / 2 checks automated across prerequisites + factors
+Hygiene-in-factor violations: none
+TDD eligible factors: 1
+TDD applied (tdd_anchor): 0
+TDD skip reason: none declared (test infra available; planner did not opt in)
 Calibration status: skipped (S task)
 Risk signals: none
 Rationale: Recovered Done Criteria require one observable behavior change; no design-bearing quality judgment was introduced.
@@ -82,9 +86,13 @@ Quality factors: 0
 Substantive total: 1
 Quality ratio: N/A (ready-light S-size task)
 Auto coverage: 1 / 2 checks automated across prerequisites + factors
+Hygiene-in-factor violations: none
+TDD eligible factors: 0
+TDD applied (tdd_anchor): 0
+TDD skip reason: docs_only
 Calibration status: skipped (ready-light)
 Risk signals: none
-Rationale: Readiness already returned proceed, but no bypass anchor exists; use one observable contract factor plus the smallest verification path.
+Rationale: Readiness already returned proceed, but no bypass anchor exists; this is a docs-only edit, so use one observable contract factor plus the smallest verification path.
 Over-engineering check: Unsupported helper, dependency, config, or abstraction requirements are over-engineering risk.
 Grade: B
 Action: dispatch allowed
@@ -98,6 +106,10 @@ Quality factors: 1
 Substantive total: 2
 Quality ratio: 50%
 Auto coverage: 1 / 3 checks automated across prerequisites + factors
+Hygiene-in-factor violations: none
+TDD eligible factors: 0
+TDD applied (tdd_anchor): 0
+TDD skip reason: none declared
 Calibration status: compact (ready-light design-bearing)
 Risk signals: design-bearing
 Design-bearing rationale: The task is still S-size, but user-visible copy or prompt wording can be correct in shape while poor in judgment, so one quality factor is justified.
@@ -113,6 +125,10 @@ Quality factors: 2
 Substantive total: 4
 Quality ratio: 50%
 Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Hygiene-in-factor violations: none
+TDD eligible factors: 2
+TDD applied (tdd_anchor): 1
+TDD anchors: `tests/front-matter.test.js` via `jest` (Parser rejects malformed front matter)
 Calibration status: skipped (S/M task)
 Risk signals: none
 Historical signal:
@@ -137,6 +153,10 @@ Quality factors: 2
 Substantive total: 4
 Quality ratio: 50%
 Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Hygiene-in-factor violations: none
+TDD eligible factors: 2
+TDD applied (tdd_anchor): 0
+TDD skip reason: no_runner (auto-derived — probe reported no test infra)
 Calibration status: skipped (S/M task)
 Risk signals: none
 Historical signal: Empty-data state — historical signal not available, proceed to rubric design.
@@ -161,6 +181,10 @@ Quality factors: 2
 Substantive total: 4
 Quality ratio: 50%
 Auto coverage: 3 / 6 checks automated across prerequisites + factors
+Hygiene-in-factor violations: none
+TDD eligible factors: 2
+TDD applied (tdd_anchor): 0
+TDD skip reason: no_runner (auto-derived — probe unavailable, treated as no test infra)
 Calibration status: skipped (S/M task)
 Risk signals: none
 Historical signal: Reliability report unavailable: Unexpected end of JSON input. Proceeding without historical signal.
@@ -177,6 +201,20 @@ probe_signal.scripts: no quality infra detected
 Grade: A
 Action: dispatch allowed
 ```
+
+### TDD skip reasons
+
+When zero factors carry an applied `tdd_anchor`, the quality card records why as one of five standardized reasons (see `skills/relay-plan/scripts/quality-card.js`):
+
+| Reason | When it applies |
+|--------|------------------|
+| `no_runner` | No test infra was detected (auto-derived from the probe signal; the planner does not need to declare this one) |
+| `docs_only` | The diff is docs-only — nothing executable to test-drive |
+| `broad_ui_judgment` | The outcome is broad visual/UX judgment, not a crisp assertion a test can pin down |
+| `exploratory_task` | The task is a spike or investigation where behavior is discovered, not specified up front |
+| `non_crisp_behavior` | Done Criteria describe behavior too loosely for a failing-test-first anchor |
+
+An unrecognized skip reason string is a fail-closed error, not a silent coercion — pick one of the five values above or leave it undeclared.
 
 ## Grading logic
 

--- a/skills/relay-plan/scripts/quality-card.js
+++ b/skills/relay-plan/scripts/quality-card.js
@@ -16,6 +16,7 @@ const TDD_SKIP_REASONS = new Set([
 function countPrerequisites(rubricYaml) {
   let inSection = false;
   let sectionIndent = null;
+  let itemIndent = null;
   let count = 0;
 
   for (const line of String(rubricYaml || "").split(/\r?\n/)) {
@@ -25,6 +26,7 @@ function countPrerequisites(rubricYaml) {
     if (section && section[2] === "prerequisites") {
       inSection = !section[3];
       sectionIndent = inSection ? section[1].length : null;
+      itemIndent = null;
       continue;
     }
 
@@ -36,8 +38,16 @@ function countPrerequisites(rubricYaml) {
       continue;
     }
 
+    // Lock onto the first item's dash indent (extractAllFactors tolerates any
+    // list indentation, including dashes at the section key's own indent);
+    // deeper dashes are nested sequences inside an entry, not new entries.
     const listItemStart = line.match(/^(\s*)-\s*/);
-    if (listItemStart && listItemStart[1].length === sectionIndent + 2) {
+    if (!listItemStart) continue;
+    const dashIndent = listItemStart[1].length;
+    if (itemIndent === null && dashIndent >= sectionIndent) {
+      itemIndent = dashIndent;
+    }
+    if (dashIndent === itemIndent) {
       count += 1;
     }
   }

--- a/skills/relay-plan/scripts/quality-card.js
+++ b/skills/relay-plan/scripts/quality-card.js
@@ -1,0 +1,172 @@
+const { extractAllFactors, firstProbeTestInfra } = require("./tdd-flavor");
+const { isRepoHygieneFactor } = require("./rubric-validation");
+
+const SUBSTANTIVE_TIERS = new Set(["contract", "quality"]);
+const TDD_SKIP_REASONS = new Set([
+  "no_runner",
+  "docs_only",
+  "broad_ui_judgment",
+  "exploratory_task",
+  "non_crisp_behavior",
+]);
+
+// Mirrors extractAllFactors's section-detection line-scan (tdd-flavor.js), but
+// counts list entries under `rubric.prerequisites` instead of parsing `factors`
+// into structured objects. There is no YAML library in this repo by design.
+function countPrerequisites(rubricYaml) {
+  let inSection = false;
+  let sectionIndent = null;
+  let count = 0;
+
+  for (const line of String(rubricYaml || "").split(/\r?\n/)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+
+    const section = line.match(/^(\s*)([A-Za-z_][\w.-]*):\s*(.*?)\s*$/);
+    if (section && section[2] === "prerequisites") {
+      inSection = !section[3];
+      sectionIndent = inSection ? section[1].length : null;
+      continue;
+    }
+
+    if (!inSection) continue;
+
+    const indent = line.match(/^\s*/)[0].length;
+    if (section && indent <= sectionIndent) {
+      inSection = false;
+      continue;
+    }
+
+    const listItemStart = line.match(/^(\s*)-\s*/);
+    if (listItemStart && listItemStart[1].length === sectionIndent + 2) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+// Reuses the existing design-bearing signal vocabulary (rubric-validation.md §
+// Risk signals: `all_contract`): risk_tags containing "design-bearing", or a
+// non-empty design_rationale. Intentionally narrower than
+// hasExplicitRiskOrDesignRationale in rubric-validation.js, which also folds
+// in risk_rationale and the "risk-bearing" tag for a different purpose
+// (ready-light factor-count leniency).
+function isDesignBearing(taskProfile) {
+  const riskTags = Array.isArray(taskProfile.risk_tags) ? taskProfile.risk_tags : [];
+  const designRationale = String(taskProfile.design_rationale || "").trim();
+  return riskTags.includes("design-bearing") || designRationale !== "";
+}
+
+function tierOf(factor) {
+  return String(factor.tier || "").toLowerCase();
+}
+
+function isSubstantiveFactor(factor) {
+  return SUBSTANTIVE_TIERS.has(tierOf(factor));
+}
+
+function isContractFactor(factor) {
+  return tierOf(factor) === "contract";
+}
+
+function isQualityFactor(factor) {
+  return tierOf(factor) === "quality";
+}
+
+function isAutomatedContractFactor(factor) {
+  return isContractFactor(factor) && String(factor.type || "").toLowerCase() === "automated";
+}
+
+function hasNonEmptyTddAnchor(factor) {
+  return Boolean(factor.tdd_anchor && String(factor.tdd_anchor).trim() !== "");
+}
+
+// TDD accountability is opt-in (see issue #730 non-goals: no mandatory TDD,
+// no top-level tdd_mode). skip_reason only records *why* nothing was applied;
+// it never blocks dispatch on its own.
+function resolveTddSkipReason({ appliedCount, tddSkipReason, probeSignal }) {
+  if (appliedCount > 0) return null;
+
+  const explicitReason = tddSkipReason == null ? "" : String(tddSkipReason).trim();
+  if (explicitReason !== "") {
+    if (!TDD_SKIP_REASONS.has(explicitReason)) {
+      throw new Error(
+        `Invalid tddSkipReason "${explicitReason}"; must be one of: ${[...TDD_SKIP_REASONS].join(", ")}`
+      );
+    }
+    return explicitReason;
+  }
+
+  if (!firstProbeTestInfra(probeSignal)) {
+    return "no_runner";
+  }
+
+  return null;
+}
+
+function buildQualityCardSummary({
+  rubricYaml,
+  taskProfile = {},
+  probeSignal = null,
+  tddSkipReason = null,
+  qualityWaiver = "",
+} = {}) {
+  const factors = extractAllFactors(rubricYaml);
+  const substantiveFactors = factors.filter(isSubstantiveFactor);
+  const contractFactors = factors.filter(isContractFactor);
+  const qualityFactors = factors.filter(isQualityFactor);
+
+  const hygieneViolations = substantiveFactors
+    .filter(isRepoHygieneFactor)
+    .map((factor) => factor.name);
+
+  const waiver = String(qualityWaiver || "").trim();
+  const warnings = [];
+
+  if (isDesignBearing(taskProfile) && qualityFactors.length === 0 && !waiver) {
+    warnings.push({
+      code: "all_contract",
+      message: "Design-bearing task has zero quality-tier factors and no quality waiver.",
+    });
+  }
+
+  if (hygieneViolations.length > 0) {
+    warnings.push({
+      code: "repo_hygiene_in_factor",
+      message: "Repo-wide lint, typecheck, or test commands are placed in factors instead of prerequisites.",
+    });
+  }
+
+  const eligibleFactors = factors.filter(isAutomatedContractFactor);
+  const appliedFactors = factors.filter(hasNonEmptyTddAnchor);
+  const anchors = appliedFactors.map((factor) => ({
+    factor: factor.name,
+    tdd_anchor: factor.tdd_anchor,
+    tdd_runner: factor.tdd_runner || null,
+  }));
+
+  const skipReason = resolveTddSkipReason({
+    appliedCount: appliedFactors.length,
+    tddSkipReason,
+    probeSignal,
+  });
+
+  return {
+    prerequisites_count: countPrerequisites(rubricYaml),
+    contract_factors: contractFactors.length,
+    quality_factors: qualityFactors.length,
+    hygiene_in_factor_violations: hygieneViolations,
+    quality_waiver: waiver,
+    warnings,
+    tdd: {
+      eligible_count: eligibleFactors.length,
+      applied_count: appliedFactors.length,
+      anchors,
+      skip_reason: skipReason,
+    },
+  };
+}
+
+module.exports = {
+  buildQualityCardSummary,
+};

--- a/skills/relay-plan/scripts/rubric-validation.js
+++ b/skills/relay-plan/scripts/rubric-validation.js
@@ -245,4 +245,5 @@ function validateReadyLightRubric({ rubricYaml, taskProfile = {} } = {}) {
 
 module.exports = {
   validateReadyLightRubric,
+  isRepoHygieneFactor,
 };

--- a/tests/relay-plan/scripts/quality-card.test.js
+++ b/tests/relay-plan/scripts/quality-card.test.js
@@ -171,6 +171,48 @@ test("leaves skip_reason null when test infra exists but the planner declared no
   assert.equal(result.tdd.skip_reason, null);
 });
 
+test("counts prerequisites at whatever list indentation the rubric uses, excluding nested sequences", () => {
+  const fourSpaceItems = [
+    "rubric:",
+    "  prerequisites:",
+    "      - command: \"npm test\"",
+    "        target: \"exit 0\"",
+    "      - command: \"tsc --noEmit\"",
+    "        target: \"exit 0\"",
+    "  factors:",
+    "    - name: X",
+    "      tier: contract",
+    "      target: \"exit 0\"",
+  ].join("\n");
+  assert.equal(buildQualityCardSummary({ rubricYaml: fourSpaceItems }).prerequisites_count, 2);
+
+  const sameIndentItems = [
+    "rubric:",
+    "  prerequisites:",
+    "  - command: \"npm test\"",
+    "    target: \"exit 0\"",
+    "  factors:",
+    "    - name: X",
+    "      tier: contract",
+    "      target: \"exit 0\"",
+  ].join("\n");
+  assert.equal(buildQualityCardSummary({ rubricYaml: sameIndentItems }).prerequisites_count, 1);
+
+  const nestedSequence = [
+    "rubric:",
+    "  prerequisites:",
+    "    - command: \"npm test\"",
+    "      args:",
+    "        - \"--verbose\"",
+    "        - \"--bail\"",
+    "  factors:",
+    "    - name: X",
+    "      tier: contract",
+    "      target: \"exit 0\"",
+  ].join("\n");
+  assert.equal(buildQualityCardSummary({ rubricYaml: nestedSequence }).prerequisites_count, 1);
+});
+
 test("counts prerequisites, contract, and quality factors on a mixed rubric", () => {
   const result = buildQualityCardSummary({
     rubricYaml: rubricWithFactors(

--- a/tests/relay-plan/scripts/quality-card.test.js
+++ b/tests/relay-plan/scripts/quality-card.test.js
@@ -1,0 +1,200 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildQualityCardSummary } = require("../../../skills/relay-plan/scripts/quality-card");
+
+const PROBE_WITH_JEST = JSON.stringify({
+  test_infra: [{ name: "jest" }],
+  project_tools: { frameworks: [] },
+});
+
+const PROBE_WITHOUT_TEST_INFRA = JSON.stringify({
+  test_infra: [],
+  project_tools: { frameworks: [] },
+});
+
+function rubricWithFactors(factors, { prerequisites = [] } = {}) {
+  return [
+    "rubric:",
+    ...(prerequisites.length
+      ? [
+        "  prerequisites:",
+        ...prerequisites.flatMap((prereq) => [
+          `    - command: "${prereq.command}"`,
+          `      target: "${prereq.target || "exit 0"}"`,
+        ]),
+      ]
+      : []),
+    "  factors:",
+    ...factors.flatMap((factor) => [
+      `    - name: ${factor.name}`,
+      `      tier: ${factor.tier || "contract"}`,
+      `      type: ${factor.type || "automated"}`,
+      ...(factor.command ? [`      command: "${factor.command}"`] : []),
+      ...(factor.criteria ? [`      criteria: "${factor.criteria}"`] : []),
+      `      target: "${factor.target || "exit 0"}"`,
+      ...(factor.tdd_anchor ? [`      tdd_anchor: "${factor.tdd_anchor}"`] : []),
+      ...(factor.tdd_runner ? [`      tdd_runner: "${factor.tdd_runner}"`] : []),
+    ]),
+  ].join("\n");
+}
+
+test("flags a repo-wide hygiene command placed in a factor", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Repo suite remains green",
+        command: "node --test tests/*/scripts/*.test.js",
+      },
+    ]),
+  });
+
+  assert.deepEqual(result.hygiene_in_factor_violations, ["Repo suite remains green"]);
+  assert.ok(result.warnings.some((warning) => warning.code === "repo_hygiene_in_factor"));
+});
+
+test("does not flag a task-specific command as hygiene", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Parser rejects invalid input",
+        command: "node --test tests/parser.test.js",
+      },
+    ]),
+  });
+
+  assert.deepEqual(result.hygiene_in_factor_violations, []);
+  assert.ok(!result.warnings.some((warning) => warning.code === "repo_hygiene_in_factor"));
+});
+
+test("warns all_contract for a design-bearing task with zero quality factors and no waiver", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      { name: "Route decision is preserved", tier: "contract" },
+    ]),
+    taskProfile: { risk_tags: ["design-bearing"] },
+  });
+
+  assert.equal(result.quality_factors, 0);
+  assert.ok(result.warnings.some((warning) => warning.code === "all_contract"));
+  assert.equal(result.quality_waiver, "");
+});
+
+test("suppresses all_contract warning and echoes the waiver when one is provided", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      { name: "Route decision is preserved", tier: "contract" },
+    ]),
+    taskProfile: { risk_tags: ["design-bearing"] },
+    qualityWaiver: "Mechanical route swap; no user-visible copy changed.",
+  });
+
+  assert.equal(result.quality_factors, 0);
+  assert.ok(!result.warnings.some((warning) => warning.code === "all_contract"));
+  assert.equal(result.quality_waiver, "Mechanical route swap; no user-visible copy changed.");
+});
+
+test("reports TDD anchors applied with their runner and null skip_reason", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Parser rejects invalid input",
+        tier: "contract",
+        type: "automated",
+        command: "node --test tests/parser.test.js",
+        tdd_anchor: "tests/parser.test.js",
+        tdd_runner: "node:test",
+      },
+    ]),
+  });
+
+  assert.equal(result.tdd.eligible_count, 1);
+  assert.equal(result.tdd.applied_count, 1);
+  assert.deepEqual(result.tdd.anchors, [
+    { factor: "Parser rejects invalid input", tdd_anchor: "tests/parser.test.js", tdd_runner: "node:test" },
+  ]);
+  assert.equal(result.tdd.skip_reason, null);
+});
+
+test("accepts an explicit standardized skip reason when no anchors are applied", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      { name: "README documents the new flag", tier: "contract", type: "evaluated", target: ">= 8/10" },
+    ]),
+    tddSkipReason: "docs_only",
+  });
+
+  assert.equal(result.tdd.applied_count, 0);
+  assert.equal(result.tdd.skip_reason, "docs_only");
+});
+
+test("throws on an unknown tddSkipReason instead of silently coercing it", () => {
+  assert.throws(() => buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      { name: "README documents the new flag", tier: "contract", type: "evaluated", target: ">= 8/10" },
+    ]),
+    tddSkipReason: "because-reasons",
+  }));
+});
+
+test("auto-derives no_runner when no anchors are applied and the probe reports no test infra", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Parser rejects invalid input",
+        tier: "contract",
+        type: "automated",
+        command: "node --test tests/parser.test.js",
+      },
+    ]),
+    probeSignal: PROBE_WITHOUT_TEST_INFRA,
+  });
+
+  assert.equal(result.tdd.applied_count, 0);
+  assert.equal(result.tdd.skip_reason, "no_runner");
+});
+
+test("leaves skip_reason null when test infra exists but the planner declared nothing", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors([
+      {
+        name: "Parser rejects invalid input",
+        tier: "contract",
+        type: "automated",
+        command: "node --test tests/parser.test.js",
+      },
+    ]),
+    probeSignal: PROBE_WITH_JEST,
+  });
+
+  assert.equal(result.tdd.applied_count, 0);
+  assert.equal(result.tdd.skip_reason, null);
+});
+
+test("counts prerequisites, contract, and quality factors on a mixed rubric", () => {
+  const result = buildQualityCardSummary({
+    rubricYaml: rubricWithFactors(
+      [
+        { name: "Parser rejects invalid input", tier: "contract" },
+        { name: "CLI renders new field", tier: "contract" },
+        {
+          name: "Error copy remains actionable",
+          tier: "quality",
+          type: "evaluated",
+          criteria: "Inspect CLI error paths for clear next actions.",
+          target: ">= 8/10",
+        },
+      ],
+      {
+        prerequisites: [
+          { command: "npm test" },
+          { command: "tsc --noEmit" },
+        ],
+      }
+    ),
+  });
+
+  assert.equal(result.prerequisites_count, 2);
+  assert.equal(result.contract_factors, 2);
+  assert.equal(result.quality_factors, 1);
+});


### PR DESCRIPTION
Closes #730. Parent epic: #718.

## What

- New pure module `skills/relay-plan/scripts/quality-card.js` exporting `buildQualityCardSummary`: prerequisites/contract/quality counts, hygiene-in-factor violation list, `all_contract` warning for design-bearing tasks with zero quality factors (suppressed by an explicit `qualityWaiver`, which is echoed), `repo_hygiene_in_factor` warning, and a TDD accountability block (eligible count, applied `tdd_anchor` count, anchor/runner paths, standardized skip reason).
- Standardized TDD skip reasons — exactly five: `no_runner` (auto-derived from probe signal), `docs_only`, `broad_ui_judgment`, `exploratory_task`, `non_crisp_behavior`. Unknown reason strings throw (fail-closed, no silent coercion).
- `rubric-validation.js`: additive export of `isRepoHygieneFactor` only; `validateReadyLightRubric` behavior unchanged.
- `references/rubric-validation.md`: all six Quality Card examples gain the new lines (one shows applied anchor + runner, one shows explicit `docs_only`, two show auto-derived `no_runner`); new "TDD skip reasons" table. `scoring_guide` low/mid/high checklist item untouched. SKILL.md untouched.
- Design-bearing signal reuses the existing vocabulary: `risk_tags` containing `design-bearing` or non-empty `design_rationale` (intentionally narrower than `hasExplicitRiskOrDesignRationale`, which also folds in `risk_rationale`/`risk-bearing` for ready-light leniency).
- Verification fix (orchestrator): `countPrerequisites` originally hardcoded `sectionIndent + 2` for list items while `extractAllFactors` tolerates any list indentation — non-canonical indentation counted factors but silently reported 0 prerequisites. Now locks onto the first dash indent; nested sequences stay excluded. Regression tests added.

## Non-goals honored

No top-level `tdd_mode`, no mandatory TDD, no subjective aesthetics score, no new dependencies; existing `evaluateTddSuggestion` reason tokens unchanged.

## Tests

- `tests/relay-plan/scripts/quality-card.test.js`: 11 tests covering hygiene-in-factor (pos/neg), `all_contract` with/without waiver, TDD applied anchors, explicit skip reason, unknown-reason throw, auto `no_runner`, undeclared-null, mixed counts, and indent-tolerance edges.
- Full repo suite: 1694 tests, 1692 pass, 0 fail, 2 pre-existing skips (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXf39ULLc7R6v21A17YXfh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 품질 카드 요약에 사전조건, 계약/품질 항목 수, TDD 적용 여부, 앵커, 스킵 사유, 위생 위반 경고가 포함되도록 확장되었습니다.
  * 디자인 성격이 있는 작업에서 품질 항목이 없고 면제가 없을 때 경고가 표시됩니다.

* **버그 수정**
  * TDD 스킵 사유가 표준화되어 더 일관되게 표시됩니다.
  * 테스트 인프라 유무와 앵커 상태에 따라 TDD 상태가 더 정확히 계산됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->