### PR TITLE
Fix advisory timeout test regex broken on main

### DIFF
--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -1091,7 +1091,7 @@ test("standard review applies the primary verdict when advisory times out during
   assert.equal(result.nextState, STATES.READY_TO_MERGE);
   assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
   assert.equal(result.advisoryReview.status, "timeout");
-  assert.match(result.advisoryReview.failureReason, /exceeded 1s timeout/);
+  assert.match(result.advisoryReview.failureReason, /timed out after 1s/);
   assert.equal(event.status, "timeout");
   assert.equal(event.consumed_by_phase, "review");
 });


### PR DESCRIPTION
main is currently red: `standard review applies the primary verdict when advisory times out during grace` fails on pristine main (verified at 7cbd6a9) because the timeout-diagnostics rework changed `advisory.js` to emit `timed out after Ns` while this assertion still expects `exceeded 1s timeout`. One-line test-only fix; full advisory test file green (33/33) with this change.

Narrow companion PR unblocking PR #855 (issue #306), whose review keeps flagging the same fix as out-of-scope on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)