### PR TITLE
docs: add test-run discipline guidance (#794)

### DIFF
--- a/skills/relay-plan/references/iteration-protocol.md
+++ b/skills/relay-plan/references/iteration-protocol.md
@@ -39,7 +39,7 @@ When Step 0a is active, also append this sentence under the final self-review st
 ```
 BEFORE LOOP: Run baseline if defined. RULE: Do NOT modify automated check commands.
 LOOP (max 5 iterations):
-  0. PREREQUISITE GATE: Run prerequisite checks. Any fails → fix before scoring factors.
+  0. PREREQUISITE GATE / TEST-RUN DISCIPLINE: Treat prerequisite checks as the final gate, not a per-iteration check. During the loop, run only targeted or touched suites needed to verify the current change; run long repo-wide prerequisites once at the end before committing, because re-running long prerequisites every iteration can consume the dispatch timeout.
   1. Run automated factors and self-evaluate evaluated factors. Record evidence in the Score Log. Use 0-10 numbers for quality factors with numeric targets.
   2. Fix the weakest required failing factor with one focused change. For below-target quality scores, optimize the lowest reviewer score without changing rubric commands.
   3. Re-run affected checks plus any previously passing factor that could regress.

--- a/skills/relay-plan/references/iteration-protocol.md
+++ b/skills/relay-plan/references/iteration-protocol.md
@@ -39,7 +39,7 @@ When Step 0a is active, also append this sentence under the final self-review st
 ```
 BEFORE LOOP: Run baseline if defined. RULE: Do NOT modify automated check commands.
 LOOP (max 5 iterations):
-  0. PREREQUISITE GATE / TEST-RUN DISCIPLINE: Treat prerequisite checks as the final gate, not a per-iteration check. During the loop, run only targeted or touched suites needed to verify the current change; run long repo-wide prerequisites once at the end before committing, because re-running long prerequisites every iteration can consume the dispatch timeout.
+  0. PREREQUISITE GATE: Test-run discipline — treat prerequisite checks as the final gate, not a per-iteration check. During the loop, run only targeted or touched suites needed to verify the current change; run long repo-wide prerequisites once at the end before committing, because re-running long prerequisites every iteration can consume the dispatch timeout.
   1. Run automated factors and self-evaluate evaluated factors. Record evidence in the Score Log. Use 0-10 numbers for quality factors with numeric targets.
   2. Fix the weakest required failing factor with one focused change. For below-target quality scores, optimize the lowest reviewer score without changing rubric commands.
   3. Re-run affected checks plus any previously passing factor that could regress.

--- a/skills/relay-plan/references/rubric-design-guide.md
+++ b/skills/relay-plan/references/rubric-design-guide.md
@@ -80,6 +80,8 @@ Rank the outcomes that would hurt most if they shipped wrong. Each kept concern 
 
 Contract is "is it there?" Quality is "is it good?" Move repo-wide checks to `prerequisites`; do not count them as substantive factors.
 
+When a prerequisite is expected to take longer than about 2 minutes, include the dispatch prompt's Test-run Discipline block so executors iterate with targeted checks and run the long prerequisite once as the final gate. Size the dispatch `--timeout` for that final gate plus implementation time; for example, use `--timeout 5400` instead of relying on Codex's 3600-second default when a repo-wide prerequisite already consumes several minutes.
+
 ### Q3: What can be measured with a command?
 
 Inventory project tools before deciding what is measurable:

--- a/skills/relay/references/prompt-template.md
+++ b/skills/relay/references/prompt-template.md
@@ -67,8 +67,11 @@ rubric:
       weight: required
 ```
 
+## Test-run Discipline
+While iterating, run only the targeted or touched suites needed to verify the current change. Treat long repo-wide prerequisite checks as the final gate: run them once at the end before committing, because re-running long prerequisites every iteration can consume the dispatch timeout.
+
 ## Iteration Protocol
-0. PREREQUISITE GATE: Run all prerequisite checks. Any fails → fix before proceeding.
+0. PREREQUISITE GATE: Follow Test-run Discipline. During iteration, run targeted checks; run long repo-wide prerequisites once as the final gate before committing. Any final prerequisite failure must be fixed before completion.
 1. Run automated checks and self-review against the rubric.
 2. Fix the weakest required factor without regressing any locked factor.
 3. Re-run the rubric, update the Score Log, then stop only when all required factors meet target.


### PR DESCRIPTION
## Dispatch Summary

```text
Committed `2e67957 docs: add test-run discipline guidance (#794)`.

Changed only the three requested reference docs:
- `skills/relay/references/prompt-template.md`
- `skills/relay-plan/references/iteration-protocol.md`
- `skills/relay-plan/references/rubric-design-guide.md`

Verification:
- `grep -ri "test-run discipline" ...` passes for both required docs.
- `grep -n "5400" skills/relay-plan/references/rubric-design-guide.md` passes.
- `git diff --check` passes.
- Full test coverage was run ser
```

## Score Log

- Run: issue-794-20260705113330215-c4fff992
- Executor: codex
- Branch: issue-794