### PR TITLE
fix: anchor Codex quota classification (#925)

### DIFF
--- a/skills/relay-review/scripts/invoke-reviewer-codex.js
+++ b/skills/relay-review/scripts/invoke-reviewer-codex.js
@@ -63,17 +63,16 @@ function isExecTimeout(error) {
 const CODEX_USAGE_LIMIT_SIGNATURE = "You've hit your usage limit";
 
 /**
- * If stdout/stderr contain the usage-limit signature, return the matching line
- * (includes the CLI's retry-at text). Otherwise null.
+ * If stdout/stderr contain an anchored CLI usage-limit error line, return it
+ * (including the CLI's retry-at text). Otherwise null.
  */
 function classifyCodexQuotaExhausted(error) {
   const combined = `${String(error?.stdout || "")}\n${String(error?.stderr || "")}`;
-  if (!combined.includes(CODEX_USAGE_LIMIT_SIGNATURE)) return null;
   const matchingLine = combined
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .find((line) => line.includes(CODEX_USAGE_LIMIT_SIGNATURE));
-  return matchingLine || CODEX_USAGE_LIMIT_SIGNATURE;
+    .find((line) => line.startsWith("ERROR:") && line.includes(CODEX_USAGE_LIMIT_SIGNATURE));
+  return matchingLine || null;
 }
 
 function writeRawResponse(filePath, error) {
@@ -136,17 +135,17 @@ function main() {
       });
     } catch (error) {
       writeRawResponse(rawResponsePath, error);
-      if (isExecTimeout(error)) {
-        throw new Error(
-          `Codex reviewer primary_review timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}); ` +
-          `model=${model || "default"}; raw_response=${rawResponsePath}`
-        );
-      }
       const quotaLine = classifyCodexQuotaExhausted(error);
       if (quotaLine) {
         throw new Error(
           `Codex reviewer primary_review failed; codex_quota_exhausted; model=${model || "default"}; ` +
           `raw_response=${rawResponsePath}; ${quotaLine}`
+        );
+      }
+      if (isExecTimeout(error)) {
+        throw new Error(
+          `Codex reviewer primary_review timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}); ` +
+          `model=${model || "default"}; raw_response=${rawResponsePath}`
         );
       }
       const recovered = readNonEmptyFile(resultPath);

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -336,6 +336,75 @@ process.exit(1);
   assert.doesNotMatch(stderr, /Codex reviewer primary_review timed out/);
 });
 
+test("codex adapter ignores usage-limit text embedded in echoed output", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-codex-quota-echo-"));
+  const fakeCodex = writeExecutable(fakeDir, "fake-codex.js", `#!/usr/bin/env node
+process.stdout.write("Echoed prompt: ERROR: You've hit your usage limit. Please preserve this fixture text.\\n");
+process.exit(1);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CODEX_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex },
+    });
+    assert.fail("expected invoke-reviewer-codex.js to fail");
+  } catch (caught) {
+    error = caught;
+  }
+
+  const stderr = String(error.stderr || "");
+  assert.doesNotMatch(stderr, /codex_quota_exhausted/);
+  assert.match(
+    stderr,
+    /^Error: Codex reviewer primary_review failed; model=default; raw_response=.+; Echoed prompt: ERROR: You've hit your usage limit\. Please preserve this fixture text\.\n$/
+  );
+});
+
+test("codex adapter prefers quota classification when quota output overlaps timeout", () => {
+  const { repoRoot, promptPath } = setupRepo();
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-codex-quota-timeout-"));
+  const usageLimitLine =
+    "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 5:47 PM.";
+  const fakeCodex = writeExecutable(fakeDir, "fake-codex.js", `#!/usr/bin/env node
+process.stderr.write(${JSON.stringify(usageLimitLine + "\n")});
+setTimeout(() => {}, 1000);
+`);
+
+  let error;
+  try {
+    execFileSync("node", [
+      CODEX_SCRIPT,
+      "--repo", repoRoot,
+      "--prompt-file", promptPath,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 5000,
+      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex, RELAY_CODEX_REVIEW_TIMEOUT: "50ms" },
+    });
+    assert.fail("expected invoke-reviewer-codex.js to fail on usage limit");
+  } catch (caught) {
+    error = caught;
+  }
+
+  const stderr = String(error.stderr || "");
+  assert.match(stderr, /codex_quota_exhausted/);
+  assert.match(stderr, /try again at 5:47 PM/);
+  assert.doesNotMatch(stderr, /Codex reviewer primary_review timed out/);
+});
+
 test("codex adapter keeps generic failure message unchanged for non-quota errors", () => {
   const { repoRoot, promptPath } = setupRepo();
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-fake-codex-generic-"));

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -376,8 +376,9 @@ test("codex adapter prefers quota classification when quota output overlaps time
   const usageLimitLine =
     "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 5:47 PM.";
   const fakeCodex = writeExecutable(fakeDir, "fake-codex.js", `#!/usr/bin/env node
-process.stderr.write(${JSON.stringify(usageLimitLine + "\n")});
-setTimeout(() => {}, 1000);
+const fs = require("fs");
+fs.writeSync(2, ${JSON.stringify(usageLimitLine + "\n")});
+setTimeout(() => {}, 10000);
 `);
 
   let error;
@@ -391,8 +392,8 @@ setTimeout(() => {}, 1000);
       cwd: repoRoot,
       encoding: "utf-8",
       stdio: "pipe",
-      timeout: 5000,
-      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex, RELAY_CODEX_REVIEW_TIMEOUT: "50ms" },
+      timeout: 20000,
+      env: { ...process.env, RELAY_CODEX_BIN: fakeCodex, RELAY_CODEX_REVIEW_TIMEOUT: "2s" },
     });
     assert.fail("expected invoke-reviewer-codex.js to fail on usage limit");
   } catch (caught) {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #925 as `31c038b`.

Changes:

- Quota detection now requires a trimmed line starting with `ERROR:`.
- Prompt-echo false positives remain generic failures.
- Anchored quota output takes precedence over timeout classification.
- Retry-at text and existing error-message shapes are preserved.
- Added regression coverage for echoed prompts and timeout/quota overlap.

Validation passed:

- Focused reviewer adapter tests
- Serialized relay-review and skills-lint suites
-
```

## Score Log

- Run: issue-925-20260711031333247-36397210
- Executor: codex
- Branch: issue-925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Codex 사용량 제한 오류 감지 로직을 개선해, 특정 오류 패턴이 명확히 일치하지 않으면 잘못 분류하지 않도록 했습니다.
  * 오류 분류 우선순위를 조정해, 사용량 제한과 시간 초과가 동시에 발생할 경우 사용량 제한을 먼저 처리합니다.
* **테스트**
  * 사용량 제한 구문이 일반 출력에만 나타나는 경우 및 사용량 제한과 시간 초과가 함께 발생하는 경우에 대한 회귀 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->