### PR TITLE
fix(review): preserve cline advisory parse failures (#887)

### DIFF
--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -100,7 +100,11 @@ function parseAdvisoryReview(text, {
       phase,
       description: "advisory review",
     });
-    const actualProfile = requireString(parsed.profile, "profile");
+    const actualProfile = (
+      parsed.profile === undefined ||
+      parsed.profile === null ||
+      (typeof parsed.profile === "string" && !parsed.profile.trim())
+    ) ? expectedProfile : requireString(parsed.profile, "profile");
     if (actualProfile !== expectedProfile) {
       throw new Error(`profile must be '${expectedProfile}', got '${actualProfile}'`);
     }

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -146,6 +146,12 @@ function buildPrompt(promptText) {
   ].join("\n");
 }
 
+function withRawAdapterOutput(error, rawOutput, rawStderr) {
+  error.rawAdapterOutput = rawOutput;
+  error.rawAdapterStderr = rawStderr;
+  return error;
+}
+
 function main() {
   const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
   const promptFile = cliArgs.getArg("--prompt-file");
@@ -212,9 +218,9 @@ function main() {
       stderr: rawStderr,
     });
   } catch (error) {
-    throw new Error(
+    throw withRawAdapterOutput(new Error(
       `${error.message}. Cline advisory review must return JSON in run_result.text or the final text content_end; relay cannot treat this as healthy advisory evidence.`
-    );
+    ), rawOutput, rawStderr);
   }
 
   let parsed = null;
@@ -232,9 +238,9 @@ function main() {
     }
   }
   if (!parsed) {
-    throw new Error(
+    throw withRawAdapterOutput(new Error(
       `Cline advisory review failed to parse any of ${candidates.length} advisory candidate(s); first failure: ${firstParseError?.message || "unknown parse failure"}`
-    );
+    ), rawOutput, rawStderr);
   }
   const output = JSON.stringify(parsed);
 
@@ -249,5 +255,13 @@ try {
   main();
 } catch (error) {
   console.error(`Error: ${error.message}`);
+  if (error.rawAdapterOutput || error.rawAdapterStderr) {
+    if (error.rawAdapterOutput) {
+      process.stderr.write(`\nRaw Cline output:\n${error.rawAdapterOutput.trim()}\n`);
+    }
+    if (error.rawAdapterStderr) {
+      process.stderr.write(`\nCline stderr:\n${error.rawAdapterStderr.trim()}\n`);
+    }
+  }
   process.exit(1);
 }

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -3,7 +3,7 @@
  * Invoke Cline CLI as a structured advisory reviewer.
  */
 
