### PR TITLE
Add ClinePass relay adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npx skills add . -g -y
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/code) or [Codex](https://chatgpt.com/codex)
-- Optional agent harness CLIs for `opencode`, `pi`, `antigravity`, or `cursor` when selecting those adapters; route policy must allow the selected provider/model route.
+- Optional agent harness CLIs for `opencode`, `pi`, `antigravity`, `cursor`, or `cline` when selecting those adapters; route policy must allow the selected provider/model route.
 - [`gh` CLI](https://cli.github.com/) authenticated with `gh auth login`
 - Git 2.20+
 - Node.js 18+
@@ -72,9 +72,9 @@ Adapter minimum versions, binary overrides, timeouts, capability gates, and prov
 
 ## Configure Routes
 
-Relay distinguishes CLI harnesses from provider/model routes. Names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` describe how relay invokes an agent. The compliance boundary is the provider/model route, for example `example/opencode-model-fast`, `example/pi-model-fast`, or `google/antigravity-cli`.
+Relay distinguishes CLI harnesses from provider/model routes. Names such as `codex`, `claude`, `opencode`, `pi`, `antigravity`, and `cline` describe how relay invokes an agent. The compliance boundary is the provider/model route, for example `example/opencode-model-fast`, `example/pi-model-fast`, `google/antigravity-cli`, or `cline-pass/glm-5.2`.
 
-Without a policy file, relay stays conservative: managed Codex and Claude CLIs are allowed by default, while OpenCode, Pi, Antigravity, and advisory reviewers require explicit route approval.
+Without a policy file, relay stays conservative: managed Codex and Claude CLIs are allowed by default, while OpenCode, Pi, Antigravity, Cline, and advisory reviewers require explicit route approval.
 
 After installing skills, ask for setup in plain language:
 

--- a/docs/comparison-and-secondary-work.md
+++ b/docs/comparison-and-secondary-work.md
@@ -24,7 +24,7 @@ PR_NUM=<pr-number>
 node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer opencode --advisory-profile blindspot --json
 ```
 
-Supported advisory reviewers are `opencode`, `pi`, and `antigravity`.
+Supported advisory reviewers are `opencode`, `pi`, `antigravity`, and `cline`.
 
 ## Comparison Implementation
 

--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -2,9 +2,9 @@
 
 Route policy answers one operational question: which provider/model route is allowed to run in each relay phase?
 
-Executor and reviewer names such as `codex`, `claude`, `opencode`, and `pi` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `example/opencode-model-fast`, `example/pi-model-fast`, `example/pi-model-deep`, or `ollama/qwen3`.
+Executor and reviewer names such as `codex`, `claude`, `opencode`, `pi`, and `cline` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `example/opencode-model-fast`, `example/pi-model-fast`, `cline-pass/glm-5.2`, or `ollama/qwen3`.
 
-Codex and Claude are the managed CLI defaults. In the default managed profile, a model-less Codex or Claude invocation is allowed because the CLI account and its managed default model are the boundary. Generated company defaults should not pin Codex or Claude model names just to make policy explicit. OpenCode, Pi, and Antigravity are routing harnesses, so managed/company profiles must require an explicit provider/model route and an allow rule before they can run.
+Codex and Claude are the managed CLI defaults. In the default managed profile, a model-less Codex or Claude invocation is allowed because the CLI account and its managed default model are the boundary. Generated company defaults should not pin Codex or Claude model names just to make policy explicit. OpenCode, Pi, Antigravity, and Cline are routing harnesses, so managed/company profiles must require an explicit provider/model route and an allow rule before they can run.
 
 ## Default Posture
 
@@ -26,7 +26,7 @@ When no policy config exists, relay loads a fail-closed default policy:
 }
 ```
 
-That means missing policy config defaults to Codex/Claude managed CLI only. `codex` and `claude` pass the gate without a pinned model route. `opencode`, `pi`, `antigravity`, and any other unmanaged harness fail unless the effective invocation includes a provider/model route and that route matches `allowed_model_routes`.
+That means missing policy config defaults to Codex/Claude managed CLI only. `codex` and `claude` pass the gate without a pinned model route. `opencode`, `pi`, `antigravity`, `cline`, and any other unmanaged harness fail unless the effective invocation includes a provider/model route and that route matches `allowed_model_routes`.
 
 ## Precedence
 

--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -32,7 +32,7 @@ $relay-config Use example/opencode-model-fast for personal advisory review
 $relay-config Use my selected OpenCode provider/model route for personal dispatch and review dogfood
 ```
 
-Route policy is based on provider/model routes, not only harness names. Managed Codex and Claude CLIs work by default when no policy exists. OpenCode, Pi, and advisory reviewers require explicit route approval. See [model-route-policy.md](model-route-policy.md) for the full policy shape and precedence order.
+Route policy is based on provider/model routes, not only harness names. Managed Codex and Claude CLIs work by default when no policy exists. OpenCode, Pi, Antigravity, Cline, and advisory reviewers require explicit route approval. See [model-route-policy.md](model-route-policy.md) for the full policy shape and precedence order.
 
 Project-local route UX lives outside the repo under `~/.relay/projects/<repo-slug>/project.json`, `~/.relay/projects/<repo-slug>/policy.json`, and `~/.relay/projects/<repo-slug>/routes.json`. Policy is authorization; `routes.json` stores preferences only and cannot grant routes. Use `relay-config plan-run --json` to preview the effective dispatch/review/advisory routing before dispatch, and use `--route-intent-file` for one-off run overrides. Dispatch persists the audited decision as `route-plan.json` in the run directory.
 
@@ -91,8 +91,8 @@ Useful dispatch flags:
 
 | Flag | Purpose |
 | --- | --- |
-| `--executor` | Select `codex`, `claude`, `opencode`, or `pi` |
-| `--model` | Pass a model override when the harness supports it; Pi should use an explicit provider/model route |
+| `--executor` | Select `codex`, `claude`, `opencode`, `pi`, `antigravity`, `cursor`, or `cline` |
+| `--model` | Pass a model override when the harness supports it; unmanaged harnesses should use an explicit provider/model route |
 | `--network-access enabled` | Enable Codex workspace-write network access for supported runs |
 | `--copy` | Copy extra gitignored files into the worktree |
 | `--register` | Register a Codex app thread or Claude relay-side receipt |
@@ -129,6 +129,7 @@ Implementation status describes the adapter surface shipped in relay. Live statu
 | `pi` | Implementation: `stable`<br>Live: `limited` by route-specific healthy dispatch canaries | Implementation: `stable`<br>Live: `limited` by route-specific reviewer canaries | Implementation: `stable`<br>Live: `limited` by route-specific advisory evidence |
 | `antigravity` | Implementation: `limited`<br>Live: `limited` by `google/antigravity-cli` healthy dispatch canary evidence | Implementation: `fail-safe-experimental`<br>Live: `blocked` until strict verdict JSON is accepted in a healthy live reviewer canary | Implementation: `fail-safe-experimental`<br>Live: `blocked` by current timeout/worktree-mutation blocker |
 | `cursor` | Implementation: `limited`<br>Live: `blocked` until route-specific healthy dispatch canaries exist | Implementation: `limited`<br>Live: `blocked` until strict verdict JSON is accepted in a healthy live reviewer canary | Implementation: `not-supported`<br>Live: `not-supported` |
+| `cline` | Implementation: `limited`<br>Live: `limited` by route-specific ClinePass smoke evidence | Implementation: `not-supported`<br>Live: `blocked` until strict verdict JSON is accepted in a healthy live reviewer canary | Implementation: `limited`<br>Live: `limited` by route policy and advisory evidence |
 
 Status meanings:
 
@@ -147,6 +148,20 @@ Timeouts are inconclusive unless the step is an intentionally bounded fail-safe 
 ### Antigravity Live Canary
 
 Antigravity dispatch has route-specific healthy live canary evidence for `google/antigravity-cli`; primary and advisory review remain fail-safe experimental until healthy reviewer canaries pass. Fake-bin tests alone do not prove live executor or reviewer success.
+
+Use the live dogfood harness documented in `skills/relay-dispatch/references/operator-utilities.md` for repeatable Antigravity evidence; keep detailed adapter semantics in `skills/relay-dispatch/references/agent-adapter-platform.md`.
+
+### ClinePass Live Canary
+
+Cline dispatch and advisory review use `cline --json -P cline-pass --cwd <repo>` and parse the final JSONL `run_result.text`. Relay never passes `cline --worktree`; the relay worktree remains the boundary. Treat Cline primary review as blocked until a live canary returns strict verdict JSON within timeout and leaves the worktree clean.
+
+Primary-review promotion requires a canary that runs the Cline reviewer path against a retained review worktree and validates all of the following:
+
+- `run_result.text` is raw JSON matching `REVIEWER_VERDICT_JSON_SCHEMA` from `skills/relay-review/scripts/review-schema.js`.
+- The invocation returns within `RELAY_CLINE_REVIEW_TIMEOUT`.
+- `git status --porcelain` is unchanged after review.
+- Timeout, malformed JSONL, missing `run_result.text`, schema rejection, or worktree mutation is recorded as a fail-safe limitation, not healthy review evidence.
+- `primary_review.supported=true` is enabled only in the same change that updates descriptor metadata, tests, and operator docs for the promoted route.
 
 Use the live dogfood harness for repeatable Pi, OpenCode, and Antigravity evidence. Full harness semantics and outcome meanings live in `skills/relay-dispatch/references/operator-utilities.md`; adapter status and healthy-path criteria live in `skills/relay-dispatch/references/agent-adapter-platform.md`.
 

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 ## Use when
 
-- Delegating implementation to an executor (`codex`, `claude`, `opencode`, `pi`, `antigravity`, `cursor`) via worktree isolation
+- Delegating implementation to an executor (`codex`, `claude`, `opencode`, `pi`, `antigravity`, `cursor`, `cline`) via worktree isolation
 - Resuming a same-run after a `changes_requested` review
 - Running background or parallel dispatches for independent tasks
 
@@ -41,9 +41,9 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -e codex
 
 For background and parallel dispatch, see `../relay/SKILL.md` § Batch Mode (single source of truth for the parallel-fork flow).
 
-Supported executors: `codex`, `claude`, `opencode`, `pi`, `antigravity`, and `cursor`. For non-default routes, pass `--executor pi`, `--executor antigravity`, `--executor cursor`, or another supported executor with a route-policy-approved model.
+Supported executors: `codex`, `claude`, `opencode`, `pi`, `antigravity`, `cursor`, and `cline`. For non-default routes, pass `--executor pi`, `--executor antigravity`, `--executor cursor`, `--executor cline`, or another supported executor with a route-policy-approved model.
 
-Default timeouts are `codex: 2400` and `claude/opencode/pi/antigravity/cursor: 1800`. Model examples, capability gates, and the 7-field executor contract are documented in `references/agent-adapter-platform.md` and `references/model-routing.md`.
+Default timeouts are `codex: 2400` and `claude/opencode/pi/antigravity/cursor/cline: 1800`. Model examples, capability gates, and the 7-field executor contract are documented in `references/agent-adapter-platform.md` and `references/model-routing.md`.
 
 ## Options
 

--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -38,6 +38,7 @@ Isolation details by built-in reviewer:
 | `pi` | `RELAY_PI_BIN` can override the binary path; `RELAY_PI_REVIEW_TIMEOUT` sets the primary-review parent timeout. Review uses a read/grep/find/ls allowlist plus dirty-worktree checks. |
 | `antigravity` | `RELAY_ANTIGRAVITY_BIN` can override the binary path; `RELAY_ANTIGRAVITY_REVIEW_TIMEOUT` sets the review/canary parent timeout as a positive duration such as `120s`, `10m`, or `1h`; the default is `1800s`. Relay targets the `agy` command-line interface only; GUI, IDE, Desktop, plugin runtime, and interactive PTY flows are not supported. |
 | `cursor` | `RELAY_CURSOR_AGENT_BIN` can override the binary path; `RELAY_CURSOR_REVIEW_TIMEOUT` sets the primary-review parent timeout. Primary review uses ask mode and parses the wrapper `result` field. |
+| `cline` | `RELAY_CLINE_BIN` can override the binary path; `RELAY_CLINE_REVIEW_TIMEOUT` sets the Cline reviewer-script parent timeout, while `--advisory-timeout` remains the outer review-runner cap and may fire first. Dispatch and advisory review invoke `cline --json -P <provider> --cwd <repo>` and parse the final JSONL `run_result.text`. Primary review is not supported until a healthy strict-verdict live canary passes. |
 
 Advisory review is non-gating for `policy.review_assurance=standard`: it starts concurrently, waits only the configured grace window on the critical path, records `advisory_review` plus `review-round-N-advisory-<reviewer>-*`, and never changes the trusted verdict or redispatch prompt. Failures, timeouts, invalid JSON, and write-policy violations are recorded without changing the primary outcome. Late artifacts are classified as metrics after a passing primary decision or redispatch evidence after changes requested.
 
@@ -53,8 +54,11 @@ For `policy.review_assurance=hardened`, the runner fails fast unless the command
 | `pi` | Yes | Yes | Yes | Dispatch has no native relay sandbox; review uses read/grep/find/ls tool allowlist plus status guard. | Primary/advisory via `--tools read,grep,find,ls` plus dirty-worktree check. | Dispatch ambient/informational; review has no network tool in the relay allowlist. | Dispatch stdout copied to result file; primary verdict JSON text; advisory JSON text. | `pi` CLI. | No. |
 | `antigravity` | Yes, limited with route-specific healthy dispatch canary evidence for `google/antigravity-cli` | Yes, fail-safe experimental until healthy live reviewer canary passes | Yes, fail-safe experimental until healthy live advisory canary passes | `agy --sandbox`; dispatch also adds the git common dir with `--add-dir`. | Dispatch read-only is unsupported; review relies on prompt instruction plus dirty-worktree check. | Ambient/informational; `agy` exposes no relay network gate. | Dispatch stdout copied to result file; primary verdict JSON text; advisory JSON text. | `agy` CLI only. | No. |
 | `cursor` | Yes, optional experimental | Yes, optional experimental | No | Dispatch uses `agent --sandbox enabled` when workspace-write is requested; relay passes `--workspace` only (never `agent --worktree`). | Primary review uses `agent --mode ask`; dispatch read-only is unsupported (fail-closed). | Ambient/informational; no relay network gate. | Dispatch stdout copied to result file; primary review parses JSON wrapper `result` field. | `agent` CLI. | Yes, `agent create-chat` when `--register` is used. |
+| `cline` | Yes, explicit route-policy approval required | No, blocked until live strict-verdict canary promotion | Yes | Informational only; relay passes `--cwd` and never `cline --worktree`. | Advisory prompt plus detached-worktree status guard; dispatch read-only is informational only. | Ambient/informational; no relay network gate. | Dispatch and advisory review parse JSONL `run_result.text`. | `cline` CLI. | No. |
 
 Antigravity support targets the Google Antigravity `agy` CLI only. Relay does not support Antigravity GUI, IDE, Desktop, plugin runtime, or interactive PTY state as a dispatch or review surface.
+
+Cline support targets the Cline CLI only. Relay does not use Cline TUI, ACP, hub dashboard, GUI state, or `cline --worktree`. Use explicit `cline-pass/*` routes plus policy allow rules for dispatch or advisory review; primary review stays unsupported until a live canary proves `REVIEWER_VERDICT_JSON_SCHEMA` output in `run_result.text`, completion within `RELAY_CLINE_REVIEW_TIMEOUT`, and no worktree mutation. Timeouts, malformed JSONL, missing `run_result.text`, schema failures, and dirty worktrees are fail-safe limitations, not healthy evidence.
 
 ## Antigravity Live Support Status
 
@@ -99,4 +103,8 @@ node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --
 # Cursor Agent CLI dispatch and primary review (optional harness; add cursor to managed_cli for slug-only models)
 node skills/relay-dispatch/scripts/dispatch.js . --executor cursor --model composer-2.5 -b issue-42 -p "..." --rubric-file rubric.yaml
 node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer cursor --reviewer-model composer-2.5 --json
+
+# ClinePass dispatch and advisory review with an explicit route
+node skills/relay-dispatch/scripts/dispatch.js . --executor cline --model cline-pass/glm-5.2 -b issue-42 -p "..." --rubric-file rubric.yaml
+node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer codex --advisory-reviewer cline --advisory-reviewer-model cline-pass/glm-5.2 --json
 ```

--- a/skills/relay-dispatch/references/model-routing.md
+++ b/skills/relay-dispatch/references/model-routing.md
@@ -5,7 +5,7 @@ Dispatch model routing answers two separate questions:
 - Which executor harness should run the task?
 - Which provider/model route, if any, should that harness use?
 
-Executor names such as `codex`, `claude`, `opencode`, `pi`, and `antigravity` select a CLI adapter. Provider/model route strings such as `example/opencode-model-fast`, `openai/gpt-5`, or `google/antigravity-cli` are the model-policy boundary.
+Executor names such as `codex`, `claude`, `opencode`, `pi`, `antigravity`, and `cline` select a CLI adapter. Provider/model route strings such as `example/opencode-model-fast`, `openai/gpt-5`, `google/antigravity-cli`, or `cline-pass/glm-5.2` are the model-policy boundary.
 
 ## Dispatch Selection
 
@@ -23,7 +23,7 @@ The selected model route still has to pass route policy before the executor runs
 
 Codex and Claude are managed CLI defaults. They may intentionally run with `model: null`, because the authenticated managed CLI account is the operational boundary.
 
-OpenCode, Pi, Antigravity, and other unmanaged harnesses should use explicit provider/model routes and matching route-policy allow rules. A missing or disallowed route fails before spawning the executor.
+OpenCode, Pi, Antigravity, Cline, and other unmanaged harnesses should use explicit provider/model routes and matching route-policy allow rules. A missing or disallowed route fails before spawning the executor.
 
 ## Executor Model Config
 
@@ -35,6 +35,10 @@ Bundled executor model config intentionally ships empty so installs do not selec
     "opencode": {
       "default_model": "example/opencode-model-fast",
       "candidate_models": ["example/opencode-model-fast"]
+    },
+    "cline": {
+      "default_model": "cline-pass/glm-5.2",
+      "candidate_models": ["cline-pass/glm-5.2"]
     }
   }
 }
@@ -49,6 +53,14 @@ The top-level `relay` skill does not invoke `relay-dispatch` as a nested skill. 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
   --executor opencode --model example/opencode-model-fast \
+  -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml
+```
+
+For ClinePass:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
+  --executor cline --model cline-pass/glm-5.2 \
   -b issue-42 --prompt-file /tmp/dispatch-42.md --rubric-file /tmp/rubric-42.yaml
 ```
 

--- a/skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js
@@ -1,0 +1,68 @@
+const fs = require("fs");
+const {
+  formatAdapterPhase,
+} = require("./transport");
+
+function parseClineJsonLine(line, { adapter, phase, lineNumber }) {
+  try {
+    return JSON.parse(line);
+  } catch (error) {
+    const context = formatAdapterPhase({ adapter, phase });
+    throw new Error(`${context} Cline JSONL line ${lineNumber} must be valid JSON: ${error.message}`);
+  }
+}
+
+function extractClineRunResultText(stdout, { adapter = "cline", phase = "unknown" } = {}) {
+  const context = formatAdapterPhase({ adapter, phase });
+  const raw = String(stdout || "");
+  if (!raw.trim()) {
+    throw new Error(`${context} Cline JSONL output is empty; no run_result.text payload found`);
+  }
+
+  let resultText = null;
+  let runResultCount = 0;
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  for (const [index, line] of lines.entries()) {
+    const event = parseClineJsonLine(line, { adapter, phase, lineNumber: index + 1 });
+    if (event?.type === "run_result") {
+      runResultCount += 1;
+      if (typeof event.text === "string") {
+        resultText = event.text;
+      }
+    }
+  }
+
+  if (resultText === null) {
+    const detail = runResultCount
+      ? "run_result events did not include a string text field"
+      : "no run_result events found";
+    throw new Error(`${context} Cline JSONL output did not include run_result.text (${detail})`);
+  }
+  if (!resultText.trim()) {
+    throw new Error(`${context} Cline run_result.text payload is empty`);
+  }
+
+  return resultText.trim();
+}
+
+function copyClineRunResultTextToResultFile({ stdoutLog, resultFile, adapter = "cline", phase = "dispatch" }) {
+  const context = formatAdapterPhase({ adapter, phase });
+  if (!stdoutLog) throw new Error(`${context} stdoutLog is required`);
+  if (!resultFile) throw new Error(`${context} resultFile is required`);
+  if (!fs.existsSync(stdoutLog)) {
+    return { copied: false, status: "missing", bytes: 0 };
+  }
+
+  const resultText = extractClineRunResultText(fs.readFileSync(stdoutLog, "utf-8"), { adapter, phase });
+  fs.writeFileSync(resultFile, `${resultText}\n`, "utf-8");
+  return {
+    copied: true,
+    status: "extracted",
+    bytes: Buffer.byteLength(`${resultText}\n`),
+  };
+}
+
+module.exports = {
+  copyClineRunResultTextToResultFile,
+  extractClineRunResultText,
+};

--- a/skills/relay-dispatch/scripts/agent-adapters/index.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/index.js
@@ -4,6 +4,7 @@ const opencode = require("../executors/opencode");
 const pi = require("../executors/pi");
 const antigravity = require("../executors/antigravity");
 const cursor = require("../executors/cursor");
+const cline = require("../executors/cline");
 const bundledModels = require("../../references/executor-models.json");
 
 const ADAPTER_PHASES = Object.freeze({
@@ -1038,6 +1039,168 @@ const DESCRIPTORS = Object.freeze({
     reviewer: {
       primaryReviewScript: "invoke-reviewer-cursor.js",
       advisoryReviewScript: null,
+    },
+  }),
+  cline: buildDescriptor({
+    name: "cline",
+    displayName: "Cline CLI",
+    executor: cline,
+    phases: {
+      [ADAPTER_PHASES.DISPATCH]: {
+        supported: true,
+        trust: "executor",
+      },
+      [ADAPTER_PHASES.PRIMARY_REVIEW]: {
+        supported: false,
+        trust: "unsupported",
+      },
+      [ADAPTER_PHASES.ADVISORY_REVIEW]: {
+        supported: true,
+        trust: "advisory",
+      },
+    },
+    capabilities: {
+      sandbox: {
+        dispatch: {
+          modes: ["workspace-write"],
+          enforced: false,
+        },
+        primaryReview: null,
+        advisoryReview: {
+          mode: "read-only",
+          enforced: false,
+          guard: "detached-worktree-status",
+        },
+      },
+      network: {
+        dispatch: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+        primaryReview: null,
+        advisoryReview: {
+          configurable: false,
+          enabledMode: "ambient",
+        },
+      },
+      readOnly: {
+        dispatch: false,
+        primaryReview: false,
+        advisoryReview: true,
+      },
+      policy: {
+        dispatch: {
+          sandbox: {
+            "workspace-write": {
+              enforcement_level: "informational",
+              mechanism: "cline-cli-cwd",
+              flags: ["--cwd"],
+              warnings: ["Cline dispatch does not provide native relay sandbox containment; relay uses the worktree boundary and never cline --worktree."],
+            },
+            "read-only": {
+              enforcement_level: "informational",
+              mechanism: "cline-cli-cwd",
+              warnings: ["Cline dispatch read-only intent is informational only and does not prevent writes."],
+            },
+          },
+          network: {
+            disabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Cline dispatch does not gate network access at the executor level."],
+            },
+            enabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Cline dispatch does not gate network access at the executor level."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "informational",
+              mechanism: "cline-cli-cwd",
+              warnings: ["Cline dispatch read-only intent is informational only and does not prevent writes."],
+            },
+            false: {
+              enforcement_level: "unsupported",
+              mechanism: "write-capable-dispatch",
+            },
+          },
+        },
+        primary_review: null,
+        advisory_review: {
+          sandbox: {
+            "read-only": {
+              enforcement_level: "informational",
+              mechanism: "detached-worktree-status-guard",
+              flags: ["prompt:do-not-modify-files", "git-status-before-after"],
+              warnings: ["Cline advisory review has no native relay sandbox; relay records post-run worktree mutation as a policy violation."],
+            },
+          },
+          network: {
+            ambient: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Cline advisory review does not gate network access at the CLI level."],
+            },
+            disabled: {
+              enforcement_level: "informational",
+              mechanism: "ambient-network",
+              warnings: ["Cline advisory review does not gate network access at the CLI level."],
+            },
+          },
+          read_only: {
+            true: {
+              enforcement_level: "prompt-only",
+              mechanism: "prompt-instruction-with-detached-worktree-status-guard",
+              flags: ["prompt:do-not-modify-files", "git-status-before-after"],
+              warnings: ["Cline advisory read-only instructions do not prevent writes; relay records post-run worktree mutation as a policy violation."],
+            },
+          },
+        },
+      },
+      transport: {
+        dispatch: "cline-cli",
+        primaryReview: null,
+        advisoryReview: "cline-cli",
+      },
+      structuredOutput: {
+        dispatch: "jsonl-run-result-text",
+        primaryReview: null,
+        advisoryReview: "jsonl-run-result-text",
+      },
+      liveSupport: {
+        status: "mvp-advisory",
+        dispatch: "supported with explicit route-policy approval",
+        primaryReview: "not-supported until healthy live reviewer canary passes",
+        advisoryReview: "supported with prompt-only read-only guard and route-policy approval",
+        until: "primary review until strict verdict JSON canary and no-mutation evidence pass",
+        healthyCriteria: {
+          primaryReview: "invoke-reviewer-cline primary-review canary returns REVIEWER_VERDICT_JSON_SCHEMA JSON within timeout and leaves git status clean",
+          failureMode: "timeouts, malformed JSONL, missing run_result.text, schema errors, or worktree mutation are fail-safe limitations, not healthy evidence",
+          promotion: "enable primary_review.supported=true only after the exact route passes the canary and descriptor/docs/tests are updated together",
+        },
+      },
+      appRegistration: {
+        supported: false,
+        transport: null,
+      },
+      modelDefaults: {
+        provider: cline.providerDefault,
+        dispatch: {
+          configKey: "cline",
+          defaultModel: bundledDefaultModel("cline"),
+        },
+        primaryReview: null,
+        advisoryReview: {
+          configKey: "cline",
+          defaultModel: bundledDefaultModel("cline"),
+        },
+      },
+    },
+    reviewer: {
+      primaryReviewScript: null,
+      advisoryReviewScript: "invoke-reviewer-cline.js",
     },
   }),
 });

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1742,7 +1742,12 @@ async function main() {
   }
   const elapsed = Math.round((Date.now() - startTime) / 1000);
 
-  adapter.finalizeResult({ stdoutLog, resultFile });
+  try {
+    adapter.finalizeResult({ stdoutLog, resultFile });
+  } catch (finalizeError) {
+    exitCode = exitCode || 1;
+    error = error || `executor_result_finalize_failed: ${String(finalizeError.message || finalizeError).split("\n")[0]}`;
+  }
 
   // --- Step 4: Collect results ---
   let resultText = "";

--- a/skills/relay-dispatch/scripts/executors/README.md
+++ b/skills/relay-dispatch/scripts/executors/README.md
@@ -22,3 +22,5 @@ opencode is an experimental dispatch executor. Reviewer policy is defined in `re
 antigravity targets the Google Antigravity `agy` CLI only. The relay adapter does not read Antigravity IDE/Desktop state, GUI sessions, plugin runtime, or PTY state. `agy --version` is recorded as CLI-version evidence separately from any desktop app version.
 
 cursor targets the Cursor Agent `agent` CLI only. Dispatch uses `--workspace` and never `agent --worktree` so relay worktree isolation stays authoritative. Primary review uses `--mode ask --output-format json` and parses the wrapper `result` field into strict verdict JSON.
+
+cline targets the Cline CLI only. Dispatch uses `--json --cwd <relay-worktree>` and never `cline --worktree` so relay worktree isolation stays authoritative. Relay parses the final JSONL `run_result.text` payload into the dispatch result file.

--- a/skills/relay-dispatch/scripts/executors/cline.js
+++ b/skills/relay-dispatch/scripts/executors/cline.js
@@ -1,0 +1,132 @@
+const { execFileSync } = require("child_process");
+const {
+  copyClineRunResultTextToResultFile,
+} = require("../agent-adapters/cline-jsonl");
+
+const PROBE_FLAGS = [
+  "--json",
+  "--cwd",
+  "--provider",
+  "--model",
+  "--timeout",
+];
+
+function resolveClineBin() {
+  return process.env.RELAY_CLINE_BIN || "cline";
+}
+
+function parseProvider(model) {
+  if (typeof model !== "string" || !model) return null;
+  const idx = model.indexOf("/");
+  if (idx <= 0) return null;
+  return model.slice(0, idx);
+}
+
+function providerForModel(model) {
+  return parseProvider(model) || "cline-pass";
+}
+
+function normalizeTimeoutSeconds(timeoutSeconds) {
+  const value = Number(timeoutSeconds);
+  if (Number.isFinite(value) && value > 0) return String(Math.floor(value));
+  return "1800";
+}
+
+function validateExecutionMode({ sandbox, networkAccess }) {
+  const warnings = [];
+  if (sandbox !== "workspace-write") {
+    warnings.push(
+      `cline executor: --sandbox '${sandbox}' is not enforced by cline; proceeding with workspace-write semantics.`
+    );
+  }
+  if (networkAccess === "enabled") {
+    warnings.push(
+      "cline executor: --network-access 'enabled' is informational only; cline does not expose relay network gating."
+    );
+  }
+  warnings.push(
+    "cline executor has no native relay sandbox; relay uses its own worktree boundary and never cline --worktree."
+  );
+  return { ok: true, warnings };
+}
+
+function buildExecCommand({ wtPath, prompt, model, timeoutSeconds }) {
+  const cmd = resolveClineBin();
+  const args = [
+    "--json",
+    "-P", providerForModel(model),
+  ];
+  if (model) args.push("-m", model);
+  args.push(
+    "--cwd", wtPath,
+    "--timeout", normalizeTimeoutSeconds(timeoutSeconds),
+    [
+      "[RELAY WORKTREE BOUNDARY]",
+      `Repository worktree: ${wtPath}`,
+      "Run every shell command from that repository worktree.",
+      "Do not read, write, git add, git commit, or create files outside that repository worktree.",
+      "Do not use cline --worktree; relay already created and owns this worktree.",
+      "",
+      prompt,
+    ].join("\n")
+  );
+  return { cmd, args, cwd: wtPath, codexGitCommonDir: null };
+}
+
+function finalizeResult({ stdoutLog, resultFile }) {
+  return copyClineRunResultTextToResultFile({ adapter: "cline", phase: "dispatch", stdoutLog, resultFile });
+}
+
+function register() {
+  return { threadId: null, raw: { provider: "cline", note: "no app registration surface" } };
+}
+
+function probe() {
+  const cmd = resolveClineBin();
+  let version;
+  try {
+    version = execFileSync(cmd, ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  } catch {
+    return { error: `${cmd} CLI not found`, raw: null };
+  }
+
+  let help = "";
+  const warnings = [];
+  try {
+    help = execFileSync(cmd, ["--help"], { encoding: "utf-8", stdio: "pipe" });
+  } catch (error) {
+    warnings.push(`cline --help failed: ${error.message}`);
+  }
+
+  const supportedFlags = PROBE_FLAGS.filter((flag) => help.includes(flag));
+  const missingFlags = PROBE_FLAGS.filter((flag) => !supportedFlags.includes(flag));
+  if (missingFlags.length) {
+    warnings.push(`cline --help does not mention expected flags: ${missingFlags.join(", ")}`);
+  }
+  if (help.includes("--worktree")) {
+    warnings.push("cline exposes --worktree; relay dispatch must use --cwd only to avoid colliding with relay worktrees.");
+  }
+
+  return {
+    error: null,
+    raw: JSON.stringify({
+      version,
+      provider_default: "cline-pass",
+      supported_flags: supportedFlags,
+      missing_flags: missingFlags,
+      warnings,
+    }),
+  };
+}
+
+module.exports = {
+  cliBinary: "cline",
+  providerDefault: "cline-pass",
+  defaultTimeout: 1800,
+  validateExecutionMode,
+  buildExecCommand,
+  finalizeResult,
+  register,
+  probe,
+  parseProvider,
+};

--- a/skills/relay-dispatch/scripts/executors/index.js
+++ b/skills/relay-dispatch/scripts/executors/index.js
@@ -5,7 +5,7 @@ const {
   supportsAgentAdapterPhase,
 } = require("../agent-adapters");
 
-const EXECUTOR_COMPAT_ORDER = ["codex", "claude", "opencode", "pi", "antigravity", "cursor"];
+const EXECUTOR_COMPAT_ORDER = ["codex", "claude", "opencode", "pi", "antigravity", "cursor", "cline"];
 
 function listExecutors() {
   const names = listAgentAdapterNames();

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -63,7 +63,7 @@ Optional advisory path: add a non-gating blind-spot lane alongside the primary r
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --reviewer codex --advisory-reviewer <name> --advisory-profile blindspot --json
 ```
-Supported advisory reviewers: `--advisory-reviewer opencode`, `--advisory-reviewer pi`, and `--advisory-reviewer antigravity`.
+Supported advisory reviewers: `--advisory-reviewer opencode`, `--advisory-reviewer pi`, `--advisory-reviewer antigravity`, and `--advisory-reviewer cline`.
 
 Advisory review is non-gating for `policy.review_assurance=standard`: it records artifacts and never replaces the primary verdict. For `policy.review_assurance=hardened`, advisory review and strict execution evidence become required gates. Full advisory timing, failure, and route semantics are in `references/runner-notes.md` and the adapter platform reference.
 

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -113,6 +113,7 @@ function buildPrompt(promptText) {
     "Do not wrap the response in markdown fences.",
     "Do not modify files, create commits, or write comments. Treat the checkout as read-only.",
     "Relay will check git status after this process and escalate any worktree mutation as a policy violation.",
+    "Do not use cline --worktree; relay already selected the review checkout with --cwd.",
     "",
     promptText,
   ].join("\n");

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Invoke Cline CLI as a structured advisory reviewer.
+ */
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const {
+  bindCliArgs,
+  modeLabel,
+} = require("../../relay-dispatch/scripts/cli-args");
+const {
+  extractClineRunResultText,
+} = require("../../relay-dispatch/scripts/agent-adapters/cline-jsonl");
+const {
+  recoverExecStdout,
+  summarizeFailure,
+} = require("./reviewer-helpers");
+const { parseAdvisoryReview } = require("./advisory-review-schema");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--json", "--help", "-h"];
+const cliArgs = bindCliArgs(args, {
+  commandName: "invoke-reviewer-cline",
+  reservedFlags: KNOWN_FLAGS,
+});
+const REVIEW_TIMEOUT_ENV = "RELAY_CLINE_REVIEW_TIMEOUT";
+const DEFAULT_REVIEW_TIMEOUT = "1800s";
+
+if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
+  console.log("Usage: invoke-reviewer-cline.js --repo <path> --prompt-file <path> [--phase advisory_review] [--model <route>] [--json]");
+  console.log("\nOptions:");
+  console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
+  console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
+  console.log(`  --model <route>      ${modeLabel("--model")} Model route, for example cline-pass/glm-5.2`);
+  console.log(`  --phase <name>       ${modeLabel("--phase")} advisory_review only`);
+  console.log(`  --json               ${modeLabel("--json")} Output JSON`);
+  process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
+}
+
+function resolvePhase(value) {
+  const phase = String(value || "advisory_review").trim();
+  if (phase !== "advisory_review") {
+    throw new Error(
+      `cline reviewer supports advisory_review only in the MVP; got ${JSON.stringify(value)}. Primary review requires separate live canary promotion.`
+    );
+  }
+  return phase;
+}
+
+function parseReviewTimeoutMs(value) {
+  const raw = String(value || "").trim();
+  const match = raw.match(/^([1-9]\d*)(ms|s|m|h)$/);
+  if (!match) {
+    throw new Error(
+      `${REVIEW_TIMEOUT_ENV} must be a positive duration like 120s, got ${JSON.stringify(value)}`
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const multipliers = { ms: 1, s: 1000, m: 60 * 1000, h: 60 * 60 * 1000 };
+  const timeoutMs = amount * multipliers[unit];
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `${REVIEW_TIMEOUT_ENV} must resolve to a safe positive millisecond timeout, got ${JSON.stringify(value)}`
+    );
+  }
+  return timeoutMs;
+}
+
+function timeoutSecondsFromDuration(value) {
+  const raw = String(value || DEFAULT_REVIEW_TIMEOUT).trim();
+  const match = raw.match(/^([1-9]\d*)(ms|s|m|h)$/);
+  if (!match) return "1800";
+  const amount = Number(match[1]);
+  const unit = match[2];
+  if (unit === "ms") return String(Math.max(1, Math.ceil(amount / 1000)));
+  if (unit === "s") return String(amount);
+  if (unit === "m") return String(amount * 60);
+  return String(amount * 60 * 60);
+}
+
+function isExecTimeout(error) {
+  return error?.code === "ETIMEDOUT" || (error?.signal === "SIGKILL" && error?.killed);
+}
+
+function providerForModel(model) {
+  if (typeof model !== "string" || !model.trim()) return "cline-pass";
+  const idx = model.indexOf("/");
+  return idx > 0 ? model.slice(0, idx) : "cline-pass";
+}
+
+function buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout }) {
+  const command = [
+    clineBin || "cline",
+    "--json",
+    "-P", providerForModel(model),
+  ];
+  if (model) command.push("-m", model);
+  command.push(
+    "--timeout", timeoutSecondsFromDuration(reviewTimeout),
+    "'Return exactly {\"ok\":true} and nothing else.'"
+  );
+  return command.join(" ");
+}
+
+function buildPrompt(promptText) {
+  return [
+    "[NON-INTERACTIVE ADVISORY REVIEW]",
+    "Return only JSON matching the advisory review shape in the prompt.",
+    "Do not wrap the response in markdown fences.",
+    "Do not modify files, create commits, or write comments. Treat the checkout as read-only.",
+    "Relay will check git status after this process and escalate any worktree mutation as a policy violation.",
+    "",
+    promptText,
+  ].join("\n");
+}
+
+function main() {
+  const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
+  const promptFile = cliArgs.getArg("--prompt-file");
+  const model = cliArgs.getArg("--model");
+  const phase = resolvePhase(cliArgs.getArg("--phase", "advisory_review"));
+  const clineBin = process.env.RELAY_CLINE_BIN || "cline";
+  const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
+  const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
+
+  if (!promptFile) {
+    throw new Error("--prompt-file is required");
+  }
+
+  const promptText = fs.readFileSync(promptFile, "utf-8").trim();
+  const fullPrompt = buildPrompt(promptText);
+
+  const execArgs = [
+    "--json",
+    "-P", providerForModel(model),
+  ];
+  if (model) execArgs.push("-m", model);
+  execArgs.push(
+    "--cwd", repoPath,
+    "--timeout", timeoutSecondsFromDuration(reviewTimeout),
+    fullPrompt
+  );
+
+  let rawOutput;
+  try {
+    rawOutput = execFileSync(clineBin, execArgs, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: parentTimeoutMs,
+      killSignal: "SIGKILL",
+      maxBuffer: 10 * 1024 * 1024,
+    }).trim();
+  } catch (error) {
+    if (isExecTimeout(error)) {
+      const diagnosticCommand = buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout });
+      throw new Error(
+        `Cline reviewer ${phase} timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}). ` +
+        "The cline --json invocation did not return before the parent-process timeout, so relay cannot treat this as healthy advisory evidence. " +
+        `First verify Cline non-interactive provider output with: ${diagnosticCommand}. ` +
+        "If that minimal command also times out, record this as a Cline CLI/provider non-interactive blocker; otherwise retry with a larger review timeout or split the review scope."
+      );
+    }
+    const recovered = recoverExecStdout(error);
+    if (!recovered) {
+      throw new Error(`Cline reviewer failed: ${summarizeFailure(error)}`);
+    }
+    rawOutput = recovered;
+  }
+
+  let advisoryText;
+  try {
+    advisoryText = extractClineRunResultText(rawOutput, { adapter: "cline", phase });
+  } catch (error) {
+    throw new Error(
+      `${error.message}. Cline advisory review must return JSON in run_result.text; relay cannot treat this as healthy advisory evidence.`
+    );
+  }
+
+  const parsed = parseAdvisoryReview(advisoryText, {
+    adapter: "cline",
+    phase,
+    profile: "blindspot",
+  });
+  const output = JSON.stringify(parsed);
+
+  if (cliArgs.hasFlag("--json")) {
+    console.log(output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -176,7 +176,7 @@ function resolveReviewerModel(data, reviewerModel, reviewerName = null, { routeP
   }
   const hintedModel = data?.model_hints?.review;
   if (typeof hintedModel === "string" && hintedModel.trim()) return { model: hintedModel.trim(), source: "model_hints" };
-  if (["opencode", "pi", "antigravity"].includes(reviewerName)) {
+  if (["opencode", "pi", "antigravity", "cline"].includes(reviewerName)) {
     return {
       model: resolveExecutorDefaultModel(reviewerName, { relayHome: process.env.RELAY_HOME }),
       source: "executor_defaults",

--- a/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapter-policy.test.js
@@ -102,6 +102,48 @@ test("policy audit records Pi primary review read-only tool allowlist metadata",
   assert.match(audit.warnings.join("\n"), /dirty worktree/i);
 });
 
+test("policy audit keeps Cline dispatch sandbox and network informational", () => {
+  const audit = buildAgentPolicyAudit({
+    descriptor: getAgentAdapterDescriptor("cline"),
+    phase: ADAPTER_PHASES.DISPATCH,
+    requested: {
+      sandbox: "read-only",
+      networkAccess: "enabled",
+      readOnly: true,
+    },
+  });
+
+  assert.equal(audit.safe, true);
+  assert.equal(audit.sandbox.enforcement_level, "informational");
+  assert.equal(audit.network.enforcement_level, "informational");
+  assert.equal(audit.read_only.enforcement_level, "informational");
+  assert.match(audit.warnings.join("\n"), /does not prevent writes/i);
+  assert.match(audit.warnings.join("\n"), /does not gate network access/i);
+  assert.deepEqual(audit.fail_closed_reasons, []);
+});
+
+test("policy audit records Cline advisory review prompt-only read-only guard", () => {
+  const audit = buildAgentPolicyAudit({
+    descriptor: getAgentAdapterDescriptor("cline"),
+    phase: ADAPTER_PHASES.ADVISORY_REVIEW,
+    requested: {
+      sandbox: "read-only",
+      networkAccess: "ambient",
+      readOnly: true,
+    },
+  });
+
+  assert.equal(audit.safe, true);
+  assert.equal(audit.sandbox.enforcement_level, "informational");
+  assert.equal(audit.network.enforcement_level, "informational");
+  assert.equal(audit.read_only.enforcement_level, "prompt-only");
+  assert.deepEqual(audit.read_only.flags, [
+    "prompt:do-not-modify-files",
+    "git-status-before-after",
+  ]);
+  assert.match(audit.warnings.join("\n"), /worktree mutation/i);
+});
+
 test("policy audit records Antigravity dispatch sandbox and add-dir metadata", () => {
   const audit = buildAgentPolicyAudit({
     descriptor: getAgentAdapterDescriptor("antigravity"),

--- a/tests/relay-dispatch/scripts/agent-adapters.test.js
+++ b/tests/relay-dispatch/scripts/agent-adapters.test.js
@@ -10,8 +10,8 @@ const {
 } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
 
 test("agent adapter registry exposes the current built-in adapters", () => {
-  assert.deepEqual(listAgentAdapterNames(), ["claude", "codex", "opencode", "pi", "antigravity", "cursor"]);
-  assert.deepEqual(listAgentAdapters().map((descriptor) => descriptor.name), ["claude", "codex", "opencode", "pi", "antigravity", "cursor"]);
+  assert.deepEqual(listAgentAdapterNames(), ["claude", "codex", "opencode", "pi", "antigravity", "cursor", "cline"]);
+  assert.deepEqual(listAgentAdapters().map((descriptor) => descriptor.name), ["claude", "codex", "opencode", "pi", "antigravity", "cursor", "cline"]);
 });
 
 test("agent adapter registry reports dispatch, primary review, and advisory review independently", () => {
@@ -34,6 +34,10 @@ test("agent adapter registry reports dispatch, primary review, and advisory revi
   assert.equal(supportsAgentAdapterPhase("antigravity", ADAPTER_PHASES.DISPATCH), true);
   assert.equal(supportsAgentAdapterPhase("antigravity", ADAPTER_PHASES.PRIMARY_REVIEW), true);
   assert.equal(supportsAgentAdapterPhase("antigravity", ADAPTER_PHASES.ADVISORY_REVIEW), true);
+
+  assert.equal(supportsAgentAdapterPhase("cline", ADAPTER_PHASES.DISPATCH), true);
+  assert.equal(supportsAgentAdapterPhase("cline", ADAPTER_PHASES.PRIMARY_REVIEW), false);
+  assert.equal(supportsAgentAdapterPhase("cline", ADAPTER_PHASES.ADVISORY_REVIEW), true);
 });
 
 test("agent adapter descriptors expose structured capabilities and the executor contract", () => {
@@ -139,16 +143,36 @@ test("agent adapter descriptors expose structured capabilities and the executor 
   assert.equal(cursor.capabilities.structuredOutput.primaryReview, "json-wrapper-result-field");
   assert.equal(cursor.reviewer.primaryReviewScript, "invoke-reviewer-cursor.js");
   assert.equal(cursor.reviewer.advisoryReviewScript, null);
+
+  const cline = getAgentAdapterDescriptor("cline");
+  assert.equal(cline.executor.cliBinary, "cline");
+  assert.equal(cline.capabilities.appRegistration.supported, false);
+  assert.equal(cline.capabilities.modelDefaults.provider, "cline-pass");
+  assert.deepEqual(cline.capabilities.sandbox.dispatch.modes, ["workspace-write"]);
+  assert.equal(cline.capabilities.sandbox.dispatch.enforced, false);
+  assert.equal(cline.phases[ADAPTER_PHASES.PRIMARY_REVIEW].supported, false);
+  assert.equal(cline.phases[ADAPTER_PHASES.ADVISORY_REVIEW].trust, "advisory");
+  assert.equal(cline.capabilities.readOnly.primaryReview, false);
+  assert.equal(cline.capabilities.readOnly.advisoryReview, true);
+  assert.equal(cline.capabilities.transport.dispatch, "cline-cli");
+  assert.equal(cline.capabilities.transport.advisoryReview, "cline-cli");
+  assert.equal(cline.capabilities.structuredOutput.dispatch, "jsonl-run-result-text");
+  assert.equal(cline.capabilities.structuredOutput.advisoryReview, "jsonl-run-result-text");
+  assert.equal(cline.capabilities.modelDefaults.dispatch.defaultModel, null);
+  assert.equal(cline.capabilities.modelDefaults.advisoryReview.defaultModel, null);
+  assert.match(cline.capabilities.liveSupport.primaryReview, /not-supported/i);
+  assert.equal(cline.reviewer.primaryReviewScript, null);
+  assert.equal(cline.reviewer.advisoryReviewScript, "invoke-reviewer-cline.js");
 });
 
 test("agent adapter registry fails closed for unknown adapters and phases", () => {
   assert.throws(
     () => getAgentAdapterDescriptor("nonexistent"),
-    /unknown agent adapter 'nonexistent'\. Supported: claude, codex, opencode, pi, antigravity, cursor/
+    /unknown agent adapter 'nonexistent'\. Supported: claude, codex, opencode, pi, antigravity, cursor, cline/
   );
   assert.throws(
     () => supportsAgentAdapterPhase("nonexistent", ADAPTER_PHASES.DISPATCH),
-    /unknown agent adapter 'nonexistent'\. Supported: claude, codex, opencode, pi, antigravity, cursor/
+    /unknown agent adapter 'nonexistent'\. Supported: claude, codex, opencode, pi, antigravity, cursor, cline/
   );
   assert.throws(
     () => supportsAgentAdapterPhase("codex", "unknown_phase"),

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -286,6 +286,49 @@ process.stdout.write("antigravity completed\\n");
   return agyPath;
 }
 
+function writeArgCaptureCline(binDir, capturePath) {
+  ensureDefaultFakeGh(binDir);
+  const clinePath = path.join(binDir, "cline");
+  fs.writeFileSync(clinePath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("3.0.36-test\\n"); process.exit(0); }
+if (args[0] === "--help") { process.stdout.write("Usage: cline --json --cwd --provider -P --model -m --timeout --worktree\\n"); process.exit(0); }
+if (!args.includes("--json")) { process.stderr.write("unsupported fake cline invocation"); process.exit(1); }
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(args), "utf-8");
+const cwd = args[args.indexOf("--cwd") + 1];
+const fileName = "captured-cline.txt";
+fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
+process.stdout.write(JSON.stringify({ type: "agent_event", event: { type: "content_start", text: "ignored" } }) + "\\n");
+process.stdout.write(JSON.stringify({ type: "run_result", text: "cline completed" }) + "\\n");
+`, "utf-8");
+  fs.chmodSync(clinePath, 0o755);
+  return clinePath;
+}
+
+function writeMalformedResultCline(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const clinePath = path.join(binDir, "cline");
+  fs.writeFileSync(clinePath, `#!/usr/bin/env node
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("3.0.36-test\\n"); process.exit(0); }
+if (args[0] === "--help") { process.stdout.write("Usage: cline --json --cwd --provider -P --model -m --timeout\\n"); process.exit(0); }
+if (!args.includes("--json")) { process.stderr.write("unsupported fake cline invocation"); process.exit(1); }
+const cwd = args[args.indexOf("--cwd") + 1];
+fs.writeFileSync(cwd + "/cline-work.txt", "work before malformed result\\n", "utf-8");
+execFileSync("git", ["-C", cwd, "add", "cline-work.txt"], { stdio: "pipe" });
+execFileSync("git", ["-C", cwd, "commit", "-m", "fake cline malformed result"], { stdio: "pipe" });
+process.stdout.write("{not-json\\n");
+`, "utf-8");
+  fs.chmodSync(clinePath, 0o755);
+  return clinePath;
+}
+
 function writeNoOpCodex(binDir) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -2938,6 +2981,89 @@ test("dispatch with --executor antigravity invokes agy and copies stdout into th
   assert.equal(manifest.policy.executor_policy.cli.binary, "agy");
   assert.equal(manifest.policy.executor_policy.cli.version, "agy 1.0.2");
   assert.deepEqual(manifest.policy.executor_policy.sandbox.flags, ["--sandbox", "--add-dir <git-common-dir>"]);
+});
+
+test("dispatch with --executor cline invokes Cline and extracts run_result.text into the result file", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-cline-dispatch",
+    allowed_model_routes: [{ route: "cline-pass/*", phases: ["dispatch"], executors: ["cline"] }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-cline-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-cline.json`);
+  writeArgCaptureCline(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const taskPrompt = "test cline task";
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "cline-test",
+    "-e", "cline",
+    "--model", "cline-pass/glm-5.2",
+    "--timeout", "31",
+    "--prompt", taskPrompt,
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.executor, "cline");
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.ok(result.commits);
+  assert.equal(fs.readFileSync(result.resultFile, "utf-8"), "cline completed\n");
+  const capturedArgs = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.deepEqual(capturedArgs.slice(0, 9), [
+    "--json",
+    "-P", "cline-pass",
+    "-m", "cline-pass/glm-5.2",
+    "--cwd", result.worktree,
+    "--timeout", "31",
+  ]);
+  assert.match(capturedArgs[9], /^\[RELAY WORKTREE BOUNDARY\]\n/);
+  assert.match(capturedArgs[9], new RegExp(`Repository worktree: ${escapeRegExp(result.worktree)}`));
+  assert.match(capturedArgs[9], /Do not use cline --worktree/);
+  assert.ok(capturedArgs[9].endsWith(buildDispatchExecPrompt(taskPrompt)));
+  assert.equal(capturedArgs.includes("--worktree"), false);
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.dispatch.last_executor, "cline");
+  assert.equal(manifest.dispatch.last_model, "cline-pass/glm-5.2");
+  assert.equal(manifest.dispatch.last_provider, "cline-pass");
+});
+
+test("dispatch with --executor cline escalates malformed JSONL through the manifest failure path", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-cline-dispatch",
+    allowed_model_routes: [{ route: "cline-pass/*", phases: ["dispatch"], executors: ["cline"] }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-cline-bin-"));
+  writeMalformedResultCline(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "cline-malformed-result",
+    "-e", "cline",
+    "--model", "cline-pass/glm-5.2",
+    "--prompt", "test cline malformed result",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.match(result.error, /executor_result_finalize_failed: .*Cline JSONL line 1 must be valid JSON/);
+  assert.equal(fs.existsSync(result.resultFile), false);
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.ESCALATED);
+  assert.equal(manifest.dispatch.last_executor, "cline");
+  assert.equal(manifest.dispatch.last_model, "cline-pass/glm-5.2");
 });
 
 test("dispatch artifacts are persisted in the run directory", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -3064,6 +3064,12 @@ test("dispatch with --executor cline escalates malformed JSONL through the manif
   assert.equal(manifest.state, STATES.ESCALATED);
   assert.equal(manifest.dispatch.last_executor, "cline");
   assert.equal(manifest.dispatch.last_model, "cline-pass/glm-5.2");
+  const commitLog = execFileSync("git", ["-C", result.worktree, "log", "--oneline", "-1"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+  assert.match(commitLog, /fake cline malformed result/);
+  assert.equal(fs.readFileSync(path.join(result.worktree, "cline-work.txt"), "utf-8"), "work before malformed result\n");
 });
 
 test("dispatch artifacts are persisted in the run directory", () => {

--- a/tests/relay-dispatch/scripts/docs-defaults.test.js
+++ b/tests/relay-dispatch/scripts/docs-defaults.test.js
@@ -255,9 +255,11 @@ test("operator docs mention every supported dispatch and review adapter", () => 
   assert.match(dispatchDocs, /--executor pi/);
   assert.match(dispatchDocs, /--executor antigravity/);
   assert.match(dispatchDocs, /--executor cursor/);
+  assert.match(dispatchDocs, /--executor cline/);
   assert.match(reviewDocs, /--reviewer pi/);
   assert.match(reviewDocs, /--reviewer antigravity/);
   assert.match(reviewDocs, /--reviewer cursor/);
+  assert.match(reviewDocs, /--advisory-reviewer cline/);
   assert.match(readRepoFile(ADAPTER_PLATFORM_DOC), /agy`? CLI only/);
 });
 

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -30,9 +30,9 @@ after(() => {
   if (TMP_ROOT) fs.rmSync(TMP_ROOT, { recursive: true, force: true });
 });
 
