### PR TITLE
Allow replacing failed fleet leaves

### DIFF
--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -3,6 +3,7 @@
 
 const { spawn } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const {
@@ -40,6 +41,8 @@ const { runReconcile } = require("../../relay-dispatch/scripts/reconcile-advisor
 const { runMergeQueue } = require("./merge-queue");
 
 const DEFAULT_PARALLEL = 4;
+const FLEET_CHILD_LOCK_TIMEOUT_MS = 5000;
+const FLEET_CHILD_LOCK_WAIT_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 const DEFAULT_DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
 const DEFAULT_PUBLISH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "publish-run.js");
 const DEFAULT_REVIEW_SCRIPT = path.join(__dirname, "..", "..", "relay-review", "scripts", "review-runner.js");
@@ -484,6 +487,61 @@ function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
   return replacements;
 }
 
+function getFleetChildLockPath(repoRoot, fleetId) {
+  return path.join(getFleetsDir(repoRoot), "locks", `fleet-${requireValidFleetId(fleetId)}-children.lock`);
+}
+
+function acquireFleetChildLock(repoRoot, fleetId) {
+  const lockPath = getFleetChildLockPath(repoRoot, fleetId);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const contents = `${JSON.stringify({
+    fleet_id: fleetId,
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquired_at: new Date().toISOString(),
+  })}\n`;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < FLEET_CHILD_LOCK_TIMEOUT_MS) {
+    try {
+      fs.writeFileSync(lockPath, contents, { encoding: "utf-8", flag: "wx" });
+      return { lockPath, contents };
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      try {
+        const existing = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+        if (existing.hostname === os.hostname() && !processIsAlive(Number(existing.pid))) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch (readError) {
+        if (readError.code === "ENOENT") continue;
+      }
+      Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
+    }
+  }
+  throw new FleetInputError(
+    `timed out waiting to update fleet children for '${fleetId}'; another relay-fleet invocation is active`
+  );
+}
+
+function releaseFleetChildLock(lock) {
+  try {
+    if (fs.readFileSync(lock.lockPath, "utf-8") === lock.contents) fs.unlinkSync(lock.lockPath);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+function withFleetChildLock(repoRoot, fleetId, callback) {
+  const lock = acquireFleetChildLock(repoRoot, fleetId);
+  try {
+    return callback();
+  } finally {
+    releaseFleetChildLock(lock);
+  }
+}
+
 function assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves, { persistedLeaves = null } = {}) {
   const fleet = readFleetManifest(repoRoot, fleetId).data;
   if (persistedLeaves) {
@@ -500,42 +558,59 @@ function assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves, { persistedLe
   return { fleet, replacements: [] };
 }
 
-function replaceFleetChildren(repoRoot, fleetId, replacements) {
+function replacedFleetChildren(fleetChildren, replacements) {
   const replacementsByOldRef = new Map(replacements.map((replacement) => [replacement.old_leaf_ref, replacement]));
-  updateFleetManifest(repoRoot, fleetId, (fleet) => {
-    const nextChildren = fleet.children.map((child) => {
-      const replacement = replacementsByOldRef.get(child.leaf_ref);
-      if (!replacement) return child;
-      return {
-        leaf_ref: replacement.new_leaf_ref,
-        run_id: null,
-        dispatch_status: DISPATCH_STATUS.PENDING,
-      };
-    });
-    return { ...fleet, children: nextChildren };
+  return fleetChildren.map((child) => {
+    const replacement = replacementsByOldRef.get(child.leaf_ref);
+    if (!replacement) return child;
+    return {
+      leaf_ref: replacement.new_leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.PENDING,
+    };
   });
 }
 
-function applyAcceptedLeafReplacements(repoRoot, fleetId, leaves, replacements) {
-  if (!replacements.length) return;
-  const originalChildren = readFleetManifest(repoRoot, fleetId).data.children;
-  replaceFleetChildren(repoRoot, fleetId, replacements);
-  try {
-    persistFleetLeaves(repoRoot, fleetId, leaves);
-  } catch (error) {
-    try {
-      updateFleetManifest(repoRoot, fleetId, (fleet) => ({
-        ...fleet,
-        children: originalChildren,
-      }));
-    } catch (rollbackError) {
-      throw new Error(
-        `failed to persist accepted leaf replacements and failed to roll back fleet manifest children: ${error.message}; rollback: ${rollbackError.message}`,
-        { cause: error }
+function applyAcceptedLeafReplacements(repoRoot, fleetId, leaves) {
+  return withFleetChildLock(repoRoot, fleetId, () => {
+    const fleet = readFleetManifest(repoRoot, fleetId).data;
+    const currentPersistedLeaves = readPersistedLeaves(repoRoot, fleetId);
+    const replacements = acceptedLeafReplacements(fleet.children, currentPersistedLeaves, leaves);
+    if (!Array.isArray(replacements)) {
+      throw new FleetInputError(
+        `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
       );
     }
-    throw error;
-  }
+    if (replacements.length === 0) {
+      if (leavesMatch(currentPersistedLeaves, leaves) && leafRefSetsMatch(fleet.children, leaves)) return [];
+      throw new FleetInputError(
+        `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
+      );
+    }
+
+    const originalChildren = fleet.children;
+    updateFleetManifest(repoRoot, fleetId, (current) => ({
+      ...current,
+      children: replacedFleetChildren(current.children, replacements),
+    }));
+    try {
+      persistFleetLeaves(repoRoot, fleetId, leaves);
+    } catch (error) {
+      try {
+        updateFleetManifest(repoRoot, fleetId, (current) => ({
+          ...current,
+          children: originalChildren,
+        }));
+      } catch (rollbackError) {
+        throw new Error(
+          `failed to persist accepted leaf replacements and failed to roll back fleet manifest children: ${error.message}; rollback: ${rollbackError.message}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
+    return replacements;
+  });
 }
 
 function assertLeavesMatchPersisted(repoRoot, fleetId, leaves) {
@@ -640,7 +715,17 @@ function cleanupDeadRuntimeChildren(repoRoot, fleetId) {
 }
 
 function setFleetChild(repoRoot, fleetId, child) {
-  return updateFleetManifest(repoRoot, fleetId, (fleet) => upsertFleetChild(fleet, child)).data;
+  return withFleetChildLock(repoRoot, fleetId, () => {
+    let childExists = true;
+    const updated = updateFleetManifest(repoRoot, fleetId, (fleet) => {
+      if (!findFleetChild(fleet, child.leaf_ref)) {
+        childExists = false;
+        return fleet;
+      }
+      return upsertFleetChild(fleet, child);
+    }).data;
+    return childExists ? updated : null;
+  });
 }
 
 function transitionFleetToDispatching(repoRoot, fleetId) {
@@ -758,12 +843,13 @@ function reconcileFleet(repoRoot, fleetId, leaves) {
     if (!leafRef || !record.data?.run_id) continue;
     const dispatchStatus = dispatchStatusForRunRecordAdoption(fleet, leafRef, record);
     if (!dispatchStatus) continue;
-    fleet = setFleetChild(repoRoot, fleetId, {
+    const updated = setFleetChild(repoRoot, fleetId, {
       leaf_ref: leafRef,
       run_id: record.data.run_id,
       dispatch_status: dispatchStatus,
       last_error: null,
     });
+    if (updated) fleet = updated;
   }
 
   cleanupDeadRuntimeChildren(repoRoot, fleetId);
@@ -774,7 +860,7 @@ function reconcileFleet(repoRoot, fleetId, leaves) {
     if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) continue;
     const leaf = leavesByRef.get(child.leaf_ref);
     if (leaf && issueLockHeld(repoRoot, fleetId, leaf)) continue;
-    fleet = setFleetChild(repoRoot, fleetId, {
+    const updated = setFleetChild(repoRoot, fleetId, {
       leaf_ref: child.leaf_ref,
       run_id: null,
       dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
@@ -782,6 +868,7 @@ function reconcileFleet(repoRoot, fleetId, leaves) {
         fallback: "dispatch interrupted before creating a run manifest",
       }),
     });
+    if (updated) fleet = updated;
   }
 
   return readFleetManifest(repoRoot, fleetId).data;
@@ -1473,21 +1560,27 @@ async function spawnDispatchForLeaf({ repoRoot, fleetId, leaf, options, activeCh
       if (!(error instanceof FleetIssueLockError)) {
         return { leaf_ref: leaf.leaf_ref, status: "failed", error: String(error.message || error) };
       }
-      setFleetChild(repoRoot, fleetId, {
+      const updated = setFleetChild(repoRoot, fleetId, {
         leaf_ref: leaf.leaf_ref,
         run_id: null,
         dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
         last_error: dispatchFailureLastError({ error: error.message }),
       });
+      if (!updated) {
+        return { leaf_ref: leaf.leaf_ref, status: "skipped_replaced" };
+      }
       return { leaf_ref: leaf.leaf_ref, status: "dispatch_failed_pre_manifest", error: error.message };
     }
 
-    setFleetChild(repoRoot, fleetId, {
+    const updated = setFleetChild(repoRoot, fleetId, {
       leaf_ref: leaf.leaf_ref,
       run_id: null,
       dispatch_status: DISPATCH_STATUS.DISPATCHING,
       last_error: null,
     });
+    if (!updated) {
+      return { leaf_ref: leaf.leaf_ref, status: "skipped_replaced" };
+    }
   }
 
   const args = buildDispatchArgs({ repoRoot, fleetId, leaf, options });
@@ -1999,12 +2092,12 @@ function readDriveLeaves({ repoRoot, fleetId, manifestPath, options }) {
     const persisted = assertLeavesMatchPersisted(repoRoot, fleetId, explicitLeaves);
     validateLeafLineage(repoRoot, explicitLeaves);
     if (persisted.replacements.length > 0) {
-      applyAcceptedLeafReplacements(repoRoot, fleetId, explicitLeaves, persisted.replacements);
+      const replacements = applyAcceptedLeafReplacements(repoRoot, fleetId, explicitLeaves);
       return {
         leaves: explicitLeaves,
         explicitLeaves,
         manifestExists,
-        replacedChildren: persisted.replacements,
+        replacedChildren: replacements,
       };
     }
     if (!persisted.leaves) {

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -43,6 +43,7 @@ const { runMergeQueue } = require("./merge-queue");
 const DEFAULT_PARALLEL = 4;
 const FLEET_CHILD_LOCK_TIMEOUT_MS = 5000;
 const FLEET_CHILD_LOCK_WAIT_ARRAY = new Int32Array(new SharedArrayBuffer(4));
+const FLEET_CHILD_TICKET_PATTERN = /^ticket-(\d+)\.(waiting|done)$/;
 const DEFAULT_DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "dispatch.js");
 const DEFAULT_PUBLISH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch", "scripts", "publish-run.js");
 const DEFAULT_REVIEW_SCRIPT = path.join(__dirname, "..", "..", "relay-review", "scripts", "review-runner.js");
@@ -366,15 +367,48 @@ function getFleetLeavesStorePath(repoRoot, fleetId) {
   return path.join(getFleetsDir(repoRoot), `${requireValidFleetId(fleetId)}.leaves.json`);
 }
 
+function getFleetLeafReplacementPath(repoRoot, fleetId) {
+  return path.join(getFleetsDir(repoRoot), `${requireValidFleetId(fleetId)}.leaves-replacement.json`);
+}
+
 function getFleetRuntimePath(repoRoot, fleetId) {
   return path.join(getFleetsDir(repoRoot), `${requireValidFleetId(fleetId)}.running.json`);
 }
 
-function writeJsonAtomically(filePath, data) {
+function syncDirectory(directoryPath) {
+  let fd = null;
+  try {
+    fd = fs.openSync(directoryPath, "r");
+    fs.fsyncSync(fd);
+  } catch (error) {
+    if (!["EINVAL", "ENOTSUP", "EISDIR", "EPERM"].includes(error.code)) throw error;
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
+function syncFile(filePath) {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  syncDirectory(path.dirname(filePath));
+}
+
+function writeJsonAtomically(filePath, data, { durable = false } = {}) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
-  fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  const fd = fs.openSync(tmpPath, "w");
+  try {
+    fs.writeFileSync(fd, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+    if (durable) fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
   fs.renameSync(tmpPath, filePath);
+  if (durable) syncDirectory(path.dirname(filePath));
 }
 
 function readJsonIfExists(filePath, fallback) {
@@ -382,9 +416,9 @@ function readJsonIfExists(filePath, fallback) {
   return JSON.parse(fs.readFileSync(filePath, "utf-8"));
 }
 
-function persistFleetLeaves(repoRoot, fleetId, leaves) {
+function persistFleetLeaves(repoRoot, fleetId, leaves, { durable = false } = {}) {
   const storePath = getFleetLeavesStorePath(repoRoot, fleetId);
-  writeJsonAtomically(storePath, { fleet_id: fleetId, leaves });
+  writeJsonAtomically(storePath, { fleet_id: fleetId, leaves }, { durable });
   return storePath;
 }
 
@@ -464,6 +498,7 @@ function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
   if (new Set(leaves.map((leaf) => leaf.leaf_ref)).size !== leaves.length) return null;
 
   const childrenByRef = new Map(fleetChildren.map((child) => [child.leaf_ref, child]));
+  const existingChildRefs = new Set(childrenByRef.keys());
   const leavesByIssue = new Map(leaves.map((leaf) => [leaf.issue_number, leaf]));
   const replacements = [];
   for (const persistedLeaf of persistedLeaves) {
@@ -473,6 +508,9 @@ function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
     // rejected so a concurrent invocation holding the old spec can never find
     // a same-keyed child to dispatch (the old ref ceases to exist on accept).
     if (leaf.leaf_ref === persistedLeaf.leaf_ref) return null;
+    // Reusing any old child key (including another replaceable child's key)
+    // would leave stale selectors able to find that key with a different spec.
+    if (existingChildRefs.has(leaf.leaf_ref)) return null;
     const child = childrenByRef.get(persistedLeaf.leaf_ref);
     if (!isReplaceableFleetChild(child)) return null;
     replacements.push({
@@ -495,35 +533,139 @@ function getFleetChildLockPath(repoRoot, fleetId) {
   return path.join(getFleetsDir(repoRoot), "locks", `fleet-${requireValidFleetId(fleetId)}-children.lock`);
 }
 
+function getFleetChildTicketDirectory(lockPath) {
+  return `${lockPath}.queue`;
+}
+
+function listFleetChildTickets(ticketDirectory) {
+  if (!fs.existsSync(ticketDirectory)) return [];
+  return fs.readdirSync(ticketDirectory)
+    .map((name) => {
+      const match = name.match(FLEET_CHILD_TICKET_PATTERN);
+      return match ? {
+        number: Number(match[1]),
+        state: match[2],
+        path: path.join(ticketDirectory, name),
+      } : null;
+    })
+    .filter(Boolean);
+}
+
+function createFleetChildTicket(lockPath, fleetId) {
+  const ticketDirectory = getFleetChildTicketDirectory(lockPath);
+  fs.mkdirSync(ticketDirectory, { recursive: true });
+
+  while (true) {
+    const tickets = listFleetChildTickets(ticketDirectory);
+    const number = tickets.reduce((highest, ticket) => Math.max(highest, ticket.number), 0) + 1;
+    const waitingPath = path.join(ticketDirectory, `ticket-${number}.waiting`);
+    const candidatePath = path.join(
+      ticketDirectory,
+      `.candidate-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    );
+    fs.writeFileSync(candidatePath, `${JSON.stringify({
+      fleet_id: fleetId,
+      pid: process.pid,
+      hostname: os.hostname(),
+      acquired_at: new Date().toISOString(),
+    })}\n`, "utf-8");
+    try {
+      fs.linkSync(candidatePath, waitingPath);
+      return { number, waitingPath, ticketDirectory };
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+    } finally {
+      try {
+        fs.unlinkSync(candidatePath);
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    }
+  }
+}
+
+function retireDeadFleetChildTickets(ticket) {
+  for (const predecessor of listFleetChildTickets(ticket.ticketDirectory)) {
+    if (predecessor.state !== "waiting" || predecessor.number >= ticket.number) continue;
+    try {
+      const owner = JSON.parse(fs.readFileSync(predecessor.path, "utf-8"));
+      if (owner.hostname !== os.hostname() || processIsAlive(Number(owner.pid))) continue;
+      fs.renameSync(predecessor.path, predecessor.path.replace(/\.waiting$/, ".done"));
+    } catch (error) {
+      if (error.code !== "ENOENT") continue;
+    }
+  }
+}
+
+function fleetChildTicketHasPredecessor(ticket) {
+  return listFleetChildTickets(ticket.ticketDirectory)
+    .some((entry) => entry.state === "waiting" && entry.number < ticket.number);
+}
+
+function releaseFleetChildTicket(ticket) {
+  const donePath = ticket.waitingPath.replace(/\.waiting$/, ".done");
+  try {
+    fs.renameSync(ticket.waitingPath, donePath);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+
+  const tickets = listFleetChildTickets(ticket.ticketDirectory);
+  const highest = tickets.reduce((value, entry) => Math.max(value, entry.number), 0);
+  for (const entry of tickets) {
+    if (entry.state !== "done" || entry.number >= highest) continue;
+    try {
+      fs.unlinkSync(entry.path);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
 function acquireFleetChildLock(repoRoot, fleetId) {
   const lockPath = getFleetChildLockPath(repoRoot, fleetId);
   fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const ticket = createFleetChildTicket(lockPath, fleetId);
   const contents = `${JSON.stringify({
     fleet_id: fleetId,
     pid: process.pid,
     hostname: os.hostname(),
     acquired_at: new Date().toISOString(),
+    ticket: ticket.number,
   })}\n`;
   const startedAt = Date.now();
 
-  while (Date.now() - startedAt < FLEET_CHILD_LOCK_TIMEOUT_MS) {
-    try {
-      fs.writeFileSync(lockPath, contents, { encoding: "utf-8", flag: "wx" });
-      return { lockPath, contents };
-    } catch (error) {
-      if (error.code !== "EEXIST") throw error;
-      try {
-        const existing = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
-        if (existing.hostname === os.hostname() && !processIsAlive(Number(existing.pid))) {
-          fs.unlinkSync(lockPath);
-          continue;
-        }
-      } catch (readError) {
-        if (readError.code === "ENOENT") continue;
+  try {
+    while (Date.now() - startedAt < FLEET_CHILD_LOCK_TIMEOUT_MS) {
+      retireDeadFleetChildTickets(ticket);
+      if (fleetChildTicketHasPredecessor(ticket)) {
+        Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
+        continue;
       }
-      Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
+      try {
+        fs.writeFileSync(lockPath, contents, { encoding: "utf-8", flag: "wx" });
+        return { lockPath, contents, ticket };
+      } catch (error) {
+        if (error.code !== "EEXIST") throw error;
+        try {
+          const existing = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+          if (existing.hostname === os.hostname() && !processIsAlive(Number(existing.pid))) {
+            // Only the lowest live ticket may reclaim the canonical lock. A
+            // contender that observed this stale owner cannot race a successor.
+            fs.unlinkSync(lockPath);
+            continue;
+          }
+        } catch (readError) {
+          if (readError.code === "ENOENT") continue;
+        }
+        Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
+      }
     }
+  } catch (error) {
+    releaseFleetChildTicket(ticket);
+    throw error;
   }
+  releaseFleetChildTicket(ticket);
   throw new FleetInputError(
     `timed out waiting to update fleet children for '${fleetId}'; another relay-fleet invocation is active`
   );
@@ -534,6 +676,8 @@ function releaseFleetChildLock(lock) {
     if (fs.readFileSync(lock.lockPath, "utf-8") === lock.contents) fs.unlinkSync(lock.lockPath);
   } catch (error) {
     if (error.code !== "ENOENT") throw error;
+  } finally {
+    releaseFleetChildTicket(lock.ticket);
   }
 }
 
@@ -575,8 +719,72 @@ function replacedFleetChildren(fleetChildren, replacements) {
   });
 }
 
+function fleetChildrenMatch(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function removeFleetLeafReplacementJournal(journalPath) {
+  try {
+    fs.unlinkSync(journalPath);
+    syncDirectory(path.dirname(journalPath));
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+function recoverAcceptedLeafReplacementUnlocked(repoRoot, fleetId) {
+  const journalPath = getFleetLeafReplacementPath(repoRoot, fleetId);
+  const journal = readJsonIfExists(journalPath, null);
+  if (!journal) return [];
+  if (
+    journal.fleet_id !== fleetId
+    || !Array.isArray(journal.original_children)
+    || !Array.isArray(journal.replacement_children)
+    || !Array.isArray(journal.original_leaves)
+    || !Array.isArray(journal.replacement_leaves)
+  ) {
+    throw new Error(`invalid fleet leaf-replacement recovery journal: ${journalPath}`);
+  }
+
+  const fleet = readFleetManifest(repoRoot, fleetId).data;
+  const persistedLeaves = readPersistedLeaves(repoRoot, fleetId);
+  const manifestIsOriginal = fleetChildrenMatch(fleet.children, journal.original_children);
+  const manifestIsReplacement = fleetChildrenMatch(fleet.children, journal.replacement_children);
+  const leavesAreOriginal = leavesMatch(persistedLeaves, journal.original_leaves);
+  const leavesAreReplacement = leavesMatch(persistedLeaves, journal.replacement_leaves);
+
+  if (manifestIsOriginal && leavesAreOriginal) {
+    removeFleetLeafReplacementJournal(journalPath);
+    return [];
+  }
+  if (manifestIsOriginal && leavesAreReplacement) {
+    updateFleetManifest(repoRoot, fleetId, (current) => ({
+      ...current,
+      children: journal.replacement_children,
+    }));
+    syncFile(getFleetManifestPath(repoRoot, fleetId));
+  } else if (manifestIsReplacement && leavesAreOriginal) {
+    persistFleetLeaves(repoRoot, fleetId, journal.replacement_leaves, { durable: true });
+  } else if (!manifestIsReplacement || !leavesAreReplacement) {
+    throw new Error(
+      `fleet leaf-replacement recovery journal does not match the manifest/leaves stores for '${fleetId}'`
+    );
+  }
+
+  removeFleetLeafReplacementJournal(journalPath);
+  return Array.isArray(journal.replacements) ? journal.replacements : [];
+}
+
+function recoverAcceptedLeafReplacement(repoRoot, fleetId) {
+  if (!fs.existsSync(getFleetLeafReplacementPath(repoRoot, fleetId))) return [];
+  return withFleetChildLock(repoRoot, fleetId, () => (
+    recoverAcceptedLeafReplacementUnlocked(repoRoot, fleetId)
+  ));
+}
+
 function applyAcceptedLeafReplacements(repoRoot, fleetId, leaves) {
   return withFleetChildLock(repoRoot, fleetId, () => {
+    recoverAcceptedLeafReplacementUnlocked(repoRoot, fleetId);
     const fleet = readFleetManifest(repoRoot, fleetId).data;
     const currentPersistedLeaves = readPersistedLeaves(repoRoot, fleetId);
     const replacements = acceptedLeafReplacements(fleet.children, currentPersistedLeaves, leaves);
@@ -593,26 +801,47 @@ function applyAcceptedLeafReplacements(repoRoot, fleetId, leaves) {
     }
 
     const originalChildren = fleet.children;
-    updateFleetManifest(repoRoot, fleetId, (current) => ({
-      ...current,
-      children: replacedFleetChildren(current.children, replacements),
-    }));
+    const replacementChildren = replacedFleetChildren(fleet.children, replacements);
+    const journalPath = getFleetLeafReplacementPath(repoRoot, fleetId);
+    writeJsonAtomically(journalPath, {
+      fleet_id: fleetId,
+      original_children: originalChildren,
+      replacement_children: replacementChildren,
+      original_leaves: currentPersistedLeaves,
+      replacement_leaves: leaves,
+      replacements,
+    }, { durable: true });
     try {
-      persistFleetLeaves(repoRoot, fleetId, leaves);
+      updateFleetManifest(repoRoot, fleetId, (current) => ({
+        ...current,
+        children: replacementChildren,
+      }));
+      syncFile(getFleetManifestPath(repoRoot, fleetId));
+      persistFleetLeaves(repoRoot, fleetId, leaves, { durable: true });
     } catch (error) {
       try {
-        updateFleetManifest(repoRoot, fleetId, (current) => ({
-          ...current,
-          children: originalChildren,
-        }));
+        const currentFleet = readFleetManifest(repoRoot, fleetId).data;
+        if (!fleetChildrenMatch(currentFleet.children, originalChildren)) {
+          updateFleetManifest(repoRoot, fleetId, (current) => ({
+            ...current,
+            children: originalChildren,
+          }));
+          syncFile(getFleetManifestPath(repoRoot, fleetId));
+        }
+        const persistedAfterFailure = readPersistedLeaves(repoRoot, fleetId);
+        if (!leavesMatch(persistedAfterFailure, currentPersistedLeaves)) {
+          persistFleetLeaves(repoRoot, fleetId, currentPersistedLeaves, { durable: true });
+        }
+        removeFleetLeafReplacementJournal(journalPath);
       } catch (rollbackError) {
         throw new Error(
-          `failed to persist accepted leaf replacements and failed to roll back fleet manifest children: ${error.message}; rollback: ${rollbackError.message}`,
+          `failed to persist accepted leaf replacements and failed to roll back fleet stores: ${error.message}; rollback: ${rollbackError.message}`,
           { cause: error }
         );
       }
       throw error;
     }
+    removeFleetLeafReplacementJournal(journalPath);
     return replacements;
   });
 }
@@ -2092,6 +2321,8 @@ function readDriveLeaves({ repoRoot, fleetId, manifestPath, options }) {
     return { leaves: explicitLeaves, explicitLeaves, manifestExists, replacedChildren: [] };
   }
 
+  const recoveredReplacements = recoverAcceptedLeafReplacement(repoRoot, fleetId);
+
   if (explicitLeaves) {
     const persisted = assertLeavesMatchPersisted(repoRoot, fleetId, explicitLeaves);
     validateLeafLineage(repoRoot, explicitLeaves);
@@ -2106,16 +2337,16 @@ function readDriveLeaves({ repoRoot, fleetId, manifestPath, options }) {
     }
     if (!persisted.leaves) {
       persistFleetLeaves(repoRoot, fleetId, explicitLeaves);
-      return { leaves: explicitLeaves, explicitLeaves, manifestExists, replacedChildren: [] };
+      return { leaves: explicitLeaves, explicitLeaves, manifestExists, replacedChildren: recoveredReplacements };
     }
-    return { leaves: persisted.leaves, explicitLeaves, manifestExists, replacedChildren: [] };
+    return { leaves: persisted.leaves, explicitLeaves, manifestExists, replacedChildren: recoveredReplacements };
   }
 
   return {
     leaves: readPersistedLeaves(repoRoot, fleetId),
     explicitLeaves: null,
     manifestExists,
-    replacedChildren: [],
+    replacedChildren: recoveredReplacements,
   };
 }
 
@@ -2457,6 +2688,7 @@ module.exports = {
   buildRedispatchArgs,
   buildReviewArgs,
   formatStatusText,
+  getFleetLeafReplacementPath,
   getFleetLeavesStorePath,
   getFleetRuntimePath,
   loadLeavesFile,
@@ -2466,4 +2698,5 @@ module.exports = {
   reviewFleet,
   runFleet,
   statusFleet,
+  withFleetChildLock,
 };

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -622,6 +622,24 @@ function releaseFleetChildTicket(ticket) {
   }
 }
 
+function publishFleetChildLock(lockPath, contents) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  fs.writeFileSync(candidatePath, contents, "utf-8");
+  try {
+    fs.linkSync(candidatePath, lockPath);
+    return true;
+  } catch (error) {
+    if (error.code !== "EEXIST") throw error;
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(candidatePath);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
 function acquireFleetChildLock(repoRoot, fleetId) {
   const lockPath = getFleetChildLockPath(repoRoot, fleetId);
   fs.mkdirSync(path.dirname(lockPath), { recursive: true });
@@ -642,24 +660,30 @@ function acquireFleetChildLock(repoRoot, fleetId) {
         Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
         continue;
       }
-      try {
-        fs.writeFileSync(lockPath, contents, { encoding: "utf-8", flag: "wx" });
+      if (publishFleetChildLock(lockPath, contents)) {
         return { lockPath, contents, ticket };
-      } catch (error) {
-        if (error.code !== "EEXIST") throw error;
-        try {
-          const existing = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
-          if (existing.hostname === os.hostname() && !processIsAlive(Number(existing.pid))) {
-            // Only the lowest live ticket may reclaim the canonical lock. A
-            // contender that observed this stale owner cannot race a successor.
-            fs.unlinkSync(lockPath);
-            continue;
-          }
-        } catch (readError) {
-          if (readError.code === "ENOENT") continue;
-        }
-        Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
       }
+      try {
+        const existingContents = fs.readFileSync(lockPath, "utf-8");
+        let existing;
+        try {
+          existing = JSON.parse(existingContents);
+        } catch {
+          // Older writers created the canonical path before populating it.
+          // The lowest live ticket can safely retire a truncated remnant.
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+        if (existing.hostname === os.hostname() && !processIsAlive(Number(existing.pid))) {
+          // Only the lowest live ticket may reclaim the canonical lock. A
+          // contender that observed this stale owner cannot race a successor.
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch (readError) {
+        if (readError.code === "ENOENT") continue;
+      }
+      Atomics.wait(FLEET_CHILD_LOCK_WAIT_ARRAY, 0, 0, 10);
     }
   } catch (error) {
     releaseFleetChildTicket(ticket);

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -458,6 +458,7 @@ function isReplaceableFleetChild(child) {
 function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
   if (!Array.isArray(persistedLeaves) || leavesMatch(persistedLeaves, leaves)) return [];
   if (!issueSetsMatch(persistedLeaves, leaves)) return null;
+  if (new Set(leaves.map((leaf) => leaf.leaf_ref)).size !== leaves.length) return null;
 
   const childrenByRef = new Map(fleetChildren.map((child) => [child.leaf_ref, child]));
   const leavesByIssue = new Map(leaves.map((leaf) => [leaf.issue_number, leaf]));
@@ -473,6 +474,11 @@ function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
       issue_number: persistedLeaf.issue_number,
     });
   }
+  const replacementsByOldRef = new Map(replacements.map((replacement) => [replacement.old_leaf_ref, replacement]));
+  const nextChildRefs = fleetChildren.map((child) => (
+    replacementsByOldRef.get(child.leaf_ref)?.new_leaf_ref || child.leaf_ref
+  ));
+  if (new Set(nextChildRefs).size !== nextChildRefs.length) return null;
   return replacements;
 }
 
@@ -495,23 +501,15 @@ function assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves, { persistedLe
 function replaceFleetChildren(repoRoot, fleetId, replacements) {
   const replacementsByOldRef = new Map(replacements.map((replacement) => [replacement.old_leaf_ref, replacement]));
   updateFleetManifest(repoRoot, fleetId, (fleet) => {
-    const nextChildren = [];
-    const seenRefs = new Set();
-    for (const child of fleet.children) {
+    const nextChildren = fleet.children.map((child) => {
       const replacement = replacementsByOldRef.get(child.leaf_ref);
-      if (!replacement) {
-        nextChildren.push(child);
-        seenRefs.add(child.leaf_ref);
-        continue;
-      }
-      if (seenRefs.has(replacement.new_leaf_ref)) continue;
-      nextChildren.push({
+      if (!replacement) return child;
+      return {
         leaf_ref: replacement.new_leaf_ref,
         run_id: null,
         dispatch_status: DISPATCH_STATUS.PENDING,
-      });
-      seenRefs.add(replacement.new_leaf_ref);
-    }
+      };
+    });
     return { ...fleet, children: nextChildren };
   });
 }

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -518,8 +518,24 @@ function replaceFleetChildren(repoRoot, fleetId, replacements) {
 
 function applyAcceptedLeafReplacements(repoRoot, fleetId, leaves, replacements) {
   if (!replacements.length) return;
+  const originalChildren = readFleetManifest(repoRoot, fleetId).data.children;
   replaceFleetChildren(repoRoot, fleetId, replacements);
-  persistFleetLeaves(repoRoot, fleetId, leaves);
+  try {
+    persistFleetLeaves(repoRoot, fleetId, leaves);
+  } catch (error) {
+    try {
+      updateFleetManifest(repoRoot, fleetId, (fleet) => ({
+        ...fleet,
+        children: originalChildren,
+      }));
+    } catch (rollbackError) {
+      throw new Error(
+        `failed to persist accepted leaf replacements and failed to roll back fleet manifest children: ${error.message}; rollback: ${rollbackError.message}`,
+        { cause: error }
+      );
+    }
+    throw error;
+  }
 }
 
 function assertLeavesMatchPersisted(repoRoot, fleetId, leaves) {

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -469,6 +469,10 @@ function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
   for (const persistedLeaf of persistedLeaves) {
     const leaf = leavesByIssue.get(persistedLeaf.issue_number);
     if (JSON.stringify(comparableLeaf(persistedLeaf)) === JSON.stringify(comparableLeaf(leaf))) continue;
+    // A changed leaf must carry a NEW leaf_ref: same-ref respecification is
+    // rejected so a concurrent invocation holding the old spec can never find
+    // a same-keyed child to dispatch (the old ref ceases to exist on accept).
+    if (leaf.leaf_ref === persistedLeaf.leaf_ref) return null;
     const child = childrenByRef.get(persistedLeaf.leaf_ref);
     if (!isReplaceableFleetChild(child)) return null;
     replacements.push({

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -443,13 +443,83 @@ function leafRefSetsMatch(left, right) {
     && leftRefs.every((leafRef, index) => leafRef === rightRefs[index]);
 }
 
-function assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves) {
+function issueSetsMatch(left, right) {
+  const leftIssues = left.map((leaf) => leaf.issue_number).sort((a, b) => a - b);
+  const rightIssues = right.map((leaf) => leaf.issue_number).sort((a, b) => a - b);
+  return leftIssues.length === rightIssues.length
+    && leftIssues.every((issueNumber, index) => issueNumber === rightIssues[index]);
+}
+
+function isReplaceableFleetChild(child) {
+  return child?.run_id === null
+    && child?.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST;
+}
+
+function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
+  if (!Array.isArray(persistedLeaves) || leavesMatch(persistedLeaves, leaves)) return [];
+  if (!issueSetsMatch(persistedLeaves, leaves)) return null;
+
+  const childrenByRef = new Map(fleetChildren.map((child) => [child.leaf_ref, child]));
+  const leavesByIssue = new Map(leaves.map((leaf) => [leaf.issue_number, leaf]));
+  const replacements = [];
+  for (const persistedLeaf of persistedLeaves) {
+    const leaf = leavesByIssue.get(persistedLeaf.issue_number);
+    if (JSON.stringify(comparableLeaf(persistedLeaf)) === JSON.stringify(comparableLeaf(leaf))) continue;
+    const child = childrenByRef.get(persistedLeaf.leaf_ref);
+    if (!isReplaceableFleetChild(child)) return null;
+    replacements.push({
+      old_leaf_ref: persistedLeaf.leaf_ref,
+      new_leaf_ref: leaf.leaf_ref,
+      issue_number: persistedLeaf.issue_number,
+    });
+  }
+  return replacements;
+}
+
+function assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves, { persistedLeaves = null } = {}) {
   const fleet = readFleetManifest(repoRoot, fleetId).data;
+  if (persistedLeaves) {
+    return {
+      fleet,
+      replacements: acceptedLeafReplacements(fleet.children, persistedLeaves, leaves),
+    };
+  }
   if (!leafRefSetsMatch(leaves, fleet.children)) {
     throw new FleetInputError(
       `--leaves-file leaf_ref set differs from fleet manifest children for '${fleetId}'; refusing to overwrite an existing fleet`
     );
   }
+  return { fleet, replacements: [] };
+}
+
+function replaceFleetChildren(repoRoot, fleetId, replacements) {
+  const replacementsByOldRef = new Map(replacements.map((replacement) => [replacement.old_leaf_ref, replacement]));
+  updateFleetManifest(repoRoot, fleetId, (fleet) => {
+    const nextChildren = [];
+    const seenRefs = new Set();
+    for (const child of fleet.children) {
+      const replacement = replacementsByOldRef.get(child.leaf_ref);
+      if (!replacement) {
+        nextChildren.push(child);
+        seenRefs.add(child.leaf_ref);
+        continue;
+      }
+      if (seenRefs.has(replacement.new_leaf_ref)) continue;
+      nextChildren.push({
+        leaf_ref: replacement.new_leaf_ref,
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.PENDING,
+      });
+      seenRefs.add(replacement.new_leaf_ref);
+    }
+    return { ...fleet, children: nextChildren };
+  });
+}
+
+function applyAcceptedLeafReplacements(repoRoot, fleetId, leaves, replacements) {
+  if (!replacements.length) return;
+  replaceFleetChildren(repoRoot, fleetId, replacements);
+  persistFleetLeaves(repoRoot, fleetId, leaves);
 }
 
 function assertLeavesMatchPersisted(repoRoot, fleetId, leaves) {
@@ -457,8 +527,8 @@ function assertLeavesMatchPersisted(repoRoot, fleetId, leaves) {
   const storeExists = fs.existsSync(storePath);
   const persisted = readPersistedLeaves(repoRoot, fleetId);
   if (!storeExists) {
-    assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves);
-    return null;
+    const { replacements } = assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves);
+    return { leaves: null, replacements };
   }
   if (persisted.length === 0) {
     throw new FleetInputError(
@@ -466,11 +536,16 @@ function assertLeavesMatchPersisted(repoRoot, fleetId, leaves) {
     );
   }
   if (!leavesMatch(persisted, leaves)) {
+    const { replacements } = assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves, { persistedLeaves: persisted });
+    if (Array.isArray(replacements) && replacements.length > 0) {
+      return { leaves, replacements };
+    }
     throw new FleetInputError(
       `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
     );
   }
-  return persisted;
+  assertLeavesMatchFleetChildren(repoRoot, fleetId, leaves);
+  return { leaves: persisted, replacements: [] };
 }
 
 function processIsAlive(pid) {
@@ -1693,6 +1768,14 @@ function formatPreManifestRetryLine(summary, fleetId) {
   ].join(" ");
 }
 
+function writeReplacementNotes(result) {
+  for (const replacement of result?.replaced_children || []) {
+    console.error(
+      `relay-fleet replaced child in fleet '${result.fleet_id}': ${replacement.old_leaf_ref} -> ${replacement.new_leaf_ref}`
+    );
+  }
+}
+
 async function statusFleet({ repoRoot, fleetId }) {
   const fleet = readFleetManifest(repoRoot, fleetId).data;
   const summary = deriveFleetSummary(repoRoot, fleet);
@@ -1885,7 +1968,7 @@ function readDriveLeaves({ repoRoot, fleetId, manifestPath, options }) {
       throw new FleetInputError("--leaves-file is required for --dry-run");
     }
     validateLeafLineage(repoRoot, explicitLeaves);
-    return { leaves: explicitLeaves, explicitLeaves, manifestExists };
+    return { leaves: explicitLeaves, explicitLeaves, manifestExists, replacedChildren: [] };
   }
 
   if (!manifestExists) {
@@ -1893,23 +1976,33 @@ function readDriveLeaves({ repoRoot, fleetId, manifestPath, options }) {
       throw new FleetInputError(`fleet manifest does not exist: ${manifestPath}; nothing to continue`);
     }
     validateLeafLineage(repoRoot, explicitLeaves);
-    return { leaves: explicitLeaves, explicitLeaves, manifestExists };
+    return { leaves: explicitLeaves, explicitLeaves, manifestExists, replacedChildren: [] };
   }
 
   if (explicitLeaves) {
     const persisted = assertLeavesMatchPersisted(repoRoot, fleetId, explicitLeaves);
     validateLeafLineage(repoRoot, explicitLeaves);
-    if (!persisted) {
-      persistFleetLeaves(repoRoot, fleetId, explicitLeaves);
-      return { leaves: explicitLeaves, explicitLeaves, manifestExists };
+    if (persisted.replacements.length > 0) {
+      applyAcceptedLeafReplacements(repoRoot, fleetId, explicitLeaves, persisted.replacements);
+      return {
+        leaves: explicitLeaves,
+        explicitLeaves,
+        manifestExists,
+        replacedChildren: persisted.replacements,
+      };
     }
-    return { leaves: persisted, explicitLeaves, manifestExists };
+    if (!persisted.leaves) {
+      persistFleetLeaves(repoRoot, fleetId, explicitLeaves);
+      return { leaves: explicitLeaves, explicitLeaves, manifestExists, replacedChildren: [] };
+    }
+    return { leaves: persisted.leaves, explicitLeaves, manifestExists, replacedChildren: [] };
   }
 
   return {
     leaves: readPersistedLeaves(repoRoot, fleetId),
     explicitLeaves: null,
     manifestExists,
+    replacedChildren: [],
   };
 }
 
@@ -2018,6 +2111,7 @@ function buildDriveResult({
   reviewResult = null,
   mergeResult = null,
   deprecatedAliases = [],
+  replacedChildren = [],
 }) {
   closeFleetIfTerminal(repoRoot, fleetId);
   const summary = deriveFleetSummary(repoRoot, readFleetManifest(repoRoot, fleetId).data);
@@ -2032,6 +2126,7 @@ function buildDriveResult({
     fleet_id: fleetId,
     fleetManifestPath,
     deprecated_aliases: deprecatedAliases,
+    replaced_children: replacedChildren,
     children: dispatchResult?.children || [],
     dispatch_children: dispatchResult?.children || [],
     reviewed_children: reviewResult?.reviewed_children || [],
@@ -2090,7 +2185,7 @@ async function runFleet(options) {
     }
   }
 
-  const { leaves, manifestExists } = readDriveLeaves({ repoRoot, fleetId, manifestPath, options });
+  const { leaves, manifestExists, replacedChildren } = readDriveLeaves({ repoRoot, fleetId, manifestPath, options });
 
   if (options.dryRun) {
     const activeChildren = new Map();
@@ -2108,6 +2203,7 @@ async function runFleet(options) {
       ok: children.every((child) => child.status === "dry_run"),
       dryRun: true,
       fleet_id: fleetId,
+      replaced_children: replacedChildren,
       children,
     };
   }
@@ -2143,6 +2239,7 @@ async function runFleet(options) {
         interrupted,
         fleetManifestPath: manifestPath,
         deprecated_aliases: deprecatedAliases,
+        replaced_children: replacedChildren,
       };
     }
 
@@ -2165,6 +2262,7 @@ async function runFleet(options) {
           dispatchResult,
           reviewResult,
           deprecatedAliases,
+          replacedChildren,
         });
       }
     }
@@ -2179,6 +2277,7 @@ async function runFleet(options) {
       reviewResult,
       mergeResult,
       deprecatedAliases,
+      replacedChildren,
     });
   } finally {
     if (options.installSignalHandlers) {
@@ -2206,6 +2305,7 @@ async function main(argv = process.argv.slice(2)) {
       throw new FleetInputError("--review cannot be combined with --resume, --leaves-file, --dry-run, or --status");
     }
     const result = await runFleet({ ...options, installSignalHandlers: true });
+    writeReplacementNotes(result);
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
     } else if (options.status) {

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -475,10 +475,12 @@ function acceptedLeafReplacements(fleetChildren, persistedLeaves, leaves) {
     });
   }
   const replacementsByOldRef = new Map(replacements.map((replacement) => [replacement.old_leaf_ref, replacement]));
-  const nextChildRefs = fleetChildren.map((child) => (
-    replacementsByOldRef.get(child.leaf_ref)?.new_leaf_ref || child.leaf_ref
-  ));
+  const nextChildren = fleetChildren.map((child) => ({
+    leaf_ref: replacementsByOldRef.get(child.leaf_ref)?.new_leaf_ref || child.leaf_ref,
+  }));
+  const nextChildRefs = nextChildren.map((child) => child.leaf_ref);
   if (new Set(nextChildRefs).size !== nextChildRefs.length) return null;
+  if (!leafRefSetsMatch(nextChildren, leaves)) return null;
   return replacements;
 }
 

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -9,6 +9,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const RELAY_FLEET_SCRIPT = path.join(REPO_ROOT, "skills", "relay-fleet", "scripts", "relay-fleet.js");
 
 const {
+  getFleetLeafReplacementPath,
   getFleetLeavesStorePath,
   getFleetRuntimePath,
   reconcileFleet,
@@ -247,6 +248,37 @@ function holdFleetChildLock(repoRoot, fleetId) {
     acquired_at: new Date().toISOString(),
   });
   return lockPath;
+}
+
+function writeFleetChildLockWorker(tmpDir) {
+  const workerPath = path.join(tmpDir, "fleet-child-lock-worker.js");
+  fs.writeFileSync(workerPath, `const fs = require("node:fs");
+const { withFleetChildLock } = require(process.env.RELAY_FLEET_SCRIPT);
+const waitArray = new Int32Array(new SharedArrayBuffer(4));
+const owner = String(process.pid);
+
+withFleetChildLock(process.env.RELAY_FLEET_REPO, process.env.RELAY_FLEET_ID, () => {
+  let ownsMarker = false;
+  try {
+    fs.writeFileSync(process.env.RELAY_FLEET_ACTIVE_MARKER, owner, { flag: "wx" });
+    ownsMarker = true;
+  } catch (error) {
+    if (error.code !== "EEXIST") throw error;
+    fs.appendFileSync(process.env.RELAY_FLEET_OVERLAP_LOG, owner + "\\n", "utf-8");
+  }
+  Atomics.wait(waitArray, 0, 0, Number(process.env.RELAY_FLEET_HOLD_MS || 800));
+  if (ownsMarker) {
+    try {
+      if (fs.readFileSync(process.env.RELAY_FLEET_ACTIVE_MARKER, "utf-8") === owner) {
+        fs.unlinkSync(process.env.RELAY_FLEET_ACTIVE_MARKER);
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+});
+`, "utf-8");
+  return workerPath;
 }
 
 function runFleet(args, { relayHome, env = {}, timeout = 30000 } = {}) {
@@ -1089,6 +1121,68 @@ test("relay-fleet replacement matrix rejects a replacement leaf_ref that collide
   }
 });
 
+test("relay-fleet replacement rejects swap and rename-chain targets so stale leaf keys keep their specifications", () => {
+  const scenarios = [
+    { name: "swap", refs: ["leaf-a", "leaf-b"], incomingRefs: ["leaf-b", "leaf-a"] },
+    {
+      name: "chain",
+      refs: ["leaf-a", "leaf-b", "leaf-c"],
+      incomingRefs: ["leaf-b", "leaf-c", "leaf-a"],
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const { relayHome, repoRoot } = setupRepo(`relay-fleet-replace-${scenario.name}-`);
+    const fleetId = `fleet-replace-${scenario.name}`;
+    const persistedLeaves = scenario.refs.map((leafRef, index) => makeLeaf(repoRoot, index + 1, {
+      issue_number: 590 + index,
+      leaf_ref: leafRef,
+      leaf_id: leafRef,
+      branch: `issue-${590 + index}-${leafRef}-original`,
+    }));
+    const incomingLeaves = scenario.incomingRefs.map((leafRef, index) => makeLeaf(repoRoot, index + 10, {
+      issue_number: 590 + index,
+      leaf_ref: leafRef,
+      leaf_id: leafRef,
+      branch: `issue-${590 + index}-${leafRef}-replacement`,
+    }));
+    createFleetManifest(repoRoot, {
+      fleetId,
+      children: persistedLeaves.map((leaf) => ({
+        leaf_ref: leaf.leaf_ref,
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+        last_error: `old failure for ${leaf.leaf_ref}`,
+      })),
+    });
+    writePersistedFleetLeaves(repoRoot, fleetId, persistedLeaves);
+    const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+    const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+    const manifestBefore = fs.readFileSync(manifestPath, "utf-8");
+    const storeBefore = fs.readFileSync(leavesStorePath, "utf-8");
+    const leavesFile = writeLeavesFile(repoRoot, incomingLeaves);
+
+    const result = runFleet([
+      "--repo", repoRoot,
+      "--fleet-id", fleetId,
+      "--leaves-file", leavesFile,
+      "--json",
+    ], { relayHome });
+
+    assert.notEqual(result.status, 0);
+    assert.equal(
+      JSON.parse(result.stderr).error,
+      `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
+    );
+    assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
+    assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+    assert.deepEqual(
+      JSON.parse(storeBefore).leaves.map((leaf) => [leaf.issue_number, leaf.leaf_ref, leaf.branch]),
+      persistedLeaves.map((leaf) => [leaf.issue_number, leaf.leaf_ref, leaf.branch])
+    );
+  }
+});
+
 test("relay-fleet replacement matrix fails closed when a manifest-only run-bearing child is omitted", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-manifest-only-run-");
   const fleetId = "fleet-replace-manifest-only-run";
@@ -1308,6 +1402,73 @@ test("relay-fleet stale dispatch selection cannot recreate a replaced child", as
   );
 });
 
+test("fleet child lock fences two concurrent stale-lock reapers", async () => {
+  const { repoRoot } = setupRepo("relay-fleet-stale-lock-reapers-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-stale-lock-reapers-hook-"));
+  const workerPath = writeFleetChildLockWorker(tmpDir);
+  const preloadPath = path.join(tmpDir, "delay-stale-lock-read.js");
+  const readMarker = path.join(tmpDir, "stale-read.flag");
+  const activeMarker = path.join(tmpDir, "callback-active.flag");
+  const overlapLog = path.join(tmpDir, "callback-overlap.log");
+  const fleetId = "fleet-stale-lock-reapers";
+  const lockPath = path.join(getFleetsDir(repoRoot), "locks", `fleet-${fleetId}-children.lock`);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  writeJson(lockPath, {
+    fleet_id: fleetId,
+    pid: 2147483647,
+    hostname: os.hostname(),
+    acquired_at: new Date(0).toISOString(),
+  });
+  fs.writeFileSync(preloadPath, `const fs = require("node:fs");
+const path = require("node:path");
+const waitArray = new Int32Array(new SharedArrayBuffer(4));
+const originalReadFileSync = fs.readFileSync;
+let delayed = false;
+
+fs.readFileSync = function delayedStaleLockRead(filePath) {
+  const result = originalReadFileSync.apply(this, arguments);
+  if (!delayed && path.resolve(String(filePath)) === path.resolve(process.env.RELAY_FLEET_DELAY_READ_PATH)) {
+    delayed = true;
+    fs.writeFileSync(process.env.RELAY_FLEET_DELAY_READ_MARKER, "read\\n", "utf-8");
+    Atomics.wait(waitArray, 0, 0, 400);
+  }
+  return result;
+};
+`, "utf-8");
+
+  const commonEnv = {
+    ...process.env,
+    RELAY_FLEET_SCRIPT,
+    RELAY_FLEET_REPO: repoRoot,
+    RELAY_FLEET_ID: fleetId,
+    RELAY_FLEET_ACTIVE_MARKER: activeMarker,
+    RELAY_FLEET_OVERLAP_LOG: overlapLog,
+    RELAY_FLEET_HOLD_MS: "800",
+  };
+  const first = spawn(process.execPath, [workerPath], {
+    env: {
+      ...commonEnv,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${preloadPath}`].filter(Boolean).join(" "),
+      RELAY_FLEET_DELAY_READ_PATH: lockPath,
+      RELAY_FLEET_DELAY_READ_MARKER: readMarker,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const firstResult = captureChildResult(first);
+  await waitFor(() => fs.existsSync(readMarker));
+
+  const second = spawn(process.execPath, [workerPath], {
+    env: commonEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const secondResult = captureChildResult(second);
+  const [firstDone, secondDone] = await Promise.all([firstResult, secondResult]);
+
+  assert.equal(firstDone.status, 0, firstDone.stderr);
+  assert.equal(secondDone.status, 0, secondDone.stderr);
+  assert.equal(fs.existsSync(overlapLog), false);
+});
+
 test("relay-fleet replacement matrix rolls back manifest when persisted leaves rewrite fails", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-rollback-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-rollback-fake-"));
@@ -1375,6 +1536,106 @@ fs.renameSync = function renameSyncWithLeavesStoreFailure(sourcePath, destPath) 
   assert.equal(JSON.parse(result.stderr).error, "simulated leaves store write failure");
   assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
   assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+});
+
+test("relay-fleet recovers a replacement interrupted after the manifest rename", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-crash-recovery-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-crash-recovery-hook-"));
+  const preloadPath = path.join(tmpDir, "kill-before-leaves-rename.js");
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const finalizeScript = writeFakeFinalizeScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const fleetId = "fleet-replace-crash-recovery";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 598,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-598-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-598-leaf-new",
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+  const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  const journalPath = getFleetLeafReplacementPath(repoRoot, fleetId);
+  fs.writeFileSync(preloadPath, `const fs = require("node:fs");
+const path = require("node:path");
+const originalRenameSync = fs.renameSync;
+
+fs.renameSync = function killBeforeLeavesRename(sourcePath, destPath) {
+  if (path.resolve(String(destPath)) === path.resolve(process.env.RELAY_FLEET_KILL_RENAME_DEST)) {
+    process.kill(process.pid, "SIGKILL");
+  }
+  return originalRenameSync.apply(this, arguments);
+};
+`, "utf-8");
+
+  const interrupted = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${preloadPath}`].filter(Boolean).join(" "),
+      RELAY_FLEET_KILL_RENAME_DEST: leavesStorePath,
+    },
+  });
+
+  assert.equal(interrupted.signal, "SIGKILL");
+  assert.equal(fs.existsSync(journalPath), true);
+  assert.deepEqual(readFleetManifest(repoRoot, fleetId).data.children, [{
+    leaf_ref: newLeaf.leaf_ref,
+    run_id: null,
+    dispatch_status: DISPATCH_STATUS.PENDING,
+  }]);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(leavesStorePath, "utf-8")).leaves.map((leaf) => leaf.leaf_ref),
+    [oldLeaf.leaf_ref]
+  );
+
+  const recovered = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--finalize-script", finalizeScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_LOG: dispatchLog },
+  });
+
+  assert.equal(recovered.status, 0, `${recovered.stderr}\n${recovered.stdout}`);
+  assert.equal(fs.existsSync(journalPath), false);
+  assert.deepEqual(JSON.parse(recovered.stdout).replaced_children, [{
+    old_leaf_ref: oldLeaf.leaf_ref,
+    new_leaf_ref: newLeaf.leaf_ref,
+    issue_number: oldLeaf.issue_number,
+  }]);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(leavesStorePath, "utf-8")).leaves.map((leaf) => leaf.leaf_ref),
+    [newLeaf.leaf_ref]
+  );
+  const dispatchEntries = readJsonLines(dispatchLog).filter((entry) => !entry.detachedChild);
+  assert.equal(dispatchEntries.length, 1);
+  assert.equal(dispatchEntries[0].branch, newLeaf.branch);
 });
 
 test("relay-fleet replacement matrix fails closed when a divergent child has a run id", () => {

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -979,6 +979,53 @@ test("relay-fleet replacement matrix replaces only run_id-null pre-manifest fail
   assert.deepEqual(persistedLeaves.map((leaf) => leaf.leaf_ref), [newLeaf.leaf_ref]);
 });
 
+test("relay-fleet replacement matrix rejects a changed leaf that keeps the same leaf_ref", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-sameref-");
+  const fleetId = "fleet-replace-sameref";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 581,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-581-leaf-old",
+  });
+  const respecifiedLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: oldLeaf.leaf_ref,
+    leaf_id: oldLeaf.leaf_id,
+    branch: "issue-581-leaf-respecified",
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  const manifestBefore = fs.readFileSync(manifestPath, "utf-8");
+  const storeBefore = fs.readFileSync(leavesStorePath, "utf-8");
+  const leavesFile = writeLeavesFile(repoRoot, [respecifiedLeaf]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(
+    JSON.parse(result.stderr).error,
+    `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
+  );
+  assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
+  assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+});
+
 test("relay-fleet replacement matrix rejects a replacement leaf_ref that collides with an unchanged sibling", () => {
   for (const replaceableFirst of [true, false]) {
     const { relayHome, repoRoot } = setupRepo(`relay-fleet-replace-collision-${replaceableFirst ? "first" : "last"}-`);

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -1469,6 +1469,45 @@ fs.readFileSync = function delayedStaleLockRead(filePath) {
   assert.equal(fs.existsSync(overlapLog), false);
 });
 
+test("fleet child lock recovers a truncated canonical lock without overlapping callbacks", async () => {
+  const { repoRoot } = setupRepo("relay-fleet-truncated-child-lock-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-truncated-child-lock-worker-"));
+  const workerPath = writeFleetChildLockWorker(tmpDir);
+  const activeMarker = path.join(tmpDir, "callback-active.flag");
+  const overlapLog = path.join(tmpDir, "callback-overlap.log");
+  const fleetId = "fleet-truncated-child-lock";
+  const lockPath = path.join(getFleetsDir(repoRoot), "locks", `fleet-${fleetId}-children.lock`);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  fs.writeFileSync(lockPath, '{"fleet_id":', "utf-8");
+
+  const commonEnv = {
+    ...process.env,
+    RELAY_FLEET_SCRIPT,
+    RELAY_FLEET_REPO: repoRoot,
+    RELAY_FLEET_ID: fleetId,
+    RELAY_FLEET_ACTIVE_MARKER: activeMarker,
+    RELAY_FLEET_OVERLAP_LOG: overlapLog,
+    RELAY_FLEET_HOLD_MS: "400",
+  };
+  const first = spawn(process.execPath, [workerPath], {
+    env: commonEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const firstResult = captureChildResult(first);
+  await waitFor(() => fs.existsSync(activeMarker));
+  const second = spawn(process.execPath, [workerPath], {
+    env: commonEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const secondResult = captureChildResult(second);
+  const [firstDone, secondDone] = await Promise.all([firstResult, secondResult]);
+
+  assert.equal(firstDone.status, 0, firstDone.stderr);
+  assert.equal(secondDone.status, 0, secondDone.stderr);
+  assert.equal(fs.existsSync(overlapLog), false);
+  assert.equal(fs.existsSync(lockPath), false);
+});
+
 test("relay-fleet replacement matrix rolls back manifest when persisted leaves rewrite fails", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-rollback-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-rollback-fake-"));

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -937,6 +937,75 @@ test("relay-fleet replacement matrix replaces only run_id-null pre-manifest fail
   assert.deepEqual(persistedLeaves.map((leaf) => leaf.leaf_ref), [newLeaf.leaf_ref]);
 });
 
+test("relay-fleet replacement matrix rolls back manifest when persisted leaves rewrite fails", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-rollback-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-rollback-fake-"));
+  const preloadScript = path.join(tmpDir, "fail-leaves-store-rename.js");
+  fs.writeFileSync(preloadScript, `const fs = require("node:fs");
+const path = require("node:path");
+const originalRenameSync = fs.renameSync;
+
+fs.renameSync = function renameSyncWithLeavesStoreFailure(sourcePath, destPath) {
+  const failDest = process.env.RELAY_FLEET_FAIL_RENAME_DEST;
+  if (failDest && path.resolve(destPath) === path.resolve(failDest)) {
+    throw new Error("simulated leaves store write failure");
+  }
+  return originalRenameSync.apply(this, arguments);
+};
+`, "utf-8");
+
+  const fleetId = "fleet-replace-rollback";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 577,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-577-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-577-leaf-new",
+  });
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  const manifestBefore = fs.readFileSync(manifestPath, "utf-8");
+  const storeBefore = fs.readFileSync(leavesStorePath, "utf-8");
+  const nodeOptions = [
+    process.env.NODE_OPTIONS,
+    `--require=${preloadScript}`,
+  ].filter(Boolean).join(" ");
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      NODE_OPTIONS: nodeOptions,
+      RELAY_FLEET_FAIL_RENAME_DEST: leavesStorePath,
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(JSON.parse(result.stderr).error, "simulated leaves store write failure");
+  assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
+  assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+});
+
 test("relay-fleet replacement matrix fails closed when a divergent child has a run id", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-runid-denied-");
   const fleetId = "fleet-replace-runid-denied";

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -111,6 +111,10 @@ function writeLeavesFile(repoRoot, leaves) {
   return leavesFile;
 }
 
+function writePersistedFleetLeaves(repoRoot, fleetId, leaves) {
+  writeJson(getFleetLeavesStorePath(repoRoot, fleetId), { fleet_id: fleetId, leaves });
+}
+
 function readJsonLines(filePath) {
   if (!fs.existsSync(filePath)) return [];
   return fs.readFileSync(filePath, "utf-8")
@@ -183,7 +187,7 @@ function writeChildRun(repoRoot, {
   return runId;
 }
 
-function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
+function waitFor(predicate, { timeoutMs = 15000, intervalMs = 25 } = {}) {
   const started = Date.now();
   return new Promise((resolve, reject) => {
     const tick = () => {
@@ -203,7 +207,7 @@ function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
   });
 }
 
-function runFleet(args, { relayHome, env = {}, timeout = 30000 } = {}) {
+function runFleet(args, { relayHome, env = {}, timeout = 120000 } = {}) {
   const result = spawnSync(process.execPath, [RELAY_FLEET_SCRIPT, ...args], {
     encoding: "utf-8",
     env: {
@@ -827,6 +831,245 @@ test("relay-fleet re-run with different leaves fails closed when the persisted l
   assert.match(result.stderr, /leaf_ref set differs from fleet manifest children/);
   assert.equal(fs.existsSync(leavesStorePath), false);
   assert.equal(fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8"), before);
+});
+
+test("relay-fleet replacement matrix byte-preserves identical persisted leaves", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-identical-");
+  const fleetId = "fleet-replace-identical";
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 572, leaf_ref: "leaf-a", leaf_id: "leaf-a" });
+  const leavesFile = writeLeavesFile(repoRoot, [leaf]);
+  const runId = writeChildRun(repoRoot, {
+    runId: "issue-572-20260517010101000-a1b2c3d4",
+    branch: leaf.branch,
+    issueNumber: leaf.issue_number,
+    leafId: leaf.leaf_id,
+    fleetId,
+    state: RUN_STATES.CLOSED,
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{ leaf_ref: leaf.leaf_ref, run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  advanceFleetManifestState(repoRoot, fleetId, FLEET_STATES.CLOSED);
+  writePersistedFleetLeaves(repoRoot, fleetId, [leaf]);
+  const manifestBefore = fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8");
+  const storeBefore = fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8");
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.deepEqual(payload.replaced_children, []);
+  assert.equal(result.stderr, "");
+  assert.equal(fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8"), manifestBefore);
+  assert.equal(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8"), storeBefore);
+});
+
+test("relay-fleet replacement matrix replaces only run_id-null pre-manifest failed children", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-premanifest-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-premanifest-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const finalizeScript = writeFakeFinalizeScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const fleetId = "fleet-replace-premanifest";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 573,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-573-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-573-leaf-new",
+  });
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--finalize-script", finalizeScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_LOG: dispatchLog },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stderr, /relay-fleet replaced child in fleet 'fleet-replace-premanifest': leaf-old -> leaf-new/);
+  const payload = JSON.parse(result.stdout);
+  assert.deepEqual(payload.replaced_children, [{
+    old_leaf_ref: "leaf-old",
+    new_leaf_ref: "leaf-new",
+    issue_number: oldLeaf.issue_number,
+  }]);
+  const dispatchEntries = readJsonLines(dispatchLog).filter((entry) => !entry.detachedChild);
+  assert.equal(dispatchEntries.length, 1);
+  assert.equal(dispatchEntries[0].branch, newLeaf.branch);
+  assert.equal(dispatchEntries[0].leafId, newLeaf.leaf_id);
+  const manifestChildren = readFleetManifest(repoRoot, fleetId).data.children;
+  assert.equal(manifestChildren.some((child) => child.leaf_ref === oldLeaf.leaf_ref), false);
+  const newChild = manifestChildren.find((child) => child.leaf_ref === newLeaf.leaf_ref);
+  assert.ok(newChild);
+  assert.equal(newChild.dispatch_status, DISPATCH_STATUS.DISPATCHED);
+  assert.equal(Object.hasOwn(newChild, "last_error"), false);
+  const persistedLeaves = JSON.parse(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8")).leaves;
+  assert.deepEqual(persistedLeaves.map((leaf) => leaf.leaf_ref), [newLeaf.leaf_ref]);
+});
+
+test("relay-fleet replacement matrix fails closed when a divergent child has a run id", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-runid-denied-");
+  const fleetId = "fleet-replace-runid-denied";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 574,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-574-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-574-leaf-new",
+  });
+  const runId = writeChildRun(repoRoot, {
+    runId: "issue-574-20260517010101000-a1b2c3d4",
+    branch: oldLeaf.branch,
+    issueNumber: oldLeaf.issue_number,
+    leafId: oldLeaf.leaf_id,
+    fleetId,
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{ leaf_ref: oldLeaf.leaf_ref, run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const manifestBefore = fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8");
+  const storeBefore = fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8");
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(
+    JSON.parse(result.stderr).error,
+    "--leaves-file differs from persisted fleet leaves for 'fleet-replace-runid-denied'; refusing to overwrite an existing fleet"
+  );
+  assert.equal(fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8"), manifestBefore);
+  assert.equal(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8"), storeBefore);
+});
+
+test("relay-fleet replacement matrix fails closed when a divergent run_id-null child is dispatching", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-dispatching-denied-");
+  const fleetId = "fleet-replace-dispatching-denied";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 575,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-575-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-575-leaf-new",
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{ leaf_ref: oldLeaf.leaf_ref, run_id: null, dispatch_status: DISPATCH_STATUS.DISPATCHING }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const manifestBefore = fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8");
+  const storeBefore = fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8");
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(
+    JSON.parse(result.stderr).error,
+    "--leaves-file differs from persisted fleet leaves for 'fleet-replace-dispatching-denied'; refusing to overwrite an existing fleet"
+  );
+  assert.equal(fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8"), manifestBefore);
+  assert.equal(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8"), storeBefore);
+});
+
+test("relay-fleet replacement matrix leaves fleet-id-only invocation on persisted leaves unchanged", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-fleet-id-only-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-fleet-id-only-fake-"));
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const finalizeScript = writeFakeFinalizeScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const fleetId = "fleet-replace-fleet-id-only";
+  const leaf = makeLeaf(repoRoot, 1, {
+    issue_number: 576,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-576-leaf-old",
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: leaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [leaf]);
+  const storeBefore = fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8");
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--dispatch-script", dispatchScript,
+    "--review-script", reviewScript,
+    "--finalize-script", finalizeScript,
+    "--json",
+  ], {
+    relayHome,
+    env: { FAKE_DISPATCH_LOG: dispatchLog },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  assert.deepEqual(payload.replaced_children, []);
+  const dispatchEntries = readJsonLines(dispatchLog).filter((entry) => !entry.detachedChild);
+  assert.equal(dispatchEntries.length, 1);
+  assert.equal(dispatchEntries[0].branch, leaf.branch);
+  assert.equal(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8"), storeBefore);
 });
 
 test("relay-fleet with only fleet-id continues ready children through merge and close", () => {

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -1000,6 +1000,67 @@ test("relay-fleet replacement matrix rejects a replacement leaf_ref that collide
   }
 });
 
+test("relay-fleet replacement matrix fails closed when a manifest-only run-bearing child is omitted", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-manifest-only-run-");
+  const fleetId = "fleet-replace-manifest-only-run";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 580,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-580-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-580-leaf-new",
+  });
+  const runId = writeChildRun(repoRoot, {
+    runId: "issue-581-20260517010101000-a1b2c3d4",
+    branch: "issue-581-leaf-run-bearing",
+    issueNumber: 581,
+    leafId: "leaf-run-bearing",
+    fleetId,
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [
+      {
+        leaf_ref: oldLeaf.leaf_ref,
+        run_id: null,
+        dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+        last_error: "old pre-manifest failure",
+      },
+      {
+        leaf_ref: "leaf-run-bearing",
+        run_id: runId,
+        dispatch_status: DISPATCH_STATUS.DISPATCHED,
+      },
+    ],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  const manifestBefore = fs.readFileSync(manifestPath, "utf-8");
+  const storeBefore = fs.readFileSync(leavesStorePath, "utf-8");
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(
+    JSON.parse(result.stderr).error,
+    `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
+  );
+  assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
+  assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+});
+
 test("relay-fleet replacement matrix rolls back manifest when persisted leaves rewrite fails", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-rollback-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-rollback-fake-"));

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -187,7 +187,7 @@ function writeChildRun(repoRoot, {
   return runId;
 }
 
-function waitFor(predicate, { timeoutMs = 15000, intervalMs = 25 } = {}) {
+function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
   const started = Date.now();
   return new Promise((resolve, reject) => {
     const tick = () => {
@@ -207,7 +207,7 @@ function waitFor(predicate, { timeoutMs = 15000, intervalMs = 25 } = {}) {
   });
 }
 
-function runFleet(args, { relayHome, env = {}, timeout = 120000 } = {}) {
+function runFleet(args, { relayHome, env = {}, timeout = 30000 } = {}) {
   const result = spawnSync(process.execPath, [RELAY_FLEET_SCRIPT, ...args], {
     encoding: "utf-8",
     env: {
@@ -935,6 +935,69 @@ test("relay-fleet replacement matrix replaces only run_id-null pre-manifest fail
   assert.equal(Object.hasOwn(newChild, "last_error"), false);
   const persistedLeaves = JSON.parse(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8")).leaves;
   assert.deepEqual(persistedLeaves.map((leaf) => leaf.leaf_ref), [newLeaf.leaf_ref]);
+});
+
+test("relay-fleet replacement matrix rejects a replacement leaf_ref that collides with an unchanged sibling", () => {
+  for (const replaceableFirst of [true, false]) {
+    const { relayHome, repoRoot } = setupRepo(`relay-fleet-replace-collision-${replaceableFirst ? "first" : "last"}-`);
+    const fleetId = `fleet-replace-collision-${replaceableFirst ? "first" : "last"}`;
+    const oldLeaf = makeLeaf(repoRoot, 1, {
+      issue_number: 578,
+      leaf_ref: "leaf-old",
+      leaf_id: "leaf-old",
+      branch: "issue-578-leaf-old",
+    });
+    const unchangedLeaf = makeLeaf(repoRoot, 2, {
+      issue_number: 579,
+      leaf_ref: "leaf-unchanged",
+      leaf_id: "leaf-unchanged",
+      branch: "issue-579-leaf-unchanged",
+    });
+    const collidingLeaf = makeLeaf(repoRoot, 3, {
+      issue_number: oldLeaf.issue_number,
+      leaf_ref: unchangedLeaf.leaf_ref,
+      leaf_id: unchangedLeaf.leaf_id,
+      branch: "issue-578-leaf-collision",
+    });
+    const replaceableChild = {
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    };
+    const unchangedChild = {
+      leaf_ref: unchangedLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.PENDING,
+    };
+    createFleetManifest(repoRoot, {
+      fleetId,
+      children: replaceableFirst
+        ? [replaceableChild, unchangedChild]
+        : [unchangedChild, replaceableChild],
+    });
+    writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf, unchangedLeaf]);
+    const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+    const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+    const manifestBefore = fs.readFileSync(manifestPath, "utf-8");
+    const storeBefore = fs.readFileSync(leavesStorePath, "utf-8");
+    const leavesFile = writeLeavesFile(repoRoot, [collidingLeaf, unchangedLeaf]);
+
+    const result = runFleet([
+      "--repo", repoRoot,
+      "--fleet-id", fleetId,
+      "--leaves-file", leavesFile,
+      "--json",
+    ], { relayHome });
+
+    assert.notEqual(result.status, 0);
+    assert.equal(
+      JSON.parse(result.stderr).error,
+      `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
+    );
+    assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
+    assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+  }
 });
 
 test("relay-fleet replacement matrix rolls back manifest when persisted leaves rewrite fails", () => {

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -14,6 +14,7 @@ const {
   reconcileFleet,
 } = require(RELAY_FLEET_SCRIPT);
 const {
+  getFleetsDir,
   getFleetIssueLockPath,
   getFleetManifestPath,
   getManifestPath,
@@ -205,6 +206,47 @@ function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
     };
     tick();
   });
+}
+
+function captureChildResult(child) {
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf-8"); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf-8"); });
+  return new Promise((resolve) => {
+    child.once("close", (status, signal) => resolve({ status, signal, stdout, stderr }));
+  });
+}
+
+function writeReadMarkerPreload(tmpDir) {
+  const preloadPath = path.join(tmpDir, "mark-read.js");
+  fs.writeFileSync(preloadPath, `const fs = require("node:fs");
+const path = require("node:path");
+const originalReadFileSync = fs.readFileSync;
+
+fs.readFileSync = function readFileSyncWithMarker(filePath) {
+  const result = originalReadFileSync.apply(this, arguments);
+  const watchedPath = process.env.RELAY_FLEET_MARK_READ_PATH;
+  const markerPath = process.env.RELAY_FLEET_READ_MARKER_PATH;
+  if (watchedPath && markerPath && path.resolve(String(filePath)) === path.resolve(watchedPath)) {
+    fs.writeFileSync(markerPath, "read\\n", "utf-8");
+  }
+  return result;
+};
+`, "utf-8");
+  return preloadPath;
+}
+
+function holdFleetChildLock(repoRoot, fleetId) {
+  const lockPath = path.join(getFleetsDir(repoRoot), "locks", `fleet-${fleetId}-children.lock`);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  writeJson(lockPath, {
+    fleet_id: fleetId,
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquired_at: new Date().toISOString(),
+  });
+  return lockPath;
 }
 
 function runFleet(args, { relayHome, env = {}, timeout = 30000 } = {}) {
@@ -1059,6 +1101,164 @@ test("relay-fleet replacement matrix fails closed when a manifest-only run-beari
   );
   assert.equal(fs.readFileSync(manifestPath, "utf-8"), manifestBefore);
   assert.equal(fs.readFileSync(leavesStorePath, "utf-8"), storeBefore);
+});
+
+test("relay-fleet replacement rechecks eligibility after a concurrent child transition", async () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-transition-race-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-transition-race-hook-"));
+  const preloadPath = writeReadMarkerPreload(tmpDir);
+  const markerPath = path.join(tmpDir, "manifest-read.flag");
+  const fleetId = "fleet-replace-transition-race";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 581,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-581-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-581-leaf-new",
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const manifestPath = getFleetManifestPath(repoRoot, fleetId);
+  const leavesStorePath = getFleetLeavesStorePath(repoRoot, fleetId);
+  const leavesFile = writeLeavesFile(repoRoot, [newLeaf]);
+  const childLockPath = holdFleetChildLock(repoRoot, fleetId);
+  const child = spawn(process.execPath, [
+    RELAY_FLEET_SCRIPT,
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", leavesFile,
+    "--json",
+  ], {
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${preloadPath}`].filter(Boolean).join(" "),
+      RELAY_FLEET_MARK_READ_PATH: manifestPath,
+      RELAY_FLEET_READ_MARKER_PATH: markerPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const childResult = captureChildResult(child);
+
+  await waitFor(() => fs.existsSync(markerPath));
+  updateFleetManifest(repoRoot, fleetId, (fleet) => ({
+    ...fleet,
+    children: fleet.children.map((entry) => entry.leaf_ref === oldLeaf.leaf_ref
+      ? { ...entry, dispatch_status: DISPATCH_STATUS.DISPATCHING }
+      : entry),
+  }));
+  fs.unlinkSync(childLockPath);
+
+  const result = await childResult;
+  assert.notEqual(result.status, 0);
+  assert.equal(
+    JSON.parse(result.stderr).error,
+    `--leaves-file differs from persisted fleet leaves for '${fleetId}'; refusing to overwrite an existing fleet`
+  );
+  assert.deepEqual(readFleetManifest(repoRoot, fleetId).data.children, [{
+    leaf_ref: oldLeaf.leaf_ref,
+    run_id: null,
+    dispatch_status: DISPATCH_STATUS.DISPATCHING,
+    last_error: "old pre-manifest failure",
+  }]);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(leavesStorePath, "utf-8")).leaves.map((leaf) => leaf.leaf_ref),
+    [oldLeaf.leaf_ref]
+  );
+});
+
+test("relay-fleet stale dispatch selection cannot recreate a replaced child", async () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-replace-stale-selection-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-replace-stale-selection-hook-"));
+  const preloadPath = writeReadMarkerPreload(tmpDir);
+  const markerPath = path.join(tmpDir, "lock-read.flag");
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const fleetId = "fleet-replace-stale-selection";
+  const oldLeaf = makeLeaf(repoRoot, 1, {
+    issue_number: 582,
+    leaf_ref: "leaf-old",
+    leaf_id: "leaf-old",
+    branch: "issue-582-leaf-old",
+  });
+  const newLeaf = makeLeaf(repoRoot, 2, {
+    issue_number: oldLeaf.issue_number,
+    leaf_ref: "leaf-new",
+    leaf_id: "leaf-new",
+    branch: "issue-582-leaf-new",
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{
+      leaf_ref: oldLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST,
+      last_error: "old pre-manifest failure",
+    }],
+  });
+  writePersistedFleetLeaves(repoRoot, fleetId, [oldLeaf]);
+  const oldLeavesFile = writeLeavesFile(repoRoot, [oldLeaf]);
+  const childLockPath = holdFleetChildLock(repoRoot, fleetId);
+  const child = spawn(process.execPath, [
+    RELAY_FLEET_SCRIPT,
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--leaves-file", oldLeavesFile,
+    "--dispatch-script", dispatchScript,
+    "--json",
+  ], {
+    env: {
+      ...process.env,
+      RELAY_HOME: relayHome,
+      RELAY_SOURCE_ROOT: REPO_ROOT,
+      FAKE_DISPATCH_LOG: dispatchLog,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${preloadPath}`].filter(Boolean).join(" "),
+      RELAY_FLEET_MARK_READ_PATH: childLockPath,
+      RELAY_FLEET_READ_MARKER_PATH: markerPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const childResult = captureChildResult(child);
+
+  await waitFor(() => fs.existsSync(markerPath));
+  updateFleetManifest(repoRoot, fleetId, (fleet) => ({
+    ...fleet,
+    children: [{
+      leaf_ref: newLeaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.PENDING,
+    }],
+  }));
+  writePersistedFleetLeaves(repoRoot, fleetId, [newLeaf]);
+  fs.unlinkSync(childLockPath);
+
+  const result = await childResult;
+  assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+  assert.equal(JSON.parse(result.stdout).children[0].status, "skipped_replaced");
+  assert.equal(fs.existsSync(dispatchLog), false);
+  assert.deepEqual(readFleetManifest(repoRoot, fleetId).data.children, [{
+    leaf_ref: newLeaf.leaf_ref,
+    run_id: null,
+    dispatch_status: DISPATCH_STATUS.PENDING,
+  }]);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(getFleetLeavesStorePath(repoRoot, fleetId), "utf-8")).leaves.map((leaf) => leaf.leaf_ref),
+    [newLeaf.leaf_ref]
+  );
 });
 
 test("relay-fleet replacement matrix rolls back manifest when persisted leaves rewrite fails", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed `9895532 Allow replacing failed fleet leaves`.

What changed:
- Added the narrow replacement path in [relay-fleet.js](/Users/sjlee/.relay/worktrees/a1abaffd/dev-relay/skills/relay-fleet/scripts/relay-fleet.js:453): only `run_id: null` + `dispatch_failed_pre_manifest`.
- Replacement updates manifest children via existing helpers and persists the new leaves store before dispatch.
- Accepted replacements emit stderr notes and `replaced_children` in JSON.
- Added the five-r
```

## Score Log

- Run: issue-870-20260709123019426-2dd53e15
- Executor: codex
- Branch: issue-870-leaf-replace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 저장된 fleet leaves와 입력 leaves를 비교해, 조건이 맞을 때만 기존 항목을 안전하게 교체하도록 확장되었습니다.
  * 실행 결과에 교체된 자식 항목 정보(대체 전/후)가 함께 제공되어 확인이 쉬워졌습니다.
* **버그 수정**
  * 특정 실패 상태의 child에 대해서만 교체가 반영되며, 동시성 상황에서도 경합으로 인한 잘못된 덮어쓰기를 방지하도록 개선되었습니다.
* **테스트**
  * 교체/불변성/경합/롤백 동작을 폭넓게 검증하는 시나리오가 추가되어 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review thread resolution (R8 procedural clearance)

All four P2 replacement-ref threads are resolved at HEAD d845b71 with replies referencing the guard (fresh-refs-only acceptance: same-ref respec, sibling collisions, and swap/rename chains fail closed) and their regression tests in tests/relay-fleet/scripts/relay-fleet.test.js. No code changed since R8; this section is the PR-body evidence for the same-HEAD recovery.


## CI completion (R10 blocker clearance)

The required test check completed SUCCESS on the reviewed HEAD 6907d16 (R10's only finding was the in-progress check; code judged correct by inspection). Same-SHA review rerun per the R10 instruction.
