### PR TITLE
fix: reclaim stale dispatch claims (#918)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1210,10 +1210,52 @@ function isDispatchClaimStale(claimPath) {
   }
 }
 
+const DISPATCH_RECLAIM_GUARD_PREFIX = ".dispatch-claim.reclaim-";
+
+function acquireDispatchReclaimGuard(runDir) {
+  const guardName = `${DISPATCH_RECLAIM_GUARD_PREFIX}${process.pid}-${crypto.randomBytes(8).toString("hex")}`;
+  const guardPath = path.join(runDir, guardName);
+  let guardFd;
+  let keepGuard = false;
+  try {
+    guardFd = fs.openSync(guardPath, "wx");
+    fs.writeFileSync(guardFd, JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString() }));
+    fs.closeSync(guardFd);
+    guardFd = undefined;
+
+    const contenders = fs.readdirSync(runDir)
+      .filter((entry) => entry.startsWith(DISPATCH_RECLAIM_GUARD_PREFIX))
+      .sort();
+    const liveContenders = [];
+    for (const contender of contenders) {
+      const contenderPath = path.join(runDir, contender);
+      if (contender === guardName || !isDispatchClaimStale(contenderPath)) {
+        liveContenders.push(contender);
+        continue;
+      }
+      try {
+        fs.unlinkSync(contenderPath);
+      } catch {
+        return null;
+      }
+    }
+    keepGuard = liveContenders[0] === guardName;
+    return keepGuard ? guardPath : null;
+  } catch {
+    if (guardFd !== undefined) fs.closeSync(guardFd);
+    return null;
+  } finally {
+    if (!keepGuard) {
+      try { fs.unlinkSync(guardPath); } catch {}
+    }
+  }
+}
+
 function isRetryCompatibleRunDir(runDir) {
   if (!fs.existsSync(runDir)) return false;
   const entries = fs.readdirSync(runDir).filter((entry) => entry !== ".DS_Store");
-  const nonClaimEntries = entries.filter((entry) => entry !== ".dispatch-claim");
+  const nonClaimEntries = entries.filter((entry) => entry !== ".dispatch-claim"
+    && !entry.startsWith(DISPATCH_RECLAIM_GUARD_PREFIX));
   if (nonClaimEntries.length > 1
     || (nonClaimEntries.length === 1 && nonClaimEntries[0] !== "done-criteria.md")) {
     return false;
@@ -1232,7 +1274,9 @@ function claimRetryCompatibleRunDir(runDir) {
   }
 
   const claimPath = path.join(runDir, ".dispatch-claim");
-  for (let attempt = 0; attempt < 2; attempt += 1) {
+  const hasReclaimGuard = () => fs.readdirSync(runDir)
+    .some((entry) => entry.startsWith(DISPATCH_RECLAIM_GUARD_PREFIX));
+  if (!fs.existsSync(claimPath) && !hasReclaimGuard()) {
     let claimFd;
     try {
       claimFd = fs.openSync(claimPath, "wx");
@@ -1245,15 +1289,36 @@ function claimRetryCompatibleRunDir(runDir) {
         try { fs.unlinkSync(claimPath); } catch {}
       }
       if (error.code !== "EEXIST") throw error;
-      if (!isDispatchClaimStale(claimPath)) return null;
-      try {
-        fs.unlinkSync(claimPath);
-      } catch (unlinkError) {
-        if (unlinkError.code !== "ENOENT") return null;
-      }
     }
   }
-  return null;
+
+  const guardPath = acquireDispatchReclaimGuard(runDir);
+  if (!guardPath) return null;
+  let claimFd;
+  let createdClaim = false;
+  try {
+    if (fs.existsSync(claimPath) && !isDispatchClaimStale(claimPath)) return null;
+    if (fs.existsSync(claimPath)) fs.unlinkSync(claimPath);
+    claimFd = fs.openSync(claimPath, "wx");
+    createdClaim = true;
+    try {
+      fs.writeFileSync(claimFd, JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString() }));
+    } finally {
+      fs.closeSync(claimFd);
+      claimFd = undefined;
+    }
+    return claimPath;
+  } catch {
+    if (claimFd !== undefined) {
+      try { fs.closeSync(claimFd); } catch {}
+    }
+    if (createdClaim) {
+      try { fs.unlinkSync(claimPath); } catch {}
+    }
+    return null;
+  } finally {
+    try { fs.unlinkSync(guardPath); } catch {}
+  }
 }
 
 function isCanonicalPlannerDoneCriteriaPath(repoRoot, runId, doneCriteriaPath) {

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1194,74 +1194,88 @@ function failRunDirCollision(runId, manifestPath) {
   process.exit(1);
 }
 
-function isDispatchClaimStale(claimPath) {
-  let claim;
+function readDispatchOwnerFile(ownerPath) {
+  let bytes;
+  let owner;
   try {
-    claim = JSON.parse(fs.readFileSync(claimPath, "utf-8"));
+    bytes = fs.readFileSync(ownerPath, "utf-8");
+    owner = JSON.parse(bytes);
   } catch {
-    return false;
+    return null;
   }
-  if (!Number.isInteger(claim?.pid) || claim.pid <= 0) return false;
+  if (!Number.isInteger(owner?.pid) || owner.pid <= 0) return null;
+  return { bytes, owner };
+}
+
+function isDispatchOwnerStale(owner) {
   try {
-    process.kill(claim.pid, 0);
+    process.kill(owner.pid, 0);
     return false;
   } catch (error) {
     return error.code === "ESRCH";
   }
 }
 
-const DISPATCH_RECLAIM_GUARD_PREFIX = ".dispatch-claim.reclaim-";
+function isDispatchClaimStale(claimPath) {
+  const validated = readDispatchOwnerFile(claimPath);
+  return validated !== null && isDispatchOwnerStale(validated.owner);
+}
+
+const DISPATCH_RECLAIM_GUARD_NAME = ".dispatch-claim.reclaim-lock";
 
 function acquireDispatchReclaimGuard(runDir) {
-  const guardName = `${DISPATCH_RECLAIM_GUARD_PREFIX}${process.pid}-${crypto.randomBytes(8).toString("hex")}`;
-  const guardPath = path.join(runDir, guardName);
-  let guardFd;
-  let keepGuard = false;
-  try {
-    guardFd = fs.openSync(guardPath, "wx");
-    fs.writeFileSync(guardFd, JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString() }));
-    fs.closeSync(guardFd);
-    guardFd = undefined;
-
-    const contenders = fs.readdirSync(runDir)
-      .filter((entry) => entry.startsWith(DISPATCH_RECLAIM_GUARD_PREFIX))
-      .sort();
-    const liveContenders = [];
-    for (const contender of contenders) {
-      const contenderPath = path.join(runDir, contender);
-      if (contender === guardName || !isDispatchClaimStale(contenderPath)) {
-        liveContenders.push(contender);
-        continue;
-      }
+  const guardPath = path.join(runDir, DISPATCH_RECLAIM_GUARD_NAME);
+  const nonce = crypto.randomBytes(16).toString("hex");
+  const payload = JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString(), nonce });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let guardFd;
+    try {
+      guardFd = fs.openSync(guardPath, "wx");
       try {
-        fs.unlinkSync(contenderPath);
+        fs.writeFileSync(guardFd, payload);
+      } finally {
+        fs.closeSync(guardFd);
+      }
+      const readback = readDispatchOwnerFile(guardPath);
+      if (readback?.owner.pid !== process.pid || readback.owner.nonce !== nonce) return null;
+      return { guardPath, nonce };
+    } catch (error) {
+      if (guardFd !== undefined) {
+        try { fs.closeSync(guardFd); } catch {}
+      }
+      if (error.code !== "EEXIST" || attempt > 0) return null;
+      const staleGuard = readDispatchOwnerFile(guardPath);
+      if (!staleGuard || !isDispatchOwnerStale(staleGuard.owner)) return null;
+      let currentBytes;
+      try {
+        currentBytes = fs.readFileSync(guardPath, "utf-8");
       } catch {
         return null;
       }
-    }
-    keepGuard = liveContenders[0] === guardName;
-    return keepGuard ? guardPath : null;
-  } catch {
-    if (guardFd !== undefined) fs.closeSync(guardFd);
-    return null;
-  } finally {
-    if (!keepGuard) {
-      try { fs.unlinkSync(guardPath); } catch {}
+      if (currentBytes !== staleGuard.bytes) return null;
+      try {
+        fs.unlinkSync(guardPath);
+      } catch (unlinkError) {
+        if (unlinkError.code !== "ENOENT") return null;
+      }
     }
   }
