### PR TITLE
Route-failure friction wiring: hints + SKILL.md pointers + doc banner (#781 A3)

### DIFF
--- a/docs/model-route-policy.md
+++ b/docs/model-route-policy.md
@@ -1,5 +1,7 @@
 # Model Route Policy
 
+> **Superseded in part:** `docs/route-config-simplification-design.md` and `docs/decisions/0007-routes-single-concept.md` supersede this document's storage and UX model: `routes.json` is now the single user-facing route concept, while `policy.json` is legacy-read-only once routes config is present. The gate semantics, phase tuples, managed CLI behavior, strict-mode denial rules, and adapter-capability separation below still apply.
+
 Route policy answers one operational question: which provider/model route is allowed to run in each relay phase?
 
 Executor and reviewer names such as `codex`, `claude`, `opencode`, `pi`, and `cline` are harness names. They select a CLI adapter and execution contract. They are not the compliance boundary. The compliance boundary is the provider/model route string, for example `example/opencode-model-fast`, `example/pi-model-fast`, `cline-pass/glm-5.2`, or `ollama/qwen3`.

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -91,6 +91,7 @@ Publication policy:
 | Timeout (with commits) | `completed-with-warning` — check worktree for uncommitted changes, proceed to review |
 | Timeout (no commits) | Increase `--timeout` or split task into smaller pieces |
 | Executor error / no commits | Read result file; revise prompt and re-dispatch |
+| Route denied or model unresolved | Run `relay-config` to register the route or set the executor default model, then re-dispatch |
 | Branch publication / PR creation failed | Inspect the dispatch error and outer-shell GitHub auth. `relay-dispatch` handles publication from the orchestrator shell. |
 | Branch conflicts | Resolve in worktree or create fresh worktree from updated main |
 | Network/transient error | Wait 30s, retry once. If it fails again, escalate to user |

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -144,6 +144,11 @@ const {
   assertRelayPolicyGate,
   buildPolicyGateFailureEnvelope,
 } = require("./relay-policy-gate");
+const {
+  hintForCliBinary,
+  hintForPolicyDecision,
+  withHint,
+} = require("./route-failure-hints");
 const { loadRelayPolicy } = require("./relay-policy");
 const { loadProjectRoutes, resolveRouteIntent, resolveRoutingDecision } = require("./relay-routing");
 const { classifyRepositoryDirt, formatRuntimeMetadataDirt } = require("./runtime-dirt");
@@ -910,7 +915,17 @@ function validateExecutorCli() {
   try {
     version = execFileSync(cli, ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim();
   } catch {
-    console.error(`Error: ${cli} CLI not found.`);
+    const message = `${cli} CLI not found.`;
+    const hint = hintForCliBinary(cli);
+    if (JSON_OUT_REQUESTED) {
+      console.log(JSON.stringify({
+        status: "failed",
+        error: message,
+        hint,
+      }, null, 2));
+    }
+    console.error(`Error: ${message}`);
+    console.error(`hint: ${hint}`);
     process.exit(1);
   }
   return { binary: cli, version };
@@ -1490,11 +1505,13 @@ async function main() {
         },
       },
     });
+    const hint = hintForPolicyDecision(envelope.policy_decision);
     if (JSON_OUT) {
-      console.log(JSON.stringify(envelope, null, 2));
+      console.log(JSON.stringify(withHint(envelope, hint), null, 2));
     } else {
       console.error(`Error: ${envelope.error}`);
     }
+    if (hint) console.error(`hint: ${hint}`);
     process.exit(1);
   }
 

