### PR TITLE
feat: thread advisory lane profile from worker to adapters (#873)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -162,16 +162,19 @@ const COMMAND_FLAGS = {
     "--repo", "--prompt-file", "--model", "--json", "--help",
   ],
   "invoke-reviewer-antigravity": [
-    "--repo", "--prompt-file", "--model", "--phase", "--json", "--help",
+    "--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help",
+  ],
+  "invoke-reviewer-cline": [
+    "--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help",
   ],
   "invoke-reviewer-cursor": [
     "--repo", "--prompt-file", "--model", "--phase", "--json", "--help",
   ],
   "invoke-reviewer-opencode": [
-    "--repo", "--prompt-file", "--model", "--phase", "--json", "--help",
+    "--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help",
   ],
   "invoke-reviewer-pi": [
-    "--repo", "--prompt-file", "--model", "--phase", "--json", "--help",
+    "--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help",
   ],
   "persist-done-criteria": [
     "--repo", "--run-id", "--text", "--file", "--json", "--help",

--- a/skills/relay-review/scripts/invoke-reviewer-antigravity.js
+++ b/skills/relay-review/scripts/invoke-reviewer-antigravity.js
@@ -16,22 +16,23 @@ const {
   recoverExecStdout,
   summarizeFailure,
 } = require("./reviewer-helpers");
-const { parseAdvisoryReview } = require("./advisory-review-schema");
+const { parseAdvisoryReview, validateAdvisoryProfile } = require("./advisory-review-schema");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
   commandName: "invoke-reviewer-antigravity",
   reservedFlags: KNOWN_FLAGS,
 });
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
-  console.log("Usage: invoke-reviewer-antigravity.js --repo <path> --prompt-file <path> [--phase <name>] [--model <route>] [--json]");
+  console.log("Usage: invoke-reviewer-antigravity.js --repo <path> --prompt-file <path> [--phase <name>] [--model <route>] [--profile <name>] [--json]");
   console.log("\nOptions:");
   console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
   console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
   console.log(`  --model <route>      ${modeLabel("--model")} Policy route label; not passed to agy`);
   console.log(`  --phase <name>       ${modeLabel("--phase")} primary_review or advisory_review`);
+  console.log(`  --profile <name>     ${modeLabel("--profile")} Advisory profile, defaults to blindspot`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
 }
@@ -42,6 +43,18 @@ function resolvePhase(value) {
     throw new Error(`--phase must be primary_review or advisory_review, got ${JSON.stringify(value)}`);
   }
   return phase;
+}
+
+function readAdvisoryProfileArg(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = String(argv[index]);
+    if (token === "--profile") {
+      const value = argv[index + 1];
+      return value && !String(value).startsWith("--") ? value : undefined;
+    }
+    if (token.startsWith("--profile=")) return token.slice("--profile=".length);
+  }
+  return undefined;
 }
 
 function parsePrintTimeoutMs(value) {
@@ -118,12 +131,12 @@ function buildPrompt(promptText, phase) {
   ].join("\n");
 }
 