+  return null;
 }
 
 function isRetryCompatibleRunDir(runDir) {
   if (!fs.existsSync(runDir)) return false;
   const entries = fs.readdirSync(runDir).filter((entry) => entry !== ".DS_Store");
   const nonClaimEntries = entries.filter((entry) => entry !== ".dispatch-claim"
-    && !entry.startsWith(DISPATCH_RECLAIM_GUARD_PREFIX));
+    && entry !== DISPATCH_RECLAIM_GUARD_NAME);
   if (nonClaimEntries.length > 1
     || (nonClaimEntries.length === 1 && nonClaimEntries[0] !== "done-criteria.md")) {
     return false;
   }
-  return !entries.includes(".dispatch-claim")
-    || isDispatchClaimStale(path.join(runDir, ".dispatch-claim"));
+  const guardCompatible = !entries.includes(DISPATCH_RECLAIM_GUARD_NAME)
+    || isDispatchClaimStale(path.join(runDir, DISPATCH_RECLAIM_GUARD_NAME));
+  return guardCompatible && (!entries.includes(".dispatch-claim")
+    || isDispatchClaimStale(path.join(runDir, ".dispatch-claim")));
 }
 
 function claimRetryCompatibleRunDir(runDir) {
@@ -1274,8 +1288,7 @@ function claimRetryCompatibleRunDir(runDir) {
   }
 
   const claimPath = path.join(runDir, ".dispatch-claim");
-  const hasReclaimGuard = () => fs.readdirSync(runDir)
-    .some((entry) => entry.startsWith(DISPATCH_RECLAIM_GUARD_PREFIX));
+  const hasReclaimGuard = () => fs.existsSync(path.join(runDir, DISPATCH_RECLAIM_GUARD_NAME));
   if (!fs.existsSync(claimPath) && !hasReclaimGuard()) {
     let claimFd;
     try {
@@ -1292,13 +1305,29 @@ function claimRetryCompatibleRunDir(runDir) {
     }
   }
 
-  const guardPath = acquireDispatchReclaimGuard(runDir);
-  if (!guardPath) return null;
+  const guard = acquireDispatchReclaimGuard(runDir);
+  if (!guard) return null;
   let claimFd;
   let createdClaim = false;
   try {
-    if (fs.existsSync(claimPath) && !isDispatchClaimStale(claimPath)) return null;
-    if (fs.existsSync(claimPath)) fs.unlinkSync(claimPath);
+    if (fs.existsSync(claimPath)) {
+      const staleClaim = readDispatchOwnerFile(claimPath);
+      if (!staleClaim || !isDispatchOwnerStale(staleClaim.owner)) return null;
+      let currentBytes;
+      try {
+        currentBytes = fs.readFileSync(claimPath, "utf-8");
+      } catch (error) {
+        if (error.code !== "ENOENT") return null;
+      }
+      if (currentBytes !== undefined) {
+        if (currentBytes !== staleClaim.bytes) return null;
+        try {
+          fs.unlinkSync(claimPath);
+        } catch (error) {
+          if (error.code !== "ENOENT") return null;
+        }
+      }
+    }
     claimFd = fs.openSync(claimPath, "wx");
     createdClaim = true;
     try {
@@ -1317,7 +1346,13 @@ function claimRetryCompatibleRunDir(runDir) {
     }
     return null;
   } finally {
-    try { fs.unlinkSync(guardPath); } catch {}
+    // If a guard owner dies in this few-syscall critical section, reclaiming it retains a
+    // theoretical concurrent-unlink window. That requires the crash plus two contenders;
+    // final ownership remains atomically arbitrated by the claim file's wx creation.
+    const currentGuard = readDispatchOwnerFile(guard.guardPath);
+    if (currentGuard?.owner.pid === process.pid && currentGuard.owner.nonce === guard.nonce) {
+      try { fs.unlinkSync(guard.guardPath); } catch {}
+    }
   }
 }
 

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1194,11 +1194,32 @@ function failRunDirCollision(runId, manifestPath) {
   process.exit(1);
 }
 
+function isDispatchClaimStale(claimPath) {
+  let claim;
+  try {
+    claim = JSON.parse(fs.readFileSync(claimPath, "utf-8"));
+  } catch {
+    return false;
+  }
+  if (!Number.isInteger(claim?.pid) || claim.pid <= 0) return false;
+  try {
+    process.kill(claim.pid, 0);
+    return false;
+  } catch (error) {
+    return error.code === "ESRCH";
+  }
+}
+
 function isRetryCompatibleRunDir(runDir) {
   if (!fs.existsSync(runDir)) return false;
   const entries = fs.readdirSync(runDir).filter((entry) => entry !== ".DS_Store");
-  return entries.length === 0
-    || (entries.length === 1 && entries[0] === "done-criteria.md");
+  const nonClaimEntries = entries.filter((entry) => entry !== ".dispatch-claim");
+  if (nonClaimEntries.length > 1
+    || (nonClaimEntries.length === 1 && nonClaimEntries[0] !== "done-criteria.md")) {
+    return false;
+  }
+  return !entries.includes(".dispatch-claim")
+    || isDispatchClaimStale(path.join(runDir, ".dispatch-claim"));
 }
 
 function claimRetryCompatibleRunDir(runDir) {
@@ -1211,20 +1232,28 @@ function claimRetryCompatibleRunDir(runDir) {
   }
 
   const claimPath = path.join(runDir, ".dispatch-claim");
-  let claimFd;
-  try {
-    claimFd = fs.openSync(claimPath, "wx");
-    fs.writeFileSync(claimFd, JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString() }));
-  } catch (error) {
-    if (claimFd !== undefined) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let claimFd;
+    try {
+      claimFd = fs.openSync(claimPath, "wx");
+      fs.writeFileSync(claimFd, JSON.stringify({ pid: process.pid, claimed_at: new Date().toISOString() }));
       fs.closeSync(claimFd);
-      try { fs.unlinkSync(claimPath); } catch {}
+      return claimPath;
+    } catch (error) {
+      if (claimFd !== undefined) {
+        fs.closeSync(claimFd);
+        try { fs.unlinkSync(claimPath); } catch {}
+      }
+      if (error.code !== "EEXIST") throw error;
+      if (!isDispatchClaimStale(claimPath)) return null;
+      try {
+        fs.unlinkSync(claimPath);
+      } catch (unlinkError) {
+        if (unlinkError.code !== "ENOENT") return null;
+      }
     }
-    if (error.code === "EEXIST") return null;
-    throw error;
   }
-  fs.closeSync(claimFd);
-  return claimPath;
+  return null;
 }
 
 function isCanonicalPlannerDoneCriteriaPath(repoRoot, runId, doneCriteriaPath) {
@@ -1739,8 +1768,6 @@ async function main() {
     runDirClaimPath = null;
   }
 
-  process.on("exit", releaseRunDirClaim);
-
   function releaseFleetIssueLock() {
     if (!fleetIssueLock) return;
     releaseIssueLock(fleetIssueLock);
@@ -1831,7 +1858,10 @@ async function main() {
     process.exit(1);
   }
 
-  process.once("exit", releaseFleetIssueLock);
+  process.once("exit", () => {
+    try { releaseRunDirClaim(); } catch {}
+    try { releaseFleetIssueLock(); } catch {}
+  });
   process.on("SIGINT", () => { void handleSignal("SIGINT"); });
   process.on("SIGTERM", () => { void handleSignal("SIGTERM"); });
 

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -5134,6 +5134,10 @@ test("dispatch reclaims a claim owned by a real exited process", async () => {
     pid: deadPid,
     claimed_at: new Date().toISOString(),
   }));
+  fs.writeFileSync(path.join(runDir, `.dispatch-claim.reclaim-${deadPid}-orphaned`), JSON.stringify({
+    pid: deadPid,
+    claimed_at: new Date().toISOString(),
+  }));
 
   const rubricFile = path.join(repoRoot, "stale-claim-rubric.yaml");
   fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: stale reclaim\n      target: dispatch proceeds\n", "utf-8");
@@ -5150,6 +5154,57 @@ test("dispatch reclaims a claim owned by a real exited process", async () => {
   });
 
   assert.equal(JSON.parse(output).status, "completed");
+});
+
+test("concurrent retries of one stale claim allow exactly one dispatch", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const runId = "stale-claim-race-20260711010101000-deadbeef";
+  const runDir = getRunDir(repoRoot, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+
+  const exitedOwner = spawn(process.execPath, ["-e", "process.exit(0)"], { stdio: "ignore" });
+  const deadPid = exitedOwner.pid;
+  await new Promise((resolve, reject) => {
+    exitedOwner.once("exit", resolve);
+    exitedOwner.once("error", reject);
+  });
+  fs.writeFileSync(path.join(runDir, ".dispatch-claim"), JSON.stringify({
+    pid: deadPid,
+    claimed_at: new Date().toISOString(),
+  }));
+
+  const markerPath = path.join(os.tmpdir(), `relay-stale-claim-race-${process.pid}-${Date.now()}.json`);
+  const rubricFile = path.join(repoRoot, "stale-claim-race-rubric.yaml");
+  fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: serialized reclaim\n      target: exactly one retry proceeds\n", "utf-8");
+  const args = withRequiredRubric([
+    "--run-id", runId,
+    "-b", "stale-claim-race",
+    "--prompt", "concurrent retry after hard kill",
+    "--rubric-file", rubricFile,
+    "--json",
+  ]);
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "1500",
+    RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: markerPath,
+  };
+  const children = [0, 1].map(() => spawn(process.execPath, [SCRIPT, repoRoot, ...args], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  }));
+  const results = await Promise.all(children.map(waitForDispatchExit));
+  try { fs.unlinkSync(markerPath); } catch {}
+
+  assert.equal(results.filter((result) => result.code === 0).length, 1);
+  const refused = results.find((result) => result.code !== 0);
+  assert.ok(refused);
+  assert.match(refused.stderr, /Refusing to overwrite existing run dir/);
 });
 
 test("exit cleanup releases the fleet issue lock when claim release throws", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -19,6 +19,7 @@ const {
   updateManifestState,
   writeManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { getFleetIssueLockPath } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 const { buildPrBody, pushAndOpenPR, resolveBranchRemote } = require("../../../skills/relay-dispatch/scripts/dispatch-publish");
 const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
 const { parseModelHints } = require("../../../skills/relay-dispatch/scripts/model-hints");
@@ -5111,6 +5112,92 @@ test("dispatch refuses a concurrent new dispatch while its empty run dir is clai
 
   assert.equal(firstResult.code, 0, firstResult.stderr);
   assert.equal(fs.existsSync(path.join(getRunDir(repoRoot, runId), ".dispatch-claim")), false);
+});
+
+test("dispatch reclaims a claim owned by a real exited process", async () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const runId = "stale-claim-20260711010101000-deadbeef";
+  const runDir = getRunDir(repoRoot, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+
+  const exitedOwner = spawn(process.execPath, ["-e", "process.exit(0)"], { stdio: "ignore" });
+  const deadPid = exitedOwner.pid;
+  await new Promise((resolve, reject) => {
+    exitedOwner.once("exit", resolve);
+    exitedOwner.once("error", reject);
+  });
+  assert.throws(() => process.kill(deadPid, 0), (error) => error.code === "ESRCH");
+  fs.writeFileSync(path.join(runDir, ".dispatch-claim"), JSON.stringify({
+    pid: deadPid,
+    claimed_at: new Date().toISOString(),
+  }));
+
+  const rubricFile = path.join(repoRoot, "stale-claim-rubric.yaml");
+  fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: stale reclaim\n      target: dispatch proceeds\n", "utf-8");
+  const output = runDispatch(repoRoot, [
+    "--run-id", runId,
+    "-b", "stale-claim-retry",
+    "--prompt", "retry after hard kill",
+    "--rubric-file", rubricFile,
+    "--json",
+  ], {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  });
+
+  assert.equal(JSON.parse(output).status, "completed");
+});
+
+test("exit cleanup releases the fleet issue lock when claim release throws", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  process.env.RELAY_HOME = relayHome;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
+  writeFakeCodex(binDir);
+  const markerPath = path.join(repoRoot, "exit-cleanup-marker.json");
+  const preloadPath = writePreloadScript(binDir, "claim-release-failure-preload.js", `
+const fs = require("fs");
+const path = require("path");
+const originalUnlinkSync = fs.unlinkSync;
+const originalWriteFileSync = fs.writeFileSync;
+let exiting = false;
+process.prependListener("exit", () => { exiting = true; });
+fs.writeFileSync = function writeFileSync(targetPath) {
+  const result = originalWriteFileSync.apply(this, arguments);
+  if (String(targetPath) === process.env.RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER) {
+    setImmediate(() => process.exit(0));
+  }
+  return result;
+};
+fs.unlinkSync = function unlinkSync(targetPath) {
+  if (exiting && path.basename(String(targetPath)) === ".dispatch-claim") {
+    const error = new Error("injected claim release failure");
+    error.code = "EIO";
+    throw error;
+  }
+  return originalUnlinkSync.apply(this, arguments);
+};`);
+  const env = withNodePreload({
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "30000",
+    RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: markerPath,
+  }, preloadPath);
+
+  const result = spawnSync(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-918",
+    "--prompt", "verify ordered cleanup",
+    "--fleet-id", "issue-918-cleanup",
+    "--json",
+  ])], { cwd: repoRoot, encoding: "utf-8", env });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(markerPath), true);
+  assert.equal(fs.existsSync(getFleetIssueLockPath(repoRoot, 918)), false);
 });
 
 test("dispatch cleans up tmp rubric files when atomic rubric persistence fails", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -5134,9 +5134,10 @@ test("dispatch reclaims a claim owned by a real exited process", async () => {
     pid: deadPid,
     claimed_at: new Date().toISOString(),
   }));
