### PR TITLE
fix(review): block behind-base rounds (#884)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -17,6 +17,7 @@ const VALUE = "value";
 const FLAGS = [
   { flag: "--all", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--allow-stacked-base-hazard", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit reason for overriding a non-default stacked PR base hazard." },
+  { flag: "--allow-behind-base", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit review opt-in to proceed when the reviewed head trails its base." },
   { flag: "--allow-conflicting-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Operator override for the in-flight-run check; logs a conflicting_run_override event." },
   { flag: "--allow-same-head", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit same-HEAD recovery opt-in; no value is consumed." },
   { flag: "--advisory-profile", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed advisory review profile selector; flag-like following tokens should mean the value is missing." },
@@ -223,7 +224,7 @@ const COMMAND_FLAGS = {
     "--diff-file", "--review-file", "--reviewer", "--reviewer-script",
     "--reviewer-model", "--advisory-reviewer", "--advisory-profile",
     "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--prepare-only",
-    "--manual-review-reason", "--independent-review-reason", "--no-comment", "--json", "--help",
+    "--manual-review-reason", "--independent-review-reason", "--allow-behind-base", "--no-comment", "--json", "--help",
   ],
 };
 

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -21,7 +21,7 @@ const { buildConvergenceSummary, formatConvergenceMarkdown } = require("./review
 const { applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { enforceRoundCap } = require("./review-runner/round-cap");
 const { passNextActionsFor, writeRoundArtifacts } = require("./review-runner/round-artifacts");
-const { maybeBlockForExecutionEvidencePreflight } = require("./review-runner/preflight");
+const { maybeBlockForBehindBasePreflight, maybeBlockForExecutionEvidencePreflight } = require("./review-runner/preflight");
 const { buildPrimaryReviewerPreflight, loadReviewText, loadRunRoutePlan, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { appendAdvisoryRunsForTrigger, resolveAdvisoryConfig } = require("./review-runner/advisory-orchestration");
@@ -36,13 +36,12 @@ if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]
 async function run() {
   assertKnownReviewRunnerFlags(args);
   const {
-    advisoryGraceArg, advisoryProfileArg, advisoryReviewerArg, advisoryReviewerModel,
+    advisoryGraceArg, advisoryProfileArg, advisoryReviewerArg, advisoryReviewerModel, allowBehindBase,
     advisoryTimeoutArg, branchArg, diffFile, doneCriteriaFile, independentReviewReason,
     jsonOut, manifestPathArg, manualReviewReason, noComment, prArg, prepareOnly, repoArg,
     repoPath, reviewFile, reviewerArg, reviewerModel, reviewerScriptArg, runIdArg,
   } = options;
   if (manualReviewReason && !reviewFile) throw new Error("--manual-review-reason requires --review-file");
-
   const { branch, issueNumber, manifest, prNumber, reviewRepoPath, runRepoPath } = resolveContext(repoPath, repoArg, manifestPathArg, runIdArg, branchArg, prArg, doneCriteriaFile);
   const { body, manifestPath } = manifest;
   let { data } = manifest;
@@ -151,6 +150,7 @@ async function run() {
     printResult({ doneCriteriaPath, diffPath, jsonOut, manifestPath, originalState: data.state, prepareOnly, prNumber, promptPath, redispatchPath: null, result, updatedManifest: null, verdictPath: null });
     return;
   }
+  if (maybeBlockForBehindBasePreflight({ allowBehindBase, data, jsonOut, result, reviewRepoPath, reviewedHeadSha, round, runRepoPath })) return;
   if (maybeBlockForExecutionEvidencePreflight({ data, jsonOut, result, reviewFile, runRepoPath, reviewedHeadSha, round, runDir, strict: hardenedAssurance })) return;
   if (hardenedAssurance && !(advisoryConfig.lanes || []).length) {
     throw new Error(

--- a/skills/relay-review/scripts/review-runner/cli.js
+++ b/skills/relay-review/scripts/review-runner/cli.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const { bindCliArgs, findUnknownFlags } = require("../../../relay-dispatch/scripts/cli-args");
 
-const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--allow-behind-base", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
 
 function parseReviewRunnerCliArgs(args) {
   const cliArgs = bindCliArgs(args, {
@@ -13,6 +13,7 @@ function parseReviewRunnerCliArgs(args) {
     args,
     cliArgs,
     options: {
+      allowBehindBase: cliArgs.hasFlag("--allow-behind-base"),
       advisoryGraceArg: cliArgs.getArg("--advisory-grace"),
       advisoryProfileArg: cliArgs.getArg("--advisory-profile"),
       advisoryReviewerArg: cliArgs.getArg("--advisory-reviewer"),

--- a/skills/relay-review/scripts/review-runner/output.js
+++ b/skills/relay-review/scripts/review-runner/output.js
@@ -22,6 +22,7 @@ function printUsage() {
   console.log(`  --advisory-reviewer-model <name> ${modeLabel("--advisory-reviewer-model")} Advisory model override`);
   console.log(`  --advisory-timeout <seconds> ${modeLabel("--advisory-timeout")} Advisory timeout`);
   console.log(`  --advisory-grace <seconds>   ${modeLabel("--advisory-grace")} Standard-mode critical-path wait window`);
+  console.log(`  --allow-behind-base          ${modeLabel("--allow-behind-base")} Proceed despite a behind-base warning`);
   console.log(`  --prepare-only               ${modeLabel("--prepare-only")} Emit prompt bundle only; do not apply verdict`);
   console.log(`  --no-comment                 ${modeLabel("--no-comment")} Do not post a PR comment`);
   console.log(`  --json                       ${modeLabel("--json")} Output JSON`);

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -1,5 +1,75 @@
 const { buildExecutionEvidencePreflight } = require("./execution-evidence");
 const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
+const { git } = require("./common");
+
+function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha }) {
+  const baseBranch = data?.git?.base_branch || "main";
+  const candidates = [`origin/${baseBranch}`, baseBranch];
+  let base = null;
+  for (const candidate of candidates) {
+    try {
+      git(reviewRepoPath, "merge-base", reviewedHeadSha, candidate);
+      base = candidate;
+      break;
+    } catch {}
+  }
+  if (!base) {
+    return { status: "not_available", base: null, behindCount: 0 };
+  }
+
+  const behindCount = Number(git(reviewRepoPath, "rev-list", "--count", `${reviewedHeadSha}..${base}`).trim());
+  return {
+    status: behindCount > 0 ? "blocked" : "pass",
+    base,
+    behindCount,
+    reason: behindCount > 0
+      ? `branch is ${behindCount} ${behindCount === 1 ? "commit" : "commits"} behind ${base}; rebase and re-run`
+      : null,
+    nextAction: behindCount > 0 ? "rebase_and_rerun" : null,
+  };
+}
+
+function maybeBlockForBehindBasePreflight({
+  allowBehindBase,
+  data,
+  jsonOut,
+  result,
+  reviewRepoPath,
+  reviewedHeadSha,
+  round,
+  runRepoPath,
+}) {
+  result.behindBasePreflight = buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha });
+  const preflight = result.behindBasePreflight;
+  if (preflight.status !== "blocked") return false;
+
+  if (allowBehindBase) {
+    preflight.status = "overridden";
+    console.error(`Warning: ${preflight.reason}; proceeding because --allow-behind-base was provided.`);
+    return false;
+  }
+
+  result.nextState = data.state;
+  appendRunEvent(runRepoPath || data.paths?.repo_root || ".", data.run_id, {
+    event: EVENTS.REVIEW_PREFLIGHT_FAILED,
+    state_from: data.state,
+    state_to: data.state,
+    head_sha: reviewedHeadSha,
+    round,
+    reason: preflight.reason,
+    preflight_type: "behind_base",
+    failure_class: "behind_base",
+    reviewer_rounds_avoided: 1,
+  });
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Review preflight blocked round ${round}: ${preflight.reason}`);
+    console.log(`  Next action: ${preflight.nextAction}`);
+  }
+  process.exitCode = 2;
+  return true;
+}
 
 function maybeBlockForExecutionEvidencePreflight({
   data,
@@ -47,5 +117,7 @@ function maybeBlockForExecutionEvidencePreflight({
 }
 
 module.exports = {
+  buildBehindBasePreflight,
+  maybeBlockForBehindBasePreflight,
   maybeBlockForExecutionEvidencePreflight,
 };

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -131,6 +131,13 @@ function writeExecutionEvidence(runDir, headSha, overrides = {}) {
   return filePath;
 }
 
+function advanceBaseAfterFork(repoRoot) {
+  fs.writeFileSync(path.join(repoRoot, "base-advance.txt"), "base advanced\n", "utf-8");
+  execFileSync("git", ["add", "base-advance.txt"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "advance base"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["push", "origin", "main"], { cwd: repoRoot, stdio: "pipe" });
+}
+
 function createUnrelatedRelayOwnedWorktree(repoRoot, branch = "issue-42") {
   const attackerParent = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-foreign-"));
   const attackerRoot = path.join(attackerParent, path.basename(repoRoot));
@@ -758,6 +765,7 @@ test("review-runner facade stays within orchestrator caps and preserves CLI help
   assert.match(help.stdout, /Usage: review-runner\.js --repo <path>/);
   assert.match(help.stdout, /--prepare-only/);
   assert.match(help.stdout, /--reviewer-script <path>/);
+  assert.match(help.stdout, /--allow-behind-base/);
 });
 
 test("prepare-only with explicit Done Criteria file skips issue inference ambiguity", () => {
@@ -2332,6 +2340,8 @@ test("reviewer-script invocation can drive a round without --review-file", () =>
 
   const result = JSON.parse(stdout);
   assert.equal(result.state, STATES.READY_TO_MERGE);
+  assert.equal(result.behindBasePreflight.status, "pass");
+  assert.equal(result.behindBasePreflight.behindCount, 0);
   assert.equal(result.reviewerScript, reviewerScript);
   assert.ok(result.rawResponsePath);
   assert.ok(fs.existsSync(result.rawResponsePath));
@@ -2340,6 +2350,132 @@ test("reviewer-script invocation can drive a round without --review-file", () =>
   assert.equal(manifest.state, STATES.READY_TO_MERGE);
   assert.equal(manifest.review.latest_verdict, "lgtm");
   assert.ok(manifest.review.last_reviewed_sha);
+});
+
+test("review-runner behind-base preflight fails fast before reviewer invocation", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  advanceBaseAfterFork(repoRoot);
+  const markerPath = path.join(repoRoot, "behind-base-reviewer-invoked.txt");
+  const reviewerScript = writeMarkerReviewerScript(repoRoot, "behind-base-reviewer.js", markerPath);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  assert.equal(fs.existsSync(markerPath), false);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.behindBasePreflight.status, "blocked");
+  assert.equal(output.behindBasePreflight.behindCount, 1);
+  assert.equal(output.behindBasePreflight.base, "origin/main");
+  assert.match(output.behindBasePreflight.reason, /branch is 1 commit behind origin\/main; rebase and re-run/);
+  assert.equal(output.nextState, STATES.REVIEW_PENDING);
+  assert.equal(output.rawResponsePath, null);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.review.rounds, 0);
+  const preflightEvent = readRunEvents(repoRoot, runId)
+    .find((event) => event.event === "review_preflight_failed" && event.preflight_type === "behind_base");
+  assert.ok(preflightEvent);
+  assert.equal(preflightEvent.failure_class, "behind_base");
+  assert.match(preflightEvent.reason, /branch is 1 commit behind origin\/main; rebase and re-run/);
+  assert.equal(preflightEvent.state_from, STATES.REVIEW_PENDING);
+  assert.equal(preflightEvent.state_to, STATES.REVIEW_PENDING);
+  assert.equal(preflightEvent.reviewer_rounds_avoided, 1);
+});
+
+test("review-runner proceeds after the reviewed branch is rebased onto its base", () => {
+  const { repoRoot, worktreePath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  advanceBaseAfterFork(repoRoot);
+  execFileSync("git", ["rebase", "origin/main"], { cwd: worktreePath, stdio: "pipe" });
+  const rebasedHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: worktreePath, encoding: "utf-8" }).trim();
+  writeExecutionEvidence(ensureRunLayout(repoRoot, runId).runDir, rebasedHead);
+  const markerPath = path.join(repoRoot, "rebased-reviewer-invoked.txt");
+  const reviewerScript = writeMarkerReviewerScript(repoRoot, "rebased-reviewer.js", markerPath);
+
+  const output = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" }));
+
+  assert.equal(output.behindBasePreflight.status, "pass");
+  assert.equal(output.behindBasePreflight.behindCount, 0);
+  assert.equal(fs.existsSync(markerPath), true);
+  assert.equal(output.state, STATES.READY_TO_MERGE);
+});
+
+test("review-runner --allow-behind-base proceeds with a visible warning", () => {
+  const { repoRoot, runId, doneCriteriaPath, diffPath } = setupRepo();
+  advanceBaseAfterFork(repoRoot);
+  const markerPath = path.join(repoRoot, "override-reviewer-invoked.txt");
+  const reviewerScript = writeMarkerReviewerScript(repoRoot, "override-reviewer.js", markerPath);
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript,
+    "--allow-behind-base",
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /Warning: branch is 1 commit behind origin\/main; rebase and re-run/);
+  assert.match(result.stderr, /--allow-behind-base/);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.behindBasePreflight.status, "overridden");
+  assert.equal(output.behindBasePreflight.behindCount, 1);
+  assert.equal(fs.existsSync(markerPath), true);
+  assert.equal(output.state, STATES.READY_TO_MERGE);
+});
+
+test("review-runner permits a branch strictly ahead of its base", () => {
+  const { repoRoot, worktreePath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  execFileSync("git", ["remote", "remove", "origin"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["add", "marker.txt"], { cwd: worktreePath, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "branch work"], { cwd: worktreePath, stdio: "pipe" });
+  const aheadHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: worktreePath, encoding: "utf-8" }).trim();
+  writeExecutionEvidence(ensureRunLayout(repoRoot, runId).runDir, aheadHead);
+  const markerPath = path.join(repoRoot, "ahead-reviewer-invoked.txt");
+  const reviewerScript = writeMarkerReviewerScript(repoRoot, "ahead-reviewer.js", markerPath);
+
+  const output = JSON.parse(execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript,
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8" }));
+
+  assert.equal(output.behindBasePreflight.status, "pass");
+  assert.equal(output.behindBasePreflight.behindCount, 0);
+  assert.equal(output.behindBasePreflight.base, "main");
+  assert.equal(fs.existsSync(markerPath), true);
+  assert.equal(output.state, STATES.READY_TO_MERGE);
 });
 
 test("review-runner execution evidence preflight blocks primary reviewer invocation", async (t) => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #884.

- Adds behind-base preflight using `origin/<base>` with local branch fallback.
- Fails with exit code 2, preserves manifest state, journals `REVIEW_PREFLIGHT_FAILED`, and avoids reviewer invocation.
- Adds documented `--allow-behind-base` override with visible warning.
- Covers behind, rebased, up-to-date, ahead-only, override, and offline fallback cases.
- Final serialized tests: 555 passed.
- Commit: `b6cd83a fix(review): block behind-base rounds (#884)`

```

## Score Log

- Run: issue-884-20260710045400427-d5970dd7
- Executor: codex
- Branch: issue-884