-function parseResult(result, phase) {
+function parseResult(result, phase, profile) {
   if (phase === "advisory_review") {
     return parseAdvisoryReview(result, {
       adapter: "antigravity",
       phase,
-      profile: "blindspot",
+      profile,
     });
   }
   return parseReviewerVerdictObject(result, {
@@ -137,6 +150,9 @@ function main() {
   const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
   const promptFile = cliArgs.getArg("--prompt-file");
   const phase = resolvePhase(cliArgs.getArg("--phase", "primary_review"));
+  const advisoryProfile = phase === "advisory_review"
+    ? validateAdvisoryProfile(readAdvisoryProfileArg(args) || "blindspot")
+    : "blindspot";
   const agyBin = process.env.RELAY_ANTIGRAVITY_BIN || "agy";
   const printTimeout = String(process.env.RELAY_ANTIGRAVITY_REVIEW_TIMEOUT || "1800s").trim();
   const parentTimeoutMs = parsePrintTimeoutMs(printTimeout);
@@ -191,7 +207,7 @@ function main() {
   if (mutationMessage) {
     throw new Error(mutationMessage);
   }
-  const parsed = parseResult(result, phase);
+  const parsed = parseResult(result, phase, advisoryProfile);
   const output = JSON.stringify(parsed);
 
   if (cliArgs.hasFlag("--json")) {

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -17,10 +17,10 @@ const {
   recoverExecStdout,
   summarizeFailure,
 } = require("./reviewer-helpers");
-const { parseAdvisoryReview } = require("./advisory-review-schema");
+const { parseAdvisoryReview, validateAdvisoryProfile } = require("./advisory-review-schema");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
   commandName: "invoke-reviewer-cline",
   reservedFlags: KNOWN_FLAGS,
@@ -31,12 +31,13 @@ const MIN_REVIEW_TIMEOUT_SECONDS = 120;
 const CLINE_TIMEOUT_HEADROOM_SECONDS = 60;
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
-  console.log("Usage: invoke-reviewer-cline.js --repo <path> --prompt-file <path> [--phase advisory_review] [--model <route>] [--json]");
+  console.log("Usage: invoke-reviewer-cline.js --repo <path> --prompt-file <path> [--phase advisory_review] [--model <route>] [--profile <name>] [--json]");
   console.log("\nOptions:");
   console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
   console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
   console.log(`  --model <route>      ${modeLabel("--model")} Model route, for example cline-pass/glm-5.2`);
   console.log(`  --phase <name>       ${modeLabel("--phase")} advisory_review only`);
+  console.log(`  --profile <name>     ${modeLabel("--profile")} Advisory profile, defaults to blindspot`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
 }
@@ -49,6 +50,18 @@ function resolvePhase(value) {
     );
   }
   return phase;
+}
+
+function readAdvisoryProfileArg(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = String(argv[index]);
+    if (token === "--profile") {
+      const value = argv[index + 1];
+      return value && !String(value).startsWith("--") ? value : undefined;
+    }
+    if (token.startsWith("--profile=")) return token.slice("--profile=".length);
+  }
+  return undefined;
 }
 
 function parseReviewTimeoutMs(value) {
@@ -138,6 +151,7 @@ function main() {
   const promptFile = cliArgs.getArg("--prompt-file");
   const model = validateModelRoute(cliArgs.getArg("--model"));
   const phase = resolvePhase(cliArgs.getArg("--phase", "advisory_review"));
+  const advisoryProfile = validateAdvisoryProfile(readAdvisoryProfileArg(args) || "blindspot");
   const clineBin = process.env.RELAY_CLINE_BIN || "cline";
   const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
   const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
@@ -210,7 +224,7 @@ function main() {
       parsed = parseAdvisoryReview(candidate, {
         adapter: "cline",
         phase,
-        profile: "blindspot",
+        profile: advisoryProfile,
       });
       break;
     } catch (error) {

--- a/skills/relay-review/scripts/invoke-reviewer-opencode.js
+++ b/skills/relay-review/scripts/invoke-reviewer-opencode.js
@@ -16,10 +16,10 @@ const {
   summarizeFailure,
 } = require("./reviewer-helpers");
 const { REVIEWER_VERDICT_JSON_SCHEMA } = require("./review-schema");
-const { parseAdvisoryReview } = require("./advisory-review-schema");
+const { parseAdvisoryReview, validateAdvisoryProfile } = require("./advisory-review-schema");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
   commandName: "invoke-reviewer-opencode",
   reservedFlags: KNOWN_FLAGS,
@@ -28,12 +28,13 @@ const REVIEW_TIMEOUT_ENV = "RELAY_OPENCODE_REVIEW_TIMEOUT";
 const DEFAULT_REVIEW_TIMEOUT = "1800s";
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
-  console.log("Usage: invoke-reviewer-opencode.js --repo <path> --prompt-file <path> [--phase <name>] [--model <name>] [--json]");
+  console.log("Usage: invoke-reviewer-opencode.js --repo <path> --prompt-file <path> [--phase <name>] [--model <name>] [--profile <name>] [--json]");
   console.log("\nOptions:");
   console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
   console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
   console.log(`  --model <name>       ${modeLabel("--model")} Model override`);
   console.log(`  --phase <name>       ${modeLabel("--phase")} primary_review or advisory_review`);
+  console.log(`  --profile <name>     ${modeLabel("--profile")} Advisory profile, defaults to blindspot`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
 }
@@ -44,6 +45,18 @@ function resolvePhase(value) {
     throw new Error(`--phase must be primary_review or advisory_review, got ${JSON.stringify(value)}`);
   }
   return phase;
+}
+
+function readAdvisoryProfileArg(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = String(argv[index]);
+    if (token === "--profile") {
+      const value = argv[index + 1];
+      return value && !String(value).startsWith("--") ? value : undefined;
+    }
+    if (token.startsWith("--profile=")) return token.slice("--profile=".length);
+  }
+  return undefined;
 }
 
 function parseReviewTimeoutMs(value) {
@@ -97,7 +110,7 @@ function buildPrompt(promptText, phase) {
   ].join("\n");
 }
 
-function parseResult(result, phase) {
+function parseResult(result, phase, profile) {
   if (phase === "primary_review") {
     return parseReviewerVerdictObject(result, {
       adapter: "opencode",
@@ -108,7 +121,7 @@ function parseResult(result, phase) {
   return parseAdvisoryReview(result, {
     adapter: "opencode",
     phase,
-    profile: "blindspot",
+    profile,
   });
 }
 
@@ -127,6 +140,9 @@ function main() {
   const promptFile = cliArgs.getArg("--prompt-file");
   const model = cliArgs.getArg("--model");
   const phase = resolvePhase(cliArgs.getArg("--phase", "advisory_review"));
+  const advisoryProfile = phase === "advisory_review"
+    ? validateAdvisoryProfile(readAdvisoryProfileArg(args) || "blindspot")
+    : "blindspot";
   const opencodeBin = process.env.RELAY_OPENCODE_BIN || "opencode";
   const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
   const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
@@ -177,7 +193,7 @@ function main() {
       "If that minimal command is also empty, record this as an OpenCode CLI/provider non-interactive blocker; otherwise tighten the review prompt or increase the live dogfood command timeout."
     );
   }
-  const parsed = parseResult(result, phase);
+  const parsed = parseResult(result, phase, advisoryProfile);
   const output = JSON.stringify(parsed);
 
   if (cliArgs.hasFlag("--json")) {

--- a/skills/relay-review/scripts/invoke-reviewer-pi.js
+++ b/skills/relay-review/scripts/invoke-reviewer-pi.js
@@ -16,10 +16,10 @@ const {
   recoverExecStdout,
   summarizeFailure,
 } = require("./reviewer-helpers");
-const { parseAdvisoryReview } = require("./advisory-review-schema");
+const { parseAdvisoryReview, validateAdvisoryProfile } = require("./advisory-review-schema");
 
 const args = process.argv.slice(2);
-const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--prompt-file", "--model", "--phase", "--profile", "--json", "--help", "-h"];
 const cliArgs = bindCliArgs(args, {
   commandName: "invoke-reviewer-pi",
   reservedFlags: KNOWN_FLAGS,
@@ -28,12 +28,13 @@ const REVIEW_TIMEOUT_ENV = "RELAY_PI_REVIEW_TIMEOUT";
 const DEFAULT_REVIEW_TIMEOUT = "1800s";
 
 if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
-  console.log("Usage: invoke-reviewer-pi.js --repo <path> --prompt-file <path> [--phase <name>] [--model <name>] [--json]");
+  console.log("Usage: invoke-reviewer-pi.js --repo <path> --prompt-file <path> [--phase <name>] [--model <name>] [--profile <name>] [--json]");
   console.log("\nOptions:");
   console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
   console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
   console.log(`  --model <name>       ${modeLabel("--model")} Model override`);
   console.log(`  --phase <name>       ${modeLabel("--phase")} primary_review or advisory_review`);
+  console.log(`  --profile <name>     ${modeLabel("--profile")} Advisory profile, defaults to blindspot`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
   process.exit(cliArgs.hasFlag(["--help", "-h"]) ? 0 : 1);
 }
@@ -44,6 +45,18 @@ function resolvePhase(value) {
     throw new Error(`--phase must be primary_review or advisory_review, got ${JSON.stringify(value)}`);
   }
   return phase;
+}
+
+function readAdvisoryProfileArg(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = String(argv[index]);
+    if (token === "--profile") {
+      const value = argv[index + 1];
+      return value && !String(value).startsWith("--") ? value : undefined;
+    }
+    if (token.startsWith("--profile=")) return token.slice("--profile=".length);
+  }
+  return undefined;
 }
 
 function parseReviewTimeoutMs(value) {
@@ -115,12 +128,12 @@ function buildPrompt(promptText, phase) {
   ].join("\n");
 }
 
-function parseResult(result, phase) {
+function parseResult(result, phase, profile) {
   if (phase === "advisory_review") {
     return parseAdvisoryReview(result, {
       adapter: "pi",
       phase,
-      profile: "blindspot",
+      profile,
     });
   }
   return parseReviewerVerdictObject(result, {
@@ -135,6 +148,9 @@ function main() {
   const promptFile = cliArgs.getArg("--prompt-file");
   const model = cliArgs.getArg("--model");
   const phase = resolvePhase(cliArgs.getArg("--phase", "primary_review"));
+  const advisoryProfile = phase === "advisory_review"
+    ? validateAdvisoryProfile(readAdvisoryProfileArg(args) || "blindspot")
+    : "blindspot";
   const piBin = process.env.RELAY_PI_BIN || "pi";
   const reviewTimeout = String(process.env[REVIEW_TIMEOUT_ENV] || DEFAULT_REVIEW_TIMEOUT).trim();
   const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
@@ -188,7 +204,7 @@ function main() {
   if (!result) {
     throw new Error(`Pi reviewer ${phase} did not produce a structured result`);
   }
-  const parsed = parseResult(result, phase);
+  const parsed = parseResult(result, phase, advisoryProfile);
   const output = JSON.stringify(parsed);
 
   if (cliArgs.hasFlag("--json")) {

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -387,6 +387,11 @@ function executeAdvisoryRequest(request) {
   let advisoryRepoPath = null;
 
   try {
+    const advisoryProfile = (
+      typeof request.profile === "string" && request.profile.trim()
+        ? validateAdvisoryProfile(request.profile)
+        : null
+    );
     const timeoutMs = parsePositiveSeconds(request.timeoutSeconds) * 1000;
     advisoryRepoPath = createAdvisoryWorktree(request.reviewRepoPath, request.runDir, request.artifactReviewerName || request.reviewerName);
     const statusBefore = captureGitStatus(advisoryRepoPath);
@@ -398,6 +403,7 @@ function executeAdvisoryRequest(request) {
       "--phase", ADAPTER_PHASES.ADVISORY_REVIEW,
     ];
     if (request.reviewerModel) execArgs.push("--model", request.reviewerModel);
+    if (advisoryProfile) execArgs.push("--profile", advisoryProfile);
 
     let stdout = "";
     let stderr = "";

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -47,6 +47,95 @@ function reviewerVerdict(overrides = {}) {
   };
 }
 
+function advisoryPayload(profile = "blindspot") {
+  return {
+    profile,
+    summary: `${profile} advisory result.`,
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  };
+}
+
+const ADVISORY_ADAPTERS = [
+  {
+    name: "opencode",
+    script: OPENCODE_SCRIPT,
+    envKey: "RELAY_OPENCODE_BIN",
+    fakeName: "fake-opencode.js",
+    extraEnv: {},
+    fakeBody: (payload, markerPath) => `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, "spawned\\n", "utf-8");
+process.stdout.write(JSON.stringify(${JSON.stringify(payload)}));
+`,
+  },
+  {
+    name: "pi",
+    script: PI_SCRIPT,
+    envKey: "RELAY_PI_BIN",
+    fakeName: "fake-pi.js",
+    extraEnv: {},
+    fakeBody: (payload, markerPath) => `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, "spawned\\n", "utf-8");
+process.stdout.write(JSON.stringify(${JSON.stringify(payload)}));
+`,
+  },
+  {
+    name: "antigravity",
+    script: ANTIGRAVITY_SCRIPT,
+    envKey: "RELAY_ANTIGRAVITY_BIN",
+    fakeName: "fake-agy.js",
+    extraEnv: { RELAY_ANTIGRAVITY_REVIEW_TIMEOUT: "45s" },
+    fakeBody: (payload, markerPath) => `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, "spawned\\n", "utf-8");
+process.stdout.write(JSON.stringify(${JSON.stringify(payload)}));
+`,
+  },
+  {
+    name: "cline",
+    script: CLINE_SCRIPT,
+    envKey: "RELAY_CLINE_BIN",
+    fakeName: "fake-cline.js",
+    extraEnv: { RELAY_CLINE_REVIEW_TIMEOUT: "120s" },
+    extraArgs: ["--model", "cline-pass/glm-5.2"],
+    fakeBody: (payload, markerPath) => `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(markerPath)}, "spawned\\n", "utf-8");
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  finishReason: "completed",
+  text: JSON.stringify(${JSON.stringify(payload)}),
+}) + "\\n");
+`,
+  },
+];
+
+function runAdvisoryAdapter(adapter, { profileArg = null, payloadProfile = "blindspot" } = {}) {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), `relay-review-fake-${adapter.name}-profile-`));
+  const markerPath = path.join(fakeDir, "spawned.txt");
+  const fakeBin = writeExecutable(fakeDir, adapter.fakeName, adapter.fakeBody(advisoryPayload(payloadProfile), markerPath));
+  const args = [
+    adapter.script,
+    "--repo", repoRoot,
+    "--prompt-file", promptPath,
+    "--phase", "advisory_review",
+    ...(adapter.extraArgs || []),
+  ];
+  if (profileArg) args.push("--profile", profileArg);
+  args.push("--json");
+  const stdout = execFileSync("node", args, {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, ...adapter.extraEnv, [adapter.envKey]: fakeBin },
+  });
+  return { stdout, markerPath };
+}
+
 function runPiAdapterWithStdout(stdoutText) {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-pi-output-"));
@@ -456,6 +545,83 @@ process.stdout.write("Sure, here is the advisory result:\\n" + JSON.stringify({
   const result = JSON.parse(stdout);
   assert.equal(result.summary, "Recovered from verbose live output.");
 });
+
+for (const adapter of ADVISORY_ADAPTERS) {
+  test(`${adapter.name} advisory adapter accepts matching --profile adversarial payload`, () => {
+    const { stdout } = runAdvisoryAdapter(adapter, {
+      profileArg: "adversarial",
+      payloadProfile: "adversarial",
+    });
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.profile, "adversarial");
+  });
+
+  test(`${adapter.name} advisory adapter keeps blindspot default and rejects adversarial payload without --profile`, () => {
+    let error;
+    try {
+      runAdvisoryAdapter(adapter, { payloadProfile: "adversarial" });
+      assert.fail(`expected ${adapter.name} adapter to reject adversarial payload on default blindspot profile`);
+    } catch (caught) {
+      error = caught;
+    }
+
+    assert.ok(error);
+    assert.notEqual(error.status, 0);
+    assert.match(String(error.stderr || ""), /profile must be 'blindspot', got 'adversarial'/);
+  });
+
+  test(`${adapter.name} advisory adapter rejects blindspot payload on adversarial lane`, () => {
+    let error;
+    try {
+      runAdvisoryAdapter(adapter, {
+        profileArg: "adversarial",
+        payloadProfile: "blindspot",
+      });
+      assert.fail(`expected ${adapter.name} adapter to reject blindspot payload on adversarial profile`);
+    } catch (caught) {
+      error = caught;
+    }
+
+    assert.ok(error);
+    assert.notEqual(error.status, 0);
+    assert.match(String(error.stderr || ""), /profile must be 'adversarial', got 'blindspot'/);
+  });
+
+  test(`${adapter.name} advisory adapter rejects unknown --profile before invoking provider`, () => {
+    const { repoRoot, promptPath } = setupRepo();
+    const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), `relay-review-fake-${adapter.name}-bad-profile-`));
+    const markerPath = path.join(fakeDir, "spawned.txt");
+    const fakeBin = writeExecutable(fakeDir, adapter.fakeName, adapter.fakeBody(advisoryPayload("blindspot"), markerPath));
+    const args = [
+      adapter.script,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--phase", "advisory_review",
+      ...(adapter.extraArgs || []),
+      "--profile", "not-a-profile",
+      "--json",
+    ];
+
+    let error;
+    try {
+      execFileSync("node", args, {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+        env: { ...process.env, ...adapter.extraEnv, [adapter.envKey]: fakeBin },
+      });
+      assert.fail(`expected ${adapter.name} adapter to reject unknown profile`);
+    } catch (caught) {
+      error = caught;
+    }
+
+    assert.ok(error);
+    assert.notEqual(error.status, 0);
+    assert.match(String(error.stderr || ""), /Unknown advisory profile/);
+    assert.equal(fs.existsSync(markerPath), false);
+  });
+}
 
 test("opencode adapter reports actionable diagnostics for empty stdout", () => {
   const { repoRoot, promptPath } = setupRepo();

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -21,7 +21,7 @@ const {
   createEnforcementFixture,
 } = require("../../relay-dispatch/scripts/test-support");
 const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
-const { finishAdvisoryReview } = require("../../../skills/relay-review/scripts/review-runner/advisory");
+const { executeAdvisoryRequest, finishAdvisoryReview } = require("../../../skills/relay-review/scripts/review-runner/advisory");
 const { buildAdvisoryPrompt } = require("../../../skills/relay-review/scripts/review-runner/advisory-prompt");
 const { applyReviewAssurancePolicy } = require("../../../skills/relay-review/scripts/review-runner/assurance");
 const { installFakeGhOnPath } = require("../fixtures/fake-gh");
@@ -451,6 +451,67 @@ setTimeout(() => {
   return filePath;
 }
 
+function advisoryPayload(profile = "blindspot") {
+  return {
+    profile,
+    summary: `${profile} advisory result.`,
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  };
+}
+
+function writeProfileLoggingReviewer(repoRoot, { logPath, payloadProfile = "blindspot" } = {}) {
+  const filePath = path.join(repoRoot, "profile-logging-reviewer.js");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)), "utf-8");
+process.stdout.write(JSON.stringify(${JSON.stringify(advisoryPayload(payloadProfile))}));
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function executeProfileRequest({ profile, payloadProfile = "blindspot" } = {}) {
+  const { repoRoot, runDir, runId } = setupRepo();
+  const logPath = path.join(runDir, "profile-reviewer-args.json");
+  const resultPath = path.join(runDir, "profile-reviewer-result.json");
+  const promptPath = path.join(runDir, "profile-reviewer-prompt.md");
+  const decisionPath = path.join(runDir, "profile-reviewer-decision.json");
+  fs.writeFileSync(promptPath, "Advisory prompt\n", "utf-8");
+  const reviewerScript = writeProfileLoggingReviewer(repoRoot, { logPath, payloadProfile });
+
+  executeAdvisoryRequest({
+    artifactReviewerName: "profile",
+    decisionPath,
+    gating: false,
+    headSha: "a".repeat(40),
+    laneIndex: 1,
+    profile,
+    promptPath,
+    requestPath: path.join(runDir, "profile-reviewer-request.json"),
+    resultPath,
+    reviewerModel: null,
+    reviewerName: "opencode",
+    reviewerPolicy: null,
+    policyDecision: null,
+    modelResolution: null,
+    reviewerScript,
+    reviewRepoPath: repoRoot,
+    round: 1,
+    runDir,
+    runId,
+    runRepoPath: repoRoot,
+    source: null,
+    startedAt: Date.now(),
+    state: STATES.REVIEW_PENDING,
+    timeoutSeconds: 5,
+    trigger: "every_round",
+  });
+
+  return { logPath, result: JSON.parse(fs.readFileSync(resultPath, "utf-8")) };
+}
+
 function waitForEvent(repoRoot, runId, predicate, { timeoutMs = 2000 } = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -460,6 +521,69 @@ function waitForEvent(repoRoot, runId, predicate, { timeoutMs = 2000 } = {}) {
   }
   return null;
 }
+
+test("executeAdvisoryRequest forwards advisory profile to reviewer argv", () => {
+  const { logPath, result } = executeProfileRequest({
+    profile: "adversarial",
+    payloadProfile: "adversarial",
+  });
+
+  const args = JSON.parse(fs.readFileSync(logPath, "utf-8"));
+  assert.equal(result.status, "success");
+  assert.deepEqual(args.slice(args.indexOf("--profile"), args.indexOf("--profile") + 2), ["--profile", "adversarial"]);
+});
+
+test("executeAdvisoryRequest omits profile argv when request has no profile", () => {
+  const { logPath, result } = executeProfileRequest({
+    payloadProfile: "blindspot",
+  });
+
+  const args = JSON.parse(fs.readFileSync(logPath, "utf-8"));
+  assert.equal(result.status, "success");
+  assert.equal(args.includes("--profile"), false);
+});
+
+test("executeAdvisoryRequest rejects unknown profile before spawning reviewer", () => {
+  const { repoRoot, runDir, runId } = setupRepo();
+  const logPath = path.join(runDir, "bad-profile-reviewer-args.json");
+  const resultPath = path.join(runDir, "bad-profile-reviewer-result.json");
+  const promptPath = path.join(runDir, "bad-profile-reviewer-prompt.md");
+  fs.writeFileSync(promptPath, "Advisory prompt\n", "utf-8");
+  const reviewerScript = writeProfileLoggingReviewer(repoRoot, { logPath, payloadProfile: "blindspot" });
+
+  executeAdvisoryRequest({
+    artifactReviewerName: "bad-profile",
+    decisionPath: path.join(runDir, "bad-profile-reviewer-decision.json"),
+    gating: false,
+    headSha: "a".repeat(40),
+    laneIndex: 1,
+    profile: "not-a-profile",
+    promptPath,
+    requestPath: path.join(runDir, "bad-profile-reviewer-request.json"),
+    resultPath,
+    reviewerModel: null,
+    reviewerName: "opencode",
+    reviewerPolicy: null,
+    policyDecision: null,
+    modelResolution: null,
+    reviewerScript,
+    reviewRepoPath: repoRoot,
+    round: 1,
+    runDir,
+    runId,
+    runRepoPath: repoRoot,
+    source: null,
+    startedAt: Date.now(),
+    state: STATES.REVIEW_PENDING,
+    timeoutSeconds: 5,
+    trigger: "every_round",
+  });
+
+  const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+  assert.equal(result.status, "failed");
+  assert.match(result.failureReason, /Unknown advisory profile/);
+  assert.equal(fs.existsSync(logPath), false);
+});
 
 function runReview({
   repoRoot,


### PR DESCRIPTION
Closes #873.

## What

The adversarial advisory profile (#844 P2) was framed into prompts but could never validate: every advisory adapter hardcoded `parseAdvisoryReview(text, { profile: "blindspot" })` and the worker never passed the lane profile.

- `executeAdvisoryRequest` now appends `--profile <request.profile>` (validated via `validateAdvisoryProfile` before spawn) to reviewer-script argv; absent profile → no flag, byte-identical behavior.
- `invoke-reviewer-{cline,pi,opencode,antigravity}.js` accept `--profile` (registered in known-flags), validate it, and pass it to `parseAdvisoryReview`. Absent → blindspot default.
- Fail-closed both directions: payload/lane profile mismatch rejects (adversarial-on-blindspot AND blindspot-on-adversarial).

## Verification

- Round-trip tests: worker request with adversarial profile → argv assertion → adapter accept/reject matrix.
- Operator-run serialized suites at this HEAD: relay-review 524/524, skills-lint 24/24, full repo suite 1980 pass / 0 fail.

## Run

Relay run `issue-873-20260709130916812-f23b2b49`. Executor died during its final serialized suite (no_result — third live occurrence of the #806 placeholder-evidence bug, workaround applied); work salvaged, verified, and committed by the orchestrator per the recovery playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)