### PR TITLE
docs: add relay-fleet goal persistence guide

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -118,3 +118,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 ## SPOF
 
 There is intentionally no daemon. A fleet makes progress only while `relay-fleet` is actively running. If the session dies, the fleet pauses; re-run with `--resume` to reconcile child manifests, skip still-running children, and continue recoverable pre-manifest failures.
+
+## /goal Persistence
+
+For long fleets, the operator may activate host `/goal` after fan-out to keep one session driving the daemonless loop. Use the copy-paste condition and idempotent operating loop in [references/goal-persistence.md](references/goal-persistence.md); the condition must name the transcript-visible `--status --json` check, not just an operator process.

--- a/skills/relay-fleet/references/goal-persistence.md
+++ b/skills/relay-fleet/references/goal-persistence.md
@@ -1,0 +1,65 @@
+# relay-fleet /goal session persistence
+
+## Why this exists
+
+`relay-fleet` is deliberately daemonless. There is no background coordinator,
+heartbeat, or watcher chain; a fleet progresses only while an operator is
+actively running the foreground commands. If that session dies, the fleet pauses
+until `--resume` reconciles child manifests and continues recoverable work.
+
+For long fleets, the operator can use the host harness `/goal` feature to keep a
+single orchestrating session driving the fleet to completion. `/goal` is a slash
+command in Claude Code 2.1.139+ and Codex CLI. The operator activates it with a
+condition string; the orchestrating agent cannot activate it for them.
+
+Two consumers read the active goal: the main model treats it as a directive, and
+a separate evaluator model decides done/not-done after every turn. The evaluator
+cannot run tools and sees only the condition plus the conversation transcript.
+Therefore a working condition MUST name a transcript-visible check command and a
+measurable end state. It must state the end state, not the operator process:
+"run the fleet commands after each change" is unenforceable, while "the status
+JSON appears in the conversation and shows the fleet is closed" is checkable.
+
+## Condition template
+
+After the initial fan-out has created the fleet, the operator fills `<fleet-id>`
+and `<N>`, then activates:
+
+```text
+/goal Keep driving relay-fleet <fleet-id> until this exact check command has been run and its output appears in the conversation transcript:
+
+node skills/relay-fleet/scripts/relay-fleet.js --repo . --fleet-id <fleet-id> --status --json
+
+Done means that JSON output contains `"fleet_state": "closed"` and every child is `merged` or explicitly `escalated`. Stop and report blocked instead if the same child cannot advance for <N> consecutive turns, or if <N> total turns pass without transcript-visible status output showing that end state.
+```
+
+## Operating loop
+
+The loop is safe because fleet commands are crash-only and idempotent. Re-running
+them reconciles persisted state instead of assuming the last session completed:
+`--resume` re-adopts children and skips live subprocesses, `--review` advances
+only children that still need review/publication/redispatch work, and
+`merge-queue.js` attempts ready children serially.
+
+On each orchestrator turn, re-run the same foreground loop with the same fleet
+id:
+
+```bash
+node skills/relay-fleet/scripts/relay-fleet.js --repo . --fleet-id <fleet-id> --resume
+node skills/relay-fleet/scripts/relay-fleet.js --repo . --fleet-id <fleet-id> --review
+node skills/relay-fleet/scripts/merge-queue.js --repo . --fleet-id <fleet-id>
+node skills/relay-fleet/scripts/relay-fleet.js --repo . --fleet-id <fleet-id> --status --json
+```
+
+The final `--status --json` command is load-bearing. Its output must appear in
+the conversation transcript so the separate evaluator can decide whether the
+condition is done.
+
+## Sprint-level variant
+
+The same pattern works one level up for sprint execution. The condition's end
+state becomes "every Plan item in the active sprint file is `[x]`", and the
+check command must print either that sprint file or a sprint-state JSON summary
+into the conversation transcript. The loop can fan out, resume, review, merge,
+and refresh fleet status underneath it, but the evaluator-friendly proof remains
+the transcript-visible sprint check showing all Plan items complete.


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed the docs-only change.

Commit: `a411209 docs: add relay-fleet goal persistence guide`

Completion audit:
- DC1: [goal-persistence.md](/Users/sjlee/.relay/worktrees/08395bcc/hydra/skills/relay-fleet/references/goal-persistence.md) includes `Why this exists`, `Condition template`, `Operating loop`, and `Sprint-level variant`.
- DC2: Evaluator limits are documented: transcript-only visibility, no tool execution, end-state wording required.
- DC3: [SKILL.md](/Users/sjlee/.r
```

## Score Log

- Run: issue-846-20260708145053576-f876d930
- Executor: codex
- Branch: issue-846