### PR TITLE
Fix relay worktree validation for linked dispatch roots (#805)

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -367,9 +367,10 @@ function isRealpathContainedWithin(basePath, candidatePath, { allowEqual = false
   }
 }
 
-function isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot }) {
+function isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRootBasenames }) {
+  const repoBasenames = new Set((repoRootBasenames || []).filter(Boolean));
   const structurallyRelayOwned = isPathContainedWithin(relayWorktreeBase, worktree)
-    && path.basename(worktree) === path.basename(repoRoot);
+    && repoBasenames.has(path.basename(worktree));
   if (!structurallyRelayOwned) {
     return false;
   }
@@ -504,8 +505,12 @@ function validateManifestPaths(paths, {
   const worktree = path.resolve(worktreeRaw);
   const relayWorktreeBase = getRelayWorktreeBase();
   const repoContainedWorktree = isPathContainedWithin(effectiveRepoRoot, worktree);
+  const relayOwnedRepoRootBasenames = [
+    path.basename(effectiveRepoRoot),
+    path.basename(repoRoot),
+  ];
   const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
-    && path.basename(worktree) === path.basename(effectiveRepoRoot);
+    && relayOwnedRepoRootBasenames.includes(path.basename(worktree));
   const expectedGitCommonDir = getWorktreeGitCommonDir(effectiveRepoRoot) || path.join(effectiveRepoRoot, ".git");
   const worktreeExists = fs.existsSync(worktree);
   if (!worktreeExists) {
@@ -540,7 +545,11 @@ function validateManifestPaths(paths, {
   const prunedRelayOwnedWorktreeForCleanup = acceptPrunedRelayOwned
     && !relayOwnedWorktree
     && (!worktreeGitCommonDir || !fs.existsSync(worktreeGitCommonDir))
-    && isRelayOwnedWorktreeShapeForCleanup({ relayWorktreeBase, worktree, repoRoot: effectiveRepoRoot });
+    && isRelayOwnedWorktreeShapeForCleanup({
+      relayWorktreeBase,
+      worktree,
+      repoRootBasenames: relayOwnedRepoRootBasenames,
+    });
 
   if (!repoContainedWorktree && !relayOwnedWorktree && !prunedRelayOwnedWorktreeForCleanup) {
     throw new Error(

--- a/tests/relay-dispatch/scripts/manifest/paths.test.js
+++ b/tests/relay-dispatch/scripts/manifest/paths.test.js
@@ -21,6 +21,36 @@ function initGitRepo(repoRoot) {
   execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot, stdio: "pipe" });
 }
 
+function commitBaseFile(repoRoot) {
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function createLinkedDispatchFixture(runId) {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-linked-dispatch-"));
+  const repoRoot = path.join(fixtureRoot, "dev-relay");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
+  commitBaseFile(repoRoot);
+
+  const linkedRoot = path.join(repoRoot, ".claude", "worktrees", "floofy-seeking-music");
+  execFileSync("git", ["worktree", "add", linkedRoot, "-b", "linked-dispatch-root"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+
+  return {
+    fixtureRoot,
+    repoRoot,
+    linkedRoot,
+    manifestPath: getManifestPath(repoRoot, runId),
+    relayWorktreeBase: path.join(process.env.RELAY_HOME, "worktrees"),
+    runId,
+  };
+}
+
 test("manifest/paths validateRunId accepts createRunId output", () => {
   const runId = createRunId({
     branch: "Issue 188 Paths",
@@ -101,6 +131,81 @@ test("manifest/paths validateManifestPaths canonicalizes same-git-common-dir rep
 
   assert.equal(result.repoRoot, path.resolve(repoRoot));
   assert.equal(result.worktreeLocation, "repo_root");
+});
+
+test("manifest/paths accepts relay worktree named after linked dispatch root when expected root is primary", () => {
+  const runId = "issue-805-20260706000901940-2ab48b13";
+  const { repoRoot, linkedRoot, manifestPath, relayWorktreeBase } = createLinkedDispatchFixture(runId);
+  const relayWorktree = path.join(relayWorktreeBase, "949b24bd", path.basename(linkedRoot));
+  execFileSync("git", ["worktree", "add", relayWorktree, "-b", "issue-805-relay"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+
+  const result = validateManifestPaths({
+    repo_root: linkedRoot,
+    worktree: relayWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "manifest/paths.test linked dispatch root relay worktree",
+  });
+
+  assert.equal(path.basename(repoRoot), "dev-relay");
+  assert.equal(path.basename(linkedRoot), "floofy-seeking-music");
+  assert.equal(result.repoRoot, path.resolve(repoRoot));
+  assert.equal(result.worktree, relayWorktree);
+  assert.equal(result.worktreeLocation, "relay_worktree");
+});
+
+test("manifest/paths rejects linked-root relay worktree basename when git common dir differs", () => {
+  const runId = "issue-805-20260706000901941-2ab48b13";
+  const { repoRoot, linkedRoot, manifestPath, relayWorktreeBase } = createLinkedDispatchFixture(runId);
+  const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-linked-attacker-"));
+  initGitRepo(attackerRoot);
+  commitBaseFile(attackerRoot);
+  const attackerRelayWorktree = path.join(relayWorktreeBase, "attacker-binding", path.basename(linkedRoot));
+  execFileSync("git", ["worktree", "add", attackerRelayWorktree, "-b", "attacker-relay"], {
+    cwd: attackerRoot,
+    stdio: "pipe",
+  });
+
+  assert.throws(
+    () => validateManifestPaths({
+      repo_root: linkedRoot,
+      worktree: attackerRelayWorktree,
+    }, {
+      expectedRepoRoot: repoRoot,
+      manifestPath,
+      runId,
+      caller: "manifest/paths.test linked dispatch wrong common dir",
+    }),
+    /is not contained under the expected repo root/
+  );
+});
+
+test("manifest/paths rejects linked-root relay worktree basename outside relay worktree base", () => {
+  const runId = "issue-805-20260706000901942-2ab48b13";
+  const { fixtureRoot, repoRoot, linkedRoot, manifestPath } = createLinkedDispatchFixture(runId);
+  const outsideRelayWorktree = path.join(fixtureRoot, "outside-relay-base", path.basename(linkedRoot));
+  execFileSync("git", ["worktree", "add", outsideRelayWorktree, "-b", "outside-relay"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+
+  assert.throws(
+    () => validateManifestPaths({
+      repo_root: linkedRoot,
+      worktree: outsideRelayWorktree,
+    }, {
+      expectedRepoRoot: repoRoot,
+      manifestPath,
+      runId,
+      caller: "manifest/paths.test linked dispatch outside relay base",
+    }),
+    /is not contained under the expected repo root/
+  );
 });
 
 test("manifest/paths cleanup mode uses canonical root for pruned same-git-common-dir worktrees", () => {


### PR DESCRIPTION
## Fix #805 — validateManifestPaths linked-worktree basename mismatch

`relayOwnedWorktreeCandidate` in `skills/relay-dispatch/scripts/manifest/paths.js` now accepts a relay worktree whose basename matches **either** the canonicalized `effectiveRepoRoot` basename **or** the manifest's raw `repo_root` basename — the value `dispatch.js` actually used to name the worktree. The git-common-dir binding requirement is unchanged: a worktree that merely shares a basename but is bound to a different `.git` is still rejected. The pruned-for-cleanup shape check receives the same tolerance.

This unblocks `recover-commit`, `recover-state`, `review-runner`, and `gate-check` for runs dispatched from a linked git worktree (e.g. Claude Code's `.claude/worktrees/<name>`), which previously required the `--manifest`-without-`--repo` workaround documented in #805.

### Tests

`tests/relay-dispatch/scripts/manifest/paths.test.js` (+105, pure additions — no pre-existing test edits):
- Regression: manifest `repo_root` = linked worktree path, relay worktree named after it, `expectedRepoRoot` = canonicalized primary root with a different basename → previously threw, now returns `worktreeLocation: "relay_worktree"`.
- Trust boundary negatives: matching basename + different git common dir → rejected; worktree outside the relay worktree base → rejected.
- Primary-root dispatch behavior unchanged (existing tests pass unmodified).

### Provenance

Codex executor run `issue-805-20260706100610644-658ece28` completed implementation, commit (7ce143c), and push; the run escalated only because dispatch auto-PR used the non-existent base ref `worktree-floofy-seeking-music` — filed separately as #809. PR created manually by the orchestrator with base `main`.

Fixes #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BBkPDghyrUzN9FdzJ2SSY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 연결된 작업 디렉터리 환경에서 경로 검증이 더 정확해졌습니다.
  * 서로 다른 저장소 루트 형태를 가진 경우에도 올바른 작업 디렉터리를 허용하고, 잘못된 경로는 더 확실하게 거부합니다.
  * 정리(cleanup) 대상 경로 판정이 개선되어, relay 관련 작업 디렉터리 처리 오류가 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->