### PR TITLE
No tooled operator path for merge_blocked -> ready_to_merge (retry unblocked merge) (#863)

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -119,7 +119,7 @@ If a PR already exists for the branch, the command no-ops the create step and st
 
 ## Operator state recovery
 
-`recover-state.js` advances a relay run's state after an external event (fix commit pushed directly, dispatch stalled, no-op re-dispatch escalated the manifest). Replaces hand-edited `manual_state_override` entries with structured `state_recovery` events and validated transitions.
+`recover-state.js` advances a relay run's state after an external event (fix commit pushed directly, dispatch stalled, no-op re-dispatch escalated the manifest, merge blocker cleared). Replaces hand-edited `manual_state_override` entries with structured `state_recovery` events and validated transitions.
 
 ```bash
 # Fix pushed directly to the PR branch → return to review without re-dispatch
@@ -134,6 +134,11 @@ node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
 # PR advanced after ready_to_merge → return to review for the new live PR HEAD
 node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
   --to review_pending --reason "PR head advanced after passing review"
+
+# Merge blocker cleared after merge_blocked → retry the merge
+node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
+  --to ready_to_merge --reason "merge blocker cleared; retry merge"
+# Next fleet drive re-run retries the merge.
 
 # No-op re-dispatch escalated the run → bring it back for a fresh review
 node skills/relay-dispatch/scripts/recover-state.js --repo . --run-id <id> \
@@ -151,6 +156,7 @@ Whitelisted transitions (unlisted pairs are rejected — use the normal dispatch
 | `changes_requested` | `review_pending` | no | fresh commit on branch (HEAD ≠ `review.last_reviewed_sha`) |
 | `changes_requested` | `review_pending` | no | same HEAD allowed only with `--allow-same-head --require-pr-body-change`, a manifest PR number (`git.pr_number` or `github.pr_number`), a prior `review-round-N-pr-body.md` snapshot, and a current GitHub PR body that differs from the latest numbered snapshot |
 | `ready_to_merge` | `review_pending` | no | live GitHub PR HEAD differs from `review.last_reviewed_sha` or `git.head_sha`; emits old/new SHA and PR number in `state_recovery` |
+| `merge_blocked` | `ready_to_merge` | no | operator cleared the blocker; next fleet drive re-run retries the merge |
 | `escalated` | `review_pending` | yes | — |
 | `escalated` | `changes_requested` | no | — |
 | `dispatched` | `changes_requested` | yes | — |

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -84,6 +84,15 @@ const RECOVERY_TRANSITIONS = Object.freeze([
     resetLastReviewedSha: false,
     description: "Dispatch hung or operator killed; unstick the manifest so re-dispatch is reachable.",
   },
+  {
+    from: STATES.MERGE_BLOCKED,
+    to: STATES.READY_TO_MERGE,
+    nextAction: "await_explicit_merge",
+    requireForce: false,
+    requireFreshCommit: false,
+    resetLastReviewedSha: false,
+    description: "Operator cleared the merge blocker; retry the explicit merge.",
+  },
 ]);
 
 function appendStateRecoveryEvent(repoRoot, runId, eventData) {

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -18,7 +18,7 @@
 const path = require("path");
 const fs = require("fs");
 const { execFileSync } = require("child_process");
-const { STATES, forceTransitionState } = require("./manifest/lifecycle");
+const { STATES, forceTransitionState, updateManifestState } = require("./manifest/lifecycle");
 const {
   getEventsPath,
   getRunDir,
@@ -91,7 +91,7 @@ const RECOVERY_TRANSITIONS = Object.freeze([
     requireForce: false,
     requireFreshCommit: false,
     resetLastReviewedSha: false,
-    description: "Operator cleared the merge blocker; retry the explicit merge.",
+    description: "Operator cleared the merge blocker; the next fleet drive re-run retries the merge queue.",
   },
 ]);
 
@@ -537,7 +537,9 @@ function main() {
     });
   }
 
-  let updated = forceTransitionState(safeData, toState, recovery.nextAction);
+  let updated = fromState === STATES.MERGE_BLOCKED && toState === STATES.READY_TO_MERGE
+    ? updateManifestState(safeData, toState, recovery.nextAction)
+    : forceTransitionState(safeData, toState, recovery.nextAction);
 
   if (recovery.resetLastReviewedSha) {
     updated.review = { ...(updated.review || {}), last_reviewed_sha: null };

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -75,6 +75,11 @@ function setupRepo({ state = STATES.CHANGES_REQUESTED, branch = "issue-211", prN
   } else if (state === STATES.READY_TO_MERGE) {
     manifest.review = { ...manifest.review, latest_verdict: "lgtm" };
     manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  } else if (state === STATES.MERGE_BLOCKED) {
+    manifest.review = { ...manifest.review, latest_verdict: "lgtm" };
+    manifest.git = { ...manifest.git, head_sha: initialHead };
+    manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+    manifest = updateManifestState(manifest, STATES.MERGE_BLOCKED, "resolve_merge_block");
   } else if (state === STATES.DISPATCHED) {
     manifest = { ...manifest, state: STATES.DISPATCHED, next_action: "await_dispatch_result" };
   }
@@ -616,6 +621,54 @@ test("escalated -> review_pending requires --force; succeeds with --force", () =
   assert.equal(manifest.state, STATES.REVIEW_PENDING);
 });
 
+test("merge_blocked -> ready_to_merge succeeds with audited reason and no --force", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({ state: STATES.MERGE_BLOCKED });
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.READY_TO_MERGE,
+    "--reason", "fresh-review gate unblocked; retry merge",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.previousState, STATES.MERGE_BLOCKED);
+  assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.nextAction, "await_explicit_merge");
+  assert.equal(result.force, false);
+  assert.equal(result.freshCommit, null);
+  assert.equal(result.prBodyOnly, null);
+  assert.equal(result.readyHeadDrift, null);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.READY_TO_MERGE);
+  assert.equal(manifest.next_action, "await_explicit_merge");
+
+  const event = readRunEvents(repoRoot, runId).find((entry) => entry.event === "state_recovery");
+  assert.equal(event?.state_from, STATES.MERGE_BLOCKED);
+  assert.equal(event?.state_to, STATES.READY_TO_MERGE);
+  assert.equal(event?.head_sha, initialHead);
+  assert.equal(event?.last_reviewed_sha, initialHead);
+  assert.equal(event?.reason, "fresh-review gate unblocked; retry merge");
+});
+
+test("merge_blocked -> ready_to_merge requires an audited reason", () => {
+  const { repoRoot, runId } = setupRepo({ state: STATES.MERGE_BLOCKED });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.READY_TO_MERGE,
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--reason <text> is required/);
+});
+
 test("unlisted transition (dispatched -> merged) rejected with allowed set listed", () => {
   const { repoRoot, runId } = setupRepo({ state: STATES.DISPATCHED });
 
@@ -630,13 +683,15 @@ test("unlisted transition (dispatched -> merged) rejected with allowed set liste
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, new RegExp(`Recovery transition '${STATES.DISPATCHED} -> ${STATES.MERGED}' is not whitelisted`));
-  assert.match(result.stderr, /Allowed: /);
-  // All whitelisted transitions must appear in the allowed list.
-  assert.match(result.stderr, new RegExp(`${STATES.CHANGES_REQUESTED} -> ${STATES.REVIEW_PENDING}`));
-  assert.match(result.stderr, new RegExp(`${STATES.READY_TO_MERGE} -> ${STATES.REVIEW_PENDING}`));
-  assert.match(result.stderr, new RegExp(`${STATES.ESCALATED} -> ${STATES.REVIEW_PENDING}`));
-  assert.match(result.stderr, new RegExp(`${STATES.ESCALATED} -> ${STATES.CHANGES_REQUESTED}`));
-  assert.match(result.stderr, new RegExp(`${STATES.DISPATCHED} -> ${STATES.CHANGES_REQUESTED}`));
+  const allowed = [
+    `${STATES.CHANGES_REQUESTED} -> ${STATES.REVIEW_PENDING}`,
+    `${STATES.READY_TO_MERGE} -> ${STATES.REVIEW_PENDING}`,
+    `${STATES.ESCALATED} -> ${STATES.REVIEW_PENDING}`,
+    `${STATES.ESCALATED} -> ${STATES.CHANGES_REQUESTED}`,
+    `${STATES.DISPATCHED} -> ${STATES.CHANGES_REQUESTED}`,
+    `${STATES.MERGE_BLOCKED} -> ${STATES.READY_TO_MERGE}`,
+  ].join(", ");
+  assert.ok(result.stderr.includes(`Allowed: ${allowed}.`), result.stderr);
 });
 
 test("--reason is required", () => {

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -669,6 +669,46 @@ test("merge_blocked -> ready_to_merge requires an audited reason", () => {
   assert.match(result.stderr, /--reason <text> is required/);
 });
 
+test("non-merge_blocked -> ready_to_merge is rejected without changing manifest state", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo({ state: STATES.CHANGES_REQUESTED });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.READY_TO_MERGE,
+    "--reason", "invalid ready recovery source",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    new RegExp(`Recovery transition '${STATES.CHANGES_REQUESTED} -> ${STATES.READY_TO_MERGE}' is not whitelisted`)
+  );
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("merge_blocked -> another target is rejected without changing manifest state", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo({ state: STATES.MERGE_BLOCKED });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "invalid merge-blocked recovery target",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    new RegExp(`Recovery transition '${STATES.MERGE_BLOCKED} -> ${STATES.REVIEW_PENDING}' is not whitelisted`)
+  );
+  assert.equal(readManifest(manifestPath).data.state, STATES.MERGE_BLOCKED);
+});
+
 test("unlisted transition (dispatched -> merged) rejected with allowed set listed", () => {
   const { repoRoot, runId } = setupRepo({ state: STATES.DISPATCHED });
 


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-863-20260709123019539-696b236a
- Branch: issue-863-unblock-whitelist
- Reason: executor total_timeout at 3600s waiting on final gate under 3-concurrent-codex load; work complete in worktree; orchestrator verified targeted test green and full relay-dispatch gate 969 pass / 0 fail
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-863-20260709123019539-696b236a.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-10T01:50:11.546Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 병합이 차단된 상태에서 병합 준비 상태로 복구할 수 있는 운영자 복구 기능을 추가했습니다.
  * 복구 시 감사 가능한 사유를 입력하도록 지원합니다.
  * 복구 후 명시적인 병합 재시도를 기다리도록 상태가 안내됩니다.

* **문서**
  * 병합 차단 해제 및 병합 재시도 절차를 복구 플레이북에 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->