### PR TITLE
Fix linked worktree dispatch path restamping (#857)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -91,6 +91,7 @@ const { normalizeReviewAssurance } = require("./manifest/review-assurance");
 const {
   createRunId,
   ensureRunLayout,
+  getCanonicalRepoRoot,
   getManifestPath,
   getRoutePlanPath,
   getRunDir,
@@ -231,7 +232,6 @@ if (UNKNOWN_FLAGS.length) {
 // Positional arg: first arg that isn't a flag and isn't consumed as a flag's value.
 const repoPathRaw = getPositionals(args, "dispatch")[0];
 const REPO_PATH = path.resolve(repoPathRaw || ".");
-const PROJECT_NAME = path.basename(REPO_PATH);
 const BRANCH = readArg(args, ["--branch", "-b"], undefined, CLI_ARG_OPTIONS);
 const RUN_ID = readArg(args, "--run-id", undefined, CLI_ARG_OPTIONS);
 const MANIFEST_INPUT = readArg(args, "--manifest", undefined, CLI_ARG_OPTIONS);
@@ -487,6 +487,14 @@ function resolveDispatchRuntime(repoRoot) {
     routeResolution,
     timeout,
   };
+}
+
+function resolveRecordedRepoRoot(repoPath) {
+  const resolvedRepoPath = path.resolve(repoPath);
+  const canonicalRepoRoot = getCanonicalRepoRoot(resolvedRepoPath);
+  return path.basename(canonicalRepoRoot) === path.basename(resolvedRepoPath)
+    ? resolvedRepoPath
+    : canonicalRepoRoot;
 }
 
 function classifyNetworkFailure(text) {
@@ -1513,9 +1521,8 @@ async function main() {
   const RELAY_HOME = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
   const wtBase = process.env.RELAY_WORKTREE_BASE || path.join(RELAY_HOME, "worktrees");
   const wtId = crypto.randomBytes(4).toString("hex");
-  let repoRoot = REPO_PATH;
-  let projectName = PROJECT_NAME;
-  let wtPath = path.join(wtBase, wtId, PROJECT_NAME);
+  let repoRoot = RESUME_MODE ? REPO_PATH : resolveRecordedRepoRoot(REPO_PATH);
+  let wtPath = null;
   let resultFile = null;
   let stdoutLog = null;
   let stderrLog = null;
@@ -1647,7 +1654,6 @@ async function main() {
       caller: "dispatch resume",
     });
     repoRoot = validatedPaths.repoRoot;
-    projectName = path.basename(repoRoot);
     branch = manifest.git?.working_branch || branch;
     runId = manifest.run_id || runId;
     wtPath = validatedPaths.worktree;
@@ -1780,10 +1786,11 @@ async function main() {
     }
     manifestPath = getManifestPath(repoRoot, runId);
     const runDir = getRunDir(repoRoot, runId);
+    wtPath = path.join(wtBase, wtId, path.basename(repoRoot));
     if (fs.existsSync(manifestPath) || (fs.existsSync(runDir) && !isPlannerAnchorOnlyRunDir(runDir))) {
       failRunDirCollision(runId, manifestPath);
     }
-    baseBranch = resolveBaseBranchForNewDispatch(repoRoot, { validateRemote: !DRY_RUN });
+    baseBranch = resolveBaseBranchForNewDispatch(REPO_PATH, { validateRemote: !DRY_RUN });
     if (fs.existsSync(wtPath)) {
       console.error(`Error: worktree path already exists: ${wtPath}`);
       process.exit(1);

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -22,6 +22,8 @@ const { STATES, forceTransitionState } = require("./manifest/lifecycle");
 const {
   getEventsPath,
   getRunDir,
+  getWorktreeGitCommonDir,
+  sameFilesystemLocation,
   validateManifestPaths,
 } = require("./manifest/paths");
 const { getActorName, writeManifest } = require("./manifest/store");
@@ -99,6 +101,15 @@ function appendStateRecoveryEvent(repoRoot, runId, eventData) {
     ),
   };
   return appendEventLineToPath(getEventsPath(repoRoot, runId), record);
+}
+
+function sameRecordedRepoCommonDir(recordedRepoRoot, resolvedRepoRoot) {
+  if (!recordedRepoRoot || !resolvedRepoRoot) return false;
+  const recordedCommonDir = getWorktreeGitCommonDir(recordedRepoRoot);
+  const resolvedCommonDir = getWorktreeGitCommonDir(resolvedRepoRoot);
+  if (!recordedCommonDir || !resolvedCommonDir) return false;
+  return recordedCommonDir === resolvedCommonDir
+    || sameFilesystemLocation(recordedCommonDir, resolvedCommonDir);
 }
 
 function printUsage(stream = console.log) {
@@ -456,12 +467,13 @@ function main() {
     allowMissingWorktree: true,
     caller: "recover-state",
   });
+  const preserveRecordedPaths = sameRecordedRepoCommonDir(data.paths?.repo_root, validatedPaths.repoRoot);
   const safeData = {
     ...data,
     paths: {
       ...(data.paths || {}),
-      repo_root: validatedPaths.repoRoot,
-      worktree: validatedPaths.worktree,
+      repo_root: preserveRecordedPaths ? data.paths.repo_root : validatedPaths.repoRoot,
+      worktree: preserveRecordedPaths ? data.paths?.worktree : validatedPaths.worktree,
     },
   };
 

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -4111,6 +4111,49 @@ test("dispatch remaps a local-only linked-worktree checkout branch to origin def
   assert.equal(ghCreateCall[baseFlagIndex + 1], "main");
 });
 
+test("dispatch names new relay worktrees after recorded canonical repo root from linked checkout (#857)", () => {
+  const { repoRoot, relayHome, remoteRoot } = setupRepo();
+  configureOriginHead(repoRoot, remoteRoot, "main");
+  const linkedPath = path.join(os.tmpdir(), `krill-857-linked-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  execFileSync("git", ["worktree", "add", "-b", "worktree-857-source", linkedPath, "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.notEqual(path.basename(linkedPath), path.basename(repoRoot));
+  const worktreeBase = fs.mkdtempSync(path.join(os.tmpdir(), "relay-worktree-base-857-"));
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/857",
+    },
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, linkedPath, ...withRequiredRubric([
+    "-b", "issue-857-linked-name",
+    "--prompt", "exercise linked checkout relay worktree naming",
+    "--json",
+  ])], {
+    cwd: linkedPath,
+    encoding: "utf-8",
+    env: {
+      ...env,
+      RELAY_WORKTREE_BASE: worktreeBase,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const manifest = readManifest(parsed.manifestPath).data;
+  const expectedRepoRoot = fs.realpathSync(repoRoot);
+  assert.equal(manifest.paths.repo_root, expectedRepoRoot);
+  assert.equal(path.basename(manifest.paths.worktree), path.basename(manifest.paths.repo_root));
+  assert.equal(path.basename(manifest.paths.worktree), path.basename(expectedRepoRoot));
+  assert.notEqual(path.basename(manifest.paths.worktree), path.basename(linkedPath));
+  assert.equal(path.dirname(path.dirname(manifest.paths.worktree)), worktreeBase);
+  assert.equal(parsed.worktree, manifest.paths.worktree);
+});
+
 test("dispatch keeps a checkout branch that exists on origin as base_branch (#809)", () => {
   const { repoRoot, relayHome, remoteRoot } = setupRepo();
   configureOriginHead(repoRoot, remoteRoot, "main");

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -15,6 +15,7 @@ const {
   updateManifestState,
   writeManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { validateManifestPaths } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-state.js");
@@ -98,6 +99,33 @@ function addCommitOnBranch(worktreePath, branch, filename = "fix.txt") {
   return newHead;
 }
 
+function createLinkedCheckout(repoRoot, prefix = "krill-recover-linked-") {
+  const linkedPath = path.join(
+    os.tmpdir(),
+    `${prefix}${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+  execFileSync("git", ["worktree", "add", "--detach", linkedPath, "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.notEqual(path.basename(linkedPath), path.basename(repoRoot));
+  return linkedPath;
+}
+
+function restampManifestWorktree({ repoRoot, manifestPath, worktreePath }) {
+  const record = readManifest(manifestPath);
+  const updated = {
+    ...record.data,
+    paths: {
+      ...(record.data.paths || {}),
+      worktree: worktreePath,
+    },
+  };
+  writeManifest(manifestPath, updated, record.body);
+  return updated;
+}
+
 function writeGhPrBodyScript(body) {
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-"));
   const ghPath = path.join(binDir, "gh");
@@ -176,6 +204,120 @@ test("changes_requested -> review_pending succeeds after a fresh commit", () => 
   assert.match(events, new RegExp(`"state_to":"${STATES.REVIEW_PENDING}"`));
   assert.match(events, new RegExp(`"head_sha":"${newHead}"`));
   assert.match(events, new RegExp(`"last_reviewed_sha":"${initialHead}"`));
+});
+
+test("recover-state --manifest from linked cwd preserves equivalent recorded repo_root and worktree bytes (#857)", () => {
+  const { repoRoot, manifestPath, runId, worktreePath, branch } = setupRepo({ state: STATES.ESCALATED });
+  const linkedPath = createLinkedCheckout(repoRoot);
+  execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const relayNamedWorktree = path.join(
+    process.env.RELAY_HOME,
+    "worktrees",
+    "issue-857",
+    path.basename(linkedPath)
+  );
+  fs.mkdirSync(path.dirname(relayNamedWorktree), { recursive: true });
+  execFileSync("git", ["worktree", "add", relayNamedWorktree, branch], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  restampManifestWorktree({ repoRoot, manifestPath, worktreePath: relayNamedWorktree });
+  const before = readManifest(manifestPath).data;
+  const recordedRepoRoot = before.paths.repo_root;
+  const recordedWorktree = before.paths.worktree;
+
+  const validated = validateManifestPaths(before.paths, {
+    expectedRepoRoot: linkedPath,
+    manifestPath,
+    runId,
+    caller: "review-runner-style #857 regression",
+  });
+  assert.equal(validated.repoRoot, path.resolve(linkedPath));
+  assert.equal(path.basename(validated.worktree), path.basename(linkedPath));
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--manifest", manifestPath,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "operator recovered from linked checkout without restamping paths",
+    "--force",
+    "--json",
+  ], {
+    cwd: linkedPath,
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: process.env.RELAY_HOME },
+  });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.previousState, STATES.ESCALATED);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+
+  const afterText = fs.readFileSync(manifestPath, "utf-8");
+  assert.ok(afterText.includes(`repo_root: '${recordedRepoRoot}'`));
+  assert.ok(afterText.includes(`worktree: '${recordedWorktree}'`));
+  const after = readManifest(manifestPath).data;
+  assert.equal(after.paths.repo_root, recordedRepoRoot);
+  assert.equal(after.paths.worktree, recordedWorktree);
+
+  const event = readRunEvents(recordedRepoRoot, runId).find((entry) => entry.event === "state_recovery");
+  assert.equal(event?.state_from, STATES.ESCALATED);
+  assert.equal(event?.state_to, STATES.REVIEW_PENDING);
+  assert.equal(event?.reason, "operator recovered from linked checkout without restamping paths");
+});
+
+test("recover-state with identical canonical root leaves recorded paths unchanged (#857)", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo({ state: STATES.ESCALATED });
+  const before = readManifest(manifestPath).data;
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "canonical root recovery should not restamp paths",
+    "--force",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  const after = readManifest(manifestPath).data;
+  assert.equal(after.paths.repo_root, before.paths.repo_root);
+  assert.equal(after.paths.worktree, before.paths.worktree);
+});
+
+test("recover-state rejects non-equivalent repo roots without writing manifest paths (#857)", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo({ state: STATES.ESCALATED });
+  const before = readManifest(manifestPath).data;
+  const unrelatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-recover-unrelated-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: unrelatedRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Recover Unrelated"], { cwd: unrelatedRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-recover-unrelated@example.com"], { cwd: unrelatedRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(unrelatedRoot, "README.md"), "unrelated\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: unrelatedRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: unrelatedRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", unrelatedRoot,
+    "--manifest", manifestPath,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "must reject unrelated repo root",
+    "--force",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /manifest paths\.repo_root/);
+  const after = readManifest(manifestPath).data;
+  assert.equal(after.state, before.state);
+  assert.equal(after.paths.repo_root, before.paths.repo_root);
+  assert.equal(after.paths.worktree, before.paths.worktree);
 });
 
 test("ready_to_merge -> review_pending succeeds when live PR HEAD drift is objective evidence", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #857.

Commit: `41abd85 Fix linked worktree dispatch path restamping (#857)`

What changed:
- New dispatch worktree leaf naming now derives from the repo root recorded in the manifest, so linked checkout names no longer leak into new relay worktree paths.
- `recover-state.js` preserves recorded `paths.repo_root` and `paths.worktree` byte-identically when the resolved root is git-common-dir-equivalent.
- Added real `git worktree add` regression tests for linked che
```

## Score Log

- Run: issue-857-20260709114256112-c48a889a
- Executor: codex
- Branch: issue-857