### PR TITLE
fleet drive: carry the review preflight nextAction/reason into operator_attention instead of bare stuck_child (#901)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -305,6 +305,9 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.execution_evidence_hash !== undefined
       ? { execution_evidence_hash: normalizeEventValue(eventData.execution_evidence_hash) }
       : {}),
+    ...(eventData.next_action !== undefined
+      ? { next_action: normalizeEventValue(eventData.next_action) }
+      : {}),
     ...(eventData.before !== undefined
       ? { before: normalizeEventValue(eventData.before) }
       : {}),

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -40,6 +40,7 @@ const {
 const { getRequestPath, readRequestArtifact } = require("../../relay-ready/scripts/relay-request");
 const { runReconcile } = require("../../relay-dispatch/scripts/reconcile-advisory");
 const { getRunLeaseStatus } = require("../../relay-dispatch/scripts/run-runtime-state");
+const { EVENTS, readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
 const { runMergeQueue } = require("./merge-queue");
 
 const DEFAULT_PARALLEL = 4;
@@ -2085,6 +2086,42 @@ function additionalAttentionReasons(child, { repoRoot, fleetId, defaultBranchNam
   return reasons;
 }
 
+// Derive-on-read (#901): when a stuck child was blocked by review preflight,
+// surface the actionable next_action/reason from the latest review_preflight_failed
+// event — but only while that blocked attempt has not been superseded by a
+// completed review round (event.round > review.rounds). Fail-open on missing
+// or unreadable events so attention stays the bare stuck_child shape.
+function stuckChildPreflightEnrichment(repoRoot, child) {
+  if (!repoRoot || !child?.run_id) return {};
+  let events;
+  try {
+    events = readRunEvents(repoRoot, child.run_id);
+  } catch {
+    return {};
+  }
+  let latest = null;
+  for (const event of events) {
+    if (event?.event === EVENTS.REVIEW_PREFLIGHT_FAILED) latest = event;
+  }
+  if (!latest) return {};
+  if (!(Number(latest.round) > Number(child.review_round ?? 0))) return {};
+
+  const enrichment = {};
+  if (latest.reason != null && latest.reason !== "") {
+    enrichment.detail = String(latest.reason);
+  }
+  // Missing-vs-empty: older events without next_action must omit the key
+  // entirely — never empty-string it.
+  if (
+    Object.prototype.hasOwnProperty.call(latest, "next_action")
+    && latest.next_action != null
+    && latest.next_action !== ""
+  ) {
+    enrichment.next_action = String(latest.next_action);
+  }
+  return enrichment;
+}
+
 function buildOperatorAttention(summary, context = {}) {
   const { repoRoot, fleetId } = context;
   const needsDefaultBranch = summary.children.some((child) => child.base_branch);
@@ -2098,10 +2135,26 @@ function buildOperatorAttention(summary, context = {}) {
       items.push({ leaf_ref: child.leaf_ref, run_id: child.run_id, reason: legacyReason });
     }
     for (const reason of additionalAttentionReasons(child, resolvedContext)) {
-      items.push({ leaf_ref: child.leaf_ref, run_id: child.run_id, reason });
+      const item = { leaf_ref: child.leaf_ref, run_id: child.run_id, reason };
+      if (reason === "stuck_child") {
+        Object.assign(item, stuckChildPreflightEnrichment(repoRoot, child));
+      }
+      items.push(item);
     }
   }
   return items;
+}
+
+function formatAttentionLine(item) {
+  let line = `  - ${item.leaf_ref}: ${item.reason}${item.run_id ? ` (${item.run_id})` : ""}`;
+  if (item.next_action && item.detail) {
+    line += ` → next: ${item.next_action} — ${item.detail}`;
+  } else if (item.next_action) {
+    line += ` → next: ${item.next_action}`;
+  } else if (item.detail) {
+    line += ` — ${item.detail}`;
+  }
+  return line;
 }
 
 function formatStatusText(summary, operatorAttention) {
@@ -2130,7 +2183,7 @@ function formatStatusText(summary, operatorAttention) {
   if (operatorAttention.length) {
     lines.push("Needs operator attention:");
     for (const item of operatorAttention) {
-      lines.push(`  - ${item.leaf_ref}: ${item.reason}${item.run_id ? ` (${item.run_id})` : ""}`);
+      lines.push(formatAttentionLine(item));
     }
   }
   return `${lines.join("\n")}\n`;

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -60,6 +60,7 @@ function maybeBlockForBehindBasePreflight({
     preflight_type: "behind_base",
     failure_class: "behind_base",
     reviewer_rounds_avoided: 1,
+    next_action: preflight.nextAction,
   });
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));
@@ -105,6 +106,7 @@ function maybeBlockForExecutionEvidencePreflight({
     reviewer_rounds_avoided: 1,
     evidence_head_sha: result.executionEvidencePreflight.evidenceHeadSha,
     execution_evidence_path: result.executionEvidencePreflight.artifactPath,
+    next_action: result.executionEvidencePreflight.nextAction,
   });
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -3967,3 +3967,268 @@ test("relay-fleet --status surfaces missing_pr, merge_blocked, high_review_round
   // branch matches default, not eligible for stuck_child) produces zero items.
   assert.equal(attention.some((item) => item.leaf_ref === "leaf-healthy"), false);
 });
+
+test("relay-fleet stuck_child operator_attention derives next_action/detail from review_preflight_failed (#901)", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-stuck-preflight-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-stuck-preflight-fake-"));
+  const fleetId = "fleet-stuck-preflight";
+  const {
+    formatStatusText: formatText,
+  } = require(RELAY_FLEET_SCRIPT);
+
+  function makeChildManifest(runId, leafId, { patch = (manifest) => manifest } = {}) {
+    fs.mkdirSync(getRunDir(repoRoot, runId), { recursive: true });
+    let manifest = createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch: `${leafId}-branch`,
+      baseBranch: "main",
+      issueNumber: Number(runId.slice(6, 9)),
+      worktreePath: path.join(repoRoot, "wt", runId),
+      fleetId,
+      leafId,
+    });
+    fs.writeFileSync(path.join(getRunDir(repoRoot, runId), "rubric.yaml"), "rubric:\n  size_class: S\n", "utf-8");
+    manifest = { ...manifest, anchor: { ...(manifest.anchor || {}), rubric_path: "rubric.yaml" } };
+    manifest = updateManifestState(manifest, RUN_STATES.DISPATCHED, "await_dispatch_result");
+    manifest = patch(manifest);
+    writeManifest(getManifestPath(repoRoot, runId), manifest);
+    return runId;
+  }
+
+  function writePreflightEvent(runId, event) {
+    const eventsPath = path.join(getRunDir(repoRoot, runId), "events.jsonl");
+    fs.writeFileSync(eventsPath, `${JSON.stringify(event)}\n`, "utf-8");
+  }
+
+  const enrichedRun = "issue-901-20260710010101000-a1b2c3d4";
+  const supersededRun = "issue-902-20260710010101000-a1b2c3d4";
+  const bareRun = "issue-903-20260710010101000-a1b2c3d4";
+  const legacyEventRun = "issue-904-20260710010101000-a1b2c3d4";
+  const multiReasonRun = "issue-905-20260710010101000-a1b2c3d4";
+  const mergeOnlyRun = "issue-906-20260710010101000-a1b2c3d4";
+
+  makeChildManifest(enrichedRun, "leaf-enriched", {
+    patch: (manifest) => ({
+      ...manifest,
+      git: { ...manifest.git, pr_number: 901 },
+    }),
+  });
+  writePreflightEvent(enrichedRun, {
+    event: "review_preflight_failed",
+    round: 1,
+    reason: "branch is 2 commits behind origin/main; rebase and re-run",
+    next_action: "rebase_and_rerun",
+    preflight_type: "behind_base",
+  });
+
+  makeChildManifest(supersededRun, "leaf-superseded", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      return {
+        ...manifest,
+        git: { ...manifest.git, pr_number: 902 },
+        review: { ...manifest.review, rounds: 1 },
+      };
+    },
+  });
+  writePreflightEvent(supersededRun, {
+    event: "review_preflight_failed",
+    round: 1,
+    reason: "stale artifact: recorded at old, reviewed at new",
+    next_action: "repair_execution_evidence",
+    preflight_type: "execution_evidence_fail",
+  });
+
+  // No events.jsonl — bare stuck_child, fail-open.
+  makeChildManifest(bareRun, "leaf-bare", {
+    patch: (manifest) => ({
+      ...manifest,
+      git: { ...manifest.git, pr_number: 903 },
+    }),
+  });
+
+  // Older event without next_action → detail only, key absent.
+  makeChildManifest(legacyEventRun, "leaf-legacy-event", {
+    patch: (manifest) => ({
+      ...manifest,
+      git: { ...manifest.git, pr_number: 904 },
+    }),
+  });
+  writePreflightEvent(legacyEventRun, {
+    event: "review_preflight_failed",
+    round: 1,
+    reason: "pre-261 run, no artifact",
+    preflight_type: "execution_evidence_missing",
+  });
+
+  // stuck_child + merge_blocked: enrich ONLY the stuck_child item.
+  makeChildManifest(multiReasonRun, "leaf-multi", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      manifest = updateManifestState(manifest, RUN_STATES.READY_TO_MERGE, "ready");
+      manifest = updateManifestState(manifest, RUN_STATES.MERGE_BLOCKED, "merge_failed");
+      return { ...manifest, git: { ...manifest.git, pr_number: 905 } };
+    },
+  });
+  writePreflightEvent(multiReasonRun, {
+    event: "review_preflight_failed",
+    round: 1,
+    reason: "branch is 1 commit behind origin/main; rebase and re-run",
+    next_action: "rebase_and_rerun",
+    preflight_type: "behind_base",
+  });
+
+  // Non-stuck attention reason stays byte-identical even if a preflight event exists.
+  makeChildManifest(mergeOnlyRun, "leaf-merge-only", {
+    patch: (manifest) => {
+      manifest = updateManifestState(manifest, RUN_STATES.REVIEW_PENDING, "await_review");
+      manifest = updateManifestState(manifest, RUN_STATES.READY_TO_MERGE, "ready");
+      manifest = updateManifestState(manifest, RUN_STATES.MERGE_BLOCKED, "merge_failed");
+      // Mark terminal-for-fleet-review so stuck_child does not fire: MERGED.
+      // Wait — we need merge_blocked without stuck_child. MERGE_BLOCKED is not
+      // terminal for fleet review, so stuck_child would also fire. Keep a live
+      // runtime pid so stuck_child is suppressed.
+      return { ...manifest, git: { ...manifest.git, pr_number: 906 } };
+    },
+  });
+  writePreflightEvent(mergeOnlyRun, {
+    event: "review_preflight_failed",
+    round: 1,
+    reason: "should not attach to merge_blocked",
+    next_action: "rebase_and_rerun",
+    preflight_type: "behind_base",
+  });
+  // Keep a live runtime child so leaf-merge-only is not stuck_child.
+  const { getFleetRuntimePath } = require(RELAY_FLEET_SCRIPT);
+  const runtimePath = getFleetRuntimePath(repoRoot, fleetId);
+  fs.mkdirSync(path.dirname(runtimePath), { recursive: true });
+  fs.writeFileSync(runtimePath, `${JSON.stringify({
+    children: { "leaf-merge-only": { pid: process.pid, started_at: new Date().toISOString() } },
+  }, null, 2)}\n`, "utf-8");
+
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [
+      { leaf_ref: "leaf-enriched", run_id: enrichedRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-superseded", run_id: supersededRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-bare", run_id: bareRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-legacy-event", run_id: legacyEventRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-multi", run_id: multiReasonRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-merge-only", run_id: mergeOnlyRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    ],
+  });
+
+  const fakeGh = writeFakeGhDefaultBranch(tmpDir, "main");
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--status",
+    "--json",
+  ], { relayHome, env: { RELAY_GH_BIN: fakeGh } });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  const attention = payload.operator_attention;
+
+  function item(leafRef, reason) {
+    return attention.find((entry) => entry.leaf_ref === leafRef && entry.reason === reason);
+  }
+
+  // Matrix row 1: newer preflight event → next_action + detail.
+  const enriched = item("leaf-enriched", "stuck_child");
+  assert.ok(enriched);
+  assert.equal(enriched.next_action, "rebase_and_rerun");
+  assert.equal(enriched.detail, "branch is 2 commits behind origin/main; rebase and re-run");
+
+  // Matrix row 2: superseded (round <= review.rounds) → no attachment.
+  const superseded = item("leaf-superseded", "stuck_child");
+  assert.ok(superseded);
+  assert.equal(Object.prototype.hasOwnProperty.call(superseded, "next_action"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(superseded, "detail"), false);
+
+  // Matrix row 3: missing events → bare stuck_child, no crash.
+  const bare = item("leaf-bare", "stuck_child");
+  assert.ok(bare);
+  assert.deepEqual(bare, { leaf_ref: "leaf-bare", run_id: bareRun, reason: "stuck_child" });
+
+  // Matrix row 4: event without next_action → detail only, key ABSENT.
+  const legacy = item("leaf-legacy-event", "stuck_child");
+  assert.ok(legacy);
+  assert.equal(legacy.detail, "pre-261 run, no artifact");
+  assert.equal(Object.prototype.hasOwnProperty.call(legacy, "next_action"), false);
+
+  // Enrich ONLY stuck_child when multiple reasons fire on the same child.
+  const multiStuck = item("leaf-multi", "stuck_child");
+  const multiMerge = item("leaf-multi", "merge_blocked");
+  assert.ok(multiStuck);
+  assert.ok(multiMerge);
+  assert.equal(multiStuck.next_action, "rebase_and_rerun");
+  assert.equal(multiStuck.detail, "branch is 1 commit behind origin/main; rebase and re-run");
+  assert.deepEqual(multiMerge, {
+    leaf_ref: "leaf-multi",
+    run_id: multiReasonRun,
+    reason: "merge_blocked",
+  });
+
+  // Non-stuck reasons stay byte-identical even with a preflight event on disk.
+  const mergeOnly = item("leaf-merge-only", "merge_blocked");
+  assert.ok(mergeOnly);
+  assert.deepEqual(mergeOnly, {
+    leaf_ref: "leaf-merge-only",
+    run_id: mergeOnlyRun,
+    reason: "merge_blocked",
+  });
+  assert.equal(item("leaf-merge-only", "stuck_child"), undefined);
+
+  // formatStatusText: enriched inline; plain items byte-identical.
+  const plainLine = "  - leaf-bare: stuck_child (issue-903-20260710010101000-a1b2c3d4)";
+  const enrichedLine = "  - leaf-enriched: stuck_child (issue-901-20260710010101000-a1b2c3d4) → next: rebase_and_rerun — branch is 2 commits behind origin/main; rebase and re-run";
+  const detailOnlyLine = "  - leaf-legacy-event: stuck_child (issue-904-20260710010101000-a1b2c3d4) — pre-261 run, no artifact";
+  const text = formatText(payload.summary, attention);
+  assert.match(text, new RegExp(`^${plainLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  assert.match(text, new RegExp(`^${enrichedLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  assert.match(text, new RegExp(`^${detailOnlyLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  // Plain merge_blocked line unchanged from pre-#901 shape.
+  assert.match(text, /  - leaf-merge-only: merge_blocked \(issue-906-20260710010101000-a1b2c3d4\)/);
+
+  // Unreadable events fail open (corrupt JSONL does not crash).
+  const corruptRun = "issue-907-20260710010101000-a1b2c3d4";
+  makeChildManifest(corruptRun, "leaf-corrupt", {
+    patch: (manifest) => ({
+      ...manifest,
+      git: { ...manifest.git, pr_number: 907 },
+    }),
+  });
+  fs.writeFileSync(path.join(getRunDir(repoRoot, corruptRun), "events.jsonl"), "{not-json\n", "utf-8");
+  createFleetManifest(repoRoot, {
+    fleetId: "fleet-stuck-corrupt",
+    children: [
+      { leaf_ref: "leaf-corrupt", run_id: corruptRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    ],
+  });
+  const corruptResult = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", "fleet-stuck-corrupt",
+    "--status",
+    "--json",
+  ], { relayHome, env: { RELAY_GH_BIN: fakeGh } });
+  assert.equal(corruptResult.status, 0, `${corruptResult.stderr}\n${corruptResult.stdout}`);
+  const corruptAttention = JSON.parse(corruptResult.stdout).operator_attention;
+  const corruptItem = corruptAttention.find((entry) => entry.reason === "stuck_child");
+  assert.deepEqual(corruptItem, {
+    leaf_ref: "leaf-corrupt",
+    run_id: corruptRun,
+    reason: "stuck_child",
+  });
+
+  // Direct unit pin: formatStatusText plain item is byte-identical to the
+  // historical one-line shape (no next/detail suffix).
+  const plainOnly = formatText(
+    { fleet_id: "x", fleet_state: "draft", total_children: 0, by_dispatch_status: {}, by_run_state: {}, children: [] },
+    [{ leaf_ref: "leaf-a", run_id: "run-a", reason: "stuck_child" }]
+  );
+  assert.match(plainOnly, /^  - leaf-a: stuck_child \(run-a\)$/m);
+  assert.doesNotMatch(plainOnly, /→ next:/);
+  assert.doesNotMatch(plainOnly, / — /);
+});

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -2439,6 +2439,7 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
   assert.ok(preflightEvent);
   assert.equal(preflightEvent.failure_class, "behind_base");
   assert.match(preflightEvent.reason, /branch is 1 commit behind origin\/main; rebase and re-run/);
+  assert.equal(preflightEvent.next_action, "rebase_and_rerun");
   assert.equal(preflightEvent.state_from, STATES.REVIEW_PENDING);
   assert.equal(preflightEvent.state_to, STATES.REVIEW_PENDING);
   assert.equal(preflightEvent.reviewer_rounds_avoided, 1);
@@ -2640,6 +2641,7 @@ test("review-runner execution evidence preflight blocks primary reviewer invocat
       assert.equal(preflightEvent.reviewer_rounds_avoided, 1);
       assert.equal(preflightEvent.evidence_head_sha, expectedEvidenceHeadSha);
       assert.equal(preflightEvent.execution_evidence_path, path.join(runDir, EXECUTION_EVIDENCE_FILENAME));
+      assert.equal(preflightEvent.next_action, "repair_execution_evidence");
     });
   }
 });


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-901-20260710091712764-31f1b83d
- Branch: issue-901
- Reason: executor implemented the full DC but stalled twice on Tailscale DNS flapping (empty stdout both times) before committing; orchestrator committed the work, rebased onto main (post-#913/#915), and ran the four-suite gate green on the rebased head
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-901-20260710091712764-31f1b83d.md; orchestrator=unknown; executor=cursor
- Recovered at (UTC): 2026-07-10T16:38:04.065Z