### PR TITLE
test: accept the title-bearing pr view field list in fake-gh (#917)

### DIFF
--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -124,7 +124,8 @@ if (args[0] === "pr" && args[1] === "view") {
   if (
     fields === "comments,commits,mergeable,statusCheckRollup" ||
     fields === "baseRefName,comments,commits,mergeable,statusCheckRollup" ||
-    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid"
+    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid" ||
+    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title"
   ) {
     writeJson({
       baseRefName: fixture.baseRefName || "main",
@@ -133,6 +134,7 @@ if (args[0] === "pr" && args[1] === "view") {
       mergeable: fixture.mergeable || "MERGEABLE",
       statusCheckRollup: fixture.statusCheckRollup || [],
       headRefOid: fixture.headRefOid || "a".repeat(40),
+      title: fixture.title || "Fixture PR",
     });
     process.exit(0);
   }


### PR DESCRIPTION
Root cause of #917 (bisected to #894 / 1c23a57): finalize-run now requests `baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title`, and `tests/relay-review/fixtures/fake-gh.js` matches `--json` field lists exactly — the new list fell through to the "unsupported data stays empty" branch, so `comments` came back empty and the review gate reported `missing` in the four relay-plan TDD integration fixtures (every machine + GitHub runners once #912's CI fix ran the real suites).

Fix: accept the new field list and serve `title` in the response. Tests-only.

Verified locally: the 4 previously failing files 49/49 green; relay-merge suite 199/199 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)