--- a/skills/relay-dispatch/scripts/route-failure-hints.js
+++ b/skills/relay-dispatch/scripts/route-failure-hints.js
@@ -1,0 +1,86 @@
+"use strict";
+
+const ROUTE_REGISTRATION_REASONS = new Set([
+  "denied_model_route",
+  "unknown_model_route",
+]);
+
+const DEFAULT_MODEL_REASONS = new Set([
+  "missing_model_route",
+  "provider_model_route_required",
+]);
+
+const KNOWN_CLI_BINARIES = [
+  "opencode",
+  "pi",
+  "agy",
+  "agent",
+  "cline",
+  "codex",
+  "claude",
+];
+
+function hintForPolicyDecision(decision) {
+  const reason = decision?.reason;
+  if (DEFAULT_MODEL_REASONS.has(reason)) {
+    return "run relay-config to set a default model for this route";
+  }
+  if (ROUTE_REGISTRATION_REASONS.has(reason)) {
+    return "run relay-config to register this route";
+  }
+  return null;
+}
+
+function hintForCliBinary(binary) {
+  const normalized = typeof binary === "string" ? binary.trim() : "";
+  if (!normalized) return null;
+  return `install the ${normalized} CLI and ensure it is on PATH`;
+}
+
+function textFromError(error) {
+  return [error?.message, error?.stdout, error?.stderr]
+    .map((part) => {
+      if (Buffer.isBuffer(part)) return part.toString("utf-8");
+      return typeof part === "string" ? part : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[\\^$+?.()|[\]{}]/g, "\\$&");
+}
+
+function hintForCliFailure(error, { binary = null } = {}) {
+  if (binary) return hintForCliBinary(binary);
+  const text = textFromError(error);
+  if (!text) return null;
+
+  for (const candidate of KNOWN_CLI_BINARIES) {
+    const escaped = escapeRegExp(candidate);
+    const cliNotFound = new RegExp(`\\b${escaped}\\b CLI not found`, "i");
+    const enoentAfterBinary = new RegExp(`\\b${escaped}\\b[^\\n]*\\bENOENT\\b`, "i");
+    const binaryAfterEnoent = new RegExp(`\\bENOENT\\b[^\\n]*\\b${escaped}\\b`, "i");
+    const commandNotFound = new RegExp(`\\b${escaped}\\b[^\\n]*(?:command not found|not found)`, "i");
+    if (
+      cliNotFound.test(text) ||
+      enoentAfterBinary.test(text) ||
+      binaryAfterEnoent.test(text) ||
+      commandNotFound.test(text)
+    ) {
+      return hintForCliBinary(candidate);
+    }
+  }
+  return null;
+}
+
+function withHint(envelope, hint) {
+  return hint ? { ...envelope, hint } : envelope;
+}
+
+module.exports = {
+  hintForCliBinary,
+  hintForCliFailure,
+  hintForPolicyDecision,
+  withHint,
+};

--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -47,6 +47,7 @@ Use a JSON file containing a non-empty `leaves[]` array. Each leaf must include:
 relay-fleet only fans out already-decomposed leaf contracts; it never splits a raw or ambiguous request itself — route that intake through `relay-ready` first and pass its leaf output here.
 
 Optional per-leaf fields are passed through to `dispatch.js`: `request_id`, `leaf_id`, `executor`, `model`, `model_hints`, `sandbox`, `network_access`, `timeout`, `reasoning`, `copy`, `test_command`, and `register`. An optional `depends_on` array of `leaf_ref` strings records ordering intent: a reference to another leaf in the *same* leaves file fails closed at load time (dispatch that leaf in an earlier wave and drop the reference here); a reference to a `leaf_ref` outside this file is accepted silently and assumed already satisfied.
+If a leaf's executor route is denied or its model is unresolved, pause that leaf and use `relay-config` to register the route or set the default before resuming the fleet.
 
 ## Commands
 

--- a/skills/relay-plan/SKILL.md
+++ b/skills/relay-plan/SKILL.md
@@ -115,6 +115,8 @@ Write the dispatch prompt and rubric YAML to temp files. The prompt uses `../rel
 
 Return a handoff summary with dispatch prompt path, rubric YAML path, Done Criteria anchor path when persisted, review assurance level, and the recommended `relay-dispatch` command. Use `--review-assurance hardened` only when task/rubric risk requires stronger verification; never derive it from executor or reviewer identity.
 
+If the recommended executor or reviewer route/model cannot resolve, point the operator to `relay-config` to register the route or set the default before dispatch.
+
 When Step 7 persisted Done Criteria, the dispatch handoff must preserve both anchors:
 
 ```bash

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -58,6 +58,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" --repo 
 Run the runner in the foreground. Do NOT background it, detach it, or return with "I'll wait for the background runner." The relay-review result is the runner's verdict; do not return until the runner exits and the new `review-round-N-verdict.json` exists.
 
 Supported primary reviewers: `--reviewer codex`, `--reviewer claude`, `--reviewer opencode`, `--reviewer pi`, `--reviewer antigravity`, and `--reviewer cursor`. Adapter precedence, environment knobs, capability gates, and model examples live in `../relay-dispatch/references/agent-adapter-platform.md`.
+If a reviewer route is denied or its model is unresolved, run `relay-config` to register the route or set the reviewer default before re-running review.
 
 Optional advisory path: add a non-gating blind-spot lane alongside the primary reviewer:
 ```bash

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -15,6 +15,7 @@ const { buildCommentBody, formatIssueList, formatScopeDrift, postComment } = req
 const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog, toIterationScoreEventEntry } = require("./review-runner/divergence");
 const { applyQualityExecutionStatus, buildExecutionEvidenceFailureVerdict, buildMissingExecutionEvidenceVerdict, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
 const { applyReviewAssurancePolicy } = require("./review-runner/assurance");
+const { printFailureAndExit } = require("./review-runner/failure-output");
 const { buildRedispatchPrompt, buildRubricGateRedispatchPrompt, computeFactorStatusFlips, computeRepeatedIssueCount, decideFlipFlopEscalation, detectChurnGrowth, summarizeLineage, toEscalatedVerdict } = require("./review-runner/redispatch");
 const { buildConvergenceSummary, formatConvergenceMarkdown } = require("./review-runner/convergence");
 const { applyVerdictToManifest } = require("./review-runner/manifest-apply");
@@ -26,8 +27,6 @@ const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { resolveAdvisoryConfig, settleAdvisoryForVerdict, startConfiguredAdvisory } = require("./review-runner/advisory-orchestration");
 const { printResult, printUsage } = require("./review-runner/output");
 const { assertKnownReviewRunnerFlags, parseReviewRunnerCliArgs } = require("./review-runner/cli");
-const { buildPolicyGateFailureEnvelope, isRelayPolicyGateError } = require("../../relay-dispatch/scripts/relay-policy-gate");
-const { buildAdapterCapabilityFailureEnvelope, isAdapterCapabilityError } = require("../../relay-dispatch/scripts/agent-adapters/policy");
 const { args, cliArgs, options } = parseReviewRunnerCliArgs(process.argv.slice(2));
 if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]))) {
   printUsage();
@@ -374,16 +373,7 @@ async function run() {
 
 if (require.main === module) {
   Promise.resolve(run()).catch((error) => {
-    if (cliArgs.hasFlag("--json") && isRelayPolicyGateError(error)) {
-      console.log(JSON.stringify(buildPolicyGateFailureEnvelope(error, {
-        ok: false,
-        ...(error.adapterCapability ? { adapter_capability: error.adapterCapability } : {}),
-      }), null, 2));
-    } else if (cliArgs.hasFlag("--json") && isAdapterCapabilityError(error)) {
-      console.log(JSON.stringify(buildAdapterCapabilityFailureEnvelope(error, { ok: false }), null, 2));
-    }
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+    printFailureAndExit(error, { jsonOut: cliArgs.hasFlag("--json") });
   });
 }
 module.exports = { applyVerdictToManifest, buildCommentBody, buildPrompt, buildRedispatchPrompt, buildReviewRunnerRubricGateFailure, detectChurnGrowth, formatIssueList, formatPriorVerdictSummary, formatScopeDrift, getGhLogin, loadRubricFromRunDir, parseRemoteHost, parseReviewVerdict, parseScoreLog, resolveIssueNumber, resolveRemoteHost, validateReviewVerdict, validateScopeDrift };

--- a/skills/relay-review/scripts/review-runner/failure-output.js
+++ b/skills/relay-review/scripts/review-runner/failure-output.js
@@ -1,0 +1,44 @@
+const { buildPolicyGateFailureEnvelope, isRelayPolicyGateError } = require("../../../relay-dispatch/scripts/relay-policy-gate");
+const { buildAdapterCapabilityFailureEnvelope, isAdapterCapabilityError } = require("../../../relay-dispatch/scripts/agent-adapters/policy");
+const {
+  hintForCliFailure,
+  hintForPolicyDecision,
+  withHint,
+} = require("../../../relay-dispatch/scripts/route-failure-hints");
+
+function emitJsonFailure(error, { jsonOut }) {
+  let hint = null;
+  if (jsonOut && isRelayPolicyGateError(error)) {
+    const envelope = buildPolicyGateFailureEnvelope(error, {
+      ok: false,
+      ...(error.adapterCapability ? { adapter_capability: error.adapterCapability } : {}),
+    });
+    hint = hintForPolicyDecision(envelope.policy_decision);
+    console.log(JSON.stringify(withHint(envelope, hint), null, 2));
+  } else if (jsonOut && isAdapterCapabilityError(error)) {
+    console.log(JSON.stringify(buildAdapterCapabilityFailureEnvelope(error, { ok: false }), null, 2));
+  } else {
+    hint = hintForCliFailure(error);
+    if (jsonOut && hint) {
+      console.log(JSON.stringify({
+        status: "failed",
+        error: error.message,
+        hint,
+      }, null, 2));
+    }
+  }
+  return hint;
+}
+
+function printFailureAndExit(error, { jsonOut }) {
+  let hint = emitJsonFailure(error, { jsonOut });
+  if (!hint && isRelayPolicyGateError(error)) hint = hintForPolicyDecision(error.decision);
+  if (!hint) hint = hintForCliFailure(error);
+  console.error(`Error: ${error.message}`);
+  if (hint) console.error(`hint: ${hint}`);
+  process.exit(1);
+}
+
+module.exports = {
+  printFailureAndExit,
+};

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -52,6 +52,8 @@ Write the dispatch prompt and rubric YAML to temp files such as `/tmp/dispatch-<
 
 `relay` owns lifecycle orchestration; `relay-dispatch` owns dispatch CLI semantics. When an operator needs a fixed executor or model, pass the dispatch options explicitly in this command. Common pass-through knobs are `--executor`, `--model`, and `--model-hints`; see `../relay-dispatch/references/model-routing.md` and `../relay-dispatch/references/cli-schema.md` for full route and option semantics.
 
+If the user names an executor whose route or model cannot resolve, invoke `relay-config` inline: ask one focused question, write the route/default, then continue the dispatch cycle instead of failing the run.
+
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
   -b issue-<N> --prompt-file /tmp/dispatch-<N>.md --rubric-file /tmp/rubric-<N>.yaml \

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -2605,10 +2605,43 @@ test("dispatch denies disallowed executor route before spawning the executor", (
   assert.equal(result.policy_decision.model, "example/opencode-model-fast");
   assert.equal(result.policy_decision.reason, "unknown_model_route");
   assert.match(result.error, /reason=unknown_model_route/);
+  assert.equal(result.hint, "run relay-config to register this route");
   assert.equal(result.adapter_capability.adapter, "opencode");
   assert.equal(result.adapter_capability.phase, "dispatch");
   assert.equal(result.adapter_capability.safe, true);
   assert.equal(result.executor_policy.adapter, "opencode");
+});
+
+test("dispatch prints relay-config route hint for text route denial", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "strict-deny-unknown",
+    deny_unknown_model_routes: true,
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-policy-denied-text-${Date.now()}.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-policy-denied-text",
+    "-p", "must not spawn opencode",
+    "-e", "opencode",
+    "-m", "example/opencode-model-fast",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    },
+  });
+
+  assert.notEqual(proc.status, 0);
+  assert.equal(fs.existsSync(capturePath), false);
+  assert.match(proc.stderr, /Error: relay policy denied model route.*reason=unknown_model_route/);
+  assert.match(proc.stderr, /hint: run relay-config to register this route/);
 });
 
 test("dispatch reports adapter-capability denial before model-route policy", () => {
@@ -2687,6 +2720,78 @@ test("dispatch opencode executor fails closed when no model route is supplied", 
   assert.equal(result.status, "failed");
   assert.equal(result.policy_decision.reason, "missing_model_route");
   assert.equal(result.policy_decision.model, null);
+  assert.equal(result.hint, "run relay-config to set a default model for this route");
+});
+
+test("dispatch prints relay-config default-model hint for text unresolved model", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  writeRelayPolicy(relayHome, {
+    profile: "allow-opencode-dispatch",
+    allowed_model_routes: [{ route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-opencode-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-missing-model-text-${Date.now()}.json`);
+  writeArgCaptureOpencode(binDir, capturePath);
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-opencode-missing-model-text",
+    "-p", "test missing opencode model route",
+    "-e", "opencode",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+    },
+  });
+
+  assert.notEqual(proc.status, 0);
+  assert.equal(fs.existsSync(capturePath), false);
+  assert.match(proc.stderr, /Error: relay policy denied model route.*reason=missing_model_route/);
+  assert.match(proc.stderr, /hint: run relay-config to set a default model for this route/);
+});
+
+test("dispatch reports install hint when executor CLI is missing in JSON and text modes", () => {
+  for (const jsonOut of [true, false]) {
+    const { repoRoot, relayHome } = setupRepo();
+    process.env.RELAY_HOME = relayHome;
+    writeRelayPolicy(relayHome, {
+      profile: "allow-opencode-dispatch",
+      allowed_model_routes: [{ route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] }],
+    });
+    const args = [
+      "-b", `issue-opencode-missing-cli-${jsonOut ? "json" : "text"}`,
+      "-p", "test missing opencode cli",
+      "-e", "opencode",
+      "-m", "example/opencode-model-fast",
+    ];
+    if (jsonOut) args.push("--json");
+
+    const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric(args)], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: createGitOnlyPath(),
+        RELAY_HOME: relayHome,
+      },
+    });
+
+    assert.notEqual(proc.status, 0);
+    assert.match(proc.stderr, /Error: opencode CLI not found\./);
+    assert.match(proc.stderr, /hint: install the opencode CLI and ensure it is on PATH/);
+    if (jsonOut) {
+      const result = JSON.parse(proc.stdout);
+      assert.equal(result.status, "failed");
+      assert.equal(result.error, "opencode CLI not found.");
+      assert.equal(result.hint, "install the opencode CLI and ensure it is on PATH");
+    } else {
+      assert.equal(proc.stdout, "");
+    }
+  }
 });
 
 test("dispatch opencode executor lets RELAY_HOME executors config override bundled model", () => {

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -466,7 +466,118 @@ test("review-runner denies opencode primary review before spawning when route po
   assert.equal(result.policy_decision.phase, "review");
   assert.equal(result.policy_decision.reviewer, "opencode");
   assert.equal(result.policy_decision.model, "example/opencode-model-fast");
+  assert.equal(result.hint, "run relay-config to register this route");
   assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
+});
+
+test("review-runner prints relay-config route hint for text primary review route denial", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "strict-routes" });
+  const logPath = path.join(repoRoot, "opencode-primary-policy-text.log");
+  const opencodeScript = writeFakeOpencode(repoRoot, {
+    logPath,
+    primaryVerdict: passVerdict(),
+  });
+  const proc = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "429",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer", "opencode",
+    "--reviewer-model", "example/opencode-model-fast",
+    "--no-comment",
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_OPENCODE_BIN: opencodeScript },
+  });
+
+  assert.notEqual(proc.status, 0);
+  assert.equal(fs.existsSync(logPath), false);
+  assert.equal(proc.stdout, "");
+  assert.match(proc.stderr, /Error: relay policy denied model route.*phase=review.*reviewer=opencode.*reason=unknown_model_route/);
+  assert.match(proc.stderr, /hint: run relay-config to register this route/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
+});
+
+test("review-runner reports relay-config default-model hint for unresolved primary reviewer model in JSON and text modes", () => {
+  for (const jsonOut of [true, false]) {
+    const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "strict-routes" });
+    const logPath = path.join(repoRoot, `opencode-primary-missing-model-${jsonOut ? "json" : "text"}.log`);
+    const opencodeScript = writeFakeOpencode(repoRoot, {
+      logPath,
+      primaryVerdict: passVerdict(),
+    });
+    const args = [
+      SCRIPT,
+      "--repo", repoRoot,
+      "--run-id", runId,
+      "--pr", "429",
+      "--done-criteria-file", doneCriteriaPath,
+      "--diff-file", diffPath,
+      "--reviewer", "opencode",
+      "--no-comment",
+    ];
+    if (jsonOut) args.push("--json");
+
+    const proc = spawnSync("node", args, {
+      encoding: "utf-8",
+      env: { ...process.env, RELAY_OPENCODE_BIN: opencodeScript },
+    });
+
+    assert.notEqual(proc.status, 0);
+    assert.equal(fs.existsSync(logPath), false);
+    assert.match(proc.stderr, /Error: relay policy denied model route.*phase=review.*reviewer=opencode.*reason=missing_model_route/);
+    assert.match(proc.stderr, /hint: run relay-config to set a default model for this route/);
+    assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING);
+    if (jsonOut) {
+      const result = JSON.parse(proc.stdout);
+      assert.equal(result.status, "failed");
+      assert.equal(result.policy_decision.reason, "missing_model_route");
+      assert.equal(result.policy_decision.model, null);
+      assert.equal(result.hint, "run relay-config to set a default model for this route");
+    } else {
+      assert.equal(proc.stdout, "");
+    }
+  }
+});
+
+test("review-runner reports install hint when primary reviewer CLI is missing in JSON and text modes", () => {
+  for (const jsonOut of [true, false]) {
+    const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo({
+      modelPolicy: "allow-opencode-primary",
+      roles: { orchestrator: "codex", executor: "codex", reviewer: "opencode" },
+    });
+    const args = [
+      SCRIPT,
+      "--repo", repoRoot,
+      "--run-id", runId,
+      "--pr", "429",
+      "--done-criteria-file", doneCriteriaPath,
+      "--diff-file", diffPath,
+      "--reviewer", "opencode",
+      "--reviewer-model", "example/opencode-model-fast",
+      "--no-comment",
+    ];
+    if (jsonOut) args.push("--json");
+
+    const proc = spawnSync("node", args, {
+      encoding: "utf-8",
+      env: { ...process.env, RELAY_OPENCODE_BIN: path.join(repoRoot, "missing-opencode") },
+    });
+
+    assert.notEqual(proc.status, 0);
+    assert.match(proc.stderr, /Error: .*opencode.*ENOENT/s);
+    assert.match(proc.stderr, /hint: install the opencode CLI and ensure it is on PATH/);
+    if (jsonOut) {
+      const result = JSON.parse(proc.stdout);
+      assert.equal(result.status, "failed");
+      assert.match(result.error, /opencode.*ENOENT/s);
+      assert.equal(result.hint, "install the opencode CLI and ensure it is on PATH");
+    } else {
+      assert.equal(proc.stdout, "");
+    }
+  }
 });
 
 test("review-runner uses manifest routing advisory defaults without changing the primary reviewer", () => {


### PR DESCRIPTION
## #781 Phase A3 — friction wiring + doc banners

Final #781 slice on top of A1 (PR #792, loader/posture) and A2 (PR #804, relay-config vocabulary): route failures now point at the fix.

### What changed

- **Error hints** — new `skills/relay-dispatch/scripts/route-failure-hints.js` (`hintForPolicyDecision`, `hintForCliBinary`, model-resolution hint) wired into `dispatch.js`; new `skills/relay-review/scripts/review-runner/failure-output.js` centralizes review-runner's failure printing (replacing the inline policy-gate/adapter-capability envelope branches) and attaches the same hints. Route-denied, unresolved-model, and uninstalled-executor failures carry an actionable relay-config hint as one text line + additive JSON `hint` field. Payloads otherwise byte-identical.
- **SKILL.md pointers** — one relay-config pointer line each in `relay`, `relay-plan`, `relay-dispatch`, `relay-review`, `relay-fleet` SKILL.md route-failure contexts; all files remain under 150 lines (138/141/109/146/120) with frontmatter untouched.
- **/relay inline flow** — `skills/relay/SKILL.md` dispatch step now instructs invoking relay-config inline (one question → write → continue) when a named executor's route/model cannot resolve, instead of failing the cycle.
- **Doc banner** — `docs/model-route-policy.md` gains a superseded-in-part banner pointing to `docs/route-config-simplification-design.md` + ADR 0007 (routes.json single concept; policy.json legacy-read-only); body unchanged.

### Tests

New tests (additions):
- `dispatch prints relay-config route hint for text route denial`
- `dispatch prints relay-config default-model hint for text unresolved model`
- `dispatch reports install hint when executor CLI is missing in JSON and text modes`
- `review-runner prints relay-config route hint for text primary review route denial`
- `review-runner reports relay-config default-model hint for unresolved primary reviewer model in JSON and text modes`
- `review-runner reports install hint when primary reviewer CLI is missing in JSON and text modes`

Pre-existing test edits (enumerated per DC2/DC6 — each changed ONLY by adding one assertion for the additive `hint` field; no existing assertion was modified or removed):
1. `dispatch denies disallowed executor route before spawning the executor` (`tests/relay-dispatch/scripts/dispatch.test.js`) — added `assert.equal(result.hint, "run relay-config to register this route")` to the existing JSON denial envelope test.
2. `dispatch opencode executor fails closed when no model route is supplied` (`tests/relay-dispatch/scripts/dispatch.test.js`) — added `assert.equal(result.hint, "run relay-config to set a default model for this route")`.
3. `review-runner denies opencode primary review before spawning when route policy disallows it` (`tests/relay-review/scripts/review-runner-advisory.test.js`) — added `assert.equal(result.hint, "run relay-config to register this route")`.

These three edits pin exactly the extended payloads and prove the field is additive: all other assertions in those tests pass byte-identical payloads.

### Provenance

Codex executor run `issue-781-20260706100610645-b0d2faf2` completed the implementation but timed out at 5400s before committing (three concurrent full-suite runs contended for the final gate). Salvaged and verified by the orchestrator in the retained worktree: dispatch.test.js 156/156, relay-review suites 432/432, all remaining suite dirs green; one known SIGINT process-group contention flake passed in isolation in both parallel worktrees. Dispatch auto-PR would also have hit the linked-worktree base-ref bug (#809); PR created manually with base `main`.

Closes the #781 A-phase (A1 → A2 → A3 complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BBkPDghyrUzN9FdzJ2SSY
