### PR TITLE
fix(relay-dispatch): start branches from origin base

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -14,6 +14,21 @@ git push origin --delete worktree-<name>
 
 After the #809 fix, new dispatches no longer publish or record local-only `worktree-*` checkout branches as `base_branch`; they fall back to the origin default branch.
 
+## Legacy local-base contamination
+
+Symptom: a PR diff includes unrelated changes from an unpushed commit that was present on the dispatching checkout's local base branch when the run was created. This applies only to runs dispatched before the origin-start-point fix for #795. New dispatch branches are created from `origin/<base>` after a fetch; if that fetch fails, dispatch falls back to the local base ref with a loud warning about contamination risk.
+
+For affected legacy runs, merge the remote base into the retained worktree branch so GitHub's merge-base can drop equivalent upstream content from the diff, then rebind execution evidence to the advanced head:
+
+```bash
+git -C <retained-worktree> fetch origin main
+git -C <retained-worktree> merge origin/main --no-edit
+node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id <id> \
+  --reason "legacy pre-#795 local-base contamination recovery"
+```
+
+Use the run's manifest `git.base_branch` in place of `main` when the run targeted a non-default base branch.
+
 ## Crash-only dispatch reconcile
 
 `reconcile-run.js` settles a run that is still `dispatched` after the dispatch supervisor died, the machine rebooted, the executor was OOM-killed, or an operator needs to check an interrupted run from another shell. It uses the run directory as the runtime state root:

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -695,6 +695,32 @@ function resolveBaseBranchForNewDispatch(repoDir, { validateRemote = true } = {}
   return fallbackToOriginDefaultBranch(repoDir, detectedBranch);
 }
 
