### PR TITLE
Make hardened advisory event-binding wait configurable, default 10s (#762)

### DIFF
--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -13,7 +13,16 @@ const {
   writeAdvisoryDecision,
 } = require("./advisory");
 
-const HARDENED_EVENT_BINDING_WAIT_MS = 1000;
+// finishAdvisoryReview polls with early return (see advisory.js), so this
+// ceiling is only fully paid when the event genuinely never lands (the
+// fail-closed failure path). 10s covers pathological parallel-runner load,
+// mirroring DEFAULT_ADVISORY_GRACE_SECONDS = 10 in advisory.js.
+const DEFAULT_HARDENED_EVENT_BINDING_WAIT_MS = 10000;
+
+function resolveHardenedBindingWaitMs(env = process.env) {
+  const raw = Number(env.RELAY_ADVISORY_EVENT_BINDING_WAIT_MS || DEFAULT_HARDENED_EVENT_BINDING_WAIT_MS);
+  return Number.isSafeInteger(raw) && raw > 0 ? raw : DEFAULT_HARDENED_EVENT_BINDING_WAIT_MS;
+}
 
 function resolveAdvisoryConfig({
   advisoryGraceArg,
@@ -166,7 +175,7 @@ async function settleAdvisoryForVerdict({ advisoryRun, config, currentState, har
       consumedByPhase: "review",
       criticalPathWaitMs,
       requireEventBoundSuccess: true,
-      waitMs: HARDENED_EVENT_BINDING_WAIT_MS,
+      waitMs: resolveHardenedBindingWaitMs(),
     });
     advisoryResult = {
       ...advisoryResult,
@@ -183,6 +192,7 @@ async function settleAdvisoryForVerdict({ advisoryRun, config, currentState, har
 
 module.exports = {
   resolveAdvisoryConfig,
+  resolveHardenedBindingWaitMs,
   settleAdvisoryForVerdict,
   startConfiguredAdvisory,
 };

--- a/tests/relay-review/scripts/advisory-orchestration.test.js
+++ b/tests/relay-review/scripts/advisory-orchestration.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { resolveHardenedBindingWaitMs } = require("../../../skills/relay-review/scripts/review-runner/advisory-orchestration");
+
+test("resolveHardenedBindingWaitMs defaults to 10000ms when the env var is unset", () => {
+  assert.equal(resolveHardenedBindingWaitMs({}), 10000);
+});
+
+test("resolveHardenedBindingWaitMs honors a valid override", () => {
+  assert.equal(resolveHardenedBindingWaitMs({ RELAY_ADVISORY_EVENT_BINDING_WAIT_MS: "2500" }), 2500);
+});
+
+test("resolveHardenedBindingWaitMs falls back to the default on invalid values", () => {
+  for (const invalid of ["0", "-5", "abc", "1.5"]) {
+    assert.equal(
+      resolveHardenedBindingWaitMs({ RELAY_ADVISORY_EVENT_BINDING_WAIT_MS: invalid }),
+      10000,
+      `expected default fallback for env value ${JSON.stringify(invalid)}`,
+    );
+  }
+});


### PR DESCRIPTION
Closes #762.

## What

- `advisory-orchestration.js`: the hard-coded `HARDENED_EVENT_BINDING_WAIT_MS = 1000` becomes `resolveHardenedBindingWaitMs(env)` — reads `RELAY_ADVISORY_EVENT_BINDING_WAIT_MS`, falls back to a new 10s default on unset/invalid values, matching the numeric-env-knob idiom in `relay-config.js`. Resolved at the call site (per invocation), not at module load. No new CLI flag.
- Why 10s is safe: `finishAdvisoryReview` polls with a 25ms interval and early return, so the ceiling is only fully paid when the advisory event genuinely never lands — the fail-closed failure path. It mirrors `DEFAULT_ADVISORY_GRACE_SECONDS = 10`.
- Fail-closed semantics unchanged: unbound successes still fail via the same `buildUnboundSuccessResult` path; `finishAdvisoryReview` and `assurance.js` untouched. Verified the old constant had exactly one usage site.
- Fixes the misclassification hazard where a slow-but-successful hardened advisory review flipped `success` → `failed` ("did not complete successfully") under load, and removes the last known parallel-suite flake source (`hardened review assurance blocks advisory failures and required findings`, untouched by design).

## Tests

- New `tests/relay-review/scripts/advisory-orchestration.test.js`: default when unset, valid override honored ("2500" → 2500), invalid values ("0", "-5", "abc", "1.5") fall back to default.
- Existing binding-failure unit tests (direct `finishAdvisoryReview` calls with `waitMs: 0`) untouched and passing.
- Agent verification: relay-review 435 pass / 0 fail; full suite 1697 tests, 1695 pass, 0 fail, 2 pre-existing skips.
- Orchestrator (independent): relay-review suite 0 fail; full suite exit 0 — 1695 pass / 0 fail / 2 skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXf39ULLc7R6v21A17YXfh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 재시도 시 이벤트 대기 시간이 더 안정적으로 처리되도록 개선했습니다.
  * 환경 설정으로 대기 시간을 조정할 수 있으며, 잘못된 값이 들어오면 안전한 기본값으로 자동 전환됩니다.

* **Tests**
  * 대기 시간 기본값, 유효한 사용자 설정, 잘못된 입력에 대한 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->