### PR TITLE
fix: harden cline advisory reviewer adapter (#850)

### DIFF
--- a/skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js
@@ -12,6 +12,71 @@ function parseClineJsonLine(line, { adapter, phase, lineNumber }) {
   }
 }
 
+function stderrTail(stderr) {
+  const text = String(stderr || "");
+  const trimmed = text.trim();
+  return trimmed ? `; stderr tail: ${trimmed.slice(-500)}` : "";
+}
+
+function previewText(value, maxLength) {
+  return String(value || "").replace(/\s+/g, " ").trim().slice(0, maxLength);
+}
+
+function extractClineAdvisoryCandidates(stdout, {
+  adapter = "cline",
+  phase = "advisory_review",
+  stderr = "",
+} = {}) {
+  const context = formatAdapterPhase({ adapter, phase });
+  const raw = String(stdout || "");
+  if (!raw.trim()) {
+    throw new Error(`${context} Cline JSONL output is empty; no advisory candidates found${stderrTail(stderr)}`);
+  }
+
+  let runResult = null;
+  let runResultCount = 0;
+  let lastTextContentEnd = null;
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  for (const [index, line] of lines.entries()) {
+    const event = parseClineJsonLine(line, { adapter, phase, lineNumber: index + 1 });
+    if (event?.type === "run_result") {
+      runResultCount += 1;
+      runResult = event;
+    }
+    if (
+      event?.type === "agent_event" &&
+      event.event?.type === "content_end" &&
+      event.event?.contentType === "text" &&
+      typeof event.event.text === "string"
+    ) {
+      lastTextContentEnd = event.event.text;
+    }
+  }
+
+  if (!runResultCount) {
+    throw new Error(`${context} Cline JSONL output did not include a run_result event (no run_result events found)${stderrTail(stderr)}`);
+  }
+
+  if (runResult?.finishReason !== "completed") {
+    const finishReason = runResult?.finishReason === undefined ? "undefined" : String(runResult.finishReason);
+    const preview = previewText(runResult?.text, 300);
+    throw new Error(
+      `${context} Cline run_result finishReason "${finishReason}" was not "completed"; run_result.text preview: ${preview}`
+    );
+  }
+
+  const candidates = [];
+  for (const candidate of [runResult?.text, lastTextContentEnd]) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      candidates.push(candidate.trim());
+    }
+  }
+  if (!candidates.length) {
+    throw new Error(`${context} Cline completed run_result did not include any non-empty advisory candidates`);
+  }
+  return candidates;
+}
+
 function extractClineRunResultText(stdout, { adapter = "cline", phase = "unknown" } = {}) {
   const context = formatAdapterPhase({ adapter, phase });
   const raw = String(stdout || "");
@@ -64,5 +129,6 @@ function copyClineRunResultTextToResultFile({ stdoutLog, resultFile, adapter = "
 
 module.exports = {
   copyClineRunResultTextToResultFile,
+  extractClineAdvisoryCandidates,
   extractClineRunResultText,
 };

--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -1,7 +1,9 @@
 const {
   formatAdapterPhase,
-  parseJsonObject,
 } = require("../../relay-dispatch/scripts/agent-adapters/transport");
+const {
+  parsePossiblyWrappedReviewerJsonObject,
+} = require("./reviewer-helpers");
 
 const ADVISORY_PROFILES = Object.freeze(["blindspot", "adversarial"]);
 const ADVISORY_SEVERITIES = new Set(["P1", "P2", "P3"]);
@@ -93,7 +95,7 @@ function parseAdvisoryReview(text, {
   const expectedProfile = validateAdvisoryProfile(profile);
   const context = formatAdapterPhase({ adapter, phase });
   try {
-    const parsed = parseJsonObject(normalizeAdvisoryJsonText(text), {
+    const parsed = parsePossiblyWrappedReviewerJsonObject(normalizeAdvisoryJsonText(text), {
       adapter,
       phase,
       description: "advisory review",

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -27,6 +27,7 @@ const cliArgs = bindCliArgs(args, {
 });
 const REVIEW_TIMEOUT_ENV = "RELAY_CLINE_REVIEW_TIMEOUT";
 const DEFAULT_REVIEW_TIMEOUT = "1800s";
+const MIN_CLINE_TIMEOUT_SECONDS = 60;
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
   console.log("Usage: invoke-reviewer-cline.js --repo <path> --prompt-file <path> [--phase advisory_review] [--model <route>] [--json]");
@@ -71,8 +72,14 @@ function parseReviewTimeoutMs(value) {
 }
 
 function clineTimeoutSecondsFromParentMs(parentTimeoutMs) {
+  const minimumChildTimeoutMs = MIN_CLINE_TIMEOUT_SECONDS * 1000;
+  if (parentTimeoutMs <= minimumChildTimeoutMs) {
+    throw new Error(
+      `${REVIEW_TIMEOUT_ENV} must be greater than ${MIN_CLINE_TIMEOUT_SECONDS}s so the parent exec timeout can outlive Cline's minimum internal timeout`
+    );
+  }
   const parentSeconds = Math.ceil(parentTimeoutMs / 1000);
-  return String(Math.max(60, parentSeconds - 60));
+  return String(Math.max(MIN_CLINE_TIMEOUT_SECONDS, parentSeconds - 60));
 }
 
 function isExecTimeout(error) {

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -11,7 +11,7 @@ const {
   modeLabel,
 } = require("../../relay-dispatch/scripts/cli-args");
 const {
-  extractClineRunResultText,
+  extractClineAdvisoryCandidates,
 } = require("../../relay-dispatch/scripts/agent-adapters/cline-jsonl");
 const {
   recoverExecStdout,
@@ -70,16 +70,9 @@ function parseReviewTimeoutMs(value) {
   return timeoutMs;
 }
 
-function timeoutSecondsFromDuration(value) {
-  const raw = String(value || DEFAULT_REVIEW_TIMEOUT).trim();
-  const match = raw.match(/^([1-9]\d*)(ms|s|m|h)$/);
-  if (!match) return "1800";
-  const amount = Number(match[1]);
-  const unit = match[2];
-  if (unit === "ms") return String(Math.max(1, Math.ceil(amount / 1000)));
-  if (unit === "s") return String(amount);
-  if (unit === "m") return String(amount * 60);
-  return String(amount * 60 * 60);
+function clineTimeoutSecondsFromParentMs(parentTimeoutMs) {
+  const parentSeconds = Math.ceil(parentTimeoutMs / 1000);
+  return String(Math.max(60, parentSeconds - 60));
 }
 
 function isExecTimeout(error) {
@@ -92,15 +85,28 @@ function providerForModel(model) {
   return idx > 0 ? model.slice(0, idx) : "cline-pass";
 }
 
+function validateModelRoute(model) {
+  if (typeof model !== "string" || !model.trim()) return null;
+  const normalized = model.trim();
+  if (!normalized.includes("/")) {
+    throw new Error(
+      `--model must use the expected modelType/model form, for example cline-pass/glm-5.2; got ${JSON.stringify(model)}`
+    );
+  }
+  return normalized;
+}
+
 function buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout }) {
+  const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
   const command = [
     clineBin || "cline",
     "--json",
+    "--yolo",
     "-P", providerForModel(model),
   ];
   if (model) command.push("-m", model);
   command.push(
-    "--timeout", timeoutSecondsFromDuration(reviewTimeout),
+    "--timeout", clineTimeoutSecondsFromParentMs(parentTimeoutMs),
     "'Return exactly {\"ok\":true} and nothing else.'"
   );
   return command.join(" ");
@@ -122,7 +128,7 @@ function buildPrompt(promptText) {
 function main() {
   const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
   const promptFile = cliArgs.getArg("--prompt-file");
-  const model = cliArgs.getArg("--model");
+  const model = validateModelRoute(cliArgs.getArg("--model"));
   const phase = resolvePhase(cliArgs.getArg("--phase", "advisory_review"));
   const clineBin = process.env.RELAY_CLINE_BIN || "cline";
   const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
@@ -137,16 +143,18 @@ function main() {
 
   const execArgs = [
     "--json",
+    "--yolo",
     "-P", providerForModel(model),
   ];
   if (model) execArgs.push("-m", model);
   execArgs.push(
     "--cwd", repoPath,
-    "--timeout", timeoutSecondsFromDuration(reviewTimeout),
+    "--timeout", clineTimeoutSecondsFromParentMs(parentTimeoutMs),
     fullPrompt
   );
 
   let rawOutput;
+  let rawStderr = "";
   try {
     rawOutput = execFileSync(clineBin, execArgs, {
       cwd: repoPath,
@@ -157,6 +165,7 @@ function main() {
       maxBuffer: 10 * 1024 * 1024,
     }).trim();
   } catch (error) {
+    rawStderr = String(error?.stderr || "");
     if (isExecTimeout(error)) {
       const diagnosticCommand = buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout });
       throw new Error(
@@ -167,26 +176,44 @@ function main() {
       );
     }
     const recovered = recoverExecStdout(error);
-    if (!recovered) {
+    if (!recovered && !rawStderr) {
       throw new Error(`Cline reviewer failed: ${summarizeFailure(error)}`);
     }
-    rawOutput = recovered;
+    rawOutput = recovered || "";
   }
 
-  let advisoryText;
+  let candidates;
   try {
-    advisoryText = extractClineRunResultText(rawOutput, { adapter: "cline", phase });
+    candidates = extractClineAdvisoryCandidates(rawOutput, {
+      adapter: "cline",
+      phase,
+      stderr: rawStderr,
+    });
   } catch (error) {
     throw new Error(
-      `${error.message}. Cline advisory review must return JSON in run_result.text; relay cannot treat this as healthy advisory evidence.`
+      `${error.message}. Cline advisory review must return JSON in run_result.text or the final text content_end; relay cannot treat this as healthy advisory evidence.`
     );
   }
 
-  const parsed = parseAdvisoryReview(advisoryText, {
-    adapter: "cline",
-    phase,
-    profile: "blindspot",
-  });
+  let parsed = null;
+  let firstParseError = null;
+  for (const candidate of candidates) {
+    try {
+      parsed = parseAdvisoryReview(candidate, {
+        adapter: "cline",
+        phase,
+        profile: "blindspot",
+      });
+      break;
+    } catch (error) {
+      if (!firstParseError) firstParseError = error;
+    }
+  }
+  if (!parsed) {
+    throw new Error(
+      `Cline advisory review failed to parse any of ${candidates.length} advisory candidate(s); first failure: ${firstParseError?.message || "unknown parse failure"}`
+    );
+  }
   const output = JSON.stringify(parsed);
 
   if (cliArgs.hasFlag("--json")) {

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -27,7 +27,8 @@ const cliArgs = bindCliArgs(args, {
 });
 const REVIEW_TIMEOUT_ENV = "RELAY_CLINE_REVIEW_TIMEOUT";
 const DEFAULT_REVIEW_TIMEOUT = "1800s";
-const MIN_CLINE_TIMEOUT_SECONDS = 60;
+const MIN_REVIEW_TIMEOUT_SECONDS = 120;
+const CLINE_TIMEOUT_HEADROOM_SECONDS = 60;
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
   console.log("Usage: invoke-reviewer-cline.js --repo <path> --prompt-file <path> [--phase advisory_review] [--model <route>] [--json]");
@@ -72,14 +73,14 @@ function parseReviewTimeoutMs(value) {
 }
 
 function clineTimeoutSecondsFromParentMs(parentTimeoutMs) {
-  const minimumChildTimeoutMs = MIN_CLINE_TIMEOUT_SECONDS * 1000;
-  if (parentTimeoutMs <= minimumChildTimeoutMs) {
+  const minimumParentMs = MIN_REVIEW_TIMEOUT_SECONDS * 1000;
+  if (parentTimeoutMs < minimumParentMs) {
     throw new Error(
-      `${REVIEW_TIMEOUT_ENV} must be greater than ${MIN_CLINE_TIMEOUT_SECONDS}s so the parent exec timeout can outlive Cline's minimum internal timeout`
+      `${REVIEW_TIMEOUT_ENV} must be at least ${MIN_REVIEW_TIMEOUT_SECONDS}s so Cline's internal timeout stays ${CLINE_TIMEOUT_HEADROOM_SECONDS}s below the parent exec timeout`
     );
   }
   const parentSeconds = Math.ceil(parentTimeoutMs / 1000);
-  return String(Math.max(MIN_CLINE_TIMEOUT_SECONDS, parentSeconds - 60));
+  return String(parentSeconds - CLINE_TIMEOUT_HEADROOM_SECONDS);
 }
 
 function isExecTimeout(error) {

--- a/tests/relay-dispatch/scripts/cline-jsonl.test.js
+++ b/tests/relay-dispatch/scripts/cline-jsonl.test.js
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  extractClineAdvisoryCandidates,
+  extractClineRunResultText,
+} = require("../../../skills/relay-dispatch/scripts/agent-adapters/cline-jsonl");
+
+test("cline advisory extraction reports empty stdout with stderr tail", () => {
+  assert.throws(
+    () => extractClineAdvisoryCandidates("", {
+      adapter: "cline",
+      phase: "advisory_review",
+      stderr: `${"x".repeat(510)} session not found`,
+    }),
+    (error) => {
+      assert.match(error.message, /adapter=cline phase=advisory_review/);
+      assert.match(error.message, /Cline JSONL output is empty/);
+      assert.match(error.message, /stderr tail:/);
+      assert.match(error.message, /session not found/);
+      assert.ok(!error.message.includes("x".repeat(510)));
+      return true;
+    }
+  );
+});
+
+test("cline advisory extraction names invalid JSONL line number", () => {
+  assert.throws(
+    () => extractClineAdvisoryCandidates("not-json\n", {
+      adapter: "cline",
+      phase: "advisory_review",
+    }),
+    /Cline JSONL line 1 must be valid JSON/
+  );
+});
+
+test("cline advisory extraction reports missing run_result with stderr tail", () => {
+  const stdout = [
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: "{\"ok\":true}" } }),
+  ].join("\n");
+
+  assert.throws(
+    () => extractClineAdvisoryCandidates(stdout, {
+      adapter: "cline",
+      phase: "advisory_review",
+      stderr: "session not found",
+    }),
+    /no run_result events found.*stderr tail: session not found/
+  );
+});
+
+test("cline advisory extraction fails on non-completed finishReason without parsing candidates", () => {
+  const stdout = JSON.stringify({
+    type: "run_result",
+    finishReason: "error",
+    durationMs: 313,
+    text: `invalid model format. Expected format: modelType/model ${"a".repeat(400)}`,
+    model: { id: "glm-5.2", provider: "cline-pass" },
+  });
+
+  assert.throws(
+    () => extractClineAdvisoryCandidates(stdout, {
+      adapter: "cline",
+      phase: "advisory_review",
+    }),
+    (error) => {
+      assert.match(error.message, /finishReason "error"/);
+      assert.match(error.message, /invalid model format\. Expected format: modelType\/model/);
+      assert.ok(error.message.length < 520, "run_result.text preview should be bounded");
+      return true;
+    }
+  );
+});
+
+test("cline advisory extraction returns run_result.text then last text content_end", () => {
+  const yoloJson = JSON.stringify({
+    schema_version: 1,
+    profile: "blindspot",
+    summary: "From content_end.",
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  });
+  const stdout = [
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: "older text" } }),
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "reasoning", text: "skip me" } }),
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "tool", text: "skip me too" } }),
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: yoloJson } }),
+    JSON.stringify({
+      type: "run_result",
+      finishReason: "completed",
+      text: "Submission recorded (verified): Output the requested JSON object verbatim ...",
+    }),
+  ].join("\n");
+
+  assert.deepEqual(
+    extractClineAdvisoryCandidates(stdout, {
+      adapter: "cline",
+      phase: "advisory_review",
+    }),
+    [
+      "Submission recorded (verified): Output the requested JSON object verbatim ...",
+      yoloJson,
+    ]
+  );
+});
+
+test("cline dispatch run_result extraction behavior remains unchanged", () => {
+  const stdout = [
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: "{\"ok\":false}" } }),
+    JSON.stringify({
+      type: "run_result",
+      finishReason: "error",
+      text: "{\"ok\": true}",
+    }),
+  ].join("\n");
+
+  assert.equal(extractClineRunResultText(stdout, { adapter: "cline", phase: "dispatch" }), "{\"ok\": true}");
+});

--- a/tests/relay-review/scripts/advisory-review-schema.test.js
+++ b/tests/relay-review/scripts/advisory-review-schema.test.js
@@ -54,7 +54,26 @@ test("advisory schema accepts a single json fenced payload with surrounding whit
   assert.equal(parsed.advisory_findings[0].title, "Exercise timeout path");
 });
 
