### PR TITLE
fleet drive reconciles a LIVE detached dispatch (row 4) — premature recover-commit publishes mid-work snapshot and skips execution evidence (#876)

### DIFF
--- a/skills/relay-dispatch/scripts/reconcile-run.js
+++ b/skills/relay-dispatch/scripts/reconcile-run.js
@@ -14,6 +14,7 @@ const { classifyRepositoryDirt } = require("./runtime-dirt");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const {
+  confirmRunLeaseSupervisorDeath,
   corruptRunLeaseEventFields,
   corruptRunLeaseReportFields,
   getDispatchResultCandidates,
@@ -289,6 +290,31 @@ async function main() {
   }
 
   const leaseStatus = getRunLeaseStatus(normalizedRepoRoot, normalizedRunId);
+  const leaseUnexpired = leaseStatus.exists
+    && leaseStatus.lease
+    && leaseStatus.remaining_s > 0;
+  if (!leaseStatus.live && leaseUnexpired && leaseStatus.reason !== "host_mismatch") {
+    const deathConfirmed = await confirmRunLeaseSupervisorDeath(leaseStatus);
+    if (!deathConfirmed) {
+      outputResult({
+        ...buildBaseResult({
+          row: 2,
+          rowName: "lease_live_within_timeout",
+          status: "running",
+          manifestPath: record.manifestPath,
+          runId: normalizedRunId,
+          data,
+          dryRun,
+          nextAction: "wait_for_executor",
+        }),
+        lease: leaseStatus.lease,
+        leaseStatus: "supervisor_pid_alive_after_reprobe",
+        elapsed_s: leaseStatus.elapsed_s,
+        remaining_s: leaseStatus.remaining_s,
+      }, jsonOut);
+      return;
+    }
+  }
   if (leaseStatus.live) {
     const timedOut = leaseStatus.elapsed_s > Number(leaseStatus.lease.timeout_s);
     if (!timedOut || !leaseStatus.canSignal) {
@@ -296,7 +322,7 @@ async function main() {
         ...buildBaseResult({
           row: 2,
           rowName: "lease_live_within_timeout",
-          status: leaseStatus.canSignal ? "running" : "running_unverified",
+          status: timedOut ? "running_unverified" : "running",
           manifestPath: record.manifestPath,
           runId: normalizedRunId,
           data,

--- a/skills/relay-dispatch/scripts/run-runtime-state.js
+++ b/skills/relay-dispatch/scripts/run-runtime-state.js
@@ -12,6 +12,7 @@ const LEASE_FILENAME = "lease.json";
 const DISPATCH_STDOUT_LOG = "dispatch-stdout.log";
 const DISPATCH_STDERR_LOG = "dispatch-stderr.log";
 const DISPATCH_RESULT_FILE = "dispatch-result.txt";
+const LEASE_DEATH_CONFIRM_DELAY_MS = 50;
 
 let posixProcessStateInspectionUnavailable = false;
 
@@ -81,6 +82,27 @@ function isProcessGroupAlive(pgid) {
   } catch (error) {
     if (error.code === "ESRCH") return false;
     if (error.code === "EPERM") return !isZombieOnlyProcessGroup(normalizedPgid);
+    return false;
+  }
+}
+
+function probeProcess(pid) {
+  const normalizedPid = Number(pid);
+  const probeLog = process.env.RELAY_TEST_PROCESS_PROBE_LOG;
+  if (probeLog) {
+    fs.appendFileSync(probeLog, `${normalizedPid}\n`, "utf-8");
+  }
+  process.kill(normalizedPid, 0);
+}
+
+function isProcessAlive(pid) {
+  if (!pid || !Number.isFinite(Number(pid))) return false;
+  try {
+    probeProcess(Number(pid));
+    return true;
+  } catch (error) {
+    if (error.code === "EPERM") return true;
+    if (error.code === "ESRCH") return false;
     return false;
   }
 }
@@ -287,17 +309,33 @@ function getRunLeaseStatus(repoRoot, runId) {
     };
   }
 
-  const live = isProcessGroupAlive(lease.pgid);
+  // The lease pid is the dispatch supervisor and is the authoritative liveness
+  // signal. The executor pgid may outlive it because unrelated inheritors (for
+  // example Codex desktop's SkyComputerUseClient notifier) can linger there.
+  const live = isProcessAlive(lease.pid);
+  const canSignal = isProcessGroupAlive(lease.pgid);
   return {
     exists: true,
     lease,
     leasePath,
     live,
-    canSignal: live,
+    canSignal,
+    // Keep these legacy reason values stable for existing observer/advisory
+    // consumers; liveness_source names the corrected probe explicitly.
     reason: live ? "process_group_alive" : "process_group_dead",
+    liveness_source: "lease_supervisor_pid",
+    process_group_live: canSignal,
     elapsed_s: elapsedS,
     remaining_s: remainingS,
   };
+}
+
+async function confirmRunLeaseSupervisorDeath(status, { intervalMs = LEASE_DEATH_CONFIRM_DELAY_MS } = {}) {
+  if (!status?.exists || !status.lease || status.live) {
+    return false;
+  }
+  await sleepAsync(intervalMs);
+  return !isProcessAlive(status.lease.pid);
 }
 
 function formatLeaseForMessage(status) {
@@ -331,6 +369,7 @@ module.exports = {
   assertNoLiveRunLease,
   corruptRunLeaseEventFields,
   corruptRunLeaseReportFields,
+  confirmRunLeaseSupervisorDeath,
   dispatchManifestPathFields,
   formatLeaseForMessage,
   getDispatchResultCandidates,

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -39,6 +39,7 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/fleet");
 const { getRequestPath, readRequestArtifact } = require("../../relay-ready/scripts/relay-request");
 const { runReconcile } = require("../../relay-dispatch/scripts/reconcile-advisory");
+const { getRunLeaseStatus } = require("../../relay-dispatch/scripts/run-runtime-state");
 const { runMergeQueue } = require("./merge-queue");
 
 const DEFAULT_PARALLEL = 4;
@@ -1274,6 +1275,13 @@ async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf,
         };
       }
       if (lastReconcile.rowName === "dead_with_result_or_work") {
+        // This branch used to mutate immediately on any dry-run row-4 verdict,
+        // bypassing the poll deadline. Re-probe the authoritative lease
+        // supervisor pid before allowing that destructive transition.
+        if (getRunLeaseStatus(repoRoot, runId).live) {
+          await sleepAsync(2000);
+          continue;
+        }
         const healed = reconcileMutating(repoRoot, runId);
         if (healed.status === "error") {
           return {
@@ -1330,12 +1338,15 @@ async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf,
     await sleepAsync(runState === RUN_STATES.DISPATCHED ? 2000 : 250);
   }
 
+  const finalRunState = readRunState(repoRoot, runId);
+  const liveLease = finalRunState === RUN_STATES.DISPATCHED
+    && getRunLeaseStatus(repoRoot, runId).live;
   return {
-    status: "dispatch_poll_timeout",
+    status: liveLease ? "dispatch_still_running" : "dispatch_poll_timeout",
     run_id: runId,
-    run_state: readRunState(repoRoot, runId),
+    run_state: finalRunState,
     reconcile: lastReconcile,
-    keep_runtime: detachedSupervisorIsAlive(repoRoot, fleetId, leaf),
+    keep_runtime: liveLease || detachedSupervisorIsAlive(repoRoot, fleetId, leaf),
   };
 }
 

--- a/tests/relay-dispatch/scripts/reconcile-run.test.js
+++ b/tests/relay-dispatch/scripts/reconcile-run.test.js
@@ -282,11 +282,12 @@ test("reconcile row 1 no-ops when manifest is not dispatched", () => {
   assert.equal(readManifest(fixture.manifestPath).data.state, STATES.REVIEW_PENDING);
 });
 
-test("reconcile row 2 reports a live lease within timeout", async (t) => {
-  const fixture = setupRepo();
+test("reconcile row 2 preserves work when an unexpired lease supervisor pid is live even if its pgid is empty", async (t) => {
+  const fixture = setupRepo({ committedWork: true });
   const child = await spawnSleeper(t);
   const leasePath = writeLease(fixture, {
-    pgid: child.pid,
+    pid: child.pid,
+    pgid: 999999,
     startedAt: new Date().toISOString(),
     timeoutS: 60,
   });
@@ -295,10 +296,52 @@ test("reconcile row 2 reports a live lease within timeout", async (t) => {
 
   assert.equal(result.row, 2);
   assert.equal(result.status, "running");
-  assert.equal(result.lease.pgid, child.pid);
+  assert.equal(result.lease.pid, child.pid);
   assert.ok(result.remaining_s > 0);
   assert.equal(fs.existsSync(leasePath), true);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.DISPATCHED);
   assert.equal(isPgidAlive(child.pid), true);
+});
+
+test("reconcile confirms an unexpired dead lease supervisor pid twice before row 4 recovery", () => {
+  const fixture = setupRepo({ committedWork: true });
+  const deadPid = 999999;
+  const probeLog = path.join(fixture.runDir, "pid-probes.log");
+  fixture.env.RELAY_TEST_PROCESS_PROBE_LOG = probeLog;
+  writeLease(fixture, {
+    pid: deadPid,
+    pgid: deadPid,
+    startedAt: new Date().toISOString(),
+    timeoutS: 60,
+  });
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 4);
+  assert.equal(result.status, "recovered");
+  assert.deepEqual(
+    fs.readFileSync(probeLog, "utf-8").trim().split(/\r?\n/),
+    [String(deadPid), String(deadPid)]
+  );
+});
+
+test("reconcile treats notifier-only pgid survivors as dead when the lease supervisor pid is dead", async (t) => {
+  const fixture = setupRepo({ committedWork: true });
+  const notifier = await spawnSleeper(t);
+  const leasePath = writeLease(fixture, {
+    pid: 999999,
+    pgid: notifier.pid,
+    startedAt: new Date().toISOString(),
+    timeoutS: 60,
+  });
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 4);
+  assert.equal(result.status, "recovered");
+  assert.equal(fs.existsSync(leasePath), false);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.REVIEW_PENDING);
+  assert.equal(isPgidAlive(notifier.pid), true);
 });
 
 test("reconcile treats a zombie-only process group lease as dead retry evidence", () => {
@@ -475,7 +518,7 @@ test("reconcile row 3 keeps the lease when a timed-out process group ignores SIG
   assert.equal(events.at(-1).executor_terminated, false);
 });
 
-test("reconcile row 4 recovers dead runs with committed work via recover-commit", () => {
+test("reconcile row 4 byte-preserves recovery for an expired lease with a dead supervisor pid", () => {
   const fixture = setupRepo({ committedWork: true });
   const leasePath = writeLease(fixture, {
     pid: 999999,

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -2426,6 +2426,60 @@ test("relay-fleet keeps live incomplete detached dispatches retry-safe", async (
   });
 });
 
+test("relay-fleet never row-4 reconciles a live unexpired lease, including at poll-budget exhaustion", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-live-lease-budget-");
+  const fleetId = "fleet-live-lease-budget";
+  const runId = "issue-876-20260710010101000-a1b2c3d4";
+  const leaf = makeLeaf(repoRoot, 1, { issue_number: 876, leaf_ref: "leaf-live-lease" });
+  writeChildRun(repoRoot, {
+    runId,
+    branch: leaf.branch,
+    issueNumber: leaf.issue_number,
+    leafId: leaf.leaf_id,
+    fleetId,
+    state: RUN_STATES.DISPATCHED,
+  });
+  const runDir = getRunDir(repoRoot, runId);
+  const resultPath = path.join(runDir, "dispatch-result.txt");
+  fs.writeFileSync(resultPath, "mid-work snapshot that must not be recovered\n", "utf-8");
+  fs.writeFileSync(path.join(runDir, "lease.json"), `${JSON.stringify({
+    pid: process.pid,
+    pgid: 999999,
+    host: os.hostname(),
+    started_at: new Date().toISOString(),
+    timeout_s: 3600,
+  }, null, 2)}\n`, "utf-8");
+  fs.mkdirSync(path.dirname(getFleetLeavesStorePath(repoRoot, fleetId)), { recursive: true });
+  writePersistedFleetLeaves(repoRoot, fleetId, [leaf]);
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [{ leaf_ref: leaf.leaf_ref, run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHING }],
+  });
+  advanceFleetManifestState(repoRoot, fleetId, FLEET_STATES.DISPATCHING);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--resume",
+    "--json",
+  ], {
+    relayHome,
+    env: { RELAY_FLEET_DISPATCH_POLL_TIMEOUT_MS: "300" },
+    timeout: 30000,
+  });
+
+  assert.notEqual(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.dispatch_children[0].status, "dispatch_still_running");
+  assert.equal(payload.dispatch_children[0].reconcile.rowName, "lease_live_within_timeout");
+  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.DISPATCHED);
+  assert.equal(fs.readFileSync(resultPath, "utf-8"), "mid-work snapshot that must not be recovered\n");
+  assert.equal(
+    readFleetManifest(repoRoot, fleetId).data.children[0].dispatch_status,
+    DISPATCH_STATUS.DISPATCHING
+  );
+});
+
 test("relay-fleet treats detached terminal child states as failed dispatch outcomes", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-terminal-detach-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-terminal-detach-fake-"));


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-876-20260710060200750-870de21a
- Branch: issue-876-live-reconcile
- Reason: reconcile-run recovered work for issue-876-20260710060200750-870de21a
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-876-20260710060200750-870de21a.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-10T06:53:00.714Z

## Root cause (required by the contract rubric)

**Why drive #1 reconciled ~20 minutes into a 3600s dispatch (budget 3660s):** `waitForDetachedDispatchProgress` ran reconcile-run in dry-run mode on each poll tick; when the dry-run classified the child as rowName `dead_with_result_or_work`, the drive immediately invoked the MUTATING reconcile — trusting the row name alone and bypassing the remaining poll deadline. The row itself was a false-dead: the liveness probe judged the supervisor dead while PID 56844 and `codex exec` PID 58488 were alive (lease unexpired, `elapsed_s: 1274` of `timeout_s: 3600`).

**Both failure directions fixed by one liveness helper:**
- *False-dead* (this incident): liveness is now decided by probing the lease supervisor `pid` directly with double confirmation across an interval; an unexpired lease with a live pid always classifies `still_running`, and the drive keeps polling to its deadline instead of reconciling.
- *False-alive* (issue comment): a dead supervisor whose pgid still contains lingering inheritors (e.g. `SkyComputerUseClient`, Codex's turn-ended notifier) previously reported `running`; pgid population no longer decides aliveness in either direction.
