### PR TITLE
fix(ci): run real test suites instead of vacuous skills glob (#912)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,35 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: node --test skills/*/scripts/*.test.js
+      - name: Guard against empty test globs
+        run: |
+          shopt -s nullglob
+          files=(
+            tests/relay-ready/scripts/*.test.js
+            tests/relay-plan/scripts/*.test.js
+            tests/relay-dispatch/scripts/*.test.js
+            tests/relay-review/scripts/*.test.js
+            tests/relay-merge/scripts/*.test.js
+            tests/relay/scripts/*.test.js
+            tests/relay-config/scripts/*.test.js
+            tests/relay-fleet/scripts/*.test.js
+            tests/skills-lint/scripts/*.test.js
+          )
+          count=${#files[@]}
+          echo "Matched $count test file(s)"
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No test files matched the suite globs; refusing vacuous CI pass"
+            exit 1
+          fi
+      - name: Run test suites
+        run: >
+          node --test --test-concurrency=1
+          tests/relay-ready/scripts/*.test.js
+          tests/relay-plan/scripts/*.test.js
+          tests/relay-dispatch/scripts/*.test.js
+          tests/relay-review/scripts/*.test.js
+          tests/relay-merge/scripts/*.test.js
+          tests/relay/scripts/*.test.js
+          tests/relay-config/scripts/*.test.js
+          tests/relay-fleet/scripts/*.test.js
+          tests/skills-lint/scripts/*.test.js


### PR DESCRIPTION
## Dispatch Summary

```text
`.github/workflows/test.yml`만 수정해 #912를 반영했습니다.

**변경 요약**
- 잘못된 `skills/*/scripts/*.test.js` glob 제거
- CLAUDE.md final gate와 동일한 9개 `tests/<suite>/scripts/*.test.js` 스위트를 `node --test --test-concurrency=1`로 실행
- 빈 glob이면 실패하는 guard step 추가 (로컬 bash 검증: 94개 매칭 / 빈 경로 0개)
- workflow/job 이름 `test` 유지

커밋: `1681e5a` — `fix(ci): run real test suites instead of vacuous skills glob (#912)`  
`origin/main` 기준 rebase 완료, 브랜치는 main보다 1커밋 ahead입니다.
```

## Score Log

- Run: issue-912-20260710182211502-2d2fead4
- Executor: cursor
- Branch: issue-912