### PR TITLE
[codex] Implement provider-aware model resolution

### DIFF
--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relay-config
 argument-hint: "[setup request or command]"
-description: Interactive setup for relay routes. Use when the user asks to set up relay, configure company/personal relay routing, enable OpenCode or Pi, add provider/model routes, check advisory-review routing, or run relay-config doctor/check.
+description: Interactive setup for relay routes. Use when the user asks to set up relay, configure company/personal relay routing, enable OpenCode or Pi, resolve model names, add provider/model routes, check advisory-review routing, or run relay-config doctor/check.
 compatibility: Requires Node.js 18+ and the sibling relay-dispatch skill.
 metadata:
   related-skills: "relay, relay-dispatch, relay-review"
@@ -22,6 +22,7 @@ Set up relay routes interactively. The user should not have to memorize command 
 - The user asks to set up or configure relay
 - The user wants company-safe strict mode, personal open mode, OpenCode/Pi opt-in, or advisory-review routing
 - The user asks whether a provider/model route such as `example/opencode-model-*` or `openai/*` is available
+- The user asks to resolve a short model name such as `glm-5.2` for a known actor
 - The user asks to create, show, or remove a route preset such as `light`, `diverse`, or `hardened`
 - The user asks to run relay doctor/check
 
@@ -76,6 +77,7 @@ Use the wrapper for shorthand, or pass through full flags:
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" init company
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" add-route 'example/opencode-model-*' --phase dispatch,advisory_review --executor opencode
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" resolve-model --phase review --reviewer opencode --model glm-5.2 --json
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset add light --dispatch opencode:example/opencode-model-fast
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset show light
@@ -107,6 +109,7 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `init personal` | `init --profile personal` |
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
+| `resolve-model --phase review --reviewer opencode --model glm-5.2` | `resolve-model --phase review --reviewer opencode --model glm-5.2` |
 | `add-route example/opencode-model-* --phase dispatch --executor opencode` | `add-route example/opencode-model-* --phase dispatch --executor opencode` |
 | `preset add light --dispatch opencode:example/opencode-model-fast` | `preset add light --dispatch opencode:example/opencode-model-fast` |
 | `preset remove light` | `preset remove light` |

--- a/skills/relay-config/references/model-catalog.md
+++ b/skills/relay-config/references/model-catalog.md
@@ -2,14 +2,14 @@
 
 Last checked: 2026-07-06. Treat as stale after 60 days.
 
-Use only when live model-list probes fail or the user asks for a recommendation. Prefer provider CLI model lists from `relay-config doctor` when available. Provider prefixes and exact route ids vary, so adapt the slug to the configured provider/model route format.
+Use only when live model-list probes fail or the user asks for a recommendation. Prefer provider CLI model lists from `relay-config doctor` when available. The executable catalog data lives in `skills/relay-dispatch/scripts/model-catalog.js`; this note is operator-facing context, not a runtime allow-list.
 
-| Model | Use when | Cost hint |
-| --- | --- | --- |
-| `glm-5.2` | Strong default for harder coding and reasoning routes. | premium |
-| `kimi-k2.7-code` | Large implementation tasks when GLM is unavailable. | premium |
-| `deepseek-v4-pro` | Larger changes with strong cost/performance balance. | pro value |
-| `minimax-m3` | General coding when a capable mid-cost route is desired. | mid |
-| `deepseek-v4-flash` | Fast iteration and low-cost preset experiments. | cheap |
+| Model | Actor routes | Use when | Cost hint |
+| --- | --- | --- | --- |
+| `glm-5.2` | `cline` -> `cline-pass/glm-5.2`; `opencode` -> `opencode-go/glm-5.2` | Strong default for harder coding and reasoning routes. | premium |
+| `kimi-k2.7-code` | `cline` -> `cline-pass/kimi-k2.7-code`; `opencode` -> `openrouter/kimi-k2.7-code` | Large implementation tasks when GLM is unavailable. | premium |
+| `deepseek-v4-pro` | `cline` -> `cline-pass/deepseek-v4-pro`; `opencode` -> `openrouter/deepseek-v4-pro` | Larger changes with strong cost/performance balance. | pro value |
+| `minimax-m3` | `cline` -> `cline-pass/minimax-m3`; `opencode` -> `openrouter/minimax-m3` | General coding when a capable mid-cost route is desired. | mid |
+| `deepseek-v4-flash` | `cline` -> `cline-pass/deepseek-v4-flash`; `opencode` -> `openrouter/deepseek-v4-flash` | Fast iteration and low-cost preset experiments. | cheap |
 
 These are selection hints, not an authority. Model quality, availability, and prices change quickly.

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -42,6 +42,7 @@ function printHelp() {
   console.log("  init company|personal [--json]");
   console.log("  show [--json]");
   console.log("  doctor [--json] [--reconcile]");
+  console.log("  resolve-model --phase <phase> [--executor <name>] [--reviewer <name>] [--model <name|provider/model>] [--fallback catalog] [--json]");
   console.log("  check <phase> <actor> [provider/model] [--json]");
   console.log("  add-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");
   console.log("  allow-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json] (deprecated; use add-route)");

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -40,6 +40,7 @@ const FLAGS = [
   { flag: "--dry-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--effective", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--executor", aliases: ["-e"], kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--fallback", kind: VALUE, mode: MODE_PARSED, valueName: "<mode>", allowedValues: ["catalog"], rationale: "Explicit model-resolution fallback selector; flag-like following tokens should mean the value is missing." },
   { flag: "--file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied input file path; keep the literal argv token." },
   { flag: "--fleet-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay fleet identifier; flag-like following tokens should mean the value is missing." },
   { flag: "--force", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
@@ -197,6 +198,7 @@ const COMMAND_FLAGS = {
   ],
   "relay-config": [
     "--profile", "--effective", "--phase", "--executor", "--reviewer", "--model",
+    "--fallback",
     "--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file",
     "--reconcile", "--review-assurance", "--advisory-profile", "--json", "--help",
   ],

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1314,9 +1314,18 @@ function summarizeRoutePlan(routePlan) {
       actor_field: value.executor ? "executor" : "reviewer",
       model: value.model || null,
       policy_reason: value.policy_decision?.reason || null,
+      model_resolution_source: value.model_resolution?.source || null,
     };
   }
   return summary;
+}
+
+function collectModelResolution(routePlan) {
+  const metadata = {};
+  for (const [phase, value] of Object.entries(routePlan?.phases || {})) {
+    if (value?.model_resolution) metadata[phase] = value.model_resolution;
+  }
+  return Object.keys(metadata).length ? metadata : null;
 }
 
 function presetAdvisorySelection(routePlan) {
@@ -2128,11 +2137,13 @@ async function main() {
       policy_decision: policyDecision,
       route_plan_path: routePlanSnapshot.path,
       route_plan_summary: summarizeRoutePlan(routePlan),
+      model_resolution: collectModelResolution(routePlan),
     });
     appendUnregisteredRouteUsedEvent(repoRoot, runId, {
       state: manifest.state,
       headSha: manifest.git?.head_sha || null,
       policyDecision,
+      modelResolution: routePlan.phases.dispatch?.model_resolution || null,
     });
   }
 