-const { execFileSync } = require("child_process");
+const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const {
@@ -14,7 +14,6 @@ const {
   extractClineAdvisoryCandidates,
 } = require("../../relay-dispatch/scripts/agent-adapters/cline-jsonl");
 const {
-  recoverExecStdout,
   summarizeFailure,
 } = require("./reviewer-helpers");
 const { parseAdvisoryReview, validateAdvisoryProfile } = require("./advisory-review-schema");
@@ -181,20 +180,18 @@ function main() {
     fullPrompt
   );
 
-  let rawOutput;
-  let rawStderr = "";
-  try {
-    rawOutput = execFileSync(clineBin, execArgs, {
-      cwd: repoPath,
-      encoding: "utf-8",
-      stdio: "pipe",
-      timeout: parentTimeoutMs,
-      killSignal: "SIGKILL",
-      maxBuffer: 10 * 1024 * 1024,
-    }).trim();
-  } catch (error) {
-    rawStderr = String(error?.stderr || "");
-    if (isExecTimeout(error)) {
+  const execResult = spawnSync(clineBin, execArgs, {
+    cwd: repoPath,
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: parentTimeoutMs,
+    killSignal: "SIGKILL",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const rawOutput = String(execResult.stdout || "").trim();
+  const rawStderr = String(execResult.stderr || "");
+  if (execResult.error || execResult.status !== 0) {
+    if (isExecTimeout(execResult.error)) {
       const diagnosticCommand = buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout });
       throw new Error(
         `Cline reviewer ${phase} timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}). ` +
@@ -203,11 +200,12 @@ function main() {
         "If that minimal command also times out, record this as a Cline CLI/provider non-interactive blocker; otherwise retry with a larger review timeout or split the review scope."
       );
     }
-    const recovered = recoverExecStdout(error);
-    if (!recovered && !rawStderr) {
-      throw new Error(`Cline reviewer failed: ${summarizeFailure(error)}`);
+    if (!rawOutput && !rawStderr) {
+      const failure = execResult.error || {
+        message: `Cline process exited with status ${execResult.status ?? "unknown"}`,
+      };
+      throw new Error(`Cline reviewer failed: ${summarizeFailure(failure)}`);
     }
-    rawOutput = recovered || "";
   }
 
   let candidates;

--- a/tests/relay-review/scripts/advisory-review-schema.test.js
+++ b/tests/relay-review/scripts/advisory-review-schema.test.js
@@ -28,6 +28,31 @@ test("advisory schema accepts normalized blindspot payloads", () => {
   assert.equal(parsed.advisory_findings[0].category, "test-gap");
 });
 
+test("advisory schema defaults missing and empty profile echoes to the lane profile", () => {
+  for (const profile of [undefined, null, "", "  \t\n"]) {
+    const parsed = parseAdvisoryReview(JSON.stringify(advisoryPayload({ profile })), {
+      profile: "blindspot",
+    });
+    assert.equal(parsed.profile, "blindspot");
+  }
+
+  const payloadWithoutProfile = advisoryPayload();
+  delete payloadWithoutProfile.profile;
+  assert.equal(
+    parseAdvisoryReview(JSON.stringify(payloadWithoutProfile), { profile: "adversarial" }).profile,
+    "adversarial"
+  );
+});
+
+test("advisory schema rejects present non-string profile values", () => {
+  for (const profile of [42, false, {}, []]) {
+    assert.throws(
+      () => parseAdvisoryReview(JSON.stringify(advisoryPayload({ profile })), { profile: "blindspot" }),
+      /profile must be a non-empty string/
+    );
+  }
+});
+
 test("advisory schema exposes the supported profile list without changing finding shape", () => {
   assert.deepEqual(ADVISORY_PROFILES, ["blindspot", "adversarial"]);
   const parsed = parseAdvisoryReview(JSON.stringify(advisoryPayload({ profile: "adversarial" })), { profile: "adversarial" });

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -1280,6 +1280,42 @@ test("review-runner accepts cline advisory review when route policy allows the r
   assert.equal(event.reviewer_policy.read_only.enforcement_level, "prompt-only");
 });
 
+test("review-runner persists raw cline JSONL when every advisory candidate fails to parse", () => {
+  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "allow-cline-advisory" });
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const rawText = "unparseable-cline-advisory-887";
+  const clineScript = path.join(repoRoot, "fake-cline-parse-failure.js");
+  fs.writeFileSync(clineScript, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "run_result",
+  finishReason: "completed",
+  text: ${JSON.stringify(rawText)},
+}) + "\\n");
+process.stderr.write("cline-provider-stderr-887\\n");
+process.exitCode = 1;
+`, "utf-8");
+  fs.chmodSync(clineScript, 0o755);
+
+  const result = runReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    primaryScript,
+    opencodeScript: null,
+    clineScript,
+    advisoryReviewer: "cline",
+    extraArgs: ["--advisory-reviewer-model", "cline-pass/glm-5.2", "--advisory-grace", "30"],
+  });
+
+  assert.equal(result.advisoryReview.status, "failed");
+  assert.equal(result.advisoryReview.rawResponsePath, path.join(runDir, "review-round-1-advisory-cline-raw-response.txt"));
+  const rawArtifact = fs.readFileSync(result.advisoryReview.rawResponsePath, "utf-8");
+  assert.match(rawArtifact, /Error: Cline advisory review failed to parse any of 1 advisory candidate/);
+  assert.match(rawArtifact, new RegExp(rawText));
+  assert.match(rawArtifact, /cline-provider-stderr-887/);
+});
+
 test("review-runner denies pi advisory model before spawning advisory reviewer", () => {
   const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "strict-routes" });
   const logPath = path.join(repoRoot, "pi-advisory-policy.log");

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -1280,7 +1280,7 @@ test("review-runner accepts cline advisory review when route policy allows the r
   assert.equal(event.reviewer_policy.read_only.enforcement_level, "prompt-only");
 });
 
-test("review-runner persists raw cline JSONL when every advisory candidate fails to parse", () => {
+test("review-runner persists raw cline JSONL and stderr after a successful exit fails to parse", () => {
   const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo({ modelPolicy: "allow-cline-advisory" });
   const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
   const rawText = "unparseable-cline-advisory-887";
@@ -1292,7 +1292,6 @@ process.stdout.write(JSON.stringify({
   text: ${JSON.stringify(rawText)},
 }) + "\\n");
 process.stderr.write("cline-provider-stderr-887\\n");
-process.exitCode = 1;
 `, "utf-8");
   fs.chmodSync(clineScript, 0o755);
 


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #887.

Changes:

- Missing/null/blank advisory `profile` now defaults to the validated lane profile.
- Explicit mismatches and non-string values remain rejected.
- Cline parse/extraction failures emit raw JSONL and captured stderr after the diagnostic line, allowing the runner to persist them via `rawResponsePath`.
- Added schema and run-artifact regression tests.

Verification:

- Targeted tests: 132/132 passed.
- Serialized relay-review + skills-lint gate: 551/5
```

## Score Log

- Run: issue-887-20260710040519146-138e37a3
- Executor: codex
- Branch: issue-887