-test("registry exposes codex, claude, opencode, pi, antigravity, and cursor", () => {
-  assert.deepEqual(listExecutors(), ["codex", "claude", "opencode", "pi", "antigravity", "cursor"]);
-  assert.deepEqual(listExecutors().sort(), ["antigravity", "claude", "codex", "cursor", "opencode", "pi"]);
+test("registry exposes codex, claude, opencode, pi, antigravity, cursor, and cline", () => {
+  assert.deepEqual(listExecutors(), ["codex", "claude", "opencode", "pi", "antigravity", "cursor", "cline"]);
+  assert.deepEqual(listExecutors().sort(), ["antigravity", "claude", "cline", "codex", "cursor", "opencode", "pi"]);
   assert.throws(() => getExecutor("nonexistent"), /unknown executor/);
 });
 
@@ -66,6 +66,14 @@ test("cursor adapter exposes the same 7 fields", () => {
     assert.ok(typeof cursor[k] !== "undefined", `missing field: ${k}`);
   }
   assert.equal(cursor.cliBinary, "agent");
+});
+
+test("cline adapter exposes the same 7 fields", () => {
+  const cline = getExecutor("cline");
+  for (const k of ["cliBinary", "defaultTimeout", "validateExecutionMode", "buildExecCommand", "finalizeResult", "register", "probe"]) {
+    assert.ok(typeof cline[k] !== "undefined", `missing field: ${k}`);
+  }
+  assert.equal(cline.cliBinary, "cline");
 });
 
 test("opencode validateExecutionMode accepts workspace-write+disabled with experimental warning", () => {
@@ -210,6 +218,45 @@ test("cursor buildExecCommand: workspace, sandbox, model, and prompt argv", () =
   assert.equal(r.args.includes("--worktree"), false);
 });
 
+test("cline buildExecCommand: json, provider, cwd, timeout, model, and no worktree flag", () => {
+  const cline = getExecutor("cline");
+  const r = cline.buildExecCommand({
+    wtPath: WT,
+    prompt: "do the thing",
+    model: "cline-pass/glm-5.2",
+    sandbox: "workspace-write",
+    timeoutSeconds: 123,
+  });
+  assert.equal(r.cmd, "cline");
+  assert.deepEqual(r.args.slice(0, 9), [
+    "--json",
+    "-P", "cline-pass",
+    "-m", "cline-pass/glm-5.2",
+    "--cwd", WT,
+    "--timeout", "123",
+  ]);
+  assert.match(r.args[9], /RELAY WORKTREE BOUNDARY/);
+  assert.match(r.args[9], new RegExp(`Repository worktree: ${WT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(r.args[9], /Do not use cline --worktree/);
+  assert.match(r.args[9], /\ndo the thing$/);
+  assert.equal(r.args.includes("--worktree"), false);
+  assert.equal(r.cwd, WT);
+  assert.equal(r.codexGitCommonDir, null);
+});
+
+test("cline buildExecCommand: omitted model still pins provider to cline-pass", () => {
+  const cline = getExecutor("cline");
+  const r = cline.buildExecCommand({
+    wtPath: "/tmp/wt",
+    prompt: "P",
+    model: null,
+    sandbox: "workspace-write",
+    timeoutSeconds: null,
+  });
+  assert.deepEqual(r.args.slice(0, 6), ["--json", "-P", "cline-pass", "--cwd", "/tmp/wt", "--timeout"]);
+  assert.equal(r.args[6], "1800");
+});
+
 test("cursor validateExecutionMode fails closed for read-only dispatch", () => {
   const cursor = getExecutor("cursor");
   const r = cursor.validateExecutionMode({ sandbox: "read-only", networkAccess: "disabled" });
@@ -226,6 +273,41 @@ test("cursor finalizeResult copies stdout into the relay result file", () => {
   const copied = cursor.finalizeResult({ stdoutLog, resultFile });
   assert.deepEqual(copied, { copied: true, status: "copied", bytes: "cursor result\n".length });
   assert.equal(fs.readFileSync(resultFile, "utf-8"), "cursor result\n");
+});
+
+test("cline finalizeResult extracts run_result.text into the relay result file", () => {
+  const cline = getExecutor("cline");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "relay-cline-finalize-"));
+  const stdoutLog = path.join(tmp, "stdout.log");
+  const resultFile = path.join(tmp, "result.txt");
+  fs.writeFileSync(stdoutLog, [
+    JSON.stringify({ type: "agent_event", event: { type: "content_start", text: "ignored" } }),
+    JSON.stringify({ type: "run_result", text: "first" }),
+    JSON.stringify({ type: "run_result", text: "final answer" }),
+    "",
+  ].join("\n"), "utf-8");
+  const copied = cline.finalizeResult({ stdoutLog, resultFile });
+  assert.deepEqual(copied, { copied: true, status: "extracted", bytes: "final answer\n".length });
+  assert.equal(fs.readFileSync(resultFile, "utf-8"), "final answer\n");
+});
+
+test("cline finalizeResult fails when JSONL is malformed or missing run_result.text", () => {
+  const cline = getExecutor("cline");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "relay-cline-finalize-invalid-"));
+  const stdoutLog = path.join(tmp, "stdout.log");
+  const resultFile = path.join(tmp, "result.txt");
+
+  fs.writeFileSync(stdoutLog, "not-json\n", "utf-8");
+  assert.throws(
+    () => cline.finalizeResult({ stdoutLog, resultFile }),
+    /Cline JSONL line 1 must be valid JSON/
+  );
+
+  fs.writeFileSync(stdoutLog, `${JSON.stringify({ type: "agent_event" })}\n`, "utf-8");
+  assert.throws(
+    () => cline.finalizeResult({ stdoutLog, resultFile }),
+    /did not include run_result\.text/
+  );
 });
 
 test("pi finalizeResult copies stdout into the relay result file", () => {
@@ -444,6 +526,59 @@ esac
     process.env.PATH = originalPath;
     if (originalBin) process.env.RELAY_CURSOR_AGENT_BIN = originalBin;
     else delete process.env.RELAY_CURSOR_AGENT_BIN;
+  }
+});
+
+test("cline probe returns {error: 'cline CLI not found', raw: null} when binary missing", () => {
+  const emptyBin = path.join(TMP_ROOT, "empty-cline-bin");
+  fs.mkdirSync(emptyBin, { recursive: true });
+  const originalPath = process.env.PATH;
+  const originalBin = process.env.RELAY_CLINE_BIN;
+  process.env.PATH = emptyBin;
+  delete process.env.RELAY_CLINE_BIN;
+  try {
+    const cline = getExecutor("cline");
+    const result = cline.probe({ timeout: 5 });
+    assert.match(result.error, /cline CLI not found/);
+    assert.equal(result.raw, null);
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalBin) process.env.RELAY_CLINE_BIN = originalBin;
+    else delete process.env.RELAY_CLINE_BIN;
+  }
+});
+
+test("cline probe payload exposes version and supported flags without live API call", () => {
+  const fakeBin = path.join(TMP_ROOT, "fake-cline-bin");
+  const fakeCline = path.join(fakeBin, "cline");
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.writeFileSync(fakeCline, `#!/bin/sh
+case "$1" in
+  --version) echo "3.0.36-test" ;;
+  --help) echo "Usage: cline --json --cwd --provider -P --model -m --timeout --worktree" ;;
+  *) exit 2 ;;
+esac
+`);
+  fs.chmodSync(fakeCline, 0o755);
+
+  const originalPath = process.env.PATH;
+  const originalBin = process.env.RELAY_CLINE_BIN;
+  process.env.PATH = `${fakeBin}${path.delimiter}${originalPath || ""}`;
+  delete process.env.RELAY_CLINE_BIN;
+  try {
+    const cline = getExecutor("cline");
+    const result = cline.probe({ timeout: 5 });
+    assert.equal(result.error, null);
+    const parsed = JSON.parse(result.raw);
+    assert.equal(parsed.version, "3.0.36-test");
+    assert.equal(parsed.provider_default, "cline-pass");
+    assert.ok(parsed.supported_flags.includes("--json"));
+    assert.ok(parsed.supported_flags.includes("--cwd"));
+    assert.ok(parsed.warnings.some((warning) => /worktree/i.test(warning)));
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalBin) process.env.RELAY_CLINE_BIN = originalBin;
+    else delete process.env.RELAY_CLINE_BIN;
   }
 });
 

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -1258,6 +1258,7 @@ process.stdout.write(JSON.stringify({
   ]);
   assert.match(loggedArgs[9], /NON-INTERACTIVE ADVISORY REVIEW/);
   assert.match(loggedArgs[9], /Return a passing review\./);
+  assert.match(loggedArgs[9], /Do not use cline --worktree; relay already selected the review checkout with --cwd\./);
   assert.equal(loggedArgs.includes("--worktree"), false);
 });
 

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -11,6 +11,7 @@ const OPENCODE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-
 const PI_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-pi.js");
 const ANTIGRAVITY_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-antigravity.js");
 const CURSOR_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-cursor.js");
+const CLINE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-cline.js");
 
 function setupRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-adapter-"));
@@ -1204,6 +1205,196 @@ test("cursor adapter rejects advisory review phase", () => {
 
   assert.ok(error);
   assert.match(String(error.stderr || ""), /primary_review only/);
+});
+
+test("cline adapter forwards json provider, cwd, timeout, model, and parses run_result.text advisory JSON", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-"));
+  const logPath = path.join(fakeDir, "cline-args.log");
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(args), "utf-8");
+process.stdout.write(JSON.stringify({ type: "agent_event", event: { type: "content_start", text: "ignored" } }) + "\\n");
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  text: JSON.stringify({
+    profile: "blindspot",
+    summary: "No blocking blind spots.",
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  }),
+}) + "\\n");
+`);
+
+  const stdout = execFileSync("node", [
+    CLINE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--model", "cline-pass/glm-5.2",
+    "--phase", "advisory_review",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      RELAY_CLINE_BIN: fakeCline,
+      RELAY_CLINE_REVIEW_TIMEOUT: "45s",
+    },
+  });
+
+  const result = JSON.parse(stdout);
+  const loggedArgs = JSON.parse(fs.readFileSync(logPath, "utf-8"));
+  assert.equal(result.profile, "blindspot");
+  assert.deepEqual(loggedArgs.slice(0, 9), [
+    "--json",
+    "-P", "cline-pass",
+    "-m", "cline-pass/glm-5.2",
+    "--cwd", repoRoot,
+    "--timeout", "45",
+  ]);
+  assert.match(loggedArgs[9], /NON-INTERACTIVE ADVISORY REVIEW/);
+  assert.match(loggedArgs[9], /Return a passing review\./);
+  assert.equal(loggedArgs.includes("--worktree"), false);
+});
+
+test("cline adapter rejects primary review phase until canary promotion", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  let error;
+  try {
+    execFileSync("node", [
+      CLINE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--phase", "primary_review",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CLINE_BIN: path.join(repoRoot, "missing-cline") },
+    });
+    assert.fail("expected invoke-reviewer-cline.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  assert.match(String(error.stderr || ""), /advisory_review only in the MVP/);
+  assert.match(String(error.stderr || ""), /Primary review requires separate live canary promotion/);
+});
+
+test("cline adapter reports adapter and phase when run_result.text is invalid advisory JSON", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-invalid-json-"));
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ type: "run_result", text: "not-json" }) + "\\n");
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CLINE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline },
+    });
+    assert.fail("expected invoke-reviewer-cline.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /adapter=cline phase=advisory_review/);
+  assert.match(stderr, /advisory review must be valid JSON/);
+});
+
+test("cline adapter reports actionable diagnostics for empty JSONL output", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-empty-"));
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+process.exit(0);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CLINE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--model", "cline-pass/glm-5.2",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline },
+    });
+    assert.fail("expected invoke-reviewer-cline.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /Cline JSONL output is empty/);
+  assert.match(stderr, /cannot treat this as healthy advisory evidence/);
+});
+
+test("cline adapter enforces parent timeout and reports timeout context", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-timeout-"));
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    type: "run_result",
+    text: JSON.stringify({
+      profile: "blindspot",
+      summary: "Too late.",
+      required_findings: [],
+      advisory_findings: [],
+      duplicate_or_low_confidence: [],
+    }),
+  }) + "\\n");
+}, 2500);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CLINE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--model", "cline-pass/glm-5.2",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 5000,
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline, RELAY_CLINE_REVIEW_TIMEOUT: "1s" },
+    });
+    assert.fail("expected invoke-reviewer-cline.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error, "expected invoke-reviewer-cline.js to fail on parent timeout");
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /Cline reviewer advisory_review timed out after 1s/);
+  assert.match(stderr, /RELAY_CLINE_REVIEW_TIMEOUT/);
+  assert.match(stderr, /cannot treat this as healthy advisory evidence/);
+  assert.match(stderr, /verify Cline non-interactive provider output/);
+  assert.doesNotMatch(String(error.stdout || ""), /Too late/);
 });
 
 test("cursor adapter fails closed when auth probe reports not logged in", () => {

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -139,6 +139,18 @@ function setupRepo({
         reviewers: ["mirror"],
       }],
     },
+    "allow-cline-advisory": {
+      profile: "allow-cline-advisory",
+      allowed_model_routes: [{
+        route: "cline-pass/*",
+        phases: ["advisory_review"],
+        reviewers: ["cline"],
+      }, {
+        route: "mirror/*",
+        phases: ["review"],
+        reviewers: ["mirror"],
+      }],
+    },
   };
   const selectedPolicy = policyByName[modelPolicy];
   if (selectedPolicy) {
@@ -258,17 +270,7 @@ setTimeout(() => {
 
 function writeFakeAdvisoryCli(repoRoot, name, { delayMs = 0, logPath = null, invalidJson = false, mutate = false } = {}) {
   const filePath = path.join(repoRoot, `fake-${name}.js`);
-  fs.writeFileSync(filePath, `#!/usr/bin/env node
-const fs = require("fs");
-const path = require("path");
-const logPath = ${JSON.stringify(logPath)};
-if (logPath) fs.appendFileSync(logPath, "advisory-start " + Date.now() + "\\n");
-if (${mutate ? "true" : "false"}) fs.writeFileSync(path.join(process.cwd(), "advisory-mutated.txt"), "bad\\n", "utf-8");
-setTimeout(() => {
-  if (${invalidJson ? "true" : "false"}) {
-    process.stdout.write("not json");
-  } else {
-    process.stdout.write(JSON.stringify({
+  const advisoryPayload = `JSON.stringify({
       profile: "blindspot",
       summary: ${JSON.stringify(`${name} advisory blind spot.`)},
       required_findings: [],
@@ -282,7 +284,23 @@ setTimeout(() => {
         confidence: 0.8
       }],
       duplicate_or_low_confidence: []
-    }));
+    })`;
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const logPath = ${JSON.stringify(logPath)};
+if (logPath) fs.appendFileSync(logPath, "advisory-start " + Date.now() + "\\n");
+if (${mutate ? "true" : "false"}) fs.writeFileSync(path.join(process.cwd(), "advisory-mutated.txt"), "bad\\n", "utf-8");
+setTimeout(() => {
+  if (${invalidJson ? "true" : "false"}) {
+    process.stdout.write("not json");
+  } else {
+    const payload = ${advisoryPayload};
+    if (${name === "cline" ? "true" : "false"}) {
+      process.stdout.write(JSON.stringify({ type: "run_result", text: payload }) + "\\n");
+    } else {
+      process.stdout.write(payload);
+    }
   }
   if (logPath) fs.appendFileSync(logPath, "advisory-end " + Date.now() + "\\n");
 }, ${Number(delayMs)});
@@ -310,6 +328,7 @@ function runReview({
   opencodeScript,
   piScript = null,
   antigravityScript = null,
+  clineScript = null,
   advisoryReviewer = "opencode",
   reviewer = "codex",
   extraArgs = [],
@@ -318,6 +337,7 @@ function runReview({
   if (opencodeScript) env.RELAY_OPENCODE_BIN = opencodeScript;
   if (piScript) env.RELAY_PI_BIN = piScript;
   if (antigravityScript) env.RELAY_ANTIGRAVITY_BIN = antigravityScript;
+  if (clineScript) env.RELAY_CLINE_BIN = clineScript;
   const advisoryModelArgs = (
     advisoryReviewer === "opencode" &&
     !extraArgs.includes("--advisory-reviewer-model")
@@ -563,6 +583,36 @@ test("review-runner accepts antigravity advisory review when route policy allows
   assert.equal(event.reviewer_policy.adapter, "antigravity");
   assert.equal(event.reviewer_policy.phase, "advisory_review");
   assert.equal(event.reviewer_policy.safe, true);
+});
+
+test("review-runner accepts cline advisory review when route policy allows the reviewer model", () => {
+  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "allow-cline-advisory" });
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const clineScript = writeFakeAdvisoryCli(repoRoot, "cline");
+
+  const result = runReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    primaryScript,
+    opencodeScript: null,
+    clineScript,
+    advisoryReviewer: "cline",
+    extraArgs: ["--advisory-reviewer-model", "cline-pass/glm-5.2", "--advisory-grace", "30"],
+  });
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === "advisory_review");
+
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(result.advisoryReview.status, "success");
+  assert.equal(result.advisoryReview.reviewer, "cline");
+  assert.ok(fs.existsSync(path.join(runDir, "review-round-1-advisory-cline.json")));
+  assert.equal(event.reviewer, "cline");
+  assert.equal(event.policy_decision.allowed, true);
+  assert.equal(event.policy_decision.model, "cline-pass/glm-5.2");
+  assert.equal(event.reviewer_policy.adapter, "cline");
+  assert.equal(event.reviewer_policy.phase, "advisory_review");
+  assert.equal(event.reviewer_policy.read_only.enforcement_level, "prompt-only");
 });
 
 test("review-runner denies pi advisory model before spawning advisory reviewer", () => {

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -166,6 +166,10 @@ test("reviewer-invoke/resolveReviewerScript resolves built-in adapters and rejec
   assert.match(piScript, /invoke-reviewer-pi\.js$/);
   const cursorScript = resolveReviewerScript("cursor");
   assert.match(cursorScript, /invoke-reviewer-cursor\.js$/);
+  assert.throws(
+    () => resolveReviewerScript("cline"),
+    /supports advisory_review but not primary_review/
+  );
   assert.throws(() => resolveReviewerScript("../bad"), /Invalid reviewer name/);
 });
 
@@ -174,6 +178,7 @@ test("reviewer-invoke/resolveReviewerScript allows parity adapters for advisory 
   assert.match(script, /invoke-reviewer-opencode\.js$/);
   assert.match(resolveReviewerScript("pi", null, { phase: ADAPTER_PHASES.ADVISORY_REVIEW }), /invoke-reviewer-pi\.js$/);
   assert.match(resolveReviewerScript("antigravity", null, { phase: ADAPTER_PHASES.ADVISORY_REVIEW }), /invoke-reviewer-antigravity\.js$/);
+  assert.match(resolveReviewerScript("cline", null, { phase: ADAPTER_PHASES.ADVISORY_REVIEW }), /invoke-reviewer-cline\.js$/);
   assert.throws(
     () => resolveReviewerScript("cursor", null, { phase: ADAPTER_PHASES.ADVISORY_REVIEW }),
     /not advisory_review/
@@ -214,6 +219,13 @@ test("reviewer-invoke/buildPrimaryReviewerPolicy records Cursor ask-mode metadat
   assert.equal(policy.sandbox.enforcement_level, "informational");
   assert.deepEqual(policy.sandbox.flags, ["--mode", "ask", "--trust", "--force", "--workspace"]);
   assert.equal(policy.read_only.enforcement_level, "prompt-only");
+});
+
+test("reviewer-invoke/buildPrimaryReviewerPolicy fails closed for Cline primary review", () => {
+  assert.throws(
+    () => buildPrimaryReviewerPolicy("cline"),
+    /adapter capability denied.*adapter=cline.*phase=primary_review/s
+  );
 });
 
 test("reviewer-invoke/buildPrimaryReviewerPolicy records Antigravity CLI version metadata", (t) => {


### PR DESCRIPTION
## Summary
- Adds Cline/ClinePass as a relay dispatch executor with JSONL `run_result.text` extraction and explicit `--cwd` worktree binding.
- Registers Cline in the adapter descriptor as dispatch + advisory-review only, with primary review blocked behind live strict-verdict canary criteria.
- Adds a Cline advisory reviewer adapter, route-policy docs, operator guidance, and regression coverage for malformed JSONL fail-safe escalation.

## Verification
- `node --test --test-name-pattern "executor cline" tests/relay-dispatch/scripts/dispatch.test.js`
- `node --test tests/relay-dispatch/scripts/executors.test.js tests/relay-dispatch/scripts/agent-adapters.test.js tests/relay-dispatch/scripts/agent-adapter-policy.test.js tests/relay-dispatch/scripts/docs-defaults.test.js tests/skills-lint/scripts/skills-lint.test.js`
- `node --test tests/relay-review/scripts/*.test.js`
- `RELAY_CLINE_REVIEW_TIMEOUT=60s node skills/relay-review/scripts/invoke-reviewer-cline.js --repo <temp-repo> --prompt-file <prompt.md> --model cline-pass/glm-5.2 --json`

## Notes
- `node --test tests/relay-dispatch/scripts/dispatch.test.js` was not used as the final full-file signal because an existing `issue-158` collision regression test can hang in this environment when run as part of the full file. The Cline dispatch cases and the relevant adapter/docs/lint suite pass independently.
- Independent subagent review found a fail-closed gap in dispatch finalization; this PR includes the fix and regression test.

Refs #770
Closes #771
Closes #772
Closes #773
Closes #774
Closes #775
Closes #776
Closes #777


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cline support across relay dispatch and advisory review flows.
  * Expanded supported executor/reviewer options to include Cline.

* **Bug Fixes**
  * Improved handling of executor result finalization so failures no longer interrupt the full run.
  * Tightened validation for Cline output and routing to fail safely on invalid or disallowed configurations.

* **Documentation**
  * Updated setup, routing, and operator guides with Cline examples and policy guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->