### PR TITLE
relay-review: embed the current effective Done Criteria (incl. amendments) into generated redispatch prompts (#883)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1303,34 +1303,19 @@ function findLatestRedispatchPrompt(runDir) {
   return latest;
 }
 
-function refreshRedispatchDoneCriteria(prompt, doneCriteria) {
-  const blockPattern = /((?:^|\n)Original Done Criteria \(scope anchor\):\r?\n<task-content source="[^"]+">\r?\n)([\s\S]*?)(\r?\n<\/task-content>)/;
-  const match = blockPattern.exec(prompt);
-  if (match) {
-    if (match[2] === doneCriteria) return prompt;
-    const refreshedBlock = match[1] + doneCriteria + match[3];
-    const blockEnd = match.index + match[0].length;
-    return prompt.slice(0, match.index) + refreshedBlock + prompt.slice(blockEnd);
-  }
-
-  if (prompt.startsWith("Rubric recovery re-dispatch\n")) {
-    const criteriaHeader = "\nDone Criteria:\n";
-    const criteriaStart = prompt.lastIndexOf(criteriaHeader);
-    if (criteriaStart !== -1) {
-      const contentStart = criteriaStart + criteriaHeader.length;
-      const convergenceStart = prompt.indexOf("\n\n## Convergence context\n", contentStart);
-      const serializationNewlineLength = convergenceStart === -1
-        ? prompt.endsWith("\r\n") ? 2 : prompt.endsWith("\n") ? 1 : 0
-        : 0;
-      const contentEnd = convergenceStart === -1
-        ? prompt.length - serializationNewlineLength
-        : convergenceStart;
-      if (prompt.slice(contentStart, contentEnd) === doneCriteria) return prompt;
-      return prompt.slice(0, contentStart) + doneCriteria + prompt.slice(contentEnd);
-    }
-  }
-
-  return null;
+function refreshRedispatchDoneCriteria(prompt, doneCriteria, previousDoneCriteria) {
+  // The embedded criteria are author-controlled Markdown: marker-looking
+  // lines (</task-content>, "Done Criteria:", convergence headings) can
+  // legitimately appear INSIDE them, so the stale block is located by the
+  // exact bytes the generating round recorded, never by structural markers.
+  if (previousDoneCriteria === doneCriteria) return { status: "ok", prompt };
+  const start = prompt.indexOf(previousDoneCriteria);
+  if (start === -1) return { status: "not_found" };
+  if (prompt.indexOf(previousDoneCriteria, start + 1) !== -1) return { status: "ambiguous" };
+  return {
+    status: "ok",
+    prompt: prompt.slice(0, start) + doneCriteria + prompt.slice(start + previousDoneCriteria.length),
+  };
 }
 
 function readTaskPrompt({ runDir, resumeMode, effectiveDoneCriteriaPath } = {}) {
@@ -1358,12 +1343,24 @@ function readTaskPrompt({ runDir, resumeMode, effectiveDoneCriteriaPath } = {}) 
           process.exit(1);
         }
         const doneCriteria = fs.readFileSync(effectiveDoneCriteriaPath, "utf-8").trim();
-        const refreshedPrompt = refreshRedispatchDoneCriteria(prompt, doneCriteria);
-        if (refreshedPrompt === null) {
+        const roundDoneCriteriaPath = path.join(runDir, `review-round-${auto.round}-done-criteria.md`);
+        if (!fs.existsSync(roundDoneCriteriaPath)) {
           console.error(`Error: cannot refresh Done Criteria in auto-discovered redispatch prompt: ${auto.path}`);
+          console.error(`  Missing the round's recorded Done Criteria artifact: ${roundDoneCriteriaPath}`);
+          console.error("  Pass --prompt-file to supply the redispatch prompt explicitly.");
           process.exit(1);
         }
-        prompt = refreshedPrompt;
+        const previousDoneCriteria = fs.readFileSync(roundDoneCriteriaPath, "utf-8").trim();
+        const refreshed = refreshRedispatchDoneCriteria(prompt, doneCriteria, previousDoneCriteria);
+        if (refreshed.status !== "ok") {
+          console.error(`Error: cannot refresh Done Criteria in auto-discovered redispatch prompt: ${auto.path}`);
+          console.error(refreshed.status === "ambiguous"
+            ? `  The round's recorded Done Criteria (${roundDoneCriteriaPath}) appear more than once in the artifact.`
+            : `  The round's recorded Done Criteria (${roundDoneCriteriaPath}) do not appear in the artifact.`);
+          console.error("  Pass --prompt-file to supply the redispatch prompt explicitly.");
+          process.exit(1);
+        }
+        prompt = refreshed.prompt;
       }
       return {
         prompt,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1303,15 +1303,34 @@ function findLatestRedispatchPrompt(runDir) {
   return latest;
 }
 
+const REDISPATCH_CRITERIA_PREFIXES = [
+  /(?:^|\n)Original Done Criteria \(scope anchor\):\r?\n<task-content source="[^"]+">\r?\n$/,
+  /(?:^|\n)Done Criteria:\r?\n$/,
+];
+
+function isGeneratorAnchoredOccurrence(prompt, start) {
+  const before = prompt.slice(Math.max(0, start - 400), start);
+  return REDISPATCH_CRITERIA_PREFIXES.some((pattern) => pattern.test(before));
+}
+
 function refreshRedispatchDoneCriteria(prompt, doneCriteria, previousDoneCriteria) {
   // The embedded criteria are author-controlled Markdown: marker-looking
   // lines (</task-content>, "Done Criteria:", convergence headings) can
   // legitimately appear INSIDE them, so the stale block is located by the
   // exact bytes the generating round recorded, never by structural markers.
   if (previousDoneCriteria === doneCriteria) return { status: "ok", prompt };
-  const start = prompt.indexOf(previousDoneCriteria);
-  if (start === -1) return { status: "not_found" };
-  if (prompt.indexOf(previousDoneCriteria, start + 1) !== -1) return { status: "ambiguous" };
+  if (!previousDoneCriteria) return { status: "not_found" };
+  const anchoredOccurrences = [];
+  let searchFrom = 0;
+  while (searchFrom <= prompt.length - previousDoneCriteria.length) {
+    const start = prompt.indexOf(previousDoneCriteria, searchFrom);
+    if (start === -1) break;
+    if (isGeneratorAnchoredOccurrence(prompt, start)) anchoredOccurrences.push(start);
+    searchFrom = start + 1;
+  }
+  if (anchoredOccurrences.length === 0) return { status: "not_found" };
+  if (anchoredOccurrences.length > 1) return { status: "ambiguous" };
+  const [start] = anchoredOccurrences;
   return {
     status: "ok",
     prompt: prompt.slice(0, start) + doneCriteria + prompt.slice(start + previousDoneCriteria.length),
@@ -1355,7 +1374,7 @@ function readTaskPrompt({ runDir, resumeMode, effectiveDoneCriteriaPath } = {}) 
         if (refreshed.status !== "ok") {
           console.error(`Error: cannot refresh Done Criteria in auto-discovered redispatch prompt: ${auto.path}`);
           console.error(refreshed.status === "ambiguous"
-            ? `  The round's recorded Done Criteria (${roundDoneCriteriaPath}) appear more than once in the artifact.`
+            ? `  The round's recorded Done Criteria (${roundDoneCriteriaPath}) appear at more than one generated Done Criteria position.`
             : `  The round's recorded Done Criteria (${roundDoneCriteriaPath}) do not appear in the artifact.`);
           console.error("  Pass --prompt-file to supply the redispatch prompt explicitly.");
           process.exit(1);

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1306,11 +1306,26 @@ function findLatestRedispatchPrompt(runDir) {
 function refreshRedispatchDoneCriteria(prompt, doneCriteria) {
   const blockPattern = /((?:^|\n)Original Done Criteria \(scope anchor\):\r?\n<task-content source="[^"]+">\r?\n)([\s\S]*?)(\r?\n<\/task-content>)/;
   const match = blockPattern.exec(prompt);
-  if (!match) return prompt;
-  if (match[2] === doneCriteria) return prompt;
-  const refreshedBlock = match[1] + doneCriteria + match[3];
-  const blockEnd = match.index + match[0].length;
-  return prompt.slice(0, match.index) + refreshedBlock + prompt.slice(blockEnd);
+  if (match) {
+    if (match[2] === doneCriteria) return prompt;
+    const refreshedBlock = match[1] + doneCriteria + match[3];
+    const blockEnd = match.index + match[0].length;
+    return prompt.slice(0, match.index) + refreshedBlock + prompt.slice(blockEnd);
+  }
+
+  if (prompt.startsWith("Rubric recovery re-dispatch\n")) {
+    const criteriaHeader = "\nDone Criteria:\n";
+    const criteriaStart = prompt.lastIndexOf(criteriaHeader);
+    if (criteriaStart !== -1) {
+      const contentStart = criteriaStart + criteriaHeader.length;
+      const convergenceStart = prompt.indexOf("\n\n## Convergence context\n", contentStart);
+      const contentEnd = convergenceStart === -1 ? prompt.length : convergenceStart;
+      if (prompt.slice(contentStart, contentEnd) === doneCriteria) return prompt;
+      return prompt.slice(0, contentStart) + doneCriteria + prompt.slice(contentEnd);
+    }
+  }
+
+  return null;
 }
 
 function readTaskPrompt({ runDir, resumeMode, effectiveDoneCriteriaPath } = {}) {
@@ -1338,7 +1353,12 @@ function readTaskPrompt({ runDir, resumeMode, effectiveDoneCriteriaPath } = {}) 
           process.exit(1);
         }
         const doneCriteria = fs.readFileSync(effectiveDoneCriteriaPath, "utf-8").trim();
-        prompt = refreshRedispatchDoneCriteria(prompt, doneCriteria);
+        const refreshedPrompt = refreshRedispatchDoneCriteria(prompt, doneCriteria);
+        if (refreshedPrompt === null) {
+          console.error(`Error: cannot refresh Done Criteria in auto-discovered redispatch prompt: ${auto.path}`);
+          process.exit(1);
+        }
+        prompt = refreshedPrompt;
       }
       return {
         prompt,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1303,14 +1303,25 @@ function findLatestRedispatchPrompt(runDir) {
   return latest;
 }
 
-function readTaskPrompt({ runDir, resumeMode } = {}) {
+function refreshRedispatchDoneCriteria(prompt, doneCriteria) {
+  const blockPattern = /((?:^|\n)Original Done Criteria \(scope anchor\):\r?\n<task-content source="[^"]+">\r?\n)([\s\S]*?)(\r?\n<\/task-content>)/;
+  const match = blockPattern.exec(prompt);
+  if (!match) return prompt;
+  if (match[2] === doneCriteria) return prompt;
+  const refreshedBlock = match[1] + doneCriteria + match[3];
+  const blockEnd = match.index + match[0].length;
+  return prompt.slice(0, match.index) + refreshedBlock + prompt.slice(blockEnd);
+}
+
+function readTaskPrompt({ runDir, resumeMode, effectiveDoneCriteriaPath } = {}) {
   if (PROMPT_FILE) {
     const promptPath = path.resolve(PROMPT_FILE);
     if (!fs.existsSync(promptPath)) {
       console.error(`Error: prompt file not found: ${promptPath}`);
       process.exit(1);
     }
-    return { prompt: fs.readFileSync(promptPath, "utf-8").trim(), source: "explicit-file", path: promptPath };
+    const prompt = fs.readFileSync(promptPath, "utf-8");
+    return { prompt: resumeMode ? prompt : prompt.trim(), source: "explicit-file", path: promptPath };
   }
 
   if (PROMPT) {
@@ -1320,8 +1331,17 @@ function readTaskPrompt({ runDir, resumeMode } = {}) {
   if (resumeMode) {
     const auto = findLatestRedispatchPrompt(runDir);
     if (auto) {
+      let prompt = fs.readFileSync(auto.path, "utf-8");
+      if (effectiveDoneCriteriaPath) {
+        if (!fs.existsSync(effectiveDoneCriteriaPath)) {
+          console.error(`Error: effective Done Criteria file not found: ${effectiveDoneCriteriaPath}`);
+          process.exit(1);
+        }
+        const doneCriteria = fs.readFileSync(effectiveDoneCriteriaPath, "utf-8").trim();
+        prompt = refreshRedispatchDoneCriteria(prompt, doneCriteria);
+      }
       return {
-        prompt: fs.readFileSync(auto.path, "utf-8").trim(),
+        prompt,
         source: "auto-discovered-redispatch",
         path: auto.path,
         round: auto.round,
@@ -1845,7 +1865,12 @@ async function main() {
   enforceRubricPersistence(manifest, manifestRunDir);
   let routePlanSnapshot = null;
 
-  const taskPromptResult = readTaskPrompt({ runDir: manifestRunDir, resumeMode: RESUME_MODE });
+  const effectiveDoneCriteriaPath = resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null;
+  const taskPromptResult = readTaskPrompt({
+    runDir: manifestRunDir,
+    resumeMode: RESUME_MODE,
+    effectiveDoneCriteriaPath,
+  });
   let taskPrompt = taskPromptResult.prompt;
   if (!RESUME_MODE && REVIEW_ASSURANCE_RAW === undefined && REVIEW_ASSURANCE_SOURCE === null) {
     try {

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1319,7 +1319,12 @@ function refreshRedispatchDoneCriteria(prompt, doneCriteria) {
     if (criteriaStart !== -1) {
       const contentStart = criteriaStart + criteriaHeader.length;
       const convergenceStart = prompt.indexOf("\n\n## Convergence context\n", contentStart);
-      const contentEnd = convergenceStart === -1 ? prompt.length : convergenceStart;
+      const serializationNewlineLength = convergenceStart === -1
+        ? prompt.endsWith("\r\n") ? 2 : prompt.endsWith("\n") ? 1 : 0
+        : 0;
+      const contentEnd = convergenceStart === -1
+        ? prompt.length - serializationNewlineLength
+        : convergenceStart;
       if (prompt.slice(contentStart, contentEnd) === doneCriteria) return prompt;
       return prompt.slice(0, contentStart) + doneCriteria + prompt.slice(contentEnd);
     }

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -2525,17 +2525,37 @@ fs.writeFileSync(output, "ok\\n", "utf-8");
   return codexPath;
 }
 
-test("dispatch resume auto-discovers latest review-round-N-redispatch.md when no prompt is given (#387)", () => {
+const NON_INTERACTIVE_DISPATCH_PREFIX =
+  "[NON-INTERACTIVE DISPATCH] This is an automated, non-interactive execution. " +
+  "Do not present plans for approval or wait for user confirmation. " +
+  "Execute the task fully and autonomously.\n\n";
+
+function redispatchPromptWithDoneCriteria(doneCriteria) {
+  return [
+    "ROUND TWO BODY",
+    "",
+    "Original Done Criteria (scope anchor):",
+    '<task-content source="request_snapshot">',
+    doneCriteria,
+    "</task-content>",
+    "",
+  ].join("\n");
+}
+
+test("dispatch resume refreshes the auto-discovered redispatch prompt from an amended Done Criteria anchor (#883)", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-auto.json`);
   writeResumeCaptureCodex(binDir, capturePath);
   const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Original clause", "utf-8");
 
   const first = JSON.parse(runDispatch(repoRoot, [
     "-b", "issue-387-auto",
     "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
     "--json",
   ], env));
 
@@ -2548,7 +2568,10 @@ test("dispatch resume auto-discovers latest review-round-N-redispatch.md when no
 
   const runDir = getRunDir(repoRoot, first.runId);
   fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), "ROUND ONE BODY\n", "utf-8");
-  fs.writeFileSync(path.join(runDir, "review-round-2-redispatch.md"), "ROUND TWO BODY\n", "utf-8");
+  const redispatchPath = path.join(runDir, "review-round-2-redispatch.md");
+  const originalArtifact = redispatchPromptWithDoneCriteria("Original clause");
+  fs.writeFileSync(redispatchPath, originalArtifact, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, "Original clause\nAmended clause", "utf-8");
 
   const second = JSON.parse(runDispatch(repoRoot, [
     "--run-id", first.runId,
@@ -2560,19 +2583,58 @@ test("dispatch resume auto-discovers latest review-round-N-redispatch.md when no
   const finalPrompt = captured[captured.length - 1];
   assert.match(finalPrompt, /ROUND TWO BODY/);
   assert.doesNotMatch(finalPrompt, /ROUND ONE BODY/);
+  assert.match(finalPrompt, /Original clause\nAmended clause/);
+  assert.equal(fs.readFileSync(redispatchPath, "utf-8"), originalArtifact);
+  const resumedManifest = readManifest(first.manifestPath).data;
+  assert.equal(resumedManifest.anchor.done_criteria_path, doneCriteriaPath);
+  assert.equal(resumedManifest.anchor.done_criteria_source, "file");
 });
 
-test("dispatch resume --prompt-file wins over redispatch auto-discovery (#387)", () => {
+test("dispatch resume leaves an unchanged auto-discovered redispatch prompt byte-identical (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-noop.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Unchanged clause\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-noop",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const artifact = redispatchPromptWithDoneCriteria("Unchanged clause");
+  fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md"), artifact, "utf-8");
+  runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.equal(captured[captured.length - 1], NON_INTERACTIVE_DISPATCH_PREFIX + artifact);
+});
+
+test("dispatch resume --prompt-file is unmodified even when the Done Criteria anchor changed (#883)", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-explicit.json`);
   writeResumeCaptureCodex(binDir, capturePath);
   const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Original clause\n", "utf-8");
 
   const first = JSON.parse(runDispatch(repoRoot, [
     "-b", "issue-387-explicit",
     "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
     "--json",
   ], env));
 
@@ -2584,10 +2646,16 @@ test("dispatch resume --prompt-file wins over redispatch auto-discovery (#387)",
   );
 
   const runDir = getRunDir(repoRoot, first.runId);
-  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), "AUTO_DISCOVERED_BODY\n", "utf-8");
+  fs.writeFileSync(
+    path.join(runDir, "review-round-1-redispatch.md"),
+    redispatchPromptWithDoneCriteria("Original clause"),
+    "utf-8"
+  );
+  fs.writeFileSync(doneCriteriaPath, "Amended clause\n", "utf-8");
 
   const explicitPath = path.join(os.tmpdir(), `relay-dispatch-explicit-${Date.now()}.md`);
-  fs.writeFileSync(explicitPath, "EXPLICIT_BODY\n", "utf-8");
+  const explicitPrompt = "EXPLICIT_BODY\n";
+  fs.writeFileSync(explicitPath, explicitPrompt, "utf-8");
 
   runDispatch(repoRoot, [
     "--run-id", first.runId,
@@ -2597,8 +2665,46 @@ test("dispatch resume --prompt-file wins over redispatch auto-discovery (#387)",
 
   const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
   const finalPrompt = captured[captured.length - 1];
-  assert.match(finalPrompt, /EXPLICIT_BODY/);
+  assert.equal(finalPrompt, NON_INTERACTIVE_DISPATCH_PREFIX + explicitPrompt);
   assert.doesNotMatch(finalPrompt, /AUTO_DISCOVERED_BODY/);
+});
+
+test("dispatch resume fails clearly when the effective Done Criteria anchor is missing (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Original clause\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-missing-dc",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+  fs.writeFileSync(
+    path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md"),
+    redispatchPromptWithDoneCriteria("Original clause"),
+    "utf-8"
+  );
+  fs.unlinkSync(doneCriteriaPath);
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /effective Done Criteria file not found/);
+  assert.match(result.stderr, new RegExp(doneCriteriaPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("dispatch resume without redispatch artifact still errors with auto-discovery hint (#387)", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -31,6 +31,7 @@ const {
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const { appendRunEvent, EVENTS, readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 const { evaluateReviewGate } = require("../../../skills/relay-merge/scripts/review-gate");
+const { buildRubricGateRedispatchPrompt } = require("../../../skills/relay-review/scripts/review-runner/redispatch");
 const { createEnforcementFixture } = require("./test-support");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
@@ -2588,6 +2589,47 @@ test("dispatch resume refreshes the auto-discovered redispatch prompt from an am
   const resumedManifest = readManifest(first.manifestPath).data;
   assert.equal(resumedManifest.anchor.done_criteria_path, doneCriteriaPath);
   assert.equal(resumedManifest.anchor.done_criteria_source, "file");
+});
+
+test("dispatch resume refreshes an auto-discovered rubric-gate redispatch prompt without rewriting it (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-rubric-gate-auto.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Original rubric-gate clause", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-rubric-gate",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const artifact = buildRubricGateRedispatchPrompt({
+    status: "rubric_state_failed_closed",
+    rubricState: "missing",
+    rubricStatus: "missing",
+    reason: "rubric missing",
+    recoveryCommand: "repair rubric",
+  }, "Original rubric-gate clause", "file");
+  const redispatchPath = path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md");
+  fs.writeFileSync(redispatchPath, artifact, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, "Original rubric-gate clause\nAmended rubric-gate clause", "utf-8");
+
+  runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.match(captured[captured.length - 1], /Original rubric-gate clause\nAmended rubric-gate clause/);
+  assert.equal(fs.readFileSync(redispatchPath, "utf-8"), artifact);
 });
 
 test("dispatch resume leaves an unchanged auto-discovered redispatch prompt byte-identical (#883)", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -2572,6 +2572,7 @@ test("dispatch resume refreshes the auto-discovered redispatch prompt from an am
   const redispatchPath = path.join(runDir, "review-round-2-redispatch.md");
   const originalArtifact = redispatchPromptWithDoneCriteria("Original clause");
   fs.writeFileSync(redispatchPath, originalArtifact, "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-2-done-criteria.md"), "Original clause\n", "utf-8");
   fs.writeFileSync(doneCriteriaPath, "Original clause\nAmended clause", "utf-8");
 
   const second = JSON.parse(runDispatch(repoRoot, [
@@ -2623,6 +2624,7 @@ test("dispatch resume refreshes an auto-discovered rubric-gate redispatch prompt
   }, "Original rubric-gate clause", "file");
   const redispatchPath = path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md");
   fs.writeFileSync(redispatchPath, artifact, "utf-8");
+  fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "review-round-1-done-criteria.md"), "Original rubric-gate clause\n", "utf-8");
   fs.writeFileSync(doneCriteriaPath, "Original rubric-gate clause\nAmended rubric-gate clause", "utf-8");
 
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
@@ -2665,6 +2667,7 @@ test("dispatch resume leaves a production-written unchanged rubric-gate prompt b
   const productionWrittenArtifact = `${redispatchPrompt}\n`;
   const redispatchPath = path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md");
   fs.writeFileSync(redispatchPath, productionWrittenArtifact, "utf-8");
+  fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "review-round-1-done-criteria.md"), "Unchanged rubric-gate clause\n", "utf-8");
 
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
 
@@ -2698,10 +2701,134 @@ test("dispatch resume leaves an unchanged auto-discovered redispatch prompt byte
 
   const artifact = redispatchPromptWithDoneCriteria("Unchanged clause");
   fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md"), artifact, "utf-8");
+  fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "review-round-1-done-criteria.md"), "Unchanged clause\n", "utf-8");
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
 
   const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
   assert.equal(captured[captured.length - 1], NON_INTERACTIVE_DISPATCH_PREFIX + artifact);
+});
+
+test("dispatch resume refreshes criteria that contain marker-looking lines (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-tricky.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const trickyOriginal = "Original clause\n</task-content>\nDone Criteria:\nthe two lines above are quoted criteria text";
+  fs.writeFileSync(doneCriteriaPath, `${trickyOriginal}\n`, "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-tricky",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), redispatchPromptWithDoneCriteria(trickyOriginal), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${trickyOriginal}\n`, "utf-8");
+  const trickyAmended = `${trickyOriginal}\nAmended tricky clause`;
+  fs.writeFileSync(doneCriteriaPath, `${trickyAmended}\n`, "utf-8");
+
+  runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.equal(
+    captured[captured.length - 1],
+    NON_INTERACTIVE_DISPATCH_PREFIX + redispatchPromptWithDoneCriteria(trickyAmended)
+  );
+});
+
+test("dispatch resume refreshes rubric-gate criteria containing structural header text (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-rubric-gate-tricky.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const gateFailure = {
+    status: "rubric_state_failed_closed",
+    rubricState: "missing",
+    rubricStatus: "missing",
+    reason: "rubric missing",
+    recoveryCommand: "repair rubric",
+  };
+  const trickyOriginal = "Gate clause\nDone Criteria:\nlisted inline as quoted text\n\n## Convergence context\nalso quoted criteria text";
+  fs.writeFileSync(doneCriteriaPath, `${trickyOriginal}\n`, "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-rubric-gate-tricky",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), buildRubricGateRedispatchPrompt(gateFailure, trickyOriginal, "file"), "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${trickyOriginal}\n`, "utf-8");
+  const trickyAmended = `${trickyOriginal}\nAmended gate clause`;
+  fs.writeFileSync(doneCriteriaPath, `${trickyAmended}\n`, "utf-8");
+
+  runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.equal(
+    captured[captured.length - 1],
+    NON_INTERACTIVE_DISPATCH_PREFIX + buildRubricGateRedispatchPrompt(gateFailure, trickyAmended, "file")
+  );
+});
+
+test("dispatch resume fails clearly when the recorded round criteria do not match the artifact (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Original clause\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-tampered",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), redispatchPromptWithDoneCriteria("Hand-edited clause"), "utf-8");
+  const roundDoneCriteriaPath = path.join(runDir, "review-round-1-done-criteria.md");
+  fs.writeFileSync(roundDoneCriteriaPath, "Original clause\n", "utf-8");
+  fs.writeFileSync(doneCriteriaPath, "Amended clause\n", "utf-8");
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /do not appear in the artifact/);
+  assert.match(result.stderr, new RegExp(roundDoneCriteriaPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("dispatch resume --prompt-file is unmodified even when the Done Criteria anchor changed (#883)", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -2592,6 +2592,83 @@ test("dispatch resume refreshes the auto-discovered redispatch prompt from an am
   assert.equal(resumedManifest.anchor.done_criteria_source, "file");
 });
 
+test("dispatch resume refreshes only the generated criteria when an issue quotes the recorded criteria (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-redispatch-quoted.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const original = "Original quoted clause";
+  const amended = `${original}\nAmended quoted clause`;
+  fs.writeFileSync(doneCriteriaPath, `${original}\n`, "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-quoted-criteria",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const quote = `ROUND TWO BODY\n\nIssue quotes the original criteria:\n${original}`;
+  const artifact = redispatchPromptWithDoneCriteria(original).replace("ROUND TWO BODY", quote);
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), artifact, "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${original}\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${amended}\n`, "utf-8");
+
+  runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  const expected = redispatchPromptWithDoneCriteria(amended).replace("ROUND TWO BODY", quote);
+  assert.equal(captured[captured.length - 1], NON_INTERACTIVE_DISPATCH_PREFIX + expected);
+});
+
+test("dispatch resume rejects criteria found at two generated Done Criteria positions (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const original = "Duplicated generated clause";
+  fs.writeFileSync(doneCriteriaPath, `${original}\n`, "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-duplicate-generated-criteria",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const artifact = redispatchPromptWithDoneCriteria(original) + redispatchPromptWithDoneCriteria(original);
+  const runDir = getRunDir(repoRoot, first.runId);
+  fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), artifact, "utf-8");
+  fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${original}\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${original}\nAmended duplicate clause\n`, "utf-8");
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /appear at more than one generated Done Criteria position/);
+});
+
 test("dispatch resume refreshes an auto-discovered rubric-gate redispatch prompt without rewriting it (#883)", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -2632,6 +2632,47 @@ test("dispatch resume refreshes an auto-discovered rubric-gate redispatch prompt
   assert.equal(fs.readFileSync(redispatchPath, "utf-8"), artifact);
 });
 
+test("dispatch resume leaves a production-written unchanged rubric-gate prompt byte-identical (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-rubric-gate-noop.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaPath, "Unchanged rubric-gate clause\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-883-rubric-gate-noop",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaPath,
+    "--json",
+  ], env));
+  const record = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    record.body
+  );
+
+  const redispatchPrompt = buildRubricGateRedispatchPrompt({
+    status: "rubric_state_failed_closed",
+    rubricState: "missing",
+    rubricStatus: "missing",
+    reason: "rubric missing",
+    recoveryCommand: "repair rubric",
+  }, "Unchanged rubric-gate clause", "file");
+  const productionWrittenArtifact = `${redispatchPrompt}\n`;
+  const redispatchPath = path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md");
+  fs.writeFileSync(redispatchPath, productionWrittenArtifact, "utf-8");
+
+  runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
+
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.equal(captured[captured.length - 1], NON_INTERACTIVE_DISPATCH_PREFIX + productionWrittenArtifact);
+  assert.equal(fs.readFileSync(redispatchPath, "utf-8"), productionWrittenArtifact);
+});
+
 test("dispatch resume leaves an unchanged auto-discovered redispatch prompt byte-identical (#883)", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-883-20260710043034796-5bd6b542
- Branch: issue-883
- Reason: reconcile-run recovered work for issue-883-20260710043034796-5bd6b542
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-883-20260710043034796-5bd6b542.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-10T04:52:36.080Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 자동으로 찾은 리디스패치 프롬프트가 최신 Done Criteria를 정확히 반영하도록 개선했습니다.
  * 재개(Resume) 시 라운드 기록된 Done Criteria를 우선 적용해 프롬프트 일관성을 높였습니다.
  * `--prompt-file`로 지정한 프롬프트는 Done Criteria 변경 여부와 무관하게 그대로 우선 적용됩니다.
* **버그 수정**
  * 관련 기준 파일/기록이 없거나 갱신이 불가한 경우, 원인 파악이 쉬운 오류로 중단되도록 개선했습니다.
* **테스트**
  * 회귀 및 다양한 시나리오를 검증하는 테스트를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->