### PR TITLE
relay-config vocabulary rewrite: routes.json mutations + add-route alias (#781 A2)

### DIFF
--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -1,34 +1,34 @@
 ---
 name: relay-config
 argument-hint: "[setup request or command]"
-description: Interactive setup for relay route policy. Use when the user asks to set up relay, configure company/personal relay policy, enable OpenCode or Pi, allow provider/model routes, check advisory-review policy, or run relay-config doctor/check.
+description: Interactive setup for relay routes. Use when the user asks to set up relay, configure company/personal relay routing, enable OpenCode or Pi, add provider/model routes, check advisory-review routing, or run relay-config doctor/check.
 compatibility: Requires Node.js 18+ and the sibling relay-dispatch skill.
 metadata:
   related-skills: "relay, relay-dispatch, relay-review"
-  keywords: "relay setup, relay config, route policy, model route, opencode, pi, advisory review, 릴레이 설정, 회사 설정, 개인 설정"
+  keywords: "relay setup, relay config, route config, model route, opencode, pi, advisory review, 릴레이 설정, 회사 설정, 개인 설정"
   entry: scripts/relay-config.js
 ---
 ## Inputs
-- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; relay policy writes to `RELAY_POLICY_PATH` or `~/.relay/policy.json`; optional `RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS` defaults model-list probes to `20000` ms.
-- Files: effective relay policy, optional repo `.relay/policy.json`, optional `~/.relay/executors.json`.
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`; writes go to `${RELAY_HOME:-~/.relay}/routes.json`; legacy `~/.relay/policy.json`, repo `.relay/policy.json`, and `~/.relay/executors.json` are read fallback only when routes.json is absent; optional `RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS` defaults model-list probes to `20000` ms.
+- Files: effective relay routes, optional repo `.relay/routes.json`, legacy fallback files listed above.
 - Sibling scripts: `${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js`, `${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/relay-config.js`.
 
 # Relay Config
 
-Set up relay route policy interactively. The user should not have to memorize command flags.
+Set up relay routes interactively. The user should not have to memorize command flags.
 
 ## Use when
 
 - The user asks to set up or configure relay
-- The user wants company-safe defaults, personal OpenCode/Pi opt-in, or advisory-review routing
-- The user asks whether a provider/model route such as `example/opencode-model-*` or `openai/*` is allowed
-- The user asks to run relay policy doctor/check
+- The user wants company-safe strict mode, personal open mode, OpenCode/Pi opt-in, or advisory-review routing
+- The user asks whether a provider/model route such as `example/opencode-model-*` or `openai/*` is available
+- The user asks to run relay doctor/check
 
 ## Do not use when
 
-- Dispatching implementation work — use `relay-dispatch`
-- Reviewing PRs — use `relay-review`
-- Coordinating parallel implementation leaves — use `relay-fleet`
+- Dispatching implementation work - use `relay-dispatch`
+- Reviewing PRs - use `relay-review`
+- Coordinating parallel implementation leaves - use `relay-fleet`
 
 ## Workflow
 
@@ -40,31 +40,31 @@ Always start with:
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" inspect --json
 ```
 
-Use the output to identify the effective policy, policy source paths, installed harnesses, and whether `~/.relay/executors.json` exists.
+Use the output to identify the effective routes, source paths, installed harnesses, and whether `~/.relay/executors.json` exists as a legacy fallback.
 
 ### 2. Infer the setup intent
 
 Infer from the user's words before asking questions:
 
-- `company`, `work`, `회사` → company profile
-- `personal`, `home`, `집`, `개인` → personal profile
-- `managed only`, `codex/claude only` → no unmanaged route opt-in
-- routes containing `/`, such as `example/opencode-model-*`, `example/pi-*`, `openai/*`, or `ollama/*` → provider/model route patterns
-- `advisory`, `reviewer`, `documentation`, `docs` → likely advisory-review phases
+- `company`, `work`, `회사` -> strict company profile
+- `personal`, `home`, `집`, `개인` -> open personal profile
+- `managed only`, `codex/claude only` -> no unmanaged provider/model route opt-in
+- routes containing `/`, such as `example/opencode-model-*`, `example/pi-*`, `openai/*`, or `ollama/*` -> provider/model route patterns
+- `advisory`, `reviewer`, `documentation`, `docs` -> likely advisory-review phases
 
 Ask only for missing decisions, one at a time. Use plain language and wait for the user's answer. Do not use host-specific question primitives as the only path; this skill must work in both Claude Code and Codex.
 
 ### 3. Propose before writing
 
-Before mutating policy, show a concise proposal:
+Before mutating routes, show a concise proposal:
 
-- profile to initialize or keep
+- profile to initialize or keep (`company` writes `strict: true`; `personal` writes `strict: false`)
 - managed CLIs that remain model-less (`codex`, `claude`)
-- allowed provider/model routes to add
+- provider/model routes to add
 - phases and actors for each route
 - default actors to set, if any
 
-Ask for confirmation. If the user already explicitly approved the exact policy in the same request, proceed and state what will be written.
+Ask for confirmation. If the user already explicitly approved the exact route changes in the same request, proceed and state what will be written.
 
 ### 4. Apply with deterministic commands
 
@@ -72,7 +72,7 @@ Use the wrapper for shorthand, or pass through full flags:
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" init company
-node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" allow-route 'example/opencode-model-*' --phase dispatch,advisory_review --executor opencode
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" add-route 'example/opencode-model-*' --phase dispatch,advisory_review --executor opencode
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
 ```
 
@@ -100,8 +100,9 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `init personal` | `init --profile personal` |
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
+| `add-route example/opencode-model-* --phase dispatch --executor opencode` | `add-route example/opencode-model-* --phase dispatch --executor opencode` |
 | `check dispatch opencode example/opencode-model-fast` | `check --phase dispatch --executor opencode --model example/opencode-model-fast` |
 | `check review opencode example/opencode-model-fast` | `check --phase review --reviewer opencode --model example/opencode-model-fast` |
 | `check advisory_review pi example/pi-model-fast` | `check --phase advisory_review --reviewer pi --model example/pi-model-fast` |
 
-Full flag forms continue to pass through. Policy semantics live in the sibling `relay-dispatch` script, not this wrapper.
+Full flag forms continue to pass through. Route semantics live in the sibling `relay-dispatch` script, not this wrapper.

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -30,7 +30,7 @@ function printJson(value) {
 function printHelp() {
   console.log("Usage: relay-config <command> [options]");
   console.log("");
-  console.log("Interactive relay route-policy setup helper. Use the skill for natural-language setup, or this wrapper for deterministic shorthand.");
+  console.log("Interactive relay route setup helper. Use the skill for natural-language setup, or this wrapper for deterministic shorthand.");
   console.log("");
   console.log("Common setup requests:");
   console.log('  "relay setup 해줘"');
@@ -43,11 +43,12 @@ function printHelp() {
   console.log("  show [--json]");
   console.log("  doctor [--json]");
   console.log("  check <phase> <actor> [provider/model] [--json]");
-  console.log("  allow-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");
+  console.log("  add-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");
+  console.log("  allow-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json] (deprecated; use add-route)");
   console.log("  deny-route <pattern> [--phase <csv>] [--executor <name>] [--reviewer <name>] [--json]");
   console.log("  set-default <path> <value> [--json]");
   console.log("");
-  console.log("Policy boundary: executor/reviewer names are harnesses; provider/model route strings are the compliance boundary.");
+  console.log("Routing boundary: executor/reviewer names are harnesses; provider/model route strings are the routing boundary.");
 }
 
 function runCore(args, { capture = false } = {}) {
@@ -78,6 +79,11 @@ function parseJsonOutput(result, label) {
   }
 }
 
+function displayToolRouteStatus(tool) {
+  if (tool.policy === "policy-disallowed") return "route-disallowed";
+  return tool.policy;
+}
+
 function inspect(jsonOut) {
   const showResult = runCore(["show", "--effective", "--json"], { capture: true });
   const doctorResult = runCore(["doctor", "--json"], { capture: true });
@@ -104,15 +110,17 @@ function inspect(jsonOut) {
   }
 
   console.log(`relay-config inspect: ${output.ok ? "ok" : "failed"}`);
-  console.log(`policy status: ${policy.status || "unknown"}`);
-  if (policy.sources?.global) console.log(`global policy: ${policy.sources.global}`);
-  if (policy.sources?.repo) console.log(`repo policy: ${policy.sources.repo}`);
+  console.log(`routes status: ${policy.status || "unknown"}`);
+  if (policy.sources?.routes?.global) console.log(`global config: ${policy.sources.routes.global}`);
+  else if (policy.sources?.global) console.log(`global config: ${policy.sources.global}`);
+  if (policy.sources?.routes?.project) console.log(`repo config: ${policy.sources.routes.project}`);
+  else if (policy.sources?.repo) console.log(`repo config: ${policy.sources.repo}`);
   console.log(`project config: ${projectConfig.status} at ${projectConfig.path || "(unresolved)"}`);
   console.log(`executors config: ${output.executorsConfig.exists ? "present" : "missing"} at ${configPath}`);
   if (Array.isArray(doctor.tools)) {
     for (const tool of doctor.tools) {
       const installed = tool.installed ? `installed at ${tool.path}` : "not installed on PATH";
-      console.log(`${tool.name}: ${installed}; ${tool.policy} (${tool.reason})`);
+      console.log(`${tool.name}: ${installed}; ${displayToolRouteStatus(tool)} (${tool.reason})`);
     }
   }
   return ok ? 0 : 1;

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -4,15 +4,18 @@ const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const {
-  buildDefaultRelayPolicy,
   evaluateRelayRoute,
   loadRelayPolicy,
   resolveRelayPolicyPath,
-  validateRelayPolicy,
 } = require("./relay-policy");
 const { loadProjectConfig } = require("./project-config");
 const { getProjectConfigPath, getProjectPolicyPath, getProjectRoutesPath, getRepoSlug } = require("./manifest/paths");
-const { loadProjectRoutes, resolveRouteIntent } = require("./relay-routing");
+const {
+  loadProjectRoutes,
+  resolveGlobalRoutesPath,
+  resolveRouteIntent,
+  validateRouteConfig,
+} = require("./relay-routing");
 const {
   findUnknownFlags,
   getPositionals,
@@ -40,6 +43,7 @@ const SUBCOMMAND_FLAGS = {
   check: new Set(["--phase", "--executor", "--reviewer", "--model", "--json", "--help"]),
   "plan-run": new Set(["--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file", "--json", "--help"]),
   "set-default": new Set(["--json", "--help"]),
+  "add-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
   "allow-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
   "deny-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
 };
@@ -64,7 +68,7 @@ function printJson(value) {
 function printHelp() {
   console.log("Usage: relay-config.js <command> [options]");
   console.log("");
-  console.log("Configure relay provider/model route policy. Executor/reviewer names are harnesses; provider/model route strings are the policy boundary.");
+  console.log("Configure relay provider/model routes. Executor/reviewer names are harnesses; provider/model route strings are the routing boundary.");
   console.log("");
   console.log("Commands:");
   console.log(`  init --profile <company|personal> ${modeLabel("--profile")} [--json ${modeLabel("--json")}]`);
@@ -73,7 +77,8 @@ function printHelp() {
   console.log(`  check --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <provider/model> ${modeLabel("--model")}] [--json ${modeLabel("--json")}]`);
   console.log(`  plan-run [--repo <path> ${modeLabel("--repo")}] [--dispatch <actor[:provider/model]> ${modeLabel("--dispatch")}] [--review <actor[:provider/model]> ${modeLabel("--review")}] [--advisory-review <actor[:provider/model]> ${modeLabel("--advisory-review")}] [--route-intent-file <path> ${modeLabel("--route-intent-file")}] [--json ${modeLabel("--json")}]`);
   console.log("  set-default <path> <value> [--json]");
-  console.log(`  allow-route <pattern> --phase <csv> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
+  console.log(`  add-route <pattern> --phase <csv> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
+  console.log(`  allow-route <pattern> --phase <csv> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}] (deprecated; use add-route)`);
   console.log(`  deny-route <pattern> [--phase <csv> ${modeLabel("--phase")}] [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
   console.log("");
   console.log("Supported default paths:");
@@ -102,38 +107,64 @@ function unsupportedFlagsForCommand(command, argv) {
   return [...new Set(unsupported)];
 }
 
-function relayPolicyPath() {
-  return resolveRelayPolicyPath();
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function writePolicy(policyPath, policy) {
-  const normalized = validateRelayPolicy(policy, policyPath);
-  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
-  fs.writeFileSync(policyPath, `${JSON.stringify(normalized, null, 2)}\n`, "utf-8");
-  return normalized;
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
 }
 
-function loadGlobalPolicyForMutation() {
-  const policyPath = relayPolicyPath();
-  const result = loadRelayPolicy({ globalPath: policyPath, repoRoot: null });
-  if (!result.ok) {
-    const error = result.errors[0];
-    throw new Error(error ? error.message : "failed to load relay policy");
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function relayRoutesPath() {
+  return resolveGlobalRoutesPath();
+}
+
+function readRoutesFile(routesPath) {
+  try {
+    return JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+  } catch (error) {
+    throw new Error(`failed to read routes config at ${routesPath}: ${error.message}`);
   }
+}
+
+function legacyShadowWarnings({ routesExisted }) {
+  if (routesExisted) return [];
+  if (!fs.existsSync(resolveRelayPolicyPath())) return [];
+  return [
+    "routes.json now takes precedence; legacy policy.json/executors.json are ignored until migration arrives in Phase C",
+  ];
+}
+
+function loadRoutesForMutation() {
+  const routesPath = relayRoutesPath();
+  const routesExisted = fs.existsSync(routesPath);
+  if (!routesExisted) {
+    return {
+      routesPath,
+      routesExisted,
+      routes: { version: 2 },
+      warnings: legacyShadowWarnings({ routesExisted }),
+    };
+  }
+  const routes = readRoutesFile(routesPath);
+  validateRouteConfig(routes, routesPath);
   return {
-    policyPath,
-    policy: result.policy,
+    routesPath,
+    routesExisted,
+    routes,
+    warnings: legacyShadowWarnings({ routesExisted }),
   };
 }
 
-function buildProfilePolicy(profile) {
-  return validateRelayPolicy(
-    {
-      ...buildDefaultRelayPolicy(),
-      profile,
-    },
-    `${profile} relay policy`
-  );
+function writeRoutes(routesPath, routes) {
+  validateRouteConfig(routes, routesPath);
+  fs.mkdirSync(path.dirname(routesPath), { recursive: true });
+  fs.writeFileSync(routesPath, `${JSON.stringify(routes, null, 2)}\n`, "utf-8");
+  return routes;
 }
 
 function requireValue(value, label) {
@@ -198,19 +229,22 @@ function routeEntry(pattern, { phases, executor, reviewer }) {
   return entry;
 }
 
-function outputMutation({ jsonOut, action, policyPath, policy, entry = null, defaultPath = null }) {
+function outputMutation({ jsonOut, action, routesPath, routes, entry = null, defaultPath = null, profile = null, warnings = [] }) {
   if (jsonOut) {
     printJson({
       ok: true,
       action,
-      path: policyPath,
+      profile,
+      path: routesPath,
       defaultPath,
       entry,
-      policy,
+      routes,
+      warnings,
     });
     return;
   }
-  console.log(`relay-config: ${action} wrote ${policyPath}`);
+  for (const warning of warnings) console.log(`warning: ${warning}`);
+  console.log(`relay-config: ${action} wrote ${routesPath}`);
 }
 
 function commandInit(positionals, jsonOut) {
@@ -218,19 +252,14 @@ function commandInit(positionals, jsonOut) {
     throw new Error("init does not accept positional arguments");
   }
   const profile = requireValue(readArg(args, "--profile", undefined, CLI_ARG_OPTIONS), "--profile");
-  const policyPath = relayPolicyPath();
-  const policy = writePolicy(policyPath, buildProfilePolicy(profile));
-  if (jsonOut) {
-    printJson({
-      ok: true,
-      action: "init",
-      profile,
-      path: policyPath,
-      policy,
-    });
-  } else {
-    console.log(`relay-config: initialized ${profile} policy at ${policyPath}`);
-  }
+  const { routesPath, routes, warnings } = loadRoutesForMutation();
+  const updated = cloneJson(routes);
+  updated.version = 2;
+  updated.strict = profile === "company";
+  if (!hasOwn(updated, "routes")) updated.routes = [];
+  if (!hasOwn(updated, "denied_routes")) updated.denied_routes = [];
+  const written = writeRoutes(routesPath, updated);
+  outputMutation({ jsonOut, action: "init", profile, routesPath, routes: written, warnings });
 }
 
 function commandShow(positionals, jsonOut) {
@@ -245,12 +274,14 @@ function commandShow(positionals, jsonOut) {
   if (jsonOut) {
     printJson(result);
   } else if (result.ok) {
-    console.log(`relay-config: effective policy status ${result.status}`);
-    console.log(`global: ${result.sources.global}`);
-    if (result.sources.repo) console.log(`repo: ${result.sources.repo}`);
+    console.log(`relay-config: effective routes status ${result.status}`);
+    const globalSource = result.sources.routes?.global || result.sources.global;
+    const repoSource = result.sources.routes?.project || result.sources.repo || result.sources.project;
+    console.log(`global config: ${globalSource}`);
+    if (repoSource) console.log(`repo config: ${repoSource}`);
     console.log(JSON.stringify(result.policy, null, 2));
   } else {
-    console.log("relay-config: effective policy failed to load");
+    console.log("relay-config: effective routes failed to load");
     for (const error of result.errors) {
       console.log(`${error.reason}: ${error.message}`);
     }
@@ -359,6 +390,11 @@ function doctorTool(policy, name) {
   };
 }
 
+function displayToolRouteStatus(tool) {
+  if (tool.policy === "policy-disallowed") return "route-disallowed";
+  return tool.policy;
+}
+
 function commandDoctor(positionals, jsonOut) {
   if (positionals.length !== 1) {
     throw new Error("doctor does not accept positional arguments");
@@ -367,7 +403,7 @@ function commandDoctor(positionals, jsonOut) {
   if (!result.ok) {
     if (jsonOut) printJson({ ok: false, status: result.status, sources: result.sources, errors: result.errors });
     else {
-      console.error("relay-config doctor: policy failed to load");
+      console.error("relay-config doctor: routes failed to load");
       for (const error of result.errors) console.error(`${error.reason}: ${error.message}`);
     }
     process.exitCode = 1;
@@ -395,10 +431,10 @@ function commandDoctor(positionals, jsonOut) {
   if (jsonOut) {
     printJson(output);
   } else {
-    console.log(`relay-config doctor: policy ${result.status}`);
+    console.log(`relay-config doctor: routes ${result.status}`);
     for (const tool of tools) {
       const installed = tool.installed ? `installed at ${tool.path}` : "not installed on PATH";
-      console.log(`${tool.name}: ${installed}; ${tool.policy} (${tool.reason})`);
+      console.log(`${tool.name}: ${installed}; ${displayToolRouteStatus(tool)} (${tool.reason})`);
     }
   }
 }
@@ -467,6 +503,10 @@ function readRouteIntentFile(filePath) {
   return parsed;
 }
 
+function humanWarning(warning) {
+  return String(warning).replace(/\bpolicy label\b/g, "route label");
+}
+
 function commandPlanRun(positionals, jsonOut) {
   if (positionals.length !== 1) {
     throw new Error("plan-run does not accept positional arguments");
@@ -501,7 +541,7 @@ function commandPlanRun(positionals, jsonOut) {
       warnings: [],
     };
     if (jsonOut) printJson(output);
-    else console.error(`relay-config plan-run: policy failed: ${policyResult.errors?.[0]?.message || "unknown policy error"}`);
+    else console.error(`relay-config plan-run: routes failed: ${policyResult.errors?.[0]?.message || "unknown route config error"}`);
     process.exitCode = 1;
     return;
   }
@@ -568,9 +608,9 @@ function commandPlanRun(positionals, jsonOut) {
     console.log(`relay-config plan-run: ${output.status}`);
     for (const phase of phaseValues) {
       const actor = phase.executor || phase.reviewer || "(none)";
-      console.log(`${phase.phase}: ${actor} model=${phase.model || "(none)"} policy=${phase.policy_decision.reason}`);
+      console.log(`${phase.phase}: ${actor} model=${phase.model || "(none)"} decision=${phase.policy_decision.reason}`);
     }
-    for (const warning of warnings) console.log(`warning: ${warning}`);
+    for (const warning of warnings) console.log(`warning: ${humanWarning(warning)}`);
   }
   if (!output.ok) process.exitCode = 1;
 }
@@ -585,14 +625,16 @@ function commandSetDefault(positionals, jsonOut) {
     throw new Error(`unsupported default path: ${defaultPath}`);
   }
 
-  const { policyPath, policy } = loadGlobalPolicyForMutation();
+  const { routesPath, routes, warnings } = loadRoutesForMutation();
+  const updated = cloneJson(routes);
   const [phase, field] = defaultPath.split(".");
-  policy.defaults[phase] = {
-    ...(policy.defaults[phase] || {}),
+  if (!hasOwn(updated, "defaults")) updated.defaults = {};
+  updated.defaults[phase] = {
+    ...(isPlainObject(updated.defaults[phase]) ? updated.defaults[phase] : {}),
     [field]: value,
   };
-  const updated = writePolicy(policyPath, policy);
-  outputMutation({ jsonOut, action: "set-default", policyPath, policy: updated, defaultPath });
+  const written = writeRoutes(routesPath, updated);
+  outputMutation({ jsonOut, action: "set-default", routesPath, routes: written, defaultPath, warnings });
 }
 
 function commandRouteMutation(positionals, jsonOut, { action, listName, requirePhase }) {
@@ -605,10 +647,12 @@ function commandRouteMutation(positionals, jsonOut, { action, listName, requireP
   const reviewer = readArg(args, "--reviewer", undefined, CLI_ARG_OPTIONS);
   const entry = routeEntry(pattern, { phases, executor, reviewer });
 
-  const { policyPath, policy } = loadGlobalPolicyForMutation();
-  policy[listName].push(entry);
-  const updated = writePolicy(policyPath, policy);
-  outputMutation({ jsonOut, action, policyPath, policy: updated, entry });
+  const { routesPath, routes, warnings } = loadRoutesForMutation();
+  const updated = cloneJson(routes);
+  if (!hasOwn(updated, listName)) updated[listName] = [];
+  updated[listName].push(entry);
+  const written = writeRoutes(routesPath, updated);
+  outputMutation({ jsonOut, action, routesPath, routes: written, entry, warnings });
 }
 
 function main() {
@@ -656,17 +700,25 @@ function main() {
     case "set-default":
       commandSetDefault(positionals, jsonOut);
       break;
-    case "allow-route":
+    case "add-route":
       commandRouteMutation(positionals, jsonOut, {
-        action: "allow-route",
-        listName: "allowed_model_routes",
+        action: "add-route",
+        listName: "routes",
+        requirePhase: true,
+      });
+      break;
+    case "allow-route":
+      console.error("Warning: allow-route is deprecated; use add-route");
+      commandRouteMutation(positionals, jsonOut, {
+        action: "add-route",
+        listName: "routes",
         requirePhase: true,
       });
       break;
     case "deny-route":
       commandRouteMutation(positionals, jsonOut, {
         action: "deny-route",
-        listName: "denied_model_routes",
+        listName: "denied_routes",
         requirePhase: false,
       });
       break;

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -252,13 +252,18 @@ function commandInit(positionals, jsonOut) {
     throw new Error("init does not accept positional arguments");
   }
   const profile = requireValue(readArg(args, "--profile", undefined, CLI_ARG_OPTIONS), "--profile");
-  const { routesPath, routes, warnings } = loadRoutesForMutation();
-  const updated = cloneJson(routes);
-  updated.version = 2;
-  updated.strict = profile === "company";
-  if (!hasOwn(updated, "routes")) updated.routes = [];
-  if (!hasOwn(updated, "denied_routes")) updated.denied_routes = [];
-  const written = writeRoutes(routesPath, updated);
+  // Overwrite semantics: init builds the profile shape from scratch so it can
+  // also recover from an invalid existing routes.json. Only the legacy-shadow
+  // warning depends on prior filesystem state.
+  const routesPath = relayRoutesPath();
+  const routesExisted = fs.existsSync(routesPath);
+  const warnings = legacyShadowWarnings({ routesExisted });
+  const written = writeRoutes(routesPath, {
+    version: 2,
+    strict: profile === "company",
+    routes: [],
+    denied_routes: [],
+  });
   outputMutation({ jsonOut, action: "init", profile, routesPath, routes: written, warnings });
 }
 

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -5,10 +5,6 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const {
-  validateRelayPolicy,
-} = require("../../../skills/relay-dispatch/scripts/relay-policy");
-
 const REPO_ROOT = path.join(__dirname, "..", "..", "..");
 const SCRIPT = path.join(REPO_ROOT, "skills", "relay-config", "scripts", "relay-config.js");
 
@@ -51,23 +47,24 @@ function parseJson(result) {
   return JSON.parse(result.stdout);
 }
 
-function readPolicy(relayHome) {
-  const policyPath = path.join(relayHome, "policy.json");
-  const policy = JSON.parse(fs.readFileSync(policyPath, "utf-8"));
-  return validateRelayPolicy(policy, policyPath);
+function readRoutes(relayHome) {
+  return JSON.parse(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"));
 }
 
-test("init company shorthand delegates to core init --profile company", () => {
+test("init company shorthand delegates to core init --profile company routes config", () => {
   const relayHome = tempDir();
 
   const result = runConfig(["init", "company", "--json"], { relayHome });
 
   assert.equal(result.status, 0, result.combined);
   assert.equal(parseJson(result).profile, "company");
-  const policy = readPolicy(relayHome);
-  assert.equal(policy.profile, "company");
-  assert.deepEqual(policy.managed_cli, ["codex", "claude"]);
-  assert.equal(Object.prototype.hasOwnProperty.call(policy.defaults.dispatch, "model"), false);
+  assert.deepEqual(readRoutes(relayHome), {
+    version: 2,
+    strict: true,
+    routes: [],
+    denied_routes: [],
+  });
+  assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), false);
 });
 
 test("show shorthand adds --effective", () => {
@@ -80,14 +77,15 @@ test("show shorthand adds --effective", () => {
   const output = parseJson(result);
   assert.equal(output.ok, true);
   assert.equal(output.status, "ok");
-  assert.equal(output.policy.profile, "personal");
+  assert.equal(output.policy.profile, "routes-config");
+  assert.equal(output.policy.deny_unknown_model_routes, false);
 });
 
 test("check shorthand maps reviewer phases to reviewer-only core checks", () => {
   const relayHome = tempDir();
   assert.equal(runConfig(["init", "company", "--json"], { relayHome }).status, 0);
   assert.equal(runConfig([
-    "allow-route",
+    "add-route",
     "example/opencode-model-*",
     "--phase",
     "advisory_review",
@@ -126,12 +124,25 @@ test("inspect reports effective policy, doctor output, and executors config stat
   assert.ok(output.doctor.tools.some((tool) => tool.name === "codex"));
 });
 
+test("inspect human output describes routes without policy prose", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig(["inspect"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  assert.match(result.stdout, /routes status:/i);
+  assert.doesNotMatch(result.stdout.replace(/policy\.json/g, "legacy-file"), /\bpolicy\b/i);
+});
+
 test("help advertises natural-language setup and provider/model boundary", () => {
   const result = runConfig(["--help"]);
 
   assert.equal(result.status, 0, result.combined);
   assert.match(result.stdout, /relay setup 해줘/);
-  assert.match(result.stdout, /provider\/model route strings are the compliance boundary/i);
+  assert.match(result.stdout, /provider\/model route strings are the routing boundary/i);
+  assert.match(result.stdout, /add-route <pattern>/);
+  assert.match(result.stdout, /allow-route <pattern>.*deprecated/i);
+  assert.doesNotMatch(result.stdout, /\bpolicy\b/i);
 });
 
 test("inspect rejects unsupported arguments instead of ignoring them", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -9,6 +9,9 @@ const {
   buildDefaultRelayPolicy,
   validateRelayPolicy,
 } = require("../../../skills/relay-dispatch/scripts/relay-policy");
+const {
+  validateRouteConfig,
+} = require("../../../skills/relay-dispatch/scripts/relay-routing");
 const { getProjectPolicyPath } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 
 const REPO_ROOT = path.join(__dirname, "..", "..", "..");
@@ -50,10 +53,27 @@ function parseJson(result) {
   return JSON.parse(result.stdout);
 }
 
+function parseJsonAllowingStderr(result) {
+  return JSON.parse(result.stdout);
+}
+
 function readPolicy(relayHome) {
   const policyPath = path.join(relayHome, "policy.json");
   const policy = JSON.parse(fs.readFileSync(policyPath, "utf-8"));
   return validateRelayPolicy(policy, policyPath);
+}
+
+function readRoutes(relayHome) {
+  return JSON.parse(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"));
+}
+
+function validateRoutes(relayHome) {
+  const routesPath = path.join(relayHome, "routes.json");
+  return validateRouteConfig(readRoutes(relayHome), routesPath);
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
 }
 
 function writeExecutable(filePath, body = "#!/bin/sh\nexit 0\n") {
@@ -72,7 +92,7 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
 }
 
-test("init --profile company writes a company-safe global policy", () => {
+test("init --profile company writes strict global routes config without optional scaffolding", () => {
   const relayHome = tempDir();
 
   const result = runConfig(["init", "--profile", "company", "--json"], { relayHome });
@@ -81,38 +101,35 @@ test("init --profile company writes a company-safe global policy", () => {
   const output = parseJson(result);
   assert.equal(output.ok, true);
   assert.equal(output.profile, "company");
-  assert.equal(output.path, path.join(relayHome, "policy.json"));
+  assert.equal(output.path, path.join(relayHome, "routes.json"));
+  assert.deepEqual(output.warnings, []);
 
-  const policy = readPolicy(relayHome);
-  assert.equal(policy.profile, "company");
-  assert.deepEqual(policy.defaults, {
-    dispatch: { executor: "codex" },
-    review: { reviewer: "codex" },
-    advisory_review: null,
+  assert.deepEqual(readRoutes(relayHome), {
+    version: 2,
+    strict: true,
+    routes: [],
+    denied_routes: [],
   });
-  assert.deepEqual(policy.managed_cli, ["codex", "claude"]);
-  assert.deepEqual(policy.allowed_model_routes, []);
-  assert.deepEqual(policy.denied_model_routes, []);
-  assert.equal(policy.deny_unknown_model_routes, true);
-  assert.equal(Object.prototype.hasOwnProperty.call(policy.defaults.dispatch, "model"), false);
-  assert.equal(Object.prototype.hasOwnProperty.call(policy.defaults.review, "model"), false);
+  assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), false);
+  assert.deepEqual(validateRoutes(relayHome).routes, []);
 });
 
-test("init --profile personal remains explicit and does not add OpenCode or Pi routes", () => {
+test("init --profile personal writes open global routes config without optional scaffolding", () => {
   const relayHome = tempDir();
 
   const result = runConfig(["init", "--profile", "personal", "--json"], { relayHome });
 
   assert.equal(result.status, 0, result.combined);
-  const policy = readPolicy(relayHome);
-  assert.equal(policy.profile, "personal");
-  assert.deepEqual(policy.managed_cli, ["codex", "claude"]);
-  assert.deepEqual(policy.allowed_model_routes, []);
-  assert.deepEqual(policy.denied_model_routes, []);
-  assert.equal(policy.deny_unknown_model_routes, true);
+  assert.deepEqual(readRoutes(relayHome), {
+    version: 2,
+    strict: false,
+    routes: [],
+    denied_routes: [],
+  });
+  assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), false);
 });
 
-test("show --effective emits deterministic JSON for the loaded effective policy", () => {
+test("show --effective emits deterministic JSON for routes-backed config", () => {
   const relayHome = tempDir();
   assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
 
@@ -122,8 +139,26 @@ test("show --effective emits deterministic JSON for the loaded effective policy"
   const output = parseJson(result);
   assert.equal(output.ok, true);
   assert.equal(output.status, "ok");
+  assert.equal(output.sources.routes.global, path.join(relayHome, "routes.json"));
+  assert.equal(output.policy.profile, "routes-config");
+  assert.equal(output.policy.deny_unknown_model_routes, true);
+});
+
+test("show --effective preserves legacy policy-only JSON behavior", () => {
+  const relayHome = tempDir();
+  writeJson(path.join(relayHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "legacy-company",
+  });
+
+  const result = runConfig(["show", "--effective", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.status, "ok");
   assert.equal(output.sources.global, path.join(relayHome, "policy.json"));
-  assert.equal(output.policy.profile, "company");
+  assert.equal(output.policy.profile, "legacy-company");
 });
 
 test("doctor uses local PATH only and labels installed disallowed harnesses as policy-disallowed", () => {
@@ -271,23 +306,26 @@ test("check exits non-zero for missing and unknown OpenCode/Pi provider routes",
   assert.equal(parseJson(unknown).decision.reason, "unknown_model_route");
 });
 
-test("set-default mutates supported default actor paths and preserves v1 policy shape", () => {
+test("set-default writes exactly the requested default path in routes config", () => {
   const relayHome = tempDir();
-  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
 
   const advisory = runConfig(["set-default", "advisory_review.reviewer", "claude", "--json"], { relayHome });
   assert.equal(advisory.status, 0, advisory.combined);
 
-  const policy = readPolicy(relayHome);
-  assert.deepEqual(policy.defaults.advisory_review, { reviewer: "claude" });
+  assert.deepEqual(readRoutes(relayHome), {
+    version: 2,
+    defaults: {
+      advisory_review: { reviewer: "claude" },
+    },
+  });
 });
 
-test("allow-route maps mixed executor phases to executors and reviewer phases to reviewers", () => {
+test("add-route maps mixed executor phases to executors and reviewer phases to reviewers", () => {
   const relayHome = tempDir();
   assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
 
   const mutation = runConfig([
-    "allow-route",
+    "add-route",
     "example/opencode-model-*",
     "--executor",
     "opencode",
@@ -297,7 +335,7 @@ test("allow-route maps mixed executor phases to executors and reviewer phases to
   ], { relayHome });
   assert.equal(mutation.status, 0, mutation.combined);
 
-  const [entry] = readPolicy(relayHome).allowed_model_routes;
+  const [entry] = readRoutes(relayHome).routes;
   assert.equal(entry.route, "example/opencode-model-*");
   assert.deepEqual(new Set(entry.phases), new Set(["advisory_review", "dispatch"]));
   assert.deepEqual(entry.executors, ["opencode"]);
@@ -336,7 +374,7 @@ test("check requires only the actor role required by the selected phase", () => 
   const relayHome = tempDir();
   assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
   assert.equal(runConfig([
-    "allow-route",
+    "add-route",
     "example/opencode-model-*",
     "--reviewer",
     "opencode",
@@ -402,7 +440,7 @@ test("deny-route preserves route scopes and denied routes win during check", () 
   const relayHome = tempDir();
   assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
   assert.equal(runConfig([
-    "allow-route",
+    "add-route",
     "example/opencode-model-*",
     "--executor",
     "opencode",
@@ -422,7 +460,7 @@ test("deny-route preserves route scopes and denied routes win during check", () 
   ], { relayHome });
   assert.equal(mutation.status, 0, mutation.combined);
 
-  const [entry] = readPolicy(relayHome).denied_model_routes;
+  const [entry] = readRoutes(relayHome).denied_routes;
   assert.deepEqual(entry, {
     route: "example/opencode-model-bad",
     phases: ["dispatch"],
@@ -441,6 +479,219 @@ test("deny-route preserves route scopes and denied routes win during check", () 
   ], { relayHome });
   assert.notEqual(denied.status, 0, denied.combined);
   assert.equal(parseJson(denied).decision.reason, "denied_model_route");
+});
+
+test("allow-route is a deprecated alias with stdout parity and one stderr line", () => {
+  const relayHome = tempDir();
+  const args = [
+    "add-route",
+    "example/opencode-model-*",
+    "--executor",
+    "opencode",
+    "--phase",
+    "dispatch",
+    "--json",
+  ];
+  const addRoute = runConfig(args, { relayHome });
+  assert.equal(addRoute.status, 0, addRoute.combined);
+
+  fs.unlinkSync(path.join(relayHome, "routes.json"));
+  const alias = runConfig(["allow-route", ...args.slice(1)], { relayHome });
+  assert.equal(alias.status, 0, alias.combined);
+  assert.equal(alias.stdout, addRoute.stdout);
+  const stderrLines = alias.stderr.trim().split(/\r?\n/).filter(Boolean);
+  assert.equal(stderrLines.length, 1);
+  assert.match(stderrLines[0], /allow-route is deprecated; use add-route/i);
+  assert.equal(parseJsonAllowingStderr(alias).action, "add-route");
+});
+
+test("mutation commands create routes.json, preserve existing v2 fields, and warn only when shadowing legacy config", () => {
+  const specs = [
+    {
+      name: "init",
+      args: ["init", "--profile", "company", "--json"],
+      assertCreated(routes) {
+        assert.deepEqual(routes, {
+          version: 2,
+          strict: true,
+          routes: [],
+          denied_routes: [],
+        });
+      },
+      assertExisting(routes) {
+        assert.equal(routes.strict, true);
+        assert.deepEqual(routes.routes, [{ route: "openai/existing", phases: ["dispatch"], executors: ["opencode"] }]);
+        assert.deepEqual(routes.denied_routes, [{ route: "openai/blocked", phases: ["review"], reviewers: ["pi"] }]);
+      },
+    },
+    {
+      name: "set-default",
+      args: ["set-default", "review.reviewer", "claude", "--json"],
+      assertCreated(routes) {
+        assert.deepEqual(routes, {
+          version: 2,
+          defaults: {
+            review: { reviewer: "claude" },
+          },
+        });
+      },
+      assertExisting(routes) {
+        assert.deepEqual(routes.defaults, {
+          dispatch: { executor: "opencode" },
+          review: { reviewer: "claude" },
+        });
+      },
+    },
+    {
+      name: "add-route",
+      args: ["add-route", "openai/new", "--phase", "dispatch", "--executor", "opencode", "--json"],
+      assertCreated(routes) {
+        assert.deepEqual(routes, {
+          version: 2,
+          routes: [{ route: "openai/new", phases: ["dispatch"], executors: ["opencode"] }],
+        });
+      },
+      assertExisting(routes) {
+        assert.deepEqual(routes.routes, [
+          { route: "openai/existing", phases: ["dispatch"], executors: ["opencode"] },
+          { route: "openai/new", phases: ["dispatch"], executors: ["opencode"] },
+        ]);
+      },
+    },
+    {
+      name: "deny-route",
+      args: ["deny-route", "openai/new-deny", "--phase", "review", "--reviewer", "pi", "--json"],
+      assertCreated(routes) {
+        assert.deepEqual(routes, {
+          version: 2,
+          denied_routes: [{ route: "openai/new-deny", phases: ["review"], reviewers: ["pi"] }],
+        });
+      },
+      assertExisting(routes) {
+        assert.deepEqual(routes.denied_routes, [
+          { route: "openai/blocked", phases: ["review"], reviewers: ["pi"] },
+          { route: "openai/new-deny", phases: ["review"], reviewers: ["pi"] },
+        ]);
+      },
+    },
+  ];
+
+  for (const spec of specs) {
+    const createdHome = tempDir(`relay-config-${spec.name}-created-`);
+    const created = runConfig(spec.args, { relayHome: createdHome });
+    assert.equal(created.status, 0, `${spec.name} create\n${created.combined}`);
+    assert.deepEqual(parseJson(created).warnings, []);
+    spec.assertCreated(readRoutes(createdHome));
+    assert.equal(fs.existsSync(path.join(createdHome, "policy.json")), false);
+
+    const existingHome = tempDir(`relay-config-${spec.name}-existing-`);
+    writeJson(path.join(existingHome, "routes.json"), {
+      version: 2,
+      strict: true,
+      defaults: {
+        dispatch: { executor: "opencode" },
+      },
+      executor_defaults: {
+        opencode: { model: "openai/existing" },
+      },
+      routes: [{ route: "openai/existing", phases: ["dispatch"], executors: ["opencode"] }],
+      denied_routes: [{ route: "openai/blocked", phases: ["review"], reviewers: ["pi"] }],
+      presets: {
+        fast: { dispatch: { executor: "opencode", model: "openai/existing" } },
+      },
+    });
+    const existing = runConfig(spec.args, { relayHome: existingHome });
+    assert.equal(existing.status, 0, `${spec.name} existing\n${existing.combined}`);
+    assert.deepEqual(parseJson(existing).warnings, []);
+    const existingRoutes = readRoutes(existingHome);
+    spec.assertExisting(existingRoutes);
+    assert.equal(existingRoutes.strict, true);
+    assert.deepEqual(existingRoutes.executor_defaults, {
+      opencode: { model: "openai/existing" },
+    });
+    assert.deepEqual(existingRoutes.presets, {
+      fast: { dispatch: { executor: "opencode", model: "openai/existing" } },
+    });
+
+    const legacyHome = tempDir(`relay-config-${spec.name}-legacy-`);
+    const legacyPath = path.join(legacyHome, "policy.json");
+    const legacyPolicy = {
+      ...buildDefaultRelayPolicy(),
+      profile: "legacy",
+      allowed_model_routes: [{ route: "legacy/*", phases: ["dispatch"], executors: ["opencode"] }],
+    };
+    writeJson(legacyPath, legacyPolicy);
+    const before = fs.readFileSync(legacyPath, "utf-8");
+    const legacy = runConfig(spec.args, { relayHome: legacyHome });
+    assert.equal(legacy.status, 0, `${spec.name} legacy\n${legacy.combined}`);
+    const legacyOutput = parseJson(legacy);
+    assert.equal(legacyOutput.warnings.length, 1);
+    assert.match(legacyOutput.warnings[0], /routes\.json now takes precedence/i);
+    assert.match(legacyOutput.warnings[0], /policy\.json\/executors\.json are ignored/i);
+    assert.equal(fs.readFileSync(legacyPath, "utf-8"), before);
+    assert.equal(fs.existsSync(path.join(legacyHome, "routes.json")), true);
+  }
+});
+
+test("route mutations preserve omitted optional keys and absent default phases", () => {
+  const addHome = tempDir("relay-config-add-omission-");
+  assert.equal(runConfig([
+    "add-route",
+    "openai/new",
+    "--phase",
+    "dispatch",
+    "--executor",
+    "opencode",
+    "--json",
+  ], { relayHome: addHome }).status, 0);
+  const addRoutes = readRoutes(addHome);
+  assert.deepEqual(Object.keys(addRoutes).sort(), ["routes", "version"]);
+  assert.equal(hasOwn(addRoutes, "strict"), false);
+  assert.equal(hasOwn(addRoutes, "defaults"), false);
+  assert.equal(hasOwn(addRoutes, "executor_defaults"), false);
+  assert.equal(hasOwn(addRoutes, "presets"), false);
+
+  const defaultHome = tempDir("relay-config-default-omission-");
+  assert.equal(runConfig([
+    "set-default",
+    "advisory_review.reviewer",
+    "pi",
+    "--json",
+  ], { relayHome: defaultHome }).status, 0);
+  const defaultRoutes = readRoutes(defaultHome);
+  assert.deepEqual(defaultRoutes, {
+    version: 2,
+    defaults: {
+      advisory_review: { reviewer: "pi" },
+    },
+  });
+  assert.equal(hasOwn(defaultRoutes.defaults, "dispatch"), false);
+  assert.equal(hasOwn(defaultRoutes.defaults, "review"), false);
+});
+
+test("validation failure leaves the routes file untouched", () => {
+  const relayHome = tempDir();
+  const routesPath = path.join(relayHome, "routes.json");
+  writeJson(routesPath, {
+    version: 2,
+    routes: [],
+    presets: [],
+  });
+  const before = fs.readFileSync(routesPath, "utf-8");
+
+  const result = runConfig([
+    "add-route",
+    "openai/new",
+    "--phase",
+    "dispatch",
+    "--executor",
+    "opencode",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0, result.combined);
+  assert.match(result.combined, /presets must be an object/);
+  assert.equal(fs.readFileSync(routesPath, "utf-8"), before);
 });
 
 test("invalid args fail closed with non-zero exits", () => {
@@ -474,14 +725,25 @@ test("subcommands reject known relay-config flags outside their supported gramma
   const show = runConfig(["show", "--effective", "--executor", "codex"], { relayHome });
   assert.notEqual(show.status, 0, show.combined);
   assert.match(show.combined, /unsupported flags for show: --executor/);
+
+  const addRoute = runConfig(["add-route", "openai/*", "--phase", "dispatch", "--model", "openai/gpt-5"], { relayHome });
+  assert.notEqual(addRoute.status, 0, addRoute.combined);
+  assert.match(addRoute.combined, /unsupported flags for add-route: --model/);
+
+  const allowRoute = runConfig(["allow-route", "openai/*", "--phase", "dispatch", "--model", "openai/gpt-5"], { relayHome });
+  assert.notEqual(allowRoute.status, 0, allowRoute.combined);
+  assert.match(allowRoute.combined, /unsupported flags for allow-route: --model/);
 });
 
-test("help explains harness actors and provider/model route boundaries", () => {
+test("help explains harness actors and provider/model route boundaries without policy prose", () => {
   const result = runConfig(["--help"]);
 
   assert.equal(result.status, 0, result.combined);
   assert.match(result.stdout, /executor\/reviewer names are harnesses/i);
-  assert.match(result.stdout, /provider\/model route strings are the policy boundary/i);
+  assert.match(result.stdout, /provider\/model route strings are the routing boundary/i);
+  assert.match(result.stdout, /add-route <pattern>/);
+  assert.match(result.stdout, /allow-route <pattern>.*deprecated/i);
+  assert.doesNotMatch(result.stdout, /\bpolicy\b/i);
 });
 
 test("plan-run previews managed Codex dispatch and review routes", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -518,10 +518,16 @@ test("mutation commands create routes.json, preserve existing v2 fields, and war
           denied_routes: [],
         });
       },
+      // init has overwrite semantics: the pre-existing config is replaced by
+      // the fresh profile shape rather than merged into.
+      overwrites: true,
       assertExisting(routes) {
-        assert.equal(routes.strict, true);
-        assert.deepEqual(routes.routes, [{ route: "openai/existing", phases: ["dispatch"], executors: ["opencode"] }]);
-        assert.deepEqual(routes.denied_routes, [{ route: "openai/blocked", phases: ["review"], reviewers: ["pi"] }]);
+        assert.deepEqual(routes, {
+          version: 2,
+          strict: true,
+          routes: [],
+          denied_routes: [],
+        });
       },
     },
     {
@@ -605,13 +611,15 @@ test("mutation commands create routes.json, preserve existing v2 fields, and war
     assert.deepEqual(parseJson(existing).warnings, []);
     const existingRoutes = readRoutes(existingHome);
     spec.assertExisting(existingRoutes);
-    assert.equal(existingRoutes.strict, true);
-    assert.deepEqual(existingRoutes.executor_defaults, {
-      opencode: { model: "openai/existing" },
-    });
-    assert.deepEqual(existingRoutes.presets, {
-      fast: { dispatch: { executor: "opencode", model: "openai/existing" } },
-    });
+    if (!spec.overwrites) {
+      assert.equal(existingRoutes.strict, true);
+      assert.deepEqual(existingRoutes.executor_defaults, {
+        opencode: { model: "openai/existing" },
+      });
+      assert.deepEqual(existingRoutes.presets, {
+        fast: { dispatch: { executor: "opencode", model: "openai/existing" } },
+      });
+    }
 
     const legacyHome = tempDir(`relay-config-${spec.name}-legacy-`);
     const legacyPath = path.join(legacyHome, "policy.json");
@@ -692,6 +700,67 @@ test("validation failure leaves the routes file untouched", () => {
   assert.notEqual(result.status, 0, result.combined);
   assert.match(result.combined, /presets must be an object/);
   assert.equal(fs.readFileSync(routesPath, "utf-8"), before);
+});
+
+test("init overwrites an invalid existing routes.json instead of failing on it", () => {
+  const relayHome = tempDir();
+  const routesPath = path.join(relayHome, "routes.json");
+  writeJson(routesPath, {
+    version: 2,
+    routes: [],
+    presets: [],
+  });
+
+  const result = runConfig(["init", "--profile", "personal", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  assert.deepEqual(readRoutes(relayHome), {
+    version: 2,
+    strict: false,
+    routes: [],
+    denied_routes: [],
+  });
+});
+
+test("init rejects profiles other than company or personal", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig(["init", "--profile", "compnay", "--json"], { relayHome });
+
+  assert.notEqual(result.status, 0, result.combined);
+  assert.match(result.combined, /--profile must be one of: company, personal/);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+});
+
+test("legacy-shadow warning three states in text mode", () => {
+  const warningPattern = /^warning: routes\.json now takes precedence; legacy policy\.json\/executors\.json are ignored/;
+  const mutationArgs = ["add-route", "openai/new", "--phase", "dispatch", "--executor", "opencode"];
+
+  const shadowHome = tempDir("relay-config-text-shadow-");
+  writeJson(path.join(shadowHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "legacy",
+  });
+  const shadow = runConfig(mutationArgs, { relayHome: shadowHome });
+  assert.equal(shadow.status, 0, shadow.combined);
+  const shadowWarningLines = shadow.stdout.split(/\r?\n/).filter((line) => warningPattern.test(line));
+  assert.equal(shadowWarningLines.length, 1, shadow.stdout);
+  assert.match(shadow.stdout, /relay-config: add-route wrote /);
+
+  const existingHome = tempDir("relay-config-text-existing-");
+  writeJson(path.join(existingHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "legacy",
+  });
+  writeJson(path.join(existingHome, "routes.json"), { version: 2, routes: [] });
+  const existing = runConfig(mutationArgs, { relayHome: existingHome });
+  assert.equal(existing.status, 0, existing.combined);
+  assert.doesNotMatch(existing.stdout, /warning:/);
+
+  const freshHome = tempDir("relay-config-text-fresh-");
+  const fresh = runConfig(mutationArgs, { relayHome: freshHome });
+  assert.equal(fresh.status, 0, fresh.combined);
+  assert.doesNotMatch(fresh.stdout, /warning:/);
 });
 
 test("invalid args fail closed with non-zero exits", () => {


### PR DESCRIPTION
## #781 Phase A2 — relay-config vocabulary rewrite

Mutation commands (`init`, `add-route`, `deny-route`, `set-default`) now operate on the unified global `routes.json` (v2, A1 substrate) instead of `policy.json`; `allow-route` survives one release as a deprecated alias; the word "policy" is gone from user-facing prose in the core script, wrapper, and SKILL.md while every JSON key/value and legacy `policy.json` filename reference stays byte-identical.

### What changed

- **Core script** (`skills/relay-dispatch/scripts/relay-config.js`): mutations write the global routes.json via `resolveGlobalRoutesPath` (RELAY_HOME honored) and validate through `validateRouteConfig` before writing; `init company` → `{version:2, strict:true, routes:[], denied_routes:[]}`, `init personal` → same with `strict:false`, both with **overwrite semantics** — init builds the profile shape from scratch (and therefore also recovers from an invalid existing routes.json); `add-route` is the primary spelling (`--phase` still required); non-init mutations never materialize omitted optional keys (`strict`, absent defaults phases, `presets`, `executor_defaults`); a mutation that creates routes.json while a legacy global `policy.json` exists emits a one-line warning (text) / `warnings` array (JSON) — no warning when routes.json already existed or no legacy file exists.
- **Deprecated alias**: `allow-route` = `add-route` with byte-identical stdout and file writes plus exactly one deprecation line on stderr.
- **Wrapper + SKILL.md** (`skills/relay-config/`): help/inspect prose reworded to routes vocabulary; SKILL.md rewritten (routes.json as write target, `add-route` examples, power-user table updated, frontmatter intact, <150 lines).
- **Read commands** (`show`, `doctor`, `check`, `plan-run`, wrapper `inspect`): no behavior change; legacy policy.json-only environments preserved verbatim.

### Review round 2 changes

- `commandInit` rebuilt to overwrite semantics per R1: fresh `{version:2, strict, routes:[], denied_routes:[]}` payload; only the legacy-shadow warning reads prior filesystem state. Matrix test's init case now asserts the full overwritten shape; new tests pin invalid-existing-file recovery and bogus-profile rejection (enforced by the pre-existing `--profile` allowed-values in cli-schema.js).
- Legacy-shadow warning three states now asserted in **text mode** as well as JSON (`legacy-shadow warning three states in text mode`).
- This PR body: complete pre-existing test-edit enumeration (below).

### Pre-existing test edits (enumerated per DC7)

Legend: (a) = pins renamed user-facing prose; (b) = exercises mutation write targets / routes-backed read.

Core suite `tests/relay-dispatch/scripts/relay-config.test.js`:
1. `init --profile company writes a company-safe global policy` → `init --profile company writes strict global routes config without optional scaffolding` — mutation retarget (b).
2. `init --profile personal remains explicit and does not add OpenCode or Pi routes` → `init --profile personal writes open global routes config without optional scaffolding` — mutation retarget (b).
3. `show --effective emits deterministic JSON for the loaded effective policy` → split into `show --effective emits deterministic JSON for routes-backed config` + `show --effective preserves legacy policy-only JSON behavior` — read-source coverage extended; legacy parity retained (a+b).
4. `set-default mutates supported default actor paths and preserves v1 policy shape` → `set-default writes exactly the requested default path in routes config` — mutation retarget (b).
5. `allow-route maps mixed executor phases to executors and reviewer phases to reviewers` → `add-route maps mixed executor phases...` — renamed to the primary spelling; alias behavior covered by the dedicated parity test (a).
6. `help explains harness actors and provider/model route boundaries` → `... without policy prose` — prose rename assertion (a).

Wrapper suite `tests/relay-config/scripts/relay-config.test.js`:
7. `init company shorthand delegates to core init --profile company` → `... routes config` — now asserts the routes.json v2 shape and that no policy.json is written — mutation retarget (b).
8. `show shorthand adds --effective` — expected `policy.profile` changed `personal` → `routes-config` and asserts `deny_unknown_model_routes: false`, because init now writes routes.json and the effective read is routes-backed (b).
9. `check shorthand maps reviewer phases to reviewer-only core checks` — setup uses `add-route` instead of `allow-route` — vocabulary rename (a).
10. `help advertises natural-language setup and provider/model boundary` — asserts "routing boundary" (was "compliance boundary"), `add-route` listed, `allow-route` marked deprecated, and no "policy" prose (a).

New tests (additions, not edits): alias parity + single stderr line; mutation matrix incl. legacy-shadow three states (JSON); text-mode three-state warning; omission preservation; validation-failure-untouched-file; init invalid-file recovery; init profile rejection; `inspect human output describes routes without policy prose` (wrapper).

### Provenance

Codex executor (run `issue-781-20260706000901940-2ab48b13`) completed the implementation; the dispatch process was harness-killed before commit. Work salvaged from the dispatch worktree and verified by the orchestrator (targeted suites + full repo suite green). R2 fixes applied as orchestrator-correction commits. Recovery tooling had to use the `--manifest` form throughout due to the linked-worktree basename-mismatch bug filed as #805.

Part of #781 (A2 of A1→A2→A3). A3 (friction wiring + doc banners) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BBkPDghyrUzN9FdzJ2SSY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 릴레이 설정이 정책 중심에서 라우트 중심으로 바뀌었으며, `routes.json` 기반 설정과 출력이 추가되었습니다.
  * `add-route` 명령이 새로 강조되고, 기본 라우트 설정과 경로별 상태 확인이 더 명확해졌습니다.

* **Bug Fixes**
  * `show`, `inspect`, `doctor` 등의 출력에서 라우트 상태와 소스 정보가 더 일관되게 표시됩니다.
  * 기존 설정 파일과의 호환성 안내 및 경고가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->