### PR TITLE
Harden model list fixtures and catalog freshness reporting

### DIFF
--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -23,6 +23,7 @@ Set up relay routes interactively. The user should not have to memorize command 
 - The user wants company-safe strict mode, personal open mode, OpenCode/Pi opt-in, or advisory-review routing
 - The user asks whether a provider/model route such as `example/opencode-model-*` or `openai/*` is available
 - The user asks to resolve a short model name such as `glm-5.2` for a known actor
+- The user asks whether model catalog entries are fresh or stale
 - The user asks to create, show, or remove a route preset such as `light`, `diverse`, or `hardened`
 - The user asks to run relay doctor/check
 
@@ -78,6 +79,7 @@ Use the wrapper for shorthand, or pass through full flags:
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" init company
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" add-route 'example/opencode-model-*' --phase dispatch,advisory_review --executor opencode
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" resolve-model --phase review --reviewer opencode --model glm-5.2 --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" catalog-report --json
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset add light --dispatch opencode:example/opencode-model-fast
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset show light
@@ -85,7 +87,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset s
 
 Generated company and personal profiles must not pin Codex or Claude model names. Do not hardcode company-specific route defaults; use the user's supplied provider/model route patterns.
 
-Consult `references/model-catalog.md` only when live model-list probes fail or the user explicitly asks for a model recommendation; otherwise prefer `doctor` probe output or the user's supplied model id.
+Consult `references/model-catalog.md` only when live model-list probes fail, the user asks for a model recommendation, or the user asks for catalog freshness; otherwise prefer `doctor` probe output or the user's supplied model id.
 
 ### 5. Verify
 
@@ -109,6 +111,7 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `init personal` | `init --profile personal` |
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
+| `catalog-report` | `catalog-report` |
 | `resolve-model --phase review --reviewer opencode --model glm-5.2` | `resolve-model --phase review --reviewer opencode --model glm-5.2` |
 | `add-route example/opencode-model-* --phase dispatch --executor opencode` | `add-route example/opencode-model-* --phase dispatch --executor opencode` |
 | `preset add light --dispatch opencode:example/opencode-model-fast` | `preset add light --dispatch opencode:example/opencode-model-fast` |

--- a/skills/relay-config/references/model-catalog.md
+++ b/skills/relay-config/references/model-catalog.md
@@ -13,3 +13,19 @@ Use only when live model-list probes fail or the user asks for a recommendation.
 | `deepseek-v4-flash` | `cline` -> `cline-pass/deepseek-v4-flash`; `opencode` -> `openrouter/deepseek-v4-flash` | Fast iteration and low-cost preset experiments. | cheap |
 
 These are selection hints, not an authority. Model quality, availability, and prices change quickly.
+
+## Freshness report
+
+Run a read-only freshness report without requiring a failed live probe:
+
+```bash
+node skills/relay-config/scripts/relay-config.js catalog-report --json
+```
+
+The report exits successfully and includes each catalog entry's `actor_routes`, `last_checked`, `age_days`, and `stale` status. Use this for scheduled visibility or preflight checks; do not treat catalog fallback as an allow-list.
+
+## Updating parser fixtures and catalog dates
+
+Live model-list parser fixtures live under `tests/relay-dispatch/fixtures/model-lists/`. When a provider CLI changes output shape, add or update the smallest representative fixture and cover it through `tests/relay-dispatch/scripts/model-resolver.test.js`. Keep headers, separators, provider/model split columns, direct provider/model rows, and extra metadata columns in fixtures when those shapes are observed.
+
+Only update `last_checked` in `skills/relay-dispatch/scripts/model-catalog.js` after verifying availability through a current provider CLI model list or equivalent authoritative provider evidence. Record route coverage by actor, keep aliases as convenience inputs, and leave actual route authorization to `routes.json`.

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -42,6 +42,7 @@ function printHelp() {
   console.log("  init company|personal [--json]");
   console.log("  show [--json]");
   console.log("  doctor [--json] [--reconcile]");
+  console.log("  catalog-report [--json]");
   console.log("  resolve-model --phase <phase> [--executor <name>] [--reviewer <name>] [--model <name|provider/model>] [--fallback catalog] [--json]");
   console.log("  check <phase> <actor> [provider/model] [--json]");
   console.log("  add-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");

--- a/skills/relay-dispatch/scripts/model-catalog.js
+++ b/skills/relay-dispatch/scripts/model-catalog.js
@@ -61,8 +61,68 @@ const MODEL_CATALOG = Object.freeze([
   },
 ]);
 
