### PR TITLE
fix(relay-fleet): continue merge queue after blocked child

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -109,7 +109,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 
 - The fleet script invokes `skills/relay-dispatch/scripts/dispatch.js` as a subprocess once per leaf and always passes `--fleet-id`.
 - `--review` invokes `skills/relay-review/scripts/review-runner.js` as foreground subprocesses for children in `internal_review_pending` or `review_pending`. Internal PASS advances to `publish_pending`; existing `publish_pending` children are published with `skills/relay-dispatch/scripts/publish-run.js`. `changes_requested` invokes `dispatch.js --manifest <child-manifest>` and re-enters the loop until the child reaches `ready_to_merge` or `escalated`.
-- `merge-queue.js` invokes `skills/relay-merge/scripts/finalize-run.js` as a subprocess for one `ready_to_merge` child at a time. It stops at the first merge failure and marks that child `merge_blocked`.
+- `merge-queue.js` invokes `skills/relay-merge/scripts/finalize-run.js` as a subprocess for one `ready_to_merge` child at a time. When a child merge fails, it marks that child `merge_blocked` and continues with the next ready child.
 - Each child dispatch owns worktree creation, in-flight run checks, executor invocation, and child run manifest writes.
 - Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
 - `--resume` reconciles both directions: it re-adopts child run manifests whose `fleet_id` points back to this fleet, marks no-manifest interrupted children as `dispatch_failed_pre_manifest`, skips still-running child subprocesses, and re-enters the review/publication/redispatch loop for children in `internal_review_pending`, `publish_pending`, `review_pending`, or `changes_requested`.

--- a/skills/relay-fleet/references/design.md
+++ b/skills/relay-fleet/references/design.md
@@ -173,9 +173,9 @@ original plan missed:
   transition because merge failures are not review feedback. (Codex #3.)
 - **Stale-base recovery design.** After child N merges, child N+1's base is stale.
   `finalize-run.js` checks the review gate + failing CI but does NOT auto-rebase
-  or re-dispatch. Phase 3's first queue implementation chooses the conservative
-  recovery path: stop at first failure, mark that child `merge_blocked`, and leave
-  recovery to the operator or a later explicit automation pass.
+  or re-dispatch. The queue marks a failed child `merge_blocked`, continues with
+  the next ready child, and leaves recovery to the operator or a later explicit
+  automation pass.
   (Codex #8.)
 
 ## Resolved questions

--- a/skills/relay-fleet/scripts/merge-queue.js
+++ b/skills/relay-fleet/scripts/merge-queue.js
@@ -234,7 +234,6 @@ async function runMergeQueue(options) {
   for (const child of queue) {
     const result = await runFinalizeForChild({ repoRoot, child, options });
     results.push(result);
-    if (result.status === "merge_blocked") break;
   }
 
   const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);

--- a/tests/relay-fleet/scripts/merge-queue.test.js
+++ b/tests/relay-fleet/scripts/merge-queue.test.js
@@ -198,7 +198,7 @@ test("merge-queue serially finalizes ready fleet children in manifest order", ()
   assert.equal(readManifest(getManifestPath(repoRoot, runB)).data.state, RUN_STATES.MERGED);
 });
 
-test("merge-queue stops at first merge failure and marks that child merge_blocked", () => {
+test("merge-queue continues after a merge failure and marks only that child merge_blocked", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-merge-red-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-merge-red-fake-"));
   const finalizeScript = writeFakeFinalizeScript(tmpDir);
@@ -247,12 +247,20 @@ test("merge-queue stops at first merge failure and marks that child merge_blocke
 
   assert.equal(result.status, 1);
   const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.results.length, 3);
+  assert.deepEqual(payload.results.map((entry) => entry.status), ["merged", "merge_blocked", "merged"]);
   assert.equal(payload.results[1].status, "merge_blocked");
-  assert.deepEqual(readJsonLines(logPath).map((entry) => entry.runId), [runA, runB]);
+  assert.deepEqual(readJsonLines(logPath).map((entry) => entry.runId), [runA, runB, runC]);
   assert.equal(readManifest(getManifestPath(repoRoot, runA)).data.state, RUN_STATES.MERGED);
   assert.equal(readManifest(getManifestPath(repoRoot, runB)).data.state, RUN_STATES.MERGE_BLOCKED);
-  assert.equal(readManifest(getManifestPath(repoRoot, runC)).data.state, RUN_STATES.READY_TO_MERGE);
+  assert.equal(readManifest(getManifestPath(repoRoot, runC)).data.state, RUN_STATES.MERGED);
   assert.equal(payload.operator_attention.some((item) => item.run_id === runB && item.reason === RUN_STATES.MERGE_BLOCKED), true);
+  const events = readJsonLines(path.join(getRunDir(repoRoot, runB), "events.jsonl"));
+  const blockedEvent = events.find((entry) => entry.event === "merge_blocked");
+  assert.equal(blockedEvent.state_from, RUN_STATES.READY_TO_MERGE);
+  assert.equal(blockedEvent.state_to, RUN_STATES.MERGE_BLOCKED);
+  assert.equal(blockedEvent.reason, "fake stale base");
 });
 
 test("merge-queue treats an empty ready queue as complete when no child needs attention", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed `1f60688 fix(relay-fleet): continue merge queue after blocked child`.

**Audit**
- Continue-past-failure: [merge-queue.js](/Users/sjlee/.relay/worktrees/36eba292/hydra/skills/relay-fleet/scripts/merge-queue.js:231) keeps the sequential `await` loop but no longer breaks on `merge_blocked`.
- A/B/C contract: [merge-queue.test.js](/Users/sjlee/.relay/worktrees/36eba292/hydra/tests/relay-fleet/scripts/merge-queue.test.js:201) now asserts A and C merge, B is `merge_blocked`,
```

## Score Log

- Run: issue-845-20260708134806408-497aa536
- Executor: codex
- Branch: issue-845