### PR TITLE
feat(relay-fleet): list repo fleets with status

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -69,6 +69,12 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
   --status
 ```
 
+Omit `--fleet-id` to list every fleet for the current repository without modifying manifests:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" --repo . --status
+```
+
 Deprecated primary entry points, to be sunset within one release: `relay-fleet.js --resume` is accepted as an alias for re-running the default drive; `relay-fleet.js --review` and `merge-queue.js` remain internal re-entry/debug paths but should not be the operator loop.
 
 Dry-run validates the leaf file and invokes child `dispatch.js --dry-run` for each leaf without writing a fleet manifest:
@@ -92,7 +98,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 - Each child dispatch owns worktree creation, in-flight run checks, executor invocation, and child run manifest writes.
 - Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
 - Re-runs reconcile both directions: they re-adopt child run manifests whose `fleet_id` points back to this fleet, mark no-manifest interrupted children as `dispatch_failed_pre_manifest`, skip still-running child subprocesses, and continue recoverable work.
-- `--status` is read-only and uses the relay-dispatch fleet summary derivation rules.
+- `--status` is read-only and uses the relay-dispatch fleet summary derivation rules. Without `--fleet-id`, it lists repo-scoped fleets and their terminal/total child counts.
 
 ## SPOF
 

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -16,6 +16,7 @@ const {
   getFleetManifestPath,
   getFleetsDir,
   getManifestPath,
+  listFleetManifestPaths,
   listManifestPaths,
   requireValidFleetId,
 } = require("../../relay-dispatch/scripts/manifest/paths");
