### PR TITLE
Add skill script reachability lint (#768)

### DIFF
--- a/docs/script-inventory-and-cleanup.md
+++ b/docs/script-inventory-and-cleanup.md
@@ -1,5 +1,9 @@
 # Script Inventory and Cleanup Policy
 
+> Superseded by `tests/skills-lint/scripts/script-reachability.test.js` for
+> ongoing enforcement. The category taxonomy and Decision Notes below remain as
+> historical rationale; do not refresh the full inventory table.
+
 This document classifies runtime scripts before deleting or moving anything. The
 main rule: a script with zero runtime imports is not automatically dead. It may be
 an operator CLI, adapter entry point, or archived measurement tool.

--- a/tests/skills-lint/scripts/script-reachability.test.js
+++ b/tests/skills-lint/scripts/script-reachability.test.js
@@ -1,0 +1,315 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SKILLS_DIR = path.join(REPO_ROOT, "skills");
+const ADAPTER_INDEX_PATH = path.join(SKILLS_DIR, "relay-dispatch", "scripts", "agent-adapters", "index.js");
+
+const PACKAGED_SCRIPT_ALLOWLIST = [
+  // Keep empty when possible. Each entry must include a justification comment.
+  // Planner-only task_profile helper is exercised by relay-plan tests and documented
+  // as planner metadata, but no packaged runtime script imports it today. Track it
+  // here rather than deleting packaged skill code in this observation-only PR.
+  "skills/relay-plan/scripts/task-profile.js",
+];
+
+function toRepoRelative(filePath, repoRoot) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function walkFiles(root, predicate = () => true) {
+  if (!fs.existsSync(root)) return [];
+  const results = [];
+  const entries = fs.readdirSync(root, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  entries.forEach((entry) => {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(fullPath, predicate));
+      return;
+    }
+    if (entry.isFile() && predicate(fullPath)) {
+      results.push(fullPath);
+    }
+  });
+  return results;
+}
+
+function listPackagedSkillScripts(repoRoot = REPO_ROOT) {
+  return walkFiles(path.join(repoRoot, "skills"), (filePath) => {
+    return filePath.endsWith(".js") && toRepoRelative(filePath, repoRoot).includes("/scripts/");
+  });
+}
+
+function listSkillSourceFiles(repoRoot = REPO_ROOT) {
+  return walkFiles(path.join(repoRoot, "skills"), (filePath) => filePath.endsWith(".js"));
+}
+
+function listReferenceFiles(repoRoot = REPO_ROOT) {
+  const skillsRoot = path.join(repoRoot, "skills");
+  const skillDocs = walkFiles(skillsRoot, (filePath) => {
+    if (path.basename(filePath) === "SKILL.md") return true;
+    const relativePath = toRepoRelative(filePath, repoRoot);
+    return /\/references\/.*\.md$/.test(relativePath);
+  });
+  return [
+    ...skillDocs,
+    path.join(repoRoot, "README.md"),
+    path.join(repoRoot, "CLAUDE.md"),
+  ].filter((filePath) => fs.existsSync(filePath));
+}
+
+function resolveSkillScriptRequire(sourcePath, requestedPath) {
+  if (!requestedPath.startsWith(".")) return null;
+  const base = path.resolve(path.dirname(sourcePath), requestedPath);
+  const candidates = [
+    base,
+    `${base}.js`,
+    path.join(base, "index.js"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate) && candidate.endsWith(".js")) || null;
+}
+
+function addRequireReachability({ reachable, repoRoot, sourceFiles }) {
+  const requirePattern = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+  sourceFiles.forEach((sourcePath) => {
+    const content = fs.readFileSync(sourcePath, "utf-8");
+    requirePattern.lastIndex = 0;
+    let match;
+    while ((match = requirePattern.exec(content)) !== null) {
+      const target = resolveSkillScriptRequire(sourcePath, match[1]);
+      if (!target) continue;
+      const relativeTarget = toRepoRelative(target, repoRoot);
+      const relativeSource = toRepoRelative(sourcePath, repoRoot);
+      if (relativeTarget.startsWith("skills/") && relativeTarget !== relativeSource) {
+        reachable.add(relativeTarget);
+      }
+    }
+  });
+}
+
+function addDocumentationReachability({ docs, reachable, repoRoot, scriptFiles }) {
+  const combinedDocs = docs
+    .map((docPath) => fs.readFileSync(docPath, "utf-8"))
+    .join("\n");
+
+  scriptFiles.forEach((scriptPath) => {
+    const basename = path.basename(scriptPath);
+    if (combinedDocs.includes(basename)) {
+      reachable.add(toRepoRelative(scriptPath, repoRoot));
+    }
+  });
+}
+
+function addAdapterDescriptorReachability({ adapterIndexPath, reachable, repoRoot }) {
+  if (!fs.existsSync(adapterIndexPath)) return;
+  const { listAgentAdapters } = require(adapterIndexPath);
+  listAgentAdapters().forEach((descriptor) => {
+    Object.values(descriptor.reviewer || {}).forEach((scriptName) => {
+      if (!scriptName) return;
+      const scriptPath = path.join(repoRoot, "skills", "relay-review", "scripts", scriptName);
+      if (fs.existsSync(scriptPath)) {
+        reachable.add(toRepoRelative(scriptPath, repoRoot));
+      }
+    });
+  });
+}
+
+function splitPathJoinArguments(rawArguments) {
+  const args = [];
+  const tokenPattern = /"([^"]*)"|'([^']*)'|__dirname/g;
+  let match;
+  while ((match = tokenPattern.exec(rawArguments)) !== null) {
+    args.push(match[0] === "__dirname" ? "__dirname" : (match[1] ?? match[2]));
+  }
+  return args;
+}
+
+function addPathJoinSpawnReachability({ reachable, repoRoot, sourceFiles }) {
+  const pathJoinPattern = /path\.join\s*\(([^)]*)\)/g;
+  sourceFiles.forEach((sourcePath) => {
+    const content = fs.readFileSync(sourcePath, "utf-8");
+    pathJoinPattern.lastIndex = 0;
+    let match;
+    while ((match = pathJoinPattern.exec(content)) !== null) {
+      const args = splitPathJoinArguments(match[1]);
+      if (args[0] !== "__dirname" || !args.some((arg) => arg.endsWith(".js"))) continue;
+
+      const resolved = path.resolve(path.dirname(sourcePath), ...args.slice(1));
+      const relative = toRepoRelative(resolved, repoRoot);
+      if (fs.existsSync(resolved) && relative.startsWith("skills/") && relative.includes("/scripts/")) {
+        reachable.add(relative);
+      }
+    }
+  });
+}
+
+function assertAllowlistEntriesExist({ allowlist, repoRoot }) {
+  allowlist.forEach((relativePath) => {
+    assert.ok(
+      fs.existsSync(path.join(repoRoot, relativePath)),
+      `script reachability allowlist entry no longer exists: ${relativePath}`,
+    );
+  });
+}
+
+function findUnreachableScripts({
+  adapterIndexPath = ADAPTER_INDEX_PATH,
+  allowlist = PACKAGED_SCRIPT_ALLOWLIST,
+  docs,
+  repoRoot = REPO_ROOT,
+  scriptFiles,
+  sourceFiles,
+} = {}) {
+  assertAllowlistEntriesExist({ allowlist, repoRoot });
+
+  const packagedScripts = scriptFiles || listPackagedSkillScripts(repoRoot);
+  const skillsSourceFiles = sourceFiles || listSkillSourceFiles(repoRoot);
+  const referenceDocs = docs || listReferenceFiles(repoRoot);
+  const reachable = new Set(allowlist);
+
+  addRequireReachability({ reachable, repoRoot, sourceFiles: skillsSourceFiles });
+  addDocumentationReachability({ docs: referenceDocs, reachable, repoRoot, scriptFiles: packagedScripts });
+  addAdapterDescriptorReachability({ adapterIndexPath, reachable, repoRoot });
+  addPathJoinSpawnReachability({ reachable, repoRoot, sourceFiles: skillsSourceFiles });
+
+  return packagedScripts
+    .map((scriptPath) => toRepoRelative(scriptPath, repoRoot))
+    .filter((relativePath) => !reachable.has(relativePath))
+    .sort();
+}
+
+function assertAllPackagedSkillScriptsReachable(options = {}) {
+  const orphans = findUnreachableScripts(options);
+  assert.deepEqual(
+    orphans,
+    [],
+    `unreachable packaged skill scripts:\n${orphans.map((orphan) => `- ${orphan}`).join("\n")}`,
+  );
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+function buildFixtureRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "script-reachability-"));
+  writeFile(path.join(repoRoot, "README.md"), "Fixture docs mention documented-tool.js.\n");
+  writeFile(path.join(repoRoot, "CLAUDE.md"), "Fixture guide.\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "SKILL.md"), "Run entrypoint.js.\n");
+  writeFile(path.join(repoRoot, "skills", "relay-dispatch", "SKILL.md"), "Adapters are registered in agent-adapters/index.js.\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "references", "tools.md"), "Use referenced-helper.js.\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "entrypoint.js"), 'require("./lib/extensionless");\nrequire("./spawner");\n');
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "lib", "extensionless.js"), "module.exports = {};\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "documented-tool.js"), "module.exports = {};\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "referenced-helper.js"), "module.exports = {};\n");
+  writeFile(
+    path.join(repoRoot, "skills", "fixture", "scripts", "spawner.js"),
+    'const path = require("node:path");\npath.join(__dirname, "dynamic-worker.js");\n',
+  );
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "dynamic-worker.js"), "module.exports = {};\n");
+  writeFile(
+    path.join(repoRoot, "skills", "relay-dispatch", "scripts", "agent-adapters", "index.js"),
+    [
+      "function listAgentAdapters() {",
+      "  return [{ reviewer: { primaryReviewScript: 'adapter-reviewer.js', advisoryReviewScript: null } }];",
+      "}",
+      "module.exports = { listAgentAdapters };",
+      "",
+    ].join("\n"),
+  );
+  writeFile(path.join(repoRoot, "skills", "relay-review", "scripts", "adapter-reviewer.js"), "module.exports = {};\n");
+  return repoRoot;
+}
+
+test("scanner reports a planted orphan by exact file name", () => {
+  const repoRoot = buildFixtureRepo();
+  const orphanPath = path.join(repoRoot, "skills", "fixture", "scripts", "zz-orphan-probe.js");
+  writeFile(orphanPath, "module.exports = {};\n");
+
+  assert.throws(
+    () => assertAllPackagedSkillScriptsReachable({
+      adapterIndexPath: path.join(repoRoot, "skills", "relay-dispatch", "scripts", "agent-adapters", "index.js"),
+      allowlist: [],
+      repoRoot,
+    }),
+    /zz-orphan-probe\.js/,
+  );
+});
+
+test("scanner recognizes require, documentation, rule 3 adapter descriptor, and rule 4 path.join dynamic reachability", () => {
+  const repoRoot = buildFixtureRepo();
+
+  assertAllPackagedSkillScriptsReachable({
+    adapterIndexPath: path.join(repoRoot, "skills", "relay-dispatch", "scripts", "agent-adapters", "index.js"),
+    allowlist: [],
+    repoRoot,
+  });
+});
+
+test("cli-schema.js command registration alone does not count as script reachability", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "script-reachability-cli-schema-"));
+  writeFile(path.join(repoRoot, "README.md"), "No command names here.\n");
+  writeFile(path.join(repoRoot, "CLAUDE.md"), "No command names here.\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "SKILL.md"), "No script references here.\n");
+  writeFile(path.join(repoRoot, "skills", "relay-dispatch", "SKILL.md"), "Adapter registry: agent-adapters/index.js.\n");
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "cli-schema.js"), [
+    "const COMMAND_FLAGS = {",
+    "  'zz-orphan-probe': ['--json'],",
+    "};",
+    "module.exports = { COMMAND_FLAGS };",
+    "",
+  ].join("\n"));
+  writeFile(path.join(repoRoot, "skills", "fixture", "scripts", "zz-orphan-probe.js"), "module.exports = {};\n");
+  writeFile(
+    path.join(repoRoot, "skills", "relay-dispatch", "scripts", "agent-adapters", "index.js"),
+    "module.exports = { listAgentAdapters: () => [] };\n",
+  );
+
+  assert.deepEqual(
+    findUnreachableScripts({
+      adapterIndexPath: path.join(repoRoot, "skills", "relay-dispatch", "scripts", "agent-adapters", "index.js"),
+      allowlist: [],
+      repoRoot,
+    }),
+    [
+      "skills/fixture/scripts/cli-schema.js",
+      "skills/fixture/scripts/zz-orphan-probe.js",
+    ],
+  );
+});
+
+test("allowlist entries must exist on disk", () => {
+  const repoRoot = buildFixtureRepo();
+
+  assert.throws(
+    () => findUnreachableScripts({
+      adapterIndexPath: path.join(repoRoot, "skills", "relay-dispatch", "scripts", "agent-adapters", "index.js"),
+      allowlist: ["skills/fixture/scripts/missing-convention-entry.js"],
+      repoRoot,
+    }),
+    /allowlist entry no longer exists/,
+  );
+});
+
+test("real adapter reviewer, executor, and advisory-worker scripts are reachable", () => {
+  const orphans = new Set(findUnreachableScripts());
+  [
+    "skills/relay-dispatch/scripts/executors/codex.js",
+    "skills/relay-dispatch/scripts/executors/opencode.js",
+    "skills/relay-review/scripts/invoke-reviewer-codex.js",
+    "skills/relay-review/scripts/invoke-reviewer-opencode.js",
+    "skills/relay-review/scripts/advisory-worker.js",
+  ].forEach((relativePath) => {
+    assert.ok(!orphans.has(relativePath), `${relativePath} must be reachable`);
+  });
+});
+
+test("all packaged skill scripts are reachable", () => {
+  assertAllPackagedSkillScriptsReachable();
+});

