### PR TITLE
relay-fleet: persist pre-manifest dispatch failure cause on the fleet child + state the same-command retry contract in the failure summary (#869)

### DIFF
--- a/skills/relay-dispatch/scripts/manifest/fleet.js
+++ b/skills/relay-dispatch/scripts/manifest/fleet.js
@@ -44,7 +44,8 @@ const DISPATCH_STATUS = Object.freeze({
 
 const DEFAULT_ISSUE_LOCK_STALE_MS = 6 * 60 * 60 * 1000;
 const FLEET_TOP_LEVEL_KEYS = Object.freeze(["fleet_id", "fleet_state", "children", "timestamps"]);
-const CHILD_KEYS = Object.freeze(["leaf_ref", "run_id", "dispatch_status"]);
+const FLEET_CHILD_LAST_ERROR_MAX_CHARS = 400;
+const CHILD_KEYS = Object.freeze(["leaf_ref", "run_id", "dispatch_status", "last_error"]);
 
 class FleetIssueLockError extends Error {
   constructor(message, details = {}) {
@@ -70,6 +71,16 @@ function validateDispatchStatus(status) {
   if (!Object.values(DISPATCH_STATUS).includes(status)) {
     throw new Error(`Unknown relay fleet dispatch_status: ${status}`);
   }
+}
+
+function normalizeFleetChildLastError(value, { fromTail = false } = {}) {
+  if (value === null || value === undefined) return null;
+  const singleLine = String(value).replace(/\s+/g, " ").trim();
+  if (!singleLine) return null;
+  if (singleLine.length <= FLEET_CHILD_LAST_ERROR_MAX_CHARS) return singleLine;
+  return fromTail
+    ? singleLine.slice(-FLEET_CHILD_LAST_ERROR_MAX_CHARS)
+    : singleLine.slice(0, FLEET_CHILD_LAST_ERROR_MAX_CHARS);
 }
 
 function assertExactKeys(object, allowedKeys, label) {
@@ -104,11 +115,14 @@ function normalizeFleetChild(child) {
     throw new Error("fleet child dispatch_failed_pre_manifest must have run_id: null");
   }
 
-  return {
+  const normalizedChild = {
     leaf_ref: leafRef,
     run_id: runId,
     dispatch_status: dispatchStatus,
   };
+  const lastError = normalizeFleetChildLastError(child.last_error);
+  if (lastError) normalizedChild.last_error = lastError;
+  return normalizedChild;
 }
 
 function normalizeTimestamps(timestamps) {
@@ -290,6 +304,7 @@ function deriveFleetSummary(repoRoot, fleet) {
       review_round: null,
       error: null,
     };
+    if (child.last_error) summaryChild.last_error = child.last_error;
 
     if (!child.run_id) {
       summaryChild.run_state = "no_run_manifest";
@@ -473,6 +488,7 @@ module.exports = {
   ALLOWED_TRANSITIONS,
   DEFAULT_ISSUE_LOCK_STALE_MS,
   DISPATCH_STATUS,
+  FLEET_CHILD_LAST_ERROR_MAX_CHARS,
   FleetIssueLockError,
   STATES,
   acquireIssueLock,
@@ -482,6 +498,7 @@ module.exports = {
   deriveFleetSummary,
   getFleetsDir,
   listFleetManifests,
+  normalizeFleetChildLastError,
   normalizeFleetChild,
   normalizeFleetManifest,
   releaseIssueLock,

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -1450,7 +1450,7 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
   if (!runId || launch.code !== 0) {
     const keepRuntime = Boolean(runId && payload?.supervisorPid);
     const lastError = dispatchFailureLastError({
-      error: launch.error,
+      error: payload?.error || launch.error,
       stderr: launch.stderr,
       fallback: launch.signal
         ? `dispatch process terminated by ${launch.signal}`

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -28,6 +28,7 @@ const {
   acquireIssueLock,
   createFleetManifest,
   deriveFleetSummary,
+  normalizeFleetChildLastError,
   readFleetManifest,
   releaseIssueLock,
   updateFleetManifest,
@@ -72,6 +73,16 @@ class FleetInputError extends Error {
     super(message);
     this.name = "FleetInputError";
   }
+}
+
+function dispatchFailureLastError({ error = null, stderr = null, fallback = null } = {}) {
+  const directError = normalizeFleetChildLastError(error);
+  if (directError) return directError;
+  // Child-process stderr can be verbose; keep the tail where the concrete
+  // failure usually appears while still enforcing the fleet child field bound.
+  const stderrTail = normalizeFleetChildLastError(stderr, { fromTail: true });
+  if (stderrTail) return stderrTail;
+  return normalizeFleetChildLastError(fallback);
 }
 
 function usage() {
@@ -660,6 +671,7 @@ function reconcileFleet(repoRoot, fleetId, leaves) {
       leaf_ref: leafRef,
       run_id: record.data.run_id,
       dispatch_status: dispatchStatus,
+      last_error: null,
     });
   }
 
@@ -675,6 +687,9 @@ function reconcileFleet(repoRoot, fleetId, leaves) {
       leaf_ref: child.leaf_ref,
       run_id: null,
       dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: dispatchFailureLastError({
+        fallback: "dispatch interrupted before creating a run manifest",
+      }),
     });
   }
 
@@ -932,6 +947,7 @@ async function pollResumeDispatchForChild({ repoRoot, fleetId, leaf, child, opti
     leaf_ref: child.leaf_ref,
     run_id: child.run_id,
     dispatch_status: dispatchStatusForDetachedProgress(progress),
+    last_error: null,
   });
   return {
     leaf_ref: child.leaf_ref,
@@ -1370,6 +1386,7 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
         leaf_ref: leaf.leaf_ref,
         run_id: null,
         dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+        last_error: dispatchFailureLastError({ error: error.message }),
       });
       return { leaf_ref: leaf.leaf_ref, status: "dispatch_failed_pre_manifest", error: error.message };
     }
@@ -1378,6 +1395,7 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
       leaf_ref: leaf.leaf_ref,
       run_id: null,
       dispatch_status: DISPATCH_STATUS.DISPATCHING,
+      last_error: null,
     });
   }
 
@@ -1431,12 +1449,20 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
 
   if (!runId || launch.code !== 0) {
     const keepRuntime = Boolean(runId && payload?.supervisorPid);
+    const lastError = dispatchFailureLastError({
+      error: launch.error,
+      stderr: launch.stderr,
+      fallback: launch.signal
+        ? `dispatch process terminated by ${launch.signal}`
+        : `dispatch process exited with code ${launch.code}`,
+    });
     setFleetChild(repoRoot, fleetId, {
       leaf_ref: leaf.leaf_ref,
       run_id: runId,
       dispatch_status: runId
         ? (keepRuntime ? DISPATCH_STATUS.DISPATCHING : DISPATCH_STATUS.PENDING)
         : DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: lastError,
     });
     if (keepRuntime) {
       upsertRuntimeProcess(repoRoot, fleetId, leaf.leaf_ref, { pid: payload.supervisorPid }, {
@@ -1462,6 +1488,7 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
     leaf_ref: leaf.leaf_ref,
     run_id: runId,
     dispatch_status: DISPATCH_STATUS.DISPATCHING,
+    last_error: null,
   });
   if (payload?.supervisorPid) {
     upsertRuntimeProcess(repoRoot, fleetId, leaf.leaf_ref, { pid: payload.supervisorPid }, {
@@ -1487,6 +1514,7 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
     leaf_ref: leaf.leaf_ref,
     run_id: runId,
     dispatch_status: dispatchStatusForDetachedProgress(progress),
+    last_error: null,
   });
 
   return {
@@ -1633,12 +1661,14 @@ function formatStatusText(summary, operatorAttention) {
   ];
   if (summary.children.length) {
     for (const child of summary.children) {
-      lines.push([
+      const childLine = [
         `  - ${child.leaf_ref}`,
         `run_id=${child.run_id || "null"}`,
         `dispatch_status=${child.dispatch_status}`,
         `run_state=${child.run_state || "unknown"}`,
-      ].join(" | "));
+      ];
+      if (child.last_error) childLine.push(`last_error=${child.last_error}`);
+      lines.push(childLine.join(" | "));
     }
   } else {
     lines.push("  (none)");
@@ -1650,6 +1680,17 @@ function formatStatusText(summary, operatorAttention) {
     }
   }
   return `${lines.join("\n")}\n`;
+}
+
+function formatPreManifestRetryLine(summary, fleetId) {
+  const failedLeaves = (summary?.children || [])
+    .filter((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST)
+    .map((child) => child.leaf_ref);
+  if (!failedLeaves.length) return null;
+  return [
+    `Pre-manifest dispatch failed for leaf(s): ${failedLeaves.join(", ")}.`,
+    `To retry, re-run the same command with --fleet-id ${fleetId}; relay-fleet will re-dispatch those children.`,
+  ].join(" ");
 }
 
 async function statusFleet({ repoRoot, fleetId }) {
@@ -2174,6 +2215,8 @@ async function main(argv = process.argv.slice(2)) {
         ? `fleet=${result.fleet_id} children=${result.summary.total_children}`
         : `fleet=${result.fleet_id} children=${result.children.length}`;
       console.log(result.ok ? `relay-fleet complete: ${summary}` : `relay-fleet needs attention: ${summary}`);
+      const retryLine = result.summary ? formatPreManifestRetryLine(result.summary, result.fleet_id) : null;
+      if (!result.ok && retryLine) console.log(retryLine);
     }
     return result.ok ? 0 : 1;
   } catch (error) {

--- a/tests/relay-dispatch/scripts/manifest/fleet.test.js
+++ b/tests/relay-dispatch/scripts/manifest/fleet.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const {
   createFleetManifest,
+  normalizeFleetChild,
   readFleetManifest,
   STATES,
   updateFleetManifest,
@@ -34,4 +35,36 @@ test("manifest/fleet updateFleetManifest rejects direct fleet_state assignment t
     /Invalid relay fleet state transition: draft -> closed/
   );
   assert.equal(readFleetManifest(repoRoot, fleetId).data.fleet_state, STATES.DRAFT);
+});
+
+test("manifest/fleet normalizes optional child last_error as a bounded single-line field", () => {
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-fleet-repo-"));
+  initGitRepo(repoRoot);
+  const fleetId = "issue-869";
+  const longMultilineError = `first line\n${"x".repeat(450)}`;
+
+  const normalized = normalizeFleetChild({
+    leaf_ref: "leaf-a",
+    run_id: null,
+    dispatch_status: "dispatch_failed_pre_manifest",
+    last_error: longMultilineError,
+  });
+
+  assert.equal(normalized.last_error.length, 400);
+  assert.doesNotMatch(normalized.last_error, /[\r\n]/);
+
+  const emptyError = normalizeFleetChild({
+    leaf_ref: "leaf-b",
+    run_id: null,
+    dispatch_status: "dispatch_failed_pre_manifest",
+    last_error: " \n\t ",
+  });
+  assert.equal(Object.hasOwn(emptyError, "last_error"), false);
+
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [normalized],
+  });
+  assert.deepEqual(readFleetManifest(repoRoot, fleetId).data.children, [normalized]);
 });

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -323,7 +323,14 @@ async function main() {
   const runDir = getRunDir(repoRoot, runId);
   appendLog({ event: "spawn", branch, leafId, fleetId, dryRun, args });
   if (has("--detach") && plan.fail_before_manifest) {
-    process.stderr.write(plan.stderr || plan.fail_before_manifest_stderr || "fake pre-manifest failure\\n");
+    if (plan.json_failure_error) {
+      process.stdout.write(JSON.stringify({
+        status: "failed",
+        error: plan.json_failure_error,
+      }) + "\\n");
+    } else {
+      process.stderr.write(plan.stderr || plan.fail_before_manifest_stderr || "fake pre-manifest failure\\n");
+    }
     process.exit(plan.exit_code || 17);
   }
   if (has("--detach") && process.env.FAKE_DETACHED_CHILD !== "1" && plan.fail_parent_after_run_id) {
@@ -334,8 +341,11 @@ async function main() {
       runDir,
       fleetId,
       branch,
+      ...(plan.json_failure_error ? { error: plan.json_failure_error } : {}),
     }) + "\\n");
-    process.stderr.write(plan.stderr || "fake parent dispatch failure after run id\\n");
+    if (plan.stderr || !plan.json_failure_error) {
+      process.stderr.write(plan.stderr || "fake parent dispatch failure after run id\\n");
+    }
     process.exit(plan.exit_code || 17);
   }
   if (has("--detach") && process.env.FAKE_DETACHED_CHILD !== "1") {
@@ -366,7 +376,14 @@ async function main() {
     await sleep(plan.delay_before_manifest_ms);
   }
   if (plan.fail_before_manifest) {
-    process.stderr.write(plan.stderr || plan.fail_before_manifest_stderr || "fake pre-manifest failure\\n");
+    if (plan.json_failure_error) {
+      process.stdout.write(JSON.stringify({
+        status: "failed",
+        error: plan.json_failure_error,
+      }) + "\\n");
+    } else {
+      process.stderr.write(plan.stderr || plan.fail_before_manifest_stderr || "fake pre-manifest failure\\n");
+    }
     process.exit(plan.exit_code || 17);
   }
   if (!dryRun && plan.create_manifest !== false) {
@@ -1193,6 +1210,76 @@ test("relay-fleet records last_error when dispatch returns a run id but exits no
   assert.equal(child.dispatch_status, DISPATCH_STATUS.PENDING);
   assert.equal(child.last_error, "fake parent failure after run id second line");
   assert.equal(payload.summary.children[0].last_error, "fake parent failure after run id second line");
+});
+
+test("relay-fleet records dispatch JSON error payloads as last_error when stderr is empty", () => {
+  const preManifestSetup = setupRepo("relay-fleet-json-premanifest-");
+  const preManifestTmp = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const preManifestDispatchScript = writeFakeDispatchScript(preManifestTmp);
+  const preManifestConfig = path.join(preManifestTmp, "config.json");
+  const preManifestLeaf = makeLeaf(preManifestSetup.repoRoot, 1, { issue_number: 486 });
+  const preManifestLeavesFile = writeLeavesFile(preManifestSetup.repoRoot, [preManifestLeaf]);
+  writeJson(preManifestConfig, {
+    [preManifestLeaf.branch]: {
+      fail_before_manifest: true,
+      json_failure_error: "json pre-manifest validation failure",
+    },
+  });
+
+  const preManifestResult = runFleet([
+    "--repo", preManifestSetup.repoRoot,
+    "--fleet-id", "fleet-json-premanifest",
+    "--leaves-file", preManifestLeavesFile,
+    "--dispatch-script", preManifestDispatchScript,
+    "--json",
+  ], {
+    relayHome: preManifestSetup.relayHome,
+    env: { FAKE_DISPATCH_CONFIG: preManifestConfig },
+  });
+
+  assert.notEqual(preManifestResult.status, 0);
+  const preManifestPayload = JSON.parse(preManifestResult.stdout);
+  assert.equal(preManifestPayload.children[0].status, "dispatch_failed_pre_manifest");
+  const preManifestChild = readFleetManifest(preManifestSetup.repoRoot, "fleet-json-premanifest").data.children[0];
+  assert.equal(preManifestChild.run_id, null);
+  assert.equal(preManifestChild.dispatch_status, DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+  assert.equal(preManifestChild.last_error, "json pre-manifest validation failure");
+  assert.equal(preManifestPayload.summary.children[0].last_error, "json pre-manifest validation failure");
+
+  const runIdSetup = setupRepo("relay-fleet-json-runid-failure-");
+  const runIdTmp = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const runIdDispatchScript = writeFakeDispatchScript(runIdTmp);
+  const runIdConfig = path.join(runIdTmp, "config.json");
+  const runIdLeaf = makeLeaf(runIdSetup.repoRoot, 1, { issue_number: 487 });
+  const runIdLeavesFile = writeLeavesFile(runIdSetup.repoRoot, [runIdLeaf]);
+  writeJson(runIdConfig, {
+    [runIdLeaf.branch]: {
+      fail_parent_after_run_id: true,
+      json_failure_error: "json run id launch failure",
+      exit_code: 19,
+    },
+  });
+
+  const runIdResult = runFleet([
+    "--repo", runIdSetup.repoRoot,
+    "--fleet-id", "fleet-json-runid-failure",
+    "--leaves-file", runIdLeavesFile,
+    "--dispatch-script", runIdDispatchScript,
+    "--json",
+  ], {
+    relayHome: runIdSetup.relayHome,
+    env: { FAKE_DISPATCH_CONFIG: runIdConfig },
+  });
+
+  assert.notEqual(runIdResult.status, 0);
+  const runIdPayload = JSON.parse(runIdResult.stdout);
+  assert.equal(runIdPayload.children[0].status, "dispatched_with_child_failure");
+  assert.match(runIdPayload.children[0].run_id, /^issue-487-/);
+  const runIdChild = readFleetManifest(runIdSetup.repoRoot, "fleet-json-runid-failure").data.children[0];
+  assert.match(runIdChild.run_id, /^issue-487-/);
+  assert.equal(runIdChild.dispatch_status, DISPATCH_STATUS.PENDING);
+  assert.equal(runIdChild.last_error, "json run id launch failure");
+  assert.equal(runIdPayload.summary.children[0].last_error, "json run id launch failure");
 });
 
 test("relay-fleet text summary states same-command retry contract only for pre-manifest failures", () => {

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -323,7 +323,19 @@ async function main() {
   const runDir = getRunDir(repoRoot, runId);
   appendLog({ event: "spawn", branch, leafId, fleetId, dryRun, args });
   if (has("--detach") && plan.fail_before_manifest) {
-    process.stderr.write("fake pre-manifest failure\\n");
+    process.stderr.write(plan.stderr || plan.fail_before_manifest_stderr || "fake pre-manifest failure\\n");
+    process.exit(plan.exit_code || 17);
+  }
+  if (has("--detach") && process.env.FAKE_DETACHED_CHILD !== "1" && plan.fail_parent_after_run_id) {
+    process.stdout.write(JSON.stringify({
+      status: "detached",
+      runId,
+      manifestPath,
+      runDir,
+      fleetId,
+      branch,
+    }) + "\\n");
+    process.stderr.write(plan.stderr || "fake parent dispatch failure after run id\\n");
     process.exit(plan.exit_code || 17);
   }
   if (has("--detach") && process.env.FAKE_DETACHED_CHILD !== "1") {
@@ -354,7 +366,7 @@ async function main() {
     await sleep(plan.delay_before_manifest_ms);
   }
   if (plan.fail_before_manifest) {
-    process.stderr.write("fake pre-manifest failure\\n");
+    process.stderr.write(plan.stderr || plan.fail_before_manifest_stderr || "fake pre-manifest failure\\n");
     process.exit(plan.exit_code || 17);
   }
   if (!dryRun && plan.create_manifest !== false) {
@@ -1049,11 +1061,11 @@ test("relay-fleet honors a racing fleet issue lock before spawning the duplicate
 
     assert.notEqual(result.status, 0);
     const fleet = readFleetManifest(repoRoot, "fleet-race").data;
-    assert.deepEqual(fleet.children, [{
-      leaf_ref: "leaf-01",
-      run_id: null,
-      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
-    }]);
+    assert.equal(fleet.children.length, 1);
+    assert.equal(fleet.children[0].leaf_ref, "leaf-01");
+    assert.equal(fleet.children[0].run_id, null);
+    assert.equal(fleet.children[0].dispatch_status, DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+    assert.match(fleet.children[0].last_error, /Refusing to dispatch: fleet issue lock is already held/);
     assert.equal(readJsonLines(logPath).length, 0);
   } finally {
     releaseIssueLock(lock);
@@ -1067,15 +1079,18 @@ test("relay-fleet records and resumes a child dispatch that fails before manifes
   const reviewScript = writeFakeReviewScript(tmpDir);
   const finalizeScript = writeFakeFinalizeScript(tmpDir);
   const configPath = path.join(tmpDir, "config.json");
-  const leaf = makeLeaf(repoRoot, 1, { issue_number: 483 });
-  const leavesFile = writeLeavesFile(repoRoot, [leaf]);
-  writeJson(configPath, { [leaf.branch]: { fail_before_manifest: true } });
+  const failedLeaf = makeLeaf(repoRoot, 1, { issue_number: 483, leaf_ref: "leaf-failed", leaf_id: "leaf-failed" });
+  const healthyLeaf = makeLeaf(repoRoot, 2, { issue_number: 484, leaf_ref: "leaf-healthy", leaf_id: "leaf-healthy" });
+  const leavesFile = writeLeavesFile(repoRoot, [failedLeaf, healthyLeaf]);
+  writeJson(configPath, { [failedLeaf.branch]: { fail_before_manifest: true } });
 
   const failed = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-premanifest",
     "--leaves-file", leavesFile,
     "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--finalize-script", finalizeScript,
     "--json",
   ], {
     relayHome,
@@ -1083,9 +1098,39 @@ test("relay-fleet records and resumes a child dispatch that fails before manifes
   });
 
   assert.notEqual(failed.status, 0);
+  const failedPayload = JSON.parse(failed.stdout);
+  const failedSummaryChild = failedPayload.summary.children.find((child) => child.leaf_ref === failedLeaf.leaf_ref);
+  assert.equal(failedSummaryChild.last_error, "fake pre-manifest failure");
+  const afterFailed = readFleetManifest(repoRoot, "fleet-premanifest").data.children;
+  const failedChild = afterFailed.find((child) => child.leaf_ref === failedLeaf.leaf_ref);
+  const healthyChild = afterFailed.find((child) => child.leaf_ref === healthyLeaf.leaf_ref);
+  assert.equal(failedChild.dispatch_status, DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+  assert.equal(failedChild.last_error, "fake pre-manifest failure");
+  assert.equal(healthyChild.dispatch_status, DISPATCH_STATUS.DISPATCHED);
+  assert.equal(Object.hasOwn(healthyChild, "last_error"), false);
+
+  const statusJson = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-premanifest",
+    "--status",
+    "--json",
+  ], { relayHome });
+  assert.equal(statusJson.status, 0, statusJson.stderr);
+  const statusPayload = JSON.parse(statusJson.stdout);
   assert.equal(
-    readFleetManifest(repoRoot, "fleet-premanifest").data.children[0].dispatch_status,
-    DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+    statusPayload.summary.children.find((child) => child.leaf_ref === failedLeaf.leaf_ref).last_error,
+    "fake pre-manifest failure"
+  );
+
+  const statusText = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-premanifest",
+    "--status",
+  ], { relayHome });
+  assert.equal(statusText.status, 0, statusText.stderr);
+  assert.match(
+    statusText.stdout,
+    /leaf-failed \| run_id=null \| dispatch_status=dispatch_failed_pre_manifest \| run_state=no_run_manifest \| last_error=fake pre-manifest failure/
   );
 
   writeJson(configPath, {});
@@ -1103,11 +1148,99 @@ test("relay-fleet records and resumes a child dispatch that fails before manifes
   });
 
   assert.equal(resumed.status, 0, `${resumed.stderr}\n${resumed.stdout}`);
-  const child = readFleetManifest(repoRoot, "fleet-premanifest").data.children[0];
+  const child = readFleetManifest(repoRoot, "fleet-premanifest").data.children
+    .find((entry) => entry.leaf_ref === failedLeaf.leaf_ref);
   assert.equal(child.dispatch_status, DISPATCH_STATUS.DISPATCHED);
   assert.match(child.run_id, /^issue-483-/);
+  assert.equal(Object.hasOwn(child, "last_error"), false);
   assert.equal(readManifest(getManifestPath(repoRoot, child.run_id)).data.state, RUN_STATES.MERGED);
   assert.equal(readFleetManifest(repoRoot, "fleet-premanifest").data.fleet_state, FLEET_STATES.CLOSED);
+});
+
+test("relay-fleet records last_error when dispatch returns a run id but exits nonzero", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-runid-failure-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const configPath = path.join(tmpDir, "config.json");
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 485 });
+  const leavesFile = writeLeavesFile(repoRoot, [leaf]);
+  writeJson(configPath, {
+    [leaf.branch]: {
+      fail_parent_after_run_id: true,
+      stderr: "fake parent failure after run id\nsecond line\n",
+      exit_code: 19,
+    },
+  });
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-runid-failure",
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_CONFIG: configPath },
+  });
+
+  assert.notEqual(result.status, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.children[0].status, "dispatched_with_child_failure");
+  assert.equal(payload.children[0].error, null);
+  assert.match(payload.children[0].run_id, /^issue-485-/);
+  const child = readFleetManifest(repoRoot, "fleet-runid-failure").data.children[0];
+  assert.match(child.run_id, /^issue-485-/);
+  assert.equal(child.dispatch_status, DISPATCH_STATUS.PENDING);
+  assert.equal(child.last_error, "fake parent failure after run id second line");
+  assert.equal(payload.summary.children[0].last_error, "fake parent failure after run id second line");
+});
+
+test("relay-fleet text summary states same-command retry contract only for pre-manifest failures", () => {
+  const failedSetup = setupRepo("relay-fleet-retry-summary-failed-");
+  const failedTmp = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const failedDispatchScript = writeFakeDispatchScript(failedTmp);
+  const failedConfig = path.join(failedTmp, "config.json");
+  const failedLeaf = makeLeaf(failedSetup.repoRoot, 1, { issue_number: 486, leaf_ref: "leaf-summary-failed" });
+  const failedLeavesFile = writeLeavesFile(failedSetup.repoRoot, [failedLeaf]);
+  writeJson(failedConfig, { [failedLeaf.branch]: { fail_before_manifest: true } });
+
+  const failed = runFleet([
+    "--repo", failedSetup.repoRoot,
+    "--fleet-id", "fleet-retry-summary",
+    "--leaves-file", failedLeavesFile,
+    "--dispatch-script", failedDispatchScript,
+  ], {
+    relayHome: failedSetup.relayHome,
+    env: { FAKE_DISPATCH_CONFIG: failedConfig },
+  });
+
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stdout, /relay-fleet needs attention: fleet=fleet-retry-summary children=1/);
+  assert.match(failed.stdout, /leaf-summary-failed/);
+  assert.match(failed.stdout, /re-run/);
+  assert.match(failed.stdout, /same command/);
+  assert.match(failed.stdout, /--fleet-id fleet-retry-summary/);
+
+  const cleanSetup = setupRepo("relay-fleet-retry-summary-clean-");
+  const cleanTmp = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
+  const cleanDispatchScript = writeFakeDispatchScript(cleanTmp);
+  const cleanReviewScript = writeFakeReviewScript(cleanTmp);
+  const cleanFinalizeScript = writeFakeFinalizeScript(cleanTmp);
+  const cleanLeavesFile = writeLeavesFile(cleanSetup.repoRoot, [
+    makeLeaf(cleanSetup.repoRoot, 1, { issue_number: 487, leaf_ref: "leaf-summary-clean" }),
+  ]);
+
+  const clean = runFleet([
+    "--repo", cleanSetup.repoRoot,
+    "--fleet-id", "fleet-retry-summary-clean",
+    "--leaves-file", cleanLeavesFile,
+    "--dispatch-script", cleanDispatchScript,
+    "--review-script", cleanReviewScript,
+    "--finalize-script", cleanFinalizeScript,
+  ], { relayHome: cleanSetup.relayHome });
+
+  assert.equal(clean.status, 0, `${clean.stderr}\n${clean.stdout}`);
+  assert.doesNotMatch(clean.stdout, /re-run/);
 });
 
 test("relay-fleet launches leaf dispatch with --detach and leaves child progress independent of the fleet supervisor", async () => {
@@ -1475,6 +1608,23 @@ test("relay-fleet reconcile adopts orphan in-flight dispatched run as dispatchin
   const child = readFleetManifest(repoRoot, fleetId).data.children[0];
   assert.equal(child.run_id, runId);
   assert.equal(child.dispatch_status, DISPATCH_STATUS.DISPATCHING);
+});
+
+test("relay-fleet reconcile records last_error for interrupted pre-manifest dispatches", () => {
+  const { repoRoot } = setupRepo("relay-fleet-reconcile-premanifest-error-");
+  const fleetId = "fleet-reconcile-premanifest-error";
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 809 });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{ leaf_ref: leaf.leaf_ref, run_id: null, dispatch_status: DISPATCH_STATUS.DISPATCHING }],
+  });
+
+  reconcileFleet(repoRoot, fleetId, [leaf]);
+
+  const child = readFleetManifest(repoRoot, fleetId).data.children[0];
+  assert.equal(child.run_id, null);
+  assert.equal(child.dispatch_status, DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST);
+  assert.equal(child.last_error, "dispatch interrupted before creating a run manifest");
 });
 
 test("relay-fleet reconcile does not let stale run records replace current child run", () => {
@@ -2108,6 +2258,10 @@ test("relay-fleet --status prints derived summary without writing the fleet mani
   assert.equal(payload.summary.by_run_state[RUN_STATES.DISPATCHED], 1);
   assert.equal(payload.summary.by_run_state[RUN_STATES.ESCALATED], 1);
   assert.equal(payload.summary.by_run_state.no_run_manifest, 1);
+  assert.equal(
+    Object.hasOwn(payload.summary.children.find((child) => child.leaf_ref === "leaf-failed"), "last_error"),
+    false
+  );
 
   const textResult = runFleet([
     "--repo", repoRoot,
@@ -2125,10 +2279,11 @@ test("relay-fleet --status prints derived summary without writing the fleet mani
     textResult.stdout,
     new RegExp(`leaf-escalated \\| run_id=${escalatedRun} \\| dispatch_status=dispatched \\| run_state=escalated`),
   );
-  assert.match(
-    textResult.stdout,
-    /leaf-failed \| run_id=null \| dispatch_status=dispatch_failed_pre_manifest \| run_state=no_run_manifest/,
+  assert.equal(
+    textResult.stdout.split("\n").find((line) => line.includes("leaf-failed")),
+    "  - leaf-failed | run_id=null | dispatch_status=dispatch_failed_pre_manifest | run_state=no_run_manifest"
   );
+  assert.doesNotMatch(textResult.stdout, /last_error=/);
   assert.match(textResult.stdout, /Needs operator attention:/);
   assert.match(textResult.stdout, new RegExp(`leaf-escalated: escalated \\(${escalatedRun}\\)`));
   assert.equal(fs.readFileSync(created.manifestPath, "utf-8"), before);


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-869-20260709114637459-03ce75b4
- Branch: issue-869-last-error
- Reason: reconcile-run recovered work for issue-869-20260709114637459-03ce75b4
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-869-20260709114637459-03ce75b4.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-09T12:05:34.277Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 디스패치 상태와 요약 출력에 각 항목의 마지막 오류 메시지가 표시되도록 개선되었습니다.
  * 재시도 및 중단된 실행 흐름에서 오류 원인이 더 자세히 남습니다.

* **Bug Fixes**
  * 멀티라인 오류가 한 줄로 정리되고 길이가 제한되도록 처리되어, 상태 표시가 더 안정적으로 보입니다.
  * 실패한 항목과 정상 항목의 상태 요약이 더 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->