### PR TITLE
fix(cleanup): process terminal missing worktrees (#885)

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -12,6 +12,7 @@
  *   --json                 Output as JSON
  *   --inspect              Health inventory only (no cleanup or shell sweep)
  *   --reconcile-merged     Reconcile merged drift for eligible non-terminal runs
+ *   --force-terminal      Remove unverifiable terminal worktrees contained under the relay base
  *   --stale-days <days>    Stale classification threshold (default: 14)
  */
 
@@ -128,6 +129,7 @@ if (hasCliFlag(["--help", "-h"])) {
   console.log(`  --reconcile-merged     ${modeLabel("--reconcile-merged")} Reconcile merged drift for eligible non-terminal runs`);
   console.log(`  --stale-days <days>    ${modeLabel("--stale-days")} Stale classification threshold (default: ${DEFAULT_STALE_DAYS})`);
   console.log(`  --force                ${modeLabel("--force")} Override a live or unverifiable run lease when removing a worktree`);
+  console.log(`  --force-terminal       ${modeLabel("--force-terminal")} Remove an unverifiable terminal worktree contained under the relay base`);
   process.exit(0);
 }
 
@@ -144,6 +146,7 @@ function run() {
   const inspectOnly = hasCliFlag("--inspect");
   const reconcileMerged = hasCliFlag("--reconcile-merged");
   const force = hasCliFlag("--force");
+  const forceTerminal = hasCliFlag("--force-terminal");
   const staleDays = parsePositiveNumber(readArg(args, "--stale-days", String(DEFAULT_STALE_DAYS), CLI_ARG_OPTIONS), "--stale-days");
   const olderThanHours = all ? 0 : parseHours(readArg(args, "--older-than", "24", CLI_ARG_OPTIONS), "--older-than");
   const now = Date.now();
@@ -155,6 +158,7 @@ function run() {
     staleDays,
     dryRun,
     force,
+    forceTerminal,
     all,
     inspectOnly,
     reconcileMerged,
@@ -189,15 +193,21 @@ function run() {
       closeCommand: `node skills/relay-dispatch/scripts/close-run.js --repo ${JSON.stringify(repoRoot)} --run-id ${JSON.stringify(runId)} --reason ${JSON.stringify("stale_non_terminal_run")}`,
     };
 
+    const terminalState = isTerminalState(data.state);
     let normalizedData = data;
+    let forcedTerminalUnverifiable = false;
     try {
       const validatedPaths = validateManifestPaths(data.paths, {
         expectedRepoRoot: repoRoot,
         manifestPath,
         runId: data.run_id,
         acceptPrunedRelayOwned: true,
+        allowMissingWorktree: terminalState,
+        acceptMissingRelayContainedForCleanup: terminalState,
+        acceptUnverifiableRelayContainedForCleanup: terminalState && forceTerminal,
         caller: "cleanup-worktrees",
       });
+      forcedTerminalUnverifiable = Boolean(validatedPaths.unverifiableRelayContainedForCleanup);
       normalizedData = {
         ...data,
         paths: {
@@ -207,15 +217,39 @@ function run() {
         },
       };
     } catch (error) {
+      let terminalForceEligible = false;
+      if (terminalState) {
+        try {
+          const forceValidatedPaths = validateManifestPaths(data.paths, {
+            expectedRepoRoot: repoRoot,
+            manifestPath,
+            runId: data.run_id,
+            acceptPrunedRelayOwned: true,
+            allowMissingWorktree: true,
+            acceptMissingRelayContainedForCleanup: true,
+            acceptUnverifiableRelayContainedForCleanup: true,
+            caller: "cleanup-worktrees",
+          });
+          terminalForceEligible = Boolean(forceValidatedPaths.unverifiableRelayContainedForCleanup);
+        } catch {
+          terminalForceEligible = false;
+        }
+      }
       const sanitizedError = /run_id must be a single path segment/.test(String(error.message || ""))
         ? `cleanup-worktrees: manifest ${JSON.stringify(path.basename(manifestPath))} has an invalid stored run_id; inspect the manifest before retrying.`
         : error.message;
       result.failed.push({
         ...baseInfo,
-        nextAction: "inspect_manifest_paths",
+        nextAction: terminalForceEligible ? "retry_with_force_terminal" : "inspect_manifest_paths",
         worktreeRemoved: false,
         branchDeleted: false,
         pruneRan: false,
+        reason: terminalForceEligible
+          ? "terminal_unverifiable_requires_force"
+          : (terminalState ? "refused_terminal_manifest_paths" : "refused_non_terminal_manifest_paths"),
+        classification: terminalForceEligible
+          ? "cleanable_terminal_unverifiable_path"
+          : "refused_manifest_paths",
         error: sanitizedError,
       });
       continue;
@@ -380,6 +414,9 @@ function run() {
       dryRun,
       deleteMergedBranch: normalizedData.state === "merged",
       acceptPrunedRelayOwned: true,
+      allowMissingWorktree: true,
+      acceptMissingRelayContainedForCleanup: true,
+      acceptUnverifiableRelayContainedForCleanup: forcedTerminalUnverifiable,
     });
 
     const item = {
@@ -391,6 +428,12 @@ function run() {
       branchDeleted: cleanupResult.summary.branchDeleted,
       pruneRan: cleanupResult.summary.pruneRan,
       error: cleanupResult.summary.error,
+      ...(forcedTerminalUnverifiable
+        ? {
+          reason: "forced_terminal_unverifiable_path",
+          classification: "cleanable_terminal_unverifiable_path",
+        }
+        : {}),
     };
 
     if (!dryRun) {

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -47,6 +47,7 @@ const FLAGS = [
   { flag: "--fleet-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay fleet identifier; flag-like following tokens should mean the value is missing." },
   { flag: "--force", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--force-finalize-nonready", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--force-terminal", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit terminal-run opt-in for removing unverifiable worktrees contained under the relay base." },
   { flag: "--head-sha", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Structured SHA field; flag-like following tokens should mean the value is missing." },
   { flag: "--help", aliases: ["-h"], kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--independent-review-reason", kind: VALUE, mode: MODE_VERBATIM, valueName: "<reason>", rationale: "Audit reason for a same-adapter independent review attempt; preserve the operator-supplied text." },
@@ -133,7 +134,7 @@ const FLAGS = [
 const COMMAND_FLAGS = {
   "cleanup-worktrees": [
     "--repo", "--older-than", "--all", "--dry-run", "--json",
-    "--inspect", "--reconcile-merged", "--stale-days", "--force", "--help",
+    "--inspect", "--reconcile-merged", "--stale-days", "--force", "--force-terminal", "--help",
   ],
   "close-run": [
     "--repo", "--run-id", "--reason", "--force", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -185,6 +185,17 @@ function runCleanup({
     }
   }
 
+  if (errors.length === 0 && !worktreeStatus.exists) {
+    if (!dryRun) {
+      try {
+        execGit(repoRoot, ["worktree", "prune"]);
+        pruneRan = true;
+      } catch (error) {
+        errors.push(`worktree prune failed: ${summarizeFailure(error)}`);
+      }
+    }
+  }
+
   if (errors.length === 0 && deleteMergedBranch && branch && branchExistsBefore) {
     if (!dryRun) {
       try {
@@ -196,7 +207,7 @@ function runCleanup({
     }
   }
 
-  if (errors.length === 0) {
+  if (errors.length === 0 && !pruneRan) {
     if (!dryRun) {
       try {
         execGit(repoRoot, ["worktree", "prune"]);

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -110,11 +110,17 @@ function runCleanup({
   dryRun = false,
   deleteMergedBranch = false,
   acceptPrunedRelayOwned = false,
+  allowMissingWorktree = false,
+  acceptMissingRelayContainedForCleanup = false,
+  acceptUnverifiableRelayContainedForCleanup = false,
 }) {
   const validatedPaths = validateManifestPaths(data?.paths, {
     expectedRepoRoot: repoRoot,
     runId: data?.run_id,
     acceptPrunedRelayOwned,
+    allowMissingWorktree,
+    acceptMissingRelayContainedForCleanup,
+    acceptUnverifiableRelayContainedForCleanup,
     caller: "runCleanup",
   });
   const normalizedData = {
@@ -129,8 +135,11 @@ function runCleanup({
   const worktreePath = normalizedData.paths?.worktree || null;
   const branch = normalizedData.git?.working_branch || null;
   const worktreeStatus = readWorktreeStatus(worktreePath);
-  const allowPrunedRelayWorktreeRemoval = acceptPrunedRelayOwned
-    && validatedPaths.prunedRelayOwnedForCleanup
+  const allowRelayBaseFallbackRemoval = acceptPrunedRelayOwned
+    && (
+      validatedPaths.prunedRelayOwnedForCleanup
+      || validatedPaths.unverifiableRelayContainedForCleanup
+    )
     && validatedPaths.worktreeLocation === "relay_worktree";
   const allowRelayOwnedStrayRemoval = worktreeStatus.exists
     && !worktreeStatus.clean
@@ -145,7 +154,7 @@ function runCleanup({
   if (
     worktreeStatus.exists
     && !worktreeStatus.clean
-    && !allowPrunedRelayWorktreeRemoval
+    && !allowRelayBaseFallbackRemoval
     && !allowRelayOwnedStrayRemoval
   ) {
     errors.push(`dirty worktree: ${worktreeStatus.text}`);
@@ -157,7 +166,7 @@ function runCleanup({
         execGit(repoRoot, ["worktree", "remove", "--force", worktreePath]);
         worktreeRemoved = true;
       } catch (error) {
-        if (allowPrunedRelayWorktreeRemoval) {
+        if (allowRelayBaseFallbackRemoval) {
           try {
             worktreeRemoved = removePrunedRelayWorktreeDirectory(worktreePath, validatedPaths.relayWorktreeBase);
             if (!worktreeRemoved) {
@@ -231,7 +240,7 @@ function runCleanup({
       worktreeRemoved,
       worktreeDirty: worktreeStatus.exists
         && !worktreeStatus.clean
-        && !allowPrunedRelayWorktreeRemoval
+        && !allowRelayBaseFallbackRemoval
         && !allowRelayOwnedStrayRemoval,
       worktreeStatus: worktreeStatus.text || null,
       branch,

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -432,6 +432,8 @@ function validateManifestPaths(paths, {
   requireWorktree = false,
   allowMissingWorktree = false,
   acceptPrunedRelayOwned = false,
+  acceptMissingRelayContainedForCleanup = false,
+  acceptUnverifiableRelayContainedForCleanup = false,
   caller = "relay manifest consumer",
 } = {}) {
   if (!paths || typeof paths !== "object" || Array.isArray(paths)) {
@@ -511,10 +513,18 @@ function validateManifestPaths(paths, {
   ];
   const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
     && relayOwnedRepoRootBasenames.includes(path.basename(worktree));
+  const relayContainedWorktreeCandidateForCleanup = isPathContainedWithin(relayWorktreeBase, worktree);
   const expectedGitCommonDir = getWorktreeGitCommonDir(effectiveRepoRoot) || path.join(effectiveRepoRoot, ".git");
   const worktreeExists = fs.existsSync(worktree);
   if (!worktreeExists) {
-    if (!allowMissingWorktree || (!repoContainedWorktree && !relayOwnedWorktreeCandidate)) {
+    if (
+      !allowMissingWorktree
+      || (
+        !repoContainedWorktree
+        && !relayOwnedWorktreeCandidate
+        && !(acceptMissingRelayContainedForCleanup && relayContainedWorktreeCandidateForCleanup)
+      )
+    ) {
       throw new Error(
         `${caller}: manifest paths.worktree ${JSON.stringify(worktree)} is not contained under the expected repo root ` +
         `${JSON.stringify(effectiveRepoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +
@@ -530,6 +540,7 @@ function validateManifestPaths(paths, {
       worktreeExists: false,
       worktreeMissing: true,
       prunedRelayOwnedForCleanup: false,
+      unverifiableRelayContainedForCleanup: false,
       relayWorktreeBase,
     };
   }
@@ -555,8 +566,19 @@ function validateManifestPaths(paths, {
       worktree,
       repoRootBasenames: relayOwnedRepoRootBasenames,
     });
+  const unverifiableRelayContainedForCleanup = acceptUnverifiableRelayContainedForCleanup
+    && !relayOwnedWorktree
+    && !prunedRelayOwnedWorktreeForCleanup
+    && (!worktreeGitCommonDir || !fs.existsSync(worktreeGitCommonDir))
+    && relayContainedWorktreeCandidateForCleanup
+    && isRealpathContainedWithin(relayWorktreeBase, worktree);
 
-  if (!repoContainedWorktree && !relayOwnedWorktree && !prunedRelayOwnedWorktreeForCleanup) {
+  if (
+    !repoContainedWorktree
+    && !relayOwnedWorktree
+    && !prunedRelayOwnedWorktreeForCleanup
+    && !unverifiableRelayContainedForCleanup
+  ) {
     throw new Error(
       `${caller}: manifest paths.worktree ${JSON.stringify(worktree)} is not contained under the expected repo root ` +
       `${JSON.stringify(effectiveRepoRoot)} and is not a relay-owned worktree under ${JSON.stringify(relayWorktreeBase)} ` +
@@ -571,6 +593,7 @@ function validateManifestPaths(paths, {
     worktreeExists: true,
     worktreeMissing: false,
     prunedRelayOwnedForCleanup: prunedRelayOwnedWorktreeForCleanup,
+    unverifiableRelayContainedForCleanup,
     relayWorktreeBase,
   };
 }

--- a/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -61,6 +61,12 @@ function writeStaleMissingRelayRun(repoRoot, { branch, updatedAt }) {
   });
   const worktreePath = path.join(getRelayWorktreeBase(), `stale-${branch}`, path.basename(repoRoot));
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.rmSync(worktreePath, { recursive: true, force: true });
 
   const layout = ensureRunLayout(repoRoot, runId);
   let manifest = createManifestSkeleton({
@@ -83,7 +89,12 @@ function writeStaleMissingRelayRun(repoRoot, { branch, updatedAt }) {
   manifest.timestamps.created_at = updatedAt;
   manifest.timestamps.updated_at = updatedAt;
   writeManifest(layout.manifestPath, manifest);
-  assert.equal(fs.existsSync(worktreePath), false, "fixture must model a pruned missing worktree");
+  assert.equal(fs.existsSync(worktreePath), false, "fixture must model a manually deleted worktree");
+  assert.match(
+    execFileSync("git", ["worktree", "list", "--porcelain"], { cwd: repoRoot, encoding: "utf-8" }),
+    new RegExp(`branch refs/heads/${branch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+    "fixture must retain the stale git worktree registration"
+  );
   return { manifestPath: layout.manifestPath, runId, worktreePath };
 }
 
@@ -702,6 +713,7 @@ test("cleanup-worktrees processes terminal manifests whose worktrees are already
         stdio: "pipe",
       });
     }
+    assert.equal(branchExists(repoRoot, `issue-295-${invocationContext}`), true);
 
     const stdout = execFileSync("node", [
       SCRIPT,
@@ -715,7 +727,9 @@ test("cleanup-worktrees processes terminal manifests whose worktrees are already
     assert.ok(cleaned, `${invocationContext} invocation must process the terminal run`);
     assert.equal(result.failed.length, 0);
     assert.equal(cleaned.worktreeRemoved, true);
+    assert.equal(cleaned.branchDeleted, true);
     assert.equal(cleaned.pruneRan, true);
+    assert.equal(branchExists(repoRoot, `issue-295-${invocationContext}`), false);
     const updated = readManifest(stale.manifestPath).data;
     assert.equal(updated.cleanup.status, "succeeded");
     const events = fs.readFileSync(path.join(path.dirname(stale.manifestPath), stale.runId, "events.jsonl"), "utf-8");

--- a/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -685,62 +685,141 @@ test("cleanup-worktrees rejects relay-base same-name worktrees before deleting u
   assert.equal(manifest.cleanup.status, "pending");
 });
 
-test("cleanup-worktrees fails closed on stale missing relay-owned manifests", () => {
+test("cleanup-worktrees processes terminal manifests whose worktrees are already missing", () => {
+  for (const invocationContext of ["canonical", "linked"]) {
+    const repoRoot = setupRepo();
+    const updatedAt = "2026-04-01T00:00:00.000Z";
+    const stale = writeStaleMissingRelayRun(repoRoot, {
+      branch: `issue-295-${invocationContext}`,
+      updatedAt,
+    });
+    let repoArg = repoRoot;
+    if (invocationContext === "linked") {
+      repoArg = path.join(os.tmpdir(), `relay-janitor-linked-${stale.runId}`);
+      execFileSync("git", ["worktree", "add", repoArg, "-b", `linked-${stale.runId}`], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+    }
+
+    const stdout = execFileSync("node", [
+      SCRIPT,
+      "--repo", repoArg,
+      "--all",
+      "--json",
+    ], { encoding: "utf-8" });
+
+    const result = JSON.parse(stdout);
+    const cleaned = result.cleaned.find((entry) => entry.runId === stale.runId);
+    assert.ok(cleaned, `${invocationContext} invocation must process the terminal run`);
+    assert.equal(result.failed.length, 0);
+    assert.equal(cleaned.worktreeRemoved, true);
+    assert.equal(cleaned.pruneRan, true);
+    const updated = readManifest(stale.manifestPath).data;
+    assert.equal(updated.cleanup.status, "succeeded");
+    const events = fs.readFileSync(path.join(path.dirname(stale.manifestPath), stale.runId, "events.jsonl"), "utf-8");
+    assert.match(events, /"event":"cleanup_result"/);
+  }
+});
+
+test("cleanup-worktrees requires --force-terminal for terminal unverifiable relay-base paths", () => {
   const repoRoot = setupRepo();
   const updatedAt = "2026-04-01T00:00:00.000Z";
-  const first = writeStaleMissingRelayRun(repoRoot, {
-    branch: "issue-295-a",
+  const { manifestPath, worktreePath } = writeRun(repoRoot, {
+    branch: "issue-885-terminal",
+    state: STATES.MERGED,
     updatedAt,
   });
-  const second = writeStaleMissingRelayRun(repoRoot, {
-    branch: "issue-295-b",
-    updatedAt,
+  const unverifiablePath = path.join(getRelayWorktreeBase(), "issue-885-shell", "unverifiable-name");
+  fs.mkdirSync(unverifiablePath, { recursive: true });
+  fs.writeFileSync(path.join(unverifiablePath, "sentinel.txt"), "keep until forced\n", "utf-8");
+  execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
   });
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: { ...record.data.paths, worktree: unverifiablePath },
+  }, record.body);
 
-  const dryRunStdout = execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--all",
-    "--dry-run",
-    "--json",
-  ], { encoding: "utf-8" });
-
-  const dryRunResult = JSON.parse(dryRunStdout);
-  const dryRunFailedIds = new Set(dryRunResult.failed.map((entry) => entry.runId));
+  const dryRunResult = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", repoRoot, "--all", "--dry-run", "--json",
+  ], { encoding: "utf-8" }));
   assert.equal(dryRunResult.cleaned.length, 0);
-  assert.equal(dryRunResult.failed.length, 2);
-  assert.equal(dryRunFailedIds.has(first.runId), true);
-  assert.equal(dryRunFailedIds.has(second.runId), true);
-  assert.match(dryRunResult.failed[0].error, /manifest paths\.worktree/);
-  assert.equal(readManifest(first.manifestPath).data.cleanup.status, "pending", "dry-run must not persist cleanup state");
+  assert.equal(dryRunResult.failed.length, 1);
+  assert.equal(dryRunResult.failed[0].reason, "terminal_unverifiable_requires_force");
+  assert.equal(dryRunResult.failed[0].classification, "cleanable_terminal_unverifiable_path");
+  assert.equal(fs.existsSync(unverifiablePath), true);
+  assert.equal(readManifest(manifestPath).data.cleanup.status, "pending");
 
-  const firstRunStdout = execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--all",
-    "--json",
-  ], { encoding: "utf-8" });
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", repoRoot, "--all", "--force-terminal", "--json",
+  ], { encoding: "utf-8" }));
+  assert.equal(result.failed.length, 0, JSON.stringify(result.failed, null, 2));
+  assert.equal(result.cleaned.length, 1);
+  assert.equal(result.cleaned[0].reason, "forced_terminal_unverifiable_path");
+  assert.equal(result.cleaned[0].worktreeRemoved, true);
+  assert.equal(fs.existsSync(unverifiablePath), false);
+  assert.equal(readManifest(manifestPath).data.cleanup.status, "succeeded");
+});
 
-  const firstRunResult = JSON.parse(firstRunStdout);
-  const failedIds = new Set(firstRunResult.failed.map((entry) => entry.runId));
-  assert.equal(firstRunResult.cleaned.length, 0);
-  assert.equal(firstRunResult.failed.length, 2);
-  assert.equal(failedIds.has(first.runId), true);
-  assert.equal(failedIds.has(second.runId), true);
-  assert.match(firstRunResult.failed[0].error, /manifest paths\.worktree/);
-  assert.equal(readManifest(first.manifestPath).data.cleanup.status, "pending");
-  assert.equal(readManifest(second.manifestPath).data.cleanup.status, "pending");
+test("cleanup-worktrees refuses non-terminal unverifiable paths with or without --force-terminal", () => {
+  for (const forceTerminal of [false, true]) {
+    const repoRoot = setupRepo();
+    const updatedAt = "2026-04-01T00:00:00.000Z";
+    const { manifestPath } = writeRun(repoRoot, {
+      branch: `issue-885-open-${forceTerminal}`,
+      state: STATES.READY_TO_MERGE,
+      updatedAt,
+    });
+    const unverifiablePath = path.join(getRelayWorktreeBase(), `open-${forceTerminal}`, "unverifiable-name");
+    fs.mkdirSync(unverifiablePath, { recursive: true });
+    fs.writeFileSync(path.join(unverifiablePath, "sentinel.txt"), "must remain\n", "utf-8");
+    const record = readManifest(manifestPath);
+    writeManifest(manifestPath, {
+      ...record.data,
+      paths: { ...record.data.paths, worktree: unverifiablePath },
+    }, record.body);
+    const cliArgs = [SCRIPT, "--repo", repoRoot, "--all", "--dry-run", "--json"];
+    if (forceTerminal) cliArgs.splice(-1, 0, "--force-terminal");
 
-  const secondRunStdout = execFileSync("node", [
-    SCRIPT,
-    "--repo", repoRoot,
-    "--all",
-    "--json",
-  ], { encoding: "utf-8" });
+    const result = JSON.parse(execFileSync("node", cliArgs, { encoding: "utf-8" }));
+    assert.equal(result.failed.length, 1);
+    assert.equal(result.failed[0].reason, "refused_non_terminal_manifest_paths");
+    assert.equal(result.failed[0].classification, "refused_manifest_paths");
+    assert.equal(fs.existsSync(unverifiablePath), true);
+    assert.equal(readManifest(manifestPath).data.cleanup.status, "pending");
+  }
+});
 
-  const secondRunResult = JSON.parse(secondRunStdout);
-  assert.equal(secondRunResult.cleaned.length, 0);
-  assert.equal(secondRunResult.failed.length, 2);
+test("cleanup-worktrees never force-removes a terminal path outside the relay worktree base", () => {
+  const repoRoot = setupRepo();
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const { manifestPath } = writeRun(repoRoot, {
+    branch: "issue-885-outside",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const outsidePath = fs.mkdtempSync(path.join(os.tmpdir(), "relay-janitor-outside-"));
+  fs.writeFileSync(path.join(outsidePath, "sentinel.txt"), "never remove\n", "utf-8");
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    paths: { ...record.data.paths, worktree: outsidePath },
+  }, record.body);
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", repoRoot, "--all", "--force-terminal", "--force", "--json",
+  ], { encoding: "utf-8" }));
+  assert.equal(result.cleaned.length, 0);
+  assert.equal(result.failed.length, 1);
+  assert.equal(result.failed[0].reason, "refused_terminal_manifest_paths");
+  assert.equal(fs.existsSync(outsidePath), true);
+  assert.equal(fs.existsSync(path.join(outsidePath, "sentinel.txt")), true);
+  assert.equal(readManifest(manifestPath).data.cleanup.status, "pending");
 });
 
 test("cleanup-worktrees removes existing relay-owned directories with pruned git bindings", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #885.

Key changes:

- Terminal manifests with missing worktrees now complete normal cleanup bookkeeping.
- Added `--force-terminal` for contained, existing-but-unverifiable terminal worktrees.
- Non-terminal runs remain fail-closed.
- Relay worktree-base containment remains mandatory.
- Dry-run output distinguishes terminal force-eligible paths from non-terminal refusals.
- Added coverage for all specified scenarios.

Validation:

- Focused tests: 22/22 passed.
-
```

## Score Log

- Run: issue-885-20260710052517056-c92a832c
- Executor: codex
- Branch: issue-885