-test("advisory schema fails closed for ambiguous fenced or prose-wrapped output", () => {
+test("advisory schema parses pure, fenced, and prose-wrapped advisory objects identically", () => {
+  const payload = JSON.stringify(advisoryPayload());
+  const context = {
+    adapter: "opencode",
+    phase: "advisory_review",
+    profile: "blindspot",
+  };
+  const expected = parseAdvisoryReview(payload, context);
+
+  assert.deepEqual(
+    parseAdvisoryReview(`\`\`\`json\n${payload}\n\`\`\``, context),
+    expected
+  );
+  assert.deepEqual(
+    parseAdvisoryReview(`Here is the advisory result:\n\n${payload}\n\nNo further notes.`, context),
+    expected
+  );
+});
+
+test("advisory schema fails closed for ambiguous object or array wrappers", () => {
   const payload = JSON.stringify(advisoryPayload());
   const context = {
     adapter: "opencode",
@@ -63,15 +82,13 @@ test("advisory schema fails closed for ambiguous fenced or prose-wrapped output"
   };
 
   for (const text of [
-    `Here is the JSON:\n${payload}`,
-    `\`\`\`json\n${payload}\n\`\`\`\nThanks.`,
+    `${payload}\n${payload}`,
+    `[${payload}]`,
     `\`\`\`json\n${payload}\n\`\`\`\n\n\`\`\`json\n${payload}\n\`\`\``,
-    `\`\`\`json\n${payload}\n${payload}\n\`\`\``,
-    `\`\`\`json\n{"profile":\n\`\`\``,
   ]) {
     assert.throws(
       () => parseAdvisoryReview(text, context),
-      /adapter=opencode phase=advisory_review advisory review must be valid JSON:/
+      /adapter=opencode phase=advisory_review advisory review must be/
     );
   }
 });

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -1271,7 +1271,7 @@ process.stdout.write(JSON.stringify({
     env: {
       ...process.env,
       RELAY_CLINE_BIN: fakeCline,
-      RELAY_CLINE_REVIEW_TIMEOUT: "45s",
+      RELAY_CLINE_REVIEW_TIMEOUT: "120s",
     },
   });
 
@@ -1574,22 +1574,13 @@ process.exit(0);
   assert.match(stderr, /cannot treat this as healthy advisory evidence/);
 });
 
-test("cline adapter enforces parent timeout and reports timeout context", () => {
+test("cline adapter rejects review timeouts without Cline headroom before executing cline", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-timeout-"));
+  const logPath = path.join(fakeDir, "cline-args.log");
   const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
-setTimeout(() => {
-  process.stdout.write(JSON.stringify({
-    type: "run_result",
-    text: JSON.stringify({
-      profile: "blindspot",
-      summary: "Too late.",
-      required_findings: [],
-      advisory_findings: [],
-      duplicate_or_low_confidence: [],
-    }),
-  }) + "\\n");
-}, 2500);
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(logPath)}, "invoked\\n", "utf-8");
 `);
 
   let error;
@@ -1605,20 +1596,18 @@ setTimeout(() => {
       encoding: "utf-8",
       stdio: "pipe",
       timeout: 5000,
-      env: { ...process.env, RELAY_CLINE_BIN: fakeCline, RELAY_CLINE_REVIEW_TIMEOUT: "1s" },
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline, RELAY_CLINE_REVIEW_TIMEOUT: "60s" },
     });
     assert.fail("expected invoke-reviewer-cline.js to fail");
   } catch (caught) {
     error = caught;
   }
 
-  assert.ok(error, "expected invoke-reviewer-cline.js to fail on parent timeout");
+  assert.ok(error, "expected invoke-reviewer-cline.js to fail before invoking cline");
+  assert.equal(fs.existsSync(logPath), false);
   const stderr = String(error.stderr || "");
-  assert.match(stderr, /Cline reviewer advisory_review timed out after 1s/);
   assert.match(stderr, /RELAY_CLINE_REVIEW_TIMEOUT/);
-  assert.match(stderr, /cannot treat this as healthy advisory evidence/);
-  assert.match(stderr, /verify Cline non-interactive provider output/);
-  assert.doesNotMatch(String(error.stdout || ""), /Too late/);
+  assert.match(stderr, /greater than 60s/);
 });
 
 test("cursor adapter fails closed when auth probe reports not logged in", () => {

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -1596,7 +1596,7 @@ fs.writeFileSync(${JSON.stringify(logPath)}, "invoked\\n", "utf-8");
       encoding: "utf-8",
       stdio: "pipe",
       timeout: 5000,
-      env: { ...process.env, RELAY_CLINE_BIN: fakeCline, RELAY_CLINE_REVIEW_TIMEOUT: "60s" },
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline, RELAY_CLINE_REVIEW_TIMEOUT: "90s" },
     });
     assert.fail("expected invoke-reviewer-cline.js to fail");
   } catch (caught) {
@@ -1607,7 +1607,7 @@ fs.writeFileSync(${JSON.stringify(logPath)}, "invoked\\n", "utf-8");
   assert.equal(fs.existsSync(logPath), false);
   const stderr = String(error.stderr || "");
   assert.match(stderr, /RELAY_CLINE_REVIEW_TIMEOUT/);
-  assert.match(stderr, /greater than 60s/);
+  assert.match(stderr, /at least 120s/);
 });
 
 test("cursor adapter fails closed when auth probe reports not logged in", () => {

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -428,7 +428,7 @@ process.stdout.write("\`\`\`json\\n" + JSON.stringify({
   assert.equal(result.summary, "No blocking blind spots.");
 });
 
-test("opencode adapter rejects prose-wrapped advisory JSON", () => {
+test("opencode adapter accepts prose-wrapped advisory JSON through shared advisory parsing", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-opencode-prose-"));
   const fakeOpencode = writeExecutable(fakeDir, "fake-opencode.js", `#!/usr/bin/env node
@@ -441,28 +441,20 @@ process.stdout.write("Sure, here is the advisory result:\\n" + JSON.stringify({
 }) + "\\n");
 `);
 
-  let error;
-  try {
-    execFileSync("node", [
-      OPENCODE_SCRIPT,
-      "--repo", repoRoot,
-      "--prompt-file", promptPath,
-      "--json",
-    ], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      stdio: "pipe",
-      env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode },
-    });
-  } catch (caught) {
-    error = caught;
-  }
+  const stdout = execFileSync("node", [
+    OPENCODE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_OPENCODE_BIN: fakeOpencode },
+  });
 
-  assert.ok(error, "expected prose-wrapped advisory JSON to fail closed");
-  assert.match(
-    String(error.stderr || ""),
-    /adapter=opencode phase=advisory_review advisory review must be valid JSON:/
-  );
+  const result = JSON.parse(stdout);
+  assert.equal(result.summary, "Recovered from verbose live output.");
 });
 
 test("opencode adapter reports actionable diagnostics for empty stdout", () => {
@@ -1254,6 +1246,7 @@ fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(args), "utf-8");
 process.stdout.write(JSON.stringify({ type: "agent_event", event: { type: "content_start", text: "ignored" } }) + "\\n");
 process.stdout.write(JSON.stringify({
   type: "run_result",
+  finishReason: "completed",
   text: JSON.stringify({
     profile: "blindspot",
     summary: "No blocking blind spots.",
@@ -1285,17 +1278,211 @@ process.stdout.write(JSON.stringify({
   const result = JSON.parse(stdout);
   const loggedArgs = JSON.parse(fs.readFileSync(logPath, "utf-8"));
   assert.equal(result.profile, "blindspot");
-  assert.deepEqual(loggedArgs.slice(0, 9), [
+  assert.deepEqual(loggedArgs.slice(0, 10), [
     "--json",
+    "--yolo",
     "-P", "cline-pass",
     "-m", "cline-pass/glm-5.2",
     "--cwd", repoRoot,
-    "--timeout", "45",
+    "--timeout", "60",
   ]);
-  assert.match(loggedArgs[9], /NON-INTERACTIVE ADVISORY REVIEW/);
-  assert.match(loggedArgs[9], /Return a passing review\./);
-  assert.match(loggedArgs[9], /Do not use cline --worktree; relay already selected the review checkout with --cwd\./);
+  assert.match(loggedArgs[10], /NON-INTERACTIVE ADVISORY REVIEW/);
+  assert.match(loggedArgs[10], /Return a passing review\./);
+  assert.match(loggedArgs[10], /Do not use cline --worktree; relay already selected the review checkout with --cwd\./);
   assert.equal(loggedArgs.includes("--worktree"), false);
+});
+
+test("cline adapter parses yolo content_end candidate when run_result text is a paraphrase", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-yolo-content-"));
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "agent_event",
+  event: { type: "content_end", contentType: "reasoning", text: "skip reasoning" },
+}) + "\\n");
+process.stdout.write(JSON.stringify({
+  type: "agent_event",
+  event: {
+    type: "content_end",
+    contentType: "text",
+    text: JSON.stringify({
+      profile: "blindspot",
+      summary: "Recovered from final content_end.",
+      required_findings: [],
+      advisory_findings: [],
+      duplicate_or_low_confidence: [],
+    }),
+  },
+}) + "\\n");
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  finishReason: "completed",
+  text: "Submission recorded (verified): Output the requested JSON object verbatim ...",
+}) + "\\n");
+`);
+
+  const stdout = execFileSync("node", [
+    CLINE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_CLINE_BIN: fakeCline },
+  });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.summary, "Recovered from final content_end.");
+});
+
+test("cline adapter reports candidate count and first parse failure when all advisory candidates fail", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-candidate-fail-"));
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "agent_event",
+  event: { type: "content_end", contentType: "text", text: "also-not-json" },
+}) + "\\n");
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  finishReason: "completed",
+  text: "not-json",
+}) + "\\n");
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CLINE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline },
+    });
+    assert.fail("expected invoke-reviewer-cline.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /failed to parse any of 2 advisory candidate/);
+  assert.match(stderr, /first failure: adapter=cline phase=advisory_review advisory review must be valid JSON/);
+});
+
+test("cline adapter rejects slash-less model before executing cline", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-model-guard-"));
+  const logPath = path.join(fakeDir, "cline-args.log");
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(logPath)}, "invoked\\n", "utf-8");
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CLINE_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--model", "glm-5.2",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CLINE_BIN: fakeCline },
+    });
+    assert.fail("expected invoke-reviewer-cline.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.equal(fs.existsSync(logPath), false);
+  assert.match(String(error.stderr || ""), /modelType\/model/);
+  assert.match(String(error.stderr || ""), /cline-pass\/glm-5\.2/);
+});
+
+test("cline adapter omits -m when model is absent and keeps default provider path", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-no-model-"));
+  const logPath = path.join(fakeDir, "cline-args.log");
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(args), "utf-8");
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  finishReason: "completed",
+  text: JSON.stringify({
+    profile: "blindspot",
+    summary: "No model flag.",
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  }),
+}) + "\\n");
+`);
+
+  const stdout = execFileSync("node", [
+    CLINE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_CLINE_BIN: fakeCline },
+  });
+
+  const result = JSON.parse(stdout);
+  const loggedArgs = JSON.parse(fs.readFileSync(logPath, "utf-8"));
+  assert.equal(result.summary, "No model flag.");
+  assert.equal(loggedArgs.includes("-m"), false);
+  assert.deepEqual(loggedArgs.slice(0, 4), ["--json", "--yolo", "-P", "cline-pass"]);
+});
+
+test("cline adapter gives cline timeout 60 seconds of parent headroom", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-headroom-"));
+  const logPath = path.join(fakeDir, "cline-args.log");
+  const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(args), "utf-8");
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  finishReason: "completed",
+  text: JSON.stringify({
+    profile: "blindspot",
+    summary: "Headroom.",
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  }),
+}) + "\\n");
+`);
+
+  execFileSync("node", [
+    CLINE_SCRIPT,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_CLINE_BIN: fakeCline, RELAY_CLINE_REVIEW_TIMEOUT: "180s" },
+  });
+
+  const loggedArgs = JSON.parse(fs.readFileSync(logPath, "utf-8"));
+  assert.equal(loggedArgs[loggedArgs.indexOf("--timeout") + 1], "120");
 });
 
 test("cline adapter rejects primary review phase until canary promotion", () => {
@@ -1328,7 +1515,7 @@ test("cline adapter reports adapter and phase when run_result.text is invalid ad
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-cline-invalid-json-"));
   const fakeCline = writeExecutable(fakeDir, "fake-cline.js", `#!/usr/bin/env node
-process.stdout.write(JSON.stringify({ type: "run_result", text: "not-json" }) + "\\n");
+process.stdout.write(JSON.stringify({ type: "run_result", finishReason: "completed", text: "not-json" }) + "\\n");
 `);
 
   let error;

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -439,7 +439,7 @@ setTimeout(() => {
   } else {
     const payload = ${advisoryPayload};
     if (${name === "cline" ? "true" : "false"}) {
-      process.stdout.write(JSON.stringify({ type: "run_result", text: payload }) + "\\n");
+      process.stdout.write(JSON.stringify({ type: "run_result", finishReason: "completed", text: payload }) + "\\n");
     } else {
       process.stdout.write(payload);
     }


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed `1d935f7 fix: harden cline advisory reviewer adapter (#850)`.

What changed:
- Added cline advisory JSONL extraction ladder with stderr tails, finishReason gating, and `run_result.text` + final text `content_end` candidates.
- Updated cline reviewer invocation with `--yolo`, slash-required `--model` guard, timeout headroom, and ordered candidate parsing.
- Switched `parseAdvisoryReview` to the shared wrapped-object parser after fence stripping.
- Added fixture-only test
```

## Score Log

- Run: issue-850-20260709113748528-fab4c9fe
- Executor: codex
- Branch: issue-850