+function daysSince(dateString, now = new Date()) {
+  const checked = Date.parse(`${dateString}T00:00:00Z`);
+  const current = now instanceof Date ? now.getTime() : Date.now();
+  if (!Number.isFinite(checked) || !Number.isFinite(current)) return null;
+  return Math.floor((current - checked) / 86400000);
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function catalogWarnings(lastChecked = CATALOG_LAST_CHECKED, now) {
+  const warnings = [
+    "catalog fallback used; verify provider/model availability before relying on this route",
+  ];
+  const checked = nonEmptyString(lastChecked) || CATALOG_LAST_CHECKED;
+  const ageDays = daysSince(checked, now);
+  if (ageDays !== null && ageDays > STALE_AFTER_DAYS) {
+    warnings.push(`stale catalog metadata: last_checked=${checked}, age_days=${ageDays}`);
+  }
+  return warnings;
+}
+
+function catalogFreshnessReport({ now = new Date() } = {}) {
+  const generatedAt = now instanceof Date ? now.toISOString() : new Date().toISOString();
+  const entries = MODEL_CATALOG.map((entry) => {
+    const lastChecked = nonEmptyString(entry.last_checked) || CATALOG_LAST_CHECKED;
+    const ageDays = daysSince(lastChecked, now);
+    const actorRoutes = entry.actor_routes || {};
+    return {
+      id: entry.id,
+      aliases: [...(entry.aliases || [])],
+      last_checked: lastChecked,
+      age_days: ageDays,
+      stale: ageDays !== null ? ageDays > STALE_AFTER_DAYS : null,
+      actor_routes: { ...actorRoutes },
+      actors: Object.keys(actorRoutes).sort(),
+      cost_hint: entry.cost_hint || null,
+      notes: entry.notes || null,
+    };
+  });
+  const summary = entries.reduce((acc, entry) => {
+    acc.total += 1;
+    if (entry.stale === true) acc.stale += 1;
+    else if (entry.stale === false) acc.fresh += 1;
+    else acc.unknown_age += 1;
+    return acc;
+  }, { total: 0, fresh: 0, stale: 0, unknown_age: 0 });
+  return {
+    generated_at: generatedAt,
+    stale_after_days: STALE_AFTER_DAYS,
+    catalog_last_checked: CATALOG_LAST_CHECKED,
+    summary,
+    entries,
+  };
+}
+
 module.exports = {
   CATALOG_LAST_CHECKED,
   MODEL_CATALOG,
   STALE_AFTER_DAYS,
+  catalogFreshnessReport,
+  catalogWarnings,
+  daysSince,
 };

--- a/skills/relay-dispatch/scripts/model-resolver.js
+++ b/skills/relay-dispatch/scripts/model-resolver.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
-const { MODEL_CATALOG, CATALOG_LAST_CHECKED, STALE_AFTER_DAYS } = require("./model-catalog");
+const { MODEL_CATALOG, CATALOG_LAST_CHECKED, catalogWarnings } = require("./model-catalog");
 const { evaluateRelayRoute } = require("./relay-policy");
 
 const PROVIDER_COLUMN_VALUES = new Set([
@@ -138,25 +138,6 @@ function liveCandidates(models, request) {
     const route = model.toLowerCase();
     return route.includes(lower) || routeBasename(route).includes(lower);
   });
-}
-
-function daysSince(dateString, now) {
-  const checked = Date.parse(`${dateString}T00:00:00Z`);
-  const current = now instanceof Date ? now.getTime() : Date.now();
-  if (!Number.isFinite(checked) || !Number.isFinite(current)) return null;
-  return Math.floor((current - checked) / 86400000);
-}
-
-function catalogWarnings(lastChecked = CATALOG_LAST_CHECKED, now) {
-  const warnings = [
-    "catalog fallback used; verify provider/model availability before relying on this route",
-  ];
-  const checked = nonEmptyString(lastChecked) || CATALOG_LAST_CHECKED;
-  const ageDays = daysSince(checked, now);
-  if (ageDays !== null && ageDays > STALE_AFTER_DAYS) {
-    warnings.push(`stale catalog metadata: last_checked=${checked}, age_days=${ageDays}`);
-  }
-  return warnings;
 }
 
 function catalogCandidateRecords({ actor, model }) {

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -31,6 +31,7 @@ const {
   resolveModelRequest,
   resolutionMetadata,
 } = require("./model-resolver");
+const { catalogFreshnessReport } = require("./model-catalog");
 
 const args = process.argv.slice(2);
 const COMMAND_NAME = "relay-config";
@@ -48,6 +49,7 @@ const SUBCOMMAND_FLAGS = {
   init: new Set(["--profile", "--json", "--help"]),
   show: new Set(["--effective", "--json", "--help"]),
   doctor: new Set(["--json", "--reconcile", "--help"]),
+  "catalog-report": new Set(["--json", "--help"]),
   "resolve-model": new Set(["--phase", "--executor", "--reviewer", "--model", "--fallback", "--json", "--help"]),
   check: new Set(["--phase", "--executor", "--reviewer", "--model", "--json", "--help"]),
   "plan-run": new Set(["--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file", "--json", "--help"]),
@@ -84,6 +86,7 @@ function printHelp() {
   console.log(`  init --profile <company|personal> ${modeLabel("--profile")} [--json ${modeLabel("--json")}]`);
   console.log(`  show --effective ${modeLabel("--effective")} [--json ${modeLabel("--json")}]`);
   console.log(`  doctor [--json ${modeLabel("--json")}] [--reconcile ${modeLabel("--reconcile")}]`);
+  console.log(`  catalog-report [--json ${modeLabel("--json")}]`);
   console.log(`  resolve-model --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <name|provider/model> ${modeLabel("--model")}] [--fallback catalog ${modeLabel("--fallback")}] [--json ${modeLabel("--json")}]`);
   console.log(`  check --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <provider/model> ${modeLabel("--model")}] [--json ${modeLabel("--json")}]`);
   console.log(`  plan-run [--repo <path> ${modeLabel("--repo")}] [--dispatch <actor[:provider/model]> ${modeLabel("--dispatch")}] [--review <actor[:provider/model]> ${modeLabel("--review")}] [--advisory-review <actor[:provider/model]> ${modeLabel("--advisory-review")}] [--route-intent-file <path> ${modeLabel("--route-intent-file")}] [--json ${modeLabel("--json")}]`);
@@ -445,6 +448,40 @@ function actorForPhaseFromArgs(phase) {
   if (EXECUTOR_PHASES.has(phase)) return requireValue(executor, "--executor");
   if (REVIEWER_PHASES.has(phase)) return requireValue(reviewer, "--reviewer");
   throw new Error(`unsupported phase: ${phase}; expected one of: ${VALID_PHASES.join(", ")}`);
+}
+
+function routeCoverage(entry) {
+  return Object.entries(entry.actor_routes || {})
+    .map(([actor, route]) => `${actor}:${route}`)
+    .join(", ") || "(none)";
+}
+
+function commandCatalogReport(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("catalog-report does not accept positional arguments");
+  }
+  const report = catalogFreshnessReport();
+  const output = {
+    ok: true,
+    catalog: report,
+  };
+
+  if (jsonOut) {
+    printJson(output);
+    return;
+  }
+
+  console.log(
+    `model catalog: ${report.summary.total} entries, ` +
+    `${report.summary.stale} stale, stale_after_days=${report.stale_after_days}`
+  );
+  for (const entry of report.entries) {
+    const status = entry.stale === true ? "stale" : entry.stale === false ? "fresh" : "unknown-age";
+    console.log(
+      `${entry.id}: ${status}; last_checked=${entry.last_checked}; ` +
+      `age_days=${entry.age_days ?? "unknown"}; routes=${routeCoverage(entry)}`
+    );
+  }
 }
 
 function optionalActorForPhaseFromArgs(phase) {
@@ -977,6 +1014,9 @@ function main() {
       break;
     case "doctor":
       commandDoctor(positionals, jsonOut);
+      break;
+    case "catalog-report":
+      commandCatalogReport(positionals, jsonOut);
       break;
     case "resolve-model":
       commandResolveModel(positionals, jsonOut);

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -162,6 +162,16 @@ test("resolve-model passes through wrapper and resolves live short model names",
   assert.equal(output.policy_decision.reason, "allowed_model_route");
 });
 
+test("catalog-report passes through wrapper", () => {
+  const result = runConfig(["catalog-report", "--json"]);
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.ok(output.catalog.summary.total > 0);
+  assert.equal(output.catalog.summary.total, output.catalog.entries.length);
+});
+
 test("preset add resolves compact actor short-model and stores explicit route provenance", () => {
   const relayHome = tempDir();
   const binDir = tempDir("relay-config-preset-model-bin-");

--- a/tests/relay-dispatch/fixtures/model-lists/opencode-lines.txt
+++ b/tests/relay-dispatch/fixtures/model-lists/opencode-lines.txt
@@ -1,0 +1,3 @@
+opencode-go/glm-5.2
+openai/gpt-5.3-codex-spark
+- openrouter/kimi-k2.7-code

--- a/tests/relay-dispatch/fixtures/model-lists/pi-table.txt
+++ b/tests/relay-dispatch/fixtures/model-lists/pi-table.txt
@@ -1,0 +1,4 @@
+provider model context notes
+-------- ----- ------- -----
+openai gpt-5-fast 128k default
+anthropic claude-4.5-sonnet 200k reasoning

--- a/tests/relay-dispatch/scripts/model-resolver.test.js
+++ b/tests/relay-dispatch/scripts/model-resolver.test.js
@@ -7,7 +7,10 @@ const path = require("path");
 const {
   resolveModelRequest,
 } = require("../../../skills/relay-dispatch/scripts/model-resolver");
-const { MODEL_CATALOG } = require("../../../skills/relay-dispatch/scripts/model-catalog");
+const {
+  MODEL_CATALOG,
+  catalogFreshnessReport,
+} = require("../../../skills/relay-dispatch/scripts/model-catalog");
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 
 function policy(overrides = {}) {
@@ -19,6 +22,27 @@ function policy(overrides = {}) {
 
 function tempDir(prefix = "relay-model-resolver-") {
   return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+const MODEL_LIST_FIXTURES = path.join(__dirname, "..", "fixtures", "model-lists");
+
+function fixturePath(name) {
+  return path.join(MODEL_LIST_FIXTURES, name);
+}
+
+function writeFixtureCli({ dir, name, expectedArg, fixtureName }) {
+  const executablePath = path.join(dir, name);
+  const argsPath = path.join(dir, `${name}-args.txt`);
+  fs.writeFileSync(executablePath, `#!/bin/sh
+printf '%s' "$1" > ${JSON.stringify(argsPath)}
+if [ "$1" = ${JSON.stringify(expectedArg)} ]; then
+  cat ${JSON.stringify(fixturePath(fixtureName))}
+  exit 0
+fi
+exit 2
+`, "utf-8");
+  fs.chmodSync(executablePath, 0o755);
+  return { executablePath, argsPath };
 }
 
 test("model resolver preserves explicit provider/model routes without probing", () => {
@@ -191,17 +215,12 @@ test("model resolver returns model_probe_failed with warning when live probe fai
 
 test("model resolver uses the Pi --list-models live probe path", () => {
   const dir = tempDir();
-  const piPath = path.join(dir, "pi");
-  const argsPath = path.join(dir, "pi-args.json");
-  fs.writeFileSync(piPath, `#!/bin/sh
-printf '["%s"]' "$1" > ${JSON.stringify(argsPath)}
-if [ "$1" = "--list-models" ]; then
-  printf 'openai/gpt-5-fast\\n'
-  exit 0
-fi
-exit 2
-`, "utf-8");
-  fs.chmodSync(piPath, 0o755);
+  const { executablePath, argsPath } = writeFixtureCli({
+    dir,
+    name: "pi",
+    expectedArg: "--list-models",
+    fixtureName: "pi-table.txt",
+  });
 
   const result = resolveModelRequest({
     phase: "dispatch",
@@ -213,10 +232,10 @@ exit 2
         { route: "openai/*", phases: ["dispatch"], executors: ["pi"] },
       ],
     }),
-    findExecutable: () => piPath,
+    findExecutable: () => executablePath,
   });
 
-  assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf-8")), ["--list-models"]);
+  assert.equal(fs.readFileSync(argsPath, "utf-8"), "--list-models");
   assert.equal(result.ok, true);
   assert.equal(result.resolved_route, "openai/gpt-5-fast");
   assert.equal(result.source, "live_probe");
@@ -225,36 +244,61 @@ exit 2
 
 test("model resolver parses Pi provider and model table columns", () => {
   const dir = tempDir();
-  const piPath = path.join(dir, "pi");
-  fs.writeFileSync(piPath, `#!/bin/sh
-if [ "$1" = "--list-models" ]; then
-  printf 'provider model context\\n'
-  printf '-------- ----- -------\\n'
-  printf 'openai gpt-5-fast 128k\\n'
-  printf 'anthropic claude-4.5-sonnet 200k\\n'
-  exit 0
-fi
-exit 2
-`, "utf-8");
-  fs.chmodSync(piPath, 0o755);
+  const { executablePath } = writeFixtureCli({
+    dir,
+    name: "pi",
+    expectedArg: "--list-models",
+    fixtureName: "pi-table.txt",
+  });
 
   const result = resolveModelRequest({
     phase: "dispatch",
     actor: "pi",
     actorField: "executor",
-    model: "gpt-5-fast",
+    model: "claude-4.5-sonnet",
     policy: policy({
       allowed_model_routes: [
-        { route: "openai/*", phases: ["dispatch"], executors: ["pi"] },
+        { route: "anthropic/*", phases: ["dispatch"], executors: ["pi"] },
       ],
     }),
-    findExecutable: () => piPath,
+    findExecutable: () => executablePath,
   });
 
   assert.equal(result.ok, true);
-  assert.equal(result.resolved_route, "openai/gpt-5-fast");
+  assert.equal(result.resolved_route, "anthropic/claude-4.5-sonnet");
   assert.equal(result.source, "live_probe");
-  assert.deepEqual(result.candidates, ["openai/gpt-5-fast"]);
+  assert.deepEqual(result.candidates, ["anthropic/claude-4.5-sonnet"]);
+});
+
+test("model resolver parses OpenCode line fixtures before catalog fallback", () => {
+  const dir = tempDir();
+  const { executablePath, argsPath } = writeFixtureCli({
+    dir,
+    name: "opencode",
+    expectedArg: "models",
+    fixtureName: "opencode-lines.txt",
+  });
+
+  const result = resolveModelRequest({
+    phase: "dispatch",
+    actor: "opencode",
+    actorField: "executor",
+    model: "glm-5.2",
+    fallback: "catalog",
+    policy: policy({
+      allowed_model_routes: [
+        { route: "opencode-go/*", phases: ["dispatch"], executors: ["opencode"] },
+      ],
+    }),
+    findExecutable: () => executablePath,
+  });
+
+  assert.equal(fs.readFileSync(argsPath, "utf-8"), "models");
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved_route, "opencode-go/glm-5.2");
+  assert.equal(result.source, "live_probe");
+  assert.deepEqual(result.candidates, ["opencode-go/glm-5.2"]);
+  assert.equal(result.warnings.some((warning) => /catalog fallback/i.test(warning)), false);
 });
 
 test("model resolver uses actor-scoped catalog fallback only when requested", () => {
@@ -307,4 +351,19 @@ test("model catalog entries carry per-entry last_checked provenance", () => {
   for (const entry of MODEL_CATALOG) {
     assert.match(entry.last_checked, /^\d{4}-\d{2}-\d{2}$/);
   }
+});
+
+test("model catalog freshness report exposes actor coverage and stale status", () => {
+  const report = catalogFreshnessReport({ now: new Date("2026-10-01T00:00:00Z") });
+
+  assert.equal(report.summary.total, MODEL_CATALOG.length);
+  assert.equal(report.summary.stale, MODEL_CATALOG.length);
+  assert.equal(report.summary.unknown_age, 0);
+  const glm = report.entries.find((entry) => entry.id === "glm-5.2");
+  assert.ok(glm);
+  assert.equal(glm.last_checked, "2026-07-06");
+  assert.equal(glm.age_days, 87);
+  assert.equal(glm.stale, true);
+  assert.deepEqual(glm.actors, ["cline", "opencode"]);
+  assert.equal(glm.actor_routes.opencode, "opencode-go/glm-5.2");
 });

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -440,6 +440,24 @@ test("doctor reports optional Pi model-list probe timeouts without masking insta
   assert.match(pi.model_probe.warning, /set RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS to adjust/);
 });
 
+test("catalog-report emits freshness JSON without requiring routes config", () => {
+  const result = runConfig(["catalog-report", "--json"]);
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.ok, true);
+  assert.equal(output.catalog.stale_after_days, 60);
+  assert.ok(output.catalog.summary.total > 0);
+  assert.equal(output.catalog.summary.total, output.catalog.entries.length);
+  const glm = output.catalog.entries.find((entry) => entry.id === "glm-5.2");
+  assert.ok(glm);
+  assert.match(glm.last_checked, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(typeof glm.age_days, "number");
+  assert.equal(typeof glm.stale, "boolean");
+  assert.deepEqual(glm.actors, ["cline", "opencode"]);
+  assert.equal(glm.actor_routes.opencode, "opencode-go/glm-5.2");
+});
+
 test("check exits zero for allowed managed CLI routes and reports the decision reason", () => {
   const relayHome = tempDir();
   assert.equal(runConfig(["init", "--profile", "company", "--json"], { relayHome }).status, 0);


### PR DESCRIPTION
## Summary
- Add fixture-driven live model-list parser coverage for Pi table output and OpenCode line output.
- Add read-only `relay-config catalog-report` JSON/text reporting for model catalog freshness and actor route coverage.
- Document fixture update workflow and catalog `last_checked` evidence requirements.

## Re-evaluation
Both follow-ups are worth doing now. #833 fixes a real parser-risk class already exposed during review by locking representative provider CLI output shapes into fixtures. #834 adds proactive catalog staleness visibility without changing routing authority or auto-updating catalog entries.

## Tests
- `node --test tests/relay-dispatch/scripts/model-resolver.test.js`
- `node --test tests/relay-dispatch/scripts/relay-config.test.js tests/relay-config/scripts/relay-config.test.js`
- `node --test tests/relay-dispatch/scripts/cli-schema.test.js`
- `node --test tests/skills-lint/scripts/*.test.js`
- `git diff --check`

Note: I also attempted the full serial project gate; it progressed through many suites but hung in `tests/relay-dispatch/scripts/cli-schema.test.js`, which passed independently above, so I interrupted that aggregate run.

Closes #833.
Closes #834.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 모델 카탈로그의 최신 상태를 확인하는 새 `catalog-report` 명령이 추가되었습니다.
  * JSON 또는 사람이 읽기 쉬운 형식으로 카탈로그 상태, 경고, 항목별 신선도 정보를 볼 수 있습니다.

* **Bug Fixes**
  * 모델 목록 조회와 카탈로그 판정 기준이 더 일관되게 동작하도록 개선되었습니다.
  * 오래된 카탈로그 경고와 항목별 상태 표시가 더 정확해졌습니다.

* **Documentation**
  * 카탈로그 신선도 확인 방법과 업데이트 절차가 안내에 추가되었습니다.

* **Tests**
  * 새 명령의 출력, 상태 스키마, 항목별 정보 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->