### PR TITLE
test: lint fake-gh pr view contracts (#928)

### DIFF
--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -2,6 +2,75 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
+const mergeGateResponse = (fixture) => ({
+  baseRefName: fixture.baseRefName || "main",
+  comments: fixture.comments || [],
+  commits: fixture.commits || [],
+  mergeable: fixture.mergeable || "MERGEABLE",
+  statusCheckRollup: fixture.statusCheckRollup || [],
+  headRefOid: fixture.headRefOid || "a".repeat(40),
+  title: fixture.title || "Fixture PR",
+});
+
+const bodySnapshotResponse = (fixture) => ({
+  body: fixture.body || "",
+  headRefOid: fixture.headRefOid || "a".repeat(40),
+  headRefName: fixture.headRefName || "",
+  closingIssuesReferences: fixture.closingIssuesReferences || [],
+});
+
+// This is the fixture's single source of truth for accepted gh pr view field lists.
+// Keep builders deterministic: generated fake-gh scripts serialize their return values.
+const PR_VIEW_JSON_REGISTRY = Object.freeze({
+  "statusCheckRollup,reviews,comments": (fixture) => ({
+    statusCheckRollup: fixture.statusCheckRollup || [],
+    reviews: fixture.reviews || [],
+    comments: fixture.comments || [],
+  }),
+  "closingIssuesReferences,body,headRefName": (fixture) => ({
+    closingIssuesReferences: fixture.closingIssuesReferences || [],
+    body: fixture.body || "",
+    headRefName: fixture.headRefName || "",
+  }),
+  "title,body,number": (fixture) => ({
+    number: fixture.number || 123,
+    title: fixture.title || "Fixture PR",
+    body: fixture.body || "",
+  }),
+  "headRefName": (fixture) => ({ headRefName: fixture.headRefName || "" }),
+  "number,headRefName,headRefOid": (fixture) => ({
+    number: fixture.number || 123,
+    headRefName: fixture.headRefName || "",
+    headRefOid: fixture.headRefOid || "a".repeat(40),
+  }),
+  "state,mergeCommit": (_fixture, loadState) => {
+    const state = loadState();
+    return { state: state.state, mergeCommit: state.mergeCommit };
+  },
+  "comments,commits,mergeable,statusCheckRollup": mergeGateResponse,
+  "baseRefName,comments,commits,mergeable,statusCheckRollup": mergeGateResponse,
+  "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid": mergeGateResponse,
+  "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title": mergeGateResponse,
+  "comments,commits,headRefOid": mergeGateResponse,
+  "comments,commits,headRefName,headRefOid": (fixture) => ({
+    comments: fixture.comments || [],
+    commits: fixture.commits || [],
+    headRefName: fixture.headRefName || "",
+    headRefOid: fixture.headRefOid || "a".repeat(40),
+  }),
+  "body": bodySnapshotResponse,
+  "body,headRefOid,headRefName,closingIssuesReferences": bodySnapshotResponse,
+  "headRefOid,headRefName,body,closingIssuesReferences": bodySnapshotResponse,
+  "mergedAt,state": (fixture) => ({ mergedAt: fixture.mergedAt || null, state: fixture.state || "OPEN" }),
+  "number,state,url,headRefName,mergedAt": (fixture) => ({
+    number: fixture.number || 123,
+    state: fixture.state || "OPEN",
+    url: fixture.url || "",
+    headRefName: fixture.headRefName || "",
+    mergedAt: fixture.mergedAt || null,
+  }),
+});
+
 function writeFakeGhScript({
   ghPath,
   fixture = {},
@@ -14,6 +83,10 @@ function writeFakeGhScript({
     throw new Error("writeFakeGhScript requires ghPath");
   }
 
+  const serializedPrViewRegistry = Object.entries(PR_VIEW_JSON_REGISTRY)
+    .map(([fields, builder]) => `${JSON.stringify(fields)}: ${builder.toString()}`)
+    .join(",\n");
+
   const script = `#!/usr/bin/env node
 const { execFileSync } = require("child_process");
 const fs = require("fs");
@@ -23,11 +96,9 @@ const capturePath = ${JSON.stringify(capturePath)};
 const logPath = ${JSON.stringify(logPath)};
 const statePath = ${JSON.stringify(statePath)};
 const merge = ${JSON.stringify(merge)};
-const prBodySnapshotFields = new Set([
-  "body",
-  "body,headRefOid,headRefName,closingIssuesReferences",
-  "headRefOid,headRefName,body,closingIssuesReferences",
-]);
+const prViewJsonRegistry = {
+${serializedPrViewRegistry}
+};
 
 if (logPath) {
   fs.appendFileSync(logPath, args.join(" ") + "\\n", "utf-8");
@@ -68,85 +139,9 @@ if (args[0] === "pr" && args[1] === "view") {
     process.exit(0);
   }
 
-  // loadPrReviewSignals asks for checks, reviews, and top-level comments in one call.
-  if (fields === "statusCheckRollup,reviews,comments") {
-    writeJson({
-      statusCheckRollup: fixture.statusCheckRollup || [],
-      reviews: fixture.reviews || [],
-      comments: fixture.comments || [],
-    });
-    process.exit(0);
-  }
-
-  // Issue inference reads the PR body plus GitHub's closing issue references.
-  if (fields === "closingIssuesReferences,body,headRefName") {
-    writeJson({
-      closingIssuesReferences: fixture.closingIssuesReferences || [],
-      body: fixture.body || "",
-      headRefName: fixture.headRefName || "",
-    });
-    process.exit(0);
-  }
-
-  // The manual PR fallback path mirrors gh issue view's title/body/number shape.
-  if (fields === "title,body,number") {
-    writeJson({
-      number: fixture.number || 123,
-      title: fixture.title || "Fixture PR",
-      body: fixture.body || "",
-    });
-    process.exit(0);
-  }
-
-  // Merge and preflight checks need the branch name without loading heavier PR data.
-  if (fields === "headRefName") {
-    writeJson({ headRefName: fixture.headRefName || "" });
-    process.exit(0);
-  }
-
-  if (fields === "number,headRefName,headRefOid") {
-    writeJson({
-      number: fixture.number || 123,
-      headRefName: fixture.headRefName || "",
-      headRefOid: fixture.headRefOid || "a".repeat(40),
-    });
-    process.exit(0);
-  }
-
-  // finalize-run polls PR terminal state after merge attempts.
-  if (fields === "state,mergeCommit") {
-    const state = loadState();
-    writeJson({ state: state.state, mergeCommit: state.mergeCommit });
-    process.exit(0);
-  }
-
-  // merge gates need the latest relay audit comment, commits, mergeability, and checks.
-  if (
-    fields === "comments,commits,mergeable,statusCheckRollup" ||
-    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup" ||
-    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid" ||
-    fields === "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title"
-  ) {
-    writeJson({
-      baseRefName: fixture.baseRefName || "main",
-      comments: fixture.comments || [],
-      commits: fixture.commits || [],
-      mergeable: fixture.mergeable || "MERGEABLE",
-      statusCheckRollup: fixture.statusCheckRollup || [],
-      headRefOid: fixture.headRefOid || "a".repeat(40),
-      title: fixture.title || "Fixture PR",
-    });
-    process.exit(0);
-  }
-
-  // Body snapshot calls must stay explicit so future field sets fail loudly.
-  if (prBodySnapshotFields.has(fields)) {
-    writeJson({
-      body: fixture.body || "",
-      headRefOid: fixture.headRefOid || "a".repeat(40),
-      headRefName: fixture.headRefName || "",
-      closingIssuesReferences: fixture.closingIssuesReferences || [],
-    });
+  const responseBuilder = prViewJsonRegistry[fields];
+  if (responseBuilder) {
+    writeJson(responseBuilder(fixture, loadState));
     process.exit(0);
   }
 
@@ -257,6 +252,7 @@ function withFakeGh(fixture, callback, options = {}) {
 }
 
 module.exports = {
+  PR_VIEW_JSON_REGISTRY,
   installFakeGhOnPath,
   withFakeGh,
   writeFakeGhScript,

--- a/tests/skills-lint/scripts/pr-view-json-contract.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.js
@@ -77,7 +77,11 @@ function tokenize(source) {
 }
 
 function nextValueToken(tokens, index, end) {
-  while (index < end && [",", "[", "]"].includes(tokens[index].value)) index += 1;
+  while (
+    index < end
+    && tokens[index].type === "punctuation"
+    && [",", "[", "]"].includes(tokens[index].value)
+  ) index += 1;
   return tokens[index];
 }
 
@@ -85,7 +89,8 @@ function enclosingArgvEnd(tokens, tokenIndex) {
   const openings = [];
   const pairs = { "(": ")", "[": "]" };
   for (let index = 0; index < tokenIndex; index += 1) {
-    const value = tokens[index].value;
+    const { type, value } = tokens[index];
+    if (type !== "punctuation") continue;
     if (pairs[value]) openings.push({ index, value });
     else if (value === ")" || value === "]") openings.pop();
   }
@@ -94,8 +99,8 @@ function enclosingArgvEnd(tokens, tokenIndex) {
 
   let depth = 0;
   for (let index = opening.index; index < tokens.length; index += 1) {
-    if (tokens[index].value === opening.value) depth += 1;
-    if (tokens[index].value === pairs[opening.value]) depth -= 1;
+    if (tokens[index].type === "punctuation" && tokens[index].value === opening.value) depth += 1;
+    if (tokens[index].type === "punctuation" && tokens[index].value === pairs[opening.value]) depth -= 1;
     if (depth === 0) return index;
   }
   return tokens.length;
@@ -118,7 +123,10 @@ function extractPrViewCallSites(source, file) {
     const valueIndex = value ? tokens.indexOf(value, jsonIndex + 1) : -1;
     const terminator = valueIndex === -1 ? null : tokens[valueIndex + 1];
     const isStandaloneString = value?.type === "string" && (
-      !terminator || [",", "]", ")"].includes(terminator.value)
+      !terminator || (
+        terminator.type === "punctuation"
+        && [",", "]", ")"].includes(terminator.value)
+      )
     );
     callSites.push({
       file,

--- a/tests/skills-lint/scripts/pr-view-json-contract.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.js
@@ -115,11 +115,18 @@ function extractPrViewCallSites(source, file) {
     ));
     if (jsonIndex === -1) continue;
     const value = nextValueToken(tokens, jsonIndex + 1, end);
+    const valueIndex = value ? tokens.indexOf(value, jsonIndex + 1) : -1;
+    const terminator = valueIndex === -1 ? null : tokens[valueIndex + 1];
+    const isStandaloneString = value?.type === "string" && (
+      !terminator || [",", "]", ")"].includes(terminator.value)
+    );
     callSites.push({
       file,
       line: tokens[index].line,
-      fields: value?.type === "string" ? value.value : null,
-      valueDescription: value ? `${value.type} ${JSON.stringify(value.value)}` : "missing value",
+      fields: isStandaloneString ? value.value : null,
+      valueDescription: value
+        ? `${value.type} ${JSON.stringify(value.value)}${isStandaloneString ? "" : " in compound expression"}`
+        : "missing value",
     });
   }
   return callSites;

--- a/tests/skills-lint/scripts/pr-view-json-contract.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.js
@@ -1,0 +1,155 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const CALL_NAMES = new Set(["gh", "execGh", "execFileSync"]);
+
+function tokenize(source) {
+  const tokens = [];
+  let index = 0;
+  let line = 1;
+  const push = (type, value, startLine) => tokens.push({ type, value, line: startLine });
+
+  while (index < source.length) {
+    const char = source[index];
+    if (/\s/.test(char)) {
+      if (char === "\n") line += 1;
+      index += 1;
+      continue;
+    }
+    if (source.startsWith("//", index)) {
+      index = source.indexOf("\n", index);
+      if (index === -1) break;
+      continue;
+    }
+    if (source.startsWith("/*", index)) {
+      const end = source.indexOf("*/", index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      line += (source.slice(index, stop).match(/\n/g) || []).length;
+      index = stop;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      const start = index;
+      const startLine = line;
+      index += 1;
+      while (index < source.length) {
+        if (source[index] === "\\") {
+          index += 2;
+          continue;
+        }
+        if (source[index] === char) {
+          index += 1;
+          break;
+        }
+        if (source[index] === "\n") line += 1;
+        index += 1;
+      }
+      const raw = source.slice(start, index);
+      try {
+        // The token is already constrained to a quoted JavaScript string literal.
+        push("string", Function(`"use strict"; return (${raw});`)(), startLine);
+      } catch {
+        // A quote inside a regular-expression literal can look string-like to this
+        // deliberately small lexer; it cannot be an argv string literal.
+        push("nonliteral", "unparsed", startLine);
+      }
+      continue;
+    }
+    if (char === "`") {
+      const startLine = line;
+      index += 1;
+      while (index < source.length) {
+        if (source[index] === "\\") index += 2;
+        else if (source[index] === "`") { index += 1; break; }
+        else { if (source[index] === "\n") line += 1; index += 1; }
+      }
+      push("nonliteral", "template", startLine);
+      continue;
+    }
+    if (/[A-Za-z_$]/.test(char)) {
+      const start = index;
+      while (index < source.length && /[A-Za-z0-9_$]/.test(source[index])) index += 1;
+      push("identifier", source.slice(start, index), line);
+      continue;
+    }
+    push("punctuation", char, line);
+    index += 1;
+  }
+  return tokens;
+}
+
+function matchingParen(tokens, openIndex) {
+  let depth = 0;
+  for (let index = openIndex; index < tokens.length; index += 1) {
+    if (tokens[index].value === "(") depth += 1;
+    if (tokens[index].value === ")") depth -= 1;
+    if (depth === 0) return index;
+  }
+  return tokens.length - 1;
+}
+
+function nextValueToken(tokens, index, end) {
+  while (index < end && [",", "[", "]"].includes(tokens[index].value)) index += 1;
+  return tokens[index];
+}
+
+function extractPrViewCallSites(source, file) {
+  const tokens = tokenize(source);
+  const callSites = [];
+  for (let index = 0; index < tokens.length - 1; index += 1) {
+    if (!CALL_NAMES.has(tokens[index].value) || tokens[index + 1].value !== "(") continue;
+    const end = matchingParen(tokens, index + 1);
+    const call = tokens.slice(index + 2, end);
+    const prIndex = call.findIndex((token, offset) => (
+      token.type === "string" && token.value === "pr" &&
+      call.slice(offset + 1).find((candidate) => candidate.type === "string")?.value === "view"
+    ));
+    if (prIndex === -1) { index = end; continue; }
+    const viewIndex = call.findIndex((token, offset) => offset > prIndex && token.type === "string" && token.value === "view");
+    const jsonIndex = call.findIndex((token, offset) => offset > viewIndex && token.type === "string" && token.value === "--json");
+    if (jsonIndex === -1) { index = end; continue; }
+    const value = nextValueToken(call, jsonIndex + 1, call.length);
+    callSites.push({
+      file,
+      line: tokens[index].line,
+      fields: value?.type === "string" ? value.value : null,
+      valueDescription: value ? `${value.type} ${JSON.stringify(value.value)}` : "missing value",
+    });
+    index = end;
+  }
+  return callSites;
+}
+
+function walkJavaScriptFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return walkJavaScriptFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith(".js") ? [entryPath] : [];
+  });
+}
+
+function extractPrViewCallSitesFromDirectory(directory) {
+  return walkJavaScriptFiles(directory).sort().flatMap((file) => (
+    extractPrViewCallSites(fs.readFileSync(file, "utf-8"), file)
+  ));
+}
+
+function comparePrViewCallSites(callSites, registry, fixturePath) {
+  const accepted = new Set(Object.keys(registry));
+  return callSites.flatMap((callSite) => {
+    const location = `${callSite.file}:${callSite.line}`;
+    if (callSite.fields === null) {
+      return [`${location} has a non-literal gh pr view --json value (${callSite.valueDescription}); fixture: ${fixturePath}`];
+    }
+    if (!accepted.has(callSite.fields)) {
+      return [`${location} uses unsupported gh pr view --json fields ${JSON.stringify(callSite.fields)}; fixture: ${fixturePath}`];
+    }
+    return [];
+  });
+}
+
+module.exports = {
+  comparePrViewCallSites,
+  extractPrViewCallSites,
+  extractPrViewCallSitesFromDirectory,
+};

--- a/tests/skills-lint/scripts/pr-view-json-contract.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.js
@@ -1,8 +1,6 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const CALL_NAMES = new Set(["gh", "execGh", "execFileSync"]);
-
 function tokenize(source) {
   const tokens = [];
   let index = 0;
@@ -78,44 +76,51 @@ function tokenize(source) {
   return tokens;
 }
 
-function matchingParen(tokens, openIndex) {
-  let depth = 0;
-  for (let index = openIndex; index < tokens.length; index += 1) {
-    if (tokens[index].value === "(") depth += 1;
-    if (tokens[index].value === ")") depth -= 1;
-    if (depth === 0) return index;
-  }
-  return tokens.length - 1;
-}
-
 function nextValueToken(tokens, index, end) {
   while (index < end && [",", "[", "]"].includes(tokens[index].value)) index += 1;
   return tokens[index];
 }
 
+function enclosingArgvEnd(tokens, tokenIndex) {
+  const openings = [];
+  const pairs = { "(": ")", "[": "]" };
+  for (let index = 0; index < tokenIndex; index += 1) {
+    const value = tokens[index].value;
+    if (pairs[value]) openings.push({ index, value });
+    else if (value === ")" || value === "]") openings.pop();
+  }
+  const opening = openings.at(-1);
+  if (!opening) return tokens.length;
+
+  let depth = 0;
+  for (let index = opening.index; index < tokens.length; index += 1) {
+    if (tokens[index].value === opening.value) depth += 1;
+    if (tokens[index].value === pairs[opening.value]) depth -= 1;
+    if (depth === 0) return index;
+  }
+  return tokens.length;
+}
+
 function extractPrViewCallSites(source, file) {
   const tokens = tokenize(source);
   const callSites = [];
-  for (let index = 0; index < tokens.length - 1; index += 1) {
-    if (!CALL_NAMES.has(tokens[index].value) || tokens[index + 1].value !== "(") continue;
-    const end = matchingParen(tokens, index + 1);
-    const call = tokens.slice(index + 2, end);
-    const prIndex = call.findIndex((token, offset) => (
-      token.type === "string" && token.value === "pr" &&
-      call.slice(offset + 1).find((candidate) => candidate.type === "string")?.value === "view"
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index].type !== "string" || tokens[index].value !== "pr") continue;
+    const end = enclosingArgvEnd(tokens, index);
+    const view = nextValueToken(tokens, index + 1, end);
+    if (view?.type !== "string" || view.value !== "view") continue;
+    const viewIndex = tokens.indexOf(view, index + 1);
+    const jsonIndex = tokens.findIndex((token, offset) => (
+      offset > viewIndex && offset < end && token.type === "string" && token.value === "--json"
     ));
-    if (prIndex === -1) { index = end; continue; }
-    const viewIndex = call.findIndex((token, offset) => offset > prIndex && token.type === "string" && token.value === "view");
-    const jsonIndex = call.findIndex((token, offset) => offset > viewIndex && token.type === "string" && token.value === "--json");
-    if (jsonIndex === -1) { index = end; continue; }
-    const value = nextValueToken(call, jsonIndex + 1, call.length);
+    if (jsonIndex === -1) continue;
+    const value = nextValueToken(tokens, jsonIndex + 1, end);
     callSites.push({
       file,
       line: tokens[index].line,
       fields: value?.type === "string" ? value.value : null,
       valueDescription: value ? `${value.type} ${JSON.stringify(value.value)}` : "missing value",
     });
-    index = end;
   }
   return callSites;
 }

--- a/tests/skills-lint/scripts/pr-view-json-contract.test.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.test.js
@@ -31,6 +31,19 @@ test("reports non-literal JSON field values at pr view call sites", () => {
   assert.match(errors[0], /fake-gh\.js/);
 });
 
+test("reports non-literal JSON fields after bracket-valued argv strings", () => {
+  for (const bracket of ["]", "["]) {
+    const callSites = extractPrViewCallSites(
+      `execGh(repo, ["pr", "view", ${JSON.stringify(bracket)}, "--json", fields]);`,
+      "skills/example.js",
+    );
+    const errors = comparePrViewCallSites(callSites, PR_VIEW_JSON_REGISTRY, FIXTURE_PATH);
+    assert.equal(callSites.length, 1, bracket);
+    assert.equal(errors.length, 1, bracket);
+    assert.match(errors[0], /skills\/example\.js:1 has a non-literal/, bracket);
+  }
+});
+
 test("reports literal-looking compound JSON field expressions as non-literal", () => {
   for (const expression of [
     '"body" + suffix',

--- a/tests/skills-lint/scripts/pr-view-json-contract.test.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.test.js
@@ -31,6 +31,23 @@ test("reports non-literal JSON field values at pr view call sites", () => {
   assert.match(errors[0], /fake-gh\.js/);
 });
 
+test("reports literal-looking compound JSON field expressions as non-literal", () => {
+  for (const expression of [
+    '"body" + suffix',
+    '"body" ? preferred : fallback',
+    '"body".trim()',
+  ]) {
+    const callSites = extractPrViewCallSites(
+      `execGh(repo, ["pr", "view", "1", "--json", ${expression}]);`,
+      "skills/example.js",
+    );
+    const errors = comparePrViewCallSites(callSites, PR_VIEW_JSON_REGISTRY, FIXTURE_PATH);
+    assert.equal(errors.length, 1, expression);
+    assert.match(errors[0], /skills\/example\.js:1 has a non-literal/, expression);
+    assert.match(errors[0], /compound expression/, expression);
+  }
+});
+
 test("enumerates pr view fields from an argv variable assembled separately", () => {
   const callSites = extractPrViewCallSites(
     `const args = [

--- a/tests/skills-lint/scripts/pr-view-json-contract.test.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.test.js
@@ -31,6 +31,23 @@ test("reports non-literal JSON field values at pr view call sites", () => {
   assert.match(errors[0], /fake-gh\.js/);
 });
 
+test("enumerates pr view fields from an argv variable assembled separately", () => {
+  const callSites = extractPrViewCallSites(
+    `const args = [
+      "pr", "view", String(prNumber),
+      "--json", "number,headRefName,headRefOid",
+    ];
+    execGhJson(repoRoot, args);`,
+    "skills/example.js",
+  );
+  assert.deepEqual(callSites, [{
+    file: "skills/example.js",
+    line: 2,
+    fields: "number,headRefName,headRefOid",
+    valueDescription: 'string "number,headRefName,headRefOid"',
+  }]);
+});
+
 test("#894 regression: missing title-bearing merge fields names finalize-run", () => {
   const titleBearingFields = "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title";
   const registryWithoutTitleBearingFields = Object.fromEntries(

--- a/tests/skills-lint/scripts/pr-view-json-contract.test.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.test.js
@@ -1,0 +1,45 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  comparePrViewCallSites,
+  extractPrViewCallSites,
+  extractPrViewCallSitesFromDirectory,
+} = require("./pr-view-json-contract");
+const { PR_VIEW_JSON_REGISTRY } = require("../../relay-review/fixtures/fake-gh");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SKILLS_DIR = path.join(REPO_ROOT, "skills");
+const FIXTURE_PATH = path.join(REPO_ROOT, "tests", "relay-review", "fixtures", "fake-gh.js");
+
+test("every production gh pr view JSON field list is accepted by fake-gh", () => {
+  const callSites = extractPrViewCallSitesFromDirectory(SKILLS_DIR);
+  const errors = comparePrViewCallSites(callSites, PR_VIEW_JSON_REGISTRY, FIXTURE_PATH);
+  assert.ok(callSites.length > 0, "expected to find production gh pr view call sites");
+  assert.deepEqual(errors, [], errors.join("\n"));
+});
+
+test("reports non-literal JSON field values at pr view call sites", () => {
+  const callSites = extractPrViewCallSites(
+    'execGh(repo, ["pr", "view", "1", "--json", fields]);',
+    "skills/example.js",
+  );
+  const errors = comparePrViewCallSites(callSites, PR_VIEW_JSON_REGISTRY, FIXTURE_PATH);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /skills\/example\.js:1 has a non-literal/);
+  assert.match(errors[0], /fake-gh\.js/);
+});
+
+test("#894 regression: missing title-bearing merge fields names finalize-run", () => {
+  const titleBearingFields = "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title";
+  const registryWithoutTitleBearingFields = Object.fromEntries(
+    Object.entries(PR_VIEW_JSON_REGISTRY).filter(([fields]) => fields !== titleBearingFields),
+  );
+  const callSites = extractPrViewCallSitesFromDirectory(SKILLS_DIR);
+  const errors = comparePrViewCallSites(callSites, registryWithoutTitleBearingFields, FIXTURE_PATH);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /skills\/relay-merge\/scripts\/finalize-run\.js:\d+/);
+  assert.match(errors[0], new RegExp(titleBearingFields));
+  assert.match(errors[0], /tests\/relay-review\/fixtures\/fake-gh\.js/);
+});


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `cb32036` (`test: lint fake-gh pr view contracts (#928)`).

Changes:

- Added a single exported enumerable `PR_VIEW_JSON_REGISTRY`.
- Generated fake-gh matching now derives from that registry.
- Added missing production field-list responses.
- Added static lint for `gh`, `execGh`, and `execFileSync` invocation forms.
- Added non-literal detection and injected-registry #894 regression coverage.
- Preserved unknown-field `{}` fallback.

Verification:

- Skills-lint: 27
```

## Score Log

- Run: issue-928-20260711005113444-2cb91d2a
- Executor: codex
- Branch: issue-928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트 및 품질**
  * GitHub PR 조회에 사용되는 JSON 필드가 지원 목록과 일치하는지 자동으로 검증합니다.
  * 지원되지 않거나 동적으로 지정된 필드 사용을 파일 위치와 함께 감지합니다.
  * 배열로 구성된 필드 목록과 병합 관련 필드 누락 사례에 대한 회귀 검사를 추가했습니다.
  * 테스트용 GitHub PR 응답 생성 방식이 다양한 필드 조합을 안정적으로 처리하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->