### PR TITLE
fix: refresh the persisted Done Criteria copy on resume (#914)

### DIFF
--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -117,6 +117,15 @@ When `--pr-title` is omitted, the PR title defaults to the linked GitHub issue t
 
 If a PR already exists for the branch, the command no-ops the create step and stamps `pr_number` from the existing PR — safe to re-run after a partial failure. Use `--dry-run` first when uncertain.
 
+## Waiting on PR checks before merge
+
+`wait-for-check.js` polls a pull request until every GitHub check reaches a terminal bucket, replacing session-improvised polling loops before `finalize-run.js` (#840):
+
+```bash
+node skills/relay-dispatch/scripts/wait-for-check.js --repo . --pr <number> --json
+# --timeout-s <s> (default 1800) / --interval-s <s> (default 15)
+```
+
 ## Operator state recovery
 
 `recover-state.js` advances a relay run's state after an external event (fix commit pushed directly, dispatch stalled, no-op re-dispatch escalated the manifest, merge blocker cleared). Replaces hand-edited `manual_state_override` entries with structured `state_recovery` events and validated transitions.

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -2003,6 +2003,23 @@ async function main() {
   enforceRubricPersistence(manifest, manifestRunDir);
   let routePlanSnapshot = null;
 
+  // A resumed run may carry a Done Criteria amendment: the operator edits the
+  // original anchor file (or passes --done-criteria-file). The durable run-dir
+  // copy must be refreshed BEFORE prompt delivery so the redispatch prompt and
+  // every later review read the same amended criteria; when the original file
+  // is gone (e.g. /tmp wiped), the persisted copy remains authoritative (#914).
+  if (RESUME_MODE && manifest?.anchor?.done_criteria_original_path && manifest?.anchor?.done_criteria_path) {
+    const livePath = resolvedDoneCriteriaPath || manifest.anchor.done_criteria_original_path;
+    const persistedPath = manifest.anchor.done_criteria_path;
+    if (fs.existsSync(livePath) && !sameFilesystemLocation(livePath, persistedPath)) {
+      const liveBytes = fs.readFileSync(livePath, "utf-8");
+      const persistedBytes = fs.existsSync(persistedPath) ? fs.readFileSync(persistedPath, "utf-8") : null;
+      if (liveBytes !== persistedBytes) {
+        copyFileAtomically(livePath, persistedPath);
+      }
+    }
+  }
+
   const effectiveDoneCriteriaPath = resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null;
   const taskPromptResult = readTaskPrompt({
     runDir: manifestRunDir,

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -2588,8 +2588,9 @@ test("dispatch resume refreshes the auto-discovered redispatch prompt from an am
   const originalArtifact = redispatchPromptWithDoneCriteria("Original clause");
   fs.writeFileSync(redispatchPath, originalArtifact, "utf-8");
   fs.writeFileSync(path.join(runDir, "review-round-2-done-criteria.md"), "Original clause\n", "utf-8");
-  // Amendments land on the persisted run-dir anchor (#897), not the original CLI path.
-  fs.writeFileSync(persistedDoneCriteriaPath, "Original clause\nAmended clause", "utf-8");
+  // The operator amends the ORIGINAL anchor file; resume re-persists the
+  // run-dir copy from it before prompt delivery (#914).
+  fs.writeFileSync(doneCriteriaPath, "Original clause\nAmended clause", "utf-8");
 
   const second = JSON.parse(runDispatch(repoRoot, [
     "--run-id", first.runId,
@@ -2605,7 +2606,12 @@ test("dispatch resume refreshes the auto-discovered redispatch prompt from an am
   assert.equal(fs.readFileSync(redispatchPath, "utf-8"), originalArtifact);
   const resumedManifest = readManifest(first.manifestPath).data;
   assert.equal(resumedManifest.anchor.done_criteria_path, persistedDoneCriteriaPath);
+  assert.equal(resumedManifest.anchor.done_criteria_original_path, doneCriteriaPath);
   assert.equal(resumedManifest.anchor.done_criteria_source, "file");
+  assert.equal(
+    fs.readFileSync(persistedDoneCriteriaPath, "utf-8"),
+    "Original clause\nAmended clause"
+  );
 });
 
 test("dispatch resume refreshes only the generated criteria when an issue quotes the recorded criteria (#883)", () => {
@@ -2638,7 +2644,7 @@ test("dispatch resume refreshes only the generated criteria when an issue quotes
   const runDir = getRunDir(repoRoot, first.runId);
   fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), artifact, "utf-8");
   fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${original}\n`, "utf-8");
-  fs.writeFileSync(path.join(runDir, "done-criteria.md"), `${amended}\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${amended}\n`, "utf-8");
 
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
 
@@ -2674,7 +2680,7 @@ test("dispatch resume rejects criteria found at two generated Done Criteria posi
   const runDir = getRunDir(repoRoot, first.runId);
   fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), artifact, "utf-8");
   fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${original}\n`, "utf-8");
-  fs.writeFileSync(path.join(runDir, "done-criteria.md"), `${original}\nAmended duplicate clause\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${original}\nAmended duplicate clause\n`, "utf-8");
 
   const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
     cwd: repoRoot,
@@ -2718,7 +2724,7 @@ test("dispatch resume refreshes an auto-discovered rubric-gate redispatch prompt
   const redispatchPath = path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md");
   fs.writeFileSync(redispatchPath, artifact, "utf-8");
   fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "review-round-1-done-criteria.md"), "Original rubric-gate clause\n", "utf-8");
-  fs.writeFileSync(path.join(getRunDir(repoRoot, first.runId), "done-criteria.md"), "Original rubric-gate clause\nAmended rubric-gate clause", "utf-8");
+  fs.writeFileSync(doneCriteriaPath, "Original rubric-gate clause\nAmended rubric-gate clause", "utf-8");
 
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
 
@@ -2829,7 +2835,7 @@ test("dispatch resume refreshes criteria that contain marker-looking lines (#883
   fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), redispatchPromptWithDoneCriteria(trickyOriginal), "utf-8");
   fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${trickyOriginal}\n`, "utf-8");
   const trickyAmended = `${trickyOriginal}\nAmended tricky clause`;
-  fs.writeFileSync(path.join(runDir, "done-criteria.md"), `${trickyAmended}\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${trickyAmended}\n`, "utf-8");
 
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
 
@@ -2875,7 +2881,7 @@ test("dispatch resume refreshes rubric-gate criteria containing structural heade
   fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), buildRubricGateRedispatchPrompt(gateFailure, trickyOriginal, "file"), "utf-8");
   fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), `${trickyOriginal}\n`, "utf-8");
   const trickyAmended = `${trickyOriginal}\nAmended gate clause`;
-  fs.writeFileSync(path.join(runDir, "done-criteria.md"), `${trickyAmended}\n`, "utf-8");
+  fs.writeFileSync(doneCriteriaPath, `${trickyAmended}\n`, "utf-8");
 
   runDispatch(repoRoot, ["--run-id", first.runId, "--json"], env);
 
@@ -2912,7 +2918,7 @@ test("dispatch resume fails clearly when the recorded round criteria do not matc
   fs.writeFileSync(path.join(runDir, "review-round-1-redispatch.md"), redispatchPromptWithDoneCriteria("Hand-edited clause"), "utf-8");
   const roundDoneCriteriaPath = path.join(runDir, "review-round-1-done-criteria.md");
   fs.writeFileSync(roundDoneCriteriaPath, "Original clause\n", "utf-8");
-  fs.writeFileSync(path.join(runDir, "done-criteria.md"), "Amended clause\n", "utf-8");
+  fs.writeFileSync(doneCriteriaPath, "Amended clause\n", "utf-8");
 
   const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
     cwd: repoRoot,
@@ -2972,17 +2978,11 @@ test("dispatch resume --prompt-file is unmodified even when the Done Criteria an
   assert.doesNotMatch(finalPrompt, /AUTO_DISCOVERED_BODY/);
 });
 
-test("dispatch resume fails clearly when the effective Done Criteria anchor is missing (#883)", () => {
-  const { repoRoot, relayHome } = setupRepo();
-  process.env.RELAY_HOME = relayHome;
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
-  writeFakeCodex(binDir);
-  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+function makePersistedAnchorResumeFixture(repoRoot, env, { branch, captureCodex } = {}) {
   const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
   fs.writeFileSync(doneCriteriaPath, "Original clause\n", "utf-8");
-
   const first = JSON.parse(runDispatch(repoRoot, [
-    "-b", "issue-883-missing-dc",
+    "-b", branch,
     "--prompt", "first pass",
     "--done-criteria-file", doneCriteriaPath,
     "--json",
@@ -2993,22 +2993,75 @@ test("dispatch resume fails clearly when the effective Done Criteria anchor is m
     updateManifestState(record.data, STATES.CHANGES_REQUESTED, "re_dispatch_requested_changes"),
     record.body
   );
+  const runDir = getRunDir(repoRoot, first.runId);
   fs.writeFileSync(
-    path.join(getRunDir(repoRoot, first.runId), "review-round-1-redispatch.md"),
+    path.join(runDir, "review-round-1-redispatch.md"),
     redispatchPromptWithDoneCriteria("Original clause"),
     "utf-8"
   );
-  const persistedDoneCriteriaPath = path.join(getRunDir(repoRoot, first.runId), "done-criteria.md");
-  fs.unlinkSync(persistedDoneCriteriaPath);
+  fs.writeFileSync(path.join(runDir, "review-round-1-done-criteria.md"), "Original clause\n", "utf-8");
+  return {
+    first,
+    doneCriteriaPath,
+    persistedDoneCriteriaPath: path.join(runDir, "done-criteria.md"),
+  };
+}
 
-  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", first.runId, "--json"], {
+test("dispatch resume re-creates a deleted run-dir copy from the original anchor (#914)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-recreate-copy.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const fixture = makePersistedAnchorResumeFixture(repoRoot, env, { branch: "issue-914-recreate-copy" });
+  fs.unlinkSync(fixture.persistedDoneCriteriaPath);
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", fixture.first.runId,
+    "--json",
+  ], env));
+  assert.equal(second.mode, "resume");
+  assert.equal(fs.readFileSync(fixture.persistedDoneCriteriaPath, "utf-8"), "Original clause\n");
+});
+
+test("dispatch resume proceeds from the persisted run-dir copy when the original anchor file is gone (#914)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  const capturePath = path.join(os.tmpdir(), `relay-dispatch-argv-${Date.now()}-missing-original.json`);
+  writeResumeCaptureCodex(binDir, capturePath);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const fixture = makePersistedAnchorResumeFixture(repoRoot, env, { branch: "issue-914-durable-copy" });
+  fs.unlinkSync(fixture.doneCriteriaPath);
+
+  const second = JSON.parse(runDispatch(repoRoot, [
+    "--run-id", fixture.first.runId,
+    "--json",
+  ], env));
+  assert.equal(second.mode, "resume");
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+  assert.match(captured[captured.length - 1], /Original clause/);
+});
+
+test("dispatch resume fails clearly when both the anchor original and the persisted copy are missing (#883)", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome };
+  const fixture = makePersistedAnchorResumeFixture(repoRoot, env, { branch: "issue-883-missing-dc" });
+  fs.unlinkSync(fixture.doneCriteriaPath);
+  fs.unlinkSync(fixture.persistedDoneCriteriaPath);
+
+  const result = spawnSync("node", [SCRIPT, repoRoot, "--run-id", fixture.first.runId, "--json"], {
     cwd: repoRoot,
     encoding: "utf-8",
     env,
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /effective Done Criteria file not found/);
-  assert.match(result.stderr, new RegExp(persistedDoneCriteriaPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(result.stderr, new RegExp(fixture.persistedDoneCriteriaPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("dispatch resume without redispatch artifact still errors with auto-discovery hint (#387)", () => {


### PR DESCRIPTION
Closes #914.

## Root cause

PR #890 (#883: embed effective Done Criteria into redispatch prompts) and PR #897 (#882: persist Done Criteria at dispatch) merged four minutes apart on 2026-07-10, each green against its own base. #897 re-points `anchor.done_criteria_path` at a durable run-dir copy for file-source anchors; #890's delivery-time refresh reads the anchor path. Result: operator amendments to the ORIGINAL file never reached the run-dir copy — the refresh no-op'd and eight #883 tests went red on origin/main.

PR #913 (merged mid-diagnosis) adapted those tests to amend the run-dir copy directly, turning the suite green — but that codifies a footgun: the documented operator amendment flow (edit your own DC file, resume) stays silently broken, and an amendment passed only at resume diverges the executor's prompt from the reviewer's anchor.

## Fix (both contracts preserved, original = single amendment surface)

On resume, when the anchor carries `done_criteria_original_path`, the run-dir copy is re-persisted from the live original (or from an explicitly passed `--done-criteria-file`) BEFORE prompt delivery:
- #883's contract holds: amendments reach the redispatch prompt AND every later review.
- #882's contract holds: a wiped original (e.g. /tmp) degrades gracefully to the durable copy.

Tests: the #883 refresh tests amend the ORIGINAL again (reverting #913's copy-amend adaptation); the anchor-missing scenario splits into three pins — deleted copy is re-created from the original, missing original proceeds from the copy, both missing fails clearly naming the effective path.

## Also: skills-lint main-red

`wait-for-check.js` (#840, PR #895) shipped with zero doc references → `all packaged skill scripts are reachable` red on main. Documented in `recovery-playbook.md` ("Waiting on PR checks before merge").

## Verification (post-rebase onto #913)

- `--test-name-pattern "#883 |#914"`: 13/13
- Full `dispatch.test.js` + full `review-runner.test.js`: exit 0
- `tests/skills-lint`: 24/24
- origin/main baseline gate (pre-fix): 9 unique failures (8× #883 + skills-lint reachability), reproduced deterministically at low load in two checkouts — gate log retained.

## Audit context

Orchestrator hotfix (narrow companion PR pattern): main-red was blocking every relay leaf's final gate, discovered via fleet-closure-trio-w1's #901 salvage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)