### PR TITLE
Accept relay-owned worktrees by git-common-dir binding, not basename

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -534,8 +534,13 @@ function validateManifestPaths(paths, {
     };
   }
   const worktreeGitCommonDir = getWorktreeGitCommonDir(worktree);
-  const relayOwnedWorktree = relayOwnedWorktreeCandidate
-    && (
+  // The git common dir is the ownership trust root: a worktree under the relay
+  // base whose common dir binds to the expected repo is relay-owned even when
+  // its directory basename was inherited from a differently-named dispatch
+  // checkout (#851). Basename matching stays required on the missing-worktree
+  // path above, where no common dir is available to verify.
+  const relayOwnedWorktree = isPathContainedWithin(relayWorktreeBase, worktree)
+    && Boolean(
       worktreeGitCommonDir
       && (
         worktreeGitCommonDir === expectedGitCommonDir

--- a/tests/relay-dispatch/scripts/manifest/paths.test.js
+++ b/tests/relay-dispatch/scripts/manifest/paths.test.js
@@ -159,6 +159,57 @@ test("manifest/paths accepts relay worktree named after linked dispatch root whe
   assert.equal(result.worktreeLocation, "relay_worktree");
 });
 
+test("manifest/paths accepts foreign-basename relay worktree when manifest repo_root is primary and common dir binds", () => {
+  const runId = "issue-851-20260708140000000-36eba292";
+  const { repoRoot, linkedRoot, manifestPath, relayWorktreeBase } = createLinkedDispatchFixture(runId);
+  const relayWorktree = path.join(relayWorktreeBase, "36eba292", path.basename(linkedRoot));
+  execFileSync("git", ["worktree", "add", relayWorktree, "-b", "issue-851-relay"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+
+  const result = validateManifestPaths({
+    repo_root: repoRoot,
+    worktree: relayWorktree,
+  }, {
+    expectedRepoRoot: repoRoot,
+    manifestPath,
+    runId,
+    caller: "manifest/paths.test foreign basename bound worktree",
+  });
+
+  assert.notEqual(path.basename(relayWorktree), path.basename(repoRoot));
+  assert.equal(result.repoRoot, path.resolve(repoRoot));
+  assert.equal(result.worktree, relayWorktree);
+  assert.equal(result.worktreeLocation, "relay_worktree");
+});
+
+test("manifest/paths rejects foreign-basename relay worktree when git common dir differs and repo_root is primary", () => {
+  const runId = "issue-851-20260708140000001-36eba292";
+  const { repoRoot, linkedRoot, manifestPath, relayWorktreeBase } = createLinkedDispatchFixture(runId);
+  const attackerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-foreign-attacker-"));
+  initGitRepo(attackerRoot);
+  commitBaseFile(attackerRoot);
+  const attackerRelayWorktree = path.join(relayWorktreeBase, "attacker-foreign", path.basename(linkedRoot));
+  execFileSync("git", ["worktree", "add", attackerRelayWorktree, "-b", "attacker-foreign-relay"], {
+    cwd: attackerRoot,
+    stdio: "pipe",
+  });
+
+  assert.throws(
+    () => validateManifestPaths({
+      repo_root: repoRoot,
+      worktree: attackerRelayWorktree,
+    }, {
+      expectedRepoRoot: repoRoot,
+      manifestPath,
+      runId,
+      caller: "manifest/paths.test foreign basename wrong common dir",
+    }),
+    /is not contained under the expected repo root/
+  );
+});
+
 test("manifest/paths rejects linked-root relay worktree basename when git common dir differs", () => {
   const runId = "issue-805-20260706000901941-2ab48b13";
   const { repoRoot, linkedRoot, manifestPath, relayWorktreeBase } = createLinkedDispatchFixture(runId);


### PR DESCRIPTION
Narrow companion PR unblocking a live merge gate (per the unblock-via-infra-PR playbook), closes #851.

## Problem
`finalize-run` on ready run `issue-845-…497aa536` failed `validateManifestPaths`: the run was dispatched from a linked worktree named `hydra`, so its relay worktree is `~/.relay/worktrees/36eba292/hydra` while the manifest records the canonical `repo_root` (`…/dev-relay`). The relay-owned check required `basename(worktree) ∈ {basename(repo_root)}` — a proxy signal — even though the worktree's git common dir binds exactly to the expected repo (the trust root the code already computes).

## Change
For an **existing** worktree under the relay base, ownership = common-dir binding, basename ignored. The **missing-worktree** path keeps the basename requirement (no common dir available to verify there). Attacker case (foreign common dir) still rejected.

## Tests
- New: foreign-basename worktree + primary repo_root + matching common dir → accepted as `relay_worktree`.
- New: same shape with a different common dir → rejected.
- `node --test --test-concurrency=1 tests/relay-dispatch/scripts/manifest/*.test.js tests/relay-merge/scripts/*.test.js` → pass 100%, fail 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * relay 작업트리 경로 검증이 더 정확해졌습니다.
  * 올바른 공통 디렉터리에 연결된 경우에는 이름이 다른 작업트리도 정상 인식되며, 신뢰할 수 없는 경로는 차단됩니다.
  * 작업트리 경로가 일부 누락된 상황에서도 검증 기준이 더 일관되게 적용됩니다.

* **Tests**
  * 관련 허용/거부 사례를 추가해 경로 검증 동작을 확인하도록 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->