### PR TITLE
Recover commit placeholder evidence replacement (#806)

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -68,7 +68,9 @@ node skills/relay-dispatch/scripts/recover-commit.js --run-id <id> \
   --reason "..." --pr-title "..." --pr-body-file /tmp/pr-body.md
 ```
 
-If the executor completed and the operator has run the verification command, but the executor died before writing `execution-evidence.json`, record the missing evidence during recovery instead of hand-writing the artifact. `recover-commit.js` writes evidence only when the run dir does not already contain `execution-evidence.json`; if the artifact exists, use `rebrand-evidence.js` for stale-HEAD rebinding rather than clobbering it.
+If the executor completed and the operator has run the verification command, but the executor died before writing `execution-evidence.json`, record the missing evidence during recovery instead of hand-writing the artifact. `recover-commit.js` writes evidence when the run dir does not already contain `execution-evidence.json`. If the artifact exists, use `rebrand-evidence.js` for stale-HEAD rebinding rather than clobbering it.
+
+The one overwrite exception is an explicit timeout placeholder replacement. When dispatch wrote fail-closed placeholder evidence (`recorded_by: "dispatch-orchestrator-v1"`, `test_command: "unspecified"`, `test_result_hash: "unspecified"`, `test_result_summary: "unspecified"`, `test_exit_code: 1`), pass `--replace-placeholder-evidence` with the full operator evidence flag set. Any real evidence, including successful evidence whose test command is merely `unspecified`, is still refused and must not be overwritten.
 
 Worked example, shaped like incident #788: the retained worktree has completed code, no evidence artifact, and the operator has a captured test log.
 
@@ -82,6 +84,14 @@ node skills/relay-dispatch/scripts/recover-commit.js --repo . --run-id issue-788
   --test-command "node --test tests/relay-dispatch/scripts/recover-commit.test.js" \
   --test-result-file /tmp/issue-788-recover-tests.txt \
   --test-exit-code 0
+
+# Only for dispatch timeout placeholders, never real evidence
+node skills/relay-dispatch/scripts/recover-commit.js --repo . --run-id issue-806 \
+  --reason "executor timed out after writing placeholder evidence; operator verified tests" \
+  --test-command "node --test tests/relay-dispatch/scripts/recover-commit.test.js" \
+  --test-result-file /tmp/issue-806-recover-tests.txt \
+  --test-exit-code 0 \
+  --replace-placeholder-evidence
 ```
 
 The resulting `execution-evidence.json` is bound to the post-recovery HEAD, preserves the test command verbatim, hashes the result file, records `test_exit_code: 0`, and uses `recorded_by: "recover-commit-operator-v1"`. The next step is the normal `review-runner.js` path. Do not use `finalize-run.js --force-finalize-nonready` when the goal is to supply real execution evidence for review.

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -90,6 +90,7 @@ const FLAGS = [
   { flag: "--request-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay-ready identifier; flag-like following tokens should mean the value is missing." },
   { flag: "--require-pr-body-change", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Require audited PR body evidence for same-HEAD recovery; no value is consumed." },
   { flag: "--review-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied verdict path; keep the literal argv token." },
+  { flag: "--replace-placeholder-evidence", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit opt-in to replace dispatch timeout placeholder evidence with operator-run evidence." },
   { flag: "--review-assurance", kind: VALUE, mode: MODE_PARSED, valueName: "<level>", allowedValues: ["standard", "hardened"], rationale: "Run-level review assurance policy; closed selector independent of agent identity." },
   { flag: "--review", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--advisory-review", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
@@ -189,7 +190,7 @@ const COMMAND_FLAGS = {
   ],
   "recover-commit": [
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",
-    "--test-command", "--test-result-file", "--test-exit-code",
+    "--test-command", "--test-result-file", "--test-exit-code", "--replace-placeholder-evidence",
     "--dry-run", "--json", "--help",
   ],
   "reconcile-run": [

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -57,6 +57,7 @@ function printHelp(exitCode) {
   console.log(`  --test-command <cmd> ${modeLabel("--test-command")} Operator-run test command for missing execution evidence`);
   console.log(`  --test-result-file <path> ${modeLabel("--test-result-file")} Operator-run test output file to hash for missing execution evidence`);
   console.log(`  --test-exit-code <n> ${modeLabel("--test-exit-code")} Operator-run test exit code for missing execution evidence`);
+  console.log(`  --replace-placeholder-evidence ${modeLabel("--replace-placeholder-evidence")} Replace dispatch timeout placeholder evidence with operator-run evidence`);
   console.log(`  --dry-run           ${modeLabel("--dry-run")} Print planned git/gh commands and manifest mutation only`);
   console.log(`  --json              ${modeLabel("--json")} Output JSON`);
   console.log("\nDecision tree:");
@@ -223,6 +224,25 @@ function warnMissingExecutionEvidence(runId) {
   );
 }
 
+function readExecutionEvidenceIfPresent(evidencePath) {
+  return JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+}
+
+function isDispatchPlaceholderEvidence(evidence) {
+  return evidence?.recorded_by === "dispatch-orchestrator-v1"
+    && evidence?.test_command === "unspecified";
+}
+
+function summarizeReplacedPlaceholderEvidence(evidence) {
+  if (!evidence) return null;
+  return {
+    recorded_by: evidence.recorded_by ?? null,
+    test_command: evidence.test_command ?? null,
+    test_exit_code: evidence.test_exit_code ?? null,
+    head_sha: evidence.head_sha ?? null,
+  };
+}
+
 function writeOperatorExecutionEvidenceIfRequested({
   runDir,
   evidencePath,
@@ -348,10 +368,14 @@ function main() {
   const reason = String(getCliArg("--reason") || "").trim();
   const prTitleArg = getCliArg("--pr-title");
   const prBodyFile = getCliArg("--pr-body-file");
+  const replacePlaceholderEvidence = hasCliFlag("--replace-placeholder-evidence");
   const operatorEvidenceFlags = ["--test-command", "--test-result-file", "--test-exit-code"]
     .filter((flag) => hasCliFlag(flag));
   validateOperatorEvidenceFlagSet(operatorEvidenceFlags);
   const operatorEvidenceRequested = operatorEvidenceFlags.length > 0;
+  if (replacePlaceholderEvidence && !operatorEvidenceRequested) {
+    throw new Error("--replace-placeholder-evidence requires --test-command, --test-result-file, and --test-exit-code");
+  }
   const testCommand = getCliArg("--test-command");
   const testResultFileArg = getCliArg("--test-result-file");
   const testExitCodeArg = getCliArg("--test-exit-code");
@@ -401,11 +425,30 @@ function main() {
   const runDir = getRunDir(validatedPaths.repoRoot, data.run_id);
   const evidencePath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
   const evidenceExists = fs.existsSync(evidencePath);
-
+  let existingEvidence = null;
+  let existingEvidenceReadError = null;
   if (operatorEvidenceRequested && evidenceExists) {
+    try {
+      existingEvidence = readExecutionEvidenceIfPresent(evidencePath);
+    } catch (error) {
+      existingEvidenceReadError = error;
+    }
+  }
+  const existingEvidenceIsPlaceholder = isDispatchPlaceholderEvidence(existingEvidence);
+  const shouldReplacePlaceholderEvidence = operatorEvidenceRequested
+    && replacePlaceholderEvidence
+    && evidenceExists
+    && existingEvidenceReadError === null
+    && existingEvidenceIsPlaceholder;
+
+  if (operatorEvidenceRequested && evidenceExists && !shouldReplacePlaceholderEvidence) {
+    const placeholderGuidance = existingEvidenceIsPlaceholder
+      ? " Pass --replace-placeholder-evidence to replace this dispatch placeholder with operator-run evidence."
+      : "";
     throw new Error(
       `${EXECUTION_EVIDENCE_FILENAME} already exists for ${data.run_id}; refusing to overwrite it. ` +
-      "Use skills/relay-dispatch/scripts/rebrand-evidence.js when existing evidence needs to be rebound to a new HEAD."
+      "Use skills/relay-dispatch/scripts/rebrand-evidence.js when existing evidence needs to be rebound to a new HEAD." +
+      placeholderGuidance
     );
   }
   const testResultFile = resolveTestResultFile(testResultFileArg);
@@ -532,7 +575,7 @@ function main() {
       throw new Error(`commit_failed: ${detail}`);
     }
   }
-  if (evidenceExists) {
+  if (evidenceExists && !shouldReplacePlaceholderEvidence) {
     const rebrandResult = rebrandEvidence(runDir, {
       newHeadSha: commitSha,
       recordedBy: "recover-commit-rebrand",
@@ -556,7 +599,7 @@ function main() {
       });
     }
   }
-  if (!evidenceExists) {
+  if (!evidenceExists || shouldReplacePlaceholderEvidence) {
     const operatorEvidence = writeOperatorExecutionEvidenceIfRequested({
       runDir,
       evidencePath,
@@ -580,9 +623,18 @@ function main() {
         operator_initiated: true,
         execution_evidence_path: operatorEvidence.path,
         execution_evidence_hash: operatorEvidence.hash,
+        ...(shouldReplacePlaceholderEvidence
+          ? {
+            override_class: "replace_placeholder_evidence",
+            affected_head_sha: commitSha,
+            prior_state: data.state,
+            required_reason: reason,
+            before: summarizeReplacedPlaceholderEvidence(existingEvidence),
+          }
+          : {}),
       });
     }
-    if (!operatorEvidenceRequested) {
+    if (!operatorEvidenceRequested && !evidenceExists) {
       warnMissingExecutionEvidence(data.run_id);
     }
   }

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -230,16 +230,24 @@ function readExecutionEvidenceIfPresent(evidencePath) {
 
 function isDispatchPlaceholderEvidence(evidence) {
   return evidence?.recorded_by === "dispatch-orchestrator-v1"
-    && evidence?.test_command === "unspecified";
+    && evidence?.test_command === "unspecified"
+    && evidence?.test_result_hash === "unspecified"
+    && evidence?.test_result_summary === "unspecified"
+    && evidence?.test_exit_code === 1;
 }
 
-function summarizeReplacedPlaceholderEvidence(evidence) {
+function summarizeReplacedPlaceholderEvidence(evidence, evidenceHash) {
   if (!evidence) return null;
   return {
+    schema_version: evidence.schema_version ?? null,
     recorded_by: evidence.recorded_by ?? null,
+    recorded_at: evidence.recorded_at ?? null,
     test_command: evidence.test_command ?? null,
+    test_result_hash: evidence.test_result_hash ?? null,
+    test_result_summary: evidence.test_result_summary ?? null,
     test_exit_code: evidence.test_exit_code ?? null,
     head_sha: evidence.head_sha ?? null,
+    evidence_hash: evidenceHash ?? null,
   };
 }
 
@@ -427,9 +435,11 @@ function main() {
   const evidenceExists = fs.existsSync(evidencePath);
   let existingEvidence = null;
   let existingEvidenceReadError = null;
+  let existingEvidenceHash = null;
   if (operatorEvidenceRequested && evidenceExists) {
     try {
       existingEvidence = readExecutionEvidenceIfPresent(evidencePath);
+      existingEvidenceHash = hashFileSha256(evidencePath);
     } catch (error) {
       existingEvidenceReadError = error;
     }
@@ -629,7 +639,7 @@ function main() {
             affected_head_sha: commitSha,
             prior_state: data.state,
             required_reason: reason,
-            before: summarizeReplacedPlaceholderEvidence(existingEvidence),
+            before: summarizeReplacedPlaceholderEvidence(existingEvidence, existingEvidenceHash),
           }
           : {}),
       });

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -132,6 +132,7 @@ test("recover-commit flags are registered with explicit required modes", () => {
     ["--test-command", VALUE, MODE_VERBATIM],
     ["--test-result-file", VALUE, MODE_VERBATIM],
     ["--test-exit-code", VALUE, MODE_PARSED],
+    ["--replace-placeholder-evidence", BOOLEAN, MODE_PARSED],
     ["--run-id", VALUE, MODE_PARSED],
     ["--dry-run", BOOLEAN, MODE_PARSED],
     ["--json", BOOLEAN, MODE_PARSED],

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -180,6 +180,7 @@ function setupRepo({
   runtimeOnlyDirty = false,
   unpushed = false,
   evidence = false,
+  placeholderEvidence = false,
   staleEvidence = false,
   manifestState = STATES.REVIEW_PENDING,
   branch = "issue-281",
@@ -247,9 +248,10 @@ function setupRepo({
     writeExecutionEvidence(runDir, {
       schema_version: 1,
       head_sha: headSha,
-      test_command: "node --test tests/relay-*/scripts/*.test.js",
+      test_command: placeholderEvidence ? "unspecified" : "node --test tests/relay-*/scripts/*.test.js",
       test_result_hash: "unspecified",
       test_result_summary: "unspecified",
+      ...(placeholderEvidence ? { test_exit_code: 1 } : {}),
       recorded_at: "2026-04-24T01:00:00.000Z",
       recorded_by: "dispatch-orchestrator-v1",
     });
@@ -701,6 +703,98 @@ test("operator test flags refuse to overwrite existing execution evidence", () =
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /execution-evidence\.json already exists/);
   assert.match(result.stderr, /rebrand-evidence\.js/);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("operator test flags replace dispatch placeholder evidence only with explicit opt-in", () => {
+  const fixture = setupRepo({ dirty: true, evidence: true, placeholderEvidence: true });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+
+  const result = runRecover(fixture, [
+    "--reason", "operator verified timeout placeholder",
+    "--test-command", "node --test tests/relay-dispatch/scripts/recover-commit.test.js",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const afterEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  assert.equal(afterEvidence.head_sha, parsed.commitSha);
+  assert.equal(afterEvidence.test_command, "node --test tests/relay-dispatch/scripts/recover-commit.test.js");
+  assert.equal(afterEvidence.test_result_hash, sha256File(resultFile));
+  assert.equal(afterEvidence.test_exit_code, 0);
+  assert.equal(afterEvidence.recorded_by, "recover-commit-operator-v1");
+
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  const operatorEvidenceEvent = events.find((entry) => entry.event === "operator_execution_evidence");
+  assert.equal(operatorEvidenceEvent.reason, "operator verified timeout placeholder");
+  assert.equal(operatorEvidenceEvent.override_class, "replace_placeholder_evidence");
+  assert.equal(operatorEvidenceEvent.affected_head_sha, parsed.commitSha);
+  assert.equal(operatorEvidenceEvent.required_reason, "operator verified timeout placeholder");
+  assert.equal(operatorEvidenceEvent.before.recorded_by, beforeEvidence.recorded_by);
+  assert.equal(operatorEvidenceEvent.before.test_command, "unspecified");
+  assert.equal(operatorEvidenceEvent.before.test_exit_code, 1);
+  assert.equal(operatorEvidenceEvent.before.head_sha, beforeEvidence.head_sha);
+  assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);
+});
+
+test("operator test flags refuse placeholder evidence without replacement opt-in", () => {
+  const fixture = setupRepo({ dirty: true, evidence: true, placeholderEvidence: true });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+
+  const result = runRecover(fixture, [
+    "--reason", "operator attempted placeholder replacement without opt-in",
+    "--test-command", "node --test",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--json",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /execution-evidence\.json already exists/);
+  assert.match(result.stderr, /--replace-placeholder-evidence/);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("operator test flags refuse to replace real execution evidence even with placeholder flag", () => {
+  const fixture = setupRepo({ dirty: true, evidence: true });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+
+  const result = runRecover(fixture, [
+    "--reason", "operator attempted real evidence replacement",
+    "--test-command", "node --test",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /execution-evidence\.json already exists/);
+  assert.match(result.stderr, /rebrand-evidence\.js/);
+  assert.doesNotMatch(result.stderr, /--replace-placeholder-evidence/);
   assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
   assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
   assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -181,6 +181,7 @@ function setupRepo({
   unpushed = false,
   evidence = false,
   placeholderEvidence = false,
+  evidenceOverrides = {},
   staleEvidence = false,
   manifestState = STATES.REVIEW_PENDING,
   branch = "issue-281",
@@ -254,6 +255,7 @@ function setupRepo({
       ...(placeholderEvidence ? { test_exit_code: 1 } : {}),
       recorded_at: "2026-04-24T01:00:00.000Z",
       recorded_by: "dispatch-orchestrator-v1",
+      ...evidenceOverrides,
     });
   }
 
@@ -716,6 +718,7 @@ test("operator test flags replace dispatch placeholder evidence only with explic
   fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
   const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
   const beforeEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  const beforeEvidenceHash = sha256File(evidencePath);
 
   const result = runRecover(fixture, [
     "--reason", "operator verified timeout placeholder",
@@ -742,10 +745,106 @@ test("operator test flags replace dispatch placeholder evidence only with explic
   assert.equal(operatorEvidenceEvent.affected_head_sha, parsed.commitSha);
   assert.equal(operatorEvidenceEvent.required_reason, "operator verified timeout placeholder");
   assert.equal(operatorEvidenceEvent.before.recorded_by, beforeEvidence.recorded_by);
+  assert.equal(operatorEvidenceEvent.before.recorded_at, beforeEvidence.recorded_at);
   assert.equal(operatorEvidenceEvent.before.test_command, "unspecified");
+  assert.equal(operatorEvidenceEvent.before.test_result_hash, "unspecified");
+  assert.equal(operatorEvidenceEvent.before.test_result_summary, "unspecified");
   assert.equal(operatorEvidenceEvent.before.test_exit_code, 1);
   assert.equal(operatorEvidenceEvent.before.head_sha, beforeEvidence.head_sha);
+  assert.equal(operatorEvidenceEvent.before.evidence_hash, beforeEvidenceHash);
   assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);
+});
+
+test("replace-placeholder-evidence rejects without operator evidence flags before recovery side effects", () => {
+  const fixture = setupRepo({ dirty: true, evidence: true, placeholderEvidence: true });
+  const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+
+  const result = runRecover(fixture, [
+    "--reason", "operator forgot evidence flags",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--replace-placeholder-evidence requires --test-command, --test-result-file, and --test-exit-code/);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("dispatched recovery replaces placeholder evidence after state transition", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    placeholderEvidence: true,
+    manifestState: STATES.DISPATCHED,
+  });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+
+  const result = runRecover(fixture, [
+    "--reason", "operator verified dispatched timeout placeholder",
+    "--test-command", "node --test tests/relay-dispatch/scripts/recover-commit.test.js",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const manifest = readManifest(fixture.manifestPath).data;
+  const afterEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  assert.equal(parsed.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.git.head_sha, parsed.commitSha);
+  assert.equal(afterEvidence.head_sha, parsed.commitSha);
+  assert.equal(afterEvidence.recorded_by, "recover-commit-operator-v1");
+  assert.equal(afterEvidence.test_exit_code, 0);
+
+  const operatorEvidenceEvent = readRunEvents(fixture.repoRoot, fixture.runId)
+    .find((entry) => entry.event === "operator_execution_evidence");
+  assert.equal(operatorEvidenceEvent.prior_state, STATES.REVIEW_PENDING);
+  assert.equal(operatorEvidenceEvent.before.head_sha, beforeEvidence.head_sha);
+});
+
+test("internal_review_pending recovery replaces placeholder evidence without publishing", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    placeholderEvidence: true,
+    manifestState: STATES.INTERNAL_REVIEW_PENDING,
+  });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+
+  const result = runRecover(fixture, [
+    "--reason", "operator verified internal review placeholder",
+    "--test-command", "node --test tests/relay-dispatch/scripts/recover-commit.test.js",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const manifest = readManifest(fixture.manifestPath).data;
+  const afterEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  assert.equal(parsed.state, STATES.INTERNAL_REVIEW_PENDING);
+  assert.equal(manifest.state, STATES.INTERNAL_REVIEW_PENDING);
+  assert.equal(manifest.git.pr_number, null);
+  assert.equal(afterEvidence.head_sha, parsed.commitSha);
+  assert.equal(afterEvidence.recorded_by, "recover-commit-operator-v1");
+  assert.equal(afterEvidence.test_exit_code, 0);
+  assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 0);
 });
 
 test("operator test flags refuse placeholder evidence without replacement opt-in", () => {
@@ -784,6 +883,43 @@ test("operator test flags refuse to replace real execution evidence even with pl
 
   const result = runRecover(fixture, [
     "--reason", "operator attempted real evidence replacement",
+    "--test-command", "node --test",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /execution-evidence\.json already exists/);
+  assert.match(result.stderr, /rebrand-evidence\.js/);
+  assert.doesNotMatch(result.stderr, /--replace-placeholder-evidence/);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("operator test flags refuse successful unspecified-command evidence even with placeholder flag", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    evidenceOverrides: {
+      test_command: "unspecified",
+      test_result_hash: "a".repeat(64),
+      test_result_summary: "codex result.txt hashed",
+      test_exit_code: 0,
+    },
+  });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+
+  const result = runRecover(fixture, [
+    "--reason", "operator attempted successful unspecified evidence replacement",
     "--test-command", "node --test",
     "--test-result-file", resultFile,
     "--test-exit-code", "0",


### PR DESCRIPTION
## Summary

Fixes #806.

Adds an explicit `recover-commit --replace-placeholder-evidence` opt-in for the timeout-placeholder recovery path. When operator test evidence is supplied, `recover-commit` now replaces an existing dispatch placeholder only if it was written by `dispatch-orchestrator-v1` with `test_command: "unspecified"`. Real execution evidence keeps the existing overwrite refusal and rebrand guidance.

## Details

- Registers `--replace-placeholder-evidence` in the shared CLI schema.
- Keeps `--test-command`, `--test-result-file`, and `--test-exit-code` as an all-or-nothing flag set.
- Journals placeholder replacement as `operator_execution_evidence` with override metadata and a `before` summary of the replaced placeholder.
- Adds regression coverage for placeholder replacement, placeholder-without-flag refusal, and real-evidence refusal even when the flag is present.

## Validation

- `node --test tests/relay-dispatch/scripts/recover-commit.test.js`
- `node --test tests/relay-dispatch/scripts/cli-schema.test.js`
- `node --test --test-concurrency=1 tests/relay-ready/scripts/*.test.js tests/relay-plan/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay/scripts/*.test.js tests/relay-config/scripts/*.test.js tests/relay-fleet/scripts/*.test.js tests/skills-lint/scripts/*.test.js`
  - 1781 tests, 1779 pass, 2 skipped, 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `recover-commit`에서 기존 실행 증거가 자리표시자 상태일 때, 새 증거로 교체할 수 있는 옵션이 추가되었습니다.
  * 관련 명령 옵션 검증이 강화되어 필요한 테스트 입력값을 함께 확인합니다.

* **Bug Fixes**
  * 이미 존재하는 증거 처리 방식이 개선되어, 실제 증거는 안전하게 보호하고 자리표시자 증거만 선택적으로 갱신됩니다.
  * 교체 시 더 자세한 기록이 남도록 동작이 보강되었습니다.

* **Tests**
  * 새 옵션과 기존 증거 교체 시나리오를 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->