--- a/tests/skills-lint/scripts/script-reachability.test.js
+++ b/tests/skills-lint/scripts/script-reachability.test.js
@@ -10,9 +10,13 @@ const ADAPTER_INDEX_PATH = path.join(SKILLS_DIR, "relay-dispatch", "scripts", "a
 
 const PACKAGED_SCRIPT_ALLOWLIST = [
   // Keep empty when possible. Each entry must include a justification comment.
-  // Planner-only task_profile helper is exercised by relay-plan tests and documented
-  // as planner metadata, but no packaged runtime script imports it today. Track it
-  // here rather than deleting packaged skill code in this observation-only PR.
+  //
+  // TEMPORARY TRACKED ORPHAN — NOT convention-invoked. task-profile.js is a
+  // confirmed orphan (docs reference references/task-profile.md, the reference
+  // doc, not this script; no runtime import, adapter registration, or dynamic
+  // spawn). This observation-only PR must not delete packaged skill code, so
+  // the orphan rides here as tracked debt. Remove this entry when issue #788
+  // (wire into relay-plan flow or delete) lands.
   "skills/relay-plan/scripts/task-profile.js",
 ];
 


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed `64c85de Add skill script reachability lint (#768)`.

Changes:
- Added [script-reachability.test.js](/Users/sjlee/.relay/worktrees/161a6348/dev-relay/tests/skills-lint/scripts/script-reachability.test.js) with scanner coverage for requires, docs basename references, adapter descriptors, dynamic `path.join(__dirname, ...)` workers, cli-schema negative coverage, allowlist validation, and planted `zz-orphan-probe.js` mutation evidence.
- Added the superseded-by banner to [
```

## Score Log

- Run: issue-768-20260705060807951-ee146628
- Executor: codex
- Branch: issue-768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 스크립트 인벤토리 관리 정책이 업데이트되어, 현재는 진행 중인 도달 가능성 검사 기준을 따르도록 안내가 정리되었습니다.
  * 기존 분류·결정 기록은 참고용으로 유지하고, 전체 인벤토리 표는 새로 갱신하지 않도록 명시했습니다.

* **테스트**
  * 스킬 스크립트의 도달 가능 여부를 검사하는 테스트가 추가되었습니다.
  * 문서, 참조, 동적 경로, 허용 목록까지 반영해 사용되지 않는 스크립트를 자동으로 감지하고 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Tracked orphan (review R1 resolution)

`skills/relay-plan/scripts/task-profile.js` is a confirmed orphan the lint itself caught (docs reference `references/task-profile.md`, the reference doc — not the script). Per the observation-only constraint, it is NOT deleted here; it rides as an honestly-labeled temporary allowlist entry bound to #788 (wire-or-delete), which removes the entry when it lands. See issue #768 "Scope amendment (review R1)".
