### PR TITLE
Restore advisory timeout wording

### DIFF
--- a/skills/relay-config/SKILL.md
+++ b/skills/relay-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relay-config
 argument-hint: "[setup request or command]"
-description: Interactive setup for relay routes. Use when the user asks to set up relay, configure company/personal relay routing, enable OpenCode or Pi, resolve model names, add provider/model routes, check advisory-review routing, or run relay-config doctor/check.
+description: Interactive setup and revision for relay routes. Use when the user asks to set up relay, configure company/personal relay routing, enable OpenCode or Pi, resolve model names, add provider/model routes, check/revise relay settings, or run relay-config doctor/check/gaps.
 compatibility: Requires Node.js 18+ and the sibling relay-dispatch skill.
 metadata:
   related-skills: "relay, relay-dispatch, relay-review"
@@ -26,6 +26,7 @@ Set up relay routes interactively. The user should not have to memorize command 
 - The user asks whether model catalog entries are fresh or stale
 - The user asks to create, show, or remove a route preset such as `light`, `diverse`, or `hardened`
 - The user asks to run relay doctor/check
+- The user asks for 설정 점검, 리바이즈, revise, drift check, or to fix relay config gaps
 
 ## Do not use when
 
@@ -55,10 +56,19 @@ Infer from the user's words before asking questions:
 - routes containing `/`, such as `example/opencode-model-*`, `example/pi-*`, `openai/*`, or `ollama/*` -> provider/model route patterns
 - `advisory`, `reviewer`, `documentation`, `docs` -> likely advisory-review phases
 - `preset`, `light`, `diverse`, `hardened`, `프리셋`, `가볍게`, `싸게`, `하드하게` -> preset CRUD or inspection
+- `설정 점검`, `점검해줘`, `리바이즈`, `revise`, `gaps`, `drift` -> revise workflow
 
 Ask only for missing decisions, one at a time. Use plain language and wait for the user's answer. Do not use host-specific question primitives as the only path; this skill must work in both Claude Code and Codex.
 
 ### 3. Propose before writing
+
+For revise requests, run:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" gaps --json
+```
+
+Present each gap with the concrete proposal from `proposal.args` in plain language. Apply only accepted proposals, verbatim, through the existing subcommands (`add-route`, `preset add`, `set-default`, `migrate`). `probe_failure` and other `automatic: false` proposals are diagnostic only; surface them without inventing an automatic fix.
 
 Before mutating routes, show a concise proposal:
 
@@ -81,7 +91,9 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" add-rout
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" resolve-model --phase review --reviewer opencode --model glm-5.2 --json
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" catalog-report --json
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default advisory_review.reviewer opencode
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" set-default executor_defaults.opencode.model example/opencode-model-fast
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset add light --dispatch opencode:example/opencode-model-fast
+node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" migrate --yes
 node "${RELAY_SKILL_ROOT:-skills}/relay-config/scripts/relay-config.js" preset show light
 ```
 