--- a/skills/relay-dispatch/scripts/model-catalog.js
+++ b/skills/relay-dispatch/scripts/model-catalog.js
@@ -7,6 +7,7 @@ const MODEL_CATALOG = Object.freeze([
   {
     id: "glm-5.2",
     aliases: ["glm-5.2", "glm"],
+    last_checked: CATALOG_LAST_CHECKED,
     cost_hint: "premium",
     notes: "Strong default for harder coding and reasoning routes.",
     actor_routes: {
@@ -17,6 +18,7 @@ const MODEL_CATALOG = Object.freeze([
   {
     id: "kimi-k2.7-code",
     aliases: ["kimi-k2.7-code", "kimi"],
+    last_checked: CATALOG_LAST_CHECKED,
     cost_hint: "premium",
     notes: "Large implementation tasks when GLM is unavailable.",
     actor_routes: {
@@ -27,6 +29,7 @@ const MODEL_CATALOG = Object.freeze([
   {
     id: "deepseek-v4-pro",
     aliases: ["deepseek-v4-pro", "deepseek-pro"],
+    last_checked: CATALOG_LAST_CHECKED,
     cost_hint: "pro value",
     notes: "Larger changes with strong cost/performance balance.",
     actor_routes: {
@@ -37,6 +40,7 @@ const MODEL_CATALOG = Object.freeze([
   {
     id: "minimax-m3",
     aliases: ["minimax-m3", "minimax"],
+    last_checked: CATALOG_LAST_CHECKED,
     cost_hint: "mid",
     notes: "General coding when a capable mid-cost route is desired.",
     actor_routes: {
@@ -47,6 +51,7 @@ const MODEL_CATALOG = Object.freeze([
   {
     id: "deepseek-v4-flash",
     aliases: ["deepseek-v4-flash", "deepseek-flash"],
+    last_checked: CATALOG_LAST_CHECKED,
     cost_hint: "cheap",
     notes: "Fast iteration and low-cost preset experiments.",
     actor_routes: {

--- a/skills/relay-dispatch/scripts/model-catalog.js
+++ b/skills/relay-dispatch/scripts/model-catalog.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const CATALOG_LAST_CHECKED = "2026-07-06";
+const STALE_AFTER_DAYS = 60;
+
+const MODEL_CATALOG = Object.freeze([
+  {
+    id: "glm-5.2",
+    aliases: ["glm-5.2", "glm"],
+    cost_hint: "premium",
+    notes: "Strong default for harder coding and reasoning routes.",
+    actor_routes: {
+      cline: "cline-pass/glm-5.2",
+      opencode: "opencode-go/glm-5.2",
+    },
+  },
+  {
+    id: "kimi-k2.7-code",
+    aliases: ["kimi-k2.7-code", "kimi"],
+    cost_hint: "premium",
+    notes: "Large implementation tasks when GLM is unavailable.",
+    actor_routes: {
+      cline: "cline-pass/kimi-k2.7-code",
+      opencode: "openrouter/kimi-k2.7-code",
+    },
+  },
+  {
+    id: "deepseek-v4-pro",
+    aliases: ["deepseek-v4-pro", "deepseek-pro"],
+    cost_hint: "pro value",
+    notes: "Larger changes with strong cost/performance balance.",
+    actor_routes: {
+      cline: "cline-pass/deepseek-v4-pro",
+      opencode: "openrouter/deepseek-v4-pro",
+    },
+  },
+  {
+    id: "minimax-m3",
+    aliases: ["minimax-m3", "minimax"],
+    cost_hint: "mid",
+    notes: "General coding when a capable mid-cost route is desired.",
+    actor_routes: {
+      cline: "cline-pass/minimax-m3",
+      opencode: "openrouter/minimax-m3",
+    },
+  },
+  {
+    id: "deepseek-v4-flash",
+    aliases: ["deepseek-v4-flash", "deepseek-flash"],
+    cost_hint: "cheap",
+    notes: "Fast iteration and low-cost preset experiments.",
+    actor_routes: {
+      cline: "cline-pass/deepseek-v4-flash",
+      opencode: "openrouter/deepseek-v4-flash",
+    },
+  },
+]);
+
+module.exports = {
+  CATALOG_LAST_CHECKED,
+  MODEL_CATALOG,
+  STALE_AFTER_DAYS,
+};

--- a/skills/relay-dispatch/scripts/model-resolver.js
+++ b/skills/relay-dispatch/scripts/model-resolver.js
@@ -1,0 +1,321 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const { MODEL_CATALOG, CATALOG_LAST_CHECKED, STALE_AFTER_DAYS } = require("./model-catalog");
+const { evaluateRelayRoute } = require("./relay-policy");
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function hasProviderModelRoute(model) {
+  const normalized = nonEmptyString(model);
+  if (!normalized) return false;
+  const separator = normalized.indexOf("/");
+  return separator > 0 && separator < normalized.length - 1;
+}
+
+function pathEntries() {
+  return String(process.env.PATH || "")
+    .split(path.delimiter)
+    .filter(Boolean);
+}
+
+function findOnPath(binaryName) {
+  const normalized = nonEmptyString(binaryName);
+  if (!normalized) return null;
+  for (const dir of pathEntries()) {
+    const candidate = path.join(dir, normalized);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep scanning PATH entries.
+    }
+  }
+  return null;
+}
+
+function modelProbeTimeoutMs() {
+  const raw = Number(process.env.RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS || 20000);
+  return Number.isSafeInteger(raw) && raw > 0 ? raw : 20000;
+}
+
+function normalizeModelLine(line) {
+  const stripped = String(line || "")
+    .trim()
+    .replace(/^[-*\u2022]\s*/, "")
+    .trim();
+  if (!stripped) return null;
+  const first = stripped.split(/\s+/)[0].replace(/,$/, "");
+  return nonEmptyString(first);
+}
+
+function uniqueStrings(values) {
+  const result = [];
+  for (const value of values || []) {
+    const normalized = nonEmptyString(value);
+    if (normalized && !result.includes(normalized)) result.push(normalized);
+  }
+  return result;
+}
+
+function probeModels(name, executable = findOnPath(name)) {
+  if (!executable || !["opencode", "pi"].includes(name)) {
+    return { status: "not_applicable", models: [], warning: null };
+  }
+  const args = name === "opencode" ? ["models"] : ["--list-models"];
+  const timeoutMs = modelProbeTimeoutMs();
+  try {
+    const output = execFileSync(executable, args, {
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: timeoutMs,
+    });
+    const models = uniqueStrings(output.split("\n").map(normalizeModelLine));
+    return { status: "ok", models, warning: null };
+  } catch (error) {
+    const detail = String(error.stderr || error.message || error).split("\n")[0];
+    const command = `${path.basename(executable)} ${args.join(" ")}`;
+    return {
+      status: "warning",
+      models: [],
+      warning: `optional model-list probe failed for ${name} (${command}) after ${timeoutMs}ms: ${detail} (set RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS to adjust)`,
+    };
+  }
+}
+
+function actorTuple({ phase, actor, actorField, model }) {
+  if (actorField === "reviewer" || phase === "review" || phase === "advisory_review") {
+    return { phase, reviewer: actor, model };
+  }
+  return { phase, executor: actor, model };
+}
+
+function policyDecision({ policy, phase, actor, actorField, model }) {
+  return evaluateRelayRoute(policy, actorTuple({ phase, actor, actorField, model }));
+}
+
+function routeBasename(route) {
+  const normalized = nonEmptyString(route);
+  if (!normalized) return "";
+  const separator = normalized.lastIndexOf("/");
+  return separator === -1 ? normalized : normalized.slice(separator + 1);
+}
+
+function liveCandidates(models, request) {
+  const wanted = nonEmptyString(request);
+  if (!wanted) return [];
+  const exact = uniqueStrings(models).filter((model) => model === wanted || routeBasename(model) === wanted);
+  if (exact.length) return exact;
+  const lower = wanted.toLowerCase();
+  return uniqueStrings(models).filter((model) => {
+    const route = model.toLowerCase();
+    return route.includes(lower) || routeBasename(route).includes(lower);
+  });
+}
+
+function daysSince(dateString, now) {
+  const checked = Date.parse(`${dateString}T00:00:00Z`);
+  const current = now instanceof Date ? now.getTime() : Date.now();
+  if (!Number.isFinite(checked) || !Number.isFinite(current)) return null;
+  return Math.floor((current - checked) / 86400000);
+}
+
+function catalogWarnings(now) {
+  const warnings = [
+    "catalog fallback used; verify provider/model availability before relying on this route",
+  ];
+  const ageDays = daysSince(CATALOG_LAST_CHECKED, now);
+  if (ageDays !== null && ageDays > STALE_AFTER_DAYS) {
+    warnings.push(`stale catalog metadata: last_checked=${CATALOG_LAST_CHECKED}, age_days=${ageDays}`);
+  }
+  return warnings;
+}
+
+function catalogCandidates({ actor, model }) {
+  const actorName = nonEmptyString(actor);
+  const wanted = nonEmptyString(model);
+  if (!actorName || !wanted) return [];
+  const lower = wanted.toLowerCase();
+  const candidates = [];
+  for (const entry of MODEL_CATALOG) {
+    const route = nonEmptyString(entry.actor_routes?.[actorName]);
+    if (!route) continue;
+    const aliases = uniqueStrings([entry.id, ...(entry.aliases || [])]).map((value) => value.toLowerCase());
+    if (aliases.includes(lower) || routeBasename(route).toLowerCase() === lower) {
+      candidates.push(route);
+    }
+  }
+  return uniqueStrings(candidates);
+}
+
+function baseResult({ phase, actor, actorField, model }) {
+  return {
+    ok: false,
+    error: null,
+    original_input: nonEmptyString(model),
+    actor: nonEmptyString(actor),
+    actor_field: actorField,
+    phase: nonEmptyString(phase),
+    requested_model: nonEmptyString(model),
+    resolved_route: null,
+    source: null,
+    candidates: [],
+    warnings: [],
+    probe: null,
+    policy_decision: null,
+  };
+}
+
+function withPolicy(result, policy, model) {
+  const decision = policyDecision({
+    policy,
+    phase: result.phase,
+    actor: result.actor,
+    actorField: result.actor_field,
+    model,
+  });
+  return {
+    ...result,
+    policy_decision: decision,
+    ok: decision.allowed === true,
+    error: decision.allowed === true ? null : decision.reason || "route_policy_denied",
+  };
+}
+
+function resolvedResult({ base, policy, route, source, candidates = [route], warnings = [], probe = null }) {
+  return withPolicy({
+    ...base,
+    resolved_route: route,
+    source,
+    candidates: uniqueStrings(candidates),
+    warnings: uniqueStrings([...(base.warnings || []), ...warnings]),
+    probe,
+  }, policy, route);
+}
+
+function resolveModelRequest({
+  phase,
+  actor,
+  actorField,
+  model = null,
+  policy,
+  fallback = "none",
+  now = new Date(),
+  probeModels: probe = probeModels,
+  findExecutable = findOnPath,
+} = {}) {
+  const base = baseResult({ phase, actor, actorField, model });
+  if (!base.phase) return { ...base, error: "missing_phase" };
+  if (!base.actor) return { ...base, error: "missing_actor_context" };
+
+  if (!base.requested_model) {
+    return {
+      ...withPolicy({ ...base, source: "model_less" }, policy, null),
+      resolved_route: null,
+    };
+  }
+
+  if (hasProviderModelRoute(base.requested_model)) {
+    return resolvedResult({
+      base,
+      policy,
+      route: base.requested_model,
+      source: "explicit_route",
+      candidates: [base.requested_model],
+    });
+  }
+
+  const executable = findExecutable(base.actor);
+  const probeResult = probe(base.actor, executable);
+  const candidates = probeResult?.status === "ok"
+    ? liveCandidates(probeResult.models, base.requested_model)
+    : [];
+  if (candidates.length === 1) {
+    return resolvedResult({
+      base,
+      policy,
+      route: candidates[0],
+      source: "live_probe",
+      candidates,
+      probe: probeResult,
+    });
+  }
+  if (candidates.length > 1) {
+    return {
+      ...base,
+      error: "ambiguous_model",
+      candidates,
+      probe: probeResult,
+    };
+  }
+  if (probeResult?.status === "ok") {
+    return {
+      ...base,
+      error: "unknown_model",
+      candidates: [],
+      probe: probeResult,
+    };
+  }
+
+  if (fallback === "catalog") {
+    const catalog = catalogCandidates({ actor: base.actor, model: base.requested_model });
+    if (catalog.length === 1) {
+      return resolvedResult({
+        base,
+        policy,
+        route: catalog[0],
+        source: "catalog_fallback",
+        candidates: catalog,
+        warnings: [
+          probeResult?.warning,
+          ...catalogWarnings(now),
+        ],
+        probe: probeResult,
+      });
+    }
+    if (catalog.length > 1) {
+      return {
+        ...base,
+        error: "ambiguous_model",
+        candidates: catalog,
+        warnings: uniqueStrings([probeResult?.warning]),
+        probe: probeResult,
+      };
+    }
+  }
+
+  return {
+    ...base,
+    error: probeResult?.status === "warning" ? "model_probe_failed" : "model_probe_unavailable",
+    warnings: uniqueStrings([probeResult?.warning]),
+    probe: probeResult,
+  };
+}
+
+function resolutionMetadata(result, { originalInput } = {}) {
+  if (!result || result.ok !== true) return null;
+  return {
+    original_input: nonEmptyString(originalInput) || result.original_input || null,
+    actor: result.actor,
+    actor_field: result.actor_field,
+    phase: result.phase,
+    requested_model: result.requested_model || null,
+    resolved_route: result.resolved_route || null,
+    source: result.source,
+    candidates: result.candidates || [],
+    warnings: result.warnings || [],
+    policy_decision: result.policy_decision || null,
+  };
+}
+
+module.exports = {
+  findOnPath,
+  hasProviderModelRoute,
+  probeModels,
+  resolveModelRequest,
+  resolutionMetadata,
+};

--- a/skills/relay-dispatch/scripts/model-resolver.js
+++ b/skills/relay-dispatch/scripts/model-resolver.js
@@ -6,6 +6,19 @@ const { execFileSync } = require("child_process");
 const { MODEL_CATALOG, CATALOG_LAST_CHECKED, STALE_AFTER_DAYS } = require("./model-catalog");
 const { evaluateRelayRoute } = require("./relay-policy");
 
+const PROVIDER_COLUMN_VALUES = new Set([
+  "anthropic",
+  "cline-pass",
+  "deepseek",
+  "google",
+  "groq",
+  "mistral",
+  "openai",
+  "openrouter",
+  "xai",
+  "zai",
+]);
+
 function nonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
@@ -49,8 +62,18 @@ function normalizeModelLine(line) {
     .replace(/^[-*\u2022]\s*/, "")
     .trim();
   if (!stripped) return null;
-  const first = stripped.split(/\s+/)[0].replace(/,$/, "");
+  if (/^-+$/.test(stripped.replace(/\s+/g, ""))) return null;
+  const tokens = stripped.split(/\s+/).map((token) => token.replace(/,$/, ""));
+  const [first, second] = tokens;
+  if (first === "provider" && second === "model") return null;
+  if (first && second && isProviderColumn(first) && !first.includes("/") && !second.includes("/")) {
+    return nonEmptyString(`${first}/${second}`);
+  }
   return nonEmptyString(first);
+}
+
+function isProviderColumn(value) {
+  return PROVIDER_COLUMN_VALUES.has(String(value || "").toLowerCase());
 }
 
 function uniqueStrings(values) {

--- a/skills/relay-dispatch/scripts/model-resolver.js
+++ b/skills/relay-dispatch/scripts/model-resolver.js
@@ -124,18 +124,19 @@ function daysSince(dateString, now) {
   return Math.floor((current - checked) / 86400000);
 }
 
-function catalogWarnings(now) {
+function catalogWarnings(lastChecked = CATALOG_LAST_CHECKED, now) {
   const warnings = [
     "catalog fallback used; verify provider/model availability before relying on this route",
   ];
-  const ageDays = daysSince(CATALOG_LAST_CHECKED, now);
+  const checked = nonEmptyString(lastChecked) || CATALOG_LAST_CHECKED;
+  const ageDays = daysSince(checked, now);
   if (ageDays !== null && ageDays > STALE_AFTER_DAYS) {
-    warnings.push(`stale catalog metadata: last_checked=${CATALOG_LAST_CHECKED}, age_days=${ageDays}`);
+    warnings.push(`stale catalog metadata: last_checked=${checked}, age_days=${ageDays}`);
   }
   return warnings;
 }
 
-function catalogCandidates({ actor, model }) {
+function catalogCandidateRecords({ actor, model }) {
   const actorName = nonEmptyString(actor);
   const wanted = nonEmptyString(model);
   if (!actorName || !wanted) return [];
@@ -146,10 +147,19 @@ function catalogCandidates({ actor, model }) {
     if (!route) continue;
     const aliases = uniqueStrings([entry.id, ...(entry.aliases || [])]).map((value) => value.toLowerCase());
     if (aliases.includes(lower) || routeBasename(route).toLowerCase() === lower) {
-      candidates.push(route);
+      candidates.push({
+        route,
+        last_checked: nonEmptyString(entry.last_checked) || CATALOG_LAST_CHECKED,
+        notes: nonEmptyString(entry.notes),
+      });
     }
   }
-  return uniqueStrings(candidates);
+  const seen = new Set();
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate.route)) return false;
+    seen.add(candidate.route);
+    return true;
+  });
 }
 
 function baseResult({ phase, actor, actorField, model }) {
@@ -213,8 +223,25 @@ function resolveModelRequest({
   if (!base.actor) return { ...base, error: "missing_actor_context" };
 
   if (!base.requested_model) {
+    const decision = policyDecision({
+      policy,
+      phase: base.phase,
+      actor: base.actor,
+      actorField: base.actor_field,
+      model: null,
+    });
+    if (decision.allowed === true && decision.reason === "managed_cli") {
+      return {
+        ...base,
+        ok: true,
+        source: "model_less",
+        resolved_route: null,
+        policy_decision: decision,
+      };
+    }
     return {
-      ...withPolicy({ ...base, source: "model_less" }, policy, null),
+      ...base,
+      error: "missing_model",
       resolved_route: null,
     };
   }
@@ -262,7 +289,8 @@ function resolveModelRequest({
   }
 
   if (fallback === "catalog") {
-    const catalog = catalogCandidates({ actor: base.actor, model: base.requested_model });
+    const catalogRecords = catalogCandidateRecords({ actor: base.actor, model: base.requested_model });
+    const catalog = catalogRecords.map((candidate) => candidate.route);
     if (catalog.length === 1) {
       return resolvedResult({
         base,
@@ -272,7 +300,7 @@ function resolveModelRequest({
         candidates: catalog,
         warnings: [
           probeResult?.warning,
-          ...catalogWarnings(now),
+          ...catalogWarnings(catalogRecords[0]?.last_checked, now),
         ],
         probe: probeResult,
       });

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -447,6 +447,14 @@ function actorForPhaseFromArgs(phase) {
   throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
 }
 
+function optionalActorForPhaseFromArgs(phase) {
+  const executor = nonEmptyString(readArg(args, "--executor", undefined, CLI_ARG_OPTIONS));
+  const reviewer = nonEmptyString(readArg(args, "--reviewer", undefined, CLI_ARG_OPTIONS));
+  if (EXECUTOR_PHASES.has(phase)) return executor;
+  if (REVIEWER_PHASES.has(phase)) return reviewer;
+  throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
+}
+
 function normalizeFallback(value) {
   const fallback = nonEmptyString(value) || "none";
   if (!["none", "catalog"].includes(fallback)) {
@@ -463,7 +471,7 @@ function commandResolveModel(positionals, jsonOut) {
   if (!VALID_PHASES.includes(phase)) {
     throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
   }
-  const actor = actorForPhaseFromArgs(phase);
+  const actor = optionalActorForPhaseFromArgs(phase);
   const model = nonEmptyString(readArg(args, "--model", undefined, CLI_ARG_OPTIONS));
   const fallback = normalizeFallback(readArg(args, "--fallback", undefined, CLI_ARG_OPTIONS));
   const policyResult = loadRelayPolicy({ repoRoot: process.cwd() });
@@ -557,13 +565,22 @@ function parseRouteSpecWithResolution(spec, phase, { policy = null, fallback = "
       modelResolution: null,
     };
   }
+  if (hasProviderModelRoute(model)) {
+    return {
+      spec: {
+        [actorField]: actor,
+        model,
+      },
+      modelResolution: null,
+    };
+  }
 
   const resolution = resolveModelRequest({
     phase,
     actor,
     actorField,
     model,
-    fallback: hasProviderModelRoute(model) ? "none" : fallback,
+    fallback,
     policy,
   });
   if (!resolution.ok) {

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -2,7 +2,6 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execFileSync } = require("child_process");
 const {
   evaluateRelayRoute,
   loadRelayPolicy,
@@ -25,6 +24,13 @@ const {
   schemaHasFlag,
 } = require("./cli-args");
 const { listDeadDispatchedRunAdvisories } = require("./reconcile-advisory");
+const {
+  findOnPath,
+  hasProviderModelRoute,
+  probeModels,
+  resolveModelRequest,
+  resolutionMetadata,
+} = require("./model-resolver");
 
 const args = process.argv.slice(2);
 const COMMAND_NAME = "relay-config";
@@ -42,6 +48,7 @@ const SUBCOMMAND_FLAGS = {
   init: new Set(["--profile", "--json", "--help"]),
   show: new Set(["--effective", "--json", "--help"]),
   doctor: new Set(["--json", "--reconcile", "--help"]),
+  "resolve-model": new Set(["--phase", "--executor", "--reviewer", "--model", "--fallback", "--json", "--help"]),
   check: new Set(["--phase", "--executor", "--reviewer", "--model", "--json", "--help"]),
   "plan-run": new Set(["--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file", "--json", "--help"]),
   "set-default": new Set(["--json", "--help"]),
@@ -77,6 +84,7 @@ function printHelp() {
   console.log(`  init --profile <company|personal> ${modeLabel("--profile")} [--json ${modeLabel("--json")}]`);
   console.log(`  show --effective ${modeLabel("--effective")} [--json ${modeLabel("--json")}]`);
   console.log(`  doctor [--json ${modeLabel("--json")}] [--reconcile ${modeLabel("--reconcile")}]`);
+  console.log(`  resolve-model --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <name|provider/model> ${modeLabel("--model")}] [--fallback catalog ${modeLabel("--fallback")}] [--json ${modeLabel("--json")}]`);
   console.log(`  check --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <provider/model> ${modeLabel("--model")}] [--json ${modeLabel("--json")}]`);
   console.log(`  plan-run [--repo <path> ${modeLabel("--repo")}] [--dispatch <actor[:provider/model]> ${modeLabel("--dispatch")}] [--review <actor[:provider/model]> ${modeLabel("--review")}] [--advisory-review <actor[:provider/model]> ${modeLabel("--advisory-review")}] [--route-intent-file <path> ${modeLabel("--route-intent-file")}] [--json ${modeLabel("--json")}]`);
   console.log("  set-default <path> <value> [--json]");
@@ -310,25 +318,6 @@ function commandShow(positionals, jsonOut) {
   if (!result.ok) process.exitCode = 1;
 }
 
-function pathEntries() {
-  return String(process.env.PATH || "")
-    .split(path.delimiter)
-    .filter(Boolean);
-}
-
-function findOnPath(binaryName) {
-  for (const dir of pathEntries()) {
-    const candidate = path.join(dir, binaryName);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // Keep scanning PATH entries.
-    }
-  }
-  return null;
-}
-
 function defaultActors(policy) {
   return [
     policy.defaults.dispatch?.executor,
@@ -353,40 +342,6 @@ function actorHasConfiguredAllowedRoute(policy, actor) {
     if (!hasActorScope) return true;
     return Boolean(entry.executors?.includes(actor) || entry.reviewers?.includes(actor));
   });
-}
-
-function modelProbeTimeoutMs() {
-  const raw = Number(process.env.RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS || 20000);
-  return Number.isSafeInteger(raw) && raw > 0 ? raw : 20000;
-}
-
-function probeModels(name, executable) {
-  if (!executable || !["opencode", "pi"].includes(name)) {
-    return { status: "not_applicable", models: [], warning: null };
-  }
-  const args = name === "opencode" ? ["models"] : ["--list-models"];
-  const timeoutMs = modelProbeTimeoutMs();
-  try {
-    const output = execFileSync(executable, args, {
-      encoding: "utf-8",
-      stdio: "pipe",
-      timeout: timeoutMs,
-    });
-    const models = output
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .filter((value, index, values) => values.indexOf(value) === index);
-    return { status: "ok", models, warning: null };
-  } catch (error) {
-    const detail = String(error.stderr || error.message || error).split("\n")[0];
-    const command = `${path.basename(executable)} ${args.join(" ")}`;
-    return {
-      status: "warning",
-      models: [],
-      warning: `optional model-list probe failed for ${name} (${command}) after ${timeoutMs}ms: ${detail} (set RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS to adjust)`,
-    };
-  }
 }
 
 function doctorTool(policy, name) {
@@ -480,6 +435,76 @@ function commandDoctor(positionals, jsonOut) {
   }
 }
 
+function actorFieldForPhase(phase) {
+  return REVIEWER_PHASES.has(phase) ? "reviewer" : "executor";
+}
+
+function actorForPhaseFromArgs(phase) {
+  const executor = nonEmptyString(readArg(args, "--executor", undefined, CLI_ARG_OPTIONS));
+  const reviewer = nonEmptyString(readArg(args, "--reviewer", undefined, CLI_ARG_OPTIONS));
+  if (EXECUTOR_PHASES.has(phase)) return requireValue(executor, "--executor");
+  if (REVIEWER_PHASES.has(phase)) return requireValue(reviewer, "--reviewer");
+  throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
+}
+
+function normalizeFallback(value) {
+  const fallback = nonEmptyString(value) || "none";
+  if (!["none", "catalog"].includes(fallback)) {
+    throw new Error("--fallback must be 'catalog' when provided");
+  }
+  return fallback;
+}
+
+function commandResolveModel(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("resolve-model does not accept positional arguments");
+  }
+  const phase = requireValue(readArg(args, "--phase", undefined, CLI_ARG_OPTIONS), "--phase");
+  if (!VALID_PHASES.includes(phase)) {
+    throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
+  }
+  const actor = actorForPhaseFromArgs(phase);
+  const model = nonEmptyString(readArg(args, "--model", undefined, CLI_ARG_OPTIONS));
+  const fallback = normalizeFallback(readArg(args, "--fallback", undefined, CLI_ARG_OPTIONS));
+  const policyResult = loadRelayPolicy({ repoRoot: process.cwd() });
+  if (!policyResult.ok) {
+    const output = {
+      ok: false,
+      error: "policy_error",
+      policy: policyResult,
+    };
+    if (jsonOut) printJson(output);
+    else console.error(`relay-config resolve-model: routes failed: ${policyResult.errors?.[0]?.message || "unknown route config error"}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const output = resolveModelRequest({
+    phase,
+    actor,
+    actorField: actorFieldForPhase(phase),
+    model,
+    fallback,
+    policy: policyResult.policy,
+  });
+  output.policy = {
+    status: policyResult.status,
+    sources: policyResult.sources,
+  };
+
+  if (jsonOut) {
+    printJson(output);
+  } else if (output.ok) {
+    console.log(output.resolved_route || "(model-less)");
+    for (const warning of output.warnings || []) console.log(`warning: ${humanWarning(warning)}`);
+  } else {
+    console.error(`${output.error}: ${output.requested_model || "(none)"}`);
+    for (const candidate of output.candidates || []) console.error(`candidate: ${candidate}`);
+    for (const warning of output.warnings || []) console.error(`warning: ${humanWarning(warning)}`);
+  }
+  if (!output.ok) process.exitCode = 1;
+}
+
 function commandCheck(positionals, jsonOut) {
   if (positionals.length !== 1) {
     throw new Error("check does not accept positional arguments");
@@ -514,19 +539,52 @@ function commandCheck(positionals, jsonOut) {
   if (!decision.allowed) process.exitCode = 1;
 }
 
-function parseRouteSpec(spec, phase) {
+function parseRouteSpecWithResolution(spec, phase, { policy = null, fallback = "catalog" } = {}) {
   const raw = nonEmptyString(spec);
-  if (!raw) return null;
+  if (!raw) return { spec: null, modelResolution: null };
   const separator = raw.indexOf(":");
   const actor = separator === -1 ? raw : raw.slice(0, separator).trim();
   const model = separator === -1 ? null : raw.slice(separator + 1).trim();
   if (!actor) throw new Error(`${phase} route must start with an actor name`);
   if (separator !== -1 && !model) throw new Error(`${phase} route model must be non-empty when ':' is used`);
   const actorField = REVIEWER_PHASES.has(phase) ? "reviewer" : "executor";
+  if (!model || !policy) {
+    return {
+      spec: {
+        [actorField]: actor,
+        ...(model ? { model } : {}),
+      },
+      modelResolution: null,
+    };
+  }
+
+  const resolution = resolveModelRequest({
+    phase,
+    actor,
+    actorField,
+    model,
+    fallback: hasProviderModelRoute(model) ? "none" : fallback,
+    policy,
+  });
+  if (!resolution.ok) {
+    const details = resolution.policy_decision?.reason || resolution.error || "unresolved";
+    const error = new Error(`failed to resolve ${phase} route ${raw}: ${details}`);
+    error.resolution = resolution;
+    throw error;
+  }
   return {
-    [actorField]: actor,
-    ...(model ? { model } : {}),
+    spec: {
+      [actorField]: actor,
+      model: resolution.resolved_route,
+    },
+    modelResolution: resolutionMetadata(resolution, { originalInput: raw }),
   };
+}
+
+function assignModelResolution(target, phase, metadata) {
+  if (!metadata) return;
+  if (!isPlainObject(target.model_resolution)) target.model_resolution = {};
+  target.model_resolution[phase] = metadata;
 }
 
 function readRouteIntentFile(filePath) {
@@ -557,13 +615,6 @@ function commandPlanRun(positionals, jsonOut) {
   const runIntent = {
     ...readRouteIntentFile(routeIntentFile),
   };
-  const dispatchSpec = parseRouteSpec(readArg(args, "--dispatch", undefined, CLI_ARG_OPTIONS), "dispatch");
-  const reviewSpec = parseRouteSpec(readArg(args, "--review", undefined, CLI_ARG_OPTIONS), "review");
-  const advisorySpec = parseRouteSpec(readArg(args, "--advisory-review", undefined, CLI_ARG_OPTIONS), "advisory_review");
-  if (dispatchSpec) runIntent.dispatch = dispatchSpec;
-  if (reviewSpec) runIntent.review = reviewSpec;
-  if (advisorySpec) runIntent.advisory_review = advisorySpec;
-
   const policyResult = loadRelayPolicy({ repoRoot });
   const projectConfig = loadProjectConfig({ repoRoot });
   const projectRoutes = loadProjectRoutes({ repoRoot });
@@ -606,6 +657,16 @@ function commandPlanRun(positionals, jsonOut) {
     return;
   }
 
+  const dispatchSpec = parseRouteSpecWithResolution(readArg(args, "--dispatch", undefined, CLI_ARG_OPTIONS), "dispatch", { policy: policyResult.policy });
+  const reviewSpec = parseRouteSpecWithResolution(readArg(args, "--review", undefined, CLI_ARG_OPTIONS), "review", { policy: policyResult.policy });
+  const advisorySpec = parseRouteSpecWithResolution(readArg(args, "--advisory-review", undefined, CLI_ARG_OPTIONS), "advisory_review", { policy: policyResult.policy });
+  if (dispatchSpec.spec) runIntent.dispatch = dispatchSpec.spec;
+  if (reviewSpec.spec) runIntent.review = reviewSpec.spec;
+  if (advisorySpec.spec) runIntent.advisory_review = advisorySpec.spec;
+  assignModelResolution(runIntent, "dispatch", dispatchSpec.modelResolution);
+  assignModelResolution(runIntent, "review", reviewSpec.modelResolution);
+  assignModelResolution(runIntent, "advisory_review", advisorySpec.modelResolution);
+
   const routePlan = resolveRouteIntent({
     runIntent,
     projectRoutes: projectRoutes.routes,
@@ -613,7 +674,7 @@ function commandPlanRun(positionals, jsonOut) {
   });
   const phaseValues = Object.values(routePlan.phases).filter(Boolean);
   const denied = phaseValues.filter((phase) => phase.policy_decision?.allowed !== true);
-  const warnings = [];
+  const warnings = modelResolutionWarnings(runIntent);
   for (const phase of phaseValues) {
     const actor = phase.executor || phase.reviewer;
     if (actor === "antigravity" && phase.model) {
@@ -725,22 +786,25 @@ function presetReferenceWarnings(routes, presetName, preset) {
   return warnings;
 }
 
-function parsePresetFromArgs() {
+function parsePresetFromArgs({ policy }) {
   const preset = {};
-  const dispatchSpec = parseRouteSpec(readArg(args, "--dispatch", undefined, CLI_ARG_OPTIONS), "dispatch");
-  const reviewSpec = parseRouteSpec(readArg(args, "--review", undefined, CLI_ARG_OPTIONS), "review");
-  const advisorySpec = parseRouteSpec(readArg(args, "--advisory-review", undefined, CLI_ARG_OPTIONS), "advisory_review");
-  if (dispatchSpec) preset.dispatch = dispatchSpec;
-  if (reviewSpec) preset.review = reviewSpec;
+  const dispatchSpec = parseRouteSpecWithResolution(readArg(args, "--dispatch", undefined, CLI_ARG_OPTIONS), "dispatch", { policy });
+  const reviewSpec = parseRouteSpecWithResolution(readArg(args, "--review", undefined, CLI_ARG_OPTIONS), "review", { policy });
+  const advisorySpec = parseRouteSpecWithResolution(readArg(args, "--advisory-review", undefined, CLI_ARG_OPTIONS), "advisory_review", { policy });
+  if (dispatchSpec.spec) preset.dispatch = dispatchSpec.spec;
+  if (reviewSpec.spec) preset.review = reviewSpec.spec;
+  assignModelResolution(preset, "dispatch", dispatchSpec.modelResolution);
+  assignModelResolution(preset, "review", reviewSpec.modelResolution);
   const advisoryProfile = nonEmptyString(readArg(args, "--advisory-profile", undefined, CLI_ARG_OPTIONS));
-  if (advisoryProfile && !advisorySpec) {
+  if (advisoryProfile && !advisorySpec.spec) {
     throw new Error("--advisory-profile requires --advisory-review");
   }
-  if (advisorySpec) {
+  if (advisorySpec.spec) {
     preset.advisory_review = {
-      ...advisorySpec,
+      ...advisorySpec.spec,
       ...(advisoryProfile ? { profile: advisoryProfile } : {}),
     };
+    assignModelResolution(preset, "advisory_review", advisorySpec.modelResolution);
   }
   const reviewAssurance = nonEmptyString(readArg(args, "--review-assurance", undefined, CLI_ARG_OPTIONS));
   if (reviewAssurance) {
@@ -750,6 +814,16 @@ function parsePresetFromArgs() {
     throw new Error("preset add requires at least one of --dispatch, --review, --advisory-review, or --review-assurance");
   }
   return preset;
+}
+
+function modelResolutionWarnings(routeIntent) {
+  const warnings = [];
+  for (const metadata of Object.values(routeIntent.model_resolution || {})) {
+    for (const warning of metadata?.warnings || []) {
+      if (warning && !warnings.includes(warning)) warnings.push(warning);
+    }
+  }
+  return warnings;
 }
 
 const PRESET_MUTATION_FLAGS = [
@@ -809,7 +883,11 @@ function commandPreset(positionals, jsonOut) {
   const updated = cloneJson(routes);
 
   if (action === "add") {
-    const preset = parsePresetFromArgs();
+    const policyResult = loadRelayPolicy({ globalRoutes: routes });
+    if (!policyResult.ok) {
+      throw new Error(policyResult.errors?.[0]?.message || "failed to load routes config for preset resolution");
+    }
+    const preset = parsePresetFromArgs({ policy: policyResult.policy });
     updated.presets = {
       ...(isPlainObject(updated.presets) ? updated.presets : {}),
       [presetName]: preset,
@@ -824,7 +902,7 @@ function commandPreset(positionals, jsonOut) {
       routes: written,
       presetName,
       preset,
-      warnings: [...warnings, ...routeWarnings],
+      warnings: [...warnings, ...modelResolutionWarnings(preset), ...routeWarnings],
     });
     return;
   }
@@ -883,6 +961,9 @@ function main() {
     case "doctor":
       commandDoctor(positionals, jsonOut);
       break;
+    case "resolve-model":
+      commandResolveModel(positionals, jsonOut);
+      break;
     case "check":
       commandCheck(positionals, jsonOut);
       break;
@@ -927,6 +1008,7 @@ try {
     printJson({
       ok: false,
       error: error.message,
+      ...(error.resolution ? { resolution: error.resolution } : {}),
     });
   } else {
     console.error(`Error: ${error.message}`);

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -263,6 +263,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.route_source !== undefined
       ? { route_source: normalizeEventValue(eventData.route_source) }
       : {}),
+    ...(eventData.model_resolution !== undefined
+      ? { model_resolution: normalizeEventValue(eventData.model_resolution) }
+      : {}),
+    ...(eventData.model_resolution_source !== undefined
+      ? { model_resolution_source: normalizeEventValue(eventData.model_resolution_source) }
+      : {}),
     ...(eventData.failure_class !== undefined
       ? { failure_class: normalizeEventValue(eventData.failure_class) }
       : {}),
@@ -374,6 +380,7 @@ function appendUnregisteredRouteUsedEvent(repoRoot, runId, {
   headSha = null,
   round = undefined,
   policyDecision,
+  modelResolution = null,
 } = {}) {
   if (policyDecision?.reason !== "unknown_allowed") return null;
   const phase = normalizeEventValue(policyDecision.phase);
@@ -390,6 +397,8 @@ function appendUnregisteredRouteUsedEvent(repoRoot, runId, {
     actor_field: actorField,
     model: policyDecision.model || null,
     policy_decision: policyDecision,
+    ...(modelResolution ? { model_resolution: modelResolution } : {}),
+    ...(modelResolution?.source ? { model_resolution_source: modelResolution.source } : {}),
   };
   if (actorField === "reviewer") {
     record.reviewer = policyDecision.reviewer || policyDecision.actor || null;

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -696,6 +696,39 @@ function runIntentSource(runIntent, phase, field) {
   return nonEmptyString(runIntent?.[ROUTE_INTENT_SOURCES_KEY]?.[phase]?.[field]) || "run_intent";
 }
 
+function normalizeStringList(value) {
+  if (!Array.isArray(value)) return [];
+  return pushUnique([], value.map(nonEmptyString).filter(Boolean));
+}
+
+function normalizeModelResolutionMetadata(metadata, { phase, actor, actorField, model } = {}) {
+  if (!isPlainObject(metadata)) return null;
+  const resolvedRoute = nonEmptyString(metadata.resolved_route);
+  const effectiveModel = nonEmptyString(model);
+  if (resolvedRoute && effectiveModel && resolvedRoute !== effectiveModel) return null;
+  return {
+    original_input: nonEmptyString(metadata.original_input) || null,
+    actor: nonEmptyString(metadata.actor) || actor || null,
+    actor_field: nonEmptyString(metadata.actor_field) || actorField || null,
+    phase: nonEmptyString(metadata.phase) || phase || null,
+    requested_model: nonEmptyString(metadata.requested_model) || null,
+    resolved_route: resolvedRoute || effectiveModel || null,
+    source: nonEmptyString(metadata.source) || null,
+    candidates: normalizeStringList(metadata.candidates),
+    warnings: normalizeStringList(metadata.warnings),
+    ...(isPlainObject(metadata.policy_decision) ? { policy_decision: cloneJson(metadata.policy_decision) } : {}),
+  };
+}
+
+function modelResolutionForPhase(runIntent, phase, { actor, actorField, model } = {}) {
+  return normalizeModelResolutionMetadata(runIntent?.model_resolution?.[phase], {
+    phase,
+    actor,
+    actorField,
+    model,
+  });
+}
+
 function normalizePresetPhase(preset, presetName, phase) {
   if (preset[phase] === undefined || preset[phase] === null) return null;
   return normalizeRouteDefault(preset[phase], phase, `preset:${presetName}`, { partial: true });
@@ -743,6 +776,18 @@ function expandRoutePreset({ runIntent = null, policy = {}, routePresetName = nu
       if (hasRunIntentField(expanded, phase, field)) continue;
       if (setRunIntentField(expanded, phase, field, value, source)) {
         filled.push({ phase, field });
+        if (field === "model") {
+          const metadata = normalizeModelResolutionMetadata(preset.model_resolution?.[phase], {
+            phase,
+            actor: presetPhase.executor || presetPhase.reviewer || null,
+            actorField: actorFieldForPhase(phase),
+            model: value,
+          });
+          if (metadata) {
+            if (!isPlainObject(expanded.model_resolution)) expanded.model_resolution = {};
+            expanded.model_resolution[phase] = metadata;
+          }
+        }
       }
     }
   }
@@ -840,6 +885,12 @@ function resolvePhaseRoute({ phase, runIntent, projectRoutes, policy, relayHome,
     ? { phase, reviewer: selected.value, model: model.value }
     : { phase, executor: selected.value, model: model.value };
   resolved.policy_decision = evaluateRelayRoute(policy, policyTuple);
+  const modelResolution = modelResolutionForPhase(runIntent, phase, {
+    actor: selected.value,
+    actorField,
+    model: model.value,
+  });
+  if (modelResolution) resolved.model_resolution = modelResolution;
   return resolved;
 }
 

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -49,9 +49,11 @@ function resolveAdvisoryConfig({
   const plannedForSelected = planned.reviewer && planned.reviewer === reviewer;
   const plannedModel = plannedForSelected ? planned.model : null;
   const plannedProfile = plannedForSelected ? planned.profile : null;
+  const modelFromPlan = reviewer && !advisoryReviewerModel && !routed.model && !routed.reviewer_model && plannedModel;
   return {
     graceSeconds: reviewer ? parseNonNegativeSeconds(advisoryGraceArg) : null,
     model: reviewer ? (advisoryReviewerModel || routed.model || routed.reviewer_model || plannedModel || null) : null,
+    modelResolution: modelFromPlan ? planned.model_resolution || null : null,
     profile: reviewer ? validateAdvisoryProfile(advisoryProfileArg || routed.profile || plannedProfile || "blindspot") : null,
     reviewer,
     source: reviewer ? (advisoryReviewerArg ? "cli" : routed.reviewer ? "routing" : "route_plan") : null,
@@ -106,6 +108,7 @@ function startConfiguredAdvisory({
     profile: config.profile,
     promptText,
     reviewerModel: advisoryModel,
+    modelResolution: config.modelResolution || null,
     reviewerName: config.reviewer,
     reviewerPolicy,
     policyDecision,

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -49,10 +49,11 @@ function resolveAdvisoryConfig({
   const plannedForSelected = planned.reviewer && planned.reviewer === reviewer;
   const plannedModel = plannedForSelected ? planned.model : null;
   const plannedProfile = plannedForSelected ? planned.profile : null;
-  const modelFromPlan = reviewer && !advisoryReviewerModel && !routed.model && !routed.reviewer_model && plannedModel;
+  const selectedModel = advisoryReviewerModel || routed.model || routed.reviewer_model || plannedModel || null;
+  const modelFromPlan = reviewer && !advisoryReviewerModel && plannedForSelected && plannedModel && selectedModel === plannedModel;
   return {
     graceSeconds: reviewer ? parseNonNegativeSeconds(advisoryGraceArg) : null,
-    model: reviewer ? (advisoryReviewerModel || routed.model || routed.reviewer_model || plannedModel || null) : null,
+    model: reviewer ? selectedModel : null,
     modelResolution: modelFromPlan ? planned.model_resolution || null : null,
     profile: reviewer ? validateAdvisoryProfile(advisoryProfileArg || routed.profile || plannedProfile || "blindspot") : null,
     reviewer,

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -126,6 +126,7 @@ function startAdvisoryReview({
   profile,
   promptText,
   policyDecision = null,
+  modelResolution = null,
   reviewerModel,
   reviewerName,
   reviewerPolicy = null,
@@ -154,6 +155,7 @@ function startAdvisoryReview({
     reviewerName,
     reviewerPolicy: effectiveReviewerPolicy,
     policyDecision,
+    modelResolution,
     reviewerScript,
     reviewRepoPath,
     round,
@@ -471,6 +473,7 @@ function executeAdvisoryRequest(request) {
       headSha: request.headSha,
       round: request.round,
       policyDecision: request.policyDecision,
+      modelResolution: request.modelResolution || null,
     });
   } catch (error) {
     status = "failed";

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -279,6 +279,10 @@ function buildPrimaryReviewerPreflight({
 }) {
   const resolvedReviewerModel = resolveReviewerModel(data, reviewerModel, reviewerName, { routePlan, repoRoot: runRepoPath });
   const effectiveReviewerModel = resolvedReviewerModel.model;
+  const reviewPhase = routePlanReviewPhase(routePlan);
+  const modelResolution = resolvedReviewerModel.source === "route_plan"
+    ? reviewPhase?.model_resolution || null
+    : null;
   const reviewerPolicy = buildReviewerPolicy({ reviewerName, reviewerScript });
   try {
     const policyDecision = assertRelayPolicyGate({
@@ -291,6 +295,7 @@ function buildPrimaryReviewerPreflight({
       effectiveReviewerModel,
       policyDecision,
       routeSource: resolvedReviewerModel.source,
+      modelResolution,
       reviewerPolicy,
     };
   } catch (error) {
@@ -312,6 +317,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
     effectiveReviewerModel,
     policyDecision,
     routeSource,
+    modelResolution,
     reviewerPolicy,
   } = reviewerPreflight || buildPrimaryReviewerPreflight({
     data,
@@ -338,6 +344,7 @@ function loadReviewText({ body, data, manifestPath, prNumber, promptPath, review
     headSha: reviewedHeadSha || null,
     round,
     policyDecision,
+    modelResolution,
   });
 
   const statusBeforeReviewer = captureGitStatus(reviewRepoPath);

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -61,7 +61,7 @@ Fast path: bypass relay-ready only for one relay-ready task with a stable review
 
 `relay` owns lifecycle orchestration; `relay-dispatch` owns dispatch CLI semantics. When an operator needs a fixed executor or model, pass the dispatch options explicitly in this command. Common pass-through knobs are `--executor`, `--model`, and `--model-hints`; see `../relay-dispatch/references/model-routing.md` and `../relay-dispatch/references/cli-schema.md` for full route and option semantics.
 
-If the user names an executor whose route or model cannot resolve, invoke `relay-config` inline: ask one focused question, write the route/default, then continue the dispatch cycle instead of failing the run.
+For actor+model wording such as "opencode glm-5.2", run `relay-config resolve-model` or preset setup first and pass only explicit provider/model route intent. For model-only wording such as "glm-5.2", do not guess an actor; ask for actor context or offer matching configured presets/routes.
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -51,6 +51,24 @@ function readRoutes(relayHome) {
   return JSON.parse(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"));
 }
 
+function writeFakeOpencode(binDir, models = []) {
+  const opencodePath = path.join(binDir, "opencode");
+  fs.writeFileSync(opencodePath, `#!/bin/sh
+if [ "$1" = "models" ]; then
+  cat <<'EOF'
+${models.join("\n")}
+EOF
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  printf 'opencode-fake\\n'
+  exit 0
+fi
+exit 0
+`, "utf-8");
+  fs.chmodSync(opencodePath, 0o755);
+}
+
 test("init company shorthand delegates to core init --profile company routes config", () => {
   const relayHome = tempDir();
 
@@ -104,6 +122,133 @@ test("check shorthand maps reviewer phases to reviewer-only core checks", () => 
 
   assert.equal(result.status, 0, result.combined);
   assert.equal(parseJson(result).decision.reason, "allowed_model_route");
+});
+
+test("resolve-model passes through wrapper and resolves live short model names", () => {
+  const relayHome = tempDir();
+  const binDir = tempDir("relay-config-model-bin-");
+  writeFakeOpencode(binDir, ["opencode-go/glm-5.2", "openai/gpt-5.3-codex-spark"]);
+  assert.equal(runConfig([
+    "add-route",
+    "opencode-go/*",
+    "--phase",
+    "review",
+    "--reviewer",
+    "opencode",
+    "--json",
+  ], { relayHome }).status, 0);
+
+  const result = runConfig([
+    "resolve-model",
+    "--phase",
+    "review",
+    "--reviewer",
+    "opencode",
+    "--model",
+    "glm-5.2",
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+    },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.resolved_route, "opencode-go/glm-5.2");
+  assert.equal(output.source, "live_probe");
+  assert.equal(output.policy_decision.reason, "allowed_model_route");
+});
+
+test("preset add resolves compact actor short-model and stores explicit route provenance", () => {
+  const relayHome = tempDir();
+  const binDir = tempDir("relay-config-preset-model-bin-");
+  writeFakeOpencode(binDir, ["opencode-go/glm-5.2"]);
+
+  const result = runConfig([
+    "preset",
+    "add",
+    "light",
+    "--dispatch",
+    "opencode:glm-5.2",
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+    },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const routes = readRoutes(relayHome);
+  assert.deepEqual(routes.presets.light.dispatch, {
+    executor: "opencode",
+    model: "opencode-go/glm-5.2",
+  });
+  assert.equal(routes.presets.light.model_resolution.dispatch.original_input, "opencode:glm-5.2");
+  assert.equal(routes.presets.light.model_resolution.dispatch.resolved_route, "opencode-go/glm-5.2");
+  assert.equal(routes.presets.light.model_resolution.dispatch.source, "live_probe");
+
+  const output = parseJson(result);
+  assert.equal(output.preset.model_resolution.dispatch.original_input, "opencode:glm-5.2");
+});
+
+test("preset add resolves cline short model through catalog fallback in open mode", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig([
+    "preset",
+    "add",
+    "diverse",
+    "--advisory-review",
+    "cline:glm-5.2",
+    "--advisory-profile",
+    "blindspot",
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const routes = readRoutes(relayHome);
+  assert.deepEqual(routes.presets.diverse.advisory_review, {
+    reviewer: "cline",
+    model: "cline-pass/glm-5.2",
+    profile: "blindspot",
+  });
+  const metadata = routes.presets.diverse.model_resolution.advisory_review;
+  assert.equal(metadata.original_input, "cline:glm-5.2");
+  assert.equal(metadata.source, "catalog_fallback");
+  assert.match(metadata.warnings.join("\n"), /catalog fallback/i);
+});
+
+test("strict preset add rejects unresolved unregistered compact routes", () => {
+  const relayHome = tempDir();
+  const binDir = tempDir("relay-config-preset-strict-bin-");
+  writeFakeOpencode(binDir, ["opencode-go/glm-5.2"]);
+  assert.equal(runConfig(["init", "company", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig([
+    "preset",
+    "add",
+    "light",
+    "--dispatch",
+    "opencode:glm-5.2",
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.combined, /unknown_model_route|unregistered/i);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.resolution.error, "unknown_model_route");
+  assert.equal(output.resolution.resolved_route, "opencode-go/glm-5.2");
 });
 
 test("preset subcommands pass through wrapper shorthand", () => {

--- a/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
@@ -339,17 +339,31 @@ test("dispatch denied route intent fails before executor invocation", () => {
 });
 
 test("dispatch emits unregistered route event for open-mode unmanaged model route", () => {
-  const { repoRoot, relayHome, rubricFile } = setupRepo();
+  const { root, repoRoot, relayHome, rubricFile } = setupRepo();
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-route-open-bin-"));
   writeFakePi(binDir);
+  const intentPath = path.join(root, "route-intent-open-model-resolution.json");
+  writeJson(intentPath, {
+    dispatch: { executor: "pi", model: "openai/unregistered" },
+    model_resolution: {
+      dispatch: {
+        original_input: "pi:unregistered",
+        actor: "pi",
+        phase: "dispatch",
+        resolved_route: "openai/unregistered",
+        source: "catalog_fallback",
+        candidates: ["openai/unregistered"],
+        warnings: ["catalog fallback used"],
+      },
+    },
+  });
 
   const proc = spawnSync(process.execPath, [
     SCRIPT, repoRoot,
     "-b", "issue-open-unregistered",
     "-p", "open route plan",
     "--rubric-file", rubricFile,
-    "--executor", "pi",
-    "--model", "openai/unregistered",
+    "--route-intent-file", intentPath,
     "--json",
   ], {
     cwd: repoRoot,
@@ -359,17 +373,23 @@ test("dispatch emits unregistered route event for open-mode unmanaged model rout
 
   assert.equal(proc.status, 0, proc.stderr);
   const output = JSON.parse(proc.stdout);
+  const snapshot = JSON.parse(fs.readFileSync(output.routePlanPath, "utf-8"));
+  assert.equal(snapshot.phases.dispatch.model_resolution.original_input, "pi:unregistered");
+  assert.equal(snapshot.phases.dispatch.model_resolution.source, "catalog_fallback");
+
   const events = fs.readFileSync(path.join(output.runDir, "events.jsonl"), "utf-8")
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line));
   const routeResolution = events.find((event) => event.event === "route_resolution");
   assert.equal(routeResolution.policy_decision.reason, "unknown_allowed");
+  assert.equal(routeResolution.model_resolution.dispatch.source, "catalog_fallback");
   const unregistered = events.find((event) => event.event === "unregistered_route_used");
   assert.equal(unregistered.phase, "dispatch");
   assert.equal(unregistered.actor_field, "executor");
   assert.equal(unregistered.executor, "pi");
   assert.equal(unregistered.model, "openai/unregistered");
+  assert.equal(unregistered.model_resolution_source, "catalog_fallback");
 });
 
 test("dispatch does not emit unregistered route event for registered route", () => {

--- a/tests/relay-dispatch/scripts/model-resolver.test.js
+++ b/tests/relay-dispatch/scripts/model-resolver.test.js
@@ -223,6 +223,40 @@ exit 2
   assert.equal(result.probe.status, "ok");
 });
 
+test("model resolver parses Pi provider and model table columns", () => {
+  const dir = tempDir();
+  const piPath = path.join(dir, "pi");
+  fs.writeFileSync(piPath, `#!/bin/sh
+if [ "$1" = "--list-models" ]; then
+  printf 'provider model context\\n'
+  printf '-------- ----- -------\\n'
+  printf 'openai gpt-5-fast 128k\\n'
+  printf 'anthropic claude-4.5-sonnet 200k\\n'
+  exit 0
+fi
+exit 2
+`, "utf-8");
+  fs.chmodSync(piPath, 0o755);
+
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "pi",
+    actorField: "executor",
+    model: "gpt-5-fast",
+    policy: policy({
+      allowed_model_routes: [
+        { route: "openai/*", phases: ["dispatch"], executors: ["pi"] },
+      ],
+    }),
+    findExecutable: () => piPath,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, "openai/gpt-5-fast");
+  assert.equal(result.source, "live_probe");
+  assert.deepEqual(result.candidates, ["openai/gpt-5-fast"]);
+});
+
 test("model resolver uses actor-scoped catalog fallback only when requested", () => {
   const withoutFallback = resolveModelRequest({
     phase: "dispatch",

--- a/tests/relay-dispatch/scripts/model-resolver.test.js
+++ b/tests/relay-dispatch/scripts/model-resolver.test.js
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const {
   resolveModelRequest,
 } = require("../../../skills/relay-dispatch/scripts/model-resolver");
+const { MODEL_CATALOG } = require("../../../skills/relay-dispatch/scripts/model-catalog");
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 
 function policy(overrides = {}) {
@@ -79,6 +80,24 @@ test("model resolver keeps managed codex model-less routes model-less", () => {
   assert.equal(result.policy_decision.reason, "managed_cli");
 });
 
+test("model resolver rejects unmanaged model-less actors with missing_model", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => {
+      throw new Error("missing unmanaged model must fail before probing");
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "missing_model");
+  assert.equal(result.resolved_route, null);
+  assert.equal(result.source, null);
+  assert.equal(result.policy_decision, null);
+});
+
 test("model resolver returns structured ambiguous_model diagnostics", () => {
   const result = resolveModelRequest({
     phase: "dispatch",
@@ -141,4 +160,12 @@ test("model resolver marks stale catalog fallback metadata", () => {
 
   assert.equal(result.ok, true);
   assert.ok(result.warnings.some((warning) => /stale catalog/i.test(warning)));
+  assert.match(result.warnings.join("\n"), /last_checked=2026-07-06/);
+});
+
+test("model catalog entries carry per-entry last_checked provenance", () => {
+  assert.ok(MODEL_CATALOG.length > 0);
+  for (const entry of MODEL_CATALOG) {
+    assert.match(entry.last_checked, /^\d{4}-\d{2}-\d{2}$/);
+  }
 });

--- a/tests/relay-dispatch/scripts/model-resolver.test.js
+++ b/tests/relay-dispatch/scripts/model-resolver.test.js
@@ -1,0 +1,144 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  resolveModelRequest,
+} = require("../../../skills/relay-dispatch/scripts/model-resolver");
+const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
+
+function policy(overrides = {}) {
+  return {
+    ...buildDefaultRelayPolicy(),
+    ...overrides,
+  };
+}
+
+test("model resolver preserves explicit provider/model routes without probing", () => {
+  let probed = false;
+  const result = resolveModelRequest({
+    phase: "review",
+    actor: "opencode",
+    actorField: "reviewer",
+    model: "opencode-go/glm-5.2",
+    policy: policy({
+      allowed_model_routes: [
+        { route: "opencode-go/*", phases: ["review"], reviewers: ["opencode"] },
+      ],
+    }),
+    probeModels: () => {
+      probed = true;
+      return { status: "ok", models: [] };
+    },
+  });
+
+  assert.equal(probed, false);
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, "opencode-go/glm-5.2");
+  assert.equal(result.source, "explicit_route");
+  assert.equal(result.policy_decision.reason, "allowed_model_route");
+});
+
+test("model resolver uses live probe for exact short model matches", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    model: "glm-5.2",
+    policy: policy({
+      allowed_model_routes: [
+        { route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] },
+      ],
+    }),
+    probeModels: () => ({
+      status: "ok",
+      models: ["opencode-go/glm-5.2", "openai/gpt-5.3-codex-spark"],
+      warning: null,
+    }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, "opencode-go/glm-5.2");
+  assert.equal(result.source, "live_probe");
+  assert.deepEqual(result.candidates, ["opencode-go/glm-5.2"]);
+});
+
+test("model resolver keeps managed codex model-less routes model-less", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "codex",
+    actorField: "executor",
+    policy: policy(),
+    probeModels: () => {
+      throw new Error("model-less managed defaults must not probe");
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, null);
+  assert.equal(result.source, "model_less");
+  assert.equal(result.policy_decision.reason, "managed_cli");
+});
+
+test("model resolver returns structured ambiguous_model diagnostics", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    model: "glm-5.2",
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => ({
+      status: "ok",
+      models: ["opencode-go/glm-5.2", "openrouter/glm-5.2"],
+      warning: null,
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "ambiguous_model");
+  assert.deepEqual(result.candidates, ["opencode-go/glm-5.2", "openrouter/glm-5.2"]);
+  assert.equal(result.resolved_route, null);
+});
+
+test("model resolver uses actor-scoped catalog fallback only when requested", () => {
+  const withoutFallback = resolveModelRequest({
+    phase: "dispatch",
+    actor: "cline",
+    actorField: "executor",
+    model: "glm-5.2",
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => ({ status: "not_applicable", models: [], warning: null }),
+  });
+  assert.equal(withoutFallback.ok, false);
+  assert.equal(withoutFallback.error, "model_probe_unavailable");
+
+  const withFallback = resolveModelRequest({
+    phase: "dispatch",
+    actor: "cline",
+    actorField: "executor",
+    model: "glm-5.2",
+    fallback: "catalog",
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => ({ status: "not_applicable", models: [], warning: null }),
+  });
+
+  assert.equal(withFallback.ok, true);
+  assert.equal(withFallback.resolved_route, "cline-pass/glm-5.2");
+  assert.equal(withFallback.source, "catalog_fallback");
+  assert.match(withFallback.warnings.join("\n"), /catalog fallback/i);
+});
+
+test("model resolver marks stale catalog fallback metadata", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "cline",
+    actorField: "executor",
+    model: "glm-5.2",
+    fallback: "catalog",
+    now: new Date("2026-10-01T00:00:00Z"),
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => ({ status: "not_applicable", models: [], warning: null }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.ok(result.warnings.some((warning) => /stale catalog/i.test(warning)));
+});

--- a/tests/relay-dispatch/scripts/model-resolver.test.js
+++ b/tests/relay-dispatch/scripts/model-resolver.test.js
@@ -1,5 +1,8 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 const {
   resolveModelRequest,
@@ -12,6 +15,10 @@ function policy(overrides = {}) {
     ...buildDefaultRelayPolicy(),
     ...overrides,
   };
+}
+
+function tempDir(prefix = "relay-model-resolver-") {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
 }
 
 test("model resolver preserves explicit provider/model routes without probing", () => {
@@ -61,6 +68,30 @@ test("model resolver uses live probe for exact short model matches", () => {
   assert.equal(result.resolved_route, "opencode-go/glm-5.2");
   assert.equal(result.source, "live_probe");
   assert.deepEqual(result.candidates, ["opencode-go/glm-5.2"]);
+});
+
+test("model resolver uses live probe for unambiguous fuzzy short model matches", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    model: "codex-spark",
+    policy: policy({
+      allowed_model_routes: [
+        { route: "openai/*", phases: ["dispatch"], executors: ["opencode"] },
+      ],
+    }),
+    probeModels: () => ({
+      status: "ok",
+      models: ["opencode-go/glm-5.2", "openai/gpt-5.3-codex-spark"],
+      warning: null,
+    }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, "openai/gpt-5.3-codex-spark");
+  assert.equal(result.source, "live_probe");
+  assert.deepEqual(result.candidates, ["openai/gpt-5.3-codex-spark"]);
 });
 
 test("model resolver keeps managed codex model-less routes model-less", () => {
@@ -116,6 +147,80 @@ test("model resolver returns structured ambiguous_model diagnostics", () => {
   assert.equal(result.error, "ambiguous_model");
   assert.deepEqual(result.candidates, ["opencode-go/glm-5.2", "openrouter/glm-5.2"]);
   assert.equal(result.resolved_route, null);
+});
+
+test("model resolver returns unknown_model when a healthy live probe has no match", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    model: "missing-model",
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => ({
+      status: "ok",
+      models: ["opencode-go/glm-5.2", "openai/gpt-5.3-codex-spark"],
+      warning: null,
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "unknown_model");
+  assert.deepEqual(result.candidates, []);
+  assert.equal(result.probe.status, "ok");
+});
+
+test("model resolver returns model_probe_failed with warning when live probe fails without fallback", () => {
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    model: "glm-5.2",
+    policy: policy({ deny_unknown_model_routes: false }),
+    probeModels: () => ({
+      status: "warning",
+      models: [],
+      warning: "optional model-list probe failed for opencode",
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "model_probe_failed");
+  assert.match(result.warnings.join("\n"), /optional model-list probe failed/);
+  assert.equal(result.probe.status, "warning");
+});
+
+test("model resolver uses the Pi --list-models live probe path", () => {
+  const dir = tempDir();
+  const piPath = path.join(dir, "pi");
+  const argsPath = path.join(dir, "pi-args.json");
+  fs.writeFileSync(piPath, `#!/bin/sh
+printf '["%s"]' "$1" > ${JSON.stringify(argsPath)}
+if [ "$1" = "--list-models" ]; then
+  printf 'openai/gpt-5-fast\\n'
+  exit 0
+fi
+exit 2
+`, "utf-8");
+  fs.chmodSync(piPath, 0o755);
+
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "pi",
+    actorField: "executor",
+    model: "gpt-5-fast",
+    policy: policy({
+      allowed_model_routes: [
+        { route: "openai/*", phases: ["dispatch"], executors: ["pi"] },
+      ],
+    }),
+    findExecutable: () => piPath,
+  });
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf-8")), ["--list-models"]);
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, "openai/gpt-5-fast");
+  assert.equal(result.source, "live_probe");
+  assert.equal(result.probe.status, "ok");
 });
 
 test("model resolver uses actor-scoped catalog fallback only when requested", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -475,6 +475,48 @@ test("check exits non-zero for missing and unknown OpenCode/Pi provider routes",
   assert.equal(parseJson(unknown).decision.reason, "unknown_model_route");
 });
 
+test("resolve-model returns structured missing_actor_context for short model without actor", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig([
+    "resolve-model",
+    "--phase",
+    "dispatch",
+    "--model",
+    "glm-5.2",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, false);
+  assert.equal(output.error, "missing_actor_context");
+  assert.equal(output.phase, "dispatch");
+  assert.equal(output.requested_model, "glm-5.2");
+});
+
+test("resolve-model returns structured missing_model for unmanaged actor without model", () => {
+  const relayHome = tempDir();
+  assert.equal(runConfig(["init", "--profile", "personal", "--json"], { relayHome }).status, 0);
+
+  const result = runConfig([
+    "resolve-model",
+    "--phase",
+    "dispatch",
+    "--executor",
+    "opencode",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, false);
+  assert.equal(output.error, "missing_model");
+  assert.equal(output.actor, "opencode");
+  assert.equal(output.resolved_route, null);
+});
+
 test("set-default writes exactly the requested default path in routes config", () => {
   const relayHome = tempDir();
 

--- a/tests/relay-dispatch/scripts/relay-routing.test.js
+++ b/tests/relay-dispatch/scripts/relay-routing.test.js
@@ -574,6 +574,37 @@ test("route preset expansion fills only unset run intent fields with preset sour
   assert.equal(result.phases.advisory_review.sources.profile, "preset:light");
 });
 
+test("route preset expansion carries model resolution metadata with resolved model", () => {
+  const result = resolveRouteIntent({
+    routePresetName: "light",
+    policy: routePolicy({
+      presets: {
+        light: {
+          dispatch: { executor: "opencode", model: "opencode-go/glm-5.2" },
+          model_resolution: {
+            dispatch: {
+              original_input: "opencode:glm-5.2",
+              actor: "opencode",
+              phase: "dispatch",
+              resolved_route: "opencode-go/glm-5.2",
+              source: "live_probe",
+              candidates: ["opencode-go/glm-5.2"],
+              warnings: [],
+            },
+          },
+        },
+      },
+      allowed_model_routes: [
+        { route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] },
+      ],
+    }),
+  });
+
+  assert.equal(result.phases.dispatch.model, "opencode-go/glm-5.2");
+  assert.equal(result.phases.dispatch.model_resolution.original_input, "opencode:glm-5.2");
+  assert.equal(result.phases.dispatch.model_resolution.source, "live_probe");
+});
+
 test("route preset expansion errors with available presets when missing or unconfigured", () => {
   assert.throws(
     () => resolveRouteIntent({

--- a/tests/relay-review/scripts/advisory-orchestration.test.js
+++ b/tests/relay-review/scripts/advisory-orchestration.test.js
@@ -45,3 +45,39 @@ test("resolveAdvisoryConfig still inherits the planned model when the planned re
   assert.equal(config.source, "route_plan");
   assert.equal(config.model, "openai/planned-model");
 });
+
+test("resolveAdvisoryConfig keeps route-plan model resolution when routed selection matches the plan", () => {
+  const modelResolution = {
+    original_input: "opencode:planned-model",
+    resolved_route: "openai/planned-model",
+    source: "catalog_fallback",
+  };
+  const config = resolveAdvisoryConfig({
+    data: {
+      routing: {
+        selected: {
+          advisory_review: {
+            reviewer: "opencode",
+            model: "openai/planned-model",
+            profile: "blindspot",
+          },
+        },
+      },
+    },
+    routePlan: {
+      phases: {
+        advisory_review: {
+          reviewer: "opencode",
+          model: "openai/planned-model",
+          profile: "blindspot",
+          model_resolution: modelResolution,
+        },
+      },
+    },
+  });
+
+  assert.equal(config.reviewer, "opencode");
+  assert.equal(config.source, "routing");
+  assert.equal(config.model, "openai/planned-model");
+  assert.deepEqual(config.modelResolution, modelResolution);
+});

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -462,6 +462,62 @@ test("review-runner records successful opencode advisory review without gating p
   assert.match(event.reviewer_policy.read_only.warnings.join("\n"), /not prevent writes/i);
 });
 
+test("review-runner advisory unregistered route event preserves route-plan model resolution provenance", () => {
+  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot);
+  writeJson(path.join(process.env.RELAY_HOME, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "open-advisory-unregistered-test",
+    deny_unknown_model_routes: false,
+  });
+  const modelResolution = {
+    original_input: "opencode:unregistered-advisory",
+    actor: "opencode",
+    actor_field: "reviewer",
+    phase: "advisory_review",
+    requested_model: "unregistered-advisory",
+    resolved_route: "openai/unregistered-advisory",
+    source: "catalog_fallback",
+    candidates: ["openai/unregistered-advisory"],
+    warnings: ["catalog fallback used"],
+  };
+  writeJson(path.join(runDir, "route-plan.json"), {
+    version: 1,
+    phases: {
+      advisory_review: {
+        reviewer: "opencode",
+        model: "openai/unregistered-advisory",
+        profile: "blindspot",
+        model_resolution: modelResolution,
+      },
+    },
+  });
+
+  const result = runReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    primaryScript,
+    opencodeScript,
+    advisoryReviewer: null,
+    extraArgs: ["--advisory-grace", "30"],
+  });
+  const events = readRunEvents(repoRoot, runId);
+  const advisoryEvent = events.find((record) => record.event === "advisory_review");
+  const unregistered = events.find((record) => record.event === "unregistered_route_used");
+
+  assert.equal(result.nextState, STATES.READY_TO_MERGE);
+  assert.equal(advisoryEvent.policy_decision.reason, "unknown_allowed");
+  assert.equal(unregistered.phase, "advisory_review");
+  assert.equal(unregistered.actor_field, "reviewer");
+  assert.equal(unregistered.reviewer, "opencode");
+  assert.equal(unregistered.model, "openai/unregistered-advisory");
+  assert.equal(unregistered.model_resolution_source, "catalog_fallback");
+  assert.deepEqual(unregistered.model_resolution, modelResolution);
+});
+
 test("review-runner accepts opencode primary review when route policy allows the reviewer model", () => {
   const { repoRoot, manifestPath, runDir, runId, doneCriteriaPath, diffPath } = setupRepo({
     modelPolicy: "allow-opencode-primary",

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -462,8 +462,8 @@ test("review-runner records successful opencode advisory review without gating p
   assert.match(event.reviewer_policy.read_only.warnings.join("\n"), /not prevent writes/i);
 });
 
-test("review-runner advisory unregistered route event preserves route-plan model resolution provenance", () => {
-  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+test("review-runner routed advisory unregistered route event preserves route-plan model resolution provenance", () => {
+  const { repoRoot, manifestPath, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
   const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
   const opencodeScript = writeFakeOpencode(repoRoot);
   writeJson(path.join(process.env.RELAY_HOME, "policy.json"), {
@@ -493,6 +493,20 @@ test("review-runner advisory unregistered route event preserves route-plan model
       },
     },
   });
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    routing: {
+      version: 1,
+      selected: {
+        advisory_review: {
+          reviewer: "opencode",
+          model: "openai/unregistered-advisory",
+          profile: "blindspot",
+        },
+      },
+    },
+  }, record.body);
 
   const result = runReview({
     repoRoot,

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -775,6 +775,26 @@ test("reviewer-invoke/loadReviewText emits unregistered route event for open-mod
 
   const helperDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-helper-"));
   const reviewerScript = writeReviewerArgEchoScript(helperDir, "reviewer-unregistered-route.js");
+  const modelResolution = {
+    original_input: "opencode:unregistered-review",
+    actor: "opencode",
+    actor_field: "reviewer",
+    phase: "review",
+    requested_model: "unregistered-review",
+    resolved_route: "openai/unregistered-review",
+    source: "catalog_fallback",
+    candidates: ["openai/unregistered-review"],
+    warnings: ["catalog fallback used"],
+  };
+  const routePlan = {
+    phases: {
+      review: {
+        reviewer: "opencode",
+        model: "openai/unregistered-review",
+        model_resolution: modelResolution,
+      },
+    },
+  };
 
   loadReviewText({
     body: "# Notes\n",
@@ -785,12 +805,13 @@ test("reviewer-invoke/loadReviewText emits unregistered route event for open-mod
     reviewFile: null,
     reviewRepoPath: repoRoot,
     reviewedHeadSha: "abc123",
-    reviewerModel: "openai/unregistered-review",
+    reviewerModel: null,
     reviewerName: "opencode",
     reviewerScript,
     round: 1,
     runDir,
     runRepoPath: repoRoot,
+    routePlan,
   });
 
   const events = fs.readFileSync(getEventsPath(repoRoot, runId), "utf-8").trim().split("\n").map((line) => JSON.parse(line));
@@ -801,6 +822,8 @@ test("reviewer-invoke/loadReviewText emits unregistered route event for open-mod
   assert.equal(unregistered.actor_field, "reviewer");
   assert.equal(unregistered.reviewer, "opencode");
   assert.equal(unregistered.model, "openai/unregistered-review");
+  assert.equal(unregistered.model_resolution_source, "catalog_fallback");
+  assert.deepEqual(unregistered.model_resolution, modelResolution);
 });
 
 test("reviewer-invoke/loadReviewText escalates when the reviewer mutates the worktree", (t) => {


### PR DESCRIPTION
## Summary

Implements the provider-aware model resolution layer for relay route intent shaping.

- adds shared resolver/catalog modules under relay-dispatch, with live model discovery first and explicit catalog fallback
- exposes `relay-config resolve-model` and wires compact `actor:short-model` preset/plan-run inputs to persist explicit provider/model routes
- records model-resolution provenance in preset metadata, route-plan phases, route-resolution events, and unregistered-route diagnostics
- updates relay/relay-config operator instructions without adding runtime adapter alias tables
- handles Pi `--list-models` table output by normalizing provider/model columns into provider/model routes

## Issue Links

Closes #825.
Closes #820.
Closes #821.
Closes #822.
Closes #823.
Closes #824.

## Validation

- `node --test tests/relay-dispatch/scripts/model-resolver.test.js`
- `node --test tests/relay-dispatch/scripts/relay-config.test.js tests/relay-config/scripts/relay-config.test.js`
- `git diff --check`
- GitHub Actions `test`: SUCCESS at `eba298cea638979a5fb68d77d69b8958eb9ff498`
- Relay review round 4: LGTM at `eba298cea638979a5fb68d77d69b8958eb9ff498`
- CodeRabbit: SUCCESS / no actionable comments on the full PR review; later incremental review was rate-limited, but GitHub status remains SUCCESS

## Notes

This assumes merged PR #813/#814 as the base work for route presets, preset word mapping, preset CRUD, `--route-preset`, and the initial static model catalog note.

The earlier Codex inline comment about Pi table output was addressed by `eba298c`; that thread is now outdated on GitHub.
