### PR TITLE
fix: guard stale dispatch supervisor results

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -3071,29 +3071,36 @@ async function main() {
     : status === "failed"
       ? "inspect_dispatch_failure"
       : dispatchSuccessNextAction;
-  manifest = updateManifestState(
-    manifest,
-    dispatchTargetState,
-    dispatchNextAction
-  );
-  const { github: _legacyGithub, ...manifestSansGithub } = manifest;
-  const { pr_number: _legacyGithubPrNumber, ...githubFields } = _legacyGithub || {};
-  const github = {
-    ...githubFields,
-    ...(prCreatedByUs !== null ? { pr_created_by_orchestrator: prCreatedByUs } : {}),
-  };
-  manifest = {
-    ...manifestSansGithub,
-    git: {
-      ...(manifestSansGithub.git || {}),
-      ...(prNumber !== null ? { pr_number: prNumber } : {}),
-      head_sha: currentHead || startHead || null,
-    },
-    ...(Object.keys(github).length ? { github } : {}),
-  };
-  writeManifest(manifestPath, manifest);
+  const freshManifest = readManifest(manifestPath).data;
+  const supervisorResultSuperseded = freshManifest.state !== STATES.DISPATCHED;
+  const intendedOutcome = `${dispatchTargetState}_${dispatchFailureClass || status}`;
+  if (supervisorResultSuperseded) {
+    manifest = freshManifest;
+  } else {
+    manifest = updateManifestState(
+      freshManifest,
+      dispatchTargetState,
+      dispatchNextAction
+    );
+    const { github: _legacyGithub, ...manifestSansGithub } = manifest;
+    const { pr_number: _legacyGithubPrNumber, ...githubFields } = _legacyGithub || {};
+    const github = {
+      ...githubFields,
+      ...(prCreatedByUs !== null ? { pr_created_by_orchestrator: prCreatedByUs } : {}),
+    };
+    manifest = {
+      ...manifestSansGithub,
+      git: {
+        ...(manifestSansGithub.git || {}),
+        ...(prNumber !== null ? { pr_number: prNumber } : {}),
+        head_sha: currentHead || startHead || null,
+      },
+      ...(Object.keys(github).length ? { github } : {}),
+    };
+    writeManifest(manifestPath, manifest);
+  }
 
-  const shouldAutoRecoverCommit = AUTO_RECOVER_COMMIT && !DRY_RUN && (
+  const shouldAutoRecoverCommit = !supervisorResultSuperseded && AUTO_RECOVER_COMMIT && !DRY_RUN && (
     status === "completed-uncommitted" ||
     (PUBLISH_POLICY === "after-internal-review" && status === "completed-with-warning" && uncommitted)
   );
@@ -3157,12 +3164,20 @@ async function main() {
   }
   appendRunEvent(repoRoot, runId, {
     event: EVENTS.DISPATCH_RESULT,
-    state_from: STATES.DISPATCHED,
+    state_from: supervisorResultSuperseded ? manifest.state : STATES.DISPATCHED,
     state_to: manifest.state,
     head_sha: currentHead || startHead || null,
-    reason: status === "failed"
-      ? `${RESUME_MODE ? "same_run_resume" : "new_dispatch"}:${error || "dispatch_failed"}`
-      : `${RESUME_MODE ? "same_run_resume" : "new_dispatch"}:${status}`,
+    reason: supervisorResultSuperseded
+      ? `supervisor_result_superseded_by_external_progress:${intendedOutcome}`
+      : status === "failed"
+        ? `${RESUME_MODE ? "same_run_resume" : "new_dispatch"}:${error || "dispatch_failed"}`
+        : `${RESUME_MODE ? "same_run_resume" : "new_dispatch"}:${status}`,
+    ...(supervisorResultSuperseded
+      ? {
+          observed_state: manifest.state,
+          intended_outcome: intendedOutcome,
+        }
+      : {}),
     publish_policy: PUBLISH_POLICY,
     executor_network: executorNetworkPolicy,
     executor_policy: executorPolicy,

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -287,6 +287,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.dispatch_failure_class !== undefined
       ? { dispatch_failure_class: normalizeEventValue(eventData.dispatch_failure_class) }
       : {}),
+    ...(eventData.observed_state !== undefined
+      ? { observed_state: normalizeEventValue(eventData.observed_state) }
+      : {}),
+    ...(eventData.intended_outcome !== undefined
+      ? { intended_outcome: normalizeEventValue(eventData.intended_outcome) }
+      : {}),
     ...(eventData.preflight_type !== undefined
       ? { preflight_type: normalizeEventValue(eventData.preflight_type) }
       : {}),

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1038,6 +1038,40 @@ setInterval(() => {}, 1000);
   return codexPath;
 }
 
+function writeTerminalFailureCodex(binDir, markerPath) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const output = args[args.indexOf("-o") + 1];
+const manifestPath = path.dirname(output) + ".md";
+fs.writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify({
+  pid: process.pid,
+  manifestPath,
+}), "utf-8");
+if (process.env.RELAY_TEST_EXTERNAL_ADVANCE === "1") {
+  const manifest = fs.readFileSync(manifestPath, "utf-8")
+    .replace(/^state: 'dispatched'$/m, "state: 'review_pending'")
+    .replace(/^next_action: 'await_dispatch_result'$/m, "next_action: 'run_review'");
+  fs.writeFileSync(manifestPath, manifest, "utf-8");
+}
+process.stderr.write("simulated executor failure\\n");
+process.exit(7);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
 function writeLeaseCheckingCodex(binDir, markerPath) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -5590,6 +5624,94 @@ test("dispatch creates a run lease while executor runs and removes it on normal 
   assert.equal(marker.lease.host, os.hostname());
   assert.equal(marker.lease.timeout_s, 2400);
   assert.equal(fs.existsSync(marker.leasePath), false);
+});
+
+test("dispatch terminal write preserves external progress and audits the superseded outcome", async (t) => {
+  const fixtures = [];
+  registerSignalFixtureCleanup(t, {
+    pids: () => fixtures.map((fixture) => fixture.marker?.pid),
+    paths: () => fixtures.flatMap((fixture) => [
+      fixture.repoRoot,
+      fixture.relayHome,
+      fixture.remoteRoot,
+      fixture.binDir,
+      fixture.markerPath,
+    ]),
+  });
+
+  function runTerminalFailure({ branch, externalAdvance }) {
+    const { repoRoot, relayHome, remoteRoot } = setupRepo();
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-terminal-failure-bin-"));
+    const markerPath = path.join(
+      os.tmpdir(),
+      `relay-dispatch-terminal-failure-${process.pid}-${Date.now()}-${externalAdvance}.json`
+    );
+    const fixture = { repoRoot, relayHome, remoteRoot, binDir, markerPath, marker: null };
+    fixtures.push(fixture);
+    writeTerminalFailureCodex(binDir, markerPath);
+    const env = {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      RELAY_HOME: relayHome,
+      ...(externalAdvance ? { RELAY_TEST_EXTERNAL_ADVANCE: "1" } : {}),
+    };
+
+    const proc = spawnSync(process.execPath, [SCRIPT, repoRoot, ...withRequiredRubric([
+      "-b", branch,
+      "--prompt", "fail after optionally advancing the manifest",
+      "--json",
+    ])], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env,
+    });
+    fixture.marker = JSON.parse(fs.readFileSync(markerPath, "utf-8"));
+    const result = JSON.parse(proc.stdout);
+    return {
+      proc,
+      result,
+      manifest: readManifest(fixture.marker.manifestPath).data,
+      events: readJsonLines(path.join(result.runDir, "events.jsonl")),
+    };
+  }
+
+  const normal = runTerminalFailure({
+    branch: "issue-926-terminal-failure-normal",
+    externalAdvance: false,
+  });
+  assert.equal(normal.proc.status, 7);
+  assert.equal(normal.result.exitCode, 7);
+  assert.equal(normal.result.runState, STATES.ESCALATED);
+  assert.equal(normal.manifest.state, STATES.ESCALATED);
+  const normalDispatchResults = normal.events.filter((event) => event.event === "dispatch_result");
+  assert.equal(normalDispatchResults.length, 1);
+  assert.equal(normalDispatchResults[0].state_from, STATES.DISPATCHED);
+  assert.equal(normalDispatchResults[0].state_to, STATES.ESCALATED);
+  assert.equal(normalDispatchResults[0].observed_state, undefined);
+  assert.equal(normalDispatchResults[0].intended_outcome, undefined);
+
+  const superseded = runTerminalFailure({
+    branch: "issue-926-terminal-failure-superseded",
+    externalAdvance: true,
+  });
+  assert.equal(superseded.proc.status, normal.proc.status);
+  assert.equal(superseded.result.exitCode, normal.result.exitCode);
+  assert.deepEqual(Object.keys(superseded.result), Object.keys(normal.result));
+  assert.equal(superseded.result.runState, STATES.REVIEW_PENDING);
+  assert.equal(superseded.manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(superseded.manifest.next_action, "run_review");
+  assert.equal(fs.existsSync(path.join(superseded.result.runDir, "lease.json")), false);
+
+  const supersededDispatchResults = superseded.events.filter((event) => event.event === "dispatch_result");
+  assert.equal(supersededDispatchResults.length, 1);
+  assert.equal(supersededDispatchResults[0].state_from, STATES.REVIEW_PENDING);
+  assert.equal(supersededDispatchResults[0].state_to, STATES.REVIEW_PENDING);
+  assert.match(
+    supersededDispatchResults[0].reason,
+    /^supervisor_result_superseded_by_external_progress/
+  );
+  assert.equal(supersededDispatchResults[0].observed_state, STATES.REVIEW_PENDING);
+  assert.equal(supersededDispatchResults[0].intended_outcome, "escalated_no_result");
 });
 
 test("dispatch keeps lease and leaves run dispatched when timeout kill leaves process group unsettled", async (t) => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `6377057` (`fix: guard stale dispatch supervisor results`). Worktree is clean.

- [dispatch.js](/Users/sjlee/.relay/worktrees/310fdb61/dev-relay/skills/relay-dispatch/scripts/dispatch.js:3074) performs a fresh disk read, skips stale terminal writes, suppresses auto-recovery mutations, and emits one shared `dispatch_result`.
- [dispatch.test.js](/Users/sjlee/.relay/worktrees/310fdb61/dev-relay/tests/relay-dispatch/scripts/dispatch.test.js:5629) pins normal and externa
```

## Score Log

- Run: issue-926-20260711031445030-04415960
- Executor: codex
- Branch: issue-926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 외부 진행으로 실행 결과가 이미 대체된 경우, 기존 상태를 덮어쓰지 않고 최신 진행 상태를 보존합니다.
  - 대체된 실행 결과를 관련 상태와 의도된 결과를 포함해 기록합니다.
  - 외부 진행이 발생하면 불필요한 자동 복구 커밋을 방지합니다.

- **버그 수정**
  - 실행 결과 처리 중 최신 상태가 손실되거나 잘못된 상태로 전환되는 문제를 수정했습니다.
  - 외부 상태 변경 및 실패 상황에 대한 기록과 복구 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->