### PR TITLE
fix: stamp execution evidence on reconcile row-4 recovery (#904)

### DIFF
--- a/skills/relay-dispatch/scripts/reconcile-run.js
+++ b/skills/relay-dispatch/scripts/reconcile-run.js
@@ -7,8 +7,13 @@ const path = require("path");
 
 const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { execGit } = require("./exec");
+const {
+  buildExecutionEvidence,
+  EXECUTION_EVIDENCE_FILENAME,
+  writeExecutionEvidence,
+} = require("./execution-evidence");
 const { STATES, updateManifestState } = require("./manifest/lifecycle");
-const { summarizeFailure, validateManifestPaths } = require("./manifest/paths");
+const { getRunDir, summarizeFailure, validateManifestPaths } = require("./manifest/paths");
 const { readManifest, writeManifest } = require("./manifest/store");
 const { classifyRepositoryDirt } = require("./runtime-dirt");
 const { resolveManifestRecord } = require("./relay-resolver");
@@ -236,6 +241,46 @@ function runRecoverCommit({ repoRoot, runId, dryRun }) {
     stdio: ["ignore", "pipe", "pipe"],
   });
   return JSON.parse(stdout);
+}
+
+/**
+ * Stamp execution-evidence.json from the executor result file after row-4 recovery,
+ * matching the normal dispatch-completion builder/shape. Leaves evidence already
+ * bound to the recovered head untouched.
+ */
+function stampExecutionEvidenceFromResult({
+  repoRoot,
+  runId,
+  resultFile,
+  recoveredHead,
+  executor,
+}) {
+  if (!resultFile || !recoveredHead) {
+    return { skipped: "missing_result_or_head" };
+  }
+  const runDir = getRunDir(repoRoot, runId);
+  const evidencePath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
+  if (fs.existsSync(evidencePath)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+      if (existing && typeof existing === "object" && existing.head_sha === recoveredHead) {
+        return { skipped: "evidence_already_bound", path: evidencePath };
+      }
+    } catch {
+      // Corrupt or unreadable evidence: fall through and rewrite like normal completion.
+    }
+  }
+  const writtenPath = writeExecutionEvidence(
+    runDir,
+    buildExecutionEvidence({
+      headSha: recoveredHead,
+      testCommand: undefined,
+      resultFilePath: resultFile,
+      executor: executor || "executor",
+      testExitCode: 0,
+    })
+  );
+  return { stamped: true, path: writtenPath };
 }
 
 async function main() {
@@ -483,6 +528,17 @@ async function main() {
         eventFields: corruptLeaseEvent,
       });
     }
