### PR TITLE
Give advisory profiles their own default timeout budgets (#905).

### DIFF
--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -22,13 +22,29 @@ const { resolveReviewerScript } = require("./reviewer-invoke");
 const DEFAULT_HARDENED_EVENT_BINDING_WAIT_MS = 10000;
 const ADVISORY_TRIGGERS = new Set(["every_round", "on_pass"]);
 const ADVISORY_PROFILE_DEFAULTS = Object.freeze({
-  blindspot: Object.freeze({ trigger: "every_round", gating: false }),
-  adversarial: Object.freeze({ trigger: "on_pass", gating: true }),
+  blindspot: Object.freeze({ trigger: "every_round", gating: false, timeoutSeconds: 900 }),
+  adversarial: Object.freeze({ trigger: "on_pass", gating: true, timeoutSeconds: 1800 }),
 });
 
 function resolveHardenedBindingWaitMs(env = process.env) {
   const raw = Number(env.RELAY_ADVISORY_EVENT_BINDING_WAIT_MS || DEFAULT_HARDENED_EVENT_BINDING_WAIT_MS);
   return Number.isSafeInteger(raw) && raw > 0 ? raw : DEFAULT_HARDENED_EVENT_BINDING_WAIT_MS;
+}
+
+function resolveAdvisoryTimeoutSeconds(explicitTimeoutArg, profile) {
+  return parsePositiveSeconds(
+    explicitTimeoutArg,
+    advisoryProfileDefaults(profile).timeoutSeconds,
+  );
+}
+
+function resolveSettlementTimeoutSeconds(explicitTimeoutArg, lanes) {
+  if (explicitTimeoutArg !== undefined && explicitTimeoutArg !== null && explicitTimeoutArg !== "") {
+    return parsePositiveSeconds(explicitTimeoutArg);
+  }
+  return Math.max(
+    ...lanes.map((lane) => advisoryProfileDefaults(lane.profile).timeoutSeconds),
+  );
 }
 
 function isPlainObject(value) {
@@ -184,7 +200,12 @@ function resolveAdvisoryConfig({
     profile: first.profile || null,
     reviewer: first.reviewer || null,
     source: lanes.length ? source : null,
-    timeoutSeconds: lanes.length ? parsePositiveSeconds(advisoryTimeoutArg) : null,
+    // Raw CLI/route override (if any). Per-lane request budgets resolve via
+    // resolveAdvisoryTimeoutSeconds(timeoutSecondsArg, lane.profile).
+    timeoutSecondsArg: advisoryTimeoutArg,
+    timeoutSeconds: lanes.length
+      ? resolveSettlementTimeoutSeconds(advisoryTimeoutArg, lanes)
+      : null,
   };
 }
 
@@ -324,7 +345,7 @@ function startConfiguredAdvisory({
       runRepoPath,
       source: lane.source,
       state: data.state,
-      timeoutSeconds: config.timeoutSeconds,
+      timeoutSeconds: resolveAdvisoryTimeoutSeconds(config.timeoutSecondsArg, lane.profile),
       trigger: lane.trigger,
     });
     advisoryRuns.push(advisoryRun);
@@ -473,10 +494,12 @@ async function settleConfiguredAdvisories({ advisoryRuns, config, currentState, 
 }
 
 module.exports = {
+  ADVISORY_PROFILE_DEFAULTS,
   appendAdvisoryRunsForTrigger,
   createAdvisorySettlementDeadline,
   preflightConfiguredAdvisoryLanes,
   resolveAdvisoryConfig,
+  resolveAdvisoryTimeoutSeconds,
   resolveHardenedBindingWaitMs,
   settleConfiguredAdvisories,
   settleAdvisoryForVerdict,

--- a/tests/relay-review/scripts/advisory-orchestration.test.js
+++ b/tests/relay-review/scripts/advisory-orchestration.test.js
@@ -2,8 +2,10 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  ADVISORY_PROFILE_DEFAULTS,
   resolveHardenedBindingWaitMs,
   resolveAdvisoryConfig,
+  resolveAdvisoryTimeoutSeconds,
 } = require("../../../skills/relay-review/scripts/review-runner/advisory-orchestration");
 const {
   validateRouteConfig,
@@ -25,6 +27,87 @@ test("resolveHardenedBindingWaitMs falls back to the default on invalid values",
       `expected default fallback for env value ${JSON.stringify(invalid)}`,
     );
   }
+});
+
+test("ADVISORY_PROFILE_DEFAULTS carries per-profile timeout budgets", () => {
+  assert.equal(ADVISORY_PROFILE_DEFAULTS.blindspot.timeoutSeconds, 900);
+  assert.equal(ADVISORY_PROFILE_DEFAULTS.adversarial.timeoutSeconds, 1800);
+});
+
+test("resolveAdvisoryTimeoutSeconds uses the adversarial profile default of 1800s", () => {
+  assert.equal(resolveAdvisoryTimeoutSeconds(undefined, "adversarial"), 1800);
+  assert.equal(resolveAdvisoryTimeoutSeconds(null, "adversarial"), 1800);
+  assert.equal(resolveAdvisoryTimeoutSeconds("", "adversarial"), 1800);
+});
+
+test("resolveAdvisoryTimeoutSeconds keeps the blindspot profile default of 900s", () => {
+  assert.equal(resolveAdvisoryTimeoutSeconds(undefined, "blindspot"), 900);
+  assert.equal(resolveAdvisoryTimeoutSeconds(null, "blindspot"), 900);
+  assert.equal(resolveAdvisoryTimeoutSeconds("", "blindspot"), 900);
+});
+
+test("resolveAdvisoryTimeoutSeconds lets an explicit override win for both profiles", () => {
+  assert.equal(resolveAdvisoryTimeoutSeconds("1200", "adversarial"), 1200);
+  assert.equal(resolveAdvisoryTimeoutSeconds("1200", "blindspot"), 1200);
+  assert.equal(resolveAdvisoryTimeoutSeconds(2400, "adversarial"), 2400);
+  assert.equal(resolveAdvisoryTimeoutSeconds(2400, "blindspot"), 2400);
+});
+
+test("resolveAdvisoryConfig settlement timeout follows adversarial profile default", () => {
+  const config = resolveAdvisoryConfig({
+    advisoryProfileArg: "adversarial",
+    advisoryReviewerArg: "opencode",
+    data: {},
+  });
+  assert.equal(config.profile, "adversarial");
+  assert.equal(config.timeoutSeconds, 1800);
+  assert.equal(resolveAdvisoryTimeoutSeconds(config.timeoutSecondsArg, config.profile), 1800);
+});
+
+test("resolveAdvisoryConfig settlement timeout keeps blindspot profile default", () => {
+  const config = resolveAdvisoryConfig({
+    advisoryProfileArg: "blindspot",
+    advisoryReviewerArg: "opencode",
+    data: {},
+  });
+  assert.equal(config.profile, "blindspot");
+  assert.equal(config.timeoutSeconds, 900);
+  assert.equal(resolveAdvisoryTimeoutSeconds(config.timeoutSecondsArg, config.profile), 900);
+});
+
+test("resolveAdvisoryConfig explicit --advisory-timeout overrides both profile defaults", () => {
+  for (const profile of ["adversarial", "blindspot"]) {
+    const config = resolveAdvisoryConfig({
+      advisoryProfileArg: profile,
+      advisoryReviewerArg: "opencode",
+      advisoryTimeoutArg: "1500",
+      data: {},
+    });
+    assert.equal(config.timeoutSeconds, 1500, `settlement timeout for ${profile}`);
+    assert.equal(
+      resolveAdvisoryTimeoutSeconds(config.timeoutSecondsArg, profile),
+      1500,
+      `lane request timeout for ${profile}`,
+    );
+  }
+});
+
+test("resolveAdvisoryConfig mixed lanes settle on the max profile default without an explicit timeout", () => {
+  const config = resolveAdvisoryConfig({
+    data: {
+      routing: {
+        selected: {
+          advisory_review: [
+            { reviewer: "opencode", model: "example/opencode-model-fast", profile: "blindspot" },
+            { reviewer: "pi", model: "openai/gpt-5", profile: "adversarial" },
+          ],
+        },
+      },
+    },
+  });
+  assert.equal(config.timeoutSeconds, 1800);
+  assert.equal(resolveAdvisoryTimeoutSeconds(config.timeoutSecondsArg, "blindspot"), 900);
+  assert.equal(resolveAdvisoryTimeoutSeconds(config.timeoutSecondsArg, "adversarial"), 1800);
 });
 
 test("resolveAdvisoryConfig does not inherit a planned model when the routed reviewer differs", () => {

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -373,7 +373,7 @@ setTimeout(() => {
   return filePath;
 }
 
-function writeFakeOpencode(repoRoot, { delayMs = 0, logPath = null, invalidJson = false, mutate = false, requiredFinding = false, primaryVerdict = null } = {}) {
+function writeFakeOpencode(repoRoot, { delayMs = 0, logPath = null, invalidJson = false, mutate = false, requiredFinding = false, primaryVerdict = null, profile = "blindspot" } = {}) {
   const filePath = path.join(repoRoot, "fake-opencode.js");
   fs.writeFileSync(filePath, `#!/usr/bin/env node
 const fs = require("fs");
@@ -388,7 +388,7 @@ setTimeout(() => {
     process.stdout.write(JSON.stringify(${JSON.stringify(primaryVerdict)}));
   } else {
     process.stdout.write(JSON.stringify({
-      profile: "blindspot",
+      profile: ${JSON.stringify(profile)},
       summary: "One advisory blind spot.",
       required_findings: ${requiredFinding ? `[{ title: "Required hardened fix", body: "Must fix before merge.", file: "README.md", line: 1, severity: "P2", category: "bypass", confidence: 0.9 }]` : "[]"},
       advisory_findings: [{
@@ -650,6 +650,73 @@ test("review-runner records successful opencode advisory review without gating p
   assert.equal(event.advisory_artifact_hash, hashFile(path.join(runDir, "review-round-1-advisory-opencode.json")));
   assert.equal(event.reviewer_policy.read_only.enforcement_level, "prompt-only");
   assert.match(event.reviewer_policy.read_only.warnings.join("\n"), /not prevent writes/i);
+});
+
+test("advisory lane request uses adversarial profile default timeout of 1800s", () => {
+  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot, { profile: "adversarial" });
+
+  runReview({
+    repoRoot,
+    runId,
+    doneCriteriaPath,
+    diffPath,
+    primaryScript,
+    opencodeScript,
+    extraArgs: ["--advisory-profile", "adversarial", "--advisory-grace", "30"],
+  });
+  const request = JSON.parse(fs.readFileSync(
+    path.join(runDir, "review-round-1-advisory-opencode-request.json"),
+    "utf-8",
+  ));
+
+  assert.equal(request.profile, "adversarial");
+  assert.equal(request.timeoutSeconds, 1800);
+});
+
+test("advisory lane request keeps blindspot profile default timeout of 900s", () => {
+  const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot);
+
+  runReview({ repoRoot, runId, doneCriteriaPath, diffPath, primaryScript, opencodeScript });
+  const request = JSON.parse(fs.readFileSync(
+    path.join(runDir, "review-round-1-advisory-opencode-request.json"),
+    "utf-8",
+  ));
+
+  assert.equal(request.profile, "blindspot");
+  assert.equal(request.timeoutSeconds, 900);
+});
+
+test("advisory lane request honors explicit --advisory-timeout for both profiles", () => {
+  for (const profile of ["adversarial", "blindspot"]) {
+    const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
+    const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+    const opencodeScript = writeFakeOpencode(repoRoot, { profile });
+
+    runReview({
+      repoRoot,
+      runId,
+      doneCriteriaPath,
+      diffPath,
+      primaryScript,
+      opencodeScript,
+      extraArgs: [
+        "--advisory-profile", profile,
+        "--advisory-timeout", "1500",
+        "--advisory-grace", "30",
+      ],
+    });
+    const request = JSON.parse(fs.readFileSync(
+      path.join(runDir, "review-round-1-advisory-opencode-request.json"),
+      "utf-8",
+    ));
+
+    assert.equal(request.profile, profile);
+    assert.equal(request.timeoutSeconds, 1500);
+  }
 });
 
 test("review-runner routed advisory unregistered route event preserves route-plan model resolution provenance", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
이슈 #905 반영을 마쳤습니다. 커밋: `3bfaf0a`.

**변경 요약**
- `ADVISORY_PROFILE_DEFAULTS`에 프로필별 `timeoutSeconds` 추가: adversarial **1800**, blindspot **900**
- 해석 우선순위: `--advisory-timeout` > 프로필 기본값 > 전역 900s
- 레인 요청 생성 시 프로필별 예산이 `timeoutSeconds`로 기록됨
- settlement 대기는 명시 오버라이드가 없으면 레인들 중 최대 프로필 기본값을 사용

**테스트**
- 해석 경로 단위 테스트 + 레인 request artifact 통합 테스트
- 직렬 스위트 569개 통과 (`relay-review` + `skills-lint`)
```

## Score Log

- Run: issue-905-20260710171743584-2442d553
- Executor: cursor
- Branch: issue-905