### PR TITLE
Classify Codex reviewer usage-limit errors as codex_quota_exhausted (#906).

### DIFF
--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -79,6 +79,14 @@ Execution evidence preflight is script territory, not AI reviewer judgment. The 
 
 When preflight blocks, JSON output includes `executionEvidencePreflight.status`, `reason`, `reviewedHeadSha`, `evidenceHeadSha` when a valid artifact exposed one, and `nextAction=repair_execution_evidence`. The same preflight object reports optional `browserEvidence.present`, plus compact browser counts when present: `viewportCount`, `screenshotCount`, `consoleErrors`, and `inspectedStateCount`. When `execution-evidence.json` includes `browser_evidence`, screenshot paths must stay inside the run artifact directory unless the entry is explicitly hash-backed with `sha256`. Repair or regenerate `execution-evidence.json` for the reviewed HEAD, then rerun the same review command. Manual `--review-file` fallback paths intentionally bypass the preflight and keep the older fail-closed verdict override so operators can apply an already-produced verdict without weakening the execution evidence gate.
 
+## Codex Quota Exhaustion
+
+When the Codex CLI exits and its stdout/stderr matches the stable usage-limit prefix `You've hit your usage limit`, `invoke-reviewer-codex.js` fails immediately with the token `codex_quota_exhausted` plus the CLI's retry-at text verbatim. The CLI already exits promptly on quota — the adapter classifies at that failure point and does not retry or wait out the review timeout.
+
+**Stall-then-quota precursor:** Repeated full-timeout stalls whose raw responses only echo the prompt (no verdict) often precede a hard usage-limit wall. Treat that pattern as an operator signal to probe Codex quota before spending another review timeout.
+
+**Fallback lanes:** Switch the primary reviewer with `--reviewer cursor --reviewer-model grok-4.5-high`, or apply an already-produced verdict via the manual `--review-file` playbook (see Execution Evidence Preflight above for the intentional preflight bypass on that path).
+
 ## Codex-only Operation Regression
 
 Codex-only operation is covered as a regression for `policy.review_assurance=hardened`, not a Codex-only policy special case. When `roles.orchestrator`, `roles.executor`, and `roles.reviewer` are all `codex`, the runner still follows the same manifest policy contract used by any other role names. Advisory evidence is required for passing hardened rounds, advisory required findings block the pass, and strict execution evidence must bind to the reviewed head.

--- a/skills/relay-review/scripts/invoke-reviewer-codex.js
+++ b/skills/relay-review/scripts/invoke-reviewer-codex.js
@@ -59,6 +59,23 @@ function isExecTimeout(error) {
   return error && (error.code === "ETIMEDOUT" || error.signal === "SIGTERM" || error.signal === "SIGKILL");
 }
 
+/** Stable prefix of the Codex CLI usage-limit line (URL/time vary). */
+const CODEX_USAGE_LIMIT_SIGNATURE = "You've hit your usage limit";
+
+/**
+ * If stdout/stderr contain the usage-limit signature, return the matching line
+ * (includes the CLI's retry-at text). Otherwise null.
+ */
+function classifyCodexQuotaExhausted(error) {
+  const combined = `${String(error?.stdout || "")}\n${String(error?.stderr || "")}`;
+  if (!combined.includes(CODEX_USAGE_LIMIT_SIGNATURE)) return null;
+  const matchingLine = combined
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.includes(CODEX_USAGE_LIMIT_SIGNATURE));
+  return matchingLine || CODEX_USAGE_LIMIT_SIGNATURE;
+}
+
 function writeRawResponse(filePath, error) {
   const stdout = String(error?.stdout || "").trim();
   const stderr = String(error?.stderr || "").trim();
@@ -123,6 +140,13 @@ function main() {
         throw new Error(
           `Codex reviewer primary_review timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}); ` +
           `model=${model || "default"}; raw_response=${rawResponsePath}`
+        );
+      }
+      const quotaLine = classifyCodexQuotaExhausted(error);
+      if (quotaLine) {
+        throw new Error(
+          `Codex reviewer primary_review failed; codex_quota_exhausted; model=${model || "default"}; ` +
+          `raw_response=${rawResponsePath}; ${quotaLine}`
         );
       }
       const recovered = readNonEmptyFile(resultPath);

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -297,6 +297,81 @@ setTimeout(() => {
   assert.match(stderr, /raw_response=/);
 });
 
+test("codex adapter classifies usage-limit stderr as codex_quota_exhausted", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-codex-quota-"));
+  const usageLimitLine =
+    "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 4:33 AM.";
+  const fakeCodex = writeExecutable(fakeDir, "fake-codex.js", `#!/usr/bin/env node
+process.stderr.write(${JSON.stringify(usageLimitLine + "\n")});
+process.exit(1);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CODEX_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--model", "codex-quota-model",
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex },
+    });
+    assert.fail("expected invoke-reviewer-codex.js to fail on usage limit");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  assert.notEqual(error.status, 0);
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /codex_quota_exhausted/);
+  assert.match(stderr, /try again at 4:33 AM/);
+  assert.match(stderr, /You've hit your usage limit/);
+  assert.match(stderr, /model=codex-quota-model/);
+  assert.doesNotMatch(stderr, /Codex reviewer primary_review timed out/);
+});
+
+test("codex adapter keeps generic failure message unchanged for non-quota errors", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-codex-generic-"));
+  const fakeCodex = writeExecutable(fakeDir, "fake-codex.js", `#!/usr/bin/env node
+process.stderr.write("some generic failure\\n");
+process.exit(1);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CODEX_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex },
+    });
+    assert.fail("expected invoke-reviewer-codex.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error);
+  assert.notEqual(error.status, 0);
+  const stderr = String(error.stderr || "");
+  assert.doesNotMatch(stderr, /codex_quota_exhausted/);
+  assert.match(
+    stderr,
+    /^Error: Codex reviewer primary_review failed; model=default; raw_response=.+; some generic failure\n$/
+  );
+});
+
 test("claude adapter can recover from a non-zero exit when stdout contains JSON", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-claude-recover-"));


### PR DESCRIPTION
## Dispatch Summary

```text
완료. `450846d` — Codex usage-limit을 `codex_quota_exhausted`로 분류합니다.

**변경 요약**
- `invoke-reviewer-codex.js`: CLI 출력에 `You've hit your usage limit`이 있으면 즉시 `codex_quota_exhausted` + retry-at 문구로 실패. 재시도/대기 없음. 그 외 실패 메시지는 기존과 동일.
- `runner-notes.md`: 토큰·시그니처·stall-then-quota 전조·fallback(`--reviewer cursor --reviewer-model grok-4.5-high` / `--review-file`) 문서화.
- 테스트: quota 분류 / generic 메시지 불변 / 성공 경로 유지.

**검증:** `571` pass, `0` fail. `origin/main` rebase 완료.백그라운드 검증은 이미 반영된 상태입니다. `invoke-reviewe
```

## Score Log

- Run: issue-906-20260710182204466-b9dfbd96
- Executor: cursor
- Branch: issue-906