+    let executionEvidence = null;
+    if (hasResult) {
+      const recoveredHead = updated.git?.head_sha || worktreeInspection.currentHead || null;
+      executionEvidence = stampExecutionEvidenceFromResult({
+        repoRoot: normalizedRepoRoot,
+        runId: normalizedRunId,
+        resultFile,
+        recoveredHead,
+        executor: data.roles?.executor || updated.roles?.executor,
+      });
+    }
     outputResult({
       ...buildBaseResult({
         row: 4,
@@ -499,6 +555,7 @@ async function main() {
       newCommits: worktreeInspection.newCommits,
       hasReviewableDirt: worktreeInspection.hasReviewableDirt,
       recovery,
+      executionEvidence,
       ...corruptLeaseReport,
     }, jsonOut);
     return;

--- a/tests/relay-dispatch/scripts/reconcile-run.test.js
+++ b/tests/relay-dispatch/scripts/reconcile-run.test.js
@@ -17,7 +17,8 @@ const {
   writeManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
 const { appendRunEvent, EVENTS, readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
-const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
+const { EXECUTION_EVIDENCE_FILENAME, buildExecutionEvidence, hashFileSha256 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
+const { buildExecutionEvidencePreflight } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "reconcile-run.js");
 
@@ -84,6 +85,7 @@ function setupRepo({
   oldShapePaths = false,
   publishPolicy = "immediate",
   ghState = {},
+  executionEvidence = true,
 } = {}) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-reconcile-run-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
@@ -151,15 +153,17 @@ function setupRepo({
   if (resultFile) {
     fs.writeFileSync(path.join(layout.runDir, "dispatch-result.txt"), resultFileContent, "utf-8");
   }
-  fs.writeFileSync(path.join(layout.runDir, EXECUTION_EVIDENCE_FILENAME), JSON.stringify({
-    schema_version: 1,
-    head_sha: dispatchHead,
-    test_command: "node --test tests/relay-dispatch/scripts/*.test.js",
-    test_result_hash: "unspecified",
-    test_result_summary: "unspecified",
-    recorded_at: "2026-05-01T01:00:00.000Z",
-    recorded_by: "dispatch-orchestrator-v1",
-  }, null, 2));
+  if (executionEvidence) {
+    fs.writeFileSync(path.join(layout.runDir, EXECUTION_EVIDENCE_FILENAME), JSON.stringify({
+      schema_version: 1,
+      head_sha: dispatchHead,
+      test_command: "node --test tests/relay-dispatch/scripts/*.test.js",
+      test_result_hash: "unspecified",
+      test_result_summary: "unspecified",
+      recorded_at: "2026-05-01T01:00:00.000Z",
+      recorded_by: "dispatch-orchestrator-v1",
+    }, null, 2));
+  }
 
   const ghPath = writeFakeGh(binDir, statePath, ghLogPath, ghState);
   const env = {
@@ -591,6 +595,105 @@ test("reconcile row 4 preserves delayed-publication internal review policy", () 
   assert.equal(manifest.next_action, "run_internal_review");
   assert.equal(manifest.git.pr_number, null);
   assert.deepEqual(fs.readFileSync(fixture.ghLogPath, "utf-8").trim(), "");
+});
+
+test("reconcile row 4 with result file stamps execution evidence and passes preflight", () => {
+  const fixture = setupRepo({
+    committedWork: true,
+    resultFile: true,
+    executionEvidence: false,
+  });
+  const resultFile = path.join(fixture.runDir, "dispatch-result.txt");
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  assert.equal(fs.existsSync(evidencePath), false);
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 4);
+  assert.equal(result.status, "recovered");
+  assert.equal(result.executionEvidence.stamped, true);
+  assert.equal(fs.existsSync(evidencePath), true);
+
+  const recoveredHead = readManifest(fixture.manifestPath).data.git.head_sha;
+  const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  const expected = buildExecutionEvidence({
+    headSha: recoveredHead,
+    testCommand: undefined,
+    resultFilePath: resultFile,
+    executor: "codex",
+    recordedAt: evidence.recorded_at,
+    testExitCode: 0,
+  });
+  assert.deepEqual(evidence, expected);
+  assert.equal(evidence.recorded_by, "dispatch-orchestrator-v1");
+  assert.equal(evidence.test_command, "unspecified");
+  assert.equal(evidence.test_result_hash, hashFileSha256(resultFile));
+  assert.equal(evidence.test_result_summary, "codex result.txt hashed");
+  assert.equal(evidence.test_exit_code, 0);
+
+  const preflight = buildExecutionEvidencePreflight({
+    runDir: fixture.runDir,
+    reviewedHead: recoveredHead,
+  });
+  assert.equal(preflight.status, "pass");
+  assert.equal(preflight.qualityExecutionStatus, "pass");
+  assert.equal(preflight.nextAction, "invoke_primary_reviewer");
+});
+
+test("reconcile row 4 without result file does not stamp execution evidence", () => {
+  const fixture = setupRepo({
+    committedWork: true,
+    executionEvidence: false,
+  });
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  assert.equal(fs.existsSync(evidencePath), false);
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 4);
+  assert.equal(result.status, "recovered");
+  assert.equal(result.executionEvidence, null);
+  assert.equal(fs.existsSync(evidencePath), false);
+
+  const recoveredHead = readManifest(fixture.manifestPath).data.git.head_sha;
+  const preflight = buildExecutionEvidencePreflight({
+    runDir: fixture.runDir,
+    reviewedHead: recoveredHead,
+  });
+  assert.equal(preflight.status, "blocked");
+  assert.equal(preflight.qualityExecutionStatus, "missing");
+  assert.equal(preflight.nextAction, "repair_execution_evidence");
+});
+
+test("reconcile row 4 leaves pre-existing evidence at the recovered head untouched", () => {
+  const fixture = setupRepo({
+    committedWork: true,
+    resultFile: true,
+    executionEvidence: false,
+  });
+  const recoveredHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], {
+    encoding: "utf-8",
+  }).trim();
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const existingEvidence = {
+    schema_version: 1,
+    head_sha: recoveredHead,
+    test_command: "node --test tests/relay-dispatch/scripts/reconcile-run.test.js",
+    test_result_hash: "a".repeat(64),
+    test_result_summary: "operator-preserved evidence",
+    test_exit_code: 0,
+    recorded_at: "2026-07-10T00:00:00.000Z",
+    recorded_by: "recover-commit-operator-v1",
+  };
+  const existingBytes = `${JSON.stringify(existingEvidence, null, 2)}\n`;
+  fs.writeFileSync(evidencePath, existingBytes, "utf-8");
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 4);
+  assert.equal(result.status, "recovered");
+  assert.equal(result.executionEvidence.skipped, "evidence_already_bound");
+  assert.equal(fs.readFileSync(evidencePath, "utf-8"), existingBytes);
 });
 
 test("reconcile row 5 treats an empty dispatch result as no completion evidence", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
이슈 #904 구현을 마쳤습니다.

**변경 요약**
- `reconcile-run.js` row 4: result 파일이 있으면 복구된 HEAD에 `execution-evidence.json`을 정상 completion과 동일한 builder로 스탬프 (`recorded_by: dispatch-orchestrator-v1`, `test_command: unspecified`, result hash, `test_exit_code: 0`)
- 이미 recovered head에 묶인 evidence는 덮어쓰지 않음
- result 파일 없으면 기존과 동일 (스탬프 없음 → preflight `missing`)

**테스트**
- (a) result 있음 → 스탬프 + preflight pass
- (b) result 없음 → evidence 미작성 + preflight blocked
- (c) recovered head에 기존 evidence → byte-identical 유지

**검
```

## Score Log

- Run: issue-904-20260710171739693-92e6950f
- Executor: cursor
- Branch: issue-904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 실행 결과 복구 시 실행 증거 파일을 자동으로 생성하거나 재사용합니다.
  - 기존 증거가 동일한 복구 헤드에 연결되어 있으면 불필요한 재작성을 건너뜁니다.
  - 손상되었거나 읽을 수 없는 증거 파일은 자동으로 새로 작성합니다.
  - 복구 결과에 실행 증거의 생성·재사용·건너뛰기 상태와 경로가 표시됩니다.

- **버그 수정**
  - 실행 증거가 없는 복구 상태를 명확히 감지하고 후속 조치를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->