+function firstErrorLine(error) {
+  const detail = [
+    error?.stderr,
+    error?.stdout,
+    error?.message,
+    String(error),
+  ].filter(Boolean)[0] || "unknown error";
+  return String(detail).split("\n")[0];
+}
+
+function resolveWorktreeStartPointForNewDispatch(repoDir, baseBranch) {
+  const originStartPoint = `refs/remotes/origin/${baseBranch}`;
+  try {
+    execGit(repoDir, ["fetch", "origin", `+refs/heads/${baseBranch}:${originStartPoint}`]);
+    return originStartPoint;
+  } catch (error) {
+    const localStartPoint = `refs/heads/${baseBranch}`;
+    console.error(
+      `[relay-dispatch] WARNING: unable to fetch origin/${baseBranch} before worktree creation ` +
+      `(${firstErrorLine(error)}); falling back to local ${localStartPoint}; ` +
+      "unpushed local commits may contaminate the dispatch PR diff."
+    );
+    return localStartPoint;
+  }
+}
+
 function shellQuote(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
@@ -1472,6 +1498,7 @@ async function main() {
   let manifestPath = MANIFEST_INPUT ? path.resolve(MANIFEST_INPUT) : null;
   let cleanupPolicy = "on_close";
   let baseBranch = "main";
+  let worktreeStartPoint = null;
   let issueNumber = inferIssueNumber(branch);
   let manifest;
   let copiedFiles = [];
@@ -1733,6 +1760,9 @@ async function main() {
     if (fs.existsSync(wtPath)) {
       console.error(`Error: worktree path already exists: ${wtPath}`);
       process.exit(1);
+    }
+    if (!DRY_RUN) {
+      worktreeStartPoint = resolveWorktreeStartPointForNewDispatch(repoRoot, baseBranch);
     }
     if (inflightRuns.length > 0 && ALLOW_CONFLICTING_RUN) {
       appendRunEvent(repoRoot, runId, {
@@ -2061,6 +2091,7 @@ async function main() {
         worktreePath: wtPath,
         branch,
         title: `Dispatch: ${branch}`,
+        startPoint: worktreeStartPoint,
         copyFiles: COPY_FILES,
         register: false,
         assertWithin,

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -124,6 +124,7 @@ function createWorktree({
   worktreePath,
   branch,
   title,
+  startPoint = null,
   includeFiles,
   copyFiles = [],
   register = false,
@@ -145,6 +146,7 @@ function createWorktree({
     title,
     register,
     pin,
+    ...(startPoint ? { startPoint } : {}),
     worktreeinclude: resolvedIncludeFiles,
   };
 
@@ -162,7 +164,9 @@ function createWorktree({
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
   try {
     try {
-      gitRunner(repoRoot, "worktree", "add", worktreePath, "-b", branch);
+      const createArgs = ["worktree", "add", worktreePath, "-b", branch];
+      if (startPoint) createArgs.push(startPoint);
+      gitRunner(repoRoot, ...createArgs);
     } catch {
       try {
         gitRunner(repoRoot, "worktree", "add", worktreePath, branch);

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -59,6 +59,38 @@ function setupRepoWithOrigin() {
   return setupRepo();
 }
 
+function revParse(repoRoot, ref) {
+  return execFileSync("git", ["rev-parse", ref], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+}
+
+function mergeBase(repoRoot, left, right) {
+  return execFileSync("git", ["merge-base", left, right], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+}
+
+function isAncestor(repoRoot, ancestor, descendant) {
+  const result = spawnSync("git", ["merge-base", "--is-ancestor", ancestor, descendant], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  return result.status === 0;
+}
+
+function commitFile(repoRoot, fileName, content, message) {
+  fs.writeFileSync(path.join(repoRoot, fileName), content, "utf-8");
+  execFileSync("git", ["add", fileName], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", message], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return revParse(repoRoot, "HEAD");
+}
+
 function configureOriginHead(repoRoot, remoteRoot, branch) {
   if (branch !== "main") {
     execFileSync("git", ["checkout", "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
@@ -4000,6 +4032,8 @@ test("dispatch remaps a local-only linked-worktree checkout branch to origin def
     encoding: "utf-8",
     stdio: "pipe",
   });
+  const localOnlySha = commitFile(linkedPath, "linked-local-only.txt", "local only\n", "linked local-only");
+  const originMainSha = revParse(linkedPath, "refs/remotes/origin/main");
   const { env, ghLogPath } = createPushPrTestEnv({
     relayHome,
     ghState: {
@@ -4026,6 +4060,9 @@ test("dispatch remaps a local-only linked-worktree checkout branch to origin def
   const manifest = readManifest(parsed.manifestPath).data;
   assert.equal(manifest.git.base_branch, "main");
   assert.notEqual(manifest.git.base_branch, localBranch);
+  assert.equal(mergeBase(linkedPath, parsed.branch, "refs/remotes/origin/main"), originMainSha);
+  assert.equal(isAncestor(linkedPath, localOnlySha, parsed.branch), false);
+  assert.equal(fs.existsSync(path.join(parsed.worktree, "linked-local-only.txt")), false);
 
   const ghCreateCall = readJsonLines(ghLogPath).find((args) => args[0] === "pr" && args[1] === "create");
   assert.ok(ghCreateCall, "expected gh pr create call");
@@ -4093,6 +4130,120 @@ test("dispatch keeps a checkout branch that exists on origin as base_branch (#80
   const baseFlagIndex = ghCreateCall.indexOf("--base");
   assert.notEqual(baseFlagIndex, -1, "expected --base flag");
   assert.equal(ghCreateCall[baseFlagIndex + 1], remoteBranch);
+});
+
+test("dispatch starts new branches at origin base when local base is ahead (#795)", () => {
+  const { repoRoot, relayHome, remoteRoot } = setupRepo();
+  configureOriginHead(repoRoot, remoteRoot, "main");
+  const originMainSha = revParse(repoRoot, "refs/remotes/origin/main");
+  const localAheadSha = commitFile(repoRoot, "local-ahead.txt", "local ahead\n", "local ahead");
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/795",
+    },
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-795-local-ahead",
+    "--prompt", "exercise local ahead base contamination",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(mergeBase(repoRoot, parsed.branch, "refs/remotes/origin/main"), originMainSha);
+  assert.equal(isAncestor(repoRoot, localAheadSha, parsed.branch), false);
+  assert.equal(fs.existsSync(path.join(parsed.worktree, "local-ahead.txt")), false);
+});
+
+test("dispatch starts new branches at origin base when local base is behind (#795)", async () => {
+  const { repoRoot, relayHome, remoteRoot } = setupRepo();
+  configureOriginHead(repoRoot, remoteRoot, "main");
+  const localMainSha = revParse(repoRoot, "HEAD");
+  const remoteOnlySha = commitFile(repoRoot, "remote-only.txt", "remote only\n", "remote only");
+  execFileSync("git", ["push", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["reset", "--hard", localMainSha], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  const pauseMarkerPath = path.join(os.tmpdir(), `relay-dispatch-behind-pause-${process.pid}-${Date.now()}.json`);
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/796",
+    },
+  });
+  const dispatchEnv = {
+    ...env,
+    RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "1500",
+    RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: pauseMarkerPath,
+  };
+
+  const proc = spawn(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-795-local-behind",
+    "--prompt", "exercise local behind base content",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    env: dispatchEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForDispatchExit(proc);
+  let result;
+  try {
+    await waitFor(() => fs.existsSync(pauseMarkerPath), {
+      timeoutMs: 30000,
+      message: "local-behind after-worktree create pause marker",
+    });
+    assert.equal(revParse(repoRoot, "issue-795-local-behind"), remoteOnlySha);
+  } finally {
+    result = await exitPromise;
+  }
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(mergeBase(repoRoot, parsed.branch, "refs/remotes/origin/main"), remoteOnlySha);
+  assert.equal(isAncestor(repoRoot, remoteOnlySha, parsed.branch), true);
+  assert.equal(fs.readFileSync(path.join(parsed.worktree, "remote-only.txt"), "utf-8"), "remote only\n");
+});
+
+test("dispatch falls back to local base with a loud warning when origin base fetch fails (#795)", () => {
+  const { repoRoot, relayHome, remoteRoot } = setupRepo();
+  configureOriginHead(repoRoot, remoteRoot, "main");
+  const localAheadSha = commitFile(repoRoot, "offline-local.txt", "offline local\n", "offline local");
+  const missingRemote = path.join(os.tmpdir(), `relay-dispatch-missing-origin-${process.pid}-${Date.now()}`);
+  execFileSync("git", ["remote", "set-url", "origin", missingRemote], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/797",
+    },
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-795-offline-fallback",
+    "--prompt", "exercise offline base fallback",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /\[relay-dispatch\] WARNING: unable to fetch origin\/main before worktree creation/);
+  assert.match(result.stderr, /falling back to local refs\/heads\/main/);
+  assert.match(result.stderr, /unpushed local commits may contaminate the dispatch PR diff/);
+
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(isAncestor(repoRoot, localAheadSha, parsed.branch), true);
+  assert.equal(fs.readFileSync(path.join(parsed.worktree, "offline-local.txt"), "utf-8"), "offline local\n");
 });
 
 test("dispatch fails closed on detached HEAD when origin HEAD is unresolved before worktree creation (#253)", () => {

--- a/tests/relay-dispatch/scripts/worktree-runtime.test.js
+++ b/tests/relay-dispatch/scripts/worktree-runtime.test.js
@@ -27,6 +27,21 @@ function setupRepo() {
   return { root, repoRoot };
 }
 
+function revParse(repoRoot, ref) {
+  return execFileSync("git", ["rev-parse", ref], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+}
+
+function commitFile(repoRoot, fileName, content, message) {
+  fs.writeFileSync(path.join(repoRoot, fileName), content, "utf-8");
+  execFileSync("git", ["add", fileName], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", message], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return revParse(repoRoot, "HEAD");
+}
+
 test("formatPlan matches the frozen create-worktree text fixture", () => {
   const actual = formatPlan({
     worktreePath: "/tmp/issue187-fixtures/relay-home/worktrees/11111111/repo",
@@ -104,6 +119,24 @@ test("createWorktree creates a fresh branch and worktree", () => {
   );
 });
 
+test("createWorktree creates a fresh branch from an explicit start point", () => {
+  const { repoRoot, root } = setupRepo();
+  const startPoint = revParse(repoRoot, "HEAD");
+  commitFile(repoRoot, "later.txt", "later\n", "later");
+  const worktreePath = path.join(root, "worktrees", "start-point", "repo");
+
+  createWorktree({
+    repoRoot,
+    worktreePath,
+    branch: "issue-795-start-point",
+    title: "Dispatch: issue-795-start-point",
+    startPoint,
+    copyFiles: [],
+  });
+
+  assert.equal(revParse(worktreePath, "HEAD"), startPoint);
+});
+
 test("createWorktree falls back to an existing branch when -b creation fails", () => {
   const { repoRoot, root } = setupRepo();
   const branch = "issue-187-existing";
@@ -123,6 +156,26 @@ test("createWorktree falls back to an existing branch when -b creation fails", (
     execFileSync("git", ["-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim(),
     branch
   );
+});
+
+test("createWorktree existing-branch fallback ignores the start point", () => {
+  const { repoRoot, root } = setupRepo();
+  const branch = "issue-795-existing";
+  const branchHead = revParse(repoRoot, "HEAD");
+  execFileSync("git", ["branch", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  const laterHead = commitFile(repoRoot, "later-existing.txt", "later\n", "later existing");
+  const worktreePath = path.join(root, "worktrees", "existing-start-point", "repo");
+
+  createWorktree({
+    repoRoot,
+    worktreePath,
+    branch,
+    title: "Dispatch: issue-795-existing",
+    startPoint: laterHead,
+    copyFiles: [],
+  });
+
+  assert.equal(revParse(worktreePath, "HEAD"), branchHead);
 });
 
 test("createWorktree forwards registration args through an adapter callback", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed: `302c8be fix(relay-dispatch): start branches from origin base`.

Changed:
- New dispatches fetch `origin/<base>` and create branches from `refs/remotes/origin/<base>`.
- Fetch failure falls back to `refs/heads/<base>` with a loud contamination warning.
- Existing-branch/resume behavior stays unchanged.
- Recovery playbook now scopes merge `origin/main` + `rebrand-evidence` to pre-fix legacy runs.

Verification:
- `node --test --test-concurrency=1 tests/relay-dispatch/s
```

## Score Log

- Run: issue-795-20260709005319343-2eafd425
- Executor: codex
- Branch: issue-795