### PR TITLE
Route presets: --route-preset, /relay natural-language mapping, preset CRUD, model catalog (#782)

### DIFF
--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -22,6 +22,7 @@ Set up relay routes interactively. The user should not have to memorize command 
 - The user asks to set up or configure relay
 - The user wants company-safe strict mode, personal open mode, OpenCode/Pi opt-in, or advisory-review routing
 - The user asks whether a provider/model route such as `example/opencode-model-*` or `openai/*` is available
+- The user asks to create, show, or remove a route preset such as `light`, `diverse`, or `hardened`
 - The user asks to run relay doctor/check
 
 ## Do not use when
@@ -51,6 +52,7 @@ Infer from the user's words before asking questions:
 - `managed only`, `codex/claude only` -> no unmanaged provider/model route opt-in
 - routes containing `/`, such as `example/opencode-model-*`, `example/pi-*`, `openai/*`, or `ollama/*` -> provider/model route patterns
 - `advisory`, `reviewer`, `documentation`, `docs` -> likely advisory-review phases
+- `preset`, `light`, `diverse`, `hardened`, `프리셋`, `가볍게`, `싸게`, `하드하게` -> preset CRUD or inspection
 
 Ask only for missing decisions, one at a time. Use plain language and wait for the user's answer. Do not use host-specific question primitives as the only path; this skill must work in both Claude Code and Codex.
 
@@ -63,6 +65,7 @@ Before mutating routes, show a concise proposal:
 - provider/model routes to add
 - phases and actors for each route
 - default actors to set, if any
+- preset name and bundle fields (`dispatch`, `review`, `advisory_review`, `review_assurance`), if requested
 
 Ask for confirmation. If the user already explicitly approved the exact route changes in the same request, proceed and state what will be written.
 
@@ -74,9 +77,13 @@ Use the wrapper for shorthand, or pass through full flags:
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" init company
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" add-route 'example/opencode-model-*' --phase dispatch,advisory_review --executor opencode
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset add light --dispatch opencode:example/opencode-model-fast
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset show light
 ```
 
 Generated company and personal profiles must not pin Codex or Claude model names. Do not hardcode company-specific route defaults; use the user's supplied provider/model route patterns.
+
+Consult `references/model-catalog.md` only when live model-list probes fail or the user explicitly asks for a model recommendation; otherwise prefer `doctor` probe output or the user's supplied model id.
 
 ### 5. Verify
 
@@ -101,6 +108,9 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
 | `add-route example/opencode-model-* --phase dispatch --executor opencode` | `add-route example/opencode-model-* --phase dispatch --executor opencode` |
+| `preset add light --dispatch opencode:example/opencode-model-fast` | `preset add light --dispatch opencode:example/opencode-model-fast` |
+| `preset remove light` | `preset remove light` |
+| `preset show light` | `preset show light` |
 | `check dispatch opencode example/opencode-model-fast` | `check --phase dispatch --executor opencode --model example/opencode-model-fast` |
 | `check review opencode example/opencode-model-fast` | `check --phase review --reviewer opencode --model example/opencode-model-fast` |
 | `check advisory_review pi example/pi-model-fast` | `check --phase advisory_review --reviewer pi --model example/pi-model-fast` |

--- a/skills/relay-config/references/model-catalog.md
+++ b/skills/relay-config/references/model-catalog.md
@@ -1,0 +1,15 @@
+# Model catalog
+
+Last checked: 2026-07-06. Treat as stale after 60 days.
+
+Use only when live model-list probes fail or the user asks for a recommendation. Prefer provider CLI model lists from `relay-config doctor` when available. Provider prefixes and exact route ids vary, so adapt the slug to the configured provider/model route format.
+
+| Model | Use when | Cost hint |
+| --- | --- | --- |
+| `glm-5.2` | Strong default for harder coding and reasoning routes. | premium |
+| `kimi-k2.7-code` | Large implementation tasks when GLM is unavailable. | premium |
+| `deepseek-v4-pro` | Larger changes with strong cost/performance balance. | pro value |
+| `minimax-m3` | General coding when a capable mid-cost route is desired. | mid |
+| `deepseek-v4-flash` | Fast iteration and low-cost preset experiments. | cheap |
+
+These are selection hints, not an authority. Model quality, availability, and prices change quickly.

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -46,6 +46,7 @@ function printHelp() {
   console.log("  add-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");
   console.log("  allow-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json] (deprecated; use add-route)");
   console.log("  deny-route <pattern> [--phase <csv>] [--executor <name>] [--reviewer <name>] [--json]");
+  console.log("  preset add|remove|show <name> [--dispatch <actor[:provider/model]>] [--review <actor[:provider/model]>] [--advisory-review <actor[:provider/model]>] [--review-assurance <standard|hardened>] [--json]");
   console.log("  set-default <path> <value> [--json]");
   console.log("");
   console.log("Routing boundary: executor/reviewer names are harnesses; provider/model route strings are the routing boundary.");

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -94,6 +94,7 @@ const FLAGS = [
   { flag: "--review", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--advisory-review", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--route-intent-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied run route intent JSON path; keep the literal argv token." },
+  { flag: "--route-preset", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed routes.json preset selector; flag-like following tokens should mean the value is missing." },
   { flag: "--manual-review-reason", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit reason for applying a manual review verdict under hardened assurance." },
   { flag: "--reviewer", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Reviewer adapter selector; flag-like following tokens should mean the value is missing." },
   { flag: "--reviewer-model", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Reviewer model selector; flag-like following tokens should mean the value is missing." },
@@ -139,7 +140,7 @@ const COMMAND_FLAGS = {
   ],
   dispatch: [
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
-    "--model", "--model-hints", "--route-intent-file", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
+    "--model", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
     "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
     "--fleet-id", "--done-criteria-file", "--publish-policy", "--review-assurance", "--register", "--auto-recover-commit", "--no-auto-recover-commit",
     "--tags", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help",
@@ -197,7 +198,7 @@ const COMMAND_FLAGS = {
   "relay-config": [
     "--profile", "--effective", "--phase", "--executor", "--reviewer", "--model",
     "--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file",
-    "--reconcile", "--json", "--help",
+    "--reconcile", "--review-assurance", "--advisory-profile", "--json", "--help",
   ],
   "rebrand-evidence": [
     "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -373,7 +373,11 @@ let AUTO_RECOVER_COMMIT = null;
 
 function resolveDispatchRuntime(repoRoot) {
   const routeResolution = loadInitialRoutePlan(repoRoot);
-  if (!REVIEW_ASSURANCE_RAW) {
+  // Route-derived review assurance is a preset-feature behavior. No-preset
+  // dispatches must stay byte-identical (DC6): a route-intent file must not
+  // change policy.review_assurance when no --route-preset was requested; those
+  // runs fall through to prompt-derived assurance extraction as before.
+  if (!REVIEW_ASSURANCE_RAW && ROUTE_PRESET) {
     const intentReviewAssurance = nonEmptyString(routeResolution.routeIntent?.review_assurance);
     const presetReviewAssurance = nonEmptyString(routeResolution.routePlan?.route_preset?.review_assurance);
     const routeReviewAssurance = intentReviewAssurance || presetReviewAssurance;

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1340,6 +1340,7 @@ function writeRoutePlanSnapshot({ repoRoot, runId, routePlan, policyResult, proj
   const snapshot = {
     version: 1,
     resolved_at: resolvedAt,
+    ...(routePlan.route_preset ? { route_preset: routePlan.route_preset } : {}),
     policy: {
       status: policyResult?.status || null,
       sources: policyResult?.sources || null,
@@ -1643,6 +1644,7 @@ async function main() {
       console.error("Error: " + formatInflightCollisionError(inflightRuns, { issueNumber: issueForCollisionCheck }));
       process.exit(1);
     }
+    runtime = resolveDispatchRuntime(repoRoot);
     runId = runId || createRunId({ issueNumber, branch });
     if (FLEET_ID && issueForCollisionCheck && !DRY_RUN) {
       try {
@@ -1667,7 +1669,6 @@ async function main() {
       console.error(`Error: worktree path already exists: ${wtPath}`);
       process.exit(1);
     }
-    runtime = resolveDispatchRuntime(repoRoot);
     if (inflightRuns.length > 0 && ALLOW_CONFLICTING_RUN) {
       appendRunEvent(repoRoot, runId, {
         event: EVENTS.CONFLICTING_RUN_OVERRIDE,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -305,6 +305,12 @@ function loadInitialRoutePlan(repoRoot) {
     executor: EXECUTOR_ARG,
     model: MODEL,
   });
+  // An explicit CLI --review-assurance always wins. Seed it into the run intent
+  // before preset expansion so a preset cannot record itself as having filled a
+  // field the CLI overrode (keeps the persisted route-plan attribution honest).
+  if (REVIEW_ASSURANCE_RAW && !nonEmptyString(routeIntent.review_assurance)) {
+    routeIntent.review_assurance = normalizeReviewAssurance(REVIEW_ASSURANCE_RAW);
+  }
   let routePlan;
   try {
     routePlan = resolveRouteIntent({

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -20,6 +20,7 @@
  *   --executor, -e <name>  Executor to use (default: codex)
  *   --model, -m <name>     Model override (default: from executor config)
  *   --model-hints <spec>   Persist per-phase model hints (phase=model,...)
+ *   --route-preset <name>  Expand named routes.json preset into unset route fields
  *   --sandbox <mode>       workspace-write | read-only (default: workspace-write)
  *   --network-access <mode> disabled | enabled (default: disabled; codex workspace-write only)
  *   --copy <file,...>      Additional files to copy
@@ -172,7 +173,7 @@ const args = process.argv.slice(2);
 
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
-  "--model", "-m", "--model-hints", "--route-intent-file", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
+  "--model", "-m", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
   "--request-id", "--leaf-id", "--fleet-id", "--done-criteria-file", "--publish-policy", "--review-assurance", "--tags",
   "--register", "--auto-recover-commit", "--no-auto-recover-commit", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help", "-h",
 ];
@@ -195,6 +196,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --model, -m        ${modeLabel("--model")} Model override`);
   console.log(`  --model-hints      ${modeLabel("--model-hints")} Persist per-phase model hints (phase=model,...)`);
   console.log(`  --route-intent-file ${modeLabel("--route-intent-file")} Read one-off run route intent JSON`);
