### PR TITLE
Fix placeholder evidence recovery (#806)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -86,6 +86,7 @@ const FLAGS = [
     rationale: "Codex reasoning_effort override; closed selector over codex CLI levels." },
   { flag: "--reconcile", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit opt-in to mutate dead dispatched runs during doctor/preflight reconciliation." },
   { flag: "--reconcile-merged", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Reconcile merged drift for ready_to_merge runs with merge evidence." },
+  { flag: "--replace-placeholder-evidence", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicitly replace timeout placeholder evidence with operator-verified evidence; no value is consumed." },
   { flag: "--register", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--repeated-issue-count", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Numeric review field; flag-like following tokens should mean the value is missing." },
   { flag: "--repo", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied repository path; keep the literal argv token." },
@@ -194,7 +195,7 @@ const COMMAND_FLAGS = {
   ],
   "recover-commit": [
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",
-    "--test-command", "--test-result-file", "--test-exit-code",
+    "--test-command", "--test-result-file", "--test-exit-code", "--replace-placeholder-evidence",
     "--dry-run", "--json", "--help",
   ],
   "reconcile-run": [

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -351,7 +351,14 @@ function main() {
   const prBodyFile = getCliArg("--pr-body-file");
   const operatorEvidenceFlags = ["--test-command", "--test-result-file", "--test-exit-code"]
     .filter((flag) => hasCliFlag(flag));
+  const replacePlaceholderEvidence = hasCliFlag("--replace-placeholder-evidence");
   validateOperatorEvidenceFlagSet(operatorEvidenceFlags);
+  if (replacePlaceholderEvidence && operatorEvidenceFlags.length === 0) {
+    throw new Error(
+      "--replace-placeholder-evidence requires operator execution evidence flags together: " +
+      "--test-command, --test-result-file, --test-exit-code"
+    );
+  }
   const operatorEvidenceRequested = operatorEvidenceFlags.length > 0;
   const testCommand = getCliArg("--test-command");
   const testResultFileArg = getCliArg("--test-result-file");
@@ -367,7 +374,6 @@ function main() {
     }
   }
   const testExitCodeProvided = hasCliFlag("--test-exit-code");
-  const replacePlaceholderEvidence = hasCliFlag("--replace-placeholder-evidence");
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
   const timestamp = nowIso();

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -57,6 +57,7 @@ function printHelp(exitCode) {
   console.log(`  --test-command <cmd> ${modeLabel("--test-command")} Operator-run test command for missing execution evidence`);
   console.log(`  --test-result-file <path> ${modeLabel("--test-result-file")} Operator-run test output file to hash for missing execution evidence`);
   console.log(`  --test-exit-code <n> ${modeLabel("--test-exit-code")} Operator-run test exit code for missing execution evidence`);
+  console.log(`  --replace-placeholder-evidence ${modeLabel("--replace-placeholder-evidence")} Replace timeout placeholder evidence with operator-run evidence`);
   console.log(`  --dry-run           ${modeLabel("--dry-run")} Print planned git/gh commands and manifest mutation only`);
   console.log(`  --json              ${modeLabel("--json")} Output JSON`);
   console.log("\nDecision tree:");
@@ -366,6 +367,7 @@ function main() {
     }
   }
   const testExitCodeProvided = hasCliFlag("--test-exit-code");
+  const replacePlaceholderEvidence = hasCliFlag("--replace-placeholder-evidence");
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
   const timestamp = nowIso();
@@ -401,12 +403,29 @@ function main() {
   const runDir = getRunDir(validatedPaths.repoRoot, data.run_id);
   const evidencePath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
   const evidenceExists = fs.existsSync(evidencePath);
+  let replacedEvidence = null;
 
   if (operatorEvidenceRequested && evidenceExists) {
-    throw new Error(
-      `${EXECUTION_EVIDENCE_FILENAME} already exists for ${data.run_id}; refusing to overwrite it. ` +
-      "Use skills/relay-dispatch/scripts/rebrand-evidence.js when existing evidence needs to be rebound to a new HEAD."
+    const existingEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+    const isPlaceholder = (
+      existingEvidence.recorded_by === "dispatch-orchestrator-v1" &&
+      existingEvidence.test_command === "unspecified"
     );
+    if (replacePlaceholderEvidence && isPlaceholder) {
+      replacedEvidence = {
+        recorded_by: existingEvidence.recorded_by,
+        test_exit_code: existingEvidence.test_exit_code ?? null,
+      };
+    } else {
+      const placeholderHint = isPlaceholder && !replacePlaceholderEvidence
+        ? " Pass --replace-placeholder-evidence to replace timeout placeholder evidence."
+        : "";
+      throw new Error(
+        `${EXECUTION_EVIDENCE_FILENAME} already exists for ${data.run_id}; refusing to overwrite it. ` +
+        "Use skills/relay-dispatch/scripts/rebrand-evidence.js when existing evidence needs to be rebound to a new HEAD." +
+        placeholderHint
+      );
+    }
   }
   const testResultFile = resolveTestResultFile(testResultFileArg);
   const testExitCode = parseTestExitCode(testExitCodeArg, testExitCodeProvided);
@@ -532,7 +551,7 @@ function main() {
       throw new Error(`commit_failed: ${detail}`);
     }
   }
-  if (evidenceExists) {
+  if (evidenceExists && !replacedEvidence) {
     const rebrandResult = rebrandEvidence(runDir, {
       newHeadSha: commitSha,
       recordedBy: "recover-commit-rebrand",
@@ -556,7 +575,7 @@ function main() {
       });
     }
   }
-  if (!evidenceExists) {
+  if (!evidenceExists || replacedEvidence) {
     const operatorEvidence = writeOperatorExecutionEvidenceIfRequested({
       runDir,
       evidencePath,
@@ -580,6 +599,7 @@ function main() {
         operator_initiated: true,
         execution_evidence_path: operatorEvidence.path,
         execution_evidence_hash: operatorEvidence.hash,
+        ...(replacedEvidence ? { before: replacedEvidence } : {}),
       });
     }
     if (!operatorEvidenceRequested) {

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -406,10 +406,16 @@ function main() {
   let replacedEvidence = null;
 
   if (operatorEvidenceRequested && evidenceExists) {
-    const existingEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+    let existingEvidence = null;
+    try {
+      const parsedEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+      if (parsedEvidence && typeof parsedEvidence === "object" && !Array.isArray(parsedEvidence)) {
+        existingEvidence = parsedEvidence;
+      }
+    } catch {}
     const isPlaceholder = (
-      existingEvidence.recorded_by === "dispatch-orchestrator-v1" &&
-      existingEvidence.test_command === "unspecified"
+      existingEvidence?.recorded_by === "dispatch-orchestrator-v1" &&
+      existingEvidence?.test_command === "unspecified"
     );
     if (replacePlaceholderEvidence && isPlaceholder) {
       replacedEvidence = {

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -132,6 +132,7 @@ test("recover-commit flags are registered with explicit required modes", () => {
     ["--test-command", VALUE, MODE_VERBATIM],
     ["--test-result-file", VALUE, MODE_VERBATIM],
     ["--test-exit-code", VALUE, MODE_PARSED],
+    ["--replace-placeholder-evidence", BOOLEAN, MODE_PARSED],
     ["--run-id", VALUE, MODE_PARSED],
     ["--dry-run", BOOLEAN, MODE_PARSED],
     ["--json", BOOLEAN, MODE_PARSED],

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -765,11 +765,38 @@ test("placeholder evidence without replacement flag is refused with the flag hin
   assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
 });
 
+test("replacement flag without operator evidence flags is rejected before recovery side effects", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    evidenceOverrides: { test_command: "unspecified", test_exit_code: 1 },
+  });
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+  const beforeManifest = fs.readFileSync(fixture.manifestPath, "utf-8");
+  const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+
+  const result = runRecover(fixture, [
+    "--reason", "replace timeout placeholder",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--replace-placeholder-evidence requires operator execution evidence flags together/);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(fs.readFileSync(fixture.manifestPath, "utf-8"), beforeManifest);
+  assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
 test("replacement flag replaces exact placeholder and journals replaced fields on operator evidence event", () => {
   const fixture = setupRepo({
     dirty: true,
     evidence: true,
-    evidenceOverrides: { test_command: "unspecified" },
+    evidenceOverrides: { test_command: "unspecified", test_exit_code: 1 },
   });
   const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
   fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
@@ -796,7 +823,7 @@ test("replacement flag replaces exact placeholder and journals replaced fields o
   const events = readRunEvents(fixture.repoRoot, fixture.runId);
   const operatorEvidenceEvent = events.find((entry) => entry.event === "operator_execution_evidence");
   assert.equal(operatorEvidenceEvent.before.recorded_by, "dispatch-orchestrator-v1");
-  assert.equal(operatorEvidenceEvent.before.test_exit_code, null);
+  assert.equal(operatorEvidenceEvent.before.test_exit_code, 1);
   assert.equal(operatorEvidenceEvent.execution_evidence_path, evidencePath);
   assert.equal(operatorEvidenceEvent.execution_evidence_hash, sha256File(evidencePath));
   assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -711,6 +711,34 @@ test("operator test flags refuse to overwrite existing execution evidence", () =
   assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
 });
 
+[
+  { name: "malformed", contents: "{not-json\n" },
+  { name: "null", contents: "null\n" },
+].forEach(({ name, contents }) => {
+  test(`operator test flags refuse to overwrite ${name} execution evidence`, () => {
+    const fixture = setupRepo({ dirty: true, evidence: true });
+    const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+    fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+    const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+    fs.writeFileSync(evidencePath, contents, "utf-8");
+
+    const result = runRecover(fixture, [
+      "--reason", `operator attempted ${name} evidence overwrite`,
+      "--test-command", "node --test",
+      "--test-result-file", resultFile,
+      "--test-exit-code", "0",
+      "--json",
+    ]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /execution-evidence\.json already exists/);
+    assert.match(result.stderr, /rebrand-evidence\.js/);
+    assert.doesNotMatch(result.stderr, /--replace-placeholder-evidence/);
+    assert.equal(fs.readFileSync(evidencePath, "utf-8"), contents);
+    assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+  });
+});
+
 test("placeholder evidence without replacement flag is refused with the flag hint", () => {
   const fixture = setupRepo({
     dirty: true,

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -180,6 +180,7 @@ function setupRepo({
   runtimeOnlyDirty = false,
   unpushed = false,
   evidence = false,
+  evidenceOverrides = {},
   staleEvidence = false,
   manifestState = STATES.REVIEW_PENDING,
   branch = "issue-281",
@@ -252,6 +253,7 @@ function setupRepo({
       test_result_summary: "unspecified",
       recorded_at: "2026-04-24T01:00:00.000Z",
       recorded_by: "dispatch-orchestrator-v1",
+      ...evidenceOverrides,
     });
   }
 
@@ -701,11 +703,105 @@ test("operator test flags refuse to overwrite existing execution evidence", () =
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /execution-evidence\.json already exists/);
   assert.match(result.stderr, /rebrand-evidence\.js/);
+  assert.doesNotMatch(result.stderr, /--replace-placeholder-evidence/);
   assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim(), beforeHead);
   assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "?? recovered.txt");
   assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
   assert.equal(readJsonLines(fixture.ghLogPath).length, 0);
   assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("placeholder evidence without replacement flag is refused with the flag hint", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    evidenceOverrides: { test_command: "unspecified" },
+  });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+
+  const result = runRecover(fixture, [
+    "--reason", "replace timeout placeholder",
+    "--test-command", "node --test",
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--json",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /execution-evidence\.json already exists/);
+  assert.match(result.stderr, /--replace-placeholder-evidence/);
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("replacement flag replaces exact placeholder and journals replaced fields on operator evidence event", () => {
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    evidenceOverrides: { test_command: "unspecified" },
+  });
+  const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+  fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+  const testCommand = "node --test tests/relay-dispatch/scripts/recover-commit.test.js";
+
+  const result = runRecover(fixture, [
+    "--reason", "replace timeout placeholder",
+    "--test-command", testCommand,
+    "--test-result-file", resultFile,
+    "--test-exit-code", "0",
+    "--replace-placeholder-evidence",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  assert.equal(evidence.head_sha, parsed.commitSha);
+  assert.equal(evidence.test_command, testCommand);
+  assert.equal(evidence.test_exit_code, 0);
+  assert.equal(evidence.recorded_by, "recover-commit-operator-v1");
+
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  const operatorEvidenceEvent = events.find((entry) => entry.event === "operator_execution_evidence");
+  assert.equal(operatorEvidenceEvent.before.recorded_by, "dispatch-orchestrator-v1");
+  assert.equal(operatorEvidenceEvent.before.test_exit_code, null);
+  assert.equal(operatorEvidenceEvent.execution_evidence_path, evidencePath);
+  assert.equal(operatorEvidenceEvent.execution_evidence_hash, sha256File(evidencePath));
+  assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);
+});
+
+[
+  { name: "recorded_by differs", overrides: { test_command: "unspecified", recorded_by: "recover-commit-operator-v1" } },
+  { name: "test_command differs", overrides: { test_command: "node --test", recorded_by: "dispatch-orchestrator-v1" } },
+  { name: "both fields differ", overrides: { test_command: "node --test", recorded_by: "codex-executor-v1" } },
+].forEach(({ name, overrides }) => {
+  test(`replacement flag refuses non-placeholder evidence when ${name}`, () => {
+    const fixture = setupRepo({ dirty: true, evidence: true, evidenceOverrides: overrides });
+    const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
+    fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
+    const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+    const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
+
+    const result = runRecover(fixture, [
+      "--reason", "attempt non-placeholder replacement",
+      "--test-command", "node --test",
+      "--test-result-file", resultFile,
+      "--test-exit-code", "0",
+      "--replace-placeholder-evidence",
+      "--json",
+    ]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /execution-evidence\.json already exists/);
+    assert.match(result.stderr, /rebrand-evidence\.js/);
+    assert.doesNotMatch(result.stderr, /Pass --replace-placeholder-evidence/);
+    assert.equal(fs.readFileSync(evidencePath, "utf-8"), beforeEvidence);
+    assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+  });
 });
 
 test("already-committed recovery leaves execution evidence byte-identical", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #806.

- Added `--replace-placeholder-evidence`.
- Exact conjunctive placeholder classification.
- Preserved refusal behavior for non-placeholder evidence.
- Reused `operator_execution_evidence`, journaling replaced fields via `before`.
- Added replacement, refusal, classification, and CLI schema tests.
- Final gate: 1,006 passed, 0 failed, 2 skipped.
- Commit: `d1dcc3b Fix placeholder evidence recovery (#806)`
- Worktree clean; branch ahead by one commit.

`git f
```

## Score Log

- Run: issue-806-20260710023620613-ce019fd1
- Executor: codex
- Branch: issue-806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * `recover-commit` 명령에 `--replace-placeholder-evidence` 옵션을 추가했습니다.
  * 타임아웃으로 생성된 placeholder 실행 증거를 명시적으로 교체할 수 있습니다.

* **버그 수정**
  * 일반 실행 증거가 실수로 덮어써지는 것을 방지합니다.
  * 증거 교체 시 기존 상태를 이벤트 기록에 남깁니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->