### PR TITLE
#882 follow-up: file-source resume remapping is untested; missing-anchor error edge cases (#902)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1201,6 +1201,32 @@ function isRetryCompatibleRunDir(runDir) {
     || (entries.length === 1 && entries[0] === "done-criteria.md");
 }
 
+function claimRetryCompatibleRunDir(runDir) {
+  fs.mkdirSync(path.dirname(runDir), { recursive: true });
+  try {
+    fs.mkdirSync(runDir);
+  } catch (error) {
+    if (error.code !== "EEXIST") throw error;
+    if (!isRetryCompatibleRunDir(runDir)) return null;
+  }
+
+  const claimPath = path.join(runDir, ".dispatch-claim");
+  let claimFd;
+  try {
+    claimFd = fs.openSync(claimPath, "wx");
+    fs.writeFileSync(claimFd, JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString() }));
+  } catch (error) {
+    if (claimFd !== undefined) {
+      fs.closeSync(claimFd);
+      try { fs.unlinkSync(claimPath); } catch {}
+    }
+    if (error.code === "EEXIST") return null;
+    throw error;
+  }
+  fs.closeSync(claimFd);
+  return claimPath;
+}
+
 function isCanonicalPlannerDoneCriteriaPath(repoRoot, runId, doneCriteriaPath) {
   if (!doneCriteriaPath) return false;
   const canonicalPath = path.join(getRunDir(repoRoot, runId), "done-criteria.md");
@@ -1701,6 +1727,19 @@ async function main() {
   let fleetIssueLock = null;
   let handlingSignal = false;
   let runtime = null;
+  let runDirClaimPath = null;
+
+  function releaseRunDirClaim() {
+    if (!runDirClaimPath) return;
+    try {
+      fs.unlinkSync(runDirClaimPath);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    runDirClaimPath = null;
+  }
+
+  process.on("exit", releaseRunDirClaim);
 
   function releaseFleetIssueLock() {
     if (!fleetIssueLock) return;
@@ -1945,8 +1984,13 @@ async function main() {
     manifestPath = getManifestPath(repoRoot, runId);
     const runDir = getRunDir(repoRoot, runId);
     wtPath = path.join(wtBase, wtId, path.basename(repoRoot));
-    if (fs.existsSync(manifestPath) || (fs.existsSync(runDir) && !isRetryCompatibleRunDir(runDir))) {
+    if (fs.existsSync(manifestPath)) {
       failRunDirCollision(runId, manifestPath);
+    }
+    if (DRY_RUN) {
+      if (fs.existsSync(runDir) && !isRetryCompatibleRunDir(runDir)) {
+        failRunDirCollision(runId, manifestPath);
+      }
     }
     baseBranch = resolveBaseBranchForNewDispatch(REPO_PATH, { validateRemote: !DRY_RUN });
     if (fs.existsSync(wtPath)) {
@@ -1955,6 +1999,8 @@ async function main() {
     }
     if (!DRY_RUN) {
       worktreeStartPoint = resolveWorktreeStartPointForNewDispatch(repoRoot, baseBranch);
+      runDirClaimPath = claimRetryCompatibleRunDir(runDir);
+      if (!runDirClaimPath) failRunDirCollision(runId, manifestPath);
     }
     if (inflightRuns.length > 0 && ALLOW_CONFLICTING_RUN) {
       appendRunEvent(repoRoot, runId, {
@@ -2374,6 +2420,7 @@ async function main() {
       projectRoutes: INITIAL_ROUTE_RESOLUTION.projectRoutes,
     });
     writeManifest(manifestPath, manifest);
+    releaseRunDirClaim();
   } else if (manifest) {
     manifest = {
       ...manifest,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1194,10 +1194,11 @@ function failRunDirCollision(runId, manifestPath) {
   process.exit(1);
 }
 
-function isPlannerAnchorOnlyRunDir(runDir) {
+function isRetryCompatibleRunDir(runDir) {
   if (!fs.existsSync(runDir)) return false;
   const entries = fs.readdirSync(runDir).filter((entry) => entry !== ".DS_Store");
-  return entries.length === 1 && entries[0] === "done-criteria.md";
+  return entries.length === 0
+    || (entries.length === 1 && entries[0] === "done-criteria.md");
 }
 
 function isCanonicalPlannerDoneCriteriaPath(repoRoot, runId, doneCriteriaPath) {
@@ -1236,7 +1237,11 @@ function persistDoneCriteria(manifest, runDir, originalPath, doneCriteriaSource)
   const persistedPath = path.join(runDir, "done-criteria.md");
   const isSelfCopy = sameFilesystemLocation(originalPath, persistedPath);
   if (!isSelfCopy) {
-    copyFileAtomically(originalPath, persistedPath);
+    try {
+      copyFileAtomically(originalPath, persistedPath);
+    } catch (error) {
+      throw new Error(`Failed to persist Done Criteria from ${originalPath}: ${error.message}`);
+    }
   }
 
   return {
@@ -1940,7 +1945,7 @@ async function main() {
     manifestPath = getManifestPath(repoRoot, runId);
     const runDir = getRunDir(repoRoot, runId);
     wtPath = path.join(wtBase, wtId, path.basename(repoRoot));
-    if (fs.existsSync(manifestPath) || (fs.existsSync(runDir) && !isPlannerAnchorOnlyRunDir(runDir))) {
+    if (fs.existsSync(manifestPath) || (fs.existsSync(runDir) && !isRetryCompatibleRunDir(runDir))) {
       failRunDirCollision(runId, manifestPath);
     }
     baseBranch = resolveBaseBranchForNewDispatch(REPO_PATH, { validateRemote: !DRY_RUN });

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -361,12 +361,16 @@ function loadDoneCriteria(repoPath, issueNumber, prNumber, doneCriteriaFile, man
   const manifestDoneCriteriaPath = manifestData?.anchor?.done_criteria_path;
   if (manifestDoneCriteriaPath) {
     if (!fs.existsSync(manifestDoneCriteriaPath)) {
-      const persistedPath = manifestData?.run_id
-        ? path.join(getRunDir(repoPath, manifestData.run_id), "done-criteria.md")
-        : path.join("<runDir>", "done-criteria.md");
+      let persistedHint = "";
+      if (manifestData?.anchor?.done_criteria_source !== "request_snapshot" && manifestData?.run_id) {
+        try {
+          const persistedPath = path.join(getRunDir(repoPath, manifestData.run_id), "done-criteria.md");
+          persistedHint = ` Newer runs persist a run-dir copy at ${persistedPath}.`;
+        } catch {}
+      }
       throw new Error(
-        `Manifest anchor.done_criteria_path points to a missing file: ${manifestDoneCriteriaPath}. ` +
-        `Newer runs persist a run-dir copy at ${persistedPath}.`
+        `Manifest anchor.done_criteria_path points to a missing file: ${manifestDoneCriteriaPath}.` +
+        persistedHint
       );
     }
     return {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -5054,6 +5054,65 @@ crypto.randomBytes = function randomBytes(size) {
   assert.match(second.stderr, /--allow-conflicting-run/);
 });
 
+test("dispatch refuses a concurrent new dispatch while its empty run dir is claimed", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const runId = "claim-race-20260711010101000-c0ffee91";
+  const markerPath = path.join(os.tmpdir(), `relay-dispatch-claim-race-${process.pid}-${Date.now()}.json`);
+  const rubricFile = path.join(repoRoot, "claim-race-rubric.yaml");
+  fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: collision guard\n      target: concurrent owner is refused\n", "utf-8");
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "1500",
+    RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: markerPath,
+  };
+  const args = withRequiredRubric([
+    "--run-id", runId,
+    "-b", "claim-race",
+    "--prompt", "first pass",
+    "--rubric-file", rubricFile,
+    "--json",
+  ]);
+  const first = spawn(process.execPath, [SCRIPT, repoRoot, ...args], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const firstExit = waitForDispatchExit(first);
+  let firstResult;
+  try {
+    await waitFor(() => fs.existsSync(markerPath), {
+      timeoutMs: 30000,
+      message: "first dispatch after-worktree create pause marker",
+    });
+    const runDir = getRunDir(repoRoot, runId);
+    assert.deepEqual(fs.readdirSync(runDir).sort(), [".dispatch-claim"]);
+
+    const second = spawnSync(process.execPath, [SCRIPT, repoRoot, ...args], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...env,
+        RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "0",
+        RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: "",
+      },
+    });
+
+    assert.notEqual(second.status, 0);
+    assert.match(second.stderr, /Refusing to overwrite existing run dir/);
+  } finally {
+    firstResult = await firstExit;
+    try { fs.unlinkSync(markerPath); } catch {}
+  }
+
+  assert.equal(firstResult.code, 0, firstResult.stderr);
+  assert.equal(fs.existsSync(path.join(getRunDir(repoRoot, runId), ".dispatch-claim")), false);
+});
+
 test("dispatch cleans up tmp rubric files when atomic rubric persistence fails", () => {
   // #158 anti-theater
   const { repoRoot, relayHome } = setupRepo();

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -7541,6 +7541,141 @@ test("dispatch preserves file source for ad-hoc done criteria paths", () => {
   assert.equal(fs.readFileSync(persistedDoneCriteriaPath, "utf-8"), "# Done Criteria\n\n- Ad-hoc file\n");
 });
 
+test("file-source resume accepts the original external Done Criteria path", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-file-resume.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaFile = path.join(repoRoot, "external-done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Resume from the original file path\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-902-file-resume",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+  const firstManifest = readManifest(first.manifestPath);
+  assert.equal(firstManifest.data.anchor.done_criteria_source, "file");
+  assert.equal(firstManifest.data.anchor.done_criteria_original_path, doneCriteriaFile);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(firstManifest.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    firstManifest.body
+  );
+
+  const resumed = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", first.runId,
+    "--prompt", "resume pass",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+
+  assert.equal(resumed.mode, "resume");
+  assert.equal(resumed.runId, first.runId);
+  assert.equal(fs.existsSync(path.join(first.worktree, "resume.txt")), true);
+  assert.equal(fs.existsSync(capturePath), true);
+});
+
+test("file-source resume rejects a different external Done Criteria path", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const doneCriteriaFile = path.join(repoRoot, "external-done-criteria.md");
+  const differentDoneCriteriaFile = path.join(repoRoot, "different-done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Original external anchor\n", "utf-8");
+  fs.writeFileSync(differentDoneCriteriaFile, "# Done Criteria\n\n- Different external anchor\n", "utf-8");
+
+  const first = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-902-file-resume-reject",
+    "--prompt", "first pass",
+    "--done-criteria-file", doneCriteriaFile,
+    "--json",
+  ], env));
+  const firstManifest = readManifest(first.manifestPath);
+  writeManifest(
+    first.manifestPath,
+    updateManifestState(firstManifest.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
+    firstManifest.body
+  );
+
+  const rejected = spawnSync("node", [SCRIPT, repoRoot,
+    "--run-id", first.runId,
+    "--prompt", "resume pass",
+    "--done-criteria-file", differentDoneCriteriaFile,
+    "--json",
+  ], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /cannot change immutable anchor\.done_criteria_path/);
+});
+
+test("Done Criteria copy failure leaves an empty run dir that can be retried", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const doneCriteriaFile = path.join(repoRoot, "copy-retry-done-criteria.md");
+  const doneCriteriaText = "# Done Criteria\n\n- Retry the same run after a copy race\n";
+  fs.writeFileSync(doneCriteriaFile, doneCriteriaText, "utf-8");
+  const rubricFile = path.join(repoRoot, "copy-retry-rubric.yaml");
+  fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: copy retry\n      target: retry succeeds\n", "utf-8");
+  const runId = "issue-902-20260710010101000-c0ffee90";
+  const runDir = getRunDir(repoRoot, runId);
+  const preloadPath = writePreloadScript(binDir, "done-criteria-copy-failure-preload.js", `const fs = require("fs");
+const path = require("path");
+const originalCopyFileSync = fs.copyFileSync;
+fs.copyFileSync = function copyFileSync(sourcePath, destPath, ...args) {
+  if (
+    path.resolve(sourcePath) === ${JSON.stringify(doneCriteriaFile)}
+    && typeof destPath === "string"
+    && destPath.endsWith(path.join("", "done-criteria.md.tmp"))
+  ) {
+    fs.unlinkSync(sourcePath);
+  }
+  return originalCopyFileSync.call(this, sourcePath, destPath, ...args);
+};`);
+  const baseEnv = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const failingEnv = withNodePreload(baseEnv, preloadPath);
+  const args = withRequiredRubric([
+    "--run-id", runId,
+    "-b", "copy-failure-retry",
+    "--prompt", "copy retry",
+    "--done-criteria-file", doneCriteriaFile,
+    "--rubric-file", rubricFile,
+    "--json",
+  ]);
+
+  const failed = spawnSync("node", [SCRIPT, repoRoot, ...args], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: failingEnv,
+  });
+
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, new RegExp(doneCriteriaFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.equal(fs.existsSync(path.join(runDir, "done-criteria.md")), false);
+  assert.equal(fs.existsSync(path.join(runDir, "done-criteria.md.tmp")), false);
+  assert.deepEqual(fs.readdirSync(runDir), []);
+
+  fs.writeFileSync(path.join(runDir, ".DS_Store"), "", "utf-8");
+  fs.writeFileSync(doneCriteriaFile, doneCriteriaText, "utf-8");
+  const retried = execFileSync("node", [SCRIPT, repoRoot, ...args], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: baseEnv,
+  });
+  const result = JSON.parse(retried);
+  assert.equal(result.status, "completed");
+  assert.equal(result.runId, runId);
+  assert.equal(fs.readFileSync(path.join(runDir, "done-criteria.md"), "utf-8"), doneCriteriaText);
+});
+
 test("dispatch dry-run includes request linkage and frozen done criteria file info", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -26,6 +26,7 @@ const {
   EXECUTION_EVIDENCE_FILENAME,
   FORCE_FINALIZE_GUIDANCE,
 } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+const { loadDoneCriteria } = require("../../../skills/relay-review/scripts/review-runner/context");
 const {
   installFakeGhOnPath,
   writeFakeGhScript: writeSharedFakeGhScript,
@@ -888,7 +889,7 @@ test("review loads the persisted run-dir Done Criteria after the dispatch input 
   );
 });
 
-test("missing manifest-anchored Done Criteria fails loudly without fallback", () => {
+test("missing request snapshot Done Criteria fails loudly without a run-dir hint", () => {
   const { repoRoot, manifestPath, runId, diffPath } = setupRepo();
   const missingDoneCriteriaPath = path.join(repoRoot, "missing-frozen-done-criteria.md");
 
@@ -913,9 +914,47 @@ test("missing manifest-anchored Done Criteria fails loudly without fallback", ()
     "--json",
   ], { encoding: "utf-8", stdio: "pipe" }), (error) => {
     assert.match(String(error.stderr), /Manifest anchor\.done_criteria_path points to a missing file/);
-    assert.match(String(error.stderr), new RegExp(`${runId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[/\\\\]done-criteria\\.md`));
+    assert.doesNotMatch(String(error.stderr), /Newer runs persist a run-dir copy at/);
     return true;
   });
+});
+
+test("missing non-request Done Criteria keeps the run-dir copy hint", () => {
+  const { repoRoot, runId } = setupRepo();
+  const missingDoneCriteriaPath = path.join(repoRoot, "missing-file-source-done-criteria.md");
+
+  assert.throws(() => loadDoneCriteria(repoRoot, null, null, null, {
+    run_id: runId,
+    anchor: {
+      done_criteria_path: missingDoneCriteriaPath,
+      done_criteria_source: "file",
+    },
+  }), (error) => {
+    assert.match(error.message, /Manifest anchor\.done_criteria_path points to a missing file/);
+    assert.match(error.message, /Newer runs persist a run-dir copy at/);
+    assert.match(error.message, new RegExp(`${runId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[/\\\\]done-criteria\\.md`));
+    return true;
+  });
+});
+
+test("malformed or missing run_id cannot replace the missing Done Criteria error", () => {
+  const { repoRoot } = setupRepo();
+  const missingDoneCriteriaPath = path.join(repoRoot, "missing-malformed-run-done-criteria.md");
+
+  for (const runId of ["../malformed", undefined]) {
+    assert.throws(() => loadDoneCriteria(repoRoot, null, null, null, {
+      run_id: runId,
+      anchor: {
+        done_criteria_path: missingDoneCriteriaPath,
+        done_criteria_source: "file",
+      },
+    }), (error) => {
+      assert.match(error.message, /Manifest anchor\.done_criteria_path points to a missing file/);
+      assert.doesNotMatch(error.message, /Newer runs persist a run-dir copy at/);
+      assert.doesNotMatch(error.message, /runId/);
+      return true;
+    });
+  }
 });
 
 test("pass verdict moves review_pending to ready_to_merge", () => {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-902-20260710102605132-8c509e84
- Branch: issue-902
- Reason: reconcile-run recovered work for issue-902-20260710102605132-8c509e84
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-902-20260710102605132-8c509e84.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-10T11:11:30.236Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 재시도 가능한 실행 디렉터리의 동시 점유를 감지해 중복 실행을 차단합니다.
  - 실행 종료 후 점유 상태가 정리됩니다.
  - Done Criteria 저장 실패 시 원본 경로를 포함한 명확한 오류를 제공합니다.
  - 누락된 Done Criteria 오류 안내가 실행 유형과 식별자 상태에 맞게 표시됩니다.
  - Done Criteria 복사 실패 후 재시도가 정상적으로 완료됩니다.

- **검증**
  - 재시도, 앵커 변경 방지, 동시 실행 차단 시나리오에 대한 테스트가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->