+  console.log(`  --route-preset     ${modeLabel("--route-preset")} Expand named routes.json preset into unset route fields`);
   console.log(`  --sandbox          ${modeLabel("--sandbox")} workspace-write | read-only (default: workspace-write)`);
   console.log(`  --network-access   ${modeLabel("--network-access")} disabled | enabled (default: disabled; codex workspace-write only)`);
   console.log(`  --copy <files>     ${modeLabel("--copy")} Additional files to copy (comma-separated)`);
@@ -238,6 +240,7 @@ const PROMPT_FILE = readArg(args, "--prompt-file", undefined, CLI_ARG_OPTIONS);
 const EXECUTOR_ARG = readArg(args, ["--executor", "-e"], undefined, CLI_ARG_OPTIONS);
 const MODEL = readArg(args, ["--model", "-m"], undefined, CLI_ARG_OPTIONS);
 const ROUTE_INTENT_FILE = readArg(args, "--route-intent-file", undefined, CLI_ARG_OPTIONS);
+const ROUTE_PRESET = readArg(args, "--route-preset", undefined, CLI_ARG_OPTIONS);
 const RELAY_HOME_FOR_ROUTES = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
 
 function failEarly(message, extra = {}) {
@@ -265,6 +268,10 @@ function readRouteIntentFile(filePath) {
   } catch (error) {
     failEarly(`failed to read route intent file at ${resolved}: ${error.message}`);
   }
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 function mergeDispatchCliIntoRunIntent(baseIntent, { executor, model }) {
@@ -298,17 +305,30 @@ function loadInitialRoutePlan(repoRoot) {
     executor: EXECUTOR_ARG,
     model: MODEL,
   });
-  return {
-    routeIntent,
-    projectRoutes,
-    policyResult,
-    routePlan: resolveRouteIntent({
+  let routePlan;
+  try {
+    routePlan = resolveRouteIntent({
       runIntent: routeIntent,
+      routePresetName: ROUTE_PRESET,
       projectRoutes: projectRoutes.routes,
       policy: policyResult.policy,
       relayHome: RELAY_HOME_FOR_ROUTES,
       repoRoot,
-    }),
+    });
+  } catch (error) {
+    const extra = {
+      error_code: error.code || "route_preset_error",
+    };
+    if (Array.isArray(error.availablePresets)) {
+      extra.available_presets = error.availablePresets;
+    }
+    failEarly(error.message, extra);
+  }
+  return {
+    routeIntent,
+    projectRoutes,
+    policyResult,
+    routePlan,
   };
 }
 
@@ -329,6 +349,7 @@ const DONE_CRITERIA_FILE = readArg(args, "--done-criteria-file", undefined, CLI_
 const REVIEW_ASSURANCE_RAW = readArg(args, "--review-assurance", undefined, CLI_ARG_OPTIONS);
 const ROUTING_TAGS = readArg(args, "--tags", "", CLI_ARG_OPTIONS);
 let REVIEW_ASSURANCE;
+let REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RAW ? "cli" : null;
 try {
   REVIEW_ASSURANCE = normalizeReviewAssurance(REVIEW_ASSURANCE_RAW || "standard");
 } catch (error) {
@@ -346,6 +367,26 @@ let AUTO_RECOVER_COMMIT = null;
 
 function resolveDispatchRuntime(repoRoot) {
   const routeResolution = loadInitialRoutePlan(repoRoot);
+  if (!REVIEW_ASSURANCE_RAW) {
+    const intentReviewAssurance = nonEmptyString(routeResolution.routeIntent?.review_assurance);
+    const presetReviewAssurance = nonEmptyString(routeResolution.routePlan?.route_preset?.review_assurance);
+    const routeReviewAssurance = intentReviewAssurance || presetReviewAssurance;
+    if (routeReviewAssurance) {
+      try {
+        REVIEW_ASSURANCE = normalizeReviewAssurance(routeReviewAssurance);
+        REVIEW_ASSURANCE_SOURCE = intentReviewAssurance
+          ? "route_intent"
+          : routeResolution.routePlan.route_preset.source;
+      } catch (error) {
+        failEarly(error.message, {
+          error_code: "invalid_review_assurance",
+          review_assurance_source: intentReviewAssurance
+            ? "route_intent"
+            : routeResolution.routePlan?.route_preset?.source || null,
+        });
+      }
+    }
+  }
   const executor = EXECUTOR_ARG || routeResolution.routePlan.phases.dispatch?.executor || "codex";
   let resolvedAdapter;
   let resolvedAdapterDescriptor;
@@ -1268,6 +1309,32 @@ function summarizeRoutePlan(routePlan) {
   return summary;
 }
 
+function presetAdvisorySelection(routePlan) {
+  const presetSource = routePlan?.route_preset?.source;
+  const advisory = routePlan?.phases?.advisory_review;
+  if (!presetSource || !advisory?.reviewer) return null;
+  const sources = advisory.sources || {};
+  const hasPresetSource = ["reviewer", "model", "profile"].some((field) => sources[field] === presetSource);
+  if (!hasPresetSource) return null;
+  return {
+    reviewer: advisory.reviewer,
+    ...(advisory.model ? { model: advisory.model } : {}),
+    ...(advisory.profile ? { profile: advisory.profile } : {}),
+  };
+}
+
+function applyPresetAdvisoryToRoutingDecision(routingDecision, routePlan) {
+  const advisory = presetAdvisorySelection(routePlan);
+  if (!advisory) return routingDecision;
+  return {
+    ...routingDecision,
+    selected: {
+      ...(routingDecision.selected || {}),
+      advisory_review: advisory,
+    },
+  };
+}
+
 function writeRoutePlanSnapshot({ repoRoot, runId, routePlan, policyResult, projectRoutes, resolvedAt = new Date().toISOString() }) {
   const routePlanPath = getRoutePlanPath(repoRoot, runId);
   const snapshot = {
@@ -1348,6 +1415,7 @@ async function main() {
   let dispatchStartTime = null;
   let fleetIssueLock = null;
   let handlingSignal = false;
+  let runtime = null;
 
   function releaseFleetIssueLock() {
     if (!fleetIssueLock) return;
@@ -1535,6 +1603,8 @@ async function main() {
       process.exit(1);
     }
 
+    runtime = resolveDispatchRuntime(repoRoot);
+
     // --- Environment drift check ---
     const currentEnv = collectEnvironmentSnapshot(repoRoot, baseBranch);
     const needsDraftEnvironmentBackfill = manifest.state === STATES.DRAFT
@@ -1597,6 +1667,7 @@ async function main() {
       console.error(`Error: worktree path already exists: ${wtPath}`);
       process.exit(1);
     }
+    runtime = resolveDispatchRuntime(repoRoot);
     if (inflightRuns.length > 0 && ALLOW_CONFLICTING_RUN) {
       appendRunEvent(repoRoot, runId, {
         event: EVENTS.CONFLICTING_RUN_OVERRIDE,
@@ -1607,7 +1678,6 @@ async function main() {
     }
   }
 
-  const runtime = resolveDispatchRuntime(repoRoot);
   EXECUTOR = runtime.executor;
   adapter = runtime.adapter;
   adapterDescriptor = runtime.adapterDescriptor;
@@ -1647,7 +1717,7 @@ async function main() {
 
   const taskPromptResult = readTaskPrompt({ runDir: manifestRunDir, resumeMode: RESUME_MODE });
   let taskPrompt = taskPromptResult.prompt;
-  if (!RESUME_MODE && REVIEW_ASSURANCE_RAW === undefined) {
+  if (!RESUME_MODE && REVIEW_ASSURANCE_RAW === undefined && REVIEW_ASSURANCE_SOURCE === null) {
     try {
       REVIEW_ASSURANCE = extractReviewAssuranceFromPrompt(taskPrompt) || REVIEW_ASSURANCE;
     } catch (error) {
@@ -1767,7 +1837,7 @@ async function main() {
       },
     },
   };
-  const routingDecision = resolveRoutingDecision({
+  let routingDecision = resolveRoutingDecision({
     policy: effectivePolicy.policy || {},
     cliTags: ROUTING_TAGS,
     taskProfile: manifest?.advisory?.guidance?.task_profile_summary || null,
@@ -1780,6 +1850,7 @@ async function main() {
     changedFiles: collectChangedFilesForRouting(RESUME_MODE ? wtPath : repoRoot, baseBranch),
     testCommands: TEST_COMMAND ? [TEST_COMMAND] : [],
   });
+  routingDecision = applyPresetAdvisoryToRoutingDecision(routingDecision, routePlan);
 
   // --- Dry run ---
   if (DRY_RUN) {

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -171,6 +171,16 @@ function writeRoutes(routesPath, routes) {
   return routes;
 }
 
+function loadGlobalPresetsForShow() {
+  const routesPath = relayRoutesPath();
+  if (!fs.existsSync(routesPath)) {
+    return {};
+  }
+  const routes = readRoutesFile(routesPath);
+  const validated = validateRouteConfig(routes, routesPath);
+  return cloneJson(validated.presets || {});
+}
+
 function requireValue(value, label) {
   const normalized = nonEmptyString(value);
   if (!normalized) throw new Error(`${label} is required`);
@@ -750,11 +760,7 @@ function commandPreset(positionals, jsonOut) {
       throw new Error("preset show accepts optional <name>");
     }
     const name = positionals[2] ? requireValue(positionals[2], "preset name") : null;
-    const result = loadRelayPolicy({ repoRoot: process.cwd() });
-    if (!result.ok) {
-      throw new Error(result.errors?.[0]?.message || "failed to load routes config");
-    }
-    const presets = cloneJson(result.policy?.presets || {});
+    const presets = loadGlobalPresetsForShow();
     const output = {
       ok: true,
       action: "preset show",

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -757,11 +757,11 @@ const PRESET_MUTATION_FLAGS = [
 ];
 
 // add-only flags describe a mutation; show/remove must reject them rather than
-// silently ignore an inapplicable flag.
+// silently ignore an inapplicable flag. Detect presence (hasCliFlag), not a
+// parsed value — a value flag given bare (e.g. `--dispatch --json`) reads back as
+// undefined but is still present and must still be rejected.
 function assertNoPresetMutationFlags(action) {
-  const present = PRESET_MUTATION_FLAGS.filter(
-    (flag) => readArg(args, flag, undefined, CLI_ARG_OPTIONS) !== undefined
-  );
+  const present = PRESET_MUTATION_FLAGS.filter((flag) => hasCliFlag(flag));
   if (present.length) {
     throw new Error(`preset ${action} does not accept ${present.join(", ")}`);
   }

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -16,6 +16,7 @@ const {
   resolveRouteIntent,
   validateRouteConfig,
 } = require("./relay-routing");
+const { normalizeReviewAssurance } = require("./manifest/review-assurance");
 const {
   findUnknownFlags,
   getPositionals,
@@ -47,6 +48,7 @@ const SUBCOMMAND_FLAGS = {
   "add-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
   "allow-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
   "deny-route": new Set(["--phase", "--executor", "--reviewer", "--json", "--help"]),
+  preset: new Set(["--dispatch", "--review", "--advisory-review", "--advisory-profile", "--review-assurance", "--json", "--help"]),
 };
 const RELAY_CONFIG_FLAG_ALIASES = new Map([
   ["-h", "--help"],
@@ -81,6 +83,7 @@ function printHelp() {
   console.log(`  add-route <pattern> --phase <csv> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
   console.log(`  allow-route <pattern> --phase <csv> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}] (deprecated; use add-route)`);
   console.log(`  deny-route <pattern> [--phase <csv> ${modeLabel("--phase")}] [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--json ${modeLabel("--json")}]`);
+  console.log(`  preset add|remove|show <name> [--dispatch <actor[:provider/model]> ${modeLabel("--dispatch")}] [--review <actor[:provider/model]> ${modeLabel("--review")}] [--advisory-review <actor[:provider/model]> ${modeLabel("--advisory-review")}] [--advisory-profile <name> ${modeLabel("--advisory-profile")}] [--review-assurance <standard|hardened> ${modeLabel("--review-assurance")}] [--json ${modeLabel("--json")}]`);
   console.log("");
   console.log("Supported default paths:");
   console.log("  dispatch.executor, review.reviewer, advisory_review.reviewer");
@@ -230,7 +233,7 @@ function routeEntry(pattern, { phases, executor, reviewer }) {
   return entry;
 }
 
-function outputMutation({ jsonOut, action, routesPath, routes, entry = null, defaultPath = null, profile = null, warnings = [] }) {
+function outputMutation({ jsonOut, action, routesPath, routes, entry = null, defaultPath = null, profile = null, presetName = null, preset = null, warnings = [] }) {
   if (jsonOut) {
     printJson({
       ok: true,
@@ -239,6 +242,8 @@ function outputMutation({ jsonOut, action, routesPath, routes, entry = null, def
       path: routesPath,
       defaultPath,
       entry,
+      presetName,
+      preset,
       routes,
       warnings,
     });
@@ -681,6 +686,140 @@ function commandRouteMutation(positionals, jsonOut, { action, listName, requireP
   outputMutation({ jsonOut, action, routesPath, routes: written, entry, warnings });
 }
 
+function presetActorForPhase(phase, value) {
+  if (!isPlainObject(value)) return null;
+  return REVIEWER_PHASES.has(phase) ? nonEmptyString(value.reviewer) : nonEmptyString(value.executor);
+}
+
+function presetReferenceWarnings(routes, presetName, preset) {
+  const warnings = [];
+  const policyResult = loadRelayPolicy({ globalRoutes: routes });
+  const policy = policyResult.ok ? policyResult.policy : null;
+  for (const phase of VALID_PHASES) {
+    const phaseValue = preset[phase];
+    if (!isPlainObject(phaseValue)) continue;
+    const actor = presetActorForPhase(phase, phaseValue);
+    if (actor && !findOnPath(actor)) {
+      warnings.push(`${actor} CLI not found on PATH for preset ${presetName} ${phase}`);
+    }
+    const model = nonEmptyString(phaseValue.model);
+    if (policy && routes.strict === true && actor && model) {
+      const decision = REVIEWER_PHASES.has(phase)
+        ? evaluateRelayRoute(policy, { phase, reviewer: actor, model })
+        : evaluateRelayRoute(policy, { phase, executor: actor, model });
+      if (decision.reason === "unknown_model_route" || decision.reason === "missing_model_route") {
+        warnings.push(`strict routes config does not register ${phase} route ${model} for ${actor}`);
+      }
+    }
+  }
+  return warnings;
+}
+
+function parsePresetFromArgs() {
+  const preset = {};
+  const dispatchSpec = parseRouteSpec(readArg(args, "--dispatch", undefined, CLI_ARG_OPTIONS), "dispatch");
+  const reviewSpec = parseRouteSpec(readArg(args, "--review", undefined, CLI_ARG_OPTIONS), "review");
+  const advisorySpec = parseRouteSpec(readArg(args, "--advisory-review", undefined, CLI_ARG_OPTIONS), "advisory_review");
+  if (dispatchSpec) preset.dispatch = dispatchSpec;
+  if (reviewSpec) preset.review = reviewSpec;
+  if (advisorySpec) {
+    const profile = nonEmptyString(readArg(args, "--advisory-profile", undefined, CLI_ARG_OPTIONS));
+    preset.advisory_review = {
+      ...advisorySpec,
+      ...(profile ? { profile } : {}),
+    };
+  }
+  const reviewAssurance = nonEmptyString(readArg(args, "--review-assurance", undefined, CLI_ARG_OPTIONS));
+  if (reviewAssurance) {
+    preset.review_assurance = normalizeReviewAssurance(reviewAssurance);
+  }
+  if (!Object.keys(preset).length) {
+    throw new Error("preset add requires at least one of --dispatch, --review, --advisory-review, or --review-assurance");
+  }
+  return preset;
+}
+
+function commandPreset(positionals, jsonOut) {
+  const action = positionals[1];
+  if (!["add", "remove", "show"].includes(action)) {
+    throw new Error("preset requires add, remove, or show");
+  }
+
+  if (action === "show") {
+    if (positionals.length !== 2 && positionals.length !== 3) {
+      throw new Error("preset show accepts optional <name>");
+    }
+    const name = positionals[2] ? requireValue(positionals[2], "preset name") : null;
+    const result = loadRelayPolicy({ repoRoot: process.cwd() });
+    if (!result.ok) {
+      throw new Error(result.errors?.[0]?.message || "failed to load routes config");
+    }
+    const presets = cloneJson(result.policy?.presets || {});
+    const output = {
+      ok: true,
+      action: "preset show",
+      presets,
+      ...(name ? { presetName: name, preset: presets[name] || null } : {}),
+    };
+    if (name && !presets[name]) {
+      throw new Error(`unknown preset: ${name}`);
+    }
+    if (jsonOut) {
+      printJson(output);
+    } else if (name) {
+      console.log(JSON.stringify(output.preset, null, 2));
+    } else {
+      console.log(JSON.stringify(presets, null, 2));
+    }
+    return;
+  }
+
+  if (positionals.length !== 3) {
+    throw new Error(`preset ${action} requires <name>`);
+  }
+  const presetName = requireValue(positionals[2], "preset name");
+  const { routesPath, routes, warnings } = loadRoutesForMutation();
+  const updated = cloneJson(routes);
+
+  if (action === "add") {
+    const preset = parsePresetFromArgs();
+    updated.presets = {
+      ...(isPlainObject(updated.presets) ? updated.presets : {}),
+      [presetName]: preset,
+    };
+    validateRouteConfig(updated, routesPath);
+    const routeWarnings = presetReferenceWarnings(updated, presetName, preset);
+    const written = writeRoutes(routesPath, updated);
+    outputMutation({
+      jsonOut,
+      action: "preset add",
+      routesPath,
+      routes: written,
+      presetName,
+      preset,
+      warnings: [...warnings, ...routeWarnings],
+    });
+    return;
+  }
+
+  if (!isPlainObject(updated.presets) || !Object.prototype.hasOwnProperty.call(updated.presets, presetName)) {
+    throw new Error(`unknown preset: ${presetName}`);
+  }
+  const removed = updated.presets[presetName];
+  delete updated.presets[presetName];
+  if (!Object.keys(updated.presets).length) delete updated.presets;
+  const written = writeRoutes(routesPath, updated);
+  outputMutation({
+    jsonOut,
+    action: "preset remove",
+    routesPath,
+    routes: written,
+    presetName,
+    preset: removed,
+    warnings,
+  });
+}
+
 function main() {
   if (!args.length || hasCliFlag(["--help", "-h"])) {
     printHelp();
@@ -747,6 +886,9 @@ function main() {
         listName: "denied_routes",
         requirePhase: false,
       });
+      break;
+    case "preset":
+      commandPreset(positionals, jsonOut);
       break;
   }
 }

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -732,11 +732,14 @@ function parsePresetFromArgs() {
   const advisorySpec = parseRouteSpec(readArg(args, "--advisory-review", undefined, CLI_ARG_OPTIONS), "advisory_review");
   if (dispatchSpec) preset.dispatch = dispatchSpec;
   if (reviewSpec) preset.review = reviewSpec;
+  const advisoryProfile = nonEmptyString(readArg(args, "--advisory-profile", undefined, CLI_ARG_OPTIONS));
+  if (advisoryProfile && !advisorySpec) {
+    throw new Error("--advisory-profile requires --advisory-review");
+  }
   if (advisorySpec) {
-    const profile = nonEmptyString(readArg(args, "--advisory-profile", undefined, CLI_ARG_OPTIONS));
     preset.advisory_review = {
       ...advisorySpec,
-      ...(profile ? { profile } : {}),
+      ...(advisoryProfile ? { profile: advisoryProfile } : {}),
     };
   }
   const reviewAssurance = nonEmptyString(readArg(args, "--review-assurance", undefined, CLI_ARG_OPTIONS));
@@ -749,10 +752,28 @@ function parsePresetFromArgs() {
   return preset;
 }
 
+const PRESET_MUTATION_FLAGS = [
+  "--dispatch", "--review", "--advisory-review", "--advisory-profile", "--review-assurance",
+];
+
+// add-only flags describe a mutation; show/remove must reject them rather than
+// silently ignore an inapplicable flag.
+function assertNoPresetMutationFlags(action) {
+  const present = PRESET_MUTATION_FLAGS.filter(
+    (flag) => readArg(args, flag, undefined, CLI_ARG_OPTIONS) !== undefined
+  );
+  if (present.length) {
+    throw new Error(`preset ${action} does not accept ${present.join(", ")}`);
+  }
+}
+
 function commandPreset(positionals, jsonOut) {
   const action = positionals[1];
   if (!["add", "remove", "show"].includes(action)) {
     throw new Error("preset requires add, remove, or show");
+  }
+  if (action !== "add") {
+    assertNoPresetMutationFlags(action);
   }
 
   if (action === "show") {

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -748,11 +748,16 @@ function expandRoutePreset({ runIntent = null, policy = {}, routePresetName = nu
   }
 
   const reviewAssurance = nonEmptyString(preset.review_assurance);
+  // Only claim review_assurance when the preset actually applies it. When the
+  // field is already set (e.g. an explicit CLI --review-assurance seeded into the
+  // run intent), the preset must not report it as filled/applied.
+  let appliedReviewAssurance = null;
   if (reviewAssurance && !Object.prototype.hasOwnProperty.call(expanded, "review_assurance")) {
     expanded.review_assurance = reviewAssurance;
     if (!isPlainObject(expanded[ROUTE_INTENT_SOURCES_KEY])) expanded[ROUTE_INTENT_SOURCES_KEY] = {};
     expanded[ROUTE_INTENT_SOURCES_KEY].review_assurance = source;
     filled.push({ field: "review_assurance" });
+    appliedReviewAssurance = reviewAssurance;
   }
 
   return {
@@ -761,7 +766,7 @@ function expandRoutePreset({ runIntent = null, policy = {}, routePresetName = nu
       name: presetName,
       source,
       filled,
-      review_assurance: reviewAssurance || null,
+      review_assurance: appliedReviewAssurance,
     },
   };
 }

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -8,6 +8,7 @@ const { getProjectRoutesPath } = require("./manifest/paths");
 const { buildDefaultRelayPolicy, evaluateRelayRoute } = require("./relay-policy");
 
 const GLOBAL_ROUTES_FILE = "routes.json";
+const ROUTE_INTENT_SOURCES_KEY = "__route_sources";
 
 function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -661,10 +662,114 @@ function defaultForPhase(policy, phase) {
   return cloneJson(buildDefaultRelayPolicy().defaults[phase]);
 }
 
+function availablePresetNames(policy) {
+  return Object.keys(policy?.presets || {}).sort();
+}
+
+function presetError(message, details = {}) {
+  const error = new Error(message);
+  for (const [key, value] of Object.entries(details)) error[key] = value;
+  return error;
+}
+
+function normalizePresetName(value) {
+  return nonEmptyString(value);
+}
+
+function hasRunIntentField(runIntent, phase, field) {
+  return isPlainObject(runIntent?.[phase])
+    && Object.prototype.hasOwnProperty.call(runIntent[phase], field);
+}
+
+function setRunIntentField(target, phase, field, value, source) {
+  const normalized = nonEmptyString(value);
+  if (!normalized) return false;
+  if (!isPlainObject(target[phase])) target[phase] = {};
+  target[phase][field] = normalized;
+  if (!isPlainObject(target[ROUTE_INTENT_SOURCES_KEY])) target[ROUTE_INTENT_SOURCES_KEY] = {};
+  if (!isPlainObject(target[ROUTE_INTENT_SOURCES_KEY][phase])) target[ROUTE_INTENT_SOURCES_KEY][phase] = {};
+  target[ROUTE_INTENT_SOURCES_KEY][phase][field] = source;
+  return true;
+}
+
+function runIntentSource(runIntent, phase, field) {
+  return nonEmptyString(runIntent?.[ROUTE_INTENT_SOURCES_KEY]?.[phase]?.[field]) || "run_intent";
+}
+
+function normalizePresetPhase(preset, presetName, phase) {
+  if (preset[phase] === undefined || preset[phase] === null) return null;
+  return normalizeRouteDefault(preset[phase], phase, `preset:${presetName}`, { partial: true });
+}
+
+function expandRoutePreset({ runIntent = null, policy = {}, routePresetName = null } = {}) {
+  const presetName = normalizePresetName(routePresetName);
+  if (!presetName) {
+    return {
+      runIntent: cloneJson(runIntent || {}),
+      routePreset: null,
+    };
+  }
+
+  const presets = policy?.presets || {};
+  const available = availablePresetNames(policy);
+  if (!available.length) {
+    throw presetError(
+      `no route presets configured; run relay-config preset add <name> to create one before using --route-preset ${presetName}`,
+      { code: "route_preset_unconfigured", availablePresets: [] }
+    );
+  }
+  if (!Object.prototype.hasOwnProperty.call(presets, presetName)) {
+    throw presetError(
+      `unknown route preset '${presetName}'; available presets: ${available.join(", ")}`,
+      { code: "unknown_route_preset", availablePresets: available }
+    );
+  }
+
+  const preset = presets[presetName];
+  if (!isPlainObject(preset)) {
+    throw presetError(`route preset '${presetName}' must be an object`, {
+      code: "invalid_route_preset",
+      availablePresets: available,
+    });
+  }
+
+  const expanded = cloneJson(runIntent || {});
+  const filled = [];
+  const source = `preset:${presetName}`;
+  for (const phase of ROUTE_PHASES) {
+    const presetPhase = normalizePresetPhase(preset, presetName, phase);
+    if (!presetPhase) continue;
+    for (const [field, value] of Object.entries(presetPhase)) {
+      if (hasRunIntentField(expanded, phase, field)) continue;
+      if (setRunIntentField(expanded, phase, field, value, source)) {
+        filled.push({ phase, field });
+      }
+    }
+  }
+
+  const reviewAssurance = nonEmptyString(preset.review_assurance);
+  if (reviewAssurance && !Object.prototype.hasOwnProperty.call(expanded, "review_assurance")) {
+    expanded.review_assurance = reviewAssurance;
+    if (!isPlainObject(expanded[ROUTE_INTENT_SOURCES_KEY])) expanded[ROUTE_INTENT_SOURCES_KEY] = {};
+    expanded[ROUTE_INTENT_SOURCES_KEY].review_assurance = source;
+    filled.push({ field: "review_assurance" });
+  }
+
+  return {
+    runIntent: expanded,
+    routePreset: {
+      name: presetName,
+      source,
+      filled,
+      review_assurance: reviewAssurance || null,
+    },
+  };
+}
+
 function pickField({ phase, field, runIntent, projectRoutes, policy }) {
   const runPhase = runIntent?.[phase];
   if (isPlainObject(runPhase) && Object.prototype.hasOwnProperty.call(runPhase, field)) {
-    return { value: nonEmptyString(runPhase[field]), source: "run_intent" };
+    return { value: nonEmptyString(runPhase[field]), source: runIntentSource(runIntent, phase, field) };
   }
   const projectPhase = projectRoutes?.defaults?.[phase];
   if (isPlainObject(projectPhase) && Object.prototype.hasOwnProperty.call(projectPhase, field)) {
@@ -735,6 +840,7 @@ function resolvePhaseRoute({ phase, runIntent, projectRoutes, policy, relayHome,
 
 function resolveRouteIntent({
   runIntent = null,
+  routePresetName = null,
   projectRoutes = null,
   policy = buildDefaultRelayPolicy(),
   relayHome = process.env.RELAY_HOME,
@@ -742,11 +848,13 @@ function resolveRouteIntent({
   executorModelResolver = null,
 } = {}) {
   const normalizedProjectRoutes = projectRoutes ? validateProjectRoutes(projectRoutes, "project routes") : null;
+  const presetExpansion = expandRoutePreset({ runIntent, policy, routePresetName });
+  const effectiveRunIntent = presetExpansion.runIntent;
   const phases = {};
   for (const phase of ROUTE_PHASES) {
     phases[phase] = resolvePhaseRoute({
       phase,
-      runIntent,
+      runIntent: effectiveRunIntent,
       projectRoutes: normalizedProjectRoutes,
       policy,
       relayHome,
@@ -756,6 +864,7 @@ function resolveRouteIntent({
   }
   return {
     version: 1,
+    ...(presetExpansion.routePreset ? { route_preset: presetExpansion.routePreset } : {}),
     phases,
   };
 }

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -43,10 +43,16 @@ function resolveAdvisoryConfig({
   if (!reviewer && (advisoryProfileArg || advisoryReviewerModel || advisoryTimeoutArg || advisoryGraceArg)) {
     throw new Error("--advisory-reviewer is required when advisory options are supplied and no manifest routing advisory reviewer is selected");
   }
+  // A route-plan model/profile was planned for planned.reviewer specifically. Only
+  // inherit it when that planned reviewer is the one actually selected, so a routed
+  // (or CLI) advisory reviewer cannot pick up a model meant for a different reviewer.
+  const plannedForSelected = planned.reviewer && planned.reviewer === reviewer;
+  const plannedModel = plannedForSelected ? planned.model : null;
+  const plannedProfile = plannedForSelected ? planned.profile : null;
   return {
     graceSeconds: reviewer ? parseNonNegativeSeconds(advisoryGraceArg) : null,
-    model: reviewer ? (advisoryReviewerModel || routed.model || routed.reviewer_model || planned.model || null) : null,
-    profile: reviewer ? validateAdvisoryProfile(advisoryProfileArg || routed.profile || planned.profile || "blindspot") : null,
+    model: reviewer ? (advisoryReviewerModel || routed.model || routed.reviewer_model || plannedModel || null) : null,
+    profile: reviewer ? validateAdvisoryProfile(advisoryProfileArg || routed.profile || plannedProfile || "blindspot") : null,
     reviewer,
     source: reviewer ? (advisoryReviewerArg ? "cli" : routed.reviewer ? "routing" : "route_plan") : null,
     timeoutSeconds: reviewer ? parsePositiveSeconds(advisoryTimeoutArg) : null,

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -39,16 +39,16 @@ function resolveAdvisoryConfig({
   const routed = data?.routing?.selected?.advisory_review && typeof data.routing.selected.advisory_review === "object"
     ? data.routing.selected.advisory_review
     : {};
-  const reviewer = advisoryReviewerArg || planned.reviewer || routed.reviewer || null;
+  const reviewer = advisoryReviewerArg || routed.reviewer || planned.reviewer || null;
   if (!reviewer && (advisoryProfileArg || advisoryReviewerModel || advisoryTimeoutArg || advisoryGraceArg)) {
     throw new Error("--advisory-reviewer is required when advisory options are supplied and no manifest routing advisory reviewer is selected");
   }
   return {
     graceSeconds: reviewer ? parseNonNegativeSeconds(advisoryGraceArg) : null,
-    model: reviewer ? (advisoryReviewerModel || planned.model || routed.model || routed.reviewer_model || null) : null,
-    profile: reviewer ? validateAdvisoryProfile(advisoryProfileArg || planned.profile || routed.profile || "blindspot") : null,
+    model: reviewer ? (advisoryReviewerModel || routed.model || routed.reviewer_model || planned.model || null) : null,
+    profile: reviewer ? validateAdvisoryProfile(advisoryProfileArg || routed.profile || planned.profile || "blindspot") : null,
     reviewer,
-    source: reviewer ? (advisoryReviewerArg ? "cli" : planned.reviewer ? "route_plan" : "routing") : null,
+    source: reviewer ? (advisoryReviewerArg ? "cli" : routed.reviewer ? "routing" : "route_plan") : null,
     timeoutSeconds: reviewer ? parsePositiveSeconds(advisoryTimeoutArg) : null,
   };
 }

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -24,6 +24,17 @@ Execute the plan -> dispatch -> review cycle. Stop at `ready_to_merge` unless th
 
 Standard Codex path: stamp `RELAY_ORCHESTRATOR=codex` and review through `review-runner --reviewer codex`. Assigned manifest roles stay immutable; acting reviewer data is recorded separately.
 
+## Route Preset Words
+
+When the user gives a routing style, map only these clear words:
+| User wording | Dispatch option |
+| --- | --- |
+| `가볍게`, `싸게`, `light` | `--route-preset light` |
+| `리뷰 다양하게`, `diverse` | `--route-preset diverse` |
+| `하드하게`, `hardened` | `--route-preset hardened` |
+
+If no wording matches, list configured presets from routes config and ask/continue with defaults; do not guess.
+
 ## Step 1: Re-Anchor and Route
 
 Run `git fetch origin`; if a sprint file exists, re-read Running Context and completed/in-flight status changes. Apply any previous-task context before proceeding.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -55,9 +55,7 @@ Fast path: bypass relay-ready only for one relay-ready task with a stable review
 
 ## Step 2: Plan
 
-**Always build a rubric.** Follow relay-plan's process: read task, recover Done Criteria, build rubric, emit handoff artifacts. Do NOT dispatch from relay-plan; Step 3 handles dispatch.
-
-Write the dispatch prompt and rubric YAML to temp files such as `/tmp/dispatch-<N>.md` and `/tmp/rubric-<N>.yaml`.
+**Always build a rubric.** Follow relay-plan's process: read task, recover Done Criteria, build rubric, emit handoff artifacts. Do NOT dispatch from relay-plan; Step 3 handles dispatch. Write the dispatch prompt and rubric YAML to temp files such as `/tmp/dispatch-<N>.md` and `/tmp/rubric-<N>.yaml`.
 
 ## Step 3: Dispatch (relay-dispatch)
 
@@ -80,14 +78,11 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/reconcile-run.js" --rep
 node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage review --repo . --run-id "$RUN_ID" --json
 ```
 
-Wait for completion. Check the manifest/result:
-- `status: "completed"` and `runState: "internal_review_pending"` → proceed to Step 4
-- `status: "completed-with-warning"` and `runState: "internal_review_pending"` → executor timed out but made progress; check worktree, proceed to Step 4
+Check the manifest/result:
+- `status: "completed"`/`"completed-with-warning"` and `runState: "internal_review_pending"` → proceed to Step 4 (on warning, the executor timed out but made progress; check the worktree)
 - `status: "failed"` and `runState: "escalated"` → inspect the dispatch error / manifest, fix and re-dispatch
 
-Capture `runId`, `manifestPath`, and `runState` from dispatch output. Do not create or look up a PR yet; publication happens only after internal review LGTM.
-
-The manifest is written under `~/.relay/runs/<repo-slug>/`. Readiness linkage is recorded there, but the run lifecycle remains execution-only. If a sprint file exists, mark the plan item in-flight.
+Capture `runId`, `manifestPath`, `runState`; do not create or look up a PR yet (publication happens only after internal review LGTM). The manifest is under `~/.relay/runs/<repo-slug>/`; if a sprint file exists, mark the plan item in-flight.
 
 ## Step 4: Review (relay-review)
 
@@ -108,9 +103,7 @@ PUBLISH_RESULT=$(node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/publis
 PR_NUM=$(node -e 'const r=JSON.parse(process.argv[1]); process.stdout.write(String(r.prNumber || ""));' "$PUBLISH_RESULT")
 ```
 
-Now run the post-publication review. This is the round that can advance to `ready_to_merge`; it includes PR CI/actions, GitHub review, and comment signals in the review prompt.
-
-Snapshot review state before invoking relay-review:
+Now run the post-publication review — the round that can advance to `ready_to_merge` (it folds in PR CI/actions, GitHub review, and comment signals). Snapshot review state first:
 ```bash
 REVIEW_BEFORE=$(node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" \
   --stage review --repo . --run-id "$RUN_ID" --pr "$PR_NUM" --json)

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -106,6 +106,34 @@ test("check shorthand maps reviewer phases to reviewer-only core checks", () => 
   assert.equal(parseJson(result).decision.reason, "allowed_model_route");
 });
 
+test("preset subcommands pass through wrapper shorthand", () => {
+  const relayHome = tempDir();
+
+  const add = runConfig([
+    "preset",
+    "add",
+    "hardened",
+    "--review-assurance",
+    "hardened",
+    "--json",
+  ], { relayHome });
+  assert.equal(add.status, 0, add.combined);
+  assert.deepEqual(readRoutes(relayHome), {
+    version: 2,
+    presets: {
+      hardened: { review_assurance: "hardened" },
+    },
+  });
+
+  const show = runConfig(["preset", "show", "hardened", "--json"], { relayHome });
+  assert.equal(show.status, 0, show.combined);
+  assert.equal(parseJson(show).preset.review_assurance, "hardened");
+
+  const remove = runConfig(["preset", "remove", "hardened", "--json"], { relayHome });
+  assert.equal(remove.status, 0, remove.combined);
+  assert.equal(Object.prototype.hasOwnProperty.call(readRoutes(relayHome), "presets"), false);
+});
+
 test("inspect reports effective policy, doctor output, and executors config state", () => {
   const relayHome = tempDir();
   const executorsPath = path.join(relayHome, "executors.json");
@@ -141,6 +169,7 @@ test("help advertises natural-language setup and provider/model boundary", () =>
   assert.match(result.stdout, /relay setup 해줘/);
   assert.match(result.stdout, /provider\/model route strings are the routing boundary/i);
   assert.match(result.stdout, /add-route <pattern>/);
+  assert.match(result.stdout, /preset add\|remove\|show/);
   assert.match(result.stdout, /allow-route <pattern>.*deprecated/i);
   assert.doesNotMatch(result.stdout, /\bpolicy\b/i);
 });

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -162,6 +162,14 @@ test("reconcile-run flags are registered with explicit required modes", () => {
   }
 });
 
+test("dispatch registers --route-preset as a parsed value flag", () => {
+  const definition = FLAGS.find((entry) => entry.flag === "--route-preset");
+  assert.ok(definition, "--route-preset should be registered");
+  assert.equal(definition.kind, VALUE);
+  assert.equal(definition.mode, MODE_PARSED);
+  assert.ok(COMMAND_FLAGS.dispatch.includes("--route-preset"));
+});
+
 const HELP_COMMANDS = [
   ["cleanup-worktrees", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "cleanup-worktrees.js")],
   ["close-run", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "close-run.js")],

--- a/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
@@ -152,7 +152,7 @@ test("dispatch dry-run expands route preset below explicit flags and records pre
   assert.equal(output.route_plan.phases.advisory_review.profile, "blindspot");
 });
 
-test("dispatch unknown route preset fails before creating run side effects", () => {
+test("dispatch unknown route preset fails before creating run side effects including fleet locks", () => {
   const { repoRoot, relayHome, rubricFile } = setupRepo();
   writeJson(path.join(relayHome, "routes.json"), {
     version: 2,
@@ -165,9 +165,10 @@ test("dispatch unknown route preset fails before creating run side effects", () 
 
   const proc = spawnSync(process.execPath, [
     SCRIPT, repoRoot,
-    "-b", "issue-unknown-preset",
+    "-b", "issue-123-unknown-preset",
     "-p", "unknown preset route plan",
     "--rubric-file", rubricFile,
+    "--fleet-id", "issue-123",
     "--route-preset", "missing",
     "--json",
   ], {
@@ -182,6 +183,7 @@ test("dispatch unknown route preset fails before creating run side effects", () 
   assert.deepEqual(output.available_presets, ["hardened", "light"]);
   assert.equal(fs.existsSync(path.join(relayHome, "runs")), false);
   assert.equal(fs.existsSync(path.join(relayHome, "worktrees")), false);
+  assert.equal(fs.existsSync(path.join(relayHome, "fleets")), false);
 });
 
 test("dispatch route preset review_assurance maps to existing review assurance path", () => {
@@ -216,6 +218,48 @@ test("dispatch route preset review_assurance maps to existing review assurance p
   assert.equal(proc.status, 0, proc.stderr);
   const output = JSON.parse(proc.stdout);
   assert.equal(output.reviewAssurance, "hardened");
+});
+
+test("dispatch persists review assurance route preset source metadata in route-plan snapshot", () => {
+  const { repoRoot, relayHome, rubricFile } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-route-preset-hardened-bin-"));
+  writeFakeCodex(binDir);
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "codex" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    presets: {
+      hardened: { review_assurance: "hardened" },
+    },
+  });
+
+  const proc = spawnSync(process.execPath, [
+    SCRIPT, repoRoot,
+    "-b", "issue-preset-hardened-real",
+    "-p", "hardened preset persisted route plan",
+    "--rubric-file", rubricFile,
+    "--route-preset", "hardened",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: relayHome, PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}` },
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  const output = JSON.parse(proc.stdout);
+  assert.equal(fs.existsSync(output.routePlanPath), true);
+  const snapshot = JSON.parse(fs.readFileSync(output.routePlanPath, "utf-8"));
+  assert.equal(snapshot.route_preset.name, "hardened");
+  assert.equal(snapshot.route_preset.source, "preset:hardened");
+  assert.equal(snapshot.route_preset.review_assurance, "hardened");
+  assert.deepEqual(snapshot.route_preset.filled, [{ field: "review_assurance" }]);
+  const manifest = readManifest(output.manifestPath).data;
+  assert.equal(manifest.policy.review_assurance, "hardened");
 });
 
 test("dispatch denied route intent fails before executor invocation", () => {

--- a/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
@@ -262,6 +262,52 @@ test("dispatch persists review assurance route preset source metadata in route-p
   assert.equal(manifest.policy.review_assurance, "hardened");
 });
 
+test("dispatch keeps explicit --review-assurance over a preset in the route-plan snapshot", () => {
+  const { repoRoot, relayHome, rubricFile } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-route-preset-cli-override-bin-"));
+  writeFakeCodex(binDir);
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "codex" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    presets: {
+      hardened: { review_assurance: "hardened" },
+    },
+  });
+
+  const proc = spawnSync(process.execPath, [
+    SCRIPT, repoRoot,
+    "-b", "issue-preset-cli-override-real",
+    "-p", "preset with explicit review-assurance override",
+    "--rubric-file", rubricFile,
+    "--route-preset", "hardened",
+    "--review-assurance", "standard",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: relayHome, PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}` },
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  const output = JSON.parse(proc.stdout);
+  // The explicit CLI flag wins for execution ...
+  const manifest = readManifest(output.manifestPath).data;
+  assert.equal(manifest.policy.review_assurance, "standard");
+  // ... and the snapshot must not attribute review_assurance to the preset.
+  const snapshot = JSON.parse(fs.readFileSync(output.routePlanPath, "utf-8"));
+  assert.equal(snapshot.route_preset.name, "hardened");
+  assert.equal(snapshot.route_preset.review_assurance, null);
+  assert.ok(
+    !snapshot.route_preset.filled.some((entry) => entry.field === "review_assurance"),
+    "preset must not claim it filled review_assurance when the CLI overrode it"
+  );
+});
+
 test("dispatch denied route intent fails before executor invocation", () => {
   const { root, repoRoot, relayHome, rubricFile } = setupRepo();
   writePolicy(relayHome, {

--- a/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
@@ -102,6 +102,122 @@ test("dispatch dry-run consumes route intent and previews route plan", () => {
   assert.equal(output.route_plan.phases.dispatch.policy_decision.reason, "allowed_model_route");
 });
 
+test("dispatch dry-run expands route preset below explicit flags and records preset sources", () => {
+  const { repoRoot, relayHome, rubricFile } = setupRepo();
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "codex" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    routes: [
+      { route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] },
+      { route: "example/opencode-model-*", phases: ["dispatch"], executors: ["codex"] },
+      { route: "example/pi-model-*", phases: ["advisory_review"], reviewers: ["pi"] },
+    ],
+    presets: {
+      light: {
+        dispatch: { executor: "opencode", model: "example/opencode-model-fast" },
+        advisory_review: { reviewer: "pi", model: "example/pi-model-fast", profile: "blindspot" },
+      },
+    },
+  });
+
+  const proc = spawnSync(process.execPath, [
+    SCRIPT, repoRoot,
+    "-b", "issue-route-preset-dry",
+    "-p", "dry preset route plan",
+    "--rubric-file", rubricFile,
+    "--route-preset", "light",
+    "--executor", "codex",
+    "--dry-run",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: relayHome },
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  const output = JSON.parse(proc.stdout);
+  assert.equal(output.executor, "codex");
+  assert.equal(output.route_plan.phases.dispatch.executor, "codex");
+  assert.equal(output.route_plan.phases.dispatch.sources.executor, "run_intent");
+  assert.equal(output.route_plan.phases.dispatch.model, "example/opencode-model-fast");
+  assert.equal(output.route_plan.phases.dispatch.sources.model, "preset:light");
+  assert.equal(output.route_plan.phases.advisory_review.reviewer, "pi");
+  assert.equal(output.route_plan.phases.advisory_review.sources.reviewer, "preset:light");
+  assert.equal(output.route_plan.phases.advisory_review.profile, "blindspot");
+});
+
+test("dispatch unknown route preset fails before creating run side effects", () => {
+  const { repoRoot, relayHome, rubricFile } = setupRepo();
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: false,
+    presets: {
+      light: { dispatch: { executor: "codex" } },
+      hardened: { review_assurance: "hardened" },
+    },
+  });
+
+  const proc = spawnSync(process.execPath, [
+    SCRIPT, repoRoot,
+    "-b", "issue-unknown-preset",
+    "-p", "unknown preset route plan",
+    "--rubric-file", rubricFile,
+    "--route-preset", "missing",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: relayHome },
+  });
+
+  assert.notEqual(proc.status, 0);
+  const output = JSON.parse(proc.stdout);
+  assert.match(output.error, /unknown route preset 'missing'/);
+  assert.deepEqual(output.available_presets, ["hardened", "light"]);
+  assert.equal(fs.existsSync(path.join(relayHome, "runs")), false);
+  assert.equal(fs.existsSync(path.join(relayHome, "worktrees")), false);
+});
+
+test("dispatch route preset review_assurance maps to existing review assurance path", () => {
+  const { repoRoot, relayHome, rubricFile } = setupRepo();
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "codex" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    presets: {
+      hardened: { review_assurance: "hardened" },
+    },
+  });
+
+  const proc = spawnSync(process.execPath, [
+    SCRIPT, repoRoot,
+    "-b", "issue-preset-hardened",
+    "-p", "hardened preset route plan",
+    "--rubric-file", rubricFile,
+    "--route-preset", "hardened",
+    "--dry-run",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: relayHome },
+  });
+
+  assert.equal(proc.status, 0, proc.stderr);
+  const output = JSON.parse(proc.stdout);
+  assert.equal(output.reviewAssurance, "hardened");
+});
+
 test("dispatch denied route intent fails before executor invocation", () => {
   const { root, repoRoot, relayHome, rubricFile } = setupRepo();
   writePolicy(relayHome, {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -15,6 +15,7 @@ const {
 const {
   getManifestPath,
   getProjectPolicyPath,
+  getProjectRoutesPath,
   getRunDir,
 } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 const {
@@ -926,18 +927,37 @@ test("preset add warns once when creating routes.json over legacy fallback confi
   assert.equal(fs.readFileSync(legacyPath, "utf-8"), before);
 });
 
-test("preset show reads effective presets and preset remove drops empty preset scaffolding", () => {
+test("preset show reads global presets and preset remove drops empty preset scaffolding", () => {
   const relayHome = tempDir();
+  const repoRoot = tempDir("relay-config-preset-show-repo-");
+  initGitRepo(repoRoot);
   writeJson(path.join(relayHome, "routes.json"), {
     version: 2,
     presets: {
       light: { dispatch: { executor: "codex" } },
     },
   });
+  writeJson(getProjectRoutesPath(repoRoot, { relayHome }), {
+    version: 2,
+    presets: {
+      light: { dispatch: { executor: "opencode" } },
+      project_only: { review: { reviewer: "claude" } },
+    },
+  });
 
-  const show = runConfig(["preset", "show", "light", "--json"], { relayHome });
+  const show = runConfig(["preset", "show", "light", "--json"], { relayHome, cwd: repoRoot });
   assert.equal(show.status, 0, show.combined);
   assert.deepEqual(parseJson(show).preset, { dispatch: { executor: "codex" } });
+
+  const showAll = runConfig(["preset", "show", "--json"], { relayHome, cwd: repoRoot });
+  assert.equal(showAll.status, 0, showAll.combined);
+  assert.deepEqual(parseJson(showAll).presets, {
+    light: { dispatch: { executor: "codex" } },
+  });
+
+  const showProjectOnly = runConfig(["preset", "show", "project_only", "--json"], { relayHome, cwd: repoRoot });
+  assert.notEqual(showProjectOnly.status, 0, showProjectOnly.combined);
+  assert.match(showProjectOnly.combined, /unknown preset: project_only/);
 
   const remove = runConfig(["preset", "remove", "light", "--json"], { relayHome });
   assert.equal(remove.status, 0, remove.combined);

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -968,6 +968,30 @@ test("preset show reads global presets and preset remove drops empty preset scaf
   assert.deepEqual(parseJson(showEmpty).presets, {});
 });
 
+test("preset show/remove reject add-only mutation flags and add requires --advisory-review for --advisory-profile", () => {
+  const relayHome = tempDir();
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    presets: {
+      light: { dispatch: { executor: "codex" } },
+    },
+  });
+
+  const removeWithFlag = runConfig(["preset", "remove", "light", "--dispatch", "opencode:fast", "--json"], { relayHome });
+  assert.notEqual(removeWithFlag.status, 0, removeWithFlag.combined);
+  assert.match(removeWithFlag.combined, /preset remove does not accept --dispatch/);
+  // The inapplicable mutation flag must be rejected before the preset is removed.
+  assert.equal(hasOwn(readRoutes(relayHome).presets, "light"), true);
+
+  const showWithFlag = runConfig(["preset", "show", "light", "--review-assurance", "hardened", "--json"], { relayHome });
+  assert.notEqual(showWithFlag.status, 0, showWithFlag.combined);
+  assert.match(showWithFlag.combined, /preset show does not accept --review-assurance/);
+
+  const addProfileNoReviewer = runConfig(["preset", "add", "p", "--advisory-profile", "blindspot", "--json"], { relayHome });
+  assert.notEqual(addProfileNoReviewer.status, 0, addProfileNoReviewer.combined);
+  assert.match(addProfileNoReviewer.combined, /--advisory-profile requires --advisory-review/);
+});
+
 test("preset mutation validation failure leaves the routes file untouched", () => {
   const relayHome = tempDir();
   const routesPath = path.join(relayHome, "routes.json");

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -987,6 +987,12 @@ test("preset show/remove reject add-only mutation flags and add requires --advis
   assert.notEqual(showWithFlag.status, 0, showWithFlag.combined);
   assert.match(showWithFlag.combined, /preset show does not accept --review-assurance/);
 
+  // A bare value flag (present without a value) must still be rejected on remove.
+  const removeBareFlag = runConfig(["preset", "remove", "light", "--dispatch", "--json"], { relayHome });
+  assert.notEqual(removeBareFlag.status, 0, removeBareFlag.combined);
+  assert.match(removeBareFlag.combined, /preset remove does not accept --dispatch/);
+  assert.equal(hasOwn(readRoutes(relayHome).presets, "light"), true);
+
   const addProfileNoReviewer = runConfig(["preset", "add", "p", "--advisory-profile", "blindspot", "--json"], { relayHome });
   assert.notEqual(addProfileNoReviewer.status, 0, addProfileNoReviewer.combined);
   assert.match(addProfileNoReviewer.combined, /--advisory-profile requires --advisory-review/);

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -843,6 +843,133 @@ test("route mutations preserve omitted optional keys and absent default phases",
   });
   assert.equal(hasOwn(defaultRoutes.defaults, "dispatch"), false);
   assert.equal(hasOwn(defaultRoutes.defaults, "review"), false);
+
+  const presetHome = tempDir("relay-config-preset-omission-");
+  assert.equal(runConfig([
+    "preset",
+    "add",
+    "hardened",
+    "--review-assurance",
+    "hardened",
+    "--json",
+  ], { relayHome: presetHome }).status, 0);
+  assert.deepEqual(readRoutes(presetHome), {
+    version: 2,
+    presets: {
+      hardened: { review_assurance: "hardened" },
+    },
+  });
+});
+
+test("preset add supports review assurance and validates referenced routes with warnings", () => {
+  const relayHome = tempDir();
+  const binDir = tempDir("relay-config-preset-bin-");
+  writeExecutable(path.join(binDir, "opencode"));
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    routes: [
+      { route: "openai/registered", phases: ["dispatch"], executors: ["opencode"] },
+    ],
+  });
+
+  const result = runConfig([
+    "preset",
+    "add",
+    "hardened",
+    "--dispatch",
+    "opencode:openai/unregistered",
+    "--advisory-review",
+    "pi:openai/advisory",
+    "--review-assurance",
+    "hardened",
+    "--json",
+  ], {
+    relayHome,
+    env: { PATH: `${binDir}${path.delimiter}/usr/bin:/bin` },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.action, "preset add");
+  assert.match(output.warnings.join("\n"), /strict routes config does not register dispatch route openai\/unregistered/i);
+  assert.match(output.warnings.join("\n"), /pi CLI not found/i);
+  assert.deepEqual(readRoutes(relayHome).presets.hardened, {
+    dispatch: { executor: "opencode", model: "openai/unregistered" },
+    advisory_review: { reviewer: "pi", model: "openai/advisory" },
+    review_assurance: "hardened",
+  });
+});
+
+test("preset add warns once when creating routes.json over legacy fallback config", () => {
+  const relayHome = tempDir();
+  const legacyPath = path.join(relayHome, "policy.json");
+  writeJson(legacyPath, {
+    ...buildDefaultRelayPolicy(),
+    profile: "legacy",
+  });
+  const before = fs.readFileSync(legacyPath, "utf-8");
+
+  const result = runConfig([
+    "preset",
+    "add",
+    "hardened",
+    "--review-assurance",
+    "hardened",
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.warnings.length, 1);
+  assert.match(output.warnings[0], /routes\.json now takes precedence/i);
+  assert.equal(fs.readFileSync(legacyPath, "utf-8"), before);
+});
+
+test("preset show reads effective presets and preset remove drops empty preset scaffolding", () => {
+  const relayHome = tempDir();
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    presets: {
+      light: { dispatch: { executor: "codex" } },
+    },
+  });
+
+  const show = runConfig(["preset", "show", "light", "--json"], { relayHome });
+  assert.equal(show.status, 0, show.combined);
+  assert.deepEqual(parseJson(show).preset, { dispatch: { executor: "codex" } });
+
+  const remove = runConfig(["preset", "remove", "light", "--json"], { relayHome });
+  assert.equal(remove.status, 0, remove.combined);
+  assert.equal(hasOwn(readRoutes(relayHome), "presets"), false);
+
+  const showEmpty = runConfig(["preset", "show", "--json"], { relayHome });
+  assert.equal(showEmpty.status, 0, showEmpty.combined);
+  assert.deepEqual(parseJson(showEmpty).presets, {});
+});
+
+test("preset mutation validation failure leaves the routes file untouched", () => {
+  const relayHome = tempDir();
+  const routesPath = path.join(relayHome, "routes.json");
+  writeJson(routesPath, {
+    version: 2,
+    routes: [],
+    presets: [],
+  });
+  const before = fs.readFileSync(routesPath, "utf-8");
+
+  const result = runConfig([
+    "preset",
+    "add",
+    "light",
+    "--dispatch",
+    "opencode:openai/new",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0, result.combined);
+  assert.match(result.combined, /presets must be an object/);
+  assert.equal(fs.readFileSync(routesPath, "utf-8"), before);
 });
 
 test("validation failure leaves the routes file untouched", () => {
@@ -970,6 +1097,10 @@ test("subcommands reject known relay-config flags outside their supported gramma
   const allowRoute = runConfig(["allow-route", "openai/*", "--phase", "dispatch", "--model", "openai/gpt-5"], { relayHome });
   assert.notEqual(allowRoute.status, 0, allowRoute.combined);
   assert.match(allowRoute.combined, /unsupported flags for allow-route: --model/);
+
+  const preset = runConfig(["preset", "show", "--model", "openai/gpt-5"], { relayHome });
+  assert.notEqual(preset.status, 0, preset.combined);
+  assert.match(preset.combined, /unsupported flags for preset: --model/);
 });
 
 test("help explains harness actors and provider/model route boundaries without policy prose", () => {
@@ -979,6 +1110,7 @@ test("help explains harness actors and provider/model route boundaries without p
   assert.match(result.stdout, /executor\/reviewer names are harnesses/i);
   assert.match(result.stdout, /provider\/model route strings are the routing boundary/i);
   assert.match(result.stdout, /add-route <pattern>/);
+  assert.match(result.stdout, /preset add\|remove\|show/);
   assert.match(result.stdout, /allow-route <pattern>.*deprecated/i);
   assert.doesNotMatch(result.stdout, /\bpolicy\b/i);
 });

--- a/tests/relay-dispatch/scripts/relay-routing.test.js
+++ b/tests/relay-dispatch/scripts/relay-routing.test.js
@@ -543,6 +543,60 @@ test("route intent resolver gives run intent precedence over project defaults", 
   assert.equal(result.phases.review.policy_decision.reason, "managed_cli");
 });
 
+test("route preset expansion fills only unset run intent fields with preset sources", () => {
+  const result = resolveRouteIntent({
+    runIntent: {
+      dispatch: { executor: "codex" },
+    },
+    routePresetName: "light",
+    policy: routePolicy({
+      presets: {
+        light: {
+          dispatch: { executor: "opencode", model: "example/opencode-model-fast" },
+          advisory_review: { reviewer: "pi", model: "example/pi-model-fast", profile: "blindspot" },
+        },
+      },
+      allowed_model_routes: [
+        { route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] },
+        { route: "example/pi-model-*", phases: ["advisory_review"], reviewers: ["pi"] },
+      ],
+    }),
+  });
+
+  assert.equal(result.route_preset.name, "light");
+  assert.equal(result.phases.dispatch.executor, "codex");
+  assert.equal(result.phases.dispatch.sources.executor, "run_intent");
+  assert.equal(result.phases.dispatch.model, "example/opencode-model-fast");
+  assert.equal(result.phases.dispatch.sources.model, "preset:light");
+  assert.equal(result.phases.advisory_review.reviewer, "pi");
+  assert.equal(result.phases.advisory_review.sources.reviewer, "preset:light");
+  assert.equal(result.phases.advisory_review.profile, "blindspot");
+  assert.equal(result.phases.advisory_review.sources.profile, "preset:light");
+});
+
+test("route preset expansion errors with available presets when missing or unconfigured", () => {
+  assert.throws(
+    () => resolveRouteIntent({
+      routePresetName: "missing",
+      policy: routePolicy({
+        presets: {
+          light: { dispatch: { executor: "codex" } },
+          hardened: { review_assurance: "hardened" },
+        },
+      }),
+    }),
+    /unknown route preset 'missing'.*available presets: hardened, light/
+  );
+
+  assert.throws(
+    () => resolveRouteIntent({
+      routePresetName: "light",
+      policy: routePolicy(),
+    }),
+    /no route presets configured.*relay-config/
+  );
+});
+
 test("route intent resolver uses project defaults before built-in managed defaults", () => {
   const result = resolveRouteIntent({
     projectRoutes: {

--- a/tests/relay-review/scripts/advisory-orchestration.test.js
+++ b/tests/relay-review/scripts/advisory-orchestration.test.js
@@ -1,7 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { resolveHardenedBindingWaitMs } = require("../../../skills/relay-review/scripts/review-runner/advisory-orchestration");
+const {
+  resolveHardenedBindingWaitMs,
+  resolveAdvisoryConfig,
+} = require("../../../skills/relay-review/scripts/review-runner/advisory-orchestration");
 
 test("resolveHardenedBindingWaitMs defaults to 10000ms when the env var is unset", () => {
   assert.equal(resolveHardenedBindingWaitMs({}), 10000);
@@ -19,4 +22,26 @@ test("resolveHardenedBindingWaitMs falls back to the default on invalid values",
       `expected default fallback for env value ${JSON.stringify(invalid)}`,
     );
   }
+});
+
+test("resolveAdvisoryConfig does not inherit a planned model when the routed reviewer differs", () => {
+  const config = resolveAdvisoryConfig({
+    data: { routing: { selected: { advisory_review: { reviewer: "opencode" } } } },
+    routePlan: { phases: { advisory_review: { reviewer: "codex", model: "openai/planned-model" } } },
+  });
+  // Selected reviewer comes from routing; the planned model was for a different
+  // planned reviewer and must not leak into the routed reviewer.
+  assert.equal(config.reviewer, "opencode");
+  assert.equal(config.source, "routing");
+  assert.equal(config.model, null);
+});
+
+test("resolveAdvisoryConfig still inherits the planned model when the planned reviewer is selected", () => {
+  const config = resolveAdvisoryConfig({
+    data: {},
+    routePlan: { phases: { advisory_review: { reviewer: "codex", model: "openai/planned-model" } } },
+  });
+  assert.equal(config.reviewer, "codex");
+  assert.equal(config.source, "route_plan");
+  assert.equal(config.model, "openai/planned-model");
 });

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -25,6 +25,7 @@ const { finishAdvisoryReview } = require("../../../skills/relay-review/scripts/r
 const { installFakeGhOnPath } = require("../fixtures/fake-gh");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
 
 function installDefaultGhFixture() {
   return installFakeGhOnPath({
@@ -40,6 +41,11 @@ test.after(() => defaultGhFixture.restore());
 
 function hashFile(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
 }
 
 function defaultRubricScores() {
@@ -220,6 +226,71 @@ function setupRepo({
   fs.writeFileSync(doneCriteriaPath, "# Done Criteria\n\n- Add advisory lane\n", "utf-8");
   fs.writeFileSync(diffPath, "diff --git a/README.md b/README.md\n+advisory\n", "utf-8");
   return { repoRoot, manifestPath, runDir, runId, doneCriteriaPath, diffPath };
+}
+
+function setupDispatchRepoForPresetAdvisory() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-preset-dispatch-"));
+  const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-preset-origin-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  process.env.RELAY_HOME = relayHome;
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["init", "--bare", remoteRoot], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Preset Dispatch"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-preset@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", remoteRoot], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const rubricFile = path.join(repoRoot, "rubric.yaml");
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const diffPath = path.join(repoRoot, "pr.diff");
+  fs.writeFileSync(rubricFile, DEFAULT_ENFORCEMENT_RUBRIC, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, "# Done Criteria\n\n- Route advisory preset\n", "utf-8");
+  fs.writeFileSync(diffPath, "diff --git a/README.md b/README.md\n+advisory preset\n", "utf-8");
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "codex" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    routes: [
+      { route: "example/opencode-model-*", phases: ["advisory_review"], reviewers: ["opencode"] },
+    ],
+    presets: {
+      diverse: {
+        advisory_review: {
+          reviewer: "opencode",
+          model: "example/opencode-model-fast",
+          profile: "blindspot",
+        },
+      },
+    },
+  });
+  return { repoRoot, relayHome, rubricFile, doneCriteriaPath, diffPath };
+}
+
+function writeNoOpCodex(binDir) {
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const output = args[args.indexOf("-o") + 1];
+fs.writeFileSync(output, "preset dispatch ok\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
 }
 
 function writePrimaryReviewer(repoRoot, verdict, { logPath = null, delayMs = 0 } = {}) {
@@ -612,6 +683,59 @@ test("review-runner uses manifest routing advisory defaults without changing the
   assert.equal(result.advisoryReview.source, "routing");
   assert.equal(manifest.review.last_reviewer, "codex");
   assert.deepEqual(manifest.roles, { orchestrator: "codex", executor: "codex", reviewer: "codex" });
+});
+
+test("preset-only dispatch starts advisory review through manifest routing selection", () => {
+  const { repoRoot, relayHome, rubricFile, doneCriteriaPath, diffPath } = setupDispatchRepoForPresetAdvisory();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-preset-bin-"));
+  writeNoOpCodex(binDir);
+
+  const dispatch = spawnSync(process.execPath, [
+    DISPATCH_SCRIPT,
+    repoRoot,
+    "-b",
+    "issue-preset-advisory",
+    "-p",
+    "dispatch with diverse route preset",
+    "--rubric-file",
+    rubricFile,
+    "--route-preset",
+    "diverse",
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+    },
+  });
+  assert.equal(dispatch.status, 0, dispatch.stderr);
+  const dispatchOutput = JSON.parse(dispatch.stdout);
+  const manifest = readManifest(dispatchOutput.manifestPath).data;
+  assert.deepEqual(manifest.routing.selected.advisory_review, {
+    reviewer: "opencode",
+    model: "example/opencode-model-fast",
+    profile: "blindspot",
+  });
+
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot);
+  const result = runReview({
+    repoRoot,
+    runId: dispatchOutput.runId,
+    doneCriteriaPath,
+    diffPath,
+    primaryScript,
+    opencodeScript,
+    advisoryReviewer: null,
+    extraArgs: ["--advisory-grace", "30"],
+  });
+
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(result.advisoryReview.reviewer, "opencode");
+  assert.equal(result.advisoryReview.source, "routing");
 });
 
 test("review-runner denies disallowed advisory model before spawning advisory reviewer", () => {


### PR DESCRIPTION
## #782 Phase B — route presets + natural language + model catalog

One word of per-run routing intent: `dispatch.js --route-preset <name>` expands a named preset from the merged routes config into unset run-intent fields (explicit flags always win), `/relay` maps natural language onto preset names, and relay-config gains preset CRUD.

### What changed

- **`dispatch.js --route-preset`** (+ `cli-schema.js` registration): expansion fills only unset fields; unknown preset errors before any side effect (no worktree/manifest/events) listing available presets; no-presets-configured error points at relay-config; preset `review_assurance` maps to the existing `--review-assurance` path; route-plan snapshot records `source: "preset:<name>"` per preset-filled field (`relay-routing.js` expansion + source attribution).
- **Advisory via preset**: preset `advisory_review` flows through the existing manifest routing-decision channel (`advisory-orchestration.js`); no new review-runner flags or manifest fields.
- **relay-config `preset add|remove|show`** (core + wrapper shorthand + SKILL.md conversational flow): A2 mutation discipline — validateRouteConfig before write, validation failure leaves the file untouched, omission preservation (no `presets: {}` scaffolding), legacy-shadow three-state warning; creation warns (not errors) on missing CLI and on strict+unregistered routes.
- **`/relay` SKILL.md**: natural-language → preset table (가볍게/싸게/light → `--route-preset light`; 리뷰 다양하게/diverse; 하드하게/hardened) + no-match behavior (list presets, don't guess); under 150 lines.
- **`skills/relay-config/references/model-catalog.md`** (new): `Last checked:` date, 60-day staleness note, cost-hint column, non-authority disclaimer; SKILL.md scopes consultation to probe failure or explicit recommendation requests.

### Pre-existing test edits (enumerated per DC6)

No existing assertions were modified or removed; `git show HEAD -- tests/` contains no deleted lines. In-place additions to pre-existing tests/helpers:
1. `help advertises natural-language setup and provider/model boundary` (wrapper suite) — one added assertion pinning preset shorthand in wrapper help.
2. `help explains harness actors and provider/model route boundaries without policy prose` (core suite) — one added assertion pinning `preset` in core help.
3. `subcommands reject known relay-config flags outside their supported grammar` (core suite) — added rows for the new `preset` subcommand grammar.
4. Test helpers extended, not behavioral: `setupRepo` and `hashFile` in `review-runner-advisory.test.js` gained preset-fixture support; `cli-schema.test.js` gained checks adjacent to `recover-commit flags are registered...` for the new `--route-preset` registration.

All other test hunks append new tests (preset expansion matrix incl. side-effect-free failure, route-plan `preset:<name>` sources, preset-driven advisory lane, preset CRUD matrix with omission preservation + legacy-shadow states + resolve-validation warnings).

### Provenance

Codex executor run `issue-782-20260706132255658-ad6ee5d0` completed implementation, commit (3e7947d), push, and self-written evidence; targeted suites green. The full-suite final gate was interrupted under 2-dispatch contention (known relay-fleet/dispatch signal-timing flake family); the orchestrator re-ran the full repo suite on the quiet machine before review — see execution evidence. Dispatch auto-PR hit the #809 base-ref bug; PR created manually with base `main`.

Closes #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BBkPDghyrUzN9FdzJ2SSY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 라우트/리레이 설정에 프리셋 **추가·조회·삭제** 기능이 추가되었습니다.
  * `dispatch`에서 `--route-preset <name>`을 사용해 라우팅 및 검토 설정에 프리셋이 반영됩니다.
  * 프리셋 도움말/CLI 안내와 전용 문서(프리셋 단어 매핑 규칙, 예시)가 확장되었습니다.
* **Bug Fixes**
  * 프리셋 기반 값 주입 및 검토 구성 우선순위/소스 표기가 더 정확해졌습니다.
* **Documentation**
  * 모델 카탈로그(만료/프로브 실패 시 안내, 비용 힌트, 사용 시나리오) 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->