@@ -94,10 +95,11 @@ function usage() {
     "Usage: relay-fleet.js --repo <path> --fleet-id <id> [--leaves-file <path>] [options]",
     "       relay-fleet.js --repo <path> --fleet-id <id> --review [options]",
     "       relay-fleet.js --repo <path> --fleet-id <id> --status [--json]",
+    "       relay-fleet.js --repo <path> --status [--json]",
     "",
     "Options:",
     `  --repo <path>          ${modeLabel("--repo")} Repository root (default: current directory)`,
-    `  --fleet-id <id>       ${modeLabel("--fleet-id")} Fleet manifest id (required)`,
+    `  --fleet-id <id>       ${modeLabel("--fleet-id")} Fleet manifest id (required except repo-wide --status)`,
     `  --leaves-file <path>  ${MODE_VERBATIM_LABEL} JSON file with already-planned leaf contracts`,
     `  --resume             ${MODE_PARSED_LABEL} Deprecated alias for the default drive command`,
     `  --review             ${MODE_PARSED_LABEL} Deprecated review-only re-entry point`,
@@ -2123,6 +2125,57 @@ function formatStatusText(summary, operatorAttention) {
   return `${lines.join("\n")}\n`;
 }
 
+function fleetListingError(manifestPath, error) {
+  const message = String(error?.message || error).replace(/\s+/g, " ").trim();
+  return `${path.basename(manifestPath)}: ${message}`;
+}
+
+function fleetListingRow(repoRoot, manifestPath) {
+  const manifestFile = path.basename(manifestPath);
+  const fleetId = manifestFile.slice(0, -path.extname(manifestFile).length);
+  try {
+    const fleet = readFleetManifest(repoRoot, fleetId).data;
+    const summary = deriveFleetSummary(repoRoot, fleet);
+    return {
+      fleet_id: summary.fleet_id,
+      fleet_state: summary.fleet_state,
+      children_total: summary.total_children,
+      children_terminal: summary.children.filter(fleetChildIsTerminal).length,
+      updated_at: fleet.timestamps.updated_at || fleet.timestamps.created_at || null,
+    };
+  } catch (error) {
+    return {
+      fleet_id: fleetId,
+      fleet_state: "error",
+      children_total: null,
+      children_terminal: null,
+      updated_at: null,
+      error: fleetListingError(manifestPath, error),
+    };
+  }
+}
+
+function listFleetStatus(repoRoot) {
+  return listFleetManifestPaths(repoRoot)
+    .map((manifestPath) => fleetListingRow(repoRoot, manifestPath))
+    .sort((left, right) => left.fleet_id.localeCompare(right.fleet_id));
+}
+
+function formatFleetStatusListingText(rows) {
+  if (!rows.length) return "No fleets found for repository.\n";
+  const lines = [
+    `Fleets: ${rows.length}`,
+    "fleet_id | fleet_state | children_terminal/children_total | updated_at",
+  ];
+  for (const row of rows) {
+    const childCounts = row.children_total === null ? "-/-" : `${row.children_terminal}/${row.children_total}`;
+    const columns = [row.fleet_id, row.fleet_state, childCounts, row.updated_at || "-"];
+    if (row.error) columns.push(`error=${row.error}`);
+    lines.push(columns.join(" | "));
+  }
+  return `${lines.join("\n")}\n`;
+}
+
 function formatPreManifestRetryLine(summary, fleetId) {
   const failedLeaves = (summary?.children || [])
     .filter((child) => child.dispatch_status === DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST)
@@ -2299,12 +2352,14 @@ const FLEET_TERMINAL_RUN_STATES = new Set([
   RUN_STATES.ESCALATED,
 ]);
 
+function fleetChildIsTerminal(child) {
+  return child.dispatch_status === DISPATCH_STATUS.DISPATCHED
+    && FLEET_TERMINAL_RUN_STATES.has(child.run_state);
+}
+
 function fleetChildrenAreTerminal(summary) {
   return summary.total_children > 0
-    && summary.children.every((child) => {
-      return child.dispatch_status === DISPATCH_STATUS.DISPATCHED
-        && FLEET_TERMINAL_RUN_STATES.has(child.run_state);
-    });
+    && summary.children.every(fleetChildIsTerminal);
 }
 
 function closeFleetIfTerminal(repoRoot, fleetId) {
@@ -2508,6 +2563,9 @@ function buildDriveResult({
 
 async function runFleet(options) {
   const repoRoot = getCanonicalRepoRoot(options.repo || ".");
+  if (options.status && !options.fleetId) {
+    return listFleetStatus(repoRoot);
+  }
   const fleetId = requireValidFleetId(options.fleetId);
   const manifestPath = getFleetManifestPath(repoRoot, fleetId);
 
@@ -2663,7 +2721,7 @@ async function main(argv = process.argv.slice(2)) {
       console.log(usage());
       return 0;
     }
-    if (!options.fleetId) {
+    if (!options.fleetId && !options.status) {
       throw new FleetInputError("--fleet-id is required");
     }
     if (options.status && (options.resume || options.leavesFile || options.dryRun)) {
@@ -2677,7 +2735,9 @@ async function main(argv = process.argv.slice(2)) {
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
     } else if (options.status) {
-      process.stdout.write(formatStatusText(result.summary, result.operator_attention));
+      process.stdout.write(Array.isArray(result)
+        ? formatFleetStatusListingText(result)
+        : formatStatusText(result.summary, result.operator_attention));
     } else {
       const summary = result.summary
         ? `fleet=${result.fleet_id} children=${result.summary.total_children}`
@@ -2686,7 +2746,7 @@ async function main(argv = process.argv.slice(2)) {
       const retryLine = result.summary ? formatPreManifestRetryLine(result.summary, result.fleet_id) : null;
       if (!result.ok && retryLine) console.log(retryLine);
     }
-    return result.ok ? 0 : 1;
+    return Array.isArray(result) ? 0 : (result.ok ? 0 : 1);
   } catch (error) {
     const message = error && error.message ? error.message : String(error);
     if (options?.json) {
@@ -2711,11 +2771,13 @@ module.exports = {
   buildPublishArgs,
   buildRedispatchArgs,
   buildReviewArgs,
+  formatFleetStatusListingText,
   formatStatusText,
   getFleetLeafReplacementPath,
   getFleetLeavesStorePath,
   getFleetRuntimePath,
   loadLeavesFile,
+  listFleetStatus,
   main,
   parseArgs,
   reconcileFleet,

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -146,6 +146,17 @@ function advanceFleetManifestState(repoRoot, fleetId, targetState) {
   return readFleetManifest(repoRoot, fleetId).data;
 }
 
+function writeFleetUpdatedAt(repoRoot, fleetId, updatedAt) {
+  const record = readFleetManifest(repoRoot, fleetId);
+  writeManifest(record.manifestPath, {
+    ...record.data,
+    timestamps: {
+      ...record.data.timestamps,
+      updated_at: updatedAt,
+    },
+  }, record.body);
+}
+
 function writeChildRun(repoRoot, {
   runId,
   branch,
@@ -3279,6 +3290,227 @@ test("relay-fleet --resume skips a still-running review subprocess", async () =>
   fs.writeFileSync(releasePath, "go\n", "utf-8");
   await new Promise((resolve) => first.on("close", resolve));
   assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
+});
+
+test("relay-fleet --status without --fleet-id lists every repo fleet in deterministic text rows", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-list-text-");
+  const otherRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-fleet-list-other-"));
+  initGitRepo(otherRepoRoot);
+  createFleetManifest(otherRepoRoot, { fleetId: "fleet-other-repo" });
+
+  const escalatedRun = "issue-871-20260710010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId: escalatedRun,
+    branch: "issue-871-fleet-listing",
+    issueNumber: 871,
+    leafId: "leaf-terminal",
+    fleetId: "fleet-zeta",
+    state: RUN_STATES.ESCALATED,
+  });
+  createFleetManifest(repoRoot, { fleetId: "fleet-alpha" });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-zeta",
+    children: [
+      { leaf_ref: "leaf-terminal", run_id: escalatedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-pending", run_id: null, dispatch_status: DISPATCH_STATUS.PENDING },
+    ],
+  });
+  advanceFleetManifestState(repoRoot, "fleet-zeta", FLEET_STATES.REVIEWING);
+  writeFleetUpdatedAt(repoRoot, "fleet-alpha", "2026-07-09T01:00:00.000Z");
+  writeFleetUpdatedAt(repoRoot, "fleet-zeta", "2026-07-10T02:00:00.000Z");
+
+  const alphaPath = getFleetManifestPath(repoRoot, "fleet-alpha");
+  const zetaPath = getFleetManifestPath(repoRoot, "fleet-zeta");
+  const before = new Map([
+    [alphaPath, fs.readFileSync(alphaPath, "utf-8")],
+    [zetaPath, fs.readFileSync(zetaPath, "utf-8")],
+  ]);
+  const result = runFleet(["--repo", repoRoot, "--status"], { relayHome });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, "");
+  assert.equal(result.stdout, [
+    "Fleets: 2",
+    "fleet_id | fleet_state | children_terminal/children_total | updated_at",
+    "fleet-alpha | draft | 0/0 | 2026-07-09T01:00:00.000Z",
+    "fleet-zeta | reviewing | 1/2 | 2026-07-10T02:00:00.000Z",
+    "",
+  ].join("\n"));
+  assert.doesNotMatch(result.stdout, /fleet-other-repo/);
+  for (const [manifestPath, content] of before) {
+    assert.equal(fs.readFileSync(manifestPath, "utf-8"), content);
+  }
+});
+
+test("relay-fleet --status --json without --fleet-id emits the stable listing fields", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-list-json-");
+  const closedRun = "issue-872-20260710010101000-a1b2c3d4";
+  writeChildRun(repoRoot, {
+    runId: closedRun,
+    branch: "issue-872-fleet-hygiene",
+    issueNumber: 872,
+    leafId: "leaf-closed",
+    fleetId: "fleet-alpha",
+    state: RUN_STATES.CLOSED,
+  });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-beta",
+    children: [{ leaf_ref: "leaf-pending", run_id: null, dispatch_status: DISPATCH_STATUS.PENDING }],
+  });
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-alpha",
+    children: [{ leaf_ref: "leaf-closed", run_id: closedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
+  });
+  writeFleetUpdatedAt(repoRoot, "fleet-alpha", "2026-07-10T03:00:00.000Z");
+  writeFleetUpdatedAt(repoRoot, "fleet-beta", "2026-07-10T04:00:00.000Z");
+
+  const result = runFleet(["--repo", repoRoot, "--status", "--json"], { relayHome });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    {
+      fleet_id: "fleet-alpha",
+      fleet_state: "draft",
+      children_total: 1,
+      children_terminal: 1,
+      updated_at: "2026-07-10T03:00:00.000Z",
+    },
+    {
+      fleet_id: "fleet-beta",
+      fleet_state: "draft",
+      children_total: 1,
+      children_terminal: 0,
+      updated_at: "2026-07-10T04:00:00.000Z",
+    },
+  ]);
+});
+
+test("relay-fleet --status --fleet-id byte-preserves single-fleet text and JSON detail", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-detail-bytes-");
+  const created = createFleetManifest(repoRoot, {
+    fleetId: "fleet-detail",
+    children: [{ leaf_ref: "leaf-pending", run_id: null, dispatch_status: DISPATCH_STATUS.PENDING }],
+  });
+  const summary = {
+    fleet_id: "fleet-detail",
+    fleet_state: "draft",
+    total_children: 1,
+    by_dispatch_status: { pending: 1 },
+    by_run_state: { no_run_manifest: 1 },
+    children: [{
+      leaf_ref: "leaf-pending",
+      run_id: null,
+      dispatch_status: "pending",
+      run_state: "no_run_manifest",
+      manifest_path: null,
+      pr_number: null,
+      base_branch: null,
+      review_round: null,
+      error: null,
+    }],
+  };
+
+  const textResult = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-detail",
+    "--status",
+  ], { relayHome });
+  assert.equal(textResult.status, 0, textResult.stderr);
+  assert.equal(textResult.stdout, [
+    "Fleet: fleet-detail",
+    "State: draft",
+    "Children: 1",
+    'Dispatch status: {"pending":1}',
+    'Run state: {"no_run_manifest":1}',
+    "Child states:",
+    "  - leaf-pending | run_id=null | dispatch_status=pending | run_state=no_run_manifest",
+    "",
+  ].join("\n"));
+
+  const jsonResult = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-detail",
+    "--status",
+    "--json",
+  ], { relayHome });
+  assert.equal(jsonResult.status, 0, jsonResult.stderr);
+  assert.equal(jsonResult.stdout, `${JSON.stringify({
+    ok: true,
+    fleet_id: "fleet-detail",
+    fleetManifestPath: created.manifestPath,
+    summary,
+    operator_attention: [],
+  }, null, 2)}\n`);
+});
+
+test("relay-fleet --status without --fleet-id returns clean empty text and JSON listings", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-list-empty-");
+  const fleetsDir = getFleetsDir(repoRoot);
+  assert.equal(fs.existsSync(fleetsDir), false);
+
+  const textResult = runFleet(["--repo", repoRoot, "--status"], { relayHome });
+  assert.equal(textResult.status, 0, textResult.stderr);
+  assert.equal(textResult.stdout, "No fleets found for repository.\n");
+  assert.equal(fs.existsSync(fleetsDir), false);
+
+  const jsonResult = runFleet(["--repo", repoRoot, "--status", "--json"], { relayHome });
+  assert.equal(jsonResult.status, 0, jsonResult.stderr);
+  assert.equal(jsonResult.stdout, "[]\n");
+  assert.equal(fs.existsSync(fleetsDir), false);
+});
+
+test("relay-fleet non-status modes without --fleet-id preserve the missing-argument error", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-list-required-");
+  for (const modeArgs of [[], ["--resume"], ["--review"], ["--dry-run"]]) {
+    const result = runFleet(["--repo", repoRoot, ...modeArgs], { relayHome });
+    assert.equal(result.status, 1, `mode ${modeArgs.join(" ")} unexpectedly succeeded`);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "Error: --fleet-id is required\n");
+  }
+});
+
+test("relay-fleet repo listing marks a corrupt manifest row and continues", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-list-corrupt-");
+  createFleetManifest(repoRoot, { fleetId: "fleet-alpha" });
+  writeFleetUpdatedAt(repoRoot, "fleet-alpha", "2026-07-10T05:00:00.000Z");
+  const corruptPath = getFleetManifestPath(repoRoot, "fleet-corrupt");
+  fs.writeFileSync(corruptPath, "---\nfleet_id: 'fleet-corrupt'\n", "utf-8");
+  const before = fs.readFileSync(corruptPath, "utf-8");
+
+  const jsonResult = runFleet(["--repo", repoRoot, "--status", "--json"], { relayHome });
+  assert.equal(jsonResult.status, 0, jsonResult.stderr);
+  assert.deepEqual(JSON.parse(jsonResult.stdout), [
+    {
+      fleet_id: "fleet-alpha",
+      fleet_state: "draft",
+      children_total: 0,
+      children_terminal: 0,
+      updated_at: "2026-07-10T05:00:00.000Z",
+    },
+    {
+      fleet_id: "fleet-corrupt",
+      fleet_state: "error",
+      children_total: null,
+      children_terminal: null,
+      updated_at: null,
+      error: "fleet-corrupt.md: Invalid manifest: missing closing frontmatter marker",
+    },
+  ]);
+
+  const textResult = runFleet(["--repo", repoRoot, "--status"], { relayHome });
+  assert.equal(textResult.status, 0, textResult.stderr);
+  assert.match(
+    textResult.stdout,
+    /fleet-corrupt \| error \| -\/- \| - \| error=fleet-corrupt\.md: Invalid manifest: missing closing frontmatter marker/,
+  );
+  assert.equal(fs.readFileSync(corruptPath, "utf-8"), before);
+});
+
+test("relay-fleet help documents repo-wide status and conditional --fleet-id", () => {
+  const result = runFleet(["--help"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /relay-fleet\.js --repo <path> --status \[--json\]/);
+  assert.match(result.stdout, /Fleet manifest id \(required except repo-wide --status\)/);
 });
 
 test("relay-fleet --status prints derived summary without writing the fleet manifest", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `8ef43a9 feat(relay-fleet): list repo fleets with status`.

Completion audit:

- Six-row listing matrix: [relay-fleet.test.js](/Users/sjlee/.relay/worktrees/dedbf486/dev-relay/tests/relay-fleet/scripts/relay-fleet.test.js:3295), covering text/JSON listing, byte-preserved detail, empty repos, missing IDs, and corrupt manifests.
- Read-only deterministic listing: [relay-fleet.js](/Users/sjlee/.relay/worktrees/dedbf486/dev-relay/skills/relay-fleet/scripts/relay-fleet.js
```

## Score Log

- Run: issue-871-20260710052022711-0b95ccb5
- Executor: codex
- Branch: issue-871-fleet-listing