### PR TITLE
Deflake relay-config doctor probe and pi advisory route-policy tests (#759)

### DIFF
--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -181,7 +181,18 @@ test("doctor includes project route provenance and best-effort model probes", ()
     cwd: repoRoot,
     env: {
       PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
-      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+      // This test asserts a successful ("ok") probe outcome, not timeout
+      // behavior (that is covered separately below by the sleep(2s) fixture
+      // in "doctor reports optional Pi model-list probe timeouts...").
+      // relay-config.js bounds each model-list probe with execFileSync's
+      // own `timeout` option (see probeModels in relay-config.js), which
+      // races real process fork/exec latency against the wall clock. Under
+      // full-suite parallel load (many test files forking subprocesses at
+      // once), that fork/exec latency for the trivial opencode/pi fixture
+      // scripts here can occasionally exceed a short window even though the
+      // fixtures themselves do no work (#759). Use a generous ceiling so the
+      // probe has real headroom to complete under contention.
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "20000",
     },
   });
 

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -504,7 +504,22 @@ test("review-runner accepts pi advisory review when route policy allows the revi
     opencodeScript: null,
     piScript,
     advisoryReviewer: "pi",
-    extraArgs: ["--advisory-reviewer-model", "openai/gpt-5"],
+    // This test asserts the advisory pipeline completes successfully, not
+    // grace-window boundary behavior (that is covered separately by the
+    // dedicated "...applies the primary verdict after advisory grace..." and
+    // "...when advisory times out during grace" tests, which use deliberate
+    // delayMs values well past their own short --advisory-grace/--advisory-timeout).
+    // review-runner.js's standard-mode settleAdvisoryForVerdict polls for the
+    // advisory result for only DEFAULT_ADVISORY_GRACE_SECONDS (10s) when this
+    // flag is not passed. Completing requires a chain of real subprocess
+    // spawns (detached advisory-worker node process -> `git worktree add` ->
+    // the fake pi reviewer node process -> a file-based round trip back to
+    // this process before the event is appended). Under full-suite parallel
+    // load (many files forking subprocesses concurrently), that chain can
+    // occasionally take longer than 10s of wall clock even though every step
+    // does effectively no work (#759). Pass a generous grace so polling has
+    // real headroom to observe completion under contention.
+    extraArgs: ["--advisory-reviewer-model", "openai/gpt-5", "--advisory-grace", "30"],
   });
   const event = readRunEvents(repoRoot, runId).find((record) => record.event === "advisory_review");
 


### PR DESCRIPTION
Closes #759. Test-side only — no production changes.

## Root causes

1. **relay-config doctor probe test**: the test set `RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS=1000` — tighter than the production default 5000ms — purely for speed. `probeModels` bounds each probe with `execFileSync`'s `timeout`, so under full-suite parallel load, fork/exec latency for the trivial fixture scripts can exceed 1s, flipping `model_probe.status` from `ok` to `warning`. Timeout *behavior* is covered by a dedicated sibling test (deliberate 2s-sleep fixture), so this test's timeout value was incidental. Raised to 20000ms with an explanatory comment.
2. **pi advisory route-policy test**: standard-mode `settleAdvisoryForVerdict` polls for the advisory result only `DEFAULT_ADVISORY_GRACE_SECONDS` (10s) when `--advisory-grace` is not passed. Completion requires a real subprocess chain (detached advisory worker → `git worktree add` → fake pi reviewer → file round trip), which can exceed 10s under runner contention. Passed `--advisory-grace 30` (a real, existing CLI flag). The wait is a poll-with-early-return ceiling (`finishAdvisoryReview`, 25ms poll), so the fast path is unaffected; grace-boundary behavior keeps its dedicated tests, untouched.

Neither is a blind timeout bump: each widens exactly the knob identified as racing, on tests that assert completion rather than timing, while the sibling timing-boundary tests remain intact. An observable-readiness rewrite was not possible test-side — both waits sit inside a single blocking CLI invocation.

## Production bug found during root-causing (not fixed here)

`HARDENED_EVENT_BINDING_WAIT_MS = 1000` (advisory-orchestration.js:16) is the same race class with **no CLI override** and can misclassify a slow-but-successful hardened advisory review as failed. Filed as #762; the affected sibling test stays untouched until that production fix lands.

## Verification

- Agent: 10/10 isolated runs per touched file; 3/3 full-suite runs (1683 tests, 1681 pass, 0 fail, 2 pre-existing skips).
- Orchestrator (independent): 3/3 isolated runs per file (19/19, 27/27); full suite exit 0 (1681 pass / 0 fail / 2 skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXf39ULLc7R6v21A17YXfh