@@ -112,6 +124,8 @@ The wrapper accepts common shorthand and delegates to `relay-dispatch/scripts/re
 | `show` | `show --effective` |
 | `doctor` | `doctor` |
 | `catalog-report` | `catalog-report` |
+| `gaps` | `gaps` |
+| `migrate --yes` | `migrate --yes` |
 | `resolve-model --phase review --reviewer opencode --model glm-5.2` | `resolve-model --phase review --reviewer opencode --model glm-5.2` |
 | `add-route example/opencode-model-* --phase dispatch --executor opencode` | `add-route example/opencode-model-* --phase dispatch --executor opencode` |
 | `preset add light --dispatch opencode:example/opencode-model-fast` | `preset add light --dispatch opencode:example/opencode-model-fast` |

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -43,6 +43,8 @@ function printHelp() {
   console.log("  show [--json]");
   console.log("  doctor [--json] [--reconcile]");
   console.log("  catalog-report [--json]");
+  console.log("  gaps [--json]");
+  console.log("  migrate [--yes] [--json]");
   console.log("  resolve-model --phase <phase> [--executor <name>] [--reviewer <name>] [--model <name|provider/model>] [--fallback catalog] [--json]");
   console.log("  check <phase> <actor> [provider/model] [--json]");
   console.log("  add-route <pattern> --phase <csv> [--executor <name>] [--reviewer <name>] [--json]");

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -125,6 +125,7 @@ const FLAGS = [
   { flag: "--verdict", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed review verdict selector; flag-like following tokens should mean the value is missing." },
   { flag: "--window-days", kind: VALUE, mode: MODE_PARSED, valueName: "<N>", rationale: "Numeric scan window; flag-like following tokens should mean the value is missing." },
   { flag: "--worktree-path", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied worktree path; keep the literal argv token." },
+  { flag: "--yes", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit confirmation for commands that would otherwise run as dry-run only." },
   { flag: "--writer-pr", kind: VALUE, mode: MODE_PARSED, valueName: "<number>", rationale: "Numeric PR selector for the writer PR; flag-like following tokens should mean the value is missing." },
 ];
 
@@ -201,7 +202,7 @@ const COMMAND_FLAGS = {
     "--profile", "--effective", "--phase", "--executor", "--reviewer", "--model",
     "--fallback",
     "--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file",
-    "--reconcile", "--review-assurance", "--advisory-profile", "--json", "--help",
+    "--reconcile", "--review-assurance", "--advisory-profile", "--yes", "--json", "--help",
   ],
   "rebrand-evidence": [
     "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const {
   evaluateRelayRoute,
@@ -10,11 +11,16 @@ const {
 const { loadProjectConfig } = require("./project-config");
 const { getProjectConfigPath, getProjectPolicyPath, getProjectRoutesPath, getRepoSlug } = require("./manifest/paths");
 const {
+  loadRouteConfig,
   loadProjectRoutes,
   resolveGlobalRoutesPath,
   resolveRouteIntent,
   validateRouteConfig,
 } = require("./relay-routing");
+const {
+  readAllRunEvents,
+  EVENTS,
+} = require("./relay-events");
 const { normalizeReviewAssurance } = require("./manifest/review-assurance");
 const {
   findUnknownFlags,
@@ -50,6 +56,8 @@ const SUBCOMMAND_FLAGS = {
   show: new Set(["--effective", "--json", "--help"]),
   doctor: new Set(["--json", "--reconcile", "--help"]),
   "catalog-report": new Set(["--json", "--help"]),
+  gaps: new Set(["--json", "--help"]),
+  migrate: new Set(["--yes", "--json", "--help"]),
   "resolve-model": new Set(["--phase", "--executor", "--reviewer", "--model", "--fallback", "--json", "--help"]),
   check: new Set(["--phase", "--executor", "--reviewer", "--model", "--json", "--help"]),
   "plan-run": new Set(["--repo", "--dispatch", "--review", "--advisory-review", "--route-intent-file", "--json", "--help"]),
@@ -87,6 +95,8 @@ function printHelp() {
   console.log(`  show --effective ${modeLabel("--effective")} [--json ${modeLabel("--json")}]`);
   console.log(`  doctor [--json ${modeLabel("--json")}] [--reconcile ${modeLabel("--reconcile")}]`);
   console.log(`  catalog-report [--json ${modeLabel("--json")}]`);
+  console.log(`  gaps [--json ${modeLabel("--json")}]`);
+  console.log(`  migrate [--yes] [--json ${modeLabel("--json")}]`);
   console.log(`  resolve-model --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <name|provider/model> ${modeLabel("--model")}] [--fallback catalog ${modeLabel("--fallback")}] [--json ${modeLabel("--json")}]`);
   console.log(`  check --phase <phase> ${modeLabel("--phase")} [--executor <name> ${modeLabel("--executor")}] [--reviewer <name> ${modeLabel("--reviewer")}] [--model <provider/model> ${modeLabel("--model")}] [--json ${modeLabel("--json")}]`);
   console.log(`  plan-run [--repo <path> ${modeLabel("--repo")}] [--dispatch <actor[:provider/model]> ${modeLabel("--dispatch")}] [--review <actor[:provider/model]> ${modeLabel("--review")}] [--advisory-review <actor[:provider/model]> ${modeLabel("--advisory-review")}] [--route-intent-file <path> ${modeLabel("--route-intent-file")}] [--json ${modeLabel("--json")}]`);
@@ -97,7 +107,7 @@ function printHelp() {
   console.log(`  preset add|remove|show <name> [--dispatch <actor[:provider/model]> ${modeLabel("--dispatch")}] [--review <actor[:provider/model]> ${modeLabel("--review")}] [--advisory-review <actor[:provider/model]> ${modeLabel("--advisory-review")}] [--advisory-profile <name> ${modeLabel("--advisory-profile")}] [--review-assurance <standard|hardened> ${modeLabel("--review-assurance")}] [--json ${modeLabel("--json")}]`);
   console.log("");
   console.log("Supported default paths:");
-  console.log("  dispatch.executor, review.reviewer, advisory_review.reviewer");
+  console.log("  dispatch.executor, review.reviewer, advisory_review.reviewer, executor_defaults.<executor>.model");
   console.log("");
   console.log(`Options: --help ${modeLabel("--help")}`);
 }
@@ -150,7 +160,7 @@ function legacyShadowWarnings({ routesExisted }) {
   if (routesExisted) return [];
   if (!fs.existsSync(resolveRelayPolicyPath())) return [];
   return [
-    "routes.json now takes precedence; legacy policy.json/executors.json are ignored until migration arrives in Phase C",
+    "routes.json now takes precedence; legacy policy.json/executors.json are ignored; run relay-config migrate to fold legacy defaults into routes.json",
   ];
 }
 
@@ -435,6 +445,453 @@ function commandDoctor(positionals, jsonOut) {
         `reconcile row ${advisory.reconcile?.row || "unknown"} (${advisory.reconcile?.rowName || "unknown"})`
       );
     }
+  }
+}
+
+function routeActorEntries(policy, listName = "allowed_model_routes") {
+  const entries = [];
+  for (const route of policy?.[listName] || []) {
+    const phases = route.phases || VALID_PHASES;
+    for (const phase of phases) {
+      const actorField = actorFieldForPhase(phase);
+      const actors = actorField === "reviewer" ? route.reviewers : route.executors;
+      for (const actor of actors || []) {
+        entries.push({
+          phase,
+          actor,
+          actorField,
+          route: route.route,
+          listName,
+        });
+      }
+    }
+  }
+  return entries;
+}
+
+function sampleRouteFromPattern(pattern) {
+  const route = nonEmptyString(pattern);
+  if (!route) return null;
+  if (!route.includes("*")) return route;
+  return route.replace(/\*/g, "fast");
+}
+
+function defaultRoutePatternForActor(actor) {
+  if (actor === "opencode") return "example/opencode-model-*";
+  if (actor === "pi") return "example/pi-*";
+  return `${actor}/*`;
+}
+
+function addRouteProposal({ phase, actor, actorField, route }) {
+  const args = ["add-route", route, "--phase", phase];
+  args.push(actorField === "reviewer" ? "--reviewer" : "--executor", actor, "--json");
+  return { subcommand: "add-route", args };
+}
+
+function diagnosticProposal() {
+  return { subcommand: "doctor", args: ["doctor", "--json"], automatic: false };
+}
+
+function migrateProposal() {
+  return { subcommand: "migrate", args: ["migrate", "--yes", "--json"] };
+}
+
+function setExecutorDefaultProposal(actor, model) {
+  return {
+    subcommand: "set-default",
+    args: ["set-default", `executor_defaults.${actor}.model`, model, "--json"],
+  };
+}
+
+function gapKey(gap) {
+  return JSON.stringify([
+    gap.type,
+    gap.actor || null,
+    gap.actor_field || null,
+    gap.phase || null,
+    gap.route || null,
+    gap.model || null,
+    gap.path || null,
+    gap.preset || null,
+  ]);
+}
+
+function pushGap(gaps, seen, gap) {
+  const key = gapKey(gap);
+  if (seen.has(key)) return;
+  seen.add(key);
+  gaps.push(gap);
+}
+
+function executorDefaultModel(policy, actor) {
+  return nonEmptyString(policy?.executor_defaults?.[actor]?.model);
+}
+
+function legacyConfigPaths({ repoRoot, relayHome }) {
+  const paths = [];
+  const globalPolicy = resolveRelayPolicyPath({ relayHome });
+  if (globalPolicy && fs.existsSync(globalPolicy)) {
+    paths.push({ kind: "global_policy", path: globalPolicy });
+  }
+  const executorsPath = process.env.RELAY_EXECUTORS_PATH || path.join(relayHome || process.env.RELAY_HOME || path.join(os.homedir(), ".relay"), "executors.json");
+  if (executorsPath && fs.existsSync(executorsPath)) {
+    paths.push({ kind: "executors", path: executorsPath });
+  }
+  const repoPolicy = repoRoot ? path.join(repoRoot, ".relay", "policy.json") : null;
+  if (repoPolicy && fs.existsSync(repoPolicy)) {
+    paths.push({ kind: "repo_policy", path: repoPolicy });
+  }
+  const projectRoutesPath = repoRoot ? getProjectRoutesPath(repoRoot, { relayHome }) : null;
+  if (projectRoutesPath && fs.existsSync(projectRoutesPath)) {
+    try {
+      const projectRoutes = readRoutesFile(projectRoutesPath);
+      if (projectRoutes?.version === 1) {
+        paths.push({ kind: "project_routes_v1", path: projectRoutesPath });
+      }
+    } catch {
+      paths.push({ kind: "project_routes_unknown", path: projectRoutesPath });
+    }
+  }
+  return paths;
+}
+
+function configuredActorSet(policy) {
+  const actors = new Set([
+    ...defaultActors(policy),
+    ...routeActors(policy),
+  ]);
+  return actors;
+}
+
+function routeConfiguredForTuple(policy, { phase, actor, actorField, model }) {
+  const tuple = actorField === "reviewer"
+    ? { phase, reviewer: actor, model }
+    : { phase, executor: actor, model };
+  const decision = evaluateRelayRoute(policy, tuple);
+  return decision.reason === "allowed_model_route" || decision.reason === "managed_cli";
+}
+
+function collectPresetGaps({ gaps, seen, policy, toolsByName }) {
+  const presets = policy?.presets || {};
+  if (!isPlainObject(presets) || Object.keys(presets).length === 0) return;
+  for (const [presetName, preset] of Object.entries(presets)) {
+    if (!isPlainObject(preset)) continue;
+    for (const phase of VALID_PHASES) {
+      const phaseValue = preset[phase];
+      if (!isPlainObject(phaseValue)) continue;
+      const actorField = actorFieldForPhase(phase);
+      const actor = nonEmptyString(phaseValue[actorField]);
+      if (!actor) continue;
+      const tool = toolsByName.get(actor);
+      if (tool && !tool.installed) {
+        pushGap(gaps, seen, {
+          type: "preset_broken",
+          preset: presetName,
+          phase,
+          actor,
+          actor_field: actorField,
+          reason: "cli_missing",
+          proposal: diagnosticProposal(),
+        });
+      }
+      const model = nonEmptyString(phaseValue.model);
+      if (policy.deny_unknown_model_routes && model) {
+        const decision = evaluateRelayRoute(policy, actorField === "reviewer"
+          ? { phase, reviewer: actor, model }
+          : { phase, executor: actor, model });
+        if (decision.reason === "unknown_model_route" || decision.reason === "missing_model_route") {
+          pushGap(gaps, seen, {
+            type: "preset_broken",
+            preset: presetName,
+            phase,
+            actor,
+            actor_field: actorField,
+            model,
+            reason: decision.reason,
+            proposal: addRouteProposal({ phase, actor, actorField, route: model }),
+          });
+        }
+      }
+    }
+  }
+}
+
+function collectUsageGaps({ gaps, seen, policy, repoRoot }) {
+  let events = [];
+  try {
+    events = readAllRunEvents(repoRoot);
+  } catch {
+    events = [];
+  }
+  const tuples = new Map();
+  for (const event of events) {
+    if (event.event !== EVENTS.UNREGISTERED_ROUTE_USED) continue;
+    const phase = nonEmptyString(event.phase || event.policy_decision?.phase);
+    const actorField = nonEmptyString(event.actor_field || event.policy_decision?.actor_field)
+      || (phase === "review" || phase === "advisory_review" ? "reviewer" : "executor");
+    const actor = nonEmptyString(actorField === "reviewer"
+      ? (event.reviewer || event.policy_decision?.reviewer || event.policy_decision?.actor)
+      : (event.executor || event.policy_decision?.executor || event.policy_decision?.actor));
+    const model = nonEmptyString(event.model || event.policy_decision?.model);
+    if (!phase || !actor || !model) continue;
+    const key = `${phase}\u0000${actorField}\u0000${actor}\u0000${model}`;
+    tuples.set(key, { phase, actorField, actor, model, count: (tuples.get(key)?.count || 0) + 1 });
+  }
+  for (const tuple of [...tuples.values()].sort((a, b) => `${a.phase}:${a.actor}:${a.model}`.localeCompare(`${b.phase}:${b.actor}:${b.model}`))) {
+    if (routeConfiguredForTuple(policy, tuple)) continue;
+    pushGap(gaps, seen, {
+      type: "unregistered_route_in_use",
+      phase: tuple.phase,
+      actor: tuple.actor,
+      actor_field: tuple.actorField,
+      model: tuple.model,
+      occurrences: tuple.count,
+      proposal: addRouteProposal({
+        phase: tuple.phase,
+        actor: tuple.actor,
+        actorField: tuple.actorField,
+        route: tuple.model,
+      }),
+    });
+  }
+}
+
+function commandGaps(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("gaps does not accept positional arguments");
+  }
+  const repoRoot = process.cwd();
+  const relayHome = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
+  const policyResult = loadRelayPolicy({ repoRoot, relayHome });
+  if (!policyResult.ok) {
+    const output = { ok: false, status: policyResult.status, sources: policyResult.sources, errors: policyResult.errors, gaps: [] };
+    if (jsonOut) printJson(output);
+    else console.error(`relay-config gaps: routes failed: ${policyResult.errors?.[0]?.message || "unknown route config error"}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const routeConfig = loadRouteConfig({ repoRoot, relayHome });
+  const toolNames = [...new Set([
+    ...DOCTOR_TOOLS,
+    ...policyResult.policy.managed_cli,
+    ...defaultActors(policyResult.policy),
+    ...routeActors(policyResult.policy),
+  ])].sort();
+  const tools = toolNames.map((name) => doctorTool(policyResult.policy, name));
+  const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+  const configuredActors = configuredActorSet(policyResult.policy);
+  const gaps = [];
+  const seen = new Set();
+
+  for (const tool of tools) {
+    if (tool.installed && !configuredActors.has(tool.name) && tool.policy === "policy-disallowed") {
+      const route = defaultRoutePatternForActor(tool.name);
+      pushGap(gaps, seen, {
+        type: "installed_cli_unrouted",
+        actor: tool.name,
+        path: tool.path,
+        phase: "dispatch",
+        actor_field: "executor",
+        proposal: addRouteProposal({ phase: "dispatch", actor: tool.name, actorField: "executor", route }),
+      });
+    }
+    if (tool.model_probe?.status === "warning") {
+      pushGap(gaps, seen, {
+        type: "probe_failure",
+        actor: tool.name,
+        path: tool.path,
+        warning: tool.model_probe.warning,
+        proposal: diagnosticProposal(),
+      });
+    }
+  }
+
+  for (const entry of [
+    ...routeActorEntries(policyResult.policy, "allowed_model_routes"),
+    ...routeActorEntries(policyResult.policy, "denied_model_routes"),
+  ]) {
+    const tool = toolsByName.get(entry.actor) || doctorTool(policyResult.policy, entry.actor);
+    if (!tool.installed) {
+      pushGap(gaps, seen, {
+        type: "route_without_cli",
+        actor: entry.actor,
+        actor_field: entry.actorField,
+        phase: entry.phase,
+        route: entry.route,
+        proposal: diagnosticProposal(),
+      });
+    }
+    if (entry.listName === "allowed_model_routes" && entry.actorField === "executor" && entry.phase === "dispatch" && !executorDefaultModel(policyResult.policy, entry.actor)) {
+      const model = sampleRouteFromPattern(entry.route);
+      if (model) {
+        pushGap(gaps, seen, {
+          type: "executor_missing_default_model",
+          actor: entry.actor,
+          phase: entry.phase,
+          route: entry.route,
+          model,
+          proposal: setExecutorDefaultProposal(entry.actor, model),
+        });
+      }
+    }
+  }
+
+  for (const legacy of legacyConfigPaths({ repoRoot, relayHome })) {
+    pushGap(gaps, seen, {
+      type: "legacy_config_present",
+      legacy_kind: legacy.kind,
+      path: legacy.path,
+      shadowed: routeConfig.status === "ok",
+      proposal: migrateProposal(),
+    });
+  }
+
+  collectPresetGaps({ gaps, seen, policy: policyResult.policy, toolsByName });
+  collectUsageGaps({ gaps, seen, policy: policyResult.policy, repoRoot });
+
+  gaps.sort((a, b) => gapKey(a).localeCompare(gapKey(b)));
+  const output = {
+    ok: true,
+    status: policyResult.status,
+    sources: policyResult.sources,
+    route_config: {
+      status: routeConfig.status,
+      sources: routeConfig.sources,
+    },
+    tools,
+    gaps,
+  };
+
+  if (jsonOut) {
+    printJson(output);
+  } else {
+    console.log(`relay-config gaps: ${gaps.length} gap${gaps.length === 1 ? "" : "s"}`);
+    for (const gap of gaps) {
+      const subject = [gap.type, gap.actor, gap.phase, gap.model || gap.route || gap.path].filter(Boolean).join(" ");
+      console.log(`${subject}: ${gap.proposal.subcommand} ${gap.proposal.args.slice(1).join(" ")}`);
+    }
+  }
+}
+
+function readOptionalJson(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  return readRoutesFile(filePath);
+}
+
+function executorDefaultsFromLegacyExecutors(filePath) {
+  const parsed = readOptionalJson(filePath);
+  const defaults = {};
+  for (const [executor, config] of Object.entries(parsed?.executors || {})) {
+    const model = nonEmptyString(config?.default_model);
+    if (model) defaults[executor] = { model };
+  }
+  return defaults;
+}
+
+function routesFromPolicy(policy, executorDefaults) {
+  const routes = {
+    version: 2,
+    strict: policy.deny_unknown_model_routes === true,
+    defaults: cloneJson(policy.defaults || {}),
+    executor_defaults: {
+      ...(isPlainObject(policy.executor_defaults) ? cloneJson(policy.executor_defaults) : {}),
+      ...executorDefaults,
+    },
+    routes: cloneJson(policy.allowed_model_routes || []),
+    denied_routes: cloneJson(policy.denied_model_routes || []),
+  };
+  if (isPlainObject(policy.presets) && Object.keys(policy.presets).length) {
+    routes.presets = cloneJson(policy.presets);
+  }
+  if (!Object.keys(routes.executor_defaults).length) delete routes.executor_defaults;
+  validateRouteConfig(routes, "migrated routes config");
+  return routes;
+}
+
+function writeMigratedMarker(filePath, routesPath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  const markerPath = `${filePath}.migrated`;
+  fs.writeFileSync(
+    markerPath,
+    `migrated into routes.json\nsource: ${filePath}\ntarget: ${routesPath}\nlegacy file retained; do not delete automatically\n`,
+    "utf-8"
+  );
+  return markerPath;
+}
+
+function commandMigrate(positionals, jsonOut) {
+  if (positionals.length !== 1) {
+    throw new Error("migrate does not accept positional arguments");
+  }
+  const repoRoot = process.cwd();
+  const relayHome = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
+  const routesPath = relayRoutesPath();
+  const executorsPath = process.env.RELAY_EXECUTORS_PATH || path.join(relayHome, "executors.json");
+  const confirmed = hasCliFlag("--yes");
+  const routesExisted = fs.existsSync(routesPath);
+  const policyResult = routesExisted
+    ? loadRelayPolicy({ repoRoot, relayHome })
+    : loadRelayPolicy({
+      repoRoot,
+      relayHome,
+      routesPath: path.join(relayHome, "__relay_config_migrate_absent_routes__.json"),
+    });
+  if (!policyResult.ok) {
+    const output = { ok: false, status: "policy_error", errors: policyResult.errors };
+    if (jsonOut) printJson(output);
+    else console.error(`relay-config migrate: legacy routes failed: ${policyResult.errors?.[0]?.message || "unknown route config error"}`);
+    process.exitCode = 1;
+    return;
+  }
+  const executorDefaults = executorDefaultsFromLegacyExecutors(executorsPath);
+  const routes = routesFromPolicy(policyResult.policy, executorDefaults);
+  const projectRoutes = loadProjectRoutes({ repoRoot, relayHome });
+  const legacyPaths = legacyConfigPaths({ repoRoot, relayHome });
+  const output = {
+    ok: true,
+    action: "migrate",
+    dry_run: !confirmed,
+    wrote: false,
+    path: routesPath,
+    routes,
+    project_routes: projectRoutes,
+    legacy: legacyPaths,
+    summary: [
+      `${routes.routes.length} allowed route(s)`,
+      `${routes.denied_routes.length} denied route(s)`,
+      `${Object.keys(routes.executor_defaults || {}).length} executor default(s)`,
+      `strict=${routes.strict === true}`,
+    ],
+  };
+
+  if (!confirmed) {
+    if (jsonOut) {
+      printJson(output);
+    } else {
+      console.log("relay-config migrate: dry run");
+      for (const line of output.summary) console.log(`  ${line}`);
+      console.log("rerun with --yes to write routes.json and .migrated marker notes");
+    }
+    return;
+  }
+
+  writeRoutes(routesPath, routes);
+  const markers = [];
+  for (const legacy of legacyPaths) {
+    const marker = writeMigratedMarker(legacy.path, routesPath);
+    if (marker) markers.push(marker);
+  }
+  output.dry_run = false;
+  output.wrote = true;
+  output.markers = markers;
+
+  if (jsonOut) {
+    printJson(output);
+  } else {
+    console.log(`relay-config migrate: wrote ${routesPath}`);
+    for (const line of output.summary) console.log(`  ${line}`);
+    for (const marker of markers) console.log(`  marker: ${marker}`);
   }
 }
 
@@ -786,18 +1243,28 @@ function commandSetDefault(positionals, jsonOut) {
   }
   const defaultPath = positionals[1];
   const value = requireValue(positionals[2], "default value");
-  if (!DEFAULT_PATHS.has(defaultPath)) {
+  const executorDefaultMatch = defaultPath.match(/^executor_defaults\.([^.\s]+)\.model$/);
+  if (!DEFAULT_PATHS.has(defaultPath) && !executorDefaultMatch) {
     throw new Error(`unsupported default path: ${defaultPath}`);
   }
 
   const { routesPath, routes, warnings } = loadRoutesForMutation();
   const updated = cloneJson(routes);
-  const [phase, field] = defaultPath.split(".");
-  if (!hasOwn(updated, "defaults")) updated.defaults = {};
-  updated.defaults[phase] = {
-    ...(isPlainObject(updated.defaults[phase]) ? updated.defaults[phase] : {}),
-    [field]: value,
-  };
+  if (executorDefaultMatch) {
+    const executor = executorDefaultMatch[1];
+    if (!hasOwn(updated, "executor_defaults")) updated.executor_defaults = {};
+    updated.executor_defaults[executor] = {
+      ...(isPlainObject(updated.executor_defaults[executor]) ? updated.executor_defaults[executor] : {}),
+      model: value,
+    };
+  } else {
+    const [phase, field] = defaultPath.split(".");
+    if (!hasOwn(updated, "defaults")) updated.defaults = {};
+    updated.defaults[phase] = {
+      ...(isPlainObject(updated.defaults[phase]) ? updated.defaults[phase] : {}),
+      [field]: value,
+    };
+  }
   const written = writeRoutes(routesPath, updated);
   outputMutation({ jsonOut, action: "set-default", routesPath, routes: written, defaultPath, warnings });
 }
@@ -1026,6 +1493,12 @@ function main() {
       break;
     case "catalog-report":
       commandCatalogReport(positionals, jsonOut);
+      break;
+    case "gaps":
+      commandGaps(positionals, jsonOut);
+      break;
+    case "migrate":
+      commandMigrate(positionals, jsonOut);
       break;
     case "resolve-model":
       commandResolveModel(positionals, jsonOut);

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -488,6 +488,23 @@ function addRouteProposal({ phase, actor, actorField, route }) {
   return { subcommand: "add-route", args };
 }
 
+function denyRouteProposal({ phase, actor, actorField, route }) {
+  const args = ["deny-route", route, "--phase", phase];
+  args.push(actorField === "reviewer" ? "--reviewer" : "--executor", actor, "--json");
+  return {
+    subcommand: "deny-route",
+    args,
+    note: `or install ${actor} manually`,
+  };
+}
+
+function removePresetProposal(presetName) {
+  return {
+    subcommand: "preset",
+    args: ["preset", "remove", presetName, "--json"],
+  };
+}
+
 function probeDiagnosticProposal() {
   return {
     kind: "diagnostic",
@@ -495,16 +512,6 @@ function probeDiagnosticProposal() {
     args: ["doctor", "--json"],
     automatic: false,
     reason: "probe_failure",
-  };
-}
-
-function manualProposal({ reason, action }) {
-  return {
-    kind: "manual",
-    args: [],
-    automatic: false,
-    reason,
-    action,
   };
 }
 
@@ -557,7 +564,14 @@ function legacyConfigPaths({ repoRoot, relayHome }) {
   if (repoPolicy && fs.existsSync(repoPolicy)) {
     paths.push({ kind: "repo_policy", path: repoPolicy });
   }
-  const projectRoutesPath = repoRoot ? getProjectRoutesPath(repoRoot, { relayHome }) : null;
+  let projectRoutesPath = null;
+  if (repoRoot) {
+    try {
+      projectRoutesPath = getProjectRoutesPath(repoRoot, { relayHome });
+    } catch {
+      projectRoutesPath = null;
+    }
+  }
   if (projectRoutesPath && fs.existsSync(projectRoutesPath)) {
     try {
       const projectRoutes = readRoutesFile(projectRoutesPath);
@@ -587,6 +601,10 @@ function routeConfiguredForTuple(policy, { phase, actor, actorField, model }) {
   return decision.reason === "allowed_model_route" || decision.reason === "managed_cli";
 }
 
+function deniedRouteConfiguredForTuple(policy, tuple) {
+  return (policy.denied_model_routes || []).some((entry) => routeEntryCoversTuple(entry, tuple));
+}
+
 function collectPresetGaps({ gaps, seen, policy, toolsByName }) {
   const presets = policy?.presets || {};
   if (!isPlainObject(presets) || Object.keys(presets).length === 0) return;
@@ -607,10 +625,7 @@ function collectPresetGaps({ gaps, seen, policy, toolsByName }) {
           actor,
           actor_field: actorField,
           reason: "cli_missing",
-          proposal: manualProposal({
-            reason: "cli_missing",
-            action: "install_cli_or_edit_preset",
-          }),
+          proposal: removePresetProposal(presetName),
         });
       }
       const model = nonEmptyString(phaseValue.model);
@@ -731,17 +746,18 @@ function commandGaps(positionals, jsonOut) {
     ...routeActorEntries(policyResult.policy, "denied_model_routes"),
   ]) {
     const tool = toolsByName.get(entry.actor) || doctorTool(policyResult.policy, entry.actor);
-    if (!tool.installed) {
+    if (
+      !tool.installed
+      && entry.listName === "allowed_model_routes"
+      && !deniedRouteConfiguredForTuple(policyResult.policy, entry)
+    ) {
       pushGap(gaps, seen, {
         type: "route_without_cli",
         actor: entry.actor,
         actor_field: entry.actorField,
         phase: entry.phase,
         route: entry.route,
-        proposal: manualProposal({
-          reason: "cli_missing",
-          action: "install_cli_or_remove_route",
-        }),
+        proposal: denyRouteProposal(entry),
       });
     }
     if (entry.listName === "allowed_model_routes" && entry.actorField === "executor" && entry.phase === "dispatch" && !executorDefaultModel(policyResult.policy, entry.actor)) {
@@ -846,6 +862,85 @@ function mergeRouteDefaults(base = {}, override = {}) {
   return merged;
 }
 
+function routeEntryCoversTuple(entry, { phase, actorField, actor, route }) {
+  if (entry.route !== route) return false;
+  if (entry.phases !== undefined && !entry.phases.includes(phase)) return false;
+  const hasActorScope = entry.executors !== undefined || entry.reviewers !== undefined;
+  if (!hasActorScope) return true;
+  const actors = actorField === "reviewer" ? entry.reviewers : entry.executors;
+  return Boolean(actor && actors?.includes(actor));
+}
+
+function routeEntryTuples(entry) {
+  const tuples = [];
+  const route = nonEmptyString(entry?.route);
+  if (!route) return tuples;
+  const phases = entry.phases || VALID_PHASES;
+  const hasActorScope = entry.executors !== undefined || entry.reviewers !== undefined;
+  for (const phase of phases) {
+    const actorField = actorFieldForPhase(phase);
+    const actors = actorField === "reviewer" ? entry.reviewers : entry.executors;
+    if (!hasActorScope) {
+      tuples.push({ phase, actorField, actor: null, route });
+      continue;
+    }
+    for (const actor of actors || []) {
+      tuples.push({ phase, actorField, actor, route });
+    }
+  }
+  return tuples;
+}
+
+function routeEntryFromTuple({ phase, actorField, actor, route }) {
+  const entry = { route, phases: [phase] };
+  if (actor) {
+    entry[actorField === "reviewer" ? "reviewers" : "executors"] = [actor];
+  }
+  return entry;
+}
+
+function appendLegacyOnlyRouteTuples(targetRoutes, legacyRoutes, listName) {
+  const existing = Array.isArray(targetRoutes[listName]) ? cloneJson(targetRoutes[listName]) : [];
+  const additions = [];
+  for (const legacyEntry of legacyRoutes[listName] || []) {
+    for (const tuple of routeEntryTuples(legacyEntry)) {
+      const covered = [...existing, ...additions].some((entry) => routeEntryCoversTuple(entry, tuple));
+      if (!covered) additions.push(routeEntryFromTuple(tuple));
+    }
+  }
+  if (existing.length || additions.length) targetRoutes[listName] = [...existing, ...additions];
+  else delete targetRoutes[listName];
+}
+
+function foldLegacyRoutesIntoExisting(existingRoutes, legacyRoutes) {
+  const folded = cloneJson(existingRoutes);
+  if (!hasOwn(folded, "version")) folded.version = 2;
+  if (!hasOwn(folded, "strict") && hasOwn(legacyRoutes, "strict")) folded.strict = legacyRoutes.strict;
+
+  const defaults = mergeRouteDefaults(legacyRoutes.defaults, folded.defaults);
+  if (Object.keys(defaults).length) folded.defaults = defaults;
+  else delete folded.defaults;
+
+  const executorDefaults = {
+    ...(isPlainObject(legacyRoutes.executor_defaults) ? cloneJson(legacyRoutes.executor_defaults) : {}),
+    ...(isPlainObject(folded.executor_defaults) ? cloneJson(folded.executor_defaults) : {}),
+  };
+  if (Object.keys(executorDefaults).length) folded.executor_defaults = executorDefaults;
+  else delete folded.executor_defaults;
+
+  const presets = {
+    ...(isPlainObject(legacyRoutes.presets) ? cloneJson(legacyRoutes.presets) : {}),
+    ...(isPlainObject(folded.presets) ? cloneJson(folded.presets) : {}),
+  };
+  if (Object.keys(presets).length) folded.presets = presets;
+  else delete folded.presets;
+
+  appendLegacyOnlyRouteTuples(folded, legacyRoutes, "routes");
+  appendLegacyOnlyRouteTuples(folded, legacyRoutes, "denied_routes");
+  validateRouteConfig(folded, "migrated routes config");
+  return folded;
+}
+
 function foldProjectRoutesV1(routes, projectRoutes) {
   if (projectRoutes.status === "absent" || projectRoutes.status === "ignored_v2") return routes;
   if (!projectRoutes.ok) {
@@ -880,13 +975,11 @@ function commandMigrate(positionals, jsonOut) {
   const executorsPath = process.env.RELAY_EXECUTORS_PATH || path.join(relayHome, "executors.json");
   const confirmed = hasCliFlag("--yes");
   const routesExisted = fs.existsSync(routesPath);
-  const policyResult = routesExisted
-    ? loadRelayPolicy({ repoRoot, relayHome })
-    : loadRelayPolicy({
-      repoRoot,
-      relayHome,
-      routesPath: path.join(relayHome, "__relay_config_migrate_absent_routes__.json"),
-    });
+  const policyResult = loadRelayPolicy({
+    repoRoot,
+    relayHome,
+    routesPath: path.join(relayHome, "__relay_config_migrate_absent_routes__.json"),
+  });
   if (!policyResult.ok) {
     const output = { ok: false, status: "policy_error", errors: policyResult.errors };
     if (jsonOut) printJson(output);
@@ -898,7 +991,10 @@ function commandMigrate(positionals, jsonOut) {
   const projectRoutes = loadProjectRoutes({ repoRoot, relayHome });
   let routes;
   try {
-    routes = foldProjectRoutesV1(routesFromPolicy(policyResult.policy, executorDefaults), projectRoutes);
+    const legacyRoutes = foldProjectRoutesV1(routesFromPolicy(policyResult.policy, executorDefaults), projectRoutes);
+    routes = routesExisted
+      ? foldLegacyRoutesIntoExisting(validateRouteConfig(readRoutesFile(routesPath), routesPath), legacyRoutes)
+      : legacyRoutes;
   } catch (error) {
     const output = { ok: false, status: "project_routes_error", errors: [{ message: error.message }], project_routes: projectRoutes };
     if (jsonOut) printJson(output);
@@ -917,8 +1013,8 @@ function commandMigrate(positionals, jsonOut) {
     project_routes: projectRoutes,
     legacy: legacyPaths,
     summary: [
-      `${routes.routes.length} allowed route(s)`,
-      `${routes.denied_routes.length} denied route(s)`,
+      `${(routes.routes || []).length} allowed route(s)`,
+      `${(routes.denied_routes || []).length} denied route(s)`,
       `${Object.keys(routes.executor_defaults || {}).length} executor default(s)`,
       `strict=${routes.strict === true}`,
     ],

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -357,6 +357,15 @@ function actorHasConfiguredAllowedRoute(policy, actor) {
   });
 }
 
+function actorHasDispatchAllowedRoute(policy, actor) {
+  return policy.allowed_model_routes.some((entry) => {
+    if (entry.phases !== undefined && !entry.phases.includes("dispatch")) return false;
+    const hasActorScope = entry.executors !== undefined || entry.reviewers !== undefined;
+    if (!hasActorScope) return true;
+    return Boolean(entry.executors?.includes(actor));
+  });
+}
+
 function doctorTool(policy, name) {
   const executable = findOnPath(name);
   const dispatchDecision = evaluateRelayRoute(policy, { phase: "dispatch", executor: name });
@@ -730,6 +739,22 @@ function commandGaps(positionals, jsonOut) {
         proposal: addRouteProposal({ phase: "dispatch", actor: tool.name, actorField: "executor", route }),
       });
     }
+    if (
+      tool.installed
+      && policyResult.policy.defaults.dispatch?.executor === tool.name
+      && tool.policy === "policy-disallowed"
+      && !actorHasDispatchAllowedRoute(policyResult.policy, tool.name)
+    ) {
+      const route = defaultRoutePatternForActor(tool.name);
+      pushGap(gaps, seen, {
+        type: "installed_cli_unrouted",
+        actor: tool.name,
+        path: tool.path,
+        phase: "dispatch",
+        actor_field: "executor",
+        proposal: addRouteProposal({ phase: "dispatch", actor: tool.name, actorField: "executor", route }),
+      });
+    }
     if (tool.model_probe?.status === "warning") {
       pushGap(gaps, seen, {
         type: "probe_failure",
@@ -835,6 +860,7 @@ function routesFromPolicy(policy, executorDefaults) {
     version: 2,
     strict: policy.deny_unknown_model_routes === true,
     defaults: cloneJson(policy.defaults || {}),
+    managed_cli: cloneJson(policy.managed_cli || []),
     executor_defaults: {
       ...(isPlainObject(policy.executor_defaults) ? cloneJson(policy.executor_defaults) : {}),
       ...executorDefaults,
@@ -845,6 +871,7 @@ function routesFromPolicy(policy, executorDefaults) {
   if (isPlainObject(policy.presets) && Object.keys(policy.presets).length) {
     routes.presets = cloneJson(policy.presets);
   }
+  if (!routes.managed_cli.length) delete routes.managed_cli;
   if (!Object.keys(routes.executor_defaults).length) delete routes.executor_defaults;
   validateRouteConfig(routes, "migrated routes config");
   return routes;
@@ -916,6 +943,7 @@ function foldLegacyRoutesIntoExisting(existingRoutes, legacyRoutes) {
   const folded = cloneJson(existingRoutes);
   if (!hasOwn(folded, "version")) folded.version = 2;
   if (!hasOwn(folded, "strict") && hasOwn(legacyRoutes, "strict")) folded.strict = legacyRoutes.strict;
+  if (!hasOwn(folded, "managed_cli") && hasOwn(legacyRoutes, "managed_cli")) folded.managed_cli = cloneJson(legacyRoutes.managed_cli);
 
   const defaults = mergeRouteDefaults(legacyRoutes.defaults, folded.defaults);
   if (Object.keys(defaults).length) folded.defaults = defaults;
@@ -941,17 +969,19 @@ function foldLegacyRoutesIntoExisting(existingRoutes, legacyRoutes) {
   return folded;
 }
 
-function foldProjectRoutesV1(routes, projectRoutes) {
-  if (projectRoutes.status === "absent" || projectRoutes.status === "ignored_v2") return routes;
+function projectRoutesV1ToV2(projectRoutes) {
+  if (projectRoutes.status === "absent" || projectRoutes.status === "ignored_v2") return null;
   if (!projectRoutes.ok) {
-    if (!projectRoutes.path) return routes;
+    if (!projectRoutes.path) return null;
     throw new Error(projectRoutes.error || "failed to load project routes v1");
   }
-  if (projectRoutes.routes?.version !== 1) return routes;
-  const folded = cloneJson(routes);
-  folded.defaults = mergeRouteDefaults(folded.defaults, projectRoutes.routes.defaults);
-  validateRouteConfig(folded, "migrated routes config");
-  return folded;
+  if (projectRoutes.routes?.version !== 1) return null;
+  const routes = {
+    version: 2,
+    defaults: cloneJson(projectRoutes.routes.defaults || {}),
+  };
+  validateRouteConfig(routes, "migrated project routes config", { project: true });
+  return routes;
 }
 
 function writeMigratedMarker(filePath, routesPath) {
@@ -976,7 +1006,6 @@ function commandMigrate(positionals, jsonOut) {
   const confirmed = hasCliFlag("--yes");
   const routesExisted = fs.existsSync(routesPath);
   const policyResult = loadRelayPolicy({
-    repoRoot,
     relayHome,
     routesPath: path.join(relayHome, "__relay_config_migrate_absent_routes__.json"),
   });
@@ -990,11 +1019,13 @@ function commandMigrate(positionals, jsonOut) {
   const executorDefaults = executorDefaultsFromLegacyExecutors(executorsPath);
   const projectRoutes = loadProjectRoutes({ repoRoot, relayHome });
   let routes;
+  let migratedProjectRoutes = null;
   try {
-    const legacyRoutes = foldProjectRoutesV1(routesFromPolicy(policyResult.policy, executorDefaults), projectRoutes);
+    const legacyRoutes = routesFromPolicy(policyResult.policy, executorDefaults);
     routes = routesExisted
       ? foldLegacyRoutesIntoExisting(validateRouteConfig(readRoutesFile(routesPath), routesPath), legacyRoutes)
       : legacyRoutes;
+    migratedProjectRoutes = projectRoutesV1ToV2(projectRoutes);
   } catch (error) {
     const output = { ok: false, status: "project_routes_error", errors: [{ message: error.message }], project_routes: projectRoutes };
     if (jsonOut) printJson(output);
@@ -1010,12 +1041,16 @@ function commandMigrate(positionals, jsonOut) {
     wrote: false,
     path: routesPath,
     routes,
-    project_routes: projectRoutes,
+    project_routes: {
+      ...projectRoutes,
+      migrated_routes: migratedProjectRoutes,
+    },
     legacy: legacyPaths,
     summary: [
       `${(routes.routes || []).length} allowed route(s)`,
       `${(routes.denied_routes || []).length} denied route(s)`,
       `${Object.keys(routes.executor_defaults || {}).length} executor default(s)`,
+      `${migratedProjectRoutes ? 1 : 0} project routes file(s) converted`,
       `strict=${routes.strict === true}`,
     ],
   };
@@ -1032,9 +1067,12 @@ function commandMigrate(positionals, jsonOut) {
   }
 
   writeRoutes(routesPath, routes);
+  if (migratedProjectRoutes && projectRoutes.path) {
+    writeRoutes(projectRoutes.path, migratedProjectRoutes);
+  }
   const markers = [];
   for (const legacy of legacyPaths) {
-    const marker = writeMigratedMarker(legacy.path, routesPath);
+    const marker = writeMigratedMarker(legacy.path, legacy.kind === "project_routes_v1" ? legacy.path : routesPath);
     if (marker) markers.push(marker);
   }
   output.dry_run = false;

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -463,7 +463,12 @@ function routeActorEntries(policy, listName = "allowed_model_routes") {
     const phases = route.phases || VALID_PHASES;
     for (const phase of phases) {
       const actorField = actorFieldForPhase(phase);
-      const actors = actorField === "reviewer" ? route.reviewers : route.executors;
+      const scopedActors = actorField === "reviewer" ? route.reviewers : route.executors;
+      const hasActorScope = route.executors !== undefined || route.reviewers !== undefined;
+      const defaultActor = actorField === "reviewer"
+        ? nonEmptyString(policy?.defaults?.[phase]?.reviewer)
+        : nonEmptyString(policy?.defaults?.[phase]?.executor);
+      const actors = hasActorScope ? scopedActors : (defaultActor ? [defaultActor] : []);
       for (const actor of actors || []) {
         entries.push({
           phase,
@@ -563,15 +568,26 @@ function legacyConfigPaths({ repoRoot, relayHome }) {
   const paths = [];
   const globalPolicy = resolveRelayPolicyPath({ relayHome });
   if (globalPolicy && fs.existsSync(globalPolicy)) {
-    paths.push({ kind: "global_policy", path: globalPolicy });
+    paths.push({ kind: "global_policy", path: globalPolicy, migration: "global_routes" });
   }
   const executorsPath = process.env.RELAY_EXECUTORS_PATH || path.join(relayHome || process.env.RELAY_HOME || path.join(os.homedir(), ".relay"), "executors.json");
   if (executorsPath && fs.existsSync(executorsPath)) {
-    paths.push({ kind: "executors", path: executorsPath });
+    paths.push({ kind: "executors", path: executorsPath, migration: "global_routes" });
   }
   const repoPolicy = repoRoot ? path.join(repoRoot, ".relay", "policy.json") : null;
   if (repoPolicy && fs.existsSync(repoPolicy)) {
-    paths.push({ kind: "repo_policy", path: repoPolicy });
+    paths.push({ kind: "repo_policy", path: repoPolicy, migration: "deferred_scoped" });
+  }
+  let projectPolicyPath = null;
+  if (repoRoot) {
+    try {
+      projectPolicyPath = getProjectPolicyPath(repoRoot, { relayHome });
+    } catch {
+      projectPolicyPath = null;
+    }
+  }
+  if (projectPolicyPath && fs.existsSync(projectPolicyPath)) {
+    paths.push({ kind: "project_policy", path: projectPolicyPath, migration: "deferred_scoped" });
   }
   let projectRoutesPath = null;
   if (repoRoot) {
@@ -585,10 +601,10 @@ function legacyConfigPaths({ repoRoot, relayHome }) {
     try {
       const projectRoutes = readRoutesFile(projectRoutesPath);
       if (projectRoutes?.version === 1) {
-        paths.push({ kind: "project_routes_v1", path: projectRoutesPath });
+        paths.push({ kind: "project_routes_v1", path: projectRoutesPath, migration: "deferred_scoped" });
       }
     } catch {
-      paths.push({ kind: "project_routes_unknown", path: projectRoutesPath });
+      paths.push({ kind: "project_routes_unknown", path: projectRoutesPath, migration: "deferred_scoped" });
     }
   }
   return paths;
@@ -607,7 +623,11 @@ function routeConfiguredForTuple(policy, { phase, actor, actorField, model }) {
     ? { phase, reviewer: actor, model }
     : { phase, executor: actor, model };
   const decision = evaluateRelayRoute(policy, tuple);
-  return decision.reason === "allowed_model_route" || decision.reason === "managed_cli";
+  return (
+    decision.reason === "allowed_model_route"
+    || decision.reason === "managed_cli"
+    || decision.reason === "denied_model_route"
+  );
 }
 
 function deniedRouteConfiguredForTuple(policy, tuple) {
@@ -969,21 +989,6 @@ function foldLegacyRoutesIntoExisting(existingRoutes, legacyRoutes) {
   return folded;
 }
 
-function projectRoutesV1ToV2(projectRoutes) {
-  if (projectRoutes.status === "absent" || projectRoutes.status === "ignored_v2") return null;
-  if (!projectRoutes.ok) {
-    if (!projectRoutes.path) return null;
-    throw new Error(projectRoutes.error || "failed to load project routes v1");
-  }
-  if (projectRoutes.routes?.version !== 1) return null;
-  const routes = {
-    version: 2,
-    defaults: cloneJson(projectRoutes.routes.defaults || {}),
-  };
-  validateRouteConfig(routes, "migrated project routes config", { project: true });
-  return routes;
-}
-
 function writeMigratedMarker(filePath, routesPath) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   const markerPath = `${filePath}.migrated`;
@@ -1018,22 +1023,28 @@ function commandMigrate(positionals, jsonOut) {
   }
   const executorDefaults = executorDefaultsFromLegacyExecutors(executorsPath);
   const projectRoutes = loadProjectRoutes({ repoRoot, relayHome });
+  const legacyPaths = legacyConfigPaths({ repoRoot, relayHome });
+  const migratableLegacy = legacyPaths.filter((legacy) => legacy.migration === "global_routes");
+  const deferredScopedLegacy = legacyPaths
+    .filter((legacy) => legacy.migration === "deferred_scoped")
+    .map((legacy) => ({
+      ...legacy,
+      status: "not_migrated",
+      reason: "scoped migration deferred",
+    }));
   let routes;
-  let migratedProjectRoutes = null;
   try {
     const legacyRoutes = routesFromPolicy(policyResult.policy, executorDefaults);
     routes = routesExisted
       ? foldLegacyRoutesIntoExisting(validateRouteConfig(readRoutesFile(routesPath), routesPath), legacyRoutes)
       : legacyRoutes;
-    migratedProjectRoutes = projectRoutesV1ToV2(projectRoutes);
   } catch (error) {
-    const output = { ok: false, status: "project_routes_error", errors: [{ message: error.message }], project_routes: projectRoutes };
+    const output = { ok: false, status: "migrate_error", errors: [{ message: error.message }], project_routes: projectRoutes };
     if (jsonOut) printJson(output);
-    else console.error(`relay-config migrate: project routes failed: ${error.message}`);
+    else console.error(`relay-config migrate: failed: ${error.message}`);
     process.exitCode = 1;
     return;
   }
-  const legacyPaths = legacyConfigPaths({ repoRoot, relayHome });
   const output = {
     ok: true,
     action: "migrate",
@@ -1043,14 +1054,15 @@ function commandMigrate(positionals, jsonOut) {
     routes,
     project_routes: {
       ...projectRoutes,
-      migrated_routes: migratedProjectRoutes,
     },
     legacy: legacyPaths,
+    not_migrated: deferredScopedLegacy,
     summary: [
       `${(routes.routes || []).length} allowed route(s)`,
       `${(routes.denied_routes || []).length} denied route(s)`,
       `${Object.keys(routes.executor_defaults || {}).length} executor default(s)`,
-      `${migratedProjectRoutes ? 1 : 0} project routes file(s) converted`,
+      `${migratableLegacy.length} global legacy file(s) folded`,
+      `${deferredScopedLegacy.length} scoped legacy file(s) not migrated - scoped migration deferred`,
       `strict=${routes.strict === true}`,
     ],
   };
@@ -1061,18 +1073,37 @@ function commandMigrate(positionals, jsonOut) {
     } else {
       console.log("relay-config migrate: dry run");
       for (const line of output.summary) console.log(`  ${line}`);
+      for (const legacy of deferredScopedLegacy) {
+        console.log(`  not migrated - scoped migration deferred: ${legacy.path}`);
+      }
       console.log("rerun with --yes to write routes.json and .migrated marker notes");
     }
     return;
   }
 
-  writeRoutes(routesPath, routes);
-  if (migratedProjectRoutes && projectRoutes.path) {
-    writeRoutes(projectRoutes.path, migratedProjectRoutes);
+  if (deferredScopedLegacy.length) {
+    output.ok = false;
+    output.status = "scoped_migration_deferred";
+    output.errors = [{
+      message: "scoped legacy config is present; global migration refused so effective scoped resolution is unchanged",
+    }];
+    if (jsonOut) {
+      printJson(output);
+    } else {
+      console.error("relay-config migrate: scoped migration deferred");
+      for (const legacy of deferredScopedLegacy) {
+        console.error(`  not migrated - scoped migration deferred: ${legacy.path}`);
+      }
+      console.error("global routes.json was not written; scoped legacy resolution is unchanged");
+    }
+    process.exitCode = 1;
+    return;
   }
+
+  writeRoutes(routesPath, routes);
   const markers = [];
-  for (const legacy of legacyPaths) {
-    const marker = writeMigratedMarker(legacy.path, legacy.kind === "project_routes_v1" ? legacy.path : routesPath);
+  for (const legacy of migratableLegacy) {
+    const marker = writeMigratedMarker(legacy.path, routesPath);
     if (marker) markers.push(marker);
   }
   output.dry_run = false;

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -488,8 +488,24 @@ function addRouteProposal({ phase, actor, actorField, route }) {
   return { subcommand: "add-route", args };
 }
 
-function diagnosticProposal() {
-  return { subcommand: "doctor", args: ["doctor", "--json"], automatic: false };
+function probeDiagnosticProposal() {
+  return {
+    kind: "diagnostic",
+    command: "doctor",
+    args: ["doctor", "--json"],
+    automatic: false,
+    reason: "probe_failure",
+  };
+}
+
+function manualProposal({ reason, action }) {
+  return {
+    kind: "manual",
+    args: [],
+    automatic: false,
+    reason,
+    action,
+  };
 }
 
 function migrateProposal() {
@@ -582,7 +598,7 @@ function collectPresetGaps({ gaps, seen, policy, toolsByName }) {
       const actorField = actorFieldForPhase(phase);
       const actor = nonEmptyString(phaseValue[actorField]);
       if (!actor) continue;
-      const tool = toolsByName.get(actor);
+      const tool = toolsByName.get(actor) || doctorTool(policy, actor);
       if (tool && !tool.installed) {
         pushGap(gaps, seen, {
           type: "preset_broken",
@@ -591,7 +607,10 @@ function collectPresetGaps({ gaps, seen, policy, toolsByName }) {
           actor,
           actor_field: actorField,
           reason: "cli_missing",
-          proposal: diagnosticProposal(),
+          proposal: manualProposal({
+            reason: "cli_missing",
+            action: "install_cli_or_edit_preset",
+          }),
         });
       }
       const model = nonEmptyString(phaseValue.model);
@@ -702,7 +721,7 @@ function commandGaps(positionals, jsonOut) {
         actor: tool.name,
         path: tool.path,
         warning: tool.model_probe.warning,
-        proposal: diagnosticProposal(),
+        proposal: probeDiagnosticProposal(),
       });
     }
   }
@@ -719,7 +738,10 @@ function commandGaps(positionals, jsonOut) {
         actor_field: entry.actorField,
         phase: entry.phase,
         route: entry.route,
-        proposal: diagnosticProposal(),
+        proposal: manualProposal({
+          reason: "cli_missing",
+          action: "install_cli_or_remove_route",
+        }),
       });
     }
     if (entry.listName === "allowed_model_routes" && entry.actorField === "executor" && entry.phase === "dispatch" && !executorDefaultModel(policyResult.policy, entry.actor)) {
@@ -769,7 +791,10 @@ function commandGaps(positionals, jsonOut) {
     console.log(`relay-config gaps: ${gaps.length} gap${gaps.length === 1 ? "" : "s"}`);
     for (const gap of gaps) {
       const subject = [gap.type, gap.actor, gap.phase, gap.model || gap.route || gap.path].filter(Boolean).join(" ");
-      console.log(`${subject}: ${gap.proposal.subcommand} ${gap.proposal.args.slice(1).join(" ")}`);
+      const proposal = gap.proposal.subcommand
+        ? `${gap.proposal.subcommand} ${gap.proposal.args.slice(1).join(" ")}`
+        : `${gap.proposal.kind || "manual"} ${gap.proposal.action || gap.proposal.reason || ""}`.trim();
+      console.log(`${subject}: ${proposal}`);
     }
   }
 }
@@ -809,6 +834,31 @@ function routesFromPolicy(policy, executorDefaults) {
   return routes;
 }
 
+function mergeRouteDefaults(base = {}, override = {}) {
+  const merged = cloneJson(base || {});
+  for (const phase of VALID_PHASES) {
+    if (!hasOwn(override || {}, phase)) continue;
+    merged[phase] = {
+      ...(isPlainObject(merged[phase]) ? merged[phase] : {}),
+      ...(isPlainObject(override[phase]) ? override[phase] : {}),
+    };
+  }
+  return merged;
+}
+
+function foldProjectRoutesV1(routes, projectRoutes) {
+  if (projectRoutes.status === "absent" || projectRoutes.status === "ignored_v2") return routes;
+  if (!projectRoutes.ok) {
+    if (!projectRoutes.path) return routes;
+    throw new Error(projectRoutes.error || "failed to load project routes v1");
+  }
+  if (projectRoutes.routes?.version !== 1) return routes;
+  const folded = cloneJson(routes);
+  folded.defaults = mergeRouteDefaults(folded.defaults, projectRoutes.routes.defaults);
+  validateRouteConfig(folded, "migrated routes config");
+  return folded;
+}
+
 function writeMigratedMarker(filePath, routesPath) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   const markerPath = `${filePath}.migrated`;
@@ -845,8 +895,17 @@ function commandMigrate(positionals, jsonOut) {
     return;
   }
   const executorDefaults = executorDefaultsFromLegacyExecutors(executorsPath);
-  const routes = routesFromPolicy(policyResult.policy, executorDefaults);
   const projectRoutes = loadProjectRoutes({ repoRoot, relayHome });
+  let routes;
+  try {
+    routes = foldProjectRoutesV1(routesFromPolicy(policyResult.policy, executorDefaults), projectRoutes);
+  } catch (error) {
+    const output = { ok: false, status: "project_routes_error", errors: [{ message: error.message }], project_routes: projectRoutes };
+    if (jsonOut) printJson(output);
+    else console.error(`relay-config migrate: project routes failed: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
   const legacyPaths = legacyConfigPaths({ repoRoot, relayHome });
   const output = {
     ok: true,

--- a/skills/relay-dispatch/scripts/relay-policy.js
+++ b/skills/relay-dispatch/scripts/relay-policy.js
@@ -431,6 +431,9 @@ function resolveProjectPolicyPath(repoRoot, relayHome) {
 function routesConfigToRelayPolicy(routeConfig) {
   const defaults = buildDefaultRelayPolicy().defaults;
   const routesDefaults = routeConfig?.defaults || {};
+  const managedCli = Array.isArray(routeConfig?.managed_cli)
+    ? routeConfig.managed_cli
+    : buildDefaultRelayPolicy().managed_cli;
   return validateRelayPolicy({
     version: 1,
     profile: "routes-config",
@@ -447,7 +450,7 @@ function routesConfigToRelayPolicy(routeConfig) {
         ? routesDefaults.advisory_review
         : defaults.advisory_review,
     },
-    managed_cli: buildDefaultRelayPolicy().managed_cli,
+    managed_cli: managedCli,
     allowed_model_routes: routeConfig?.routes || [],
     denied_model_routes: routeConfig?.denied_routes || [],
     routing_rules: [],

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -488,6 +488,11 @@ function normalizeExecutorDefaults(value, sourceLabel) {
   return normalized;
 }
 
+function normalizeManagedCli(value, sourceLabel) {
+  if (value === undefined) return undefined;
+  return assertNonEmptyStringArray(value, "managed_cli", sourceLabel);
+}
+
 function normalizePresets(value, sourceLabel) {
   if (value === undefined) return {};
   if (!isPlainObject(value)) {
@@ -526,7 +531,9 @@ function validateRouteConfig(routes, sourceLabel = "routes config", { project = 
     routes: normalizeRouteEntries(routes.routes, "routes", sourceLabel),
     denied_routes: normalizeRouteEntries(routes.denied_routes, "denied_routes", sourceLabel),
     presets: normalizePresets(routes.presets, sourceLabel),
+    managed_cli: normalizeManagedCli(routes.managed_cli, sourceLabel),
   };
+  if (routes.managed_cli === undefined) delete normalized.managed_cli;
   // Preserve omission: a scope that does not set strict must not override
   // another scope's strict at merge time (mergeRouteConfigs keys off
   // hasOwnProperty, so materializing a default false here would defeat it).

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -442,7 +442,8 @@ function executeAdvisoryRequest(request) {
     } else if (outcome.timeout) {
       status = "timeout";
       failureReason = (
-        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s; ` +
+        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s ` +
+        `(exceeded ${timeoutMs / 1000}s timeout); ` +
         `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
       );
     } else if (outcome.error || outcome.code !== 0) {

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -442,8 +442,7 @@ function executeAdvisoryRequest(request) {
     } else if (outcome.timeout) {
       status = "timeout";
       failureReason = (
-        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s ` +
-        `(exceeded ${timeoutMs / 1000}s timeout); ` +
+        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s; ` +
         `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
       );
     } else if (outcome.error || outcome.code !== 0) {

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -51,6 +51,29 @@ function readRoutes(relayHome) {
   return JSON.parse(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"));
 }
 
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function legacyPolicy(overrides = {}) {
+  return {
+    version: 1,
+    profile: "test",
+    defaults: {
+      dispatch: { executor: "codex" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    managed_cli: ["codex", "claude"],
+    allowed_model_routes: [],
+    denied_model_routes: [],
+    routing_rules: [],
+    deny_unknown_model_routes: true,
+    ...overrides,
+  };
+}
+
 function writeFakeOpencode(binDir, models = []) {
   const opencodePath = path.join(binDir, "opencode");
   fs.writeFileSync(opencodePath, `#!/bin/sh
@@ -67,6 +90,18 @@ fi
 exit 0
 `, "utf-8");
   fs.chmodSync(opencodePath, 0o755);
+}
+
+function writeFakeCli(binDir, name) {
+  const cliPath = path.join(binDir, name);
+  fs.writeFileSync(cliPath, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '${name}-fake\\n'
+  exit 0
+fi
+exit 0
+`, "utf-8");
+  fs.chmodSync(cliPath, 0o755);
 }
 
 test("init company shorthand delegates to core init --profile company routes config", () => {
@@ -287,6 +322,91 @@ test("preset subcommands pass through wrapper shorthand", () => {
   const remove = runConfig(["preset", "remove", "hardened", "--json"], { relayHome });
   assert.equal(remove.status, 0, remove.combined);
   assert.equal(Object.prototype.hasOwnProperty.call(readRoutes(relayHome), "presets"), false);
+});
+
+test("migrate keeps project scoped legacy policy out of global routes and converts project v1 in place", () => {
+  const relayHome = tempDir();
+  const projectRoutesPath = parseJson(runConfig(["inspect", "--json"], { relayHome })).projectConfig.path.replace(/project\.json$/, "routes.json");
+  writeJson(path.join(relayHome, "policy.json"), legacyPolicy({
+    allowed_model_routes: [
+      { route: "*", phases: ["dispatch"], executors: ["opencode"] },
+      { route: "global/*", phases: ["dispatch"], executors: ["codex"] },
+    ],
+  }));
+  writeJson(projectRoutesPath.replace(/routes\.json$/, "policy.json"), legacyPolicy({
+    defaults: {
+      dispatch: { executor: "opencode" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    allowed_model_routes: [
+      { route: "project/*", phases: ["dispatch"], executors: ["opencode"] },
+    ],
+  }));
+  writeJson(projectRoutesPath, {
+    version: 1,
+    defaults: {
+      dispatch: { executor: "opencode", model: "project/model" },
+    },
+  });
+
+  const result = runConfig(["migrate", "--yes", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.combined);
+  const globalRoutes = readRoutes(relayHome);
+  assert.equal(globalRoutes.defaults.dispatch.executor, "codex");
+  assert.equal(globalRoutes.routes.some((route) => route.route === "project/*"), false);
+  assert.deepEqual(JSON.parse(fs.readFileSync(projectRoutesPath, "utf-8")), {
+    version: 2,
+    defaults: {
+      dispatch: { executor: "opencode", model: "project/model" },
+    },
+  });
+});
+
+test("migrate preserves narrowed managed_cli so model-less claude stays denied", () => {
+  const relayHome = tempDir();
+  writeJson(path.join(relayHome, "policy.json"), legacyPolicy({
+    managed_cli: ["codex"],
+  }));
+
+  const before = runConfig(["check", "review", "claude", "--json"], { relayHome });
+  assert.notEqual(before.status, 0);
+  assert.equal(JSON.parse(before.stdout).decision.reason, "missing_model_route");
+
+  const migrate = runConfig(["migrate", "--yes", "--json"], { relayHome });
+  assert.equal(migrate.status, 0, migrate.combined);
+  assert.deepEqual(readRoutes(relayHome).managed_cli, ["codex"]);
+
+  const after = runConfig(["check", "review", "claude", "--json"], { relayHome });
+  assert.notEqual(after.status, 0);
+  assert.equal(JSON.parse(after.stdout).decision.reason, "missing_model_route");
+});
+
+test("gaps reports installed strict default executor with no usable route", () => {
+  const relayHome = tempDir();
+  const binDir = tempDir("relay-config-pi-bin-");
+  writeFakeCli(binDir, "pi");
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "pi" },
+    },
+  });
+
+  const result = runConfig(["gaps", "--json"], {
+    relayHome,
+    env: { PATH: `${binDir}${path.delimiter}/usr/bin:/bin` },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  const gap = output.gaps.find((item) => item.actor === "pi" && item.phase === "dispatch");
+  assert.ok(gap, JSON.stringify(output.gaps, null, 2));
+  assert.match(gap.type, /installed_cli_unrouted|executor_missing_default_model/);
+  assert.ok(["add-route", "set-default"].includes(gap.proposal.subcommand), JSON.stringify(gap.proposal));
+  assert.ok(gap.proposal.args.length > 1);
 });
 
 test("inspect reports effective policy, doctor output, and executors config state", () => {

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -324,16 +324,17 @@ test("preset subcommands pass through wrapper shorthand", () => {
   assert.equal(Object.prototype.hasOwnProperty.call(readRoutes(relayHome), "presets"), false);
 });
 
-test("migrate keeps project scoped legacy policy out of global routes and converts project v1 in place", () => {
+test("migrate punts scoped legacy without writing markers or changing effective resolution", () => {
   const relayHome = tempDir();
   const projectRoutesPath = parseJson(runConfig(["inspect", "--json"], { relayHome })).projectConfig.path.replace(/project\.json$/, "routes.json");
+  const projectPolicyPath = projectRoutesPath.replace(/routes\.json$/, "policy.json");
   writeJson(path.join(relayHome, "policy.json"), legacyPolicy({
     allowed_model_routes: [
       { route: "*", phases: ["dispatch"], executors: ["opencode"] },
       { route: "global/*", phases: ["dispatch"], executors: ["codex"] },
     ],
   }));
-  writeJson(projectRoutesPath.replace(/routes\.json$/, "policy.json"), legacyPolicy({
+  writeJson(projectPolicyPath, legacyPolicy({
     defaults: {
       dispatch: { executor: "opencode" },
       review: { reviewer: "codex" },
@@ -350,18 +351,26 @@ test("migrate keeps project scoped legacy policy out of global routes and conver
     },
   });
 
+  const before = runConfig(["check", "dispatch", "opencode", "project/model", "--json"], { relayHome });
   const result = runConfig(["migrate", "--yes", "--json"], { relayHome });
 
-  assert.equal(result.status, 0, result.combined);
-  const globalRoutes = readRoutes(relayHome);
-  assert.equal(globalRoutes.defaults.dispatch.executor, "codex");
-  assert.equal(globalRoutes.routes.some((route) => route.route === "project/*"), false);
+  assert.notEqual(result.status, 0, result.combined);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.status, "scoped_migration_deferred");
+  assert.ok(output.not_migrated.some((legacy) => legacy.kind === "project_policy"));
+  assert.ok(output.not_migrated.some((legacy) => legacy.kind === "project_routes_v1"));
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+  assert.equal(fs.existsSync(`${projectPolicyPath}.migrated`), false);
+  assert.equal(fs.existsSync(`${projectRoutesPath}.migrated`), false);
   assert.deepEqual(JSON.parse(fs.readFileSync(projectRoutesPath, "utf-8")), {
-    version: 2,
+    version: 1,
     defaults: {
       dispatch: { executor: "opencode", model: "project/model" },
     },
   });
+  const after = runConfig(["check", "dispatch", "opencode", "project/model", "--json"], { relayHome });
+  assert.equal(after.status, before.status);
+  assert.deepEqual(JSON.parse(after.stdout).decision, JSON.parse(before.stdout).decision);
 });
 
 test("migrate preserves narrowed managed_cli so model-less claude stays denied", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -75,6 +75,14 @@ function parseJsonAllowingStderr(result) {
   return JSON.parse(result.stdout);
 }
 
+function applyProposal(proposal, options) {
+  assert.ok(Array.isArray(proposal.args), "proposal args must be an array");
+  assert.notEqual(proposal.args.length, 0, "proposal args must be applicable");
+  const result = runConfig(proposal.args, options);
+  assert.equal(result.status, 0, result.combined);
+  return parseJson(result);
+}
+
 function readPolicy(relayHome) {
   const policyPath = path.join(relayHome, "policy.json");
   const policy = JSON.parse(fs.readFileSync(policyPath, "utf-8"));
@@ -1184,19 +1192,14 @@ test("gaps --json reports observed route drift with verbatim proposals and no wr
   const routeWithoutCli = byType.get("route_without_cli")?.[0];
   assert.equal(routeWithoutCli?.actor, "ghost");
   assert.deepEqual(routeWithoutCli.proposal, {
-    kind: "manual",
-    args: [],
-    automatic: false,
-    reason: "cli_missing",
-    action: "install_cli_or_remove_route",
+    subcommand: "deny-route",
+    args: ["deny-route", "ghost/*", "--phase", "review", "--reviewer", "ghost", "--json"],
+    note: "or install ghost manually",
   });
   const missingCliPreset = byType.get("preset_broken")?.find((gap) => gap.reason === "cli_missing");
   assert.deepEqual(missingCliPreset?.proposal, {
-    kind: "manual",
-    args: [],
-    automatic: false,
-    reason: "cli_missing",
-    action: "install_cli_or_edit_preset",
+    subcommand: "preset",
+    args: ["preset", "remove", "missingcli", "--json"],
   });
   const strictPreset = byType.get("preset_broken")?.find((gap) => gap.model === "openai/unregistered");
   assert.deepEqual(strictPreset?.proposal, {
@@ -1206,15 +1209,33 @@ test("gaps --json reports observed route drift with verbatim proposals and no wr
   assert.equal(byType.get("probe_failure")?.length, 2);
   for (const gap of output.gaps) {
     assert.ok(Array.isArray(gap.proposal.args), `${gap.type} missing proposal args`);
-    if (gap.proposal.automatic === false) {
+    if (gap.type === "probe_failure") {
+      assert.equal(gap.proposal.automatic, false, `${gap.type} must be diagnostic`);
       assert.ok(gap.proposal.reason, `${gap.type} non-automatic proposal missing reason`);
     } else {
       assert.equal(typeof gap.proposal?.subcommand, "string", `${gap.type} missing proposal subcommand`);
+      assert.notEqual(gap.proposal.args.length, 0, `${gap.type} has empty applicable proposal`);
     }
   }
   assert.equal(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"), beforeRoutes);
   assert.equal(fs.readFileSync(eventsPath, "utf-8"), beforeEvents);
   assert.equal(fs.existsSync(path.join(relayHome, "policy.json.migrated")), false);
+
+  const options = {
+    relayHome,
+    cwd: repoRoot,
+    env: {
+      PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+    },
+  };
+  applyProposal(routeWithoutCli.proposal, options);
+  applyProposal(missingCliPreset.proposal, options);
+  applyProposal(strictPreset.proposal, options);
+  const rerun = parseJson(runConfig(["gaps", "--json"], options));
+  assert.equal(rerun.gaps.some((gap) => gap.type === "route_without_cli" && gap.actor === "ghost"), false);
+  assert.equal(rerun.gaps.some((gap) => gap.type === "preset_broken" && gap.preset === "missingcli"), false);
+  assert.equal(rerun.gaps.some((gap) => gap.type === "preset_broken" && gap.model === "openai/unregistered"), false);
 });
 
 test("migrate requires confirmation and preserves legacy effective route resolution", () => {
@@ -1313,6 +1334,108 @@ test("migrate requires confirmation and preserves legacy effective route resolut
   assert.match(fs.readFileSync(path.join(relayHome, "policy.json.migrated"), "utf-8"), /migrated into routes\.json/);
   assert.match(fs.readFileSync(path.join(relayHome, "executors.json.migrated"), "utf-8"), /migrated into routes\.json/);
   assert.match(fs.readFileSync(`${projectRoutesPath}.migrated`, "utf-8"), /migrated into routes\.json/);
+});
+
+test("migrate folds shadowed legacy routes into existing routes config without changing covered tuples", () => {
+  const relayHome = tempDir("relay-config-shadowed-migrate-home-");
+  const repoRoot = tempDir("relay-config-shadowed-migrate-repo-");
+  initGitRepo(repoRoot);
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "codex" },
+    },
+    executor_defaults: {
+      opencode: { model: "existing/model-fast" },
+    },
+    routes: [
+      { route: "existing/*", phases: ["dispatch"], executors: ["opencode"] },
+      { route: "shared/*", phases: ["dispatch"], executors: ["opencode"] },
+    ],
+  });
+  writeJson(path.join(relayHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "shadowed-legacy",
+    defaults: {
+      dispatch: { executor: "opencode" },
+      review: { reviewer: "pi" },
+      advisory_review: null,
+    },
+    allowed_model_routes: [
+      { route: "shared/*", phases: ["dispatch"], executors: ["opencode"] },
+      { route: "legacy/*", phases: ["review"], reviewers: ["pi"] },
+    ],
+    denied_model_routes: [],
+    deny_unknown_model_routes: true,
+  });
+  writeJson(path.join(relayHome, "executors.json"), {
+    executors: {
+      opencode: { default_model: "legacy/model-fast" },
+    },
+  });
+
+  const tuples = [
+    ["dispatch", "opencode", "existing/model-fast"],
+    ["dispatch", "opencode", "shared/model-fast"],
+    ["dispatch", "opencode", "unknown/model-fast"],
+  ];
+  const resolveMatrix = () => tuples.map(([phase, actor, model]) => {
+    const result = runConfig([
+      "check",
+      "--phase",
+      phase,
+      "--executor",
+      actor,
+      "--model",
+      model,
+      "--json",
+    ], { relayHome, cwd: repoRoot });
+    const parsed = JSON.parse(result.stdout);
+    return {
+      phase,
+      actor,
+      model,
+      status: result.status,
+      ok: parsed.ok,
+      reason: parsed.decision.reason,
+      matchedRoute: parsed.decision.matchedRoute || null,
+    };
+  });
+
+  const before = resolveMatrix();
+  const migrated = runConfig(["migrate", "--yes", "--json"], { relayHome, cwd: repoRoot });
+  assert.equal(migrated.status, 0, migrated.combined);
+  const output = parseJson(migrated);
+  assert.equal(output.wrote, true);
+  assert.deepEqual(resolveMatrix(), before);
+
+  const routes = readRoutes(relayHome);
+  assert.deepEqual(routes.executor_defaults.opencode, { model: "existing/model-fast" });
+  assert.equal(routes.routes.filter((entry) => entry.route === "shared/*").length, 1);
+  assert.ok(routes.routes.some((entry) => (
+    entry.route === "legacy/*"
+    && entry.phases?.includes("review")
+    && entry.reviewers?.includes("pi")
+  )));
+});
+
+test("gaps and migrate return JSON outside a git repo", () => {
+  const relayHome = tempDir("relay-config-nongit-home-");
+  const nonGit = tempDir("relay-config-nongit-cwd-");
+
+  const gaps = runConfig(["gaps", "--json"], { relayHome, cwd: nonGit });
+  assert.equal(gaps.status, 0, gaps.combined);
+  const gapsOutput = parseJson(gaps);
+  assert.equal(gapsOutput.ok, true);
+  assert.equal(gapsOutput.route_config.sources.project, null);
+
+  const migrate = runConfig(["migrate", "--json"], { relayHome, cwd: nonGit });
+  assert.equal(migrate.status, 0, migrate.combined);
+  const migrateOutput = parseJson(migrate);
+  assert.equal(migrateOutput.ok, true);
+  assert.equal(migrateOutput.dry_run, true);
+  assert.equal(migrateOutput.project_routes.path, null);
 });
 
 test("validation failure leaves the routes file untouched", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -1112,6 +1112,9 @@ test("gaps --json reports observed route drift with verbatim proposals and no wr
       strictbad: {
         dispatch: { executor: "opencode", model: "openai/unregistered" },
       },
+      missingcli: {
+        review: { reviewer: "ghost" },
+      },
     },
   });
   writeJson(path.join(relayHome, "policy.json"), {
@@ -1178,15 +1181,36 @@ test("gaps --json reports observed route drift with verbatim proposals and no wr
   });
   assert.equal(byType.get("legacy_config_present")?.[0]?.proposal.subcommand, "migrate");
   assert.equal(byType.get("unregistered_route_in_use")?.[0]?.model, "example/pi-model-fast");
-  assert.equal(byType.get("route_without_cli")?.[0]?.actor, "ghost");
-  assert.deepEqual(byType.get("preset_broken")?.[0]?.proposal, {
+  const routeWithoutCli = byType.get("route_without_cli")?.[0];
+  assert.equal(routeWithoutCli?.actor, "ghost");
+  assert.deepEqual(routeWithoutCli.proposal, {
+    kind: "manual",
+    args: [],
+    automatic: false,
+    reason: "cli_missing",
+    action: "install_cli_or_remove_route",
+  });
+  const missingCliPreset = byType.get("preset_broken")?.find((gap) => gap.reason === "cli_missing");
+  assert.deepEqual(missingCliPreset?.proposal, {
+    kind: "manual",
+    args: [],
+    automatic: false,
+    reason: "cli_missing",
+    action: "install_cli_or_edit_preset",
+  });
+  const strictPreset = byType.get("preset_broken")?.find((gap) => gap.model === "openai/unregistered");
+  assert.deepEqual(strictPreset?.proposal, {
     subcommand: "add-route",
     args: ["add-route", "openai/unregistered", "--phase", "dispatch", "--executor", "opencode", "--json"],
   });
   assert.equal(byType.get("probe_failure")?.length, 2);
   for (const gap of output.gaps) {
-    assert.equal(typeof gap.proposal?.subcommand, "string", `${gap.type} missing proposal subcommand`);
     assert.ok(Array.isArray(gap.proposal.args), `${gap.type} missing proposal args`);
+    if (gap.proposal.automatic === false) {
+      assert.ok(gap.proposal.reason, `${gap.type} non-automatic proposal missing reason`);
+    } else {
+      assert.equal(typeof gap.proposal?.subcommand, "string", `${gap.type} missing proposal subcommand`);
+    }
   }
   assert.equal(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"), beforeRoutes);
   assert.equal(fs.readFileSync(eventsPath, "utf-8"), beforeEvents);
@@ -1221,7 +1245,8 @@ test("migrate requires confirmation and preserves legacy effective route resolut
       opencode: { default_model: "openai/gpt-5.3-codex-spark" },
     },
   });
-  writeJson(getProjectRoutesPath(repoRoot, { relayHome }), {
+  const projectRoutesPath = getProjectRoutesPath(repoRoot, { relayHome });
+  writeJson(projectRoutesPath, {
     version: 1,
     defaults: {
       dispatch: { executor: "opencode", model: "openai/gpt-5.3-codex-spark" },
@@ -1265,14 +1290,29 @@ test("migrate requires confirmation and preserves legacy effective route resolut
   const output = parseJson(migrated);
   assert.equal(output.wrote, true);
   assert.equal(output.routes.strict, true);
+  assert.deepEqual(output.routes.defaults.dispatch, {
+    executor: "opencode",
+    model: "openai/gpt-5.3-codex-spark",
+  });
+  assert.deepEqual(output.routes.defaults.advisory_review, {
+    reviewer: "pi",
+    model: "example/pi-model-fast",
+    profile: "blindspot",
+  });
   assert.deepEqual(readRoutes(relayHome).executor_defaults, {
     opencode: { model: "openai/gpt-5.3-codex-spark" },
   });
   assert.deepEqual(resolveMatrix(), before);
+  const retainedProjectRoutes = `${projectRoutesPath}.retained`;
+  fs.renameSync(projectRoutesPath, retainedProjectRoutes);
+  assert.deepEqual(resolveMatrix(), before);
+  fs.renameSync(retainedProjectRoutes, projectRoutesPath);
   assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), true);
   assert.equal(fs.existsSync(path.join(relayHome, "executors.json")), true);
+  assert.equal(fs.existsSync(projectRoutesPath), true);
   assert.match(fs.readFileSync(path.join(relayHome, "policy.json.migrated"), "utf-8"), /migrated into routes\.json/);
   assert.match(fs.readFileSync(path.join(relayHome, "executors.json.migrated"), "utf-8"), /migrated into routes\.json/);
+  assert.match(fs.readFileSync(`${projectRoutesPath}.migrated`, "utf-8"), /migrated into routes\.json/);
 });
 
 test("validation failure leaves the routes file untouched", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -1238,7 +1238,87 @@ test("gaps --json reports observed route drift with verbatim proposals and no wr
   assert.equal(rerun.gaps.some((gap) => gap.type === "preset_broken" && gap.model === "openai/unregistered"), false);
 });
 
-test("migrate requires confirmation and preserves legacy effective route resolution", () => {
+test("gaps reports missing executor default for default actor covered only by unscoped route", () => {
+  const relayHome = tempDir("relay-config-unscoped-default-home-");
+  const repoRoot = tempDir("relay-config-unscoped-default-repo-");
+  const binDir = tempDir("relay-config-unscoped-default-bin-");
+  initGitRepo(repoRoot);
+  writeExecutable(path.join(binDir, "opencode"), "#!/bin/sh\nexit 0\n");
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    defaults: {
+      dispatch: { executor: "opencode" },
+    },
+    routes: [
+      { route: "openai/*", phases: ["dispatch"] },
+    ],
+  });
+
+  const result = runConfig(["gaps", "--json"], {
+    relayHome,
+    cwd: repoRoot,
+    env: { PATH: `${binDir}${path.delimiter}/usr/bin:/bin` },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  const gap = output.gaps.find((item) => (
+    item.type === "executor_missing_default_model"
+    && item.actor === "opencode"
+    && item.phase === "dispatch"
+    && item.route === "openai/*"
+  ));
+  assert.ok(gap, JSON.stringify(output.gaps, null, 2));
+  assert.deepEqual(gap.proposal, {
+    subcommand: "set-default",
+    args: ["set-default", "executor_defaults.opencode.model", "openai/fast", "--json"],
+  });
+});
+
+test("gaps suppresses historical unregistered usage when tuple is now denied", () => {
+  const relayHome = tempDir("relay-config-denied-usage-home-");
+  const repoRoot = tempDir("relay-config-denied-usage-repo-");
+  initGitRepo(repoRoot);
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    denied_routes: [
+      { route: "example/pi-model-fast", phases: ["dispatch"], executors: ["pi"] },
+    ],
+  });
+
+  withRelayHome(relayHome, () => {
+    appendRunEvent(repoRoot, "issue-784-20260708010101000-a1b2c3d4", {
+      event: EVENTS.UNREGISTERED_ROUTE_USED,
+      reason: "unknown_allowed",
+      phase: "dispatch",
+      actor_field: "executor",
+      executor: "pi",
+      model: "example/pi-model-fast",
+      policy_decision: {
+        allowed: true,
+        reason: "unknown_allowed",
+        phase: "dispatch",
+        actor: "pi",
+        executor: "pi",
+        model: "example/pi-model-fast",
+      },
+    });
+  });
+
+  const result = runConfig(["gaps", "--json"], { relayHome, cwd: repoRoot });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  assert.equal(output.gaps.some((gap) => (
+    gap.type === "unregistered_route_in_use"
+    && gap.actor === "pi"
+    && gap.model === "example/pi-model-fast"
+  )), false, JSON.stringify(output.gaps, null, 2));
+});
+
+test("migrate requires confirmation and preserves global legacy effective route resolution", () => {
   const relayHome = tempDir("relay-config-migrate-home-");
   const repoRoot = tempDir("relay-config-migrate-repo-");
   initGitRepo(repoRoot);
@@ -1264,14 +1344,6 @@ test("migrate requires confirmation and preserves legacy effective route resolut
   writeJson(path.join(relayHome, "executors.json"), {
     executors: {
       opencode: { default_model: "openai/gpt-5.3-codex-spark" },
-    },
-  });
-  const projectRoutesPath = getProjectRoutesPath(repoRoot, { relayHome });
-  writeJson(projectRoutesPath, {
-    version: 1,
-    defaults: {
-      dispatch: { executor: "opencode", model: "openai/gpt-5.3-codex-spark" },
-      advisory_review: { reviewer: "pi", model: "example/pi-model-fast", profile: "blindspot" },
     },
   });
 
@@ -1318,13 +1390,6 @@ test("migrate requires confirmation and preserves legacy effective route resolut
     reviewer: "pi",
     profile: "blindspot",
   });
-  assert.deepEqual(JSON.parse(fs.readFileSync(projectRoutesPath, "utf-8")), {
-    version: 2,
-    defaults: {
-      dispatch: { executor: "opencode", model: "openai/gpt-5.3-codex-spark" },
-      advisory_review: { reviewer: "pi", model: "example/pi-model-fast", profile: "blindspot" },
-    },
-  });
   assert.deepEqual(readRoutes(relayHome).executor_defaults, {
     opencode: { model: "openai/gpt-5.3-codex-spark" },
   });
@@ -1338,10 +1403,79 @@ test("migrate requires confirmation and preserves legacy effective route resolut
   fs.renameSync(retainedExecutors, path.join(relayHome, "executors.json"));
   assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), true);
   assert.equal(fs.existsSync(path.join(relayHome, "executors.json")), true);
-  assert.equal(fs.existsSync(projectRoutesPath), true);
   assert.match(fs.readFileSync(path.join(relayHome, "policy.json.migrated"), "utf-8"), /migrated into routes\.json/);
   assert.match(fs.readFileSync(path.join(relayHome, "executors.json.migrated"), "utf-8"), /migrated into routes\.json/);
-  assert.match(fs.readFileSync(`${projectRoutesPath}.migrated`, "utf-8"), /migrated into routes\.json/);
+});
+
+test("migrate refuses repo-scoped legacy policy without markers or resolution changes", () => {
+  const relayHome = tempDir("relay-config-scoped-migrate-home-");
+  const repoRoot = tempDir("relay-config-scoped-migrate-repo-");
+  initGitRepo(repoRoot);
+  writeJson(path.join(relayHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "global-legacy",
+    managed_cli: ["codex"],
+    allowed_model_routes: [
+      { route: "*", phases: ["dispatch"], executors: ["opencode"] },
+    ],
+    denied_model_routes: [],
+    deny_unknown_model_routes: true,
+  });
+  writeJson(path.join(repoRoot, ".relay", "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "repo-legacy",
+    managed_cli: ["codex"],
+    defaults: {
+      dispatch: { executor: "opencode" },
+      review: { reviewer: "codex" },
+      advisory_review: null,
+    },
+    allowed_model_routes: [
+      { route: "repo/*", phases: ["dispatch"], executors: ["opencode"] },
+    ],
+    denied_model_routes: [],
+    deny_unknown_model_routes: true,
+  });
+
+  const check = (model) => {
+    const result = runConfig([
+      "check",
+      "--phase",
+      "dispatch",
+      "--executor",
+      "opencode",
+      "--model",
+      model,
+      "--json",
+    ], { relayHome, cwd: repoRoot });
+    const parsed = JSON.parse(result.stdout);
+    return {
+      status: result.status,
+      ok: parsed.ok,
+      reason: parsed.decision.reason,
+      matchedRoute: parsed.decision.matchedRoute || null,
+    };
+  };
+  const before = {
+    repo: check("repo/model-fast"),
+    global: check("global/model-fast"),
+  };
+
+  const migrated = runConfig(["migrate", "--yes", "--json"], { relayHome, cwd: repoRoot });
+
+  assert.notEqual(migrated.status, 0, migrated.combined);
+  const output = JSON.parse(migrated.stdout);
+  assert.equal(output.status, "scoped_migration_deferred");
+  assert.equal(output.wrote, false);
+  assert.ok(output.not_migrated.some((legacy) => legacy.kind === "repo_policy"));
+  assert.match(output.summary.join("\n"), /scoped legacy file\(s\) not migrated/);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+  assert.equal(fs.existsSync(path.join(relayHome, "policy.json.migrated")), false);
+  assert.equal(fs.existsSync(path.join(repoRoot, ".relay", "policy.json.migrated")), false);
+  assert.deepEqual({
+    repo: check("repo/model-fast"),
+    global: check("global/model-fast"),
+  }, before);
 });
 
 test("migrate folds shadowed legacy routes into existing routes config without changing covered tuples", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -1386,10 +1386,9 @@ test("migrate requires confirmation and preserves global legacy effective route 
   assert.deepEqual(output.routes.defaults.dispatch, {
     executor: "opencode",
   });
-  assert.deepEqual(output.routes.defaults.advisory_review, {
-    reviewer: "pi",
-    profile: "blindspot",
-  });
+  assert.deepEqual(output.routes.defaults.advisory_review, [
+    { gating: false, profile: "blindspot", reviewer: "pi", trigger: "every_round" },
+  ]);
   assert.deepEqual(readRoutes(relayHome).executor_defaults, {
     opencode: { model: "openai/gpt-5.3-codex-spark" },
   });

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -28,6 +28,7 @@ const {
 } = require("../../../skills/relay-dispatch/scripts/manifest/lifecycle");
 const {
   EVENTS,
+  appendRunEvent,
   readRunEvents,
 } = require("../../../skills/relay-dispatch/scripts/relay-events");
 
@@ -96,6 +97,16 @@ function hasOwn(object, key) {
 function writeExecutable(filePath, body = "#!/bin/sh\nexit 0\n") {
   fs.writeFileSync(filePath, body, "utf-8");
   fs.chmodSync(filePath, 0o755);
+}
+
+function writeProbeFailingTool(binDir, name, probeArg) {
+  writeExecutable(path.join(binDir, name), `#!/bin/sh
+if [ "$1" = "${probeArg}" ]; then
+  echo '${name} probe unavailable' >&2
+  exit 2
+fi
+exit 0
+`);
 }
 
 function initGitRepo(repoRoot) {
@@ -1080,6 +1091,188 @@ test("preset mutation validation failure leaves the routes file untouched", () =
   assert.notEqual(result.status, 0, result.combined);
   assert.match(result.combined, /presets must be an object/);
   assert.equal(fs.readFileSync(routesPath, "utf-8"), before);
+});
+
+test("gaps --json reports observed route drift with verbatim proposals and no writes", () => {
+  const relayHome = tempDir("relay-config-gaps-home-");
+  const repoRoot = tempDir("relay-config-gaps-repo-");
+  initGitRepo(repoRoot);
+  const binDir = tempDir("relay-config-gaps-bin-");
+  writeProbeFailingTool(binDir, "opencode", "models");
+  writeProbeFailingTool(binDir, "pi", "--list-models");
+
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    strict: true,
+    routes: [
+      { route: "example/opencode-model-*", phases: ["dispatch"], executors: ["opencode"] },
+      { route: "ghost/*", phases: ["review"], reviewers: ["ghost"] },
+    ],
+    presets: {
+      strictbad: {
+        dispatch: { executor: "opencode", model: "openai/unregistered" },
+      },
+    },
+  });
+  writeJson(path.join(relayHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "legacy",
+    allowed_model_routes: [{ route: "legacy/*", phases: ["dispatch"], executors: ["opencode"] }],
+  });
+  writeJson(path.join(relayHome, "executors.json"), {
+    executors: {
+      opencode: { default_model: "example/opencode-model-fast" },
+    },
+  });
+
+  withRelayHome(relayHome, () => {
+    appendRunEvent(repoRoot, "issue-783-20260708010101000-a1b2c3d4", {
+      event: EVENTS.UNREGISTERED_ROUTE_USED,
+      reason: "unknown_allowed",
+      phase: "dispatch",
+      actor_field: "executor",
+      executor: "pi",
+      model: "example/pi-model-fast",
+      policy_decision: {
+        allowed: true,
+        reason: "unknown_allowed",
+        phase: "dispatch",
+        actor: "pi",
+        executor: "pi",
+        model: "example/pi-model-fast",
+      },
+    });
+  });
+  const eventsPath = withRelayHome(relayHome, () => path.join(
+    getRunDir(repoRoot, "issue-783-20260708010101000-a1b2c3d4"),
+    "events.jsonl"
+  ));
+  const beforeRoutes = fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8");
+  const beforeEvents = fs.readFileSync(eventsPath, "utf-8");
+
+  const result = runConfig(["gaps", "--json"], {
+    relayHome,
+    cwd: repoRoot,
+    env: {
+      PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+    },
+  });
+
+  assert.equal(result.status, 0, result.combined);
+  const output = parseJson(result);
+  const byType = output.gaps.reduce((map, gap) => {
+    if (!map.has(gap.type)) map.set(gap.type, []);
+    map.get(gap.type).push(gap);
+    return map;
+  }, new Map());
+  assert.equal(byType.get("installed_cli_unrouted")?.[0]?.actor, "pi");
+  assert.deepEqual(byType.get("installed_cli_unrouted")[0].proposal, {
+    subcommand: "add-route",
+    args: ["add-route", "example/pi-*", "--phase", "dispatch", "--executor", "pi", "--json"],
+  });
+  assert.equal(byType.get("executor_missing_default_model")?.[0]?.actor, "opencode");
+  assert.deepEqual(byType.get("executor_missing_default_model")[0].proposal, {
+    subcommand: "set-default",
+    args: ["set-default", "executor_defaults.opencode.model", "example/opencode-model-fast", "--json"],
+  });
+  assert.equal(byType.get("legacy_config_present")?.[0]?.proposal.subcommand, "migrate");
+  assert.equal(byType.get("unregistered_route_in_use")?.[0]?.model, "example/pi-model-fast");
+  assert.equal(byType.get("route_without_cli")?.[0]?.actor, "ghost");
+  assert.deepEqual(byType.get("preset_broken")?.[0]?.proposal, {
+    subcommand: "add-route",
+    args: ["add-route", "openai/unregistered", "--phase", "dispatch", "--executor", "opencode", "--json"],
+  });
+  assert.equal(byType.get("probe_failure")?.length, 2);
+  for (const gap of output.gaps) {
+    assert.equal(typeof gap.proposal?.subcommand, "string", `${gap.type} missing proposal subcommand`);
+    assert.ok(Array.isArray(gap.proposal.args), `${gap.type} missing proposal args`);
+  }
+  assert.equal(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"), beforeRoutes);
+  assert.equal(fs.readFileSync(eventsPath, "utf-8"), beforeEvents);
+  assert.equal(fs.existsSync(path.join(relayHome, "policy.json.migrated")), false);
+});
+
+test("migrate requires confirmation and preserves legacy effective route resolution", () => {
+  const relayHome = tempDir("relay-config-migrate-home-");
+  const repoRoot = tempDir("relay-config-migrate-repo-");
+  initGitRepo(repoRoot);
+  writeJson(path.join(relayHome, "policy.json"), {
+    ...buildDefaultRelayPolicy(),
+    profile: "legacy-open",
+    defaults: {
+      dispatch: { executor: "opencode" },
+      review: { reviewer: "codex" },
+      advisory_review: { reviewer: "pi", profile: "blindspot" },
+    },
+    managed_cli: ["codex", "claude"],
+    allowed_model_routes: [
+      { route: "openai/*", phases: ["dispatch"], executors: ["opencode"] },
+      { route: "example/pi-*", phases: ["advisory_review"], reviewers: ["pi"] },
+    ],
+    denied_model_routes: [
+      { route: "openai/blocked", phases: ["dispatch"], executors: ["opencode"] },
+    ],
+    routing_rules: [],
+    deny_unknown_model_routes: true,
+  });
+  writeJson(path.join(relayHome, "executors.json"), {
+    executors: {
+      opencode: { default_model: "openai/gpt-5.3-codex-spark" },
+    },
+  });
+  writeJson(getProjectRoutesPath(repoRoot, { relayHome }), {
+    version: 1,
+    defaults: {
+      dispatch: { executor: "opencode", model: "openai/gpt-5.3-codex-spark" },
+      advisory_review: { reviewer: "pi", model: "example/pi-model-fast", profile: "blindspot" },
+    },
+  });
+
+  const tuples = [
+    ["dispatch", "opencode", "openai/gpt-5.3-codex-spark"],
+    ["dispatch", "opencode", "openai/blocked"],
+    ["advisory_review", "pi", "example/pi-model-fast"],
+    ["review", "codex", null],
+  ];
+  const resolveMatrix = () => tuples.map(([phase, actor, model]) => {
+    const args = ["check", "--phase", phase];
+    if (phase === "dispatch") args.push("--executor", actor);
+    else args.push("--reviewer", actor);
+    if (model) args.push("--model", model);
+    args.push("--json");
+    const result = runConfig(args, { relayHome, cwd: repoRoot });
+    const parsed = JSON.parse(result.stdout);
+    return {
+      phase,
+      actor,
+      model,
+      status: result.status,
+      ok: parsed.ok,
+      reason: parsed.decision.reason,
+      matchedRoute: parsed.decision.matchedRoute || null,
+    };
+  });
+
+  const before = resolveMatrix();
+  const dry = runConfig(["migrate", "--json"], { relayHome, cwd: repoRoot });
+  assert.equal(dry.status, 0, dry.combined);
+  assert.equal(parseJson(dry).dry_run, true);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+
+  const migrated = runConfig(["migrate", "--yes", "--json"], { relayHome, cwd: repoRoot });
+  assert.equal(migrated.status, 0, migrated.combined);
+  const output = parseJson(migrated);
+  assert.equal(output.wrote, true);
+  assert.equal(output.routes.strict, true);
+  assert.deepEqual(readRoutes(relayHome).executor_defaults, {
+    opencode: { model: "openai/gpt-5.3-codex-spark" },
+  });
+  assert.deepEqual(resolveMatrix(), before);
+  assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), true);
+  assert.equal(fs.existsSync(path.join(relayHome, "executors.json")), true);
+  assert.match(fs.readFileSync(path.join(relayHome, "policy.json.migrated"), "utf-8"), /migrated into routes\.json/);
+  assert.match(fs.readFileSync(path.join(relayHome, "executors.json.migrated"), "utf-8"), /migrated into routes\.json/);
 });
 
 test("validation failure leaves the routes file untouched", () => {

--- a/tests/relay-dispatch/scripts/relay-config.test.js
+++ b/tests/relay-dispatch/scripts/relay-config.test.js
@@ -1313,21 +1313,29 @@ test("migrate requires confirmation and preserves legacy effective route resolut
   assert.equal(output.routes.strict, true);
   assert.deepEqual(output.routes.defaults.dispatch, {
     executor: "opencode",
-    model: "openai/gpt-5.3-codex-spark",
   });
   assert.deepEqual(output.routes.defaults.advisory_review, {
     reviewer: "pi",
-    model: "example/pi-model-fast",
     profile: "blindspot",
+  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(projectRoutesPath, "utf-8")), {
+    version: 2,
+    defaults: {
+      dispatch: { executor: "opencode", model: "openai/gpt-5.3-codex-spark" },
+      advisory_review: { reviewer: "pi", model: "example/pi-model-fast", profile: "blindspot" },
+    },
   });
   assert.deepEqual(readRoutes(relayHome).executor_defaults, {
     opencode: { model: "openai/gpt-5.3-codex-spark" },
   });
   assert.deepEqual(resolveMatrix(), before);
-  const retainedProjectRoutes = `${projectRoutesPath}.retained`;
-  fs.renameSync(projectRoutesPath, retainedProjectRoutes);
+  const retainedPolicy = path.join(relayHome, "policy.json.retained");
+  const retainedExecutors = path.join(relayHome, "executors.json.retained");
+  fs.renameSync(path.join(relayHome, "policy.json"), retainedPolicy);
+  fs.renameSync(path.join(relayHome, "executors.json"), retainedExecutors);
   assert.deepEqual(resolveMatrix(), before);
-  fs.renameSync(retainedProjectRoutes, projectRoutesPath);
+  fs.renameSync(retainedPolicy, path.join(relayHome, "policy.json"));
+  fs.renameSync(retainedExecutors, path.join(relayHome, "executors.json"));
   assert.equal(fs.existsSync(path.join(relayHome, "policy.json")), true);
   assert.equal(fs.existsSync(path.join(relayHome, "executors.json")), true);
   assert.equal(fs.existsSync(projectRoutesPath), true);


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented locally on branch `issue-783`.

Changes:
- Added `relay-config gaps --json` with read-only gap detection and verbatim proposals.
- Added confirmation-gated `relay-config migrate --yes`; dry-run by default, no legacy deletion, writes `.migrated` marker notes.
- Extended `set-default` for `executor_defaults.<executor>.model`.
- Updated relay-config skill revise workflow for “설정 점검/리바이즈”.
- Added fixture coverage for all gap classes plus migrate equivalence.
- Restored advisory timeout 
```

## Score Log

- Run: issue-783-20260708123338704-4521864f
- Executor: codex
- Branch: issue-783