### PR TITLE
fix(relay-merge): preserve squash merge subjects

### DIFF
--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -82,7 +82,7 @@ const cliArgs = bindCliArgs(args, {
 });
 const helpRequested = cliArgs.hasFlag(["--help", "-h"]);
 
-if (!args.length || helpRequested) {
+function printHelpAndExit() {
   console.log("Usage: finalize-run.js (--repo <path> --run-id <id> | --repo <path> --pr <number> | --manifest <path>) [options]");
   console.log("\nMerge a ready relay run, then finalize cleanup and manifest metadata.");
   console.log("\nOptions:");
@@ -128,6 +128,12 @@ function mergeFlag(method) {
     default:
       throw new Error(`Unsupported merge method: ${method}`);
   }
+}
+
+function buildSquashSubject(prTitle, prNumber) {
+  if (typeof prTitle !== "string" || !prTitle) return null;
+  const suffix = ` (#${prNumber})`;
+  return prTitle.endsWith(suffix) ? prTitle : `${prTitle}${suffix}`;
 }
 
 function buildMergeFinalizeReason({
@@ -179,7 +185,7 @@ function fetchReviewContext(repoPath, prNumber) {
 
 function fetchPreMergeContext(repoPath, prNumber) {
   const raw = execGh(repoPath, ["pr", "view", String(prNumber),
-    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid"]);
+    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title"]);
   const parsed = JSON.parse(raw);
   const checks = parsed.statusCheckRollup || [];
   return {
@@ -188,6 +194,7 @@ function fetchPreMergeContext(repoPath, prNumber) {
     commits: parsed.commits || [],
     mergeable: parsed.mergeable || null,
     headRefOid: parsed.headRefOid || null,
+    title: typeof parsed.title === "string" && parsed.title ? parsed.title : null,
     checks,
     unsafeChecks: checks.filter(isUnsafeStatusCheck),
   };
@@ -784,6 +791,10 @@ function appendDurableLearnings({
 }
 
 function main() {
+  if (!args.length || helpRequested) {
+    printHelpAndExit();
+  }
+
   const unknownFlags = findUnknownFlags(args, "finalize-run");
   if (unknownFlags.length) {
     throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
@@ -912,6 +923,7 @@ function main() {
   let reviewGate = null;
   let stackedBaseGuard = { status: "not_checked", reason: null };
   let currentHeadSha = safeData.git?.head_sha || null;
+  let prTitle = null;
   const skipReviewRubricAudit = summarizeRubricAuditForSkip(safeData, {
     runDir: getRunDir(validatedPaths.repoRoot, safeData.run_id),
   });
@@ -982,6 +994,7 @@ function main() {
     } else if (skipReviewReason) {
       assertSkipReviewGate(repoPath, safeData, { prNumber, currentHeadSha, dryRun, skipReviewRubricAudit });
       const preMerge = fetchPreMergeContext(repoPath, prNumber);
+      prTitle = preMerge.title;
       stackedBaseGuard = buildStackedBaseGuard(
         repoPath,
         prNumber,
@@ -1004,6 +1017,7 @@ function main() {
       });
     } else if (safeData.state === STATES.READY_TO_MERGE) {
       const preMerge = fetchPreMergeContext(repoPath, prNumber);
+      prTitle = preMerge.title;
       reviewGate = evaluateReviewGate({
         prNumber,
         comments: preMerge.comments,
@@ -1046,6 +1060,7 @@ function main() {
       assertPreMergeSafety(preMerge, prNumber);
     } else if (forceFinalizeNonready) {
       const preMerge = fetchPreMergeContext(repoPath, prNumber);
+      prTitle = preMerge.title;
       stackedBaseGuard = buildStackedBaseGuard(
         repoPath,
         prNumber,
@@ -1091,7 +1106,16 @@ function main() {
     }
     if (!dryRun && !isMergedPrState(prMergeState)) {
       try {
-        execGh(repoPath, ["pr", "merge", String(prNumber), mergeFlag(mergeMethod)]);
+        const mergeArgs = ["pr", "merge", String(prNumber), mergeFlag(mergeMethod)];
+        if (mergeMethod === "squash") {
+          const subject = buildSquashSubject(prTitle, prNumber);
+          if (subject) {
+            mergeArgs.push("--subject", subject);
+          } else {
+            console.error(`Note: PR title unavailable for PR #${prNumber}; proceeding with subjectless squash merge.`);
+          }
+        }
+        execGh(repoPath, mergeArgs);
         mergePerformed = true;
         prMergeState = fetchPrMergeState(repoPath, prNumber);
       } catch (error) {
@@ -1302,9 +1326,13 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(`Error: ${error.message}`);
-  process.exit(1);
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
 }
+
+module.exports = { buildSquashSubject };

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -39,6 +39,13 @@ test("finalize-run help includes review-bypass decision tree", () => {
   )));
 });
 
+test("buildSquashSubject appends the PR suffix exactly once", () => {
+  const { buildSquashSubject } = require(SCRIPT);
+
+  assert.equal(buildSquashSubject("fix(relay): keep squash title", 864), "fix(relay): keep squash title (#864)");
+  assert.equal(buildSquashSubject("fix(relay): keep squash title (#864)", 864), "fix(relay): keep squash title (#864)");
+});
+
 function buildManifestForState(manifest, targetState) {
   switch (targetState) {
     case STATES.DRAFT:
@@ -264,6 +271,7 @@ function writeFakeGh(logPath, {
   mergeCommitAfterMerge = { oid: "merged-sha" },
   prMergeExitCode = 0,
   prMergeStderr = "",
+  title = "fix(relay): finalize test PR",
 } = {}) {
   const ghPath = path.join(path.dirname(logPath), "fake-gh.js");
   const statePath = path.join(path.dirname(logPath), "fake-gh-state.json");
@@ -282,6 +290,7 @@ function writeFakeGh(logPath, {
     mergeCommitAfterMerge,
     prMergeExitCode,
     prMergeStderr,
+    title,
   }), "utf-8");
   fs.writeFileSync(ghPath, `#!/usr/bin/env node
 const fs = require("fs");
@@ -315,7 +324,8 @@ if (args[0] === "pr" && args[1] === "view") {
     comments: state.comments,
     commits: state.commits,
     mergeable: state.mergeable,
-    statusCheckRollup: state.statusCheckRollup
+    statusCheckRollup: state.statusCheckRollup,
+    title: state.title
   }));
 }
 if (args[0] === "pr" && args[1] === "list") {
@@ -487,7 +497,91 @@ test("finalize-run force-finalize merges an escalated run with an auditable even
   assert.equal(fs.existsSync(worktreePath), false);
   assert.equal(branchExists(repoRoot, branch), false);
   assert.equal(remoteBranchExists(repoRoot, branch), false);
-  assert.match(fs.readFileSync(logPath, "utf-8"), /pr merge 123 --squash/);
+  assert.match(fs.readFileSync(logPath, "utf-8"), /pr merge 123 --squash --subject fix\(relay\): finalize test PR \(#123\)/);
+});
+
+test("finalize-run derives squash subject from the current PR title", () => {
+  const fixture = setupRepo();
+  const title = "fix(relay): preserve conventional squash titles";
+  const { logPath } = execFinalize(fixture, {
+    ghOptions: {
+      title,
+      comments: [DEFAULT_REVIEW_COMMENT],
+    },
+  });
+
+  const ghLog = fs.readFileSync(logPath, "utf-8");
+  assert.match(ghLog, new RegExp(`^pr merge 123 --squash --subject ${title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(#123\\)$`, "m"));
+});
+
+test("finalize-run does not double-suffix an already-suffixed squash title", () => {
+  const fixture = setupRepo();
+  const title = "fix(relay): preserve conventional squash titles (#123)";
+  const { logPath } = execFinalize(fixture, {
+    ghOptions: {
+      title,
+      comments: [DEFAULT_REVIEW_COMMENT],
+    },
+  });
+
+  const mergeLine = fs.readFileSync(logPath, "utf-8")
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("pr merge "));
+  assert.equal(mergeLine, `pr merge 123 --squash --subject ${title}`);
+});
+
+for (const method of ["merge", "rebase"]) {
+  test(`finalize-run preserves the ${method} invocation without a subject`, () => {
+    const fixture = setupRepo();
+    const { logPath } = execFinalize(fixture, {
+      extraArgs: ["--merge-method", method],
+      ghOptions: {
+        title: "fix(relay): title must not affect non-squash merges",
+        comments: [DEFAULT_REVIEW_COMMENT],
+      },
+    });
+
+    const mergeLine = fs.readFileSync(logPath, "utf-8")
+      .split(/\r?\n/)
+      .find((line) => line.startsWith("pr merge "));
+    assert.equal(mergeLine, `pr merge 123 --${method}`);
+  });
+}
+
+test("finalize-run notes a missing title and proceeds with subjectless squash", () => {
+  const fixture = setupRepo();
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    title: null,
+    comments: [DEFAULT_REVIEW_COMMENT],
+    commits: [
+      {
+        oid: fixture.headSha,
+        committedDate: DEFAULT_COMMIT_DATE,
+      },
+    ],
+  });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /^Note: PR title unavailable for PR #123; proceeding with subjectless squash merge\.\n$/);
+  assert.equal(JSON.parse(result.stdout).state, STATES.MERGED);
+  const mergeLine = fs.readFileSync(logPath, "utf-8")
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("pr merge "));
+  assert.equal(mergeLine, "pr merge 123 --squash");
 });
 
 test("finalize-run default squash collapses TDD red branch history to one base commit", () => {
@@ -544,7 +638,8 @@ if (args[0] === "pr" && args[1] === "view") {
     comments: [{ body: "<!-- relay-review -->\\n## Relay Review\\nVerdict: PASS\\nRounds: 1", createdAt: ${JSON.stringify(DEFAULT_COMMIT_DATE)} }],
     commits: [{ oid: ${JSON.stringify(headSha)}, committedDate: ${JSON.stringify(DEFAULT_COMMIT_DATE)} }],
     mergeable: "MERGEABLE",
-    statusCheckRollup: []
+    statusCheckRollup: [],
+    title: "test(relay): collapse TDD history"
   }));
   process.exit(0);
 }


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `3cb2638` (`fix(relay-merge): preserve squash merge subjects`). Working tree is clean.

### Completion audit

| Criterion | Proof |
|---|---|
| Squash adds derived `--subject` | [finalize-run.js](/Users/sjlee/.relay/worktrees/d00f5791/dev-relay/skills/relay-merge/scripts/finalize-run.js:1109), [test](/Users/sjlee/.relay/worktrees/d00f5791/dev-relay/tests/relay-merge/scripts/finalize-run.test.js:503) |
| Existing `(#n)` suffix deduplicated by pure helper | [helper](/U
```

## Score Log

- Run: issue-864-20260710060200998-6ecc69fb
- Executor: codex
- Branch: issue-864-squash-subject