-  fs.writeFileSync(path.join(runDir, `.dispatch-claim.reclaim-${deadPid}-orphaned`), JSON.stringify({
+  fs.writeFileSync(path.join(runDir, ".dispatch-claim.reclaim-lock"), JSON.stringify({
     pid: deadPid,
     claimed_at: new Date().toISOString(),
+    nonce: "orphaned",
   }));
 
   const rubricFile = path.join(repoRoot, "stale-claim-rubric.yaml");
@@ -5156,7 +5157,7 @@ test("dispatch reclaims a claim owned by a real exited process", async () => {
   assert.equal(JSON.parse(output).status, "completed");
 });
 
-test("concurrent retries of one stale claim allow exactly one dispatch", async () => {
+test("a live stale-claim reclaimer cannot be preempted by a later contender", async () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
@@ -5176,7 +5177,23 @@ test("concurrent retries of one stale claim allow exactly one dispatch", async (
     claimed_at: new Date().toISOString(),
   }));
 
-  const markerPath = path.join(os.tmpdir(), `relay-stale-claim-race-${process.pid}-${Date.now()}.json`);
+  const markerPath = path.join(os.tmpdir(), `relay-stale-claim-race-${process.pid}-${Date.now()}.marker`);
+  const releasePath = `${markerPath}.release`;
+  const preloadPath = writePreloadScript(binDir, "stale-claim-reclaim-pause-preload.js", `
+const fs = require("fs");
+const path = require("path");
+const originalReadFileSync = fs.readFileSync;
+let paused = false;
+fs.readFileSync = function readFileSync(targetPath) {
+  if (!paused && path.basename(String(targetPath)) === ".dispatch-claim.reclaim-lock") {
+    paused = true;
+    fs.writeFileSync(process.env.RELAY_TEST_RECLAIM_MARKER, "locked");
+    while (!fs.existsSync(process.env.RELAY_TEST_RECLAIM_RELEASE)) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+    }
+  }
+  return originalReadFileSync.apply(this, arguments);
+};`);
   const rubricFile = path.join(repoRoot, "stale-claim-race-rubric.yaml");
   fs.writeFileSync(rubricFile, "rubric:\n  factors:\n    - name: serialized reclaim\n      target: exactly one retry proceeds\n", "utf-8");
   const args = withRequiredRubric([
@@ -5186,25 +5203,39 @@ test("concurrent retries of one stale claim allow exactly one dispatch", async (
     "--rubric-file", rubricFile,
     "--json",
   ]);
-  const env = {
+  const env = withNodePreload({
     ...process.env,
     PATH: `${binDir}:${process.env.PATH}`,
     RELAY_HOME: relayHome,
-    RELAY_TEST_AFTER_WORKTREE_CREATE_PAUSE_MS: "1500",
-    RELAY_TEST_AFTER_WORKTREE_CREATE_MARKER: markerPath,
-  };
-  const children = [0, 1].map(() => spawn(process.execPath, [SCRIPT, repoRoot, ...args], {
+    RELAY_TEST_RECLAIM_MARKER: markerPath,
+    RELAY_TEST_RECLAIM_RELEASE: releasePath,
+  }, preloadPath);
+  const first = spawn(process.execPath, [SCRIPT, repoRoot, ...args], {
     cwd: repoRoot,
     env,
     stdio: ["ignore", "pipe", "pipe"],
-  }));
-  const results = await Promise.all(children.map(waitForDispatchExit));
-  try { fs.unlinkSync(markerPath); } catch {}
-
-  assert.equal(results.filter((result) => result.code === 0).length, 1);
-  const refused = results.find((result) => result.code !== 0);
-  assert.ok(refused);
-  assert.match(refused.stderr, /Refusing to overwrite existing run dir/);
+  });
+  const firstExit = waitForDispatchExit(first);
+  let firstResult;
+  try {
+    await waitFor(() => fs.existsSync(markerPath), {
+      timeoutMs: 30000,
+      message: "stale-claim reclaimer critical-section marker",
+    });
+    const second = spawnSync(process.execPath, [SCRIPT, repoRoot, ...args], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome },
+    });
+    assert.notEqual(second.status, 0);
+    assert.match(second.stderr, /Refusing to overwrite existing run dir/);
+  } finally {
+    fs.writeFileSync(releasePath, "release");
+    firstResult = await firstExit;
+    try { fs.unlinkSync(markerPath); } catch {}
+    try { fs.unlinkSync(releasePath); } catch {}
+  }
+  assert.equal(firstResult.code, 0, firstResult.stderr);
 });
 
 test("exit cleanup releases the fleet issue lock when claim release throws", () => {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -951,7 +951,7 @@ test("malformed or missing run_id cannot replace the missing Done Criteria error
     }), (error) => {
       assert.match(error.message, /Manifest anchor\.done_criteria_path points to a missing file/);
       assert.doesNotMatch(error.message, /Newer runs persist a run-dir copy at/);
-      assert.doesNotMatch(error.message, /runId/);
+      assert.doesNotMatch(error.message, /\.\.\/malformed/);
       return true;
     });
   }


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #918.

- Reclaims `.dispatch-claim` only when signal-0 probing proves the PID dead (`ESRCH`).
- Preserves collision refusal for live or `EPERM` owners.
- Makes exit cleanup ordered and best-effort.
- Adds stale-owner, live-owner, and cleanup-resilience coverage.
- Fixes the malformed run-ID assertion.
- Commit: `67f7179 fix: reclaim stale dispatch claims (#918)`

Focused tests passed. The required serialized suite was attempted once but stalled in the existing dis
```

## Score Log

- Run: issue-918-20260711004541506-9c41e750
- Executor: codex
- Branch: issue-918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 중단된 작업의 stale claim을 안전하게 회수하여 재시도를 안정화했습니다.
  * 작업 종료 시 claim 해제 중 오류가 발생해도 관련 잠금이 정상적으로 해제됩니다.
  * 잘못된 실행 경로가 오류 메시지에 노출되지 않도록 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->