### PR TITLE
fix: persist done criteria at dispatch (#882)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1159,8 +1159,11 @@ function copyFileAtomically(sourcePath, finalPath) {
   }
 }
 
-function persistDoneCriteria(manifest, runDir, originalPath) {
+function persistDoneCriteria(manifest, runDir, originalPath, doneCriteriaSource) {
   if (!originalPath) return manifest;
+  // Request/leaf-bound anchors already live durably under ~/.relay/requests/
+  // and the request->run->review linkage depends on that exact path identity.
+  if (doneCriteriaSource === "request_snapshot") return manifest;
 
   const persistedPath = path.join(runDir, "done-criteria.md");
   const isSelfCopy = sameFilesystemLocation(originalPath, persistedPath);
@@ -2126,7 +2129,7 @@ async function main() {
       fleetId: FLEET_ID,
     });
     ensureRunLayout(repoRoot, runId);
-    manifest = persistDoneCriteria(manifest, manifestRunDir, resolvedDoneCriteriaPath);
+    manifest = persistDoneCriteria(manifest, manifestRunDir, resolvedDoneCriteriaPath, doneCriteriaSource);
     manifest = {
       ...manifest,
       paths: {

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1159,6 +1159,27 @@ function copyFileAtomically(sourcePath, finalPath) {
   }
 }
 
+function persistDoneCriteria(manifest, runDir, originalPath) {
+  if (!originalPath) return manifest;
+
+  const persistedPath = path.join(runDir, "done-criteria.md");
+  const isSelfCopy = sameFilesystemLocation(originalPath, persistedPath);
+  if (!isSelfCopy) {
+    copyFileAtomically(originalPath, persistedPath);
+  }
+
+  return {
+    ...manifest,
+    anchor: {
+      ...(manifest.anchor || {}),
+      done_criteria_path: persistedPath,
+      ...(path.resolve(originalPath) === path.resolve(persistedPath)
+        ? {}
+        : { done_criteria_original_path: originalPath }),
+    },
+  };
+}
+
 function getPersistedRubricPath(runDir, rubricPath = "rubric.yaml") {
   const containment = validateRubricPathContainment(rubricPath, runDir);
   if (!containment.valid) {
@@ -1824,11 +1845,16 @@ async function main() {
 
   if (RESUME_MODE) {
     try {
+      const resumeDoneCriteriaPath = resolvedDoneCriteriaPath
+        && manifest?.anchor?.done_criteria_original_path
+        && sameFilesystemLocation(resolvedDoneCriteriaPath, manifest.anchor.done_criteria_original_path)
+          ? manifest.anchor.done_criteria_path
+          : resolvedDoneCriteriaPath;
       validateResumeRequestLinkage(manifest, {
         requestId: REQUEST_ID,
         leafId: LEAF_ID,
         fleetId: FLEET_ID,
-        doneCriteriaPath: resolvedDoneCriteriaPath,
+        doneCriteriaPath: resumeDoneCriteriaPath,
       });
       if (REVIEW_ASSURANCE_RAW !== undefined) {
         validateResumeReviewAssurance(manifest, REVIEW_ASSURANCE);
@@ -2073,6 +2099,13 @@ async function main() {
   };
 
   if (!RESUME_MODE) {
+    const doneCriteriaSource = inferDoneCriteriaSource({
+      repoRoot,
+      runId,
+      doneCriteriaPath: resolvedDoneCriteriaPath,
+      requestId: REQUEST_ID,
+      leafId: LEAF_ID,
+    });
     manifest = createManifestSkeleton({
       repoRoot,
       runId,
@@ -2087,17 +2120,13 @@ async function main() {
       requestId: REQUEST_ID || null,
       leafId: LEAF_ID || null,
       doneCriteriaPath: resolvedDoneCriteriaPath,
-      doneCriteriaSource: inferDoneCriteriaSource({
-        repoRoot,
-        runId,
-        doneCriteriaPath: resolvedDoneCriteriaPath,
-        requestId: REQUEST_ID,
-        leafId: LEAF_ID,
-      }),
+      doneCriteriaSource,
       reviewAssurance: REVIEW_ASSURANCE,
       modelHints: MODEL_HINTS,
       fleetId: FLEET_ID,
     });
+    ensureRunLayout(repoRoot, runId);
+    manifest = persistDoneCriteria(manifest, manifestRunDir, resolvedDoneCriteriaPath);
     manifest = {
       ...manifest,
       paths: {

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -4,6 +4,7 @@ const path = require("path");
 const {
   getCanonicalRepoRoot,
   getExpectedManifestRepoRoot,
+  getRunDir,
   parsePositiveInt,
   validateManifestPaths,
 } = require("../../../relay-dispatch/scripts/manifest/paths");
@@ -360,8 +361,12 @@ function loadDoneCriteria(repoPath, issueNumber, prNumber, doneCriteriaFile, man
   const manifestDoneCriteriaPath = manifestData?.anchor?.done_criteria_path;
   if (manifestDoneCriteriaPath) {
     if (!fs.existsSync(manifestDoneCriteriaPath)) {
+      const persistedPath = manifestData?.run_id
+        ? path.join(getRunDir(repoPath, manifestData.run_id), "done-criteria.md")
+        : path.join("<runDir>", "done-criteria.md");
       throw new Error(
-        `Manifest anchor.done_criteria_path points to a missing file: ${manifestDoneCriteriaPath}`
+        `Manifest anchor.done_criteria_path points to a missing file: ${manifestDoneCriteriaPath}. ` +
+        `Newer runs persist a run-dir copy at ${persistedPath}.`
       );
     }
     return {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -6889,12 +6889,15 @@ test("dispatch stores request linkage and frozen done criteria anchor in manifes
   assert.equal(result.status, "completed");
   assert.equal(result.requestId, "req-20260409010101000");
   assert.equal(result.leafId, "leaf-01");
-  assert.equal(result.doneCriteriaPath, doneCriteriaFile);
+  const persistedDoneCriteriaPath = path.join(getRunDir(repoRoot, result.runId), "done-criteria.md");
+  assert.equal(result.doneCriteriaPath, persistedDoneCriteriaPath);
+  assert.equal(fs.readFileSync(persistedDoneCriteriaPath, "utf-8"), "# Done Criteria\n\n- Intake snapshot\n");
 
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.source.request_id, "req-20260409010101000");
   assert.equal(manifest.source.leaf_id, "leaf-01");
-  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_path, persistedDoneCriteriaPath);
+  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
   assert.equal(manifest.anchor.done_criteria_source, "request_snapshot");
 });
 
@@ -6928,7 +6931,9 @@ test("dispatch infers planner_decision for canonical run-dir done criteria ancho
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.run_id, runId);
   assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_original_path, undefined);
   assert.equal(manifest.anchor.done_criteria_source, "planner_decision");
+  assert.deepEqual(fs.readdirSync(runDir).filter((name) => name === "done-criteria.md"), ["done-criteria.md"]);
 });
 
 test("dispatch preserves file source for ad-hoc done criteria paths", () => {
@@ -6949,8 +6954,11 @@ test("dispatch preserves file source for ad-hoc done criteria paths", () => {
 
   assert.equal(result.status, "completed");
   const manifest = readManifest(result.manifestPath).data;
-  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  const persistedDoneCriteriaPath = path.join(getRunDir(repoRoot, result.runId), "done-criteria.md");
+  assert.equal(manifest.anchor.done_criteria_path, persistedDoneCriteriaPath);
+  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
   assert.equal(manifest.anchor.done_criteria_source, "file");
+  assert.equal(fs.readFileSync(persistedDoneCriteriaPath, "utf-8"), "# Done Criteria\n\n- Ad-hoc file\n");
 });
 
 test("dispatch dry-run includes request linkage and frozen done criteria file info", () => {
@@ -7016,7 +7024,8 @@ test("dispatch resume rejects changes to immutable intake linkage", () => {
   assert.match(result.stderr, /cannot change immutable anchor\.done_criteria_path/);
 
   const manifest = readManifest(first.manifestPath).data;
-  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_path, path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"));
+  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
   assert.equal(manifest.source.request_id, "req-20260409030303000");
 });
 
@@ -7057,12 +7066,13 @@ test("dispatch resume keeps the original intake linkage when the same immutable 
   assert.equal(second.runId, first.runId);
   assert.equal(second.requestId, "req-20260409050505000");
   assert.equal(second.leafId, "leaf-01");
-  assert.equal(second.doneCriteriaPath, doneCriteriaFile);
+  assert.equal(second.doneCriteriaPath, path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"));
 
   const manifest = readManifest(first.manifestPath).data;
   assert.equal(manifest.source.request_id, "req-20260409050505000");
   assert.equal(manifest.source.leaf_id, "leaf-01");
-  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_path, path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"));
+  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
 });
 
 test("dispatch resume rejects adding intake linkage to a run that started without it", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -6889,15 +6889,17 @@ test("dispatch stores request linkage and frozen done criteria anchor in manifes
   assert.equal(result.status, "completed");
   assert.equal(result.requestId, "req-20260409010101000");
   assert.equal(result.leafId, "leaf-01");
-  const persistedDoneCriteriaPath = path.join(getRunDir(repoRoot, result.runId), "done-criteria.md");
-  assert.equal(result.doneCriteriaPath, persistedDoneCriteriaPath);
-  assert.equal(fs.readFileSync(persistedDoneCriteriaPath, "utf-8"), "# Done Criteria\n\n- Intake snapshot\n");
+  // Request/leaf-bound anchors stay at the durable request-store path:
+  // no run-dir copy, no re-point — the request->run->review linkage
+  // depends on that exact path identity.
+  assert.equal(result.doneCriteriaPath, doneCriteriaFile);
+  assert.equal(fs.existsSync(path.join(getRunDir(repoRoot, result.runId), "done-criteria.md")), false);
 
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.source.request_id, "req-20260409010101000");
   assert.equal(manifest.source.leaf_id, "leaf-01");
-  assert.equal(manifest.anchor.done_criteria_path, persistedDoneCriteriaPath);
-  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_original_path, undefined);
   assert.equal(manifest.anchor.done_criteria_source, "request_snapshot");
 });
 
@@ -7024,8 +7026,8 @@ test("dispatch resume rejects changes to immutable intake linkage", () => {
   assert.match(result.stderr, /cannot change immutable anchor\.done_criteria_path/);
 
   const manifest = readManifest(first.manifestPath).data;
-  assert.equal(manifest.anchor.done_criteria_path, path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"));
-  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_original_path, undefined);
   assert.equal(manifest.source.request_id, "req-20260409030303000");
 });
 
@@ -7066,13 +7068,13 @@ test("dispatch resume keeps the original intake linkage when the same immutable 
   assert.equal(second.runId, first.runId);
   assert.equal(second.requestId, "req-20260409050505000");
   assert.equal(second.leafId, "leaf-01");
-  assert.equal(second.doneCriteriaPath, path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"));
+  assert.equal(second.doneCriteriaPath, doneCriteriaFile);
 
   const manifest = readManifest(first.manifestPath).data;
   assert.equal(manifest.source.request_id, "req-20260409050505000");
   assert.equal(manifest.source.leaf_id, "leaf-01");
-  assert.equal(manifest.anchor.done_criteria_path, path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"));
-  assert.equal(manifest.anchor.done_criteria_original_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_path, doneCriteriaFile);
+  assert.equal(manifest.anchor.done_criteria_original_path, undefined);
 });
 
 test("dispatch resume rejects adding intake linkage to a run that started without it", () => {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -838,6 +838,56 @@ test("prepare-only loads frozen Done Criteria from manifest anchor before GitHub
   assert.match(doneCriteriaText, /Use the persisted intake snapshot/);
 });
 
+test("review loads the persisted run-dir Done Criteria after the dispatch input is deleted", () => {
+  const { repoRoot, diffPath } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-codex-bin-"));
+  writeFakeCodex(binDir);
+  const originalDoneCriteriaPath = path.join(os.tmpdir(), `relay-done-criteria-${process.pid}-${Date.now()}.md`);
+  const rubricPath = path.join(repoRoot, "review-persistence-rubric.yaml");
+  fs.writeFileSync(
+    originalDoneCriteriaPath,
+    "# Persisted Done Criteria\n\n- Review survives deleting the dispatch input\n",
+    "utf-8"
+  );
+  fs.writeFileSync(rubricPath, "rubric:\n  factors:\n    - name: persistence\n      target: review loads the run copy\n", "utf-8");
+
+  const dispatch = execFileSync("node", [
+    DISPATCH_SCRIPT,
+    repoRoot,
+    "--branch", "persist-done-criteria-review",
+    "--prompt", "verify persisted done criteria",
+    "--done-criteria-file", originalDoneCriteriaPath,
+    "--rubric-file", rubricPath,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+  });
+  const dispatchResult = JSON.parse(dispatch);
+  const dispatchManifest = readManifest(dispatchResult.manifestPath).data;
+  assert.equal(dispatchManifest.anchor.done_criteria_original_path, originalDoneCriteriaPath);
+  fs.unlinkSync(originalDoneCriteriaPath);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", dispatchResult.runId,
+    "--pr", "123",
+    "--diff-file", diffPath,
+    "--prepare-only",
+    "--json",
+  ], { encoding: "utf-8", stdio: "pipe" });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.doneCriteriaPath, path.join(dispatchResult.runDir, "review-round-1-done-criteria.md"));
+  assert.match(
+    fs.readFileSync(result.doneCriteriaPath, "utf-8"),
+    /Review survives deleting the dispatch input/
+  );
+});
+
 test("missing manifest-anchored Done Criteria fails loudly without fallback", () => {
   const { repoRoot, manifestPath, runId, diffPath } = setupRepo();
   const missingDoneCriteriaPath = path.join(repoRoot, "missing-frozen-done-criteria.md");
@@ -863,6 +913,7 @@ test("missing manifest-anchored Done Criteria fails loudly without fallback", ()
     "--json",
   ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
     assert.match(String(error.stderr), /Manifest anchor\.done_criteria_path points to a missing file/);
+    assert.match(String(error.stderr), new RegExp(`${runId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[/\\\\]done-criteria\\.md`));
     return true;
   });
 });


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #882.

- New dispatches persist Done Criteria at `<runDir>/done-criteria.md`.
- Original-path provenance and source classification are preserved.
- Canonical planner self-copy and resume behavior remain unchanged.
- Review survives deletion of the original file.
- Legacy anchors continue working; missing-file errors now mention the run-dir copy.
- Serialized gate: 1,544 passed, 0 failed, 2 skipped.
- Commit: `8bebd31 fix: persist done criteria at dispatch (#882)`

```

## Score Log

- Run: issue-882-20260710062920531-8f3602af
- Executor: codex
- Branch: issue-882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 디스패치 실행 시 Done Criteria가 실행 디렉터리에 자동으로 저장됩니다.
  * 원본 입력 파일이 삭제되거나 이동되어도 리뷰 단계에서 저장된 기준을 계속 사용할 수 있습니다.
  * 재개 작업에서 원본과 저장된 Done Criteria의 연결 상태를 정확히 확인합니다.

* **버그 수정**
  * 실행 매니페스트가 저장된 Done Criteria 경로와 원본 경로를 올바르게 표시합니다.
  * 저장된 기준이 누락된 경우 실행 ID와 관련 경로가 포함된 안내 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->