### PR TITLE
relay-review: confidence-banded reviewer findings (low/medium/high) (#306)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -362,6 +362,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.duplicate_low_confidence_count !== undefined
       ? { duplicate_low_confidence_count: normalizeEventValue(eventData.duplicate_low_confidence_count) }
       : {}),
+    ...(eventData.confidence_downgrade !== undefined
+      ? { confidence_downgrade: eventData.confidence_downgrade === true }
+      : {}),
+    ...(eventData.low_confidence_count !== undefined
+      ? { low_confidence_count: normalizeEventValue(eventData.low_confidence_count) }
+      : {}),
     ...(eventData.elapsed_ms !== undefined
       ? { elapsed_ms: normalizeEventValue(eventData.elapsed_ms) }
       : {}),

--- a/skills/relay-review/references/reviewer-prompt.md
+++ b/skills/relay-review/references/reviewer-prompt.md
@@ -80,6 +80,8 @@ If a rubric is present:
 
 Do not invent nitpicks. Style-only suggestions are not review findings.
 
+Score every issue's confidence. high = clear defect, reproducible from diff alone. medium = likely defect, may need execution to confirm. low = stylistic or speculative, do not block on this alone.
+
 ### Verification evidence
 
 In your summary, enumerate each Done Criteria item with one of four statuses, based on diff evidence:

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -327,6 +327,7 @@ async function run() {
   updatedManifest = applyReviewerIdentity(updatedManifest, noComment || internalReview, runRepoPath);
   writeManifest(manifestPath, updatedManifest, body);
   appendRunEvent(runRepoPath, data.run_id, { event: EVENTS.ESCALATION_DECISION, state_from: data.state, state_to: updatedManifest.state, head_sha: reviewedHeadSha, ...escalationDecision });
+  const reviewApplyReason = confidenceDowngradeApplied ? "pass" : rubricGateFailure ? rubricGateFailure.status : verdict.verdict;
   appendRunEvent(runRepoPath, data.run_id, {
     event: EVENTS.REVIEW_APPLY,
     state_from: data.state,
@@ -334,7 +335,7 @@ async function run() {
     head_sha: reviewedHeadSha,
     round,
     reviewer: reviewerName,
-    reason: rubricGateFailure ? rubricGateFailure.status : verdict.verdict,
+    reason: reviewApplyReason,
     lineage_summary: escalationDecision.lineage_summary || lineageSummary,
     ...(confidenceDowngradeApplied ? {
       confidence_downgrade: true,

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -10,7 +10,7 @@ const { appendIterationScore, appendRunEvent, appendScoreDivergence, EVENTS } = 
 const { git, writeText } = require("./review-runner/common");
 const { applyReviewerIdentity, getGhLogin, parseRemoteHost, resolveContext, resolveIssueNumber, resolveRemoteHost } = require("./review-runner/context");
 const { buildPrompt, formatPriorVerdictSummary } = require("./review-runner/prompt");
-const { isLowConfidenceAdvisoryPass, parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
+const { parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
 const { buildCommentBody, formatIssueList, formatScopeDrift, postComment } = require("./review-runner/comment");
 const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog, toIterationScoreEventEntry } = require("./review-runner/divergence");
 const { applyQualityExecutionStatus, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
@@ -275,9 +275,11 @@ async function run() {
     : null;
   const confidenceDowngradeApplied = confidenceDowngrade.applied && !rubricGateFailure;
   const verdictPath = path.join(runDir, `review-round-${round}-verdict.json`);
+  const appliedVerdict = rubricGateFailure ? "changes_requested" : confidenceDowngradeApplied ? "pass" : verdict.verdict;
   const verdictRecord = rubricGateFailure
     ? {
       ...verdict,
+      applied_verdict: appliedVerdict,
       relay_gate: {
         status: rubricGateFailure.status,
         layer: rubricGateFailure.layer,
@@ -288,7 +290,7 @@ async function run() {
         recovery: rubricGateFailure.recovery,
       },
     }
-    : verdict;
+    : { ...verdict, applied_verdict: appliedVerdict };
   writeText(verdictPath, `${JSON.stringify(verdictRecord, null, 2)}\n`);
 
   let redispatchPath = null;
@@ -356,12 +358,8 @@ async function run() {
     });
   }
 
-  result.appliedVerdict = rubricGateFailure ? "changes_requested" : isLowConfidenceAdvisoryPass(verdict) ? "pass" : verdict.verdict;
-  result.confidenceDowngrade = confidenceDowngradeApplied ? {
-    originalVerdict: verdict.verdict,
-    appliedVerdict: "pass",
-    lowConfidenceCount: confidenceDowngrade.lowConfidenceCount,
-  } : null;
+  result.appliedVerdict = appliedVerdict;
+  result.confidenceDowngrade = confidenceDowngradeApplied ? { originalVerdict: verdict.verdict, appliedVerdict: "pass", lowConfidenceCount: confidenceDowngrade.lowConfidenceCount } : null;
   result.nextState = updatedManifest.state;
   result.redispatchPath = redispatchPath;
   result.repeatedIssueCount = repeatedIssueCount;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -338,8 +338,10 @@ async function run() {
     reviewer: reviewerName,
     reason: rubricGateFailure ? rubricGateFailure.status : verdict.verdict,
     lineage_summary: escalationDecision.lineage_summary || lineageSummary,
-    confidence_downgrade: confidenceDowngrade.applied,
-    low_confidence_count: confidenceDowngrade.lowConfidenceCount,
+    ...(confidenceDowngrade.applied ? {
+      confidence_downgrade: true,
+      low_confidence_count: confidenceDowngrade.lowConfidenceCount,
+    } : {}),
   });
 
   if (Array.isArray(verdict.rubric_scores) && verdict.rubric_scores.length > 0) {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -10,7 +10,7 @@ const { appendIterationScore, appendRunEvent, appendScoreDivergence, EVENTS } = 
 const { git, writeText } = require("./review-runner/common");
 const { applyReviewerIdentity, getGhLogin, parseRemoteHost, resolveContext, resolveIssueNumber, resolveRemoteHost } = require("./review-runner/context");
 const { buildPrompt, formatPriorVerdictSummary } = require("./review-runner/prompt");
-const { parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
+const { buildConfidenceDowngrade, isLowConfidenceAdvisoryPass, parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
 const { buildCommentBody, formatIssueList, formatScopeDrift, postComment } = require("./review-runner/comment");
 const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog, toIterationScoreEventEntry } = require("./review-runner/divergence");
 const { applyQualityExecutionStatus, buildExecutionEvidenceFailureVerdict, buildMissingExecutionEvidenceVerdict, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
@@ -246,10 +246,12 @@ async function run() {
     disallowPassReason: prSignalsPassBlockReason,
   });
 
-  const repeatedIssueCount = verdict.verdict === "changes_requested" ? computeRepeatedIssueCount(runDir, round, verdict.issues) : 0;
+  const confidenceDowngrade = buildConfidenceDowngrade(verdict);
+  const blockingChangesRequested = verdict.verdict === "changes_requested" && !confidenceDowngrade.applied;
+  const repeatedIssueCount = blockingChangesRequested ? computeRepeatedIssueCount(runDir, round, verdict.issues) : 0;
   const lineageSummary = summarizeLineage(verdict.issues);
   let escalationDecision = { round, trigger: "none", factors: [], traces: [], lineage_summary: lineageSummary, decision: "continue", reason: "no_trigger" };
-  if (verdict.verdict === "changes_requested" && repeatedIssueCount >= 3) {
+  if (blockingChangesRequested && repeatedIssueCount >= 3) {
     verdict = toEscalatedVerdict(
       verdict,
       `Repeated identical review issues hit ${repeatedIssueCount} consecutive rounds.`
@@ -292,7 +294,7 @@ async function run() {
   writeText(verdictPath, `${JSON.stringify(verdictRecord, null, 2)}\n`);
 
   let redispatchPath = null;
-  if (verdict.verdict === "changes_requested" || rubricGateFailure) {
+  if ((verdict.verdict === "changes_requested" && !confidenceDowngrade.applied) || rubricGateFailure) {
     redispatchPath = rubricGateFailure
       ? rubricGateRedispatchPath
       : path.join(runDir, `review-round-${round}-redispatch.md`);
@@ -336,6 +338,8 @@ async function run() {
     reviewer: reviewerName,
     reason: rubricGateFailure ? rubricGateFailure.status : verdict.verdict,
     lineage_summary: escalationDecision.lineage_summary || lineageSummary,
+    confidence_downgrade: confidenceDowngrade.applied,
+    low_confidence_count: confidenceDowngrade.lowConfidenceCount,
   });
 
   if (Array.isArray(verdict.rubric_scores) && verdict.rubric_scores.length > 0) {
@@ -351,7 +355,12 @@ async function run() {
     });
   }
 
-  result.appliedVerdict = rubricGateFailure ? "changes_requested" : verdict.verdict;
+  result.appliedVerdict = rubricGateFailure ? "changes_requested" : isLowConfidenceAdvisoryPass(verdict) ? "pass" : verdict.verdict;
+  result.confidenceDowngrade = confidenceDowngrade.applied ? {
+    originalVerdict: verdict.verdict,
+    appliedVerdict: "pass",
+    lowConfidenceCount: confidenceDowngrade.lowConfidenceCount,
+  } : null;
   result.nextState = updatedManifest.state;
   result.redispatchPath = redispatchPath;
   result.repeatedIssueCount = repeatedIssueCount;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -10,12 +10,12 @@ const { appendIterationScore, appendRunEvent, appendScoreDivergence, EVENTS } = 
 const { git, writeText } = require("./review-runner/common");
 const { applyReviewerIdentity, getGhLogin, parseRemoteHost, resolveContext, resolveIssueNumber, resolveRemoteHost } = require("./review-runner/context");
 const { buildPrompt, formatPriorVerdictSummary } = require("./review-runner/prompt");
-const { buildConfidenceDowngrade, isLowConfidenceAdvisoryPass, parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
+const { isLowConfidenceAdvisoryPass, parseReviewVerdict, validateReviewVerdict, validateScopeDrift } = require("./review-runner/verdict");
 const { buildCommentBody, formatIssueList, formatScopeDrift, postComment } = require("./review-runner/comment");
 const { buildScoreDivergenceAnalysis, loadPrBody, parseScoreLog, toIterationScoreEventEntry } = require("./review-runner/divergence");
-const { applyQualityExecutionStatus, buildExecutionEvidenceFailureVerdict, buildMissingExecutionEvidenceVerdict, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
-const { applyReviewAssurancePolicy } = require("./review-runner/assurance");
+const { applyQualityExecutionStatus, computeQualityExecutionStatus } = require("./review-runner/execution-evidence");
 const { printFailureAndExit } = require("./review-runner/failure-output");
+const { applyPassEquivalentGates } = require("./review-runner/confidence-downgrade");
 const { buildRedispatchPrompt, buildRubricGateRedispatchPrompt, computeFactorStatusFlips, computeRepeatedIssueCount, decideFlipFlopEscalation, detectChurnGrowth, summarizeLineage, toEscalatedVerdict } = require("./review-runner/redispatch");
 const { buildConvergenceSummary, formatConvergenceMarkdown } = require("./review-runner/convergence");
 const { applyVerdictToManifest } = require("./review-runner/manifest-apply");
@@ -230,23 +230,17 @@ async function run() {
     hardenedAssurance,
     verdict,
   }));
-  verdict = applyReviewAssurancePolicy(verdict, {
+  const gateResult = applyPassEquivalentGates(verdict, {
     advisoryResult,
+    disallowPassReason: prSignalsPassBlockReason,
+    executionStatus,
     hardenedAssurance,
+    internalReview,
     manualReviewReason,
     reviewFile,
   });
-  if (verdict.verdict === "pass" && executionStatus.status !== "pass") {
-    verdict = executionStatus.status === "missing"
-      ? buildMissingExecutionEvidenceVerdict(verdict)
-      : buildExecutionEvidenceFailureVerdict(verdict);
-  }
-  validateReviewVerdict(verdict, {
-    passNextActions: passNextActionsFor(internalReview),
-    disallowPassReason: prSignalsPassBlockReason,
-  });
-
-  const confidenceDowngrade = buildConfidenceDowngrade(verdict);
+  verdict = gateResult.verdict;
+  const confidenceDowngrade = gateResult.confidenceDowngrade;
   const blockingChangesRequested = verdict.verdict === "changes_requested" && !confidenceDowngrade.applied;
   const repeatedIssueCount = blockingChangesRequested ? computeRepeatedIssueCount(runDir, round, verdict.issues) : 0;
   const lineageSummary = summarizeLineage(verdict.issues);
@@ -273,9 +267,10 @@ async function run() {
   if (convergenceSummary) writeText(path.join(runDir, `review-round-${round}-convergence.md`), `${formatConvergenceMarkdown(convergenceSummary)}\n`);
 
   const rubricGateRedispatchPath = path.join(runDir, `review-round-${round}-redispatch.md`);
-  const rubricGateFailure = verdict.verdict === "pass"
+  const rubricGateFailure = verdict.verdict === "pass" || confidenceDowngrade.applied
     ? buildReviewRunnerRubricGateFailure(data.run_id, rubricGateRedispatchPath, rubricLoad)
     : null;
+  const confidenceDowngradeApplied = confidenceDowngrade.applied && !rubricGateFailure;
   const verdictPath = path.join(runDir, `review-round-${round}-verdict.json`);
   const verdictRecord = rubricGateFailure
     ? {
@@ -338,7 +333,7 @@ async function run() {
     reviewer: reviewerName,
     reason: rubricGateFailure ? rubricGateFailure.status : verdict.verdict,
     lineage_summary: escalationDecision.lineage_summary || lineageSummary,
-    ...(confidenceDowngrade.applied ? {
+    ...(confidenceDowngradeApplied ? {
       confidence_downgrade: true,
       low_confidence_count: confidenceDowngrade.lowConfidenceCount,
     } : {}),
@@ -358,7 +353,7 @@ async function run() {
   }
 
   result.appliedVerdict = rubricGateFailure ? "changes_requested" : isLowConfidenceAdvisoryPass(verdict) ? "pass" : verdict.verdict;
-  result.confidenceDowngrade = confidenceDowngrade.applied ? {
+  result.confidenceDowngrade = confidenceDowngradeApplied ? {
     originalVerdict: verdict.verdict,
     appliedVerdict: "pass",
     lowConfidenceCount: confidenceDowngrade.lowConfidenceCount,

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -241,9 +241,10 @@ async function run() {
   });
   verdict = gateResult.verdict;
   const confidenceDowngrade = gateResult.confidenceDowngrade;
+  let analysisVerdict = confidenceDowngrade.applied ? gateResult.passEquivalentVerdict : verdict;
   const blockingChangesRequested = verdict.verdict === "changes_requested" && !confidenceDowngrade.applied;
-  const repeatedIssueCount = blockingChangesRequested ? computeRepeatedIssueCount(runDir, round, verdict.issues) : 0;
-  const lineageSummary = summarizeLineage(verdict.issues);
+  const repeatedIssueCount = blockingChangesRequested ? computeRepeatedIssueCount(runDir, round, analysisVerdict.issues) : 0;
+  const lineageSummary = summarizeLineage(analysisVerdict.issues);
   let escalationDecision = { round, trigger: "none", factors: [], traces: [], lineage_summary: lineageSummary, decision: "continue", reason: "no_trigger" };
   if (blockingChangesRequested && repeatedIssueCount >= 3) {
     verdict = toEscalatedVerdict(
@@ -251,18 +252,20 @@ async function run() {
       `Repeated identical review issues hit ${repeatedIssueCount} consecutive rounds.`
     );
     escalationDecision = { ...escalationDecision, trigger: "repeated_issues", decision: "escalate", reason: "repeated_issues" };
+    analysisVerdict = verdict;
   }
-  const factorFlips = computeFactorStatusFlips(runDir, round, verdict);
+  const factorFlips = computeFactorStatusFlips(runDir, round, analysisVerdict);
   if (factorFlips.length && escalationDecision.trigger !== "repeated_issues") {
-    escalationDecision = { round, trigger: "flip_flop", ...decideFlipFlopEscalation({ verdict, factorFlips, repeatedIssueCount }) };
+    escalationDecision = { round, trigger: "flip_flop", ...decideFlipFlopEscalation({ verdict: analysisVerdict, factorFlips, repeatedIssueCount }) };
   }
   if (escalationDecision.decision === "escalate" && escalationDecision.trigger === "flip_flop") {
     verdict = toEscalatedVerdict(
       verdict,
       factorFlips.map(({ factor, trace }) => `Rubric factor '${factor}' status flipped across 3 rounds (trace: ${trace.join("→")}). Owner decision required — reviewer cannot converge autonomously.`).join("; ")
     );
+    analysisVerdict = verdict;
   }
-  const convergenceSummary = buildConvergenceSummary({ runDir, round, verdict, factorFlips, repeatedIssueCount });
+  const convergenceSummary = buildConvergenceSummary({ runDir, round, verdict: analysisVerdict, factorFlips, repeatedIssueCount });
   result.convergenceSummary = convergenceSummary;
   if (convergenceSummary) writeText(path.join(runDir, `review-round-${round}-convergence.md`), `${formatConvergenceMarkdown(convergenceSummary)}\n`);
 

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -407,7 +407,7 @@ function executeAdvisoryRequest(request) {
     } else if (outcome.timeout) {
       status = "timeout";
       failureReason = (
-        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s; ` +
+        `${request.reviewerName} reviewer advisory_review exceeded ${timeoutMs / 1000}s timeout; ` +
         `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
       );
     } else if (outcome.error || outcome.code !== 0) {

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -407,7 +407,7 @@ function executeAdvisoryRequest(request) {
     } else if (outcome.timeout) {
       status = "timeout";
       failureReason = (
-        `${request.reviewerName} reviewer advisory_review exceeded ${timeoutMs / 1000}s timeout; ` +
+        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s; ` +
         `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
       );
     } else if (outcome.error || outcome.code !== 0) {

--- a/skills/relay-review/scripts/review-runner/assurance.js
+++ b/skills/relay-review/scripts/review-runner/assurance.js
@@ -6,6 +6,7 @@ function buildAssuranceIssue(title, body) {
     line: 1,
     category: "quality",
     severity: "high",
+    confidence: "high",
     lineage: "new",
   };
 }

--- a/skills/relay-review/scripts/review-runner/comment.js
+++ b/skills/relay-review/scripts/review-runner/comment.js
@@ -1,10 +1,14 @@
 const { gh } = require("./common");
+const { isLowConfidenceAdvisoryPass } = require("./verdict");
 
 const REVIEW_MARKER = "<!-- relay-review -->";
 const REVIEW_ROUND_MARKER = "<!-- relay-review-round -->";
 
-function formatIssueList(issues) {
-  return issues.map((issue) => `- ${issue.file}:${issue.line} — ${issue.title}: ${issue.body}`).join("\n");
+function formatIssueList(issues, { includeConfidence = false } = {}) {
+  return issues.map((issue) => {
+    const confidence = includeConfidence && issue.confidence ? `[${issue.confidence}] ` : "";
+    return `- ${issue.file}:${issue.line} — ${confidence}${issue.title}: ${issue.body}`;
+  }).join("\n");
 }
 
 function appendCommentWarnings(commentBody, warnings = []) {
@@ -68,6 +72,21 @@ function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } 
       `Quality Review: ${formatStatus(verdict.quality_review_status)}`,
       `Quality Execution: ${formatStatus(verdict.quality_execution_status)}`,
       `Rounds: ${round}`,
+    ].join("\n"), warnings);
+  }
+
+  if (isLowConfidenceAdvisoryPass(verdict)) {
+    return appendCommentWarnings([
+      REVIEW_MARKER,
+      "## Relay Review",
+      "Verdict: LGTM",
+      `Summary: ${verdict.summary}`,
+      `Contract: ${formatStatus(verdict.contract_status)}`,
+      `Quality Review: ${formatStatus(verdict.quality_review_status)}`,
+      `Quality Execution: ${formatStatus(verdict.quality_execution_status)}`,
+      `Rounds: ${round}`,
+      "Low-confidence findings (non-blocking):",
+      formatIssueList(verdict.issues, { includeConfidence: true }),
     ].join("\n"), warnings);
   }
 

--- a/skills/relay-review/scripts/review-runner/confidence-downgrade.js
+++ b/skills/relay-review/scripts/review-runner/confidence-downgrade.js
@@ -43,7 +43,9 @@ function applyPassEquivalentGates(verdict, {
   }
   validateReviewVerdict(verdict, { passNextActions, disallowPassReason });
 
-  return { confidenceDowngrade, verdict };
+  const passEquivalentVerdict = confidenceDowngrade.applied ? gateVerdict : verdict;
+
+  return { confidenceDowngrade, passEquivalentVerdict, verdict };
 }
 
 module.exports = { applyPassEquivalentGates };

--- a/skills/relay-review/scripts/review-runner/confidence-downgrade.js
+++ b/skills/relay-review/scripts/review-runner/confidence-downgrade.js
@@ -1,0 +1,49 @@
+const { applyReviewAssurancePolicy } = require("./assurance");
+const {
+  buildExecutionEvidenceFailureVerdict,
+  buildMissingExecutionEvidenceVerdict,
+} = require("./execution-evidence");
+const { passNextActionsFor } = require("./round-artifacts");
+const {
+  buildConfidenceDowngrade,
+  buildLowConfidencePassGateVerdict,
+  validateReviewVerdict,
+} = require("./verdict");
+
+function applyPassEquivalentGates(verdict, {
+  advisoryResult,
+  disallowPassReason,
+  executionStatus,
+  hardenedAssurance,
+  internalReview,
+  manualReviewReason,
+  reviewFile,
+}) {
+  const passNextActions = passNextActionsFor(internalReview);
+  let confidenceDowngrade = buildConfidenceDowngrade(verdict);
+  let gateVerdict = confidenceDowngrade.applied
+    ? buildLowConfidencePassGateVerdict(verdict, passNextActions)
+    : verdict;
+
+  gateVerdict = applyReviewAssurancePolicy(gateVerdict, {
+    advisoryResult,
+    hardenedAssurance,
+    manualReviewReason,
+    reviewFile,
+  });
+  if (gateVerdict.verdict === "pass" && executionStatus.status !== "pass") {
+    gateVerdict = executionStatus.status === "missing"
+      ? buildMissingExecutionEvidenceVerdict(gateVerdict)
+      : buildExecutionEvidenceFailureVerdict(gateVerdict);
+  }
+  validateReviewVerdict(gateVerdict, { passNextActions, disallowPassReason });
+  if (gateVerdict.verdict !== "pass" || !confidenceDowngrade.applied) {
+    verdict = gateVerdict;
+    confidenceDowngrade = buildConfidenceDowngrade(verdict);
+  }
+  validateReviewVerdict(verdict, { passNextActions, disallowPassReason });
+
+  return { confidenceDowngrade, verdict };
+}
+
+module.exports = { applyPassEquivalentGates };

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -604,12 +604,20 @@ function formatPriorRoundContext(runDir, round) {
 
   const { scanPriorVerdicts } = require("./redispatch");
   const { formatIssueList } = require("./comment");
+  const { getAppliedVerdict } = require("./verdict");
 
   const lines = [];
   scanPriorVerdicts(runDir, round, (verdict, roundNum) => {
-    const parts = [`### Round ${roundNum}: ${verdict.verdict}`, verdict.summary];
+    const appliedVerdict = getAppliedVerdict(verdict);
+    const label = appliedVerdict && appliedVerdict !== verdict?.verdict
+      ? `${verdict.verdict} (applied: ${appliedVerdict})`
+      : verdict.verdict;
+    const parts = [`### Round ${roundNum}: ${label}`, verdict.summary];
     if (Array.isArray(verdict.issues) && verdict.issues.length) {
-      parts.push("Issues flagged:", formatIssueList(verdict.issues));
+      parts.push(
+        appliedVerdict === "changes_requested" ? "Issues flagged:" : "Advisory issues preserved from the raw verdict:",
+        formatIssueList(verdict.issues)
+      );
     }
     lines.push(parts.join("\n"));
   });

--- a/skills/relay-review/scripts/review-runner/convergence.js
+++ b/skills/relay-review/scripts/review-runner/convergence.js
@@ -7,13 +7,15 @@ const {
   summarizeLineage,
 } = require("./redispatch");
 const { getRubricScoreNumber } = require("./score-utils");
+const { getAppliedVerdict } = require("./verdict");
 
 const LINEAGE_ORDER = ["deepening", "repeat", "stale", "new", "newly_scoreable", "unknown"];
 const SUMMARY_VERDICTS = new Set(["pass", "changes_requested", "escalated"]);
 
 function statusForRoundVerdict(round, verdict) {
-  if (round < 3 || !SUMMARY_VERDICTS.has(verdict?.verdict)) return null;
-  if (verdict.verdict === "pass") return "converged";
+  const appliedVerdict = getAppliedVerdict(verdict);
+  if (round < 3 || !SUMMARY_VERDICTS.has(appliedVerdict)) return null;
+  if (appliedVerdict === "pass") return "converged";
   if (round >= 5) return "decision_recommended";
   return "watch";
 }
@@ -62,7 +64,7 @@ function findImmediatePriorChangesRequested(runDir, round) {
     prior = verdict;
     return false;
   });
-  return prior?.verdict === "changes_requested" && Array.isArray(prior.issues) ? prior : null;
+  return getAppliedVerdict(prior) === "changes_requested" && Array.isArray(prior.issues) ? prior : null;
 }
 
 function currentIssueFactors(issue, verdict) {

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -184,6 +184,7 @@ function buildExecutionEvidenceFailureVerdict(verdict) {
       line: 1,
       category: "quality",
       severity: "high",
+      confidence: "high",
     }],
   };
 }

--- a/skills/relay-review/scripts/review-runner/manifest-apply.js
+++ b/skills/relay-review/scripts/review-runner/manifest-apply.js
@@ -36,7 +36,9 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
   let nextAction;
   let latestVerdict;
 
-  if (verdict.verdict === "pass") {
+  const appliesAsPass = verdict.verdict === "pass" || isLowConfidenceAdvisoryPass(verdict);
+
+  if (appliesAsPass) {
     if (rubricGateFailure) {
       nextState = STATES.CHANGES_REQUESTED;
       nextAction = "repair_rubric_and_redispatch";
@@ -52,16 +54,6 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
         ? "internal_lgtm"
         : "lgtm";
     }
-  } else if (verdict.verdict === "changes_requested" && isLowConfidenceAdvisoryPass(verdict)) {
-    nextState = data.state === STATES.INTERNAL_REVIEW_PENDING
-      ? STATES.PUBLISH_PENDING
-      : STATES.READY_TO_MERGE;
-    nextAction = data.state === STATES.INTERNAL_REVIEW_PENDING
-      ? "publish_pr"
-      : "await_explicit_merge";
-    latestVerdict = data.state === STATES.INTERNAL_REVIEW_PENDING
-      ? "internal_lgtm"
-      : "lgtm";
   } else if (verdict.verdict === "changes_requested") {
     nextState = STATES.CHANGES_REQUESTED;
     nextAction = "re_dispatch_requested_changes";

--- a/skills/relay-review/scripts/review-runner/manifest-apply.js
+++ b/skills/relay-review/scripts/review-runner/manifest-apply.js
@@ -1,4 +1,5 @@
 const { STATES, updateManifestState } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
+const { isLowConfidenceAdvisoryPass } = require("./verdict");
 
 function refreshManifestWithoutStateChange(data, nextAction) {
   return {
@@ -51,6 +52,16 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
         ? "internal_lgtm"
         : "lgtm";
     }
+  } else if (verdict.verdict === "changes_requested" && isLowConfidenceAdvisoryPass(verdict)) {
+    nextState = data.state === STATES.INTERNAL_REVIEW_PENDING
+      ? STATES.PUBLISH_PENDING
+      : STATES.READY_TO_MERGE;
+    nextAction = data.state === STATES.INTERNAL_REVIEW_PENDING
+      ? "publish_pr"
+      : "await_explicit_merge";
+    latestVerdict = data.state === STATES.INTERNAL_REVIEW_PENDING
+      ? "internal_lgtm"
+      : "lgtm";
   } else if (verdict.verdict === "changes_requested") {
     nextState = STATES.CHANGES_REQUESTED;
     nextAction = "re_dispatch_requested_changes";
@@ -75,7 +86,7 @@ function applyVerdictToManifest(data, verdict, round, prNumber, reviewedHeadSha,
       ...(updated.review || {}),
       rounds: round,
       latest_verdict: latestVerdict,
-      repeated_issue_count: verdict.verdict === "changes_requested" ? repeatedIssueCount : 0,
+      repeated_issue_count: verdict.verdict === "changes_requested" && !isLowConfidenceAdvisoryPass(verdict) ? repeatedIssueCount : 0,
       ...(options.lineageSummary ? { last_lineage_summary: options.lineageSummary } : {}),
       last_reviewed_sha: reviewedHeadSha || null,
       ...buildReviewStatusFields(verdict),

--- a/skills/relay-review/scripts/review-runner/prompt.js
+++ b/skills/relay-review/scripts/review-runner/prompt.js
@@ -2,6 +2,7 @@ const path = require("path");
 const { REVIEWER_VERDICT_JSON_SCHEMA } = require("../review-schema");
 const { readText } = require("./common");
 const { formatPriorRoundContext, loadProjectConventions } = require("./context");
+const { getAppliedVerdict } = require("./verdict");
 
 const REVIEWER_PROMPT_PATH = path.join(__dirname, "..", "..", "references", "reviewer-prompt.md");
 const TDD_ANCHOR_LINE_REGEX = /^\s*tdd_anchor:\s*\S+/m;
@@ -195,6 +196,7 @@ function withTerminalPunctuation(value) {
 function collectRejectedApproaches(verdicts) {
   const grouped = new Map();
   verdicts.forEach((verdict, index) => {
+    if (getAppliedVerdict(verdict) !== "changes_requested") return;
     const roundNum = verdicts.length - index;
     for (const issue of Array.isArray(verdict.issues) ? verdict.issues : []) {
       const factor = compactText(issue?.factor);
@@ -212,6 +214,14 @@ function collectRejectedApproaches(verdicts) {
     }
   });
   return [...grouped.values()].filter((group) => group.entries.length);
+}
+
+function formatHistoryVerdict(verdict) {
+  const appliedVerdict = getAppliedVerdict(verdict);
+  if (appliedVerdict && appliedVerdict !== verdict?.verdict) {
+    return `${verdict.verdict} (applied: ${appliedVerdict})`;
+  }
+  return verdict?.verdict || "unknown";
 }
 
 function formatRejectedApproachEntry(entry) {
@@ -245,7 +255,7 @@ function formatPriorVerdictSummary(verdicts) {
     const rubricSummary = Array.isArray(verdict.rubric_scores) && verdict.rubric_scores.length
       ? verdict.rubric_scores.map((score) => `${score.factor}: ${score.observed} (target ${score.target}, ${score.status})`).join("; ")
       : "no rubric scores";
-    return `- Round ${roundNum}: ${verdict.verdict} — ${verdict.summary} [${issueCount} issue(s), lineage: ${formatLineageCounts(lineageSummary)}; ${rubricSummary}]`;
+    return `- Round ${roundNum}: ${formatHistoryVerdict(verdict)} — ${verdict.summary} [${issueCount} issue(s), lineage: ${formatLineageCounts(lineageSummary)}; ${rubricSummary}]`;
   });
   const rejectedApproaches = formatRejectedApproaches(verdicts);
   if (!rejectedApproaches) return ["Prior review rounds:", ...lines].join("\n");

--- a/skills/relay-review/scripts/review-runner/redispatch.js
+++ b/skills/relay-review/scripts/review-runner/redispatch.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { formatIssueList, formatScopeDrift } = require("./comment");
 const { formatPriorVerdictSummary } = require("./prompt");
 const { getRubricScoreNumber, getRubricTargetNumber } = require("./score-utils");
+const { getAppliedVerdict } = require("./verdict");
 
 const FLIP_STATES = new Set(["pass", "fail"]);
 const LINEAGE_VALUES = ["deepening", "repeat", "stale", "new", "newly_scoreable", "unknown"];
@@ -235,7 +236,7 @@ function computeRepeatedIssueCount(runDir, round, issues) {
   let repeating = new Set(issues.map(fingerprintIssue));
   let count = 1;
   scanPriorVerdicts(runDir, round, (verdict) => {
-    if (verdict.verdict !== "changes_requested" || !Array.isArray(verdict.issues) || verdict.issues.length === 0) {
+    if (getAppliedVerdict(verdict) !== "changes_requested" || !Array.isArray(verdict.issues) || verdict.issues.length === 0) {
       return false;
     }
     const prior = new Set(verdict.issues.map(fingerprintIssue));

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -8,6 +8,7 @@ const {
 } = require("./score-utils");
 
 const ALLOWED_VERDICTS = new Set(["pass", "changes_requested", "escalated"]);
+const ALLOWED_APPLIED_VERDICTS = new Set(["pass", "changes_requested", "escalated"]);
 const ALLOWED_NEXT_ACTIONS = new Set(["publish_pending", "ready_to_merge", "changes_requested", "escalated"]);
 const ALLOWED_REVIEW_STATUSES = new Set(["pass", "fail", "not_run"]);
 const ALLOWED_EXECUTION_STATUSES = new Set(["pass", "fail", "not_run", "missing"]);
@@ -73,6 +74,12 @@ function isLowConfidenceAdvisoryPass(verdict) {
     && Array.isArray(verdict.issues)
     && verdict.issues.length > 0
     && verdict.issues.every((issue) => issue?.confidence === "low");
+}
+
+function getAppliedVerdict(verdict) {
+  if (ALLOWED_APPLIED_VERDICTS.has(verdict?.applied_verdict)) return verdict.applied_verdict;
+  if (isLowConfidenceAdvisoryPass(verdict)) return "pass";
+  return verdict?.verdict || null;
 }
 
 function buildConfidenceDowngrade(verdict) {
@@ -266,6 +273,7 @@ function validateReviewVerdict(data, options = {}) {
 }
 
 module.exports = {
+  ALLOWED_APPLIED_VERDICTS,
   ALLOWED_EXECUTION_STATUSES,
   ALLOWED_ISSUE_CONFIDENCE_VALUES,
   ALLOWED_LINEAGE_VALUES,
@@ -273,6 +281,7 @@ module.exports = {
   ALLOWED_REVIEW_STATUSES,
   buildConfidenceDowngrade,
   buildLowConfidencePassGateVerdict,
+  getAppliedVerdict,
   isLowConfidenceAdvisoryPass,
   parseReviewVerdict,
   validateIssue,

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -13,6 +13,9 @@ const ALLOWED_REVIEW_STATUSES = new Set(["pass", "fail", "not_run"]);
 const ALLOWED_EXECUTION_STATUSES = new Set(["pass", "fail", "not_run", "missing"]);
 const ALLOWED_SCORE_TIERS = new Set(["contract", "quality"]);
 const ALLOWED_LINEAGE_VALUES = new Set(["new", "deepening", "repeat", "stale", "newly_scoreable", "unknown"]);
+const ALLOWED_ISSUE_CONFIDENCE_VALUES = new Set(
+  REVIEW_VERDICT_JSON_SCHEMA.properties.issues.items.properties.confidence.enum
+);
 const OPTIONAL_ISSUE_REJECTION_METADATA = ["factor", "attempted_approach", "fix_direction"];
 const ALLOWED_DRIFT_STATUSES = new Set(
   REVIEW_VERDICT_JSON_SCHEMA.properties.scope_drift.properties.missing.items.properties.status.enum
@@ -49,6 +52,9 @@ function validateIssue(issue, index) {
   if (!Number.isInteger(issue.line) || issue.line <= 0) {
     throw new Error(`${location}.line must be a positive integer`);
   }
+  if (!ALLOWED_ISSUE_CONFIDENCE_VALUES.has(issue.confidence)) {
+    throw new Error(`${location}.confidence must be one of: ${Array.from(ALLOWED_ISSUE_CONFIDENCE_VALUES).join(", ")}`);
+  }
   for (const key of OPTIONAL_ISSUE_REJECTION_METADATA) {
     if (issue[key] !== undefined && issue[key] !== null && !String(issue[key] || "").trim()) {
       throw new Error(`${location}.${key} must be a non-empty string, null, or absent`);
@@ -60,6 +66,23 @@ function validateIssue(issue, index) {
   if (issue.relates_to !== undefined && issue.relates_to !== null && (typeof issue.relates_to !== "string" || !issue.relates_to.trim())) {
     throw new Error(`${location}.relates_to must be a non-empty string or null when present`);
   }
+}
+
+function isLowConfidenceAdvisoryPass(verdict) {
+  return verdict?.verdict === "changes_requested"
+    && Array.isArray(verdict.issues)
+    && verdict.issues.length > 0
+    && verdict.issues.every((issue) => issue?.confidence === "low");
+}
+
+function buildConfidenceDowngrade(verdict) {
+  const lowConfidenceCount = Array.isArray(verdict?.issues)
+    ? verdict.issues.filter((issue) => issue?.confidence === "low").length
+    : 0;
+  return {
+    applied: isLowConfidenceAdvisoryPass(verdict),
+    lowConfidenceCount,
+  };
 }
 
 function validateRubricScore(score, index) {
@@ -232,9 +255,12 @@ function validateReviewVerdict(data, options = {}) {
 
 module.exports = {
   ALLOWED_EXECUTION_STATUSES,
+  ALLOWED_ISSUE_CONFIDENCE_VALUES,
   ALLOWED_LINEAGE_VALUES,
   ALLOWED_SCORE_TIERS,
   ALLOWED_REVIEW_STATUSES,
+  buildConfidenceDowngrade,
+  isLowConfidenceAdvisoryPass,
   parseReviewVerdict,
   validateIssue,
   validateReviewVerdict,

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -69,11 +69,22 @@ function validateIssue(issue, index) {
   }
 }
 
+function hasBlockingRubricScores(verdict) {
+  return (Array.isArray(verdict?.rubric_scores) ? verdict.rubric_scores : []).some((score) => {
+    if (score?.status === "fail") return true;
+    if (score?.tier !== "quality") return false;
+    const numericScore = getRubricScoreNumber(score);
+    const targetScore = getRubricTargetNumber(score);
+    return numericScore !== null && targetScore !== null && numericScore < targetScore;
+  });
+}
+
 function isLowConfidenceAdvisoryPass(verdict) {
   return verdict?.verdict === "changes_requested"
     && Array.isArray(verdict.issues)
     && verdict.issues.length > 0
-    && verdict.issues.every((issue) => issue?.confidence === "low");
+    && verdict.issues.every((issue) => issue?.confidence === "low")
+    && !hasBlockingRubricScores(verdict);
 }
 
 function getAppliedVerdict(verdict) {
@@ -282,6 +293,7 @@ module.exports = {
   buildConfidenceDowngrade,
   buildLowConfidencePassGateVerdict,
   getAppliedVerdict,
+  hasBlockingRubricScores,
   isLowConfidenceAdvisoryPass,
   parseReviewVerdict,
   validateIssue,

--- a/skills/relay-review/scripts/review-runner/verdict.js
+++ b/skills/relay-review/scripts/review-runner/verdict.js
@@ -85,6 +85,18 @@ function buildConfidenceDowngrade(verdict) {
   };
 }
 
+function buildLowConfidencePassGateVerdict(verdict, passNextActions = ["ready_to_merge"]) {
+  const nextActions = Array.isArray(passNextActions)
+    ? passNextActions
+    : Array.from(passNextActions || []);
+  return {
+    ...verdict,
+    verdict: "pass",
+    next_action: nextActions[0] || "ready_to_merge",
+    issues: [],
+  };
+}
+
 function validateRubricScore(score, index) {
   const location = `rubric_scores[${index}]`;
   if (!score || typeof score !== "object" || Array.isArray(score)) {
@@ -260,6 +272,7 @@ module.exports = {
   ALLOWED_SCORE_TIERS,
   ALLOWED_REVIEW_STATUSES,
   buildConfidenceDowngrade,
+  buildLowConfidencePassGateVerdict,
   isLowConfidenceAdvisoryPass,
   parseReviewVerdict,
   validateIssue,

--- a/skills/relay-review/scripts/review-schema.js
+++ b/skills/relay-review/scripts/review-schema.js
@@ -41,6 +41,7 @@ const REVIEW_VERDICT_PROPERTIES = {
         "line",
         "category",
         "severity",
+        "confidence",
         "factor",
         "attempted_approach",
         "fix_direction",
@@ -54,6 +55,10 @@ const REVIEW_VERDICT_PROPERTIES = {
         line: { type: "integer", minimum: 1 },
         category: { type: "string", minLength: 1 },
         severity: { type: "string", minLength: 1 },
+        confidence: {
+          type: "string",
+          enum: ["low", "medium", "high"],
+        },
         ...REJECTION_METADATA_PROPERTIES,
         lineage: {
           type: "string",

--- a/tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js
@@ -19,8 +19,7 @@ test("dispatch timeout diagnostics distinguish total_timeout and no_result", () 
 
 test("advisory timeout wording includes reviewer model and raw response", () => {
   const source = fs.readFileSync(ADVISORY_SCRIPT, "utf-8");
-  assert.match(source, /reviewer advisory_review exceeded/);
-  assert.match(source, /timeout/);
+  assert.match(source, /reviewer advisory_review timed out after/);
   assert.ok(source.includes("model=${request.reviewerModel || \"default\"}"));
   assert.ok(source.includes("raw_response=${rawResponsePath}"));
 });

--- a/tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-timeout-diagnostics.test.js
@@ -19,7 +19,8 @@ test("dispatch timeout diagnostics distinguish total_timeout and no_result", () 
 
 test("advisory timeout wording includes reviewer model and raw response", () => {
   const source = fs.readFileSync(ADVISORY_SCRIPT, "utf-8");
-  assert.match(source, /reviewer advisory_review timed out after/);
+  assert.match(source, /reviewer advisory_review exceeded/);
+  assert.match(source, /timeout/);
   assert.ok(source.includes("model=${request.reviewerModel || \"default\"}"));
   assert.ok(source.includes("raw_response=${rawResponsePath}"));
 });

--- a/tests/relay-review/scripts/convergence.test.js
+++ b/tests/relay-review/scripts/convergence.test.js
@@ -98,6 +98,25 @@ test("round 3 summary lists repeated factors, lineage counts, score trends, and 
   assert.deepEqual(summary.flip_candidates, [{ factor: "BEHAVIOR", trace: ["pass", "fail", "pass"] }]);
 });
 
+test("round 3 summary treats applied-pass advisory history as non-repeating", () => {
+  const runDir = tempRunDir();
+  writeVerdict(runDir, 2, {
+    verdict: "changes_requested",
+    applied_verdict: "pass",
+    issues: [issue({ line: 9, confidence: "low" })],
+    rubric_scores: [score("Behavior", 7, "pass")],
+  });
+  const verdict = {
+    verdict: "changes_requested",
+    issues: [issue({ line: 11, lineage: "repeat" })],
+    rubric_scores: [score("BEHAVIOR", 6, "fail")],
+  };
+
+  const summary = buildSummary({ runDir, round: 3, verdict, repeatedIssueCount: 1 });
+
+  assert.deepEqual(summary.repeated_factors, []);
+});
+
 test("round 5 summary recommends an operator decision path", async (t) => {
   await t.test("decide_semantics", () => {
     const runDir = tempRunDir();

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -86,7 +86,7 @@ function changesRequestedVerdict() {
       file: "README.md",
       line: 1,
       category: "contract",
-      severity: "high",
+      severity: "high", confidence: "high",
     }],
   };
 }

--- a/tests/relay-review/scripts/review-runner-comment.test.js
+++ b/tests/relay-review/scripts/review-runner-comment.test.js
@@ -45,3 +45,27 @@ test("comment/buildCommentBody preserves rubric gate failures as CHANGES_REQUEST
   assert.match(body, /Quality Execution: MISSING/);
   assert.match(body, /Recovery command: node dispatch\.js/);
 });
+
+test("comment/buildCommentBody surfaces downgraded low-confidence findings as non-blocking notes", () => {
+  const body = buildCommentBody({
+    verdict: "changes_requested",
+    summary: "Only speculative findings remain.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    issues: [{
+      title: "Consider tighter naming",
+      body: "This may be easier to scan with a more specific helper name.",
+      file: "src/view.js",
+      line: 7,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+    }],
+  }, 4);
+
+  assert.match(body, /Verdict: LGTM/);
+  assert.match(body, /Low-confidence findings \(non-blocking\):/);
+  assert.match(body, /src\/view\.js:7 — \[low\] Consider tighter naming/);
+  assert.doesNotMatch(body, /Verdict: CHANGES_REQUESTED/);
+});

--- a/tests/relay-review/scripts/review-runner-manifest-apply.test.js
+++ b/tests/relay-review/scripts/review-runner-manifest-apply.test.js
@@ -131,6 +131,18 @@ function makeVerdict(verdict, nextAction) {
   };
 }
 
+function makeIssue(confidence = "high") {
+  return {
+    title: "Check auth flow",
+    body: "The auth branch may skip token refresh.",
+    file: "src/auth.js",
+    line: 42,
+    category: "bug",
+    severity: "high",
+    confidence,
+  };
+}
+
 function normalizeUpdatedTimestamp(manifest) {
   return {
     ...manifest,
@@ -315,6 +327,66 @@ test("manifest-apply/applyVerdictToManifest preserves the CHANGES_REQUESTED fiel
       last_gate: null,
     },
   });
+});
+
+test("manifest-apply/applyVerdictToManifest downgrades only all-low-confidence changes_requested verdicts", async (t) => {
+  const cases = [
+    {
+      label: "all-low changes_requested becomes external ready_to_merge",
+      state: STATES.REVIEW_PENDING,
+      verdict: { ...makeVerdict("changes_requested", "changes_requested"), issues: [makeIssue("low"), makeIssue("low")] },
+      expectedState: STATES.READY_TO_MERGE,
+      expectedAction: "await_explicit_merge",
+      expectedLatest: "lgtm",
+      expectedRepeated: 0,
+    },
+    {
+      label: "all-low internal changes_requested becomes publish_pending",
+      state: STATES.INTERNAL_REVIEW_PENDING,
+      verdict: { ...makeVerdict("changes_requested", "changes_requested"), issues: [makeIssue("low")] },
+      expectedState: STATES.PUBLISH_PENDING,
+      expectedAction: "publish_pr",
+      expectedLatest: "internal_lgtm",
+      expectedRepeated: 0,
+    },
+    {
+      label: "medium confidence remains changes_requested",
+      state: STATES.REVIEW_PENDING,
+      verdict: { ...makeVerdict("changes_requested", "changes_requested"), issues: [makeIssue("low"), makeIssue("medium")] },
+      expectedState: STATES.CHANGES_REQUESTED,
+      expectedAction: "re_dispatch_requested_changes",
+      expectedLatest: "changes_requested",
+      expectedRepeated: 4,
+    },
+    {
+      label: "high confidence remains changes_requested",
+      state: STATES.REVIEW_PENDING,
+      verdict: { ...makeVerdict("changes_requested", "changes_requested"), issues: [makeIssue("high")] },
+      expectedState: STATES.CHANGES_REQUESTED,
+      expectedAction: "re_dispatch_requested_changes",
+      expectedLatest: "changes_requested",
+      expectedRepeated: 4,
+    },
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.label, () => {
+      const manifest = createManifestInState(testCase.state);
+      const result = applyVerdictToManifest(
+        manifest,
+        testCase.verdict,
+        3,
+        testCase.state === STATES.INTERNAL_REVIEW_PENDING ? null : 189,
+        "abc123",
+        4
+      );
+
+      assert.equal(result.state, testCase.expectedState);
+      assert.equal(result.next_action, testCase.expectedAction);
+      assert.equal(result.review.latest_verdict, testCase.expectedLatest);
+      assert.equal(result.review.repeated_issue_count, testCase.expectedRepeated);
+    });
+  }
 });
 
 test("manifest-apply/applyVerdictToManifest refreshes same-state CHANGES_REQUESTED without a transition", () => {

--- a/tests/relay-review/scripts/review-runner-prompt.test.js
+++ b/tests/relay-review/scripts/review-runner-prompt.test.js
@@ -230,6 +230,30 @@ test("prompt/formatPriorVerdictSummary includes lineage counts without rejection
   assert.doesNotMatch(summary, /Previously rejected approaches/);
 });
 
+test("prompt/formatPriorVerdictSummary labels applied-pass advisory rounds without rejected approaches", () => {
+  const summary = formatPriorVerdictSummary([{
+    verdict: "changes_requested",
+    applied_verdict: "pass",
+    summary: "Only advisory naming notes remain.",
+    issues: [{
+      title: "Consider clearer naming",
+      body: "The helper name may be easier to scan.",
+      file: "src/a.js",
+      line: 12,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+      factor: "Readability",
+      attempted_approach: "Kept the helper name unchanged.",
+      fix_direction: "Rename only if it improves readability.",
+    }],
+    rubric_scores: [],
+  }]);
+
+  assert.match(summary, /Round 1: changes_requested \(applied: pass\) — Only advisory naming notes remain/);
+  assert.doesNotMatch(summary, /Previously rejected approaches/);
+});
+
 test("prompt/formatPriorVerdictSummary groups rejection metadata by factor and caps latest entries", () => {
   const summary = formatPriorVerdictSummary([
     {

--- a/tests/relay-review/scripts/review-runner-redispatch.test.js
+++ b/tests/relay-review/scripts/review-runner-redispatch.test.js
@@ -108,6 +108,23 @@ test("redispatch/computeRepeatedIssueCount keeps identical non-regression finger
   });
 });
 
+test("redispatch/computeRepeatedIssueCount treats applied-pass downgrade history as a pass boundary", () => {
+  const runDir = tempRunDir();
+  const issue = { file: "repeat-after-downgrade.js", line: 14, category: "bug", title: "Keep retry guard" };
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({
+    verdict: "changes_requested",
+    applied_verdict: "changes_requested",
+    issues: [issue],
+  }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({
+    verdict: "changes_requested",
+    applied_verdict: "pass",
+    issues: [{ ...issue, line: 27, confidence: "low" }],
+  }), "utf-8");
+
+  assert.equal(computeRepeatedIssueCount(runDir, 3, [{ ...issue, line: 42 }]), 1);
+});
+
 test("redispatch/scanPriorVerdicts walks reverse-chronological rounds and skips missing files", () => {
   const runDir = tempRunDir();
   for (const round of [1, 3, 4]) {

--- a/tests/relay-review/scripts/review-runner-verdict.test.js
+++ b/tests/relay-review/scripts/review-runner-verdict.test.js
@@ -17,6 +17,7 @@ function makeIssue(overrides = {}) {
     file: "skills/relay-review/scripts/review-runner.js",
     category: "bug",
     severity: "high",
+    confidence: "high",
     line: 42,
     ...overrides,
   };
@@ -186,6 +187,16 @@ test("verdict/validateIssue preserves the malformed-field matrix", async (t) => 
       label: "missing severity",
       issue: makeIssue({ severity: "" }),
       expected: /issues\[0\]\.severity is required/,
+    },
+    {
+      label: "missing confidence",
+      issue: makeIssue({ confidence: undefined }),
+      expected: /issues\[0\]\.confidence must be one of: low, medium, high/,
+    },
+    {
+      label: "invalid confidence",
+      issue: makeIssue({ confidence: "certain" }),
+      expected: /issues\[0\]\.confidence must be one of: low, medium, high/,
     },
     {
       label: "line must be positive integer",

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -683,7 +683,7 @@ test("review-runner snapshots PR body separately for round 2", () => {
       file: "README.md",
       line: 1,
       category: "contract",
-      severity: "high",
+      severity: "high", confidence: "high",
     }],
     rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
@@ -1277,7 +1277,7 @@ test("review-runner fail-closes reviewer PASS into changes_requested when execut
   const commentBody = fs.readFileSync(commentCapturePath, "utf-8");
 
   const manifest = readManifest(manifestPath).data;
-  const reviewApplyEvent = readRunEvents(repoRoot, runId).find((event) => event.event === "review_apply");
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
 
   assert.equal(result.appliedVerdict, "changes_requested");
   assert.equal(result.state, STATES.CHANGES_REQUESTED);
@@ -1318,7 +1318,7 @@ test("review-runner stores the runner-computed quality_execution_status in the v
       file: "src/index.js",
       line: 10,
       category: "contract",
-      severity: "high",
+      severity: "high", confidence: "high",
     }],
     rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
@@ -1397,7 +1397,7 @@ test("review-runner fail-closes reviewer PASS into changes_requested when execut
   const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
   const commentBody = fs.readFileSync(commentCapturePath, "utf-8");
   const manifest = readManifest(manifestPath).data;
-  const reviewApplyEvent = readRunEvents(repoRoot, runId).find((event) => event.event === "review_apply");
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
 
   assert.equal(result.appliedVerdict, "changes_requested");
   assert.equal(result.state, STATES.CHANGES_REQUESTED);
@@ -1580,7 +1580,7 @@ test("changes_requested verdict creates a re-dispatch artifact", () => {
         file: "src/index.js",
         line: 12,
         category: "contract",
-        severity: "high",
+        severity: "high", confidence: "high",
       },
     ],
     rubric_scores: defaultRubricScores(),
@@ -1616,6 +1616,74 @@ test("changes_requested verdict creates a re-dispatch artifact", () => {
   assert.deepEqual(manifest.review.last_lineage_summary, { deepening: 0, repeat: 0, stale: 0, new: 0, newly_scoreable: 0, unknown: 1 });
 });
 
+test("all-low-confidence changes_requested verdict applies as advisory pass while preserving findings", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath, runId } = setupRepo();
+  const reviewFile = writeVerdict(repoRoot, "low-confidence-changes.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative quality notes remain.",
+    contract_status: "pass",
+    quality_review_status: "fail",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [
+      {
+        title: "Consider clearer helper naming",
+        body: "The helper name may be easier to scan if it mentions the state it returns.",
+        file: "src/index.js",
+        line: 12,
+        category: "quality",
+        severity: "low",
+        confidence: "low",
+      },
+      {
+        title: "Consider localizing the loop variable",
+        body: "The loop variable is readable as-is, but a narrower name might reduce scan time.",
+        file: "src/index.js",
+        line: 20,
+        category: "quality",
+        severity: "low",
+        confidence: "low",
+      },
+    ],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  const manifest = readManifest(manifestPath).data;
+  const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
+
+  assert.equal(result.appliedVerdict, "pass");
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.redispatchPath, null);
+  assert.deepEqual(result.confidenceDowngrade, {
+    originalVerdict: "changes_requested",
+    appliedVerdict: "pass",
+    lowConfidenceCount: 2,
+  });
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.equal(manifest.review.latest_verdict, "lgtm");
+  assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.issues.length, 2);
+  assert.ok(verdictRecord.issues.every((issue) => issue.confidence === "low"));
+  assert.equal(reviewApplyEvent?.reason, "changes_requested");
+  assert.equal(reviewApplyEvent?.confidence_downgrade, true);
+  assert.equal(reviewApplyEvent?.low_confidence_count, 2);
+});
+
 test("review-runner records rubric_scores as iteration_score events", () => {
   const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
   const reviewFile = writeVerdict(repoRoot, "changes-with-scores.json", {
@@ -1632,7 +1700,7 @@ test("review-runner records rubric_scores as iteration_score events", () => {
         file: "src/index.js",
         line: 12,
         category: "contract",
-        severity: "high",
+        severity: "high", confidence: "high",
       },
     ],
     rubric_scores: [
@@ -1731,7 +1799,7 @@ test("review-runner records score divergence and appends warning text to the PR 
         file: "src/index.js",
         line: 12,
         category: "contract",
-        severity: "high",
+        severity: "high", confidence: "high",
       },
     ],
     rubric_scores: [
@@ -1826,7 +1894,7 @@ test("review-runner keeps event journals on the manifest repo slug when --repo i
         file: "src/index.js",
         line: 12,
         category: "contract",
-        severity: "high",
+        severity: "high", confidence: "high",
       },
     ],
     rubric_scores: [
@@ -2074,7 +2142,7 @@ test("invalid pass verdict is rejected", () => {
         file: "x.js",
         line: 1,
         category: "contract",
-        severity: "low",
+        severity: "low", confidence: "low",
       },
     ],
     rubric_scores: defaultRubricScores(),
@@ -2232,7 +2300,7 @@ test("invalid scope_drift missing status is rejected", () => {
     contract_status: "fail",
     quality_review_status: "not_run",
     next_action: "changes_requested",
-    issues: [{ title: "Missing", body: "Not implemented", file: "x.js", line: 1, category: "contract", severity: "high" }],
+    issues: [{ title: "Missing", body: "Not implemented", file: "x.js", line: 1, category: "contract", severity: "high", confidence: "high" }],
     rubric_scores: defaultRubricScores(),
     scope_drift: {
       creep: [],
@@ -2261,7 +2329,7 @@ test("changes_requested verdict with scope_drift includes drift in redispatch", 
     contract_status: "fail",
     quality_review_status: "not_run",
     next_action: "changes_requested",
-    issues: [{ title: "Creep", body: "Unrelated change", file: "extra.js", line: 1, category: "scope", severity: "medium" }],
+    issues: [{ title: "Creep", body: "Unrelated change", file: "extra.js", line: 1, category: "scope", severity: "medium", confidence: "medium" }],
     rubric_scores: defaultRubricScores(),
     scope_drift: {
       creep: [{ file: "extra.js", reason: "Not in Done Criteria" }],
@@ -2354,7 +2422,7 @@ process.stdout.write(JSON.stringify({
     file: "marker.txt",
     line: 1,
     category: "contract",
-    severity: "high"
+    severity: "high", confidence: "high"
   }],
   rubric_scores: ${JSON.stringify(defaultRubricScores())},
   scope_drift: { creep: [], missing: [] }
@@ -2426,7 +2494,7 @@ test("repeated identical issues escalate on the third consecutive round", () => 
         file: "src/index.js",
         line: 12,
         category: "contract",
-        severity: "high",
+        severity: "high", confidence: "high",
       },
     ],
     rubric_scores: defaultRubricScores(),
@@ -2501,7 +2569,7 @@ test("rubric factor flip-flops fail closed for stale lineage without waiting for
       file: "src/index.js",
       line: 12,
       category: "Behavior",
-      severity: "high",
+      severity: "high", confidence: "high",
       lineage: "stale",
       relates_to: "Round 2 Behavior",
     }],
@@ -2525,7 +2593,7 @@ test("formatPriorVerdictSummary produces correct round numbers and rubric summar
     {
       verdict: "changes_requested",
       summary: "Missing tests",
-      issues: [{ title: "a", body: "b", file: "x.js", line: 1, category: "contract", severity: "high" }],
+      issues: [{ title: "a", body: "b", file: "x.js", line: 1, category: "contract", severity: "high", confidence: "high" }],
       rubric_scores: [
         { factor: "Coverage", target: ">= 8", observed: "5", status: "fail", tier: "contract", notes: "low" },
       ],
@@ -2534,8 +2602,8 @@ test("formatPriorVerdictSummary produces correct round numbers and rubric summar
       verdict: "changes_requested",
       summary: "No auth guard",
       issues: [
-        { title: "c", body: "d", file: "y.js", line: 2, category: "quality", severity: "medium" },
-        { title: "e", body: "f", file: "z.js", line: 3, category: "contract", severity: "high" },
+        { title: "c", body: "d", file: "y.js", line: 2, category: "quality", severity: "medium", confidence: "medium" },
+        { title: "e", body: "f", file: "z.js", line: 3, category: "contract", severity: "high", confidence: "high" },
       ],
       rubric_scores: [],
     },
@@ -2613,7 +2681,7 @@ test("round 2 review prompt contains Prior Round Context section", () => {
       file: "src/index.js",
       line: 10,
       category: "contract",
-      severity: "high",
+      severity: "high", confidence: "high",
     }],
     rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
@@ -2672,7 +2740,7 @@ test("round 2 redispatch artifact contains prior round summary", () => {
       file: "src/index.js",
       line: 5,
       category: "contract",
-      severity: "high",
+      severity: "high", confidence: "high",
     }],
     rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
@@ -2706,7 +2774,7 @@ test("round 2 redispatch artifact contains prior round summary", () => {
       file: "src/index.js",
       line: 5,
       category: "contract",
-      severity: "high",
+      severity: "high", confidence: "high",
     }],
     rubric_scores: defaultRubricScores(),
     scope_drift: { creep: [], missing: [] },
@@ -2828,7 +2896,7 @@ test("buildRedispatchPrompt includes churn WARNING when churnGrowth is provided"
   fs.writeFileSync(helperPath, [
     `process.argv = ["node", "helper.js", "--repo", "/dev/null", "--branch", "x", "--pr", "1"];`,
     `const { buildRedispatchPrompt } = require(${JSON.stringify(SCRIPT)});`,
-    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high" }], scope_drift: { creep: [], missing: [] } };`,
+    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high", confidence: "high" }], scope_drift: { creep: [], missing: [] } };`,
     `const churn = { prevPrevLines: 50, prevLines: 80, curLines: 120 };`,
     `const result = buildRedispatchPrompt(verdict, "AC: do X", null, 3, churn);`,
     `process.stdout.write(result);`,
@@ -2843,7 +2911,7 @@ test("buildRedispatchPrompt omits churn WARNING when churnGrowth is null", () =>
   fs.writeFileSync(helperPath, [
     `process.argv = ["node", "helper.js", "--repo", "/dev/null", "--branch", "x", "--pr", "1"];`,
     `const { buildRedispatchPrompt } = require(${JSON.stringify(SCRIPT)});`,
-    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high" }], scope_drift: { creep: [], missing: [] } };`,
+    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high", confidence: "high" }], scope_drift: { creep: [], missing: [] } };`,
     `const result = buildRedispatchPrompt(verdict, "AC: do X", null, 3, null);`,
     `process.stdout.write(result);`,
   ].join("\n"), "utf-8");
@@ -2861,7 +2929,7 @@ test("buildRedispatchPrompt includes prior-round factor flips", () => {
   fs.writeFileSync(helperPath, [
     `process.argv = ["node", "helper.js", "--repo", "/dev/null", "--branch", "x", "--pr", "1"];`,
     `const { buildRedispatchPrompt } = require(${JSON.stringify(SCRIPT)});`,
-    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high" }], scope_drift: { creep: [], missing: [] } };`,
+    `const verdict = { verdict: "changes_requested", summary: "test", issues: [{ title: "t", body: "b", file: "x.js", line: 1, category: "contract", severity: "high", confidence: "high" }], scope_drift: { creep: [], missing: [] } };`,
     `process.stdout.write(buildRedispatchPrompt(verdict, "AC: do X", ${JSON.stringify(runDir)}, 4, null));`,
   ].join("\n"), "utf-8");
   const out = execFileSync("node", [helperPath], { encoding: "utf-8" });

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -1692,6 +1692,124 @@ test("all-low-confidence changes_requested verdict applies as advisory pass whil
   assert.equal(reviewApplyEvent?.low_confidence_count, 2);
 });
 
+test("all-low-confidence changes_requested verdict with a failing rubric score stays changes_requested", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath, runId } = setupRepo();
+  const reviewFile = writeVerdict(repoRoot, "low-confidence-failing-rubric-score.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative notes remain, but the rubric still fails.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Consider clearer helper naming",
+      body: "The helper name may be easier to scan if it mentions the state it returns.",
+      file: "src/index.js",
+      line: 12,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+    }],
+    rubric_scores: [{
+      factor: "Default enforcement rubric",
+      target: ">= 1/1",
+      observed: "0/1",
+      status: "fail",
+      tier: "contract",
+      notes: "The enforcement fixture rubric is not satisfied.",
+    }],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" }));
+  const manifest = readManifest(manifestPath).data;
+  const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
+
+  assert.equal(result.appliedVerdict, "changes_requested");
+  assert.equal(result.confidenceDowngrade, null);
+  assert.equal(result.state, STATES.CHANGES_REQUESTED);
+  assert.ok(result.redispatchPath);
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+  assert.equal(manifest.next_action, "re_dispatch_requested_changes");
+  assert.equal(manifest.review.latest_verdict, "changes_requested");
+  assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.applied_verdict, "changes_requested");
+  assert.equal(verdictRecord.rubric_scores[0].status, "fail");
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
+});
+
+test("all-low-confidence changes_requested verdict with a below-target quality score stays changes_requested", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath, runId } = setupRepo();
+  const reviewFile = writeVerdict(repoRoot, "low-confidence-below-target-quality-score.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative notes remain, but a required quality factor is below target.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Consider clearer helper naming",
+      body: "The helper name may be easier to scan if it mentions the state it returns.",
+      file: "src/index.js",
+      line: 12,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+    }],
+    rubric_scores: [{
+      factor: "Implementation clarity",
+      target: ">= 8/10",
+      observed: "7/10",
+      score: 7,
+      target_score: 8,
+      status: "not_run",
+      tier: "quality",
+      notes: "Reviewer did not mark fail, but the score is below the required target.",
+    }],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" }));
+  const manifest = readManifest(manifestPath).data;
+  const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
+
+  assert.equal(result.appliedVerdict, "changes_requested");
+  assert.equal(result.confidenceDowngrade, null);
+  assert.equal(result.state, STATES.CHANGES_REQUESTED);
+  assert.ok(result.redispatchPath);
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+  assert.equal(manifest.next_action, "re_dispatch_requested_changes");
+  assert.equal(manifest.review.latest_verdict, "changes_requested");
+  assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.applied_verdict, "changes_requested");
+  assert.equal(verdictRecord.rubric_scores[0].score, 7);
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
+});
+
 test("all-low-confidence changes_requested verdict is rejected by pass scope-drift gates", () => {
   const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
   const reviewFile = writeVerdict(repoRoot, "low-confidence-scope-drift.json", {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -2756,6 +2756,83 @@ test("rubric factor flip-flops preserve pass verdicts when there are zero repeat
   assert.equal(manifest.review.last_escalation_decision.reason, "progressive_deepening");
 });
 
+test("low-confidence downgrade is pass-equivalent for flip-flop escalation", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "Behavior", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "behavior", status: "fail" }] }), "utf-8");
+  updateManifestRecord(manifestPath, (data) => ({ ...data, review: { ...(data.review || {}), rounds: 2 } }));
+  const reviewFile = writeVerdict(repoRoot, "flip-low-confidence.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative behavior notes remain.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Consider clearer behavior helper naming",
+      body: "The helper name may be easier to scan if it mentions behavior.",
+      file: "src/index.js",
+      line: 12,
+      category: "Behavior",
+      severity: "low",
+      confidence: "low",
+    }],
+    rubric_scores: [{ factor: "BEHAVIOR", target: ">= 1/1", observed: "1/1", status: "pass", tier: "contract", notes: "Recovered." }],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123", "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath, "--review-file", reviewFile, "--no-comment", "--json"], { encoding: "utf-8" }));
+  const verdict = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  const manifest = readManifest(manifestPath).data;
+
+  assert.equal(result.appliedVerdict, "pass");
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.repeatedIssueCount, 0);
+  assert.equal(verdict.verdict, "changes_requested");
+  assert.equal(verdict.issues[0].confidence, "low");
+  assert.equal(manifest.review.latest_verdict, "lgtm");
+  assert.equal(manifest.review.last_escalation_decision.decision, "continue");
+  assert.equal(manifest.review.last_escalation_decision.reason, "progressive_deepening");
+  assert.deepEqual(manifest.review.last_lineage_summary, { deepening: 0, repeat: 0, stale: 0, new: 0, newly_scoreable: 0, unknown: 0 });
+});
+
+test("genuine changes_requested still escalates on pass-fail-pass flip-flop", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  fs.writeFileSync(path.join(runDir, "review-round-1-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "Behavior", status: "pass" }] }), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-verdict.json"), JSON.stringify({ verdict: "changes_requested", rubric_scores: [{ factor: "behavior", status: "fail" }] }), "utf-8");
+  updateManifestRecord(manifestPath, (data) => ({ ...data, review: { ...(data.review || {}), rounds: 2 } }));
+  const reviewFile = writeVerdict(repoRoot, "flip-genuine-changes.json", {
+    verdict: "changes_requested",
+    summary: "Behavior blocker remains.",
+    contract_status: "fail",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Behavior blocker remains",
+      body: "The current behavior still misses a done criteria branch.",
+      file: "src/index.js",
+      line: 12,
+      category: "Behavior",
+      severity: "high",
+      confidence: "high",
+    }],
+    rubric_scores: [{ factor: "BEHAVIOR", target: ">= 1/1", observed: "1/1", status: "pass", tier: "contract", notes: "Recovered score conflicts with blocker." }],
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123", "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath, "--review-file", reviewFile, "--no-comment", "--json"], { encoding: "utf-8" }));
+  const manifest = readManifest(manifestPath).data;
+
+  assert.equal(result.appliedVerdict, "escalated");
+  assert.equal(result.state, STATES.ESCALATED);
+  assert.equal(manifest.review.latest_verdict, "escalated");
+  assert.equal(manifest.review.last_escalation_decision.decision, "escalate");
+  assert.equal(manifest.review.last_escalation_decision.reason, "flip_flop_thrash");
+});
+
 test("rubric factor flip-flops fail closed for stale lineage without waiting for three repeats", () => {
   const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
   const runDir = ensureRunLayout(repoRoot, runId).runDir;

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -1162,6 +1162,7 @@ test("pass verdict preserves assigned reviewer role and records the acting revie
   assert.equal(manifest.roles.reviewer, "claude");
   assert.equal(manifest.review.last_reviewer, "codex");
   assert.equal(reviewApplyEvent?.reviewer, "codex");
+  assert.equal(reviewApplyEvent?.reason, "pass");
   assert.equal("confidence_downgrade" in reviewApplyEvent, false);
   assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });
@@ -1617,6 +1618,7 @@ test("changes_requested verdict creates a re-dispatch artifact", () => {
   assert.equal(manifest.review.latest_verdict, "changes_requested");
   assert.equal(manifest.review.repeated_issue_count, 1);
   assert.deepEqual(manifest.review.last_lineage_summary, { deepening: 0, repeat: 0, stale: 0, new: 0, newly_scoreable: 0, unknown: 1 });
+  assert.equal(reviewApplyEvent?.reason, "changes_requested");
   assert.equal("confidence_downgrade" in reviewApplyEvent, false);
   assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });
@@ -1684,7 +1686,7 @@ test("all-low-confidence changes_requested verdict applies as advisory pass whil
   assert.equal(verdictRecord.verdict, "changes_requested");
   assert.equal(verdictRecord.issues.length, 2);
   assert.ok(verdictRecord.issues.every((issue) => issue.confidence === "low"));
-  assert.equal(reviewApplyEvent?.reason, "changes_requested");
+  assert.equal(reviewApplyEvent?.reason, "pass");
   assert.equal(reviewApplyEvent?.confidence_downgrade, true);
   assert.equal(reviewApplyEvent?.low_confidence_count, 2);
 });

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -1684,6 +1684,7 @@ test("all-low-confidence changes_requested verdict applies as advisory pass whil
   assert.equal(manifest.state, STATES.READY_TO_MERGE);
   assert.equal(manifest.review.latest_verdict, "lgtm");
   assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.applied_verdict, "pass");
   assert.equal(verdictRecord.issues.length, 2);
   assert.ok(verdictRecord.issues.every((issue) => issue.confidence === "low"));
   assert.equal(reviewApplyEvent?.reason, "pass");
@@ -1781,6 +1782,7 @@ test("all-low-confidence changes_requested verdict is blocked by failed executio
   assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
   assert.equal(manifest.review.latest_verdict, "changes_requested");
   assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.applied_verdict, "changes_requested");
   assert.equal(verdictRecord.issues[0].file, EXECUTION_EVIDENCE_FILENAME);
   assert.equal("confidence_downgrade" in reviewApplyEvent, false);
   assert.equal("low_confidence_count" in reviewApplyEvent, false);
@@ -1833,6 +1835,7 @@ test("all-low-confidence changes_requested verdict is blocked by rubric gate fai
   assert.equal(manifest.next_action, "repair_rubric_and_redispatch");
   assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
   assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.applied_verdict, "changes_requested");
   assert.equal(verdictRecord.issues[0].confidence, "low");
   assert.equal(verdictRecord.relay_gate.status, "rubric_state_failed_closed");
   assert.equal("confidence_downgrade" in reviewApplyEvent, false);
@@ -1885,9 +1888,11 @@ test("mixed-confidence changes_requested verdict records no downgrade event mark
   ], { encoding: "utf-8" });
 
   const result = JSON.parse(stdout);
+  const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
   const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
 
   assert.equal(result.appliedVerdict, "changes_requested");
+  assert.equal(verdictRecord.applied_verdict, "changes_requested");
   assert.equal("confidence_downgrade" in reviewApplyEvent, false);
   assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -1162,6 +1162,8 @@ test("pass verdict preserves assigned reviewer role and records the acting revie
   assert.equal(manifest.roles.reviewer, "claude");
   assert.equal(manifest.review.last_reviewer, "codex");
   assert.equal(reviewApplyEvent?.reviewer, "codex");
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });
 
 test("review-runner appends escalation_decision event on a clean no-trigger round", () => {
@@ -1565,7 +1567,7 @@ test("review-runner fails closed when branch+PR resolution only finds a stale te
 });
 
 test("changes_requested verdict creates a re-dispatch artifact", () => {
-  const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath, runId } = setupRepo();
   const reviewFile = writeVerdict(repoRoot, "changes.json", {
     verdict: "changes_requested",
     summary: "One requirement is missing.",
@@ -1608,12 +1610,15 @@ test("changes_requested verdict creates a re-dispatch artifact", () => {
   assert.match(redispatchText, /src\/index.js:12/);
 
   const manifest = readManifest(manifestPath).data;
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
   assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
   assert.equal(manifest.next_action, "re_dispatch_requested_changes");
   assert.equal(manifest.review.rounds, 1);
   assert.equal(manifest.review.latest_verdict, "changes_requested");
   assert.equal(manifest.review.repeated_issue_count, 1);
   assert.deepEqual(manifest.review.last_lineage_summary, { deepening: 0, repeat: 0, stale: 0, new: 0, newly_scoreable: 0, unknown: 1 });
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });
 
 test("all-low-confidence changes_requested verdict applies as advisory pass while preserving findings", () => {
@@ -1682,6 +1687,59 @@ test("all-low-confidence changes_requested verdict applies as advisory pass whil
   assert.equal(reviewApplyEvent?.reason, "changes_requested");
   assert.equal(reviewApplyEvent?.confidence_downgrade, true);
   assert.equal(reviewApplyEvent?.low_confidence_count, 2);
+});
+
+test("mixed-confidence changes_requested verdict records no downgrade event marker", () => {
+  const { repoRoot, doneCriteriaPath, diffPath, runId } = setupRepo();
+  const reviewFile = writeVerdict(repoRoot, "mixed-confidence-changes.json", {
+    verdict: "changes_requested",
+    summary: "One speculative issue and one blocking issue remain.",
+    contract_status: "fail",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [
+      {
+        title: "Consider clearer helper naming",
+        body: "The helper name may be easier to scan if it mentions the state it returns.",
+        file: "src/index.js",
+        line: 12,
+        category: "quality",
+        severity: "low",
+        confidence: "low",
+      },
+      {
+        title: "Missing smoke file",
+        body: "The PR does not add the required smoke.txt output.",
+        file: "src/index.js",
+        line: 20,
+        category: "contract",
+        severity: "high",
+        confidence: "high",
+      },
+    ],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
+
+  assert.equal(result.appliedVerdict, "changes_requested");
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });
 
 test("review-runner records rubric_scores as iteration_score events", () => {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -1627,7 +1627,7 @@ test("all-low-confidence changes_requested verdict applies as advisory pass whil
     verdict: "changes_requested",
     summary: "Only speculative quality notes remain.",
     contract_status: "pass",
-    quality_review_status: "fail",
+    quality_review_status: "pass",
     quality_execution_status: "pass",
     next_action: "changes_requested",
     issues: [
@@ -1687,6 +1687,154 @@ test("all-low-confidence changes_requested verdict applies as advisory pass whil
   assert.equal(reviewApplyEvent?.reason, "changes_requested");
   assert.equal(reviewApplyEvent?.confidence_downgrade, true);
   assert.equal(reviewApplyEvent?.low_confidence_count, 2);
+});
+
+test("all-low-confidence changes_requested verdict is rejected by pass scope-drift gates", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewFile = writeVerdict(repoRoot, "low-confidence-scope-drift.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative quality notes remain, but a Done Criteria item is partial.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Consider clearer helper naming",
+      body: "The helper name may be easier to scan if it mentions the state it returns.",
+      file: "src/index.js",
+      line: 12,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+    }],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: {
+      creep: [],
+      missing: [{ criteria: "Add smoke.txt", status: "partial" }],
+    },
+  });
+
+  assert.throws(() => execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
+    assert.match(String(error.stderr), /PASS verdict cannot have scope_drift\.missing entries with status not_done, changed, or partial/);
+    return true;
+  });
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.review.latest_verdict, "pending");
+});
+
+test("all-low-confidence changes_requested verdict is blocked by failed execution evidence", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath, runId } = setupRepo();
+  const runDir = ensureRunLayout(repoRoot, runId).runDir;
+  fs.unlinkSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME));
+  const reviewFile = writeVerdict(repoRoot, "low-confidence-missing-execution.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative quality notes remain.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Consider clearer helper naming",
+      body: "The helper name may be easier to scan if it mentions the state it returns.",
+      file: "src/index.js",
+      line: 12,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+    }],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" }));
+  const manifest = readManifest(manifestPath).data;
+  const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
+
+  assert.equal(result.appliedVerdict, "changes_requested");
+  assert.equal(result.confidenceDowngrade, null);
+  assert.equal(result.state, STATES.CHANGES_REQUESTED);
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+  assert.equal(manifest.review.latest_verdict, "changes_requested");
+  assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.issues[0].file, EXECUTION_EVIDENCE_FILENAME);
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
+});
+
+test("all-low-confidence changes_requested verdict is blocked by rubric gate failure", () => {
+  const { repoRoot, manifestPath, doneCriteriaPath, diffPath, runId } = setupRepo();
+  configureRubricFixture({ manifestPath, repoRoot, runId, state: "missing" });
+  const reviewFile = writeVerdict(repoRoot, "low-confidence-missing-rubric.json", {
+    verdict: "changes_requested",
+    summary: "Only speculative quality notes remain.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Consider clearer helper naming",
+      body: "The helper name may be easier to scan if it mentions the state it returns.",
+      file: "src/index.js",
+      line: 12,
+      category: "quality",
+      severity: "low",
+      confidence: "low",
+    }],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  });
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--branch", "issue-42",
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--review-file", reviewFile,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" }));
+  const manifest = readManifest(manifestPath).data;
+  const verdictRecord = JSON.parse(fs.readFileSync(result.verdictPath, "utf-8"));
+  const reviewApplyEvent = [...readRunEvents(repoRoot, runId)].reverse().find((event) => event.event === "review_apply");
+
+  assert.equal(result.appliedVerdict, "changes_requested");
+  assert.equal(result.confidenceDowngrade, null);
+  assert.equal(result.reviewGate.status, "rubric_state_failed_closed");
+  assert.equal(result.reviewGate.rubricState, "missing");
+  assert.equal(result.state, STATES.CHANGES_REQUESTED);
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+  assert.equal(manifest.next_action, "repair_rubric_and_redispatch");
+  assert.equal(manifest.review.latest_verdict, "rubric_state_failed_closed");
+  assert.equal(verdictRecord.verdict, "changes_requested");
+  assert.equal(verdictRecord.issues[0].confidence, "low");
+  assert.equal(verdictRecord.relay_gate.status, "rubric_state_failed_closed");
+  assert.equal("confidence_downgrade" in reviewApplyEvent, false);
+  assert.equal("low_confidence_count" in reviewApplyEvent, false);
 });
 
 test("mixed-confidence changes_requested verdict records no downgrade event marker", () => {

--- a/tests/relay-review/scripts/review-schema.test.js
+++ b/tests/relay-review/scripts/review-schema.test.js
@@ -33,7 +33,7 @@ test("schema/verdict issues mark rejection metadata as nullable+required (OpenAI
   }
 });
 
-test("schema/verdict issue required matrix lists all 11 properties (strict-mode complete)", async (t) => {
+test("schema/verdict issue required matrix lists all 12 properties (strict-mode complete)", async (t) => {
   for (const [label, schema] of [
     ["runner", REVIEW_VERDICT_JSON_SCHEMA],
     ["reviewer", REVIEWER_VERDICT_JSON_SCHEMA],
@@ -48,12 +48,30 @@ test("schema/verdict issue required matrix lists all 11 properties (strict-mode 
         "line",
         "category",
         "severity",
+        "confidence",
         "factor",
         "attempted_approach",
         "fix_direction",
         "lineage",
         "relates_to",
       ]);
+    });
+  }
+});
+
+test("schema/verdict issue confidence enum is required", async (t) => {
+  for (const [label, schema] of [
+    ["runner", REVIEW_VERDICT_JSON_SCHEMA],
+    ["reviewer", REVIEWER_VERDICT_JSON_SCHEMA],
+  ]) {
+    await t.test(label, () => {
+      const issue = issueSchema(schema);
+
+      assert.deepEqual(issue.properties.confidence, {
+        type: "string",
+        enum: ["low", "medium", "high"],
+      });
+      assert.equal(issue.required.includes("confidence"), true, "confidence must be required");
     });
   }
 });


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-306-20260708134824707-8762967a
- Branch: issue-306
- Reason: executor total_timeout after 5400s while collecting the final full-suite gate; implementation complete in retained worktree (17 files, 309 insertions); timeout-path placeholder evidence moved aside as execution-evidence.timeout-placeholder.json; operator ran relay-review suite serialized in the worktree: 450/450 pass
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-306-20260708134824707-8762967a.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-08T15:32:22.066Z

## Schema-change risk and mitigation (Done Criteria 8)

This PR adds a required `confidence` field to `issues[]` in both reviewer verdict schemas. That class of change carries the strict-mode bootstrap-paradox risk: the reviewer that reviews future rounds runs on the previously-installed schema, so a strict-mode-incompatible schema (an `additionalProperties:false` object whose properties are not all listed in `required`) would brick subsequent reviews. Mitigation: the structural invariant test in `tests/relay-review/scripts/review-runner-verdict.test.js` ("schema/strict-mode invariant") verifies every such object lists every property in `required`; it passes on this branch, and back-compat is fail-closed — pre-#306 payloads without `confidence` are rejected with an error naming the field rather than silently defaulted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리뷰 이슈에 `high/medium/low` 신뢰도를 표시하고, 저신뢰는 비차단 안내 섹션으로 별도 렌더링됩니다.
  * 저신뢰 “changes requested”는 패스에 준하는 판정으로 처리되어, 상태 전환/병합 흐름이 통일됩니다.
  * 리뷰 이벤트에 신뢰도 다운그레이드 및 저신뢰 개수 메타데이터가 포함됩니다.
* **Bug Fixes**
  * 신뢰도에 따라 반복/에스컬레이션 및 게이트 동작이 더 정확하게 반영됩니다.
* **Tests**
  * 신뢰도 필드/스키마/코멘트/상태 전환 시나리오 검증이 강화됐습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->