### PR TITLE
Crash-only Phase 1: non-destructive signal handling + interruption journaling in dispatch.js (#800)

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -236,7 +236,7 @@ Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/e
 
 | Event | Emitted by |
 |-------|------------|
-| `dispatch_start`, `dispatch_result`, `environment_drift`, `model_hints_updated` | `relay-dispatch/scripts/dispatch.js` |
+| `dispatch_start`, `dispatch_interrupted`, `dispatch_result`, `environment_drift`, `model_hints_updated` | `relay-dispatch/scripts/dispatch.js` |
 | `publish_result` | `relay-dispatch/scripts/publish-run.js` |
 | `recover_commit`, `recover_commit_failed`, `execution_evidence_rebranded` | `relay-dispatch/scripts/recover-commit.js`, `rebrand-evidence.js` |
 | `iteration_score`, `rubric_quality`, `score_divergence` | `relay-dispatch/scripts/relay-events.js` (helpers) |

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1659,6 +1659,10 @@ async function main() {
         executor_network: executorNetworkPolicy,
         executor_policy: executorPolicy,
       },
+      dispatch: {
+        ...(manifest.dispatch || {}),
+        publish_policy: PUBLISH_POLICY,
+      },
       routing: routingDecision,
       routes: {
         plan_path: "route-plan.json",

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -671,6 +671,18 @@ function maybePauseBeforeExecutorSpawnForTest() {
   return new Promise((resolve) => setTimeout(resolve, pauseMs));
 }
 
+function maybePauseAfterWorktreeCreateForTest() {
+  const pauseMs = Number(process.env.RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS || 0);
+  if (!Number.isFinite(pauseMs) || pauseMs <= 0) return Promise.resolve();
+  const markerPath = process.env.RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER;
+  if (markerPath) {
+    try {
+      fs.writeFileSync(markerPath, JSON.stringify({ pid: process.pid, ts: Date.now() }), "utf-8");
+    } catch {}
+  }
+  return new Promise((resolve) => setTimeout(resolve, pauseMs));
+}
+
 function latestRunEvent(repoRoot, runId) {
   const events = readRunEvents(repoRoot, runId);
   return events.length ? events[events.length - 1] : null;
@@ -1102,10 +1114,37 @@ async function main() {
     fleetIssueLock = null;
   }
 
+  function persistInterruptedManifestForSignal() {
+    if (!manifest || !manifestPath || !runId) return false;
+    try {
+      const runDir = getRunDir(repoRoot, runId);
+      ensureRunLayout(repoRoot, runId);
+      if (RUBRIC_FILE && !hasRubricPath(manifest)) {
+        const rubricSrc = path.resolve(RUBRIC_FILE);
+        const persistedRubric = getPersistedRubricPath(runDir, "rubric.yaml");
+        copyFileAtomically(rubricSrc, persistedRubric.resolvedPath);
+        manifest = {
+          ...manifest,
+          anchor: {
+            ...(manifest.anchor || {}),
+            rubric_path: persistedRubric.rubricPath,
+          },
+        };
+      }
+      if (!fs.existsSync(manifestPath)) {
+        writeManifest(manifestPath, manifest);
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function journalDispatchInterrupted(signal, executorTerminated) {
     if (!manifest || !runId) return;
     let runDir;
     try {
+      if (!persistInterruptedManifestForSignal()) return;
       runDir = getRunDir(repoRoot, runId);
       if (!fs.existsSync(runDir)) return;
       appendRunEvent(repoRoot, runId, {
@@ -1145,13 +1184,12 @@ async function main() {
     if (signal === "SIGINT") {
       const pgid = executorPgid || executorPid;
       terminateProcessTree(executorPid);
+      executorTerminated = await waitForProcessGroupExit(pgid);
       if (executorClosePromise) {
-        executorTerminated = await Promise.race([
-          executorClosePromise.then(() => true),
-          waitForProcessGroupExit(pgid),
+        await Promise.race([
+          executorClosePromise.catch(() => null),
+          sleepAsync(100),
         ]);
-      } else {
-        executorTerminated = await waitForProcessGroupExit(pgid);
       }
     }
     journalDispatchInterrupted(signal, executorTerminated);
@@ -1212,8 +1250,9 @@ async function main() {
       console.error(`Error: manifest repo root is not a git repository: ${repoRoot}`);
       process.exit(1);
     }
-    const latestEvent = manifest.state === STATES.DISPATCHED ? latestRunEvent(repoRoot, runId) : null;
-    const resumesInterruptedDispatch = latestEvent?.event === EVENTS.DISPATCH_INTERRUPTED;
+    const interruptibleResumeState = manifest.state === STATES.DISPATCHED || manifest.state === STATES.DRAFT;
+    const latestEvent = interruptibleResumeState ? latestRunEvent(repoRoot, runId) : null;
+    const resumesInterruptedDispatch = interruptibleResumeState && latestEvent?.event === EVENTS.DISPATCH_INTERRUPTED;
     if (resumesInterruptedDispatch && isProcessGroupAlive(latestEvent.executor_pgid)) {
       console.error(
         `Error: interrupted executor process group is still alive for run '${runId}' ` +
@@ -1575,6 +1614,44 @@ async function main() {
   };
 
   if (!RESUME_MODE) {
+    manifest = createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch,
+      baseBranch,
+      issueNumber,
+      worktreePath: wtPath,
+      orchestrator: resolveRoleBinding("RELAY_ORCHESTRATOR", "unknown"),
+      executor: EXECUTOR,
+      reviewer: resolveRoleBinding("RELAY_REVIEWER", "unknown"),
+      cleanupPolicy,
+      requestId: REQUEST_ID || null,
+      leafId: LEAF_ID || null,
+      doneCriteriaPath: resolvedDoneCriteriaPath,
+      doneCriteriaSource: inferDoneCriteriaSource({
+        repoRoot,
+        runId,
+        doneCriteriaPath: resolvedDoneCriteriaPath,
+        requestId: REQUEST_ID,
+        leafId: LEAF_ID,
+      }),
+      reviewAssurance: REVIEW_ASSURANCE,
+      modelHints: MODEL_HINTS,
+      fleetId: FLEET_ID,
+    });
+    manifest = {
+      ...manifest,
+      policy: {
+        ...(manifest.policy || {}),
+        executor_network: executorNetworkPolicy,
+        executor_policy: executorPolicy,
+      },
+      routing: routingDecision,
+      routes: {
+        plan_path: "route-plan.json",
+        summary: summarizeRoutePlan(routePlan),
+      },
+    };
     try {
       const created = createWorktree({
         repoRoot,
@@ -1590,6 +1667,7 @@ async function main() {
       console.error(`Error: ${error.message}`);
       process.exit(1);
     }
+    await maybePauseAfterWorktreeCreateForTest();
 
     // Merge base branch into worktree so the executor works on merged state.
     // Prevents wasted rounds from stale-base conflicts or CI failures.
@@ -1617,34 +1695,9 @@ async function main() {
     }
 
     const environment = collectEnvironmentSnapshot(repoRoot, baseBranch);
-    manifest = createManifestSkeleton({
-      repoRoot,
-      runId,
-      branch,
-      baseBranch,
-      issueNumber,
-      worktreePath: wtPath,
-      orchestrator: resolveRoleBinding("RELAY_ORCHESTRATOR", "unknown"),
-      executor: EXECUTOR,
-      reviewer: resolveRoleBinding("RELAY_REVIEWER", "unknown"),
-      cleanupPolicy,
-      environment,
-      requestId: REQUEST_ID || null,
-      leafId: LEAF_ID || null,
-      doneCriteriaPath: resolvedDoneCriteriaPath,
-      doneCriteriaSource: inferDoneCriteriaSource({
-        repoRoot,
-        runId,
-        doneCriteriaPath: resolvedDoneCriteriaPath,
-        requestId: REQUEST_ID,
-        leafId: LEAF_ID,
-      }),
-      reviewAssurance: REVIEW_ASSURANCE,
-      modelHints: MODEL_HINTS,
-      fleetId: FLEET_ID,
-    });
     manifest = {
       ...manifest,
+      environment,
       policy: {
         ...(manifest.policy || {}),
         executor_network: executorNetworkPolicy,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1296,6 +1296,19 @@ async function main() {
 
     // --- Environment drift check ---
     const currentEnv = collectEnvironmentSnapshot(repoRoot, baseBranch);
+    const needsDraftEnvironmentBackfill = manifest.state === STATES.DRAFT
+      && resumesInterruptedDispatch
+      && (
+        !manifest.environment
+        || ["node_version", "main_sha", "lockfile_hash", "dispatch_ts"].every((field) => manifest.environment[field] == null)
+      );
+    if (needsDraftEnvironmentBackfill) {
+      manifest = {
+        ...manifest,
+        environment: currentEnv,
+      };
+      writeManifest(manifestPath, manifest);
+    }
     const drift = compareEnvironmentSnapshot(manifest.environment, currentEnv);
     if (drift.length) {
       const driftMsg = drift.map(d => `${d.field}: ${d.from} → ${d.to}`).join(", ");

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -629,16 +629,46 @@ function terminateProcessTree(pid) {
   } catch {}
 }
 
+function probeProcessGroup(pgid) {
+  const normalizedPgid = Number(pgid);
+  if (process.env.RELAY_TEST_PROCESS_GROUP_ALIVE_EPERM === String(normalizedPgid)) {
+    const error = new Error("operation not permitted");
+    error.code = "EPERM";
+    throw error;
+  }
+  process.kill(process.platform === "win32" ? normalizedPgid : -normalizedPgid, 0);
+}
+
 function isProcessGroupAlive(pgid) {
   if (!pgid || !Number.isFinite(Number(pgid))) return false;
   try {
-    process.kill(-Number(pgid), 0);
+    probeProcessGroup(pgid);
     return true;
   } catch (error) {
     if (error.code === "ESRCH") return false;
     if (error.code === "EPERM") return true;
     return false;
   }
+}
+
+function sleepAsync(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForProcessGroupExit(pgid, { timeoutMs = 1500, intervalMs = 50 } = {}) {
+  if (!pgid || !Number.isFinite(Number(pgid))) return false;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessGroupAlive(pgid)) return true;
+    await sleepAsync(Math.min(intervalMs, Math.max(1, deadline - Date.now())));
+  }
+  return !isProcessGroupAlive(pgid);
+}
+
+function maybePauseBeforeExecutorSpawnForTest() {
+  const pauseMs = Number(process.env.RELAY_TEST_BEFORE_EXECUTOR_SPAWN_PAUSE_MS || 0);
+  if (!Number.isFinite(pauseMs) || pauseMs <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, pauseMs));
 }
 
 function latestRunEvent(repoRoot, runId) {
@@ -1061,6 +1091,7 @@ async function main() {
   let copiedFiles = [];
   let executorPid = null;
   let executorPgid = null;
+  let executorClosePromise = null;
   let dispatchStartTime = null;
   let fleetIssueLock = null;
   let handlingSignal = false;
@@ -1100,17 +1131,28 @@ async function main() {
         : "node skills/relay-dispatch/scripts/dispatch.js --manifest <manifest-path>";
       const suffix = signal === "SIGTERM" && !executorTerminated
         ? " The executor may still be running and may complete on its own."
+        : signal === "SIGINT" && executorPid && !executorTerminated
+          ? " Executor termination was requested, but the process group may still be running."
         : "";
       console.error(`Dispatch interrupted by ${signal}; retained worktree at ${wtPath || "(unknown)"}. Resume with: ${command}.${suffix}`);
     } catch {}
   }
 
-  function handleSignal(signal) {
+  async function handleSignal(signal) {
     if (handlingSignal) return;
     handlingSignal = true;
-    const executorTerminated = signal === "SIGINT";
-    if (executorTerminated) {
+    let executorTerminated = false;
+    if (signal === "SIGINT") {
+      const pgid = executorPgid || executorPid;
       terminateProcessTree(executorPid);
+      if (executorClosePromise) {
+        executorTerminated = await Promise.race([
+          executorClosePromise.then(() => true),
+          waitForProcessGroupExit(pgid),
+        ]);
+      } else {
+        executorTerminated = await waitForProcessGroupExit(pgid);
+      }
     }
     journalDispatchInterrupted(signal, executorTerminated);
     releaseFleetIssueLock();
@@ -1119,8 +1161,8 @@ async function main() {
   }
 
   process.once("exit", releaseFleetIssueLock);
-  process.on("SIGINT", () => handleSignal("SIGINT"));
-  process.on("SIGTERM", () => handleSignal("SIGTERM"));
+  process.on("SIGINT", () => { void handleSignal("SIGINT"); });
+  process.on("SIGTERM", () => { void handleSignal("SIGTERM"); });
 
   if (RESUME_MODE) {
     const manifestRecord = resolveManifestRecord({
@@ -1820,6 +1862,7 @@ async function main() {
     executor_policy: executorPolicy,
     policy_decision: policyDecision,
   });
+  await maybePauseBeforeExecutorSpawnForTest();
 
   // Redirect stdout/stderr to files. Using spawn with detached: true gives us
   // a killable process group (terminateProcessTree sends SIGTERM to -pid).
@@ -1832,7 +1875,7 @@ async function main() {
   executorPid = child.pid;
   executorPgid = child.pid;
 
-  const execResult = await new Promise((resolve) => {
+  executorClosePromise = new Promise((resolve) => {
     let timedOut = false;
     const timer = setTimeout(() => {
       timedOut = true;
@@ -1849,6 +1892,9 @@ async function main() {
       resolve({ code: 1, signal: null, timedOut, spawnError: e });
     });
   });
+  const execResult = await executorClosePromise;
+  if (handlingSignal) return;
+  executorClosePromise = null;
   executorPid = null;
   executorPgid = null;
 

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -125,7 +125,7 @@ const {
 } = require("./manifest/guidance");
 const { STATES, updateManifestState } = require("./manifest/lifecycle");
 const { resolveManifestRecord } = require("./relay-resolver");
-const { appendRunEvent, appendUnregisteredRouteUsedEvent, EVENTS } = require("./relay-events");
+const { appendRunEvent, appendUnregisteredRouteUsedEvent, EVENTS, readRunEvents } = require("./relay-events");
 const {
   ADAPTER_PHASES,
   getAgentAdapterDescriptor,
@@ -629,6 +629,23 @@ function terminateProcessTree(pid) {
   } catch {}
 }
 
+function isProcessGroupAlive(pgid) {
+  if (!pgid || !Number.isFinite(Number(pgid))) return false;
+  try {
+    process.kill(-Number(pgid), 0);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") return false;
+    if (error.code === "EPERM") return true;
+    return false;
+  }
+}
+
+function latestRunEvent(repoRoot, runId) {
+  const events = readRunEvents(repoRoot, runId);
+  return events.length ? events[events.length - 1] : null;
+}
+
 function validateResumeRequestLinkage(manifest, { requestId, leafId, fleetId, doneCriteriaPath }) {
   const checks = [
     {
@@ -1042,9 +1059,11 @@ async function main() {
   let issueNumber = inferIssueNumber(branch);
   let manifest;
   let copiedFiles = [];
-  let createdWorktree = false;
   let executorPid = null;
+  let executorPgid = null;
+  let dispatchStartTime = null;
   let fleetIssueLock = null;
+  let handlingSignal = false;
 
   function releaseFleetIssueLock() {
     if (!fleetIssueLock) return;
@@ -1052,18 +1071,56 @@ async function main() {
     fleetIssueLock = null;
   }
 
-  function cleanup() {
-    terminateProcessTree(executorPid);
-    releaseFleetIssueLock();
-    if (createdWorktree) {
-      removeWorktree({ repoRoot, worktreePath: wtPath });
+  function journalDispatchInterrupted(signal, executorTerminated) {
+    if (!manifest || !runId) return;
+    let runDir;
+    try {
+      runDir = getRunDir(repoRoot, runId);
+      if (!fs.existsSync(runDir)) return;
+      appendRunEvent(repoRoot, runId, {
+        event: EVENTS.DISPATCH_INTERRUPTED,
+        state_from: manifest.state || null,
+        state_to: manifest.state || null,
+        reason: "signal",
+        signal,
+        executor_pid: executorPid,
+        executor_pgid: executorPgid,
+        elapsed_s: dispatchStartTime ? Math.max(0, Math.round((Date.now() - dispatchStartTime) / 1000)) : null,
+        timeout_s: TIMEOUT,
+        executor_terminated: executorTerminated,
+        worktree: wtPath || null,
+      });
+    } catch {}
+  }
+
+  function printSignalRecoveryHint(signal, executorTerminated) {
+    try {
+      const command = manifestPath
+        ? `node skills/relay-dispatch/scripts/dispatch.js --manifest ${manifestPath}`
+        : "node skills/relay-dispatch/scripts/dispatch.js --manifest <manifest-path>";
+      const suffix = signal === "SIGTERM" && !executorTerminated
+        ? " The executor may still be running and may complete on its own."
+        : "";
+      console.error(`Dispatch interrupted by ${signal}; retained worktree at ${wtPath || "(unknown)"}. Resume with: ${command}.${suffix}`);
+    } catch {}
+  }
+
+  function handleSignal(signal) {
+    if (handlingSignal) return;
+    handlingSignal = true;
+    const executorTerminated = signal === "SIGINT";
+    if (executorTerminated) {
+      terminateProcessTree(executorPid);
     }
+    journalDispatchInterrupted(signal, executorTerminated);
+    releaseFleetIssueLock();
+    printSignalRecoveryHint(signal, executorTerminated);
     process.exit(1);
   }
 
   process.once("exit", releaseFleetIssueLock);
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
+  process.on("SIGINT", () => handleSignal("SIGINT"));
+  process.on("SIGTERM", () => handleSignal("SIGTERM"));
 
   if (RESUME_MODE) {
     const manifestRecord = resolveManifestRecord({
@@ -1113,7 +1170,17 @@ async function main() {
       console.error(`Error: manifest repo root is not a git repository: ${repoRoot}`);
       process.exit(1);
     }
-    if (manifest.state !== STATES.CHANGES_REQUESTED) {
+    const latestEvent = manifest.state === STATES.DISPATCHED ? latestRunEvent(repoRoot, runId) : null;
+    const resumesInterruptedDispatch = latestEvent?.event === EVENTS.DISPATCH_INTERRUPTED;
+    if (resumesInterruptedDispatch && isProcessGroupAlive(latestEvent.executor_pgid)) {
+      console.error(
+        `Error: interrupted executor process group is still alive for run '${runId}' ` +
+        `(pid=${latestEvent.executor_pid ?? "unknown"}, pgid=${latestEvent.executor_pgid}). ` +
+        "Wait for it to finish, or kill that process group before resuming."
+      );
+      process.exit(1);
+    }
+    if (manifest.state !== STATES.CHANGES_REQUESTED && !resumesInterruptedDispatch) {
       console.error(`Error: same-run resume requires state='${STATES.CHANGES_REQUESTED}', got '${manifest.state}'`);
       process.exit(1);
     }
@@ -1477,7 +1544,6 @@ async function main() {
         assertWithin,
       });
       copiedFiles = created.copiedFiles;
-      createdWorktree = true;
     } catch (error) {
       console.error(`Error: ${error.message}`);
       process.exit(1);
@@ -1710,6 +1776,7 @@ async function main() {
   let exitCode = 0;
   let error = null;
   const startTime = Date.now();
+  dispatchStartTime = startTime;
   let stderrText = "";
 
   // Record HEAD before execution so we can measure only new work.
@@ -1719,7 +1786,12 @@ async function main() {
   } catch {}
 
   const dispatchFromState = manifest.state;
-  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest = manifest.state === STATES.DISPATCHED
+    ? {
+        ...manifest,
+        next_action: "await_dispatch_result",
+      }
+    : updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
   manifest = {
     ...manifest,
     git: {
@@ -1758,6 +1830,7 @@ async function main() {
   if (execCwd) spawnOpts.cwd = execCwd;
   const child = nodeSpawn(cmd, execArgs, spawnOpts);
   executorPid = child.pid;
+  executorPgid = child.pid;
 
   const execResult = await new Promise((resolve) => {
     let timedOut = false;
@@ -1777,6 +1850,7 @@ async function main() {
     });
   });
   executorPid = null;
+  executorPgid = null;
 
   if (execResult.timedOut) {
     exitCode = 1;

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -23,6 +23,8 @@ const EVENTS = Object.freeze({
   CLEANUP_RESULT: "cleanup_result",
   CLOSE: "close",
   CONFLICTING_RUN_OVERRIDE: "conflicting_run_override",
+  // Consumer: dispatch resume gate and Phase 2 reconciler use this to resume or reconcile interrupted dispatches.
+  DISPATCH_INTERRUPTED: "dispatch_interrupted",
   DISPATCH_RESULT: "dispatch_result",
   DISPATCH_START: "dispatch_start",
   ENVIRONMENT_DRIFT: "environment_drift",
@@ -203,6 +205,27 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
     ...(eventData.executor !== undefined
       ? { executor: normalizeEventValue(eventData.executor) }
+      : {}),
+    ...(eventData.signal !== undefined
+      ? { signal: normalizeEventValue(eventData.signal) }
+      : {}),
+    ...(eventData.executor_pid !== undefined
+      ? { executor_pid: normalizeEventValue(eventData.executor_pid) }
+      : {}),
+    ...(eventData.executor_pgid !== undefined
+      ? { executor_pgid: normalizeEventValue(eventData.executor_pgid) }
+      : {}),
+    ...(eventData.elapsed_s !== undefined
+      ? { elapsed_s: normalizeEventValue(eventData.elapsed_s) }
+      : {}),
+    ...(eventData.timeout_s !== undefined
+      ? { timeout_s: normalizeEventValue(eventData.timeout_s) }
+      : {}),
+    ...(eventData.executor_terminated !== undefined
+      ? { executor_terminated: eventData.executor_terminated === true }
+      : {}),
+    ...(eventData.worktree !== undefined
+      ? { worktree: normalizeEventValue(eventData.worktree) }
       : {}),
     ...(eventData.phase !== undefined
       ? { phase: normalizeEventValue(eventData.phase) }

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1498,7 +1498,7 @@ test("dispatch SIGINT does not treat leader exit as process-group termination wh
   }
 });
 
-test("dispatch interruption immediately after worktree creation journals a resumable manifest", async () => {
+test("dispatch interruption immediately after worktree creation preserves delayed publication on resume", async () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-after-worktree-bin-"));
@@ -1518,6 +1518,7 @@ test("dispatch interruption immediately after worktree creation journals a resum
   const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
     "-b", "issue-800-after-worktree-signal",
     "--prompt", "pause immediately after worktree create",
+    "--publish-policy", "after-internal-review",
     "--json",
   ])], {
     cwd: repoRoot,
@@ -1562,6 +1563,7 @@ test("dispatch interruption immediately after worktree creation journals a resum
     assert.equal(fs.realpathSync(manifest.paths.worktree), fs.realpathSync(worktreePath));
     assert.ok(fs.existsSync(manifest.paths.worktree), "after-worktree signal must preserve the retained worktree");
     assert.ok(manifest.anchor?.rubric_path, "signal-written manifest must retain the rubric anchor for resume");
+    assert.equal(manifest.dispatch?.publish_policy, "after-internal-review");
     assert.equal(manifest.environment.node_version, null);
     assert.equal(manifest.environment.dispatch_ts, null);
 
@@ -1586,11 +1588,16 @@ test("dispatch interruption immediately after worktree creation journals a resum
       RELAY_HOME: relayHome,
     }));
     assert.equal(resume.mode, "resume");
+    assert.equal(resume.publishPolicy, "after-internal-review");
     assert.equal(resume.runId, manifest.run_id);
     assert.equal(resume.worktree, manifest.paths.worktree);
-    assert.equal(resume.runState, STATES.REVIEW_PENDING);
+    assert.equal(resume.runState, STATES.INTERNAL_REVIEW_PENDING);
 
     const resumedManifest = readManifest(manifestPath).data;
+    assert.equal(resumedManifest.dispatch.publish_policy, "after-internal-review");
+    assert.equal(resumedManifest.state, STATES.INTERNAL_REVIEW_PENDING);
+    assert.equal(resumedManifest.next_action, "run_internal_review");
+    assert.equal(resumedManifest.git.pr_number, null);
     assert.equal(resumedManifest.environment.node_version, process.version);
     assert.equal(typeof resumedManifest.environment.dispatch_ts, "string");
     assert.match(resumedManifest.environment.main_sha, /^[0-9a-f]{40}$/);

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1399,6 +1399,131 @@ test("dispatch SIGINT terminates executor group and preserves worktree while jou
   await runInterruptedDispatchSignalTest("SIGINT");
 });
 
+test("dispatch handles interruption before executor spawn without removing the worktree", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-pre-spawn-bin-"));
+  const markerPath = path.join(os.tmpdir(), `relay-dispatch-pre-spawn-${process.pid}-${Date.now()}.json`);
+  writeSleepingCodex(binDir);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_BEFORE_EXECUTOR_SPAWN_PAUSE_MS: "30000",
+    RELAY_TEST_EXECUTOR_MARKER: markerPath,
+  };
+  let manifestPath = null;
+
+  const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-800-pre-spawn-signal",
+    "--prompt", "pause before spawn",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForDispatchExit(proc);
+
+  try {
+    manifestPath = await waitFor(() => {
+      const candidate = listManifestPaths(repoRoot)[0];
+      if (!candidate) return null;
+      const manifest = readManifest(candidate).data;
+      const events = readRunEvents(repoRoot, manifest.run_id);
+      return events.some((event) => event.event === "dispatch_start") ? candidate : null;
+    }, { timeoutMs: 30000, message: "dispatch_start before executor spawn" });
+
+    proc.kill("SIGINT");
+    const result = await exitPromise;
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, /Dispatch interrupted by SIGINT/);
+
+    const manifest = readManifest(manifestPath).data;
+    assert.equal(manifest.state, STATES.DISPATCHED);
+    assert.ok(fs.existsSync(manifest.paths.worktree), "pre-spawn signal must preserve the retained worktree");
+    assert.equal(fs.existsSync(markerPath), false, "executor must not have spawned before the pre-spawn signal");
+
+    const interruptedEvent = readRunEvents(repoRoot, manifest.run_id).at(-1);
+    assert.equal(interruptedEvent.event, "dispatch_interrupted");
+    assert.equal(interruptedEvent.signal, "SIGINT");
+    assert.equal(interruptedEvent.executor_pid, null);
+    assert.equal(interruptedEvent.executor_pgid, null);
+    assert.equal(interruptedEvent.executor_terminated, false);
+    assert.equal(interruptedEvent.worktree, manifest.paths.worktree);
+    assert.equal(interruptedEvent.state_from, STATES.DISPATCHED);
+    assert.equal(interruptedEvent.state_to, STATES.DISPATCHED);
+  } finally {
+    if (!proc.killed) {
+      proc.kill("SIGTERM");
+    }
+  }
+});
+
+test("dispatch exits and preserves worktree when interruption journaling fails", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-journal-fail-bin-"));
+  const markerPath = path.join(os.tmpdir(), `relay-dispatch-journal-fail-${process.pid}-${Date.now()}.json`);
+  writeSleepingCodex(binDir);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_EXECUTOR_MARKER: markerPath,
+  };
+  let marker = null;
+  let manifestPath = null;
+  let manifest = null;
+
+  const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-800-journal-failure",
+    "--prompt", "sleep until journal failure interruption",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForDispatchExit(proc);
+
+  try {
+    marker = await waitFor(() => {
+      if (!fs.existsSync(markerPath)) return null;
+      return JSON.parse(fs.readFileSync(markerPath, "utf-8"));
+    }, { timeoutMs: 30000, message: "fake executor marker" });
+    manifestPath = await waitFor(() => listManifestPaths(repoRoot)[0], {
+      timeoutMs: 30000,
+      message: "dispatch manifest path",
+    });
+    manifest = readManifest(manifestPath).data;
+    const eventsPath = getEventsPath(repoRoot, manifest.run_id);
+    fs.rmSync(eventsPath, { force: true });
+    fs.symlinkSync(path.join(os.tmpdir(), `relay-dispatch-events-target-${process.pid}-${Date.now()}`), eventsPath);
+
+    proc.kill("SIGTERM");
+    const result = await exitPromise;
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, /Dispatch interrupted by SIGTERM/);
+
+    const updatedManifest = readManifest(manifestPath).data;
+    assert.equal(updatedManifest.state, STATES.DISPATCHED);
+    assert.ok(fs.existsSync(updatedManifest.paths.worktree), "journal failure signal path must preserve the retained worktree");
+    assert.equal(isPgidAlive(marker.pgid), true, "SIGTERM must still leave the executor process group alive when journaling fails");
+  } finally {
+    const pgid = marker?.pgid;
+    if (pgid) {
+      killPgid(pgid);
+      await waitForPgidDead(pgid);
+    }
+    if (!proc.killed) {
+      proc.kill("SIGTERM");
+    }
+  }
+});
+
 function makeDispatchedResumeFixture(repoRoot, env, { appendInterruptedEvent, pgid = 987654, pid = pgid } = {}) {
   const first = JSON.parse(runDispatch(repoRoot, [
     "-b", `issue-800-resume-${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -1495,6 +1620,42 @@ test("dispatch refuses interrupted resume while recorded pgid is still alive", a
     killPgid(blocker.pid);
     await Promise.race([blockerExit, sleep(5000)]);
   }
+});
+
+test("dispatch refuses interrupted resume when pgid probe returns EPERM", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const epermPgid = 424242;
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_PROCESS_GROUP_ALIVE_EPERM: String(epermPgid),
+  };
+  const first = makeDispatchedResumeFixture(repoRoot, env, {
+    appendInterruptedEvent: true,
+    pid: epermPgid,
+    pgid: epermPgid,
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume interrupted dispatch",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    env,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /interrupted executor process group is still alive/);
+  assert.match(result.stderr, new RegExp(`pid=${epermPgid}`));
+  assert.match(result.stderr, /Wait for it to finish, or kill that process group before resuming/);
+  assert.equal(readManifest(first.manifestPath).data.state, STATES.DISPATCHED);
 });
 
 test("dispatch still refuses resume from non-interrupted dispatched state", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -936,6 +936,43 @@ setInterval(() => {}, 1000);
   return codexPath;
 }
 
+function writeLeaderExitDescendantCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const { spawn } = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const marker = process.env.RELAY_TEST_EXECUTOR_MARKER;
+const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"], {
+  stdio: "ignore",
+});
+child.unref();
+if (marker) {
+  setTimeout(() => {
+    fs.writeFileSync(marker, JSON.stringify({ pid: process.pid, pgid: process.pid, childPid: child.pid }), "utf-8");
+  }, 250);
+}
+process.on("SIGTERM", () => {
+  if (marker) {
+    fs.writeFileSync(marker + ".terminated", JSON.stringify({ pid: process.pid, childPid: child.pid, signal: "SIGTERM" }), "utf-8");
+  }
+  process.exit(143);
+});
+setInterval(() => {}, 1000);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
 async function waitForDispatchExit(proc) {
   let stdout = "";
   let stderr = "";
@@ -1397,6 +1434,164 @@ test("dispatch SIGTERM preserves executor and worktree while journaling dispatch
 
 test("dispatch SIGINT terminates executor group and preserves worktree while journaling dispatch_interrupted", async () => {
   await runInterruptedDispatchSignalTest("SIGINT");
+});
+
+test("dispatch SIGINT does not treat leader exit as process-group termination while a descendant remains", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-leader-exit-bin-"));
+  const markerPath = path.join(os.tmpdir(), `relay-dispatch-leader-exit-${process.pid}-${Date.now()}.json`);
+  writeLeaderExitDescendantCodex(binDir);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_EXECUTOR_MARKER: markerPath,
+  };
+  let marker = null;
+
+  const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-800-sigint-descendant",
+    "--prompt", "leader exits but descendant ignores sigterm",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForDispatchExit(proc);
+
+  try {
+    marker = await waitFor(() => {
+      if (!fs.existsSync(markerPath)) return null;
+      return JSON.parse(fs.readFileSync(markerPath, "utf-8"));
+    }, { timeoutMs: 30000, message: "fake executor marker" });
+    const manifestPath = await waitFor(() => listManifestPaths(repoRoot)[0], {
+      timeoutMs: 30000,
+      message: "dispatch manifest path",
+    });
+
+    proc.kill("SIGINT");
+    const result = await exitPromise;
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, /Executor termination was requested, but the process group may still be running/);
+
+    const manifest = readManifest(manifestPath).data;
+    const interruptedEvent = readRunEvents(repoRoot, manifest.run_id).at(-1);
+    assert.equal(interruptedEvent.event, "dispatch_interrupted");
+    assert.equal(interruptedEvent.signal, "SIGINT");
+    assert.equal(interruptedEvent.executor_pid, marker.pid);
+    assert.equal(interruptedEvent.executor_pgid, marker.pgid);
+    assert.equal(interruptedEvent.executor_terminated, false);
+    assert.equal(isPgidAlive(marker.pgid), true, "descendant keeps the executor process group alive");
+  } finally {
+    if (marker?.pgid) {
+      try {
+        process.kill(-Number(marker.pgid), "SIGKILL");
+      } catch {}
+      await waitForPgidDead(marker.pgid);
+    }
+    if (!proc.killed) {
+      proc.kill("SIGTERM");
+    }
+  }
+});
+
+test("dispatch interruption immediately after worktree creation journals a resumable manifest", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-after-worktree-bin-"));
+  const markerPath = path.join(os.tmpdir(), `relay-dispatch-after-worktree-${process.pid}-${Date.now()}.json`);
+  const pauseMarkerPath = path.join(os.tmpdir(), `relay-dispatch-after-worktree-pause-${process.pid}-${Date.now()}.json`);
+  writeSleepingCodex(binDir);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "30000",
+    RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: pauseMarkerPath,
+    RELAY_TEST_EXECUTOR_MARKER: markerPath,
+  };
+  let manifestPath = null;
+
+  const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-800-after-worktree-signal",
+    "--prompt", "pause immediately after worktree create",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForDispatchExit(proc);
+
+  try {
+    await waitFor(() => fs.existsSync(pauseMarkerPath), {
+      timeoutMs: 30000,
+      message: "after-worktree create pause marker",
+    });
+    const repoRootReal = fs.realpathSync(repoRoot);
+    const worktreePath = await waitFor(() => {
+      const output = execFileSync("git", ["worktree", "list", "--porcelain"], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+      const paths = output
+        .split("\n")
+        .filter((line) => line.startsWith("worktree "))
+        .map((line) => line.slice("worktree ".length));
+      return paths.find((candidate) => fs.realpathSync(candidate) !== repoRootReal) || null;
+    }, { timeoutMs: 30000, message: "created dispatch worktree" });
+
+    proc.kill("SIGTERM");
+    const result = await exitPromise;
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, /Dispatch interrupted by SIGTERM/);
+    assert.match(result.stderr, /Resume with: node skills\/relay-dispatch\/scripts\/dispatch\.js --manifest /);
+    assert.equal(fs.existsSync(markerPath), false, "executor must not spawn in the after-worktree pause");
+
+    manifestPath = await waitFor(() => listManifestPaths(repoRoot)[0], {
+      timeoutMs: 5000,
+      message: "signal-written dispatch manifest path",
+    });
+    const manifest = readManifest(manifestPath).data;
+    assert.equal(manifest.state, STATES.DRAFT);
+    assert.equal(fs.realpathSync(manifest.paths.worktree), fs.realpathSync(worktreePath));
+    assert.ok(fs.existsSync(manifest.paths.worktree), "after-worktree signal must preserve the retained worktree");
+    assert.ok(manifest.anchor?.rubric_path, "signal-written manifest must retain the rubric anchor for resume");
+
+    const interruptedEvent = readRunEvents(repoRoot, manifest.run_id).at(-1);
+    assert.equal(interruptedEvent.event, "dispatch_interrupted");
+    assert.equal(interruptedEvent.signal, "SIGTERM");
+    assert.equal(interruptedEvent.executor_pid, null);
+    assert.equal(interruptedEvent.executor_pgid, null);
+    assert.equal(interruptedEvent.executor_terminated, false);
+    assert.equal(interruptedEvent.worktree, manifest.paths.worktree);
+    assert.equal(interruptedEvent.state_from, STATES.DRAFT);
+    assert.equal(interruptedEvent.state_to, STATES.DRAFT);
+
+    writeFakeCodex(binDir);
+    const resume = JSON.parse(runDispatch(repoRoot, [
+      "--manifest", manifestPath,
+      "--prompt", "resume after early interruption",
+      "--json",
+    ], {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    }));
+    assert.equal(resume.mode, "resume");
+    assert.equal(resume.runId, manifest.run_id);
+    assert.equal(resume.worktree, manifest.paths.worktree);
+    assert.equal(resume.runState, STATES.REVIEW_PENDING);
+  } finally {
+    if (!proc.killed) {
+      proc.kill("SIGTERM");
+    }
+  }
 });
 
 test("dispatch handles interruption before executor spawn without removing the worktree", async () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1562,6 +1562,8 @@ test("dispatch interruption immediately after worktree creation journals a resum
     assert.equal(fs.realpathSync(manifest.paths.worktree), fs.realpathSync(worktreePath));
     assert.ok(fs.existsSync(manifest.paths.worktree), "after-worktree signal must preserve the retained worktree");
     assert.ok(manifest.anchor?.rubric_path, "signal-written manifest must retain the rubric anchor for resume");
+    assert.equal(manifest.environment.node_version, null);
+    assert.equal(manifest.environment.dispatch_ts, null);
 
     const interruptedEvent = readRunEvents(repoRoot, manifest.run_id).at(-1);
     assert.equal(interruptedEvent.event, "dispatch_interrupted");
@@ -1587,6 +1589,14 @@ test("dispatch interruption immediately after worktree creation journals a resum
     assert.equal(resume.runId, manifest.run_id);
     assert.equal(resume.worktree, manifest.paths.worktree);
     assert.equal(resume.runState, STATES.REVIEW_PENDING);
+
+    const resumedManifest = readManifest(manifestPath).data;
+    assert.equal(resumedManifest.environment.node_version, process.version);
+    assert.equal(typeof resumedManifest.environment.dispatch_ts, "string");
+    assert.match(resumedManifest.environment.main_sha, /^[0-9a-f]{40}$/);
+    assert.equal(resumedManifest.environment.lockfile_hash, null);
+    const resumeEvents = readRunEvents(repoRoot, manifest.run_id);
+    assert.equal(resumeEvents.some((event) => event.event === "environment_drift"), false);
   } finally {
     if (!proc.killed) {
       proc.kill("SIGTERM");

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1,7 +1,7 @@
 // canary: bare-string `event === "..."` reader assertions in this file are deliberate canaries against EVENTS schema drift; do not port to EVENTS.X (see #313).
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync, spawnSync } = require("child_process");
+const { execFileSync, spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -28,6 +28,7 @@ const {
   RUBRIC_SIZE_UNPARSEABLE,
 } = require("../../../skills/relay-dispatch/scripts/rubric-size");
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
+const { appendRunEvent, EVENTS, readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 const { evaluateReviewGate } = require("../../../skills/relay-merge/scripts/review-gate");
 const { createEnforcementFixture } = require("./test-support");
 
@@ -860,6 +861,94 @@ function runDispatch(repoRoot, args, env) {
   });
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(condition, { timeoutMs = 5000, intervalMs = 50, message = "condition" } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const value = condition();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${message}${lastError ? `: ${lastError.message}` : ""}`);
+}
+
+function isPgidAlive(pgid) {
+  if (!pgid) return false;
+  try {
+    process.kill(-Number(pgid), 0);
+    return true;
+  } catch (error) {
+    if (error.code === "EPERM") return true;
+    if (error.code === "ESRCH") return false;
+    return false;
+  }
+}
+
+function killPgid(pgid) {
+  if (!pgid) return;
+  try {
+    process.kill(-Number(pgid), "SIGTERM");
+  } catch {}
+}
+
+async function waitForPgidDead(pgid) {
+  await waitFor(() => !isPgidAlive(pgid), {
+    timeoutMs: 5000,
+    message: `process group ${pgid} to exit`,
+  });
+}
+
+function writeSleepingCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const marker = process.env.RELAY_TEST_EXECUTOR_MARKER;
+if (marker) {
+  fs.writeFileSync(marker, JSON.stringify({ pid: process.pid, pgid: process.pid }), "utf-8");
+}
+process.on("SIGTERM", () => {
+  if (marker) {
+    fs.writeFileSync(marker + ".terminated", JSON.stringify({ pid: process.pid, signal: "SIGTERM" }), "utf-8");
+  }
+  process.exit(143);
+});
+setInterval(() => {}, 1000);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
+async function waitForDispatchExit(proc) {
+  let stdout = "";
+  let stderr = "";
+  proc.stdout.setEncoding("utf-8");
+  proc.stderr.setEncoding("utf-8");
+  proc.stdout.on("data", (chunk) => { stdout += chunk; });
+  proc.stderr.on("data", (chunk) => { stderr += chunk; });
+  const result = await new Promise((resolve) => {
+    proc.on("close", (code, signal) => resolve({ code, signal }));
+  });
+  return { ...result, stdout, stderr };
+}
+
 function readExecutionEvidence(runDir) {
   return JSON.parse(fs.readFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"));
 }
@@ -1218,6 +1307,218 @@ test("dispatch reuses the same run and worktree on resume", () => {
   assert.match(events, /"event":"dispatch_start"/);
   assert.match(events, /"reason":"same_run_resume"/);
   assert.match(events, /"reason":"same_run_resume:completed"/);
+});
+
+async function runInterruptedDispatchSignalTest(signalName) {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-sleep-bin-"));
+  const markerPath = path.join(os.tmpdir(), `relay-dispatch-sleep-${process.pid}-${Date.now()}-${signalName}.json`);
+  writeSleepingCodex(binDir);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_EXECUTOR_MARKER: markerPath,
+  };
+  let marker = null;
+  let interruptedEvent = null;
+
+  const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", `issue-800-${signalName.toLowerCase()}`,
+    "--prompt", "sleep until interrupted",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForDispatchExit(proc);
+
+  try {
+    marker = await waitFor(() => {
+      if (!fs.existsSync(markerPath)) return null;
+      return JSON.parse(fs.readFileSync(markerPath, "utf-8"));
+    }, { timeoutMs: 30000, message: "fake executor marker" });
+    const manifestPath = await waitFor(() => listManifestPaths(repoRoot)[0], {
+      timeoutMs: 30000,
+      message: "dispatch manifest path",
+    });
+
+    proc.kill(signalName);
+    const result = await exitPromise;
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, new RegExp(`Dispatch interrupted by ${signalName}`));
+    assert.match(result.stderr, /Resume with: node skills\/relay-dispatch\/scripts\/dispatch\.js --manifest /);
+    if (signalName === "SIGTERM") {
+      assert.match(result.stderr, /executor may still be running/);
+    }
+
+    const manifest = readManifest(manifestPath).data;
+    assert.equal(manifest.state, STATES.DISPATCHED);
+    assert.ok(fs.existsSync(manifest.paths.worktree), "signal handling must preserve the retained worktree");
+
+    const events = readRunEvents(repoRoot, manifest.run_id);
+    interruptedEvent = events.at(-1);
+    assert.equal(interruptedEvent.event, "dispatch_interrupted");
+    assert.equal(interruptedEvent.signal, signalName);
+    assert.equal(interruptedEvent.executor_pid, marker.pid);
+    assert.equal(interruptedEvent.executor_pgid, marker.pgid);
+    assert.equal(interruptedEvent.timeout_s, 2400);
+    assert.equal(typeof interruptedEvent.elapsed_s, "number");
+    assert.ok(interruptedEvent.elapsed_s >= 0);
+    assert.equal(interruptedEvent.worktree, manifest.paths.worktree);
+    assert.equal(interruptedEvent.state_from, STATES.DISPATCHED);
+    assert.equal(interruptedEvent.state_to, STATES.DISPATCHED);
+
+    if (signalName === "SIGTERM") {
+      assert.equal(interruptedEvent.executor_terminated, false);
+      assert.equal(isPgidAlive(marker.pgid), true, "SIGTERM must not kill the detached executor process group");
+    } else {
+      assert.equal(interruptedEvent.executor_terminated, true);
+      await waitForPgidDead(marker.pgid);
+    }
+  } finally {
+    const pgid = interruptedEvent?.executor_pgid || marker?.pgid;
+    if (signalName === "SIGTERM" && pgid) {
+      killPgid(pgid);
+      await waitForPgidDead(pgid);
+    }
+    if (!proc.killed) {
+      proc.kill("SIGTERM");
+    }
+  }
+}
+
+test("dispatch SIGTERM preserves executor and worktree while journaling dispatch_interrupted", async () => {
+  await runInterruptedDispatchSignalTest("SIGTERM");
+});
+
+test("dispatch SIGINT terminates executor group and preserves worktree while journaling dispatch_interrupted", async () => {
+  await runInterruptedDispatchSignalTest("SIGINT");
+});
+
+function makeDispatchedResumeFixture(repoRoot, env, { appendInterruptedEvent, pgid = 987654, pid = pgid } = {}) {
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", `issue-800-resume-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    "--prompt", "first pass",
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  const dispatchedManifest = {
+    ...record.data,
+    state: STATES.DISPATCHED,
+    next_action: "await_dispatch_result",
+  };
+  writeManifest(first.manifestPath, dispatchedManifest, record.body);
+  if (appendInterruptedEvent) {
+    appendRunEvent(repoRoot, first.runId, {
+      event: EVENTS.DISPATCH_INTERRUPTED,
+      state_from: STATES.DISPATCHED,
+      state_to: STATES.DISPATCHED,
+      reason: "signal",
+      signal: "SIGTERM",
+      executor_pid: pid,
+      executor_pgid: pgid,
+      elapsed_s: 1,
+      timeout_s: 2400,
+      executor_terminated: false,
+      worktree: first.worktree,
+    });
+  }
+  return first;
+}
+
+test("dispatch resumes from dispatched when latest event is dispatch_interrupted and recorded pgid is dead", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const first = makeDispatchedResumeFixture(repoRoot, env, { appendInterruptedEvent: true });
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", first.runId,
+    "--prompt", "resume interrupted dispatch",
+    "--json",
+  ], env));
+
+  assert.equal(second.mode, "resume");
+  assert.equal(second.runId, first.runId);
+  assert.equal(second.worktree, first.worktree);
+  assert.equal(second.runState, STATES.REVIEW_PENDING);
+  const events = readRunEvents(repoRoot, first.runId);
+  assert.equal(events.at(-2).event, "dispatch_start");
+  assert.equal(events.at(-2).state_from, STATES.DISPATCHED);
+  assert.equal(events.at(-2).state_to, STATES.DISPATCHED);
+  assert.equal(events.at(-1).event, "dispatch_result");
+});
+
+test("dispatch refuses interrupted resume while recorded pgid is still alive", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const blocker = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  const blockerExit = new Promise((resolve) => blocker.on("close", resolve));
+  blocker.unref();
+
+  try {
+    const first = makeDispatchedResumeFixture(repoRoot, env, {
+      appendInterruptedEvent: true,
+      pid: blocker.pid,
+      pgid: blocker.pid,
+    });
+
+    const result = spawnSync(process.execPath, [SCRIPT, repoRoot,
+      "--run-id", first.runId,
+      "--prompt", "resume interrupted dispatch",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      env,
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /interrupted executor process group is still alive/);
+    assert.match(result.stderr, new RegExp(`pid=${blocker.pid}`));
+    assert.match(result.stderr, /Wait for it to finish, or kill that process group before resuming/);
+    assert.equal(readManifest(first.manifestPath).data.state, STATES.DISPATCHED);
+  } finally {
+    killPgid(blocker.pid);
+    await Promise.race([blockerExit, sleep(5000)]);
+  }
+});
+
+test("dispatch still refuses resume from non-interrupted dispatched state", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const first = makeDispatchedResumeFixture(repoRoot, env, { appendInterruptedEvent: false });
+
+  const result = spawnSync(process.execPath, [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume non-interrupted dispatch",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    env,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /same-run resume requires state='changes_requested', got 'dispatched'/);
+  assert.equal(readManifest(first.manifestPath).data.state, STATES.DISPATCHED);
 });
 
 function writeResumeCaptureCodex(binDir, capturePath) {

--- a/tests/relay-dispatch/scripts/relay-events-enum.test.js
+++ b/tests/relay-dispatch/scripts/relay-events-enum.test.js
@@ -167,6 +167,7 @@ test("EVENTS is a frozen object map for current run journal event names", () => 
   assert.equal(Object.values(EVENTS).includes("register"), false);
   assert.equal(EVENTS.GUIDANCE_SELECTED, "guidance_selected");
   assert.equal(EVENTS.BYPASS_OVERRIDE_BY_USER, "bypass_override_by_user");
+  assert.equal(EVENTS.DISPATCH_INTERRUPTED, "dispatch_interrupted");
   assert.equal(EVENTS.READINESS_CHECK_FAILED, "readiness_check_failed");
   assert.equal(EVENTS.READINESS_CHECK_FAILED_NONTTY, "readiness_check_failed_nontty");
   assert.equal(EVENTS.READINESS_PROBE, "readiness_probe");


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-800-20260705234805031-4092e1ce
- Branch: issue-800
- Reason: executor timed out at 5400s with complete uncommitted Phase 1 work; targeted suite verified 829/829 pass
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-800-20260705234805031-4092e1ce.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-06T01:49:31.353Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 중단 시 `dispatch_interrupted` 이벤트가 추가 기록되고, 중단/재개 판단에 필요한 실행 이력이 더 풍부해졌습니다(추가 필드 포함).
* **Bug Fixes**
  * SIGINT/SIGTERM 처리 및 프로세스 그룹 종료 대기 흐름이 개선되어 잘못된 재개를 줄이고, 재시작 안내가 더 명확해졌습니다.
  * 재개 시 최신 `dispatch_interrupted` 여부 및 환경 스냅샷 누락 백필이 보강되었습니다.
* **Documentation**
  * “Known events today” 표에 `dispatch_interrupted`가 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->