### PR TITLE
Add relay operational visibility commands

### DIFF
--- a/docs/operational-observability-prd.md
+++ b/docs/operational-observability-prd.md
@@ -1,0 +1,159 @@
+# Operational Visibility for Relay Runs
+
+## Source
+
+This PRD covers #826 and child issues #827-#830. Provider-aware model resolution is intentionally separate and owned by #825.
+
+## Problem
+
+When dispatch or review appears silent, operators currently have to inspect manifests, leases, logs, worktrees, PR state, and recovery dry-runs by hand. The missing product surface is not another orchestrator. It is one small operational answer:
+
+```text
+What is this run doing?
+Is it alive?
+Did it produce work?
+What should I do next?
+```
+
+## Product Direction
+
+- Derive status from existing artifacts before writing new state.
+- Wrap existing recovery tools before inventing new transitions.
+- Prefer one clear JSON row over a background process.
+- Make hangs visible before making fallback automatic.
+- Keep runtime adapters explicit and simple.
+
+## Non-Goals
+
+- No daemon or watch mode.
+- No hidden model aliases; use #825 for model resolution.
+- No automatic provider fallback in v1.
+- No standalone review-only product in v1.
+- No fleet-planning changes in v1.
+- No new manifest state transitions.
+
+## V1 Scope
+
+### 1. Run Observer
+
+Add `skills/relay-dispatch/scripts/run-observer.js`.
+
+The observer is read-only. It accepts `--repo` plus `--run-id` or `--manifest`, then emits one row:
+
+```json
+{
+  "run_id": "issue-123-...",
+  "state": "dispatched",
+  "manifest_path": "...",
+  "run_dir": "...",
+  "lease": {
+    "status": "process_group_alive",
+    "live": true,
+    "elapsed_s": 91,
+    "remaining_s": 1709
+  },
+  "logs": {
+    "stdout_path": "...",
+    "stderr_path": "...",
+    "last_output_at": "2026-07-08T12:00:00Z",
+    "silent_for_s": 91,
+    "stdout_tail": "",
+    "stderr_tail": ""
+  },
+  "worktree": {
+    "path": "...",
+    "exists": true,
+    "reviewable_dirt": false,
+    "new_commits": 0
+  },
+  "pr": {
+    "number": null,
+    "state": null
+  },
+  "classification": "running_silent",
+  "next_action": {
+    "kind": "wait_or_reconcile",
+    "command": "node skills/relay-dispatch/scripts/reconcile-run.js --repo ... --run-id ... --dry-run --json"
+  }
+}
+```
+
+Classification is intentionally small:
+
+- `running_with_output`
+- `running_silent`
+- `timed_out_live`
+- `dead_with_work`
+- `dead_no_work`
+- `missing_worktree`
+- `branch_without_pr`
+- `pr_without_manifest_stamp`
+- `ready_to_merge`
+- `merged_not_finalized`
+- `unknown_needs_manual_inspection`
+
+### 2. Status Command
+
+Add `skills/relay/scripts/relay-status.js`.
+
+Supported forms:
+
+```bash
+node skills/relay/scripts/relay-status.js --repo . --run-id <id> --json
+node skills/relay/scripts/relay-status.js --repo . --issue 123 --json
+```
+
+`--issue` is a thin manifest lookup convenience. It reports selection reason and candidates instead of silently guessing across multiple active runs. GitHub lookup failure must not prevent local status output.
+
+### 3. Recovery Command
+
+Add `skills/relay/scripts/relay-recover.js`.
+
+Supported forms:
+
+```bash
+node skills/relay/scripts/relay-recover.js --repo . --run-id <id> --dry-run --json
+node skills/relay/scripts/relay-recover.js --repo . --issue 123 --dry-run --json
+```
+
+Default behavior is dry-run. `--apply` is required for mutation. Safe dispatched recovery delegates to `reconcile-run.js`; unsafe states print manual guidance. This command must not assign manifest state directly.
+
+### 4. Timeout Diagnostics
+
+Improve existing timeout surfaces without changing execution policy:
+
+- dispatch timeout distinguishes `total_timeout` from `no_result` where inferable,
+- dispatch timeout/no-result output includes stdout, stderr, and result paths,
+- primary Codex reviewer timeout includes reviewer phase, model, timeout, and raw response path,
+- advisory timeout keeps current non-gating behavior while using aligned wording.
+
+## Test Plan
+
+Targeted coverage:
+
+```bash
+node --test \
+  tests/relay-dispatch/scripts/run-observer.test.js \
+  tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js \
+  tests/relay/scripts/relay-status-recover.test.js \
+  tests/relay-review/scripts/invoke-reviewer.test.js
+```
+
+Lint/reachability:
+
+```bash
+node --test tests/skills-lint/scripts/*.test.js
+```
+
+Full final gate remains the repo command from `AGENTS.md`. If it stalls, isolate the failing file before broadening scope.
+
+## Deferred Work
+
+These remain deliberately out of v1:
+
+- heartbeat writer,
+- idle timeout killer,
+- automatic provider fallback chain,
+- standalone read-only review command,
+- fleet candidate scoring,
+- GraphQL review-thread integration.

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -2284,7 +2284,10 @@ async function main() {
 
   if (execResult.timedOut) {
     exitCode = 1;
-    error = `executor timed out after ${TIMEOUT}s`;
+    error = (
+      `executor total_timeout after ${TIMEOUT}s; ` +
+      `stdout=${stdoutLog}; stderr=${stderrLog}; result=${resultFile}`
+    );
   } else if (execResult.spawnError) {
     exitCode = 1;
     error = execResult.spawnError.message.split("\n")[0];
@@ -2354,6 +2357,11 @@ async function main() {
   let uncommitted = dirt.reviewableStatus;
 
   const hasResult = resultText !== "";
+  const dispatchFailureClass = execResult.timedOut
+    ? "total_timeout"
+    : !hasResult
+    ? "no_result"
+    : networkFailure || null;
 
   // Detect approval-wait: executor stopped to ask for confirmation instead of working.
   const BLOCKED_PATTERNS = [
@@ -2371,7 +2379,10 @@ async function main() {
     error = error || `executor blocked on approval: ${resultText.split("\n")[0].slice(0, 120)}`;
   } else if (!hasResult) {
     status = "failed";
-    error = error || "executor produced no structured result file or summary (silent failure)";
+    error = error || (
+      `executor no_result: produced no structured result file or summary (silent failure); ` +
+      `stdout=${stdoutLog}; stderr=${stderrLog}; result=${resultFile}`
+    );
   } else if (execResult.timedOut && hasWork) {
     status = "completed-with-warning";
   } else if (exitCode === 0 && !gitLog && dirt.hasOnlyRuntimeMetadataDirt && EXECUTOR !== "codex") {
@@ -2569,6 +2580,7 @@ async function main() {
     executor_policy: executorPolicy,
     policy_decision: policyDecision,
     failure_class: networkFailure,
+    dispatch_failure_class: dispatchFailureClass,
     execution_evidence_path: executionEvidencePath,
     execution_evidence_hash: executionEvidencePath ? hashFileSha256(executionEvidencePath) : null,
   });
@@ -2625,6 +2637,7 @@ async function main() {
     elapsed: `${elapsed}s`,
     exitCode,
     error,
+    dispatchFailureClass,
     registered: !!threadId,
     threadId,
     commits: gitLog,

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -266,6 +266,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.failure_class !== undefined
       ? { failure_class: normalizeEventValue(eventData.failure_class) }
       : {}),
+    ...(eventData.dispatch_failure_class !== undefined
+      ? { dispatch_failure_class: normalizeEventValue(eventData.dispatch_failure_class) }
+      : {}),
     ...(eventData.preflight_type !== undefined
       ? { preflight_type: normalizeEventValue(eventData.preflight_type) }
       : {}),

--- a/skills/relay-dispatch/scripts/run-observer.js
+++ b/skills/relay-dispatch/scripts/run-observer.js
@@ -364,5 +364,6 @@ if (require.main === module) {
 
 module.exports = {
   classify,
+  formatText,
   observeRun,
 };

--- a/skills/relay-dispatch/scripts/run-observer.js
+++ b/skills/relay-dispatch/scripts/run-observer.js
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const { bindCliArgs, findUnknownFlags, modeLabel } = require("./cli-args");
+const { execGh, execGit } = require("./exec");
+const { STATES } = require("./manifest/lifecycle");
+const { getCanonicalRepoRoot, getRunDir, validateManifestPaths } = require("./manifest/paths");
+const { classifyRepositoryDirt } = require("./runtime-dirt");
+const { resolveManifestRecord } = require("./relay-resolver");
+const {
+  getDispatchResultCandidates,
+  getRunArtifactPaths,
+  getRunLeaseStatus,
+} = require("./run-runtime-state");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--run-id", "--manifest", "--json", "--help", "-h"];
+const CLI_ARG_OPTIONS = { commandName: "run-observer", reservedFlags: KNOWN_FLAGS };
+const cliArgs = bindCliArgs(args, CLI_ARG_OPTIONS);
+
+function hasCliFlag(flag) {
+  return cliArgs.hasFlag(flag);
+}
+
+function usage() {
+  return [
+    "Usage: run-observer.js --repo <path> (--run-id <id> | --manifest <path>) [--json]",
+    "",
+    "Build a read-only status row for one relay run from existing local artifacts.",
+    "",
+    "Options:",
+    `  --repo <path>      ${modeLabel("--repo")} Repository root (default: .)`,
+    `  --run-id <id>      ${modeLabel("--run-id")} Relay run identifier`,
+    `  --manifest <path>  ${modeLabel("--manifest")} Relay manifest path`,
+    `  --json             ${modeLabel("--json")} Output JSON`,
+    `  --help, -h         ${modeLabel("--help")} Show help`,
+  ].join("\n");
+}
+
+function statFile(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile() ? stat : null;
+  } catch {
+    return null;
+  }
+}
+
+function readTail(filePath, maxBytes = 4000) {
+  const stat = statFile(filePath);
+  if (!stat || stat.size <= 0) return "";
+  const length = Math.min(maxBytes, stat.size);
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    fs.readSync(fd, buffer, 0, length, stat.size - length);
+    return buffer.toString("utf-8").trimEnd();
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function isoFromMs(ms) {
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+function maxMtimeIso(paths) {
+  let max = null;
+  for (const filePath of paths.filter(Boolean)) {
+    const stat = statFile(filePath);
+    if (!stat || stat.size <= 0) continue;
+    max = max === null ? stat.mtimeMs : Math.max(max, stat.mtimeMs);
+  }
+  return isoFromMs(max);
+}
+
+function secondsSince(iso) {
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return null;
+  return Math.max(0, Math.floor((Date.now() - parsed) / 1000));
+}
+
+function safeGit(repoPath, argv) {
+  try {
+    return execGit(repoPath, argv);
+  } catch {
+    return null;
+  }
+}
+
+function countRange(repoPath, range) {
+  const raw = safeGit(repoPath, ["rev-list", "--count", range]);
+  const count = Number(raw);
+  return Number.isInteger(count) && count > 0 ? count : 0;
+}
+
+function countNewCommits(worktreePath, data) {
+  if (!worktreePath || !fs.existsSync(worktreePath)) return 0;
+  const startHead = data.git?.head_sha || null;
+  if (startHead && safeGit(worktreePath, ["rev-parse", "--verify", startHead])) {
+    return countRange(worktreePath, `${startHead}..HEAD`);
+  }
+  const baseBranch = data.git?.base_branch || "main";
+  for (const ref of [`refs/remotes/origin/${baseBranch}`, baseBranch]) {
+    if (safeGit(worktreePath, ["rev-parse", "--verify", ref])) {
+      return countRange(worktreePath, `${ref}..HEAD`);
+    }
+  }
+  return 0;
+}
+
+function inspectWorktree(worktreePath, data) {
+  const exists = !!worktreePath && fs.existsSync(worktreePath);
+  if (!exists) {
+    return {
+      path: worktreePath || null,
+      exists: false,
+      reviewable_dirt: false,
+      new_commits: 0,
+      current_head: data.git?.head_sha || null,
+    };
+  }
+  const statusText = safeGit(worktreePath, ["status", "--porcelain"]) || "";
+  const currentHead = safeGit(worktreePath, ["rev-parse", "HEAD"]) || data.git?.head_sha || null;
+  return {
+    path: worktreePath,
+    exists: true,
+    reviewable_dirt: classifyRepositoryDirt(statusText).hasReviewableDirt,
+    new_commits: countNewCommits(worktreePath, data),
+    current_head: currentHead,
+  };
+}
+
+function hasNonEmptyFile(filePath) {
+  const stat = statFile(filePath);
+  return !!stat && stat.size > 0;
+}
+
+function firstNonEmptyResult(repoRoot, runId, data) {
+  return getDispatchResultCandidates(repoRoot, runId, data).find(hasNonEmptyFile) || null;
+}
+
+function inspectPr(repoRoot, data) {
+  const storedNumber = data.git?.pr_number ?? null;
+  const branch = data.git?.working_branch || null;
+  if (storedNumber) {
+    try {
+      const raw = execGh(repoRoot, [
+        "pr", "view", String(storedNumber),
+        "--json", "number,state,url,headRefName,mergedAt",
+      ], { timeout: 5000 });
+      const parsed = JSON.parse(raw);
+      return {
+        number: parsed.number ?? storedNumber,
+        state: parsed.state || "unknown",
+        url: parsed.url || null,
+        head_ref: parsed.headRefName || branch,
+        source: "manifest",
+        lookup_status: "ok",
+      };
+    } catch (error) {
+      return {
+        number: storedNumber,
+        state: "unknown",
+        url: null,
+        head_ref: branch,
+        source: "manifest",
+        lookup_status: "github_unavailable",
+        error: String(error.message || error),
+      };
+    }
+  }
+  if (!branch) {
+    return { number: null, state: null, url: null, head_ref: null, source: "none", lookup_status: "skipped" };
+  }
+  try {
+    const raw = execGh(repoRoot, [
+      "pr", "list",
+      "--head", branch,
+      "--state", "all",
+      "--json", "number,state,url,headRefName,mergedAt",
+    ], { timeout: 5000 });
+    const candidates = JSON.parse(raw);
+    const pr = Array.isArray(candidates) && candidates.length ? candidates[0] : null;
+    if (!pr) {
+      return { number: null, state: null, url: null, head_ref: branch, source: "branch", lookup_status: "not_found" };
+    }
+    return {
+      number: pr.number ?? null,
+      state: pr.state || "unknown",
+      url: pr.url || null,
+      head_ref: pr.headRefName || branch,
+      source: "branch",
+      lookup_status: "ok",
+    };
+  } catch (error) {
+    return {
+      number: null,
+      state: "unknown",
+      url: null,
+      head_ref: branch,
+      source: "branch",
+      lookup_status: "github_unavailable",
+      error: String(error.message || error),
+    };
+  }
+}
+
+function buildLogs(paths) {
+  const lastOutputAt = maxMtimeIso([paths.stdoutLog, paths.stderrLog]);
+  return {
+    stdout_path: paths.stdoutLog,
+    stderr_path: paths.stderrLog,
+    result_path: paths.resultFile,
+    last_output_at: lastOutputAt,
+    silent_for_s: secondsSince(lastOutputAt),
+    stdout_tail: readTail(paths.stdoutLog),
+    stderr_tail: readTail(paths.stderrLog),
+  };
+}
+
+function classify({ data, lease, logs, worktree, pr, resultFile }) {
+  if (data.state === STATES.READY_TO_MERGE) return "ready_to_merge";
+  if (data.state === STATES.MERGED) return "merged_not_finalized";
+  if (!worktree.exists && data.state !== STATES.MERGED && data.state !== STATES.CLOSED) return "missing_worktree";
+  if (lease.live && Number(lease.remaining_s) <= 0) return "timed_out_live";
+  if (lease.live) return logs.last_output_at ? "running_with_output" : "running_silent";
+  if (pr.number && !data.git?.pr_number) return "pr_without_manifest_stamp";
+  if (!pr.number && data.state === STATES.REVIEW_PENDING) return "branch_without_pr";
+  if (
+    data.state === STATES.DISPATCHED
+    && (resultFile || worktree.new_commits > 0 || worktree.reviewable_dirt)
+  ) {
+    return "dead_with_work";
+  }
+  if (data.state === STATES.DISPATCHED) return "dead_no_work";
+  return "unknown_needs_manual_inspection";
+}
+
+function commandFor(repoRoot, runId, kind, manifestPath = null) {
+  const repoArg = JSON.stringify(repoRoot);
+  const runArg = JSON.stringify(runId);
+  const manifestArg = JSON.stringify(manifestPath || runId);
+  if (kind === "recover") {
+    return `node skills/relay/scripts/relay-recover.js --repo ${repoArg} --run-id ${runArg} --dry-run --json`;
+  }
+  if (kind === "reconcile") {
+    return `node skills/relay-dispatch/scripts/reconcile-run.js --repo ${repoArg} --run-id ${runArg} --dry-run --json`;
+  }
+  if (kind === "resume") {
+    return `node skills/relay-dispatch/scripts/dispatch.js --manifest ${manifestArg}`;
+  }
+  if (kind === "merge") {
+    return `node skills/relay-merge/scripts/finalize-run.js --run-id ${runArg} --json`;
+  }
+  return `node skills/relay/scripts/relay-status.js --repo ${repoArg} --run-id ${runArg} --json`;
+}
+
+function nextActionFor(classification, repoRoot, runId, manifestPath) {
+  const table = {
+    running_with_output: ["wait_or_reconcile", "reconcile"],
+    running_silent: ["wait_or_reconcile", "reconcile"],
+    timed_out_live: ["reconcile_timeout", "reconcile"],
+    dead_with_work: ["recover", "recover"],
+    dead_no_work: ["resume_dispatch", "resume"],
+    missing_worktree: ["manual_inspection", "status"],
+    branch_without_pr: ["publish_or_reconcile", "reconcile"],
+    pr_without_manifest_stamp: ["reconcile_or_review", "reconcile"],
+    ready_to_merge: ["merge_when_approved", "merge"],
+    merged_not_finalized: ["finalize_cleanup", "merge"],
+    unknown_needs_manual_inspection: ["manual_inspection", "status"],
+  };
+  const [kind, commandKind] = table[classification] || table.unknown_needs_manual_inspection;
+  return { kind, command: commandFor(repoRoot, runId, commandKind, manifestPath) };
+}
+
+function observeRun({ repo = ".", runId, manifestPath } = {}) {
+  const repoRoot = getCanonicalRepoRoot(path.resolve(repo));
+  const record = resolveManifestRecord({ repoRoot, runId, manifestPath, includeTerminal: true });
+  const data = record.data;
+  const normalizedRunId = data.run_id;
+  const validated = validateManifestPaths(data.paths, {
+    expectedRepoRoot: repoRoot,
+    manifestPath: record.manifestPath,
+    runId: normalizedRunId,
+    allowMissingWorktree: true,
+    caller: "run-observer",
+  });
+  const normalizedRepoRoot = validated.repoRoot;
+  const paths = getRunArtifactPaths(normalizedRepoRoot, normalizedRunId);
+  const lease = getRunLeaseStatus(normalizedRepoRoot, normalizedRunId);
+  const logs = buildLogs(paths);
+  const worktree = inspectWorktree(validated.worktree, data);
+  const pr = inspectPr(normalizedRepoRoot, data);
+  const resultFile = firstNonEmptyResult(normalizedRepoRoot, normalizedRunId, data);
+  const classification = classify({ data, lease, logs, worktree, pr, resultFile });
+  return {
+    run_id: normalizedRunId,
+    state: data.state,
+    manifest_path: record.manifestPath,
+    run_dir: getRunDir(normalizedRepoRoot, normalizedRunId),
+    lease: {
+      status: lease.status || lease.reason,
+      live: lease.live,
+      can_signal: lease.canSignal,
+      elapsed_s: lease.elapsed_s,
+      remaining_s: lease.remaining_s,
+      path: lease.leasePath,
+      error: lease.error || null,
+    },
+    logs,
+    worktree,
+    pr,
+    result_file: resultFile,
+    classification,
+    next_action: nextActionFor(classification, normalizedRepoRoot, normalizedRunId, record.manifestPath),
+  };
+}
+
+function formatText(row) {
+  return [
+    `Run: ${row.run_id}`,
+    `State: ${row.state}`,
+    `Lease: ${row.lease.status || "unknown"}, elapsed ${row.lease.elapsed_s ?? "?"}s, remaining ${row.lease.remaining_s ?? "?"}s`,
+    `Output: ${row.logs.last_output_at ? `silent for ${row.logs.silent_for_s}s` : "no output observed"}`,
+    `Worktree: ${row.worktree.exists ? "exists" : "missing"}, reviewable=${row.worktree.reviewable_dirt}, commits=${row.worktree.new_commits}`,
+    `PR: ${row.pr.number ? `#${row.pr.number} ${row.pr.state}` : row.pr.lookup_status}`,
+    `Classification: ${row.classification}`,
+    `Next: ${row.next_action.kind}`,
+    `Command: ${row.next_action.command}`,
+  ].join("\n");
+}
+
+function main() {
+  if (!args.length || hasCliFlag(["--help", "-h"])) {
+    console.log(usage());
+    process.exit(hasCliFlag(["--help", "-h"]) ? 0 : 1);
+  }
+  const unknownFlags = findUnknownFlags(args, KNOWN_FLAGS);
+  if (unknownFlags.length) {
+    throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  }
+  const repo = cliArgs.getArg("--repo", ".");
+  const runId = cliArgs.getArg("--run-id");
+  const manifestPath = cliArgs.getArg("--manifest");
+  if (!runId && !manifestPath) throw new Error("--run-id or --manifest is required");
+  if (runId && manifestPath) throw new Error("--run-id and --manifest are mutually exclusive");
+  const row = observeRun({ repo, runId, manifestPath });
+  console.log(hasCliFlag("--json") ? JSON.stringify(row, null, 2) : formatText(row));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`run-observer: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  classify,
+  observeRun,
+};

--- a/skills/relay-review/scripts/invoke-reviewer-codex.js
+++ b/skills/relay-review/scripts/invoke-reviewer-codex.js
@@ -16,6 +16,8 @@ const { parseReviewerJsonObject, summarizeFailure } = require("./reviewer-helper
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--json", "--help", "-h"];
+const REVIEW_TIMEOUT_ENV = "RELAY_CODEX_REVIEW_TIMEOUT";
+const DEFAULT_REVIEW_TIMEOUT = "900s";
 const cliArgs = bindCliArgs(args, {
   commandName: "invoke-reviewer-codex",
   reservedFlags: KNOWN_FLAGS,
@@ -37,11 +39,40 @@ function readNonEmptyFile(filePath) {
   return text || null;
 }
 
+function parseReviewTimeoutMs(value) {
+  const text = String(value || DEFAULT_REVIEW_TIMEOUT).trim();
+  const match = text.match(/^(\d+)(ms|s|m)?$/);
+  if (!match) {
+    throw new Error(`${REVIEW_TIMEOUT_ENV} must be a duration like 900s, 15m, or 60000ms`);
+  }
+  const amount = Number(match[1]);
+  const unit = match[2] || "ms";
+  const multiplier = unit === "m" ? 60 * 1000 : unit === "s" ? 1000 : 1;
+  const ms = amount * multiplier;
+  if (!Number.isSafeInteger(ms) || ms <= 0) {
+    throw new Error(`${REVIEW_TIMEOUT_ENV} must resolve to a positive timeout`);
+  }
+  return ms;
+}
+
+function isExecTimeout(error) {
+  return error && (error.code === "ETIMEDOUT" || error.signal === "SIGTERM" || error.signal === "SIGKILL");
+}
+
+function writeRawResponse(filePath, error) {
+  const stdout = String(error?.stdout || "").trim();
+  const stderr = String(error?.stderr || "").trim();
+  const text = stderr ? [stdout, "", "stderr:", stderr].filter(Boolean).join("\n") : stdout;
+  fs.writeFileSync(filePath, `${text || "(no output)"}\n`, "utf-8");
+}
+
 function main() {
   const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
   const promptFile = cliArgs.getArg("--prompt-file");
   const model = cliArgs.getArg("--model");
   const codexBin = process.env.RELAY_CODEX_BIN || "codex";
+  const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
+  const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
 
   if (!promptFile) {
     throw new Error("--prompt-file is required");
@@ -50,6 +81,7 @@ function main() {
   const promptText = fs.readFileSync(promptFile, "utf-8").trim();
   const schemaPath = path.join(os.tmpdir(), `relay-review-schema-${process.pid}-${Date.now()}.json`);
   const resultPath = path.join(os.tmpdir(), `relay-review-codex-${process.pid}-${Date.now()}.json`);
+  const rawResponsePath = path.join(os.tmpdir(), `relay-review-codex-${process.pid}-${Date.now()}-raw-response.txt`);
 
   try {
     fs.writeFileSync(schemaPath, `${JSON.stringify(REVIEWER_VERDICT_JSON_SCHEMA, null, 2)}\n`, "utf-8");
@@ -81,12 +113,24 @@ function main() {
         cwd: repoPath,
         encoding: "utf-8",
         stdio: "pipe",
+        timeout: parentTimeoutMs,
+        killSignal: "SIGKILL",
         maxBuffer: 10 * 1024 * 1024,
       });
     } catch (error) {
+      writeRawResponse(rawResponsePath, error);
+      if (isExecTimeout(error)) {
+        throw new Error(
+          `Codex reviewer primary_review timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}); ` +
+          `model=${model || "default"}; raw_response=${rawResponsePath}`
+        );
+      }
       const recovered = readNonEmptyFile(resultPath);
       if (!recovered) {
-        throw new Error(`Codex reviewer failed: ${summarizeFailure(error)}`);
+        throw new Error(
+          `Codex reviewer primary_review failed; model=${model || "default"}; ` +
+          `raw_response=${rawResponsePath}; ${summarizeFailure(error)}`
+        );
       }
     }
 
@@ -107,6 +151,9 @@ function main() {
   } finally {
     try { fs.unlinkSync(schemaPath); } catch {}
     try { fs.unlinkSync(resultPath); } catch {}
+    if (fs.existsSync(rawResponsePath) && fs.statSync(rawResponsePath).size === 0) {
+      try { fs.unlinkSync(rawResponsePath); } catch {}
+    }
   }
 }
 

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -404,7 +404,10 @@ function executeAdvisoryRequest(request) {
       ].join("\n") + "\n");
     } else if (outcome.timeout) {
       status = "timeout";
-      failureReason = `advisory reviewer exceeded ${timeoutMs / 1000}s timeout`;
+      failureReason = (
+        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s; ` +
+        `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
+      );
     } else if (outcome.error || outcome.code !== 0) {
       status = "failed";
       failureReason = outcome.error ? outcome.error.message : `advisory reviewer exited with code ${outcome.code}`;

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -66,6 +66,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . \
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/reconcile-run.js" --repo . --run-id "$RUN_ID" --dry-run --json
+node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/relay-recover.js" --repo . --run-id "$RUN_ID" --dry-run --json
 node "${RELAY_SKILL_ROOT:-skills}/relay/scripts/run-preflight.js" --stage review --repo . --run-id "$RUN_ID" --json
 ```
 

--- a/skills/relay/scripts/relay-recover.js
+++ b/skills/relay/scripts/relay-recover.js
@@ -58,8 +58,6 @@ function planFor(row, repoRoot) {
     "timed_out_live",
     "dead_with_work",
     "dead_no_work",
-    "branch_without_pr",
-    "pr_without_manifest_stamp",
   ].includes(row.classification)) {
     return {
       action: "delegate_reconcile",
@@ -138,6 +136,9 @@ function main() {
   const repo = cliArgs.getArg("--repo", ".");
   const runIdArg = cliArgs.getArg("--run-id");
   const issueArg = cliArgs.getArg("--issue");
+  if (hasCliFlag("--dry-run") && hasCliFlag("--apply")) {
+    throw new Error("--dry-run and --apply are mutually exclusive");
+  }
   const apply = hasCliFlag("--apply");
   if ((runIdArg && issueArg) || (!runIdArg && !issueArg)) {
     throw new Error("exactly one of --run-id or --issue is required");

--- a/skills/relay/scripts/relay-recover.js
+++ b/skills/relay/scripts/relay-recover.js
@@ -84,13 +84,13 @@ function resolveRun({ repoRoot, runId, issueArg }) {
   const issueNumber = Number(issueArg);
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) throw new Error("--issue must be a positive integer");
   const selection = selectIssueRuns(repoRoot, issueNumber);
-  if (!selection.selected_run_id) {
-    const error = new Error(`no relay run found for issue #${issueNumber}`);
+  if (selection.selection_reason === "multiple_active_runs") {
+    const error = new Error(`multiple active relay runs found for issue #${issueNumber}; pass --run-id`);
     error.selection = selection;
     throw error;
   }
-  if (selection.selection_reason === "multiple_active_runs") {
-    const error = new Error(`multiple active relay runs found for issue #${issueNumber}; pass --run-id`);
+  if (!selection.selected_run_id) {
+    const error = new Error(`no relay run found for issue #${issueNumber}`);
     error.selection = selection;
     throw error;
   }

--- a/skills/relay/scripts/relay-recover.js
+++ b/skills/relay/scripts/relay-recover.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const {
+  bindCliArgs,
+  findUnknownFlags,
+  modeLabel,
+} = require("../../relay-dispatch/scripts/cli-args");
+const { getCanonicalRepoRoot } = require("../../relay-dispatch/scripts/manifest/paths");
+const { observeRun } = require("../../relay-dispatch/scripts/run-observer");
+const { selectIssueRuns } = require("./relay-status");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--run-id", "--issue", "--apply", "--dry-run", "--json", "--help", "-h"];
+const CLI_ARG_OPTIONS = { commandName: "relay-recover", reservedFlags: KNOWN_FLAGS };
+const cliArgs = bindCliArgs(args, CLI_ARG_OPTIONS);
+
+function hasCliFlag(flag) {
+  return cliArgs.hasFlag(flag);
+}
+
+function usage() {
+  return [
+    "Usage: relay-recover.js --repo <path> (--run-id <id> | --issue <number>) [--dry-run | --apply] [--json]",
+    "",
+    "Choose the safe existing recovery command for a relay run. Defaults to dry-run.",
+    "",
+    "Options:",
+    `  --repo <path>  ${modeLabel("--repo")} Repository root (default: .)`,
+    `  --run-id <id>  ${modeLabel("--run-id")} Relay run identifier`,
+    `  --issue <n>    ${modeLabel("--issue")} GitHub issue number`,
+    `  --dry-run      ${modeLabel("--dry-run")} Print planned command without mutating (default)`,
+    `  --apply        ${modeLabel("--apply")} Execute safe delegated recovery`,
+    `  --json         ${modeLabel("--json")} Output JSON`,
+    `  --help, -h     ${modeLabel("--help")} Show help`,
+  ].join("\n");
+}
+
+function shellCommand(argv) {
+  return argv.map((part) => JSON.stringify(String(part))).join(" ");
+}
+
+function planFor(row, repoRoot) {
+  const reconcile = [
+    process.execPath,
+    "skills/relay-dispatch/scripts/reconcile-run.js",
+    "--repo", repoRoot,
+    "--run-id", row.run_id,
+    "--json",
+  ];
+  const reconcileDryRun = [...reconcile, "--dry-run"];
+  if ([
+    "running_with_output",
+    "running_silent",
+    "timed_out_live",
+    "dead_with_work",
+    "dead_no_work",
+    "branch_without_pr",
+    "pr_without_manifest_stamp",
+  ].includes(row.classification)) {
+    return {
+      action: "delegate_reconcile",
+      safe_to_apply: row.classification !== "running_with_output" && row.classification !== "running_silent",
+      command: reconcile,
+      dry_run_command: reconcileDryRun,
+      reason: row.classification,
+    };
+  }
+  return {
+    action: "manual_guidance",
+    safe_to_apply: false,
+    command: null,
+    dry_run_command: null,
+    reason: row.classification,
+    guidance: row.next_action.command,
+  };
+}
+
+function resolveRun({ repoRoot, runId, issueArg }) {
+  if (runId) return runId;
+  const issueNumber = Number(issueArg);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) throw new Error("--issue must be a positive integer");
+  const selection = selectIssueRuns(repoRoot, issueNumber);
+  if (!selection.selected_run_id) {
+    const error = new Error(`no relay run found for issue #${issueNumber}`);
+    error.selection = selection;
+    throw error;
+  }
+  if (selection.selection_reason === "multiple_active_runs") {
+    const error = new Error(`multiple active relay runs found for issue #${issueNumber}; pass --run-id`);
+    error.selection = selection;
+    throw error;
+  }
+  return selection.selected_run_id;
+}
+
+function runCommand(argv, repoRoot) {
+  const stdout = execFileSync(argv[0], argv.slice(1), {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return stdout.trim() ? JSON.parse(stdout) : null;
+}
+
+function formatText(result) {
+  const lines = [
+    `Run: ${result.run_id}`,
+    `Classification: ${result.classification}`,
+    `Action: ${result.plan.action}`,
+    `Safe to apply: ${result.plan.safe_to_apply}`,
+  ];
+  if (result.plan.dry_run_command) {
+    lines.push(`Dry-run: ${shellCommand(result.plan.dry_run_command)}`);
+  }
+  if (result.plan.command) {
+    lines.push(`Apply: ${shellCommand(result.plan.command)}`);
+  }
+  if (result.plan.guidance) {
+    lines.push(`Guidance: ${result.plan.guidance}`);
+  }
+  if (result.applied) {
+    lines.push("Applied: yes");
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  if (!args.length || hasCliFlag(["--help", "-h"])) {
+    console.log(usage());
+    process.exit(hasCliFlag(["--help", "-h"]) ? 0 : 1);
+  }
+  const unknownFlags = findUnknownFlags(args, KNOWN_FLAGS);
+  if (unknownFlags.length) throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  const repo = cliArgs.getArg("--repo", ".");
+  const runIdArg = cliArgs.getArg("--run-id");
+  const issueArg = cliArgs.getArg("--issue");
+  const apply = hasCliFlag("--apply");
+  if ((runIdArg && issueArg) || (!runIdArg && !issueArg)) {
+    throw new Error("exactly one of --run-id or --issue is required");
+  }
+  const repoRoot = getCanonicalRepoRoot(path.resolve(repo));
+  const runId = resolveRun({ repoRoot, runId: runIdArg, issueArg });
+  const row = observeRun({ repo: repoRoot, runId });
+  const plan = planFor(row, repoRoot);
+  const result = {
+    ok: true,
+    dry_run: !apply,
+    applied: false,
+    run_id: row.run_id,
+    classification: row.classification,
+    row,
+    plan,
+    result: null,
+  };
+  if (apply) {
+    if (!plan.safe_to_apply || !plan.command) {
+      throw new Error(`refusing to apply unsafe recovery for ${row.classification}; inspect guidance first`);
+    }
+    result.result = runCommand(plan.command, repoRoot);
+    result.applied = true;
+  }
+  console.log(hasCliFlag("--json") ? JSON.stringify(result, null, 2) : formatText(result));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`relay-recover: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  planFor,
+};

--- a/skills/relay/scripts/relay-status.js
+++ b/skills/relay/scripts/relay-status.js
@@ -11,7 +11,7 @@ const {
 const { getCanonicalRepoRoot } = require("../../relay-dispatch/scripts/manifest/paths");
 const { listManifestRecords } = require("../../relay-dispatch/scripts/manifest/store");
 const { isTerminalState } = require("../../relay-dispatch/scripts/manifest/lifecycle");
-const { observeRun } = require("../../relay-dispatch/scripts/run-observer");
+const { formatText, observeRun } = require("../../relay-dispatch/scripts/run-observer");
 
 const args = process.argv.slice(2);
 const KNOWN_FLAGS = ["--repo", "--run-id", "--issue", "--json", "--help", "-h"];
@@ -69,20 +69,6 @@ function selectIssueRuns(repoRoot, issueNumber) {
   };
 }
 
-function formatRow(row) {
-  return [
-    `Run: ${row.run_id}`,
-    `State: ${row.state}`,
-    `Lease: ${row.lease.status || "unknown"}, elapsed ${row.lease.elapsed_s ?? "?"}s, remaining ${row.lease.remaining_s ?? "?"}s`,
-    `Output: ${row.logs.last_output_at ? `silent for ${row.logs.silent_for_s}s` : "no output observed"}`,
-    `Worktree: ${row.worktree.exists ? "exists" : "missing"}, reviewable=${row.worktree.reviewable_dirt}, commits=${row.worktree.new_commits}`,
-    `PR: ${row.pr.number ? `#${row.pr.number} ${row.pr.state}` : row.pr.lookup_status}`,
-    `Classification: ${row.classification}`,
-    `Next: ${row.next_action.kind}`,
-    `Command: ${row.next_action.command}`,
-  ].join("\n");
-}
-
 function formatIssueNoRun(selection) {
   if (selection.selection_reason === "multiple_active_runs") {
     return [
@@ -117,7 +103,7 @@ function main() {
   const repoRoot = getCanonicalRepoRoot(path.resolve(repo));
   if (runId) {
     const row = observeRun({ repo: repoRoot, runId });
-    console.log(hasCliFlag("--json") ? JSON.stringify({ ok: true, row }, null, 2) : formatRow(row));
+    console.log(hasCliFlag("--json") ? JSON.stringify({ ok: true, row }, null, 2) : formatText(row));
     return;
   }
   const issueNumber = Number(issueArg);
@@ -129,7 +115,7 @@ function main() {
   }
   const row = observeRun({ repo: repoRoot, runId: selection.selected_run_id });
   const payload = { ok: true, selection, row };
-  console.log(hasCliFlag("--json") ? JSON.stringify(payload, null, 2) : `${formatRow(row)}\nSelection: ${selection.selection_reason}`);
+  console.log(hasCliFlag("--json") ? JSON.stringify(payload, null, 2) : `${formatText(row)}\nSelection: ${selection.selection_reason}`);
 }
 
 if (require.main === module) {

--- a/skills/relay/scripts/relay-status.js
+++ b/skills/relay/scripts/relay-status.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("path");
+
+const {
+  bindCliArgs,
+  findUnknownFlags,
+  modeLabel,
+} = require("../../relay-dispatch/scripts/cli-args");
+const { getCanonicalRepoRoot } = require("../../relay-dispatch/scripts/manifest/paths");
+const { listManifestRecords } = require("../../relay-dispatch/scripts/manifest/store");
+const { isTerminalState } = require("../../relay-dispatch/scripts/manifest/lifecycle");
+const { observeRun } = require("../../relay-dispatch/scripts/run-observer");
+
+const args = process.argv.slice(2);
+const KNOWN_FLAGS = ["--repo", "--run-id", "--issue", "--json", "--help", "-h"];
+const CLI_ARG_OPTIONS = { commandName: "relay-status", reservedFlags: KNOWN_FLAGS };
+const cliArgs = bindCliArgs(args, CLI_ARG_OPTIONS);
+
+function hasCliFlag(flag) {
+  return cliArgs.hasFlag(flag);
+}
+
+function usage() {
+  return [
+    "Usage: relay-status.js --repo <path> (--run-id <id> | --issue <number>) [--json]",
+    "",
+    "Print read-only operational status for a relay run or issue.",
+    "",
+    "Options:",
+    `  --repo <path>  ${modeLabel("--repo")} Repository root (default: .)`,
+    `  --run-id <id>  ${modeLabel("--run-id")} Relay run identifier`,
+    `  --issue <n>    ${modeLabel("--issue")} GitHub issue number`,
+    `  --json         ${modeLabel("--json")} Output JSON`,
+    `  --help, -h     ${modeLabel("--help")} Show help`,
+  ].join("\n");
+}
+
+function manifestIssueNumber(record) {
+  const value = Number(record?.data?.issue?.number);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function selectIssueRuns(repoRoot, issueNumber) {
+  const candidates = listManifestRecords(repoRoot)
+    .filter((record) => manifestIssueNumber(record) === issueNumber);
+  const active = candidates.filter((record) => !isTerminalState(record.data?.state));
+  const selected = active[0] || candidates[0] || null;
+  return {
+    issue: issueNumber,
+    selected_run_id: selected?.data?.run_id || null,
+    selection_reason: active.length === 1
+      ? "single_active_run"
+      : active.length > 1
+      ? "multiple_active_runs"
+      : candidates.length === 1
+      ? "single_terminal_or_closed_run"
+      : candidates.length > 1
+      ? "multiple_terminal_or_closed_runs"
+      : "no_run",
+    candidates: candidates.map((record) => ({
+      run_id: record.data?.run_id || path.basename(record.manifestPath, ".md"),
+      state: record.data?.state || "unknown",
+      manifest_path: record.manifestPath,
+      updated_at: record.data?.timestamps?.updated_at || null,
+    })),
+  };
+}
+
+function formatRow(row) {
+  return [
+    `Run: ${row.run_id}`,
+    `State: ${row.state}`,
+    `Lease: ${row.lease.status || "unknown"}, elapsed ${row.lease.elapsed_s ?? "?"}s, remaining ${row.lease.remaining_s ?? "?"}s`,
+    `Output: ${row.logs.last_output_at ? `silent for ${row.logs.silent_for_s}s` : "no output observed"}`,
+    `Worktree: ${row.worktree.exists ? "exists" : "missing"}, reviewable=${row.worktree.reviewable_dirt}, commits=${row.worktree.new_commits}`,
+    `PR: ${row.pr.number ? `#${row.pr.number} ${row.pr.state}` : row.pr.lookup_status}`,
+    `Classification: ${row.classification}`,
+    `Next: ${row.next_action.kind}`,
+    `Command: ${row.next_action.command}`,
+  ].join("\n");
+}
+
+function formatIssueNoRun(selection) {
+  return [
+    `Issue: #${selection.issue}`,
+    "Run: none",
+    `Selection: ${selection.selection_reason}`,
+    "Next: dispatch or inspect issue manually",
+  ].join("\n");
+}
+
+function main() {
+  if (!args.length || hasCliFlag(["--help", "-h"])) {
+    console.log(usage());
+    process.exit(hasCliFlag(["--help", "-h"]) ? 0 : 1);
+  }
+  const unknownFlags = findUnknownFlags(args, KNOWN_FLAGS);
+  if (unknownFlags.length) throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+  const repo = cliArgs.getArg("--repo", ".");
+  const runId = cliArgs.getArg("--run-id");
+  const issueArg = cliArgs.getArg("--issue");
+  if ((runId && issueArg) || (!runId && !issueArg)) {
+    throw new Error("exactly one of --run-id or --issue is required");
+  }
+  const repoRoot = getCanonicalRepoRoot(path.resolve(repo));
+  if (runId) {
+    const row = observeRun({ repo: repoRoot, runId });
+    console.log(hasCliFlag("--json") ? JSON.stringify({ ok: true, row }, null, 2) : formatRow(row));
+    return;
+  }
+  const issueNumber = Number(issueArg);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) throw new Error("--issue must be a positive integer");
+  const selection = selectIssueRuns(repoRoot, issueNumber);
+  if (!selection.selected_run_id) {
+    console.log(hasCliFlag("--json") ? JSON.stringify({ ok: true, selection, row: null }, null, 2) : formatIssueNoRun(selection));
+    return;
+  }
+  const row = observeRun({ repo: repoRoot, runId: selection.selected_run_id });
+  const payload = { ok: true, selection, row };
+  console.log(hasCliFlag("--json") ? JSON.stringify(payload, null, 2) : `${formatRow(row)}\nSelection: ${selection.selection_reason}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`relay-status: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  selectIssueRuns,
+};

--- a/skills/relay/scripts/relay-status.js
+++ b/skills/relay/scripts/relay-status.js
@@ -46,7 +46,8 @@ function selectIssueRuns(repoRoot, issueNumber) {
   const candidates = listManifestRecords(repoRoot)
     .filter((record) => manifestIssueNumber(record) === issueNumber);
   const active = candidates.filter((record) => !isTerminalState(record.data?.state));
-  const selected = active[0] || candidates[0] || null;
+  const ambiguousActive = active.length > 1;
+  const selected = ambiguousActive ? null : active[0] || candidates[0] || null;
   return {
     issue: issueNumber,
     selected_run_id: selected?.data?.run_id || null,
@@ -83,6 +84,15 @@ function formatRow(row) {
 }
 
 function formatIssueNoRun(selection) {
+  if (selection.selection_reason === "multiple_active_runs") {
+    return [
+      `Issue: #${selection.issue}`,
+      "Run: ambiguous",
+      "Selection: multiple_active_runs",
+      `Candidates: ${selection.candidates.map((candidate) => candidate.run_id).join(", ")}`,
+      "Next: pass --run-id for the intended run",
+    ].join("\n");
+  }
   return [
     `Issue: #${selection.issue}`,
     "Run: none",

--- a/tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js
@@ -1,0 +1,25 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
+const ADVISORY_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner", "advisory.js");
+
+test("dispatch timeout diagnostics distinguish total_timeout and no_result", () => {
+  const source = fs.readFileSync(DISPATCH_SCRIPT, "utf-8");
+  assert.match(source, /executor total_timeout after/);
+  assert.match(source, /executor no_result: produced no structured result file or summary/);
+  assert.match(source, /dispatchFailureClass/);
+  assert.match(source, /dispatch_failure_class/);
+  assert.ok(source.includes("stdout=${stdoutLog}"));
+  assert.ok(source.includes("stderr=${stderrLog}"));
+  assert.ok(source.includes("result=${resultFile}"));
+});
+
+test("advisory timeout wording includes reviewer model and raw response", () => {
+  const source = fs.readFileSync(ADVISORY_SCRIPT, "utf-8");
+  assert.match(source, /reviewer advisory_review timed out after/);
+  assert.ok(source.includes("model=${request.reviewerModel || \"default\"}"));
+  assert.ok(source.includes("raw_response=${rawResponsePath}"));
+});

--- a/tests/relay-dispatch/scripts/relay-events.test.js
+++ b/tests/relay-dispatch/scripts/relay-events.test.js
@@ -324,6 +324,21 @@ const RUN_EVENT_FIELD_CASES = [
       guidance_artifact_path: "guidance-metadata.json",
     },
   },
+  {
+    label: "dispatch failure class",
+    fields: {
+      event: EVENTS.DISPATCH_RESULT,
+      state_from: "dispatched",
+      state_to: "escalated",
+      reason: "new_dispatch:executor failed",
+      failure_class: null,
+      dispatch_failure_class: "no_result",
+    },
+    expected: {
+      failure_class: null,
+      dispatch_failure_class: "no_result",
+    },
+  },
 ];
 
 test("appendRunEvent round-trips optional fields when provided", () => {

--- a/tests/relay-dispatch/scripts/run-observer.test.js
+++ b/tests/relay-dispatch/scripts/run-observer.test.js
@@ -1,0 +1,233 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawn } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { observeRun } = require("../../../skills/relay-dispatch/scripts/run-observer");
+
+function writeFakeGh(binDir) {
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "list") {
+  process.stdout.write("[]");
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "view") {
+  process.stdout.write(JSON.stringify({ number: Number(args[2]), state: "OPEN", url: "https://example.test/pr/" + args[2], headRefName: "issue-827" }));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return ghPath;
+}
+
+function setupRun({ state = STATES.DISPATCHED, missingWorktree = false } = {}) {
+  const previousRelayHome = process.env.RELAY_HOME;
+  const previousGh = process.env.RELAY_GH_BIN;
+  const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-observer-repo-")));
+  const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-observer-home-")));
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-observer-gh-")));
+  process.env.RELAY_HOME = relayHome;
+  process.env.RELAY_GH_BIN = writeFakeGh(binDir);
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Observer Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-observer@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const worktreePath = path.join(repoRoot, "worktrees", "issue-827");
+  if (!missingWorktree) {
+    fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+    execFileSync("git", ["worktree", "add", worktreePath, "-b", "issue-827"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+  }
+  const startHead = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: missingWorktree ? repoRoot : worktreePath,
+    encoding: "utf-8",
+  }).trim();
+  const runId = createRunId({
+    issueNumber: 827,
+    branch: "issue-827",
+    timestamp: new Date("2026-07-08T00:00:00.000Z"),
+  });
+  const layout = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-827",
+    baseBranch: "main",
+    issueNumber: 827,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest.anchor.rubric_path = "rubric.yaml";
+  manifest.git.head_sha = startHead;
+  manifest = updateManifestState(manifest, state, state === STATES.DISPATCHED ? "await_dispatch_result" : "next");
+  writeManifest(layout.manifestPath, manifest);
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  size_class: S\n", "utf-8");
+
+  return {
+    repoRoot,
+    relayHome,
+    runId,
+    runDir: layout.runDir,
+    manifestPath: layout.manifestPath,
+    worktreePath,
+    restore() {
+      if (previousRelayHome === undefined) delete process.env.RELAY_HOME;
+      else process.env.RELAY_HOME = previousRelayHome;
+      if (previousGh === undefined) delete process.env.RELAY_GH_BIN;
+      else process.env.RELAY_GH_BIN = previousGh;
+    },
+  };
+}
+
+function spawnSleep() {
+  const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child;
+}
+
+function writeLease(fixture, child, timeoutS = 60) {
+  fs.writeFileSync(path.join(fixture.runDir, "lease.json"), JSON.stringify({
+    pid: process.pid,
+    pgid: child.pid,
+    host: os.hostname(),
+    started_at: new Date().toISOString(),
+    timeout_s: timeoutS,
+  }, null, 2), "utf-8");
+}
+
+function writeExpiredLease(fixture, child) {
+  fs.writeFileSync(path.join(fixture.runDir, "lease.json"), JSON.stringify({
+    pid: process.pid,
+    pgid: child.pid,
+    host: os.hostname(),
+    started_at: new Date(Date.now() - 5000).toISOString(),
+    timeout_s: 1,
+  }, null, 2), "utf-8");
+}
+
+function killChild(child) {
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {}
+}
+
+test("observer classifies a live run with output", () => {
+  const fixture = setupRun();
+  const child = spawnSleep();
+  try {
+    writeLease(fixture, child);
+    fs.writeFileSync(path.join(fixture.runDir, "dispatch-stdout.log"), "working\n", "utf-8");
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.classification, "running_with_output");
+    assert.equal(row.lease.live, true);
+    assert.match(row.logs.stdout_tail, /working/);
+  } finally {
+    killChild(child);
+    fixture.restore();
+  }
+});
+
+test("observer classifies a live silent run", () => {
+  const fixture = setupRun();
+  const child = spawnSleep();
+  try {
+    writeLease(fixture, child);
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.classification, "running_silent");
+    assert.equal(row.logs.last_output_at, null);
+  } finally {
+    killChild(child);
+    fixture.restore();
+  }
+});
+
+test("observer classifies a live timed-out run", () => {
+  const fixture = setupRun();
+  const child = spawnSleep();
+  try {
+    writeExpiredLease(fixture, child);
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.classification, "timed_out_live");
+    assert.equal(row.lease.live, true);
+    assert.equal(row.lease.remaining_s, 0);
+  } finally {
+    killChild(child);
+    fixture.restore();
+  }
+});
+
+test("observer classifies a dead run with no work", () => {
+  const fixture = setupRun();
+  try {
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.classification, "dead_no_work");
+    assert.equal(row.result_file, null);
+    assert.equal(row.worktree.reviewable_dirt, false);
+    assert.match(row.next_action.command, new RegExp(`--manifest ${JSON.stringify(fixture.manifestPath).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    fixture.restore();
+  }
+});
+
+test("observer classifies dead work", () => {
+  const fixture = setupRun();
+  try {
+    fs.writeFileSync(path.join(fixture.worktreePath, "changed.txt"), "work\n", "utf-8");
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.classification, "dead_with_work");
+    assert.equal(row.worktree.reviewable_dirt, true);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test("observer classifies missing worktree", () => {
+  const fixture = setupRun({ missingWorktree: true });
+  try {
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.classification, "missing_worktree");
+    assert.equal(row.worktree.exists, false);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test("observer reports corrupt lease without mutating", () => {
+  const fixture = setupRun();
+  try {
+    const leasePath = path.join(fixture.runDir, "lease.json");
+    fs.writeFileSync(leasePath, "{bad json", "utf-8");
+    const before = fs.readFileSync(leasePath, "utf-8");
+    const row = observeRun({ repo: fixture.repoRoot, runId: fixture.runId });
+    assert.equal(row.lease.status, "corrupt");
+    assert.equal(fs.readFileSync(leasePath, "utf-8"), before);
+  } finally {
+    fixture.restore();
+  }
+});

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -172,6 +172,42 @@ process.exit(1);
   assert.equal(result.summary, "Recovered.");
 });
 
+test("codex adapter timeout reports model and raw response path", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-codex-timeout-"));
+  const fakeCodex = writeExecutable(fakeDir, "fake-codex.js", `#!/usr/bin/env node
+setTimeout(() => {
+  process.stdout.write("late output\\n");
+}, 1000);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CODEX_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--model", "codex-test-model",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 5000,
+      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex, RELAY_CODEX_REVIEW_TIMEOUT: "10ms" },
+    });
+    assert.fail("expected invoke-reviewer-codex.js to time out");
+  } catch (caught) {
+    error = caught;
+  }
+
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /Codex reviewer primary_review timed out after 10ms/);
+  assert.match(stderr, /RELAY_CODEX_REVIEW_TIMEOUT/);
+  assert.match(stderr, /model=codex-test-model/);
+  assert.match(stderr, /raw_response=/);
+});
+
 test("claude adapter can recover from a non-zero exit when stdout contains JSON", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-claude-recover-"));

--- a/tests/relay/scripts/relay-status-recover.test.js
+++ b/tests/relay/scripts/relay-status-recover.test.js
@@ -1,0 +1,95 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { selectIssueRuns } = require("../../../skills/relay/scripts/relay-status");
+const { planFor } = require("../../../skills/relay/scripts/relay-recover");
+
+function setupRepo() {
+  const previousRelayHome = process.env.RELAY_HOME;
+  const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-status-repo-")));
+  const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-status-home-")));
+  process.env.RELAY_HOME = relayHome;
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Status Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-status@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return {
+    repoRoot,
+    relayHome,
+    restore() {
+      if (previousRelayHome === undefined) delete process.env.RELAY_HOME;
+      else process.env.RELAY_HOME = previousRelayHome;
+    },
+  };
+}
+
+function writeRun(fixture, { issueNumber = 828, state = STATES.DISPATCHED, suffix = "a" } = {}) {
+  const runId = createRunId({
+    issueNumber,
+    branch: `issue-${issueNumber}-${suffix}`,
+    timestamp: new Date(`2026-07-08T00:00:0${suffix === "a" ? 0 : 1}.000Z`),
+  });
+  const layout = ensureRunLayout(fixture.repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot: fixture.repoRoot,
+    runId,
+    branch: `issue-${issueNumber}-${suffix}`,
+    baseBranch: "main",
+    issueNumber,
+    worktreePath: fixture.repoRoot,
+  });
+  manifest.anchor.rubric_path = "rubric.yaml";
+  if (state !== STATES.DRAFT) {
+    manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  }
+  writeManifest(layout.manifestPath, manifest);
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  size_class: S\n", "utf-8");
+  return runId;
+}
+
+test("relay-status selects a single active issue run", () => {
+  const fixture = setupRepo();
+  try {
+    const runId = writeRun(fixture);
+    const selection = selectIssueRuns(fixture.repoRoot, 828);
+    assert.equal(selection.selected_run_id, runId);
+    assert.equal(selection.selection_reason, "single_active_run");
+    assert.equal(selection.candidates.length, 1);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test("relay-recover plans reconcile for dead work but refuses missing worktree", () => {
+  const recoverable = planFor({
+    run_id: "issue-829-20260708000000000-aaaaaaaa",
+    classification: "dead_with_work",
+    next_action: { command: "ignored" },
+  }, "/tmp/repo");
+  assert.equal(recoverable.action, "delegate_reconcile");
+  assert.equal(recoverable.safe_to_apply, true);
+  assert.ok(recoverable.command.includes("skills/relay-dispatch/scripts/reconcile-run.js"));
+
+  const unsafe = planFor({
+    run_id: "issue-829-20260708000000000-bbbbbbbb",
+    classification: "missing_worktree",
+    next_action: { command: "inspect manually" },
+  }, "/tmp/repo");
+  assert.equal(unsafe.action, "manual_guidance");
+  assert.equal(unsafe.safe_to_apply, false);
+  assert.equal(unsafe.guidance, "inspect manually");
+});

--- a/tests/relay/scripts/relay-status-recover.test.js
+++ b/tests/relay/scripts/relay-status-recover.test.js
@@ -74,6 +74,20 @@ test("relay-status selects a single active issue run", () => {
   }
 });
 
+test("relay-status refuses to select an arbitrary active issue run", () => {
+  const fixture = setupRepo();
+  try {
+    writeRun(fixture, { issueNumber: 828, suffix: "a" });
+    writeRun(fixture, { issueNumber: 828, suffix: "b" });
+    const selection = selectIssueRuns(fixture.repoRoot, 828);
+    assert.equal(selection.selected_run_id, null);
+    assert.equal(selection.selection_reason, "multiple_active_runs");
+    assert.equal(selection.candidates.length, 2);
+  } finally {
+    fixture.restore();
+  }
+});
+
 test("relay-recover plans reconcile for dead work but refuses missing worktree", () => {
   const recoverable = planFor({
     run_id: "issue-829-20260708000000000-aaaaaaaa",

--- a/tests/relay/scripts/relay-status-recover.test.js
+++ b/tests/relay/scripts/relay-status-recover.test.js
@@ -121,7 +121,12 @@ test("relay-recover refuses to apply running runs", () => {
 });
 
 test("relay-recover gives manual guidance for terminal or unknown runs", () => {
-  for (const classification of ["ready_to_merge", "unknown_needs_manual_inspection"]) {
+  for (const classification of [
+    "ready_to_merge",
+    "unknown_needs_manual_inspection",
+    "branch_without_pr",
+    "pr_without_manifest_stamp",
+  ]) {
     const plan = planFor({
       run_id: "issue-829-20260708000000000-dddddddd",
       classification,
@@ -131,4 +136,17 @@ test("relay-recover gives manual guidance for terminal or unknown runs", () => {
     assert.equal(plan.safe_to_apply, false);
     assert.equal(plan.guidance, "inspect manually");
   }
+});
+
+test("relay-recover rejects conflicting apply and dry-run flags", () => {
+  assert.throws(
+    () => execFileSync(process.execPath, [
+      "skills/relay/scripts/relay-recover.js",
+      "--repo", ".",
+      "--run-id", "issue-829-20260708000000000-dddddddd",
+      "--dry-run",
+      "--apply",
+    ], { cwd: path.resolve(__dirname, "../../.."), encoding: "utf-8", stdio: "pipe" }),
+    /--dry-run and --apply are mutually exclusive/,
+  );
 });

--- a/tests/relay/scripts/relay-status-recover.test.js
+++ b/tests/relay/scripts/relay-status-recover.test.js
@@ -107,3 +107,28 @@ test("relay-recover plans reconcile for dead work but refuses missing worktree",
   assert.equal(unsafe.safe_to_apply, false);
   assert.equal(unsafe.guidance, "inspect manually");
 });
+
+test("relay-recover refuses to apply running runs", () => {
+  for (const classification of ["running_with_output", "running_silent"]) {
+    const plan = planFor({
+      run_id: "issue-829-20260708000000000-cccccccc",
+      classification,
+      next_action: { command: "inspect running process" },
+    }, "/tmp/repo");
+    assert.equal(plan.action, "delegate_reconcile");
+    assert.equal(plan.safe_to_apply, false);
+  }
+});
+
+test("relay-recover gives manual guidance for terminal or unknown runs", () => {
+  for (const classification of ["ready_to_merge", "unknown_needs_manual_inspection"]) {
+    const plan = planFor({
+      run_id: "issue-829-20260708000000000-dddddddd",
+      classification,
+      next_action: { command: "inspect manually" },
+    }, "/tmp/repo");
+    assert.equal(plan.action, "manual_guidance");
+    assert.equal(plan.safe_to_apply, false);
+    assert.equal(plan.guidance, "inspect manually");
+  }
+});


### PR DESCRIPTION
## Summary

Implements #826 with the v1 operational visibility scope:

- adds a read-only run observer for manifest/lease/log/worktree/PR-derived status rows
- adds relay-facing `relay-status.js` and dry-run-first `relay-recover.js`
- improves dispatch/review timeout diagnostics without provider fallback automation
- adds a concise PRD documenting the intentionally small v1 boundary

Closes #827.
Closes #828.
Closes #829.
Closes #830.
Closes #826.

## Notes

This keeps model/provider resolution out of scope; #825 remains the owner for provider-aware model resolution.

`relay-recover.js --apply` only delegates safe classifications to existing recovery commands. It does not assign manifest state directly.

## Verification

Passed:

```bash
node --test tests/relay-dispatch/scripts/run-observer.test.js tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js tests/relay/scripts/relay-status-recover.test.js tests/skills-lint/scripts/*.test.js
node --test tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js tests/relay-review/scripts/invoke-reviewer.test.js
node --test tests/relay-dispatch/scripts/run-observer.test.js tests/relay/scripts/relay-status-recover.test.js tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js tests/relay-review/scripts/invoke-reviewer.test.js
node --test tests/relay-dispatch/scripts/run-observer.test.js tests/relay/scripts/relay-status-recover.test.js tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js tests/relay-review/scripts/invoke-reviewer.test.js
```

Also passed:

```bash
git diff --check
```

Attempted full final gate from `AGENTS.md`. It was interrupted after `tests/relay-dispatch/scripts/dispatch.test.js` stalled in existing detach/dispatch subprocess fixtures under current machine load. A direct stale-result regression found during that run was fixed and the specific case then passed:

```bash
node --test --test-concurrency=1 --test-name-pattern 'dispatch resume clears stale structured result before executor attempt' tests/relay-dispatch/scripts/dispatch.test.js
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 릴레이 실행 상태를 읽기 전용으로 확인하는 상태 조회와 실행 관찰 기능이 추가되었습니다.
  * 안전한 복구 흐름이 도입되어, 기본은 미리보기 방식으로 동작하고 필요 시에만 적용할 수 있습니다.
  * 타임아웃 진단이 강화되어 실행 실패 시 더 구체적인 경로와 원인 정보를 확인할 수 있습니다.

* **Bug Fixes**
  * 실행 실패 분류와 오류 메시지가 더 일관되고 상세하게 표시됩니다.
  * 타임아웃 시 결과 응답에 원문 로그와 관련 경로가 포함됩니다.

* **Tests**
  * 상태 조회, 관찰, 복구, 타임아웃 진단에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->