### PR TITLE
fix: retry advisory parse failures once within lane budget (#932)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -380,6 +380,12 @@ function appendRunEvent(repoRoot, runId, eventData) {
     ...(eventData.raw_response_path !== undefined
       ? { raw_response_path: normalizeEventValue(eventData.raw_response_path) }
       : {}),
+    ...(eventData.raw_response_paths !== undefined
+      ? { raw_response_paths: normalizeEventValue(eventData.raw_response_paths) }
+      : {}),
+    ...(eventData.attempt_count !== undefined
+      ? { attempt_count: normalizeEventValue(eventData.attempt_count) }
+      : {}),
     ...(eventData.required_count !== undefined
       ? { required_count: normalizeEventValue(eventData.required_count) }
       : {}),

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -19,6 +19,16 @@ const { writeText } = require("./common");
 
 const DEFAULT_ADVISORY_TIMEOUT_SECONDS = 900;
 const DEFAULT_ADVISORY_GRACE_SECONDS = 10;
+/** Floor for a second advisory attempt when the adapter is not cline. */
+const MIN_ADVISORY_RETRY_TIMEOUT_SECONDS = 1;
+/**
+ * Cline's adapter refuses parent budgets below 120s (see invoke-reviewer-cline.js).
+ * A retry with less remaining budget cannot succeed, so skip it.
+ */
+const CLINE_MIN_ADVISORY_RETRY_TIMEOUT_SECONDS = 120;
+/** Stable adapter-side signal: output obtained, no advisory candidate validated. */
+const ADAPTER_PARSE_FAILURE_SIGNAL_RE =
+  /failed to parse any of \d+ advisory candidate/i;
 
 function parsePositiveSeconds(value, fallback = DEFAULT_ADVISORY_TIMEOUT_SECONDS) {
   if (value === undefined || value === null || value === "") return fallback;
@@ -210,13 +220,41 @@ function startAdvisoryReview({
   };
 }
 
-function writeRawResponse(runDir, round, reviewerName, stdout, stderr) {
-  const rawResponsePath = path.join(runDir, `review-round-${round}-advisory-${reviewerName}-raw-response.txt`);
+function writeRawResponse(runDir, round, reviewerName, stdout, stderr, { attempt = null } = {}) {
+  const suffix = Number.isInteger(attempt) && attempt > 0
+    ? `-raw-response-attempt-${attempt}.txt`
+    : "-raw-response.txt";
+  const rawResponsePath = path.join(runDir, `review-round-${round}-advisory-${reviewerName}${suffix}`);
   const text = stderr.trim()
     ? [stdout.trim(), "", "stderr:", stderr.trim()].filter(Boolean).join("\n")
     : stdout.trim();
   writeText(rawResponsePath, `${text}\n`);
   return rawResponsePath;
+}
+
+function promoteRawResponseToAttempt(rawResponsePath, attemptNumber) {
+  const attemptPath = rawResponsePath.replace(
+    /-raw-response\.txt$/,
+    `-raw-response-attempt-${attemptNumber}.txt`
+  );
+  if (attemptPath === rawResponsePath) {
+    throw new Error(`cannot promote raw response path to attempt artifact: ${rawResponsePath}`);
+  }
+  fs.renameSync(rawResponsePath, attemptPath);
+  return attemptPath;
+}
+
+function minAdvisoryRetryTimeoutSeconds(reviewerName) {
+  return reviewerName === "cline"
+    ? CLINE_MIN_ADVISORY_RETRY_TIMEOUT_SECONDS
+    : MIN_ADVISORY_RETRY_TIMEOUT_SECONDS;
+}
+
+function isAdapterParseFailureSignal({ stdout, stderr, outcome }) {
+  const hasOutput = Boolean(String(stdout || "").trim() || String(stderr || "").trim());
+  if (!hasOutput) return false;
+  const haystack = [stderr, stdout, outcome?.error?.message].filter(Boolean).join("\n");
+  return ADAPTER_PARSE_FAILURE_SIGNAL_RE.test(haystack);
 }
 
 function buildDeferredResult(advisoryRun, { criticalPathWaitMs = 0, consumedByPhase = "metrics" } = {}) {
@@ -384,12 +422,15 @@ function waitForDecisionTiming(request, waitMs = 300) {
  * RELAY_CLINE_REVIEW_TIMEOUT so one number governs both the parent
  * execFileSync kill and the adapter's internal --timeout derivation.
  * Direct (non-advisory) cline invocations keep the env contract unchanged.
+ * Callers may pass timeoutSeconds to reflect a remaining retry budget.
  */
-function buildAdvisoryAdapterEnv(request) {
+function buildAdvisoryAdapterEnv(request, { timeoutSeconds } = {}) {
   const env = { ...process.env };
   if (request.reviewerName === "cline") {
-    const timeoutSeconds = parsePositiveSeconds(request.timeoutSeconds);
-    env.RELAY_CLINE_REVIEW_TIMEOUT = `${timeoutSeconds}s`;
+    const seconds = parsePositiveSeconds(
+      timeoutSeconds !== undefined ? timeoutSeconds : request.timeoutSeconds
+    );
+    env.RELAY_CLINE_REVIEW_TIMEOUT = `${seconds}s`;
   }
   return env;
 }
@@ -398,6 +439,8 @@ function executeAdvisoryRequest(request) {
   let artifactPath = null;
   let failureReason = null;
   let rawResponsePath = null;
+  let rawResponsePaths = [];
+  let attemptCount = 0;
   let status = "success";
   let counts = { required_count: 0, advisory_count: 0, duplicate_low_confidence_count: 0 };
   let advisoryRepoPath = null;
@@ -408,8 +451,10 @@ function executeAdvisoryRequest(request) {
         ? validateAdvisoryProfile(request.profile)
         : null
     );
-    const timeoutMs = parsePositiveSeconds(request.timeoutSeconds) * 1000;
-    advisoryRepoPath = createAdvisoryWorktree(request.reviewRepoPath, request.runDir, request.artifactReviewerName || request.reviewerName);
+    const laneBudgetMs = parsePositiveSeconds(request.timeoutSeconds) * 1000;
+    const laneStartedAt = Date.now();
+    const artifactName = request.artifactReviewerName || request.reviewerName;
+    advisoryRepoPath = createAdvisoryWorktree(request.reviewRepoPath, request.runDir, artifactName);
     const statusBefore = captureGitStatus(advisoryRepoPath);
     const execArgs = [
       request.reviewerScript,
@@ -421,38 +466,54 @@ function executeAdvisoryRequest(request) {
     if (request.reviewerModel) execArgs.push("--model", request.reviewerModel);
     if (advisoryProfile) execArgs.push("--profile", advisoryProfile);
 
-    let stdout = "";
-    let stderr = "";
-    let outcome = { code: 0 };
-    try {
-      const execOptions = {
-        cwd: advisoryRepoPath,
-        encoding: "utf-8",
-        maxBuffer: 10 * 1024 * 1024,
-        stdio: "pipe",
-        timeout: timeoutMs,
-      };
-      if (request.reviewerName === "cline") {
-        execOptions.env = buildAdvisoryAdapterEnv(request);
+    function runAdapterAttempt(timeoutMs) {
+      attemptCount += 1;
+      let stdout = "";
+      let stderr = "";
+      let outcome = { code: 0 };
+      try {
+        const execOptions = {
+          cwd: advisoryRepoPath,
+          encoding: "utf-8",
+          maxBuffer: 10 * 1024 * 1024,
+          stdio: "pipe",
+          timeout: timeoutMs,
+        };
+        if (request.reviewerName === "cline") {
+          execOptions.env = buildAdvisoryAdapterEnv(request, {
+            timeoutSeconds: Math.max(1, Math.ceil(timeoutMs / 1000)),
+          });
+        }
+        stdout = execFileSync(process.execPath, execArgs, execOptions).trim();
+      } catch (error) {
+        stdout = String(error.stdout || "").trim();
+        stderr = String(error.stderr || "").trim();
+        outcome = {
+          code: Number.isInteger(error.status) ? error.status : null,
+          error,
+          signal: error.signal,
+          timeout: error.code === "ETIMEDOUT" || error.signal === "SIGTERM",
+        };
       }
-      stdout = execFileSync(process.execPath, execArgs, execOptions).trim();
-    } catch (error) {
-      stdout = String(error.stdout || "").trim();
-      stderr = String(error.stderr || "").trim();
-      outcome = {
-        code: Number.isInteger(error.status) ? error.status : null,
-        error,
-        signal: error.signal,
-        timeout: error.code === "ETIMEDOUT" || error.signal === "SIGTERM",
-      };
+      const attemptRawPath = writeRawResponse(
+        request.runDir,
+        request.round,
+        artifactName,
+        stdout,
+        stderr
+      );
+      rawResponsePaths.push(attemptRawPath);
+      rawResponsePath = attemptRawPath;
+      return { stdout, stderr, outcome, rawPath: attemptRawPath };
     }
 
-    rawResponsePath = writeRawResponse(request.runDir, request.round, request.artifactReviewerName || request.reviewerName, stdout, stderr);
-    const statusAfter = captureGitStatus(advisoryRepoPath);
-    if (statusBefore !== statusAfter) {
+    function applyPolicyViolation(statusAfter) {
       status = "policy_violation";
       failureReason = "advisory_reviewer_modified_worktree";
-      artifactPath = path.join(request.runDir, `review-round-${request.round}-advisory-${request.artifactReviewerName || request.reviewerName}-policy-violation.txt`);
+      artifactPath = path.join(
+        request.runDir,
+        `review-round-${request.round}-advisory-${artifactName}-policy-violation.txt`
+      );
       writeText(artifactPath, [
         "Advisory reviewer write policy violation detected.",
         "",
@@ -465,22 +526,15 @@ function executeAdvisoryRequest(request) {
         "Status after advisory reviewer:",
         statusAfter || "(clean)",
       ].join("\n") + "\n");
-    } else if (outcome.timeout) {
-      status = "timeout";
-      failureReason = (
-        `${request.reviewerName} reviewer advisory_review timed out after ${timeoutMs / 1000}s; ` +
-        `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
+    }
+
+    function applySuccess(parsed) {
+      status = "success";
+      failureReason = null;
+      artifactPath = path.join(
+        request.runDir,
+        `review-round-${request.round}-advisory-${artifactName}.json`
       );
-    } else if (outcome.error || outcome.code !== 0) {
-      status = "failed";
-      failureReason = outcome.error ? outcome.error.message : `advisory reviewer exited with code ${outcome.code}`;
-    } else {
-      const parsed = parseAdvisoryReview(stdout, {
-        adapter: request.reviewerName,
-        phase: "advisory_review",
-        profile: request.profile,
-      });
-      artifactPath = path.join(request.runDir, `review-round-${request.round}-advisory-${request.artifactReviewerName || request.reviewerName}.json`);
       writeText(artifactPath, `${JSON.stringify(parsed, null, 2)}\n`);
       counts = {
         required_count: parsed.required_findings.length,
@@ -488,6 +542,90 @@ function executeAdvisoryRequest(request) {
         duplicate_low_confidence_count: parsed.duplicate_or_low_confidence.length,
       };
     }
+
+    /**
+     * Classify one adapter attempt.
+     * Returns { kind: "success"|"policy_violation"|"timeout"|"failed"|"parse_failure", ... }.
+     * parse_failure is the only retryable class (model-output variance).
+     */
+    function classifyAttempt({ stdout, stderr, outcome, rawPath }) {
+      const statusAfter = captureGitStatus(advisoryRepoPath);
+      if (statusBefore !== statusAfter) {
+        return { kind: "policy_violation", statusAfter };
+      }
+      if (outcome.timeout) {
+        return {
+          kind: "timeout",
+          failureReason: (
+            `${request.reviewerName} reviewer advisory_review timed out after ${laneBudgetMs / 1000}s; ` +
+            `model=${request.reviewerModel || "default"}; raw_response=${rawPath}`
+          ),
+        };
+      }
+      if (outcome.error || outcome.code !== 0) {
+        const execFailureReason = outcome.error
+          ? outcome.error.message
+          : `advisory reviewer exited with code ${outcome.code}`;
+        if (isAdapterParseFailureSignal({ stdout, stderr, outcome })) {
+          return { kind: "parse_failure", failureReason: execFailureReason };
+        }
+        return { kind: "failed", failureReason: execFailureReason };
+      }
+      try {
+        const parsed = parseAdvisoryReview(stdout, {
+          adapter: request.reviewerName,
+          phase: "advisory_review",
+          profile: request.profile,
+        });
+        return { kind: "success", parsed };
+      } catch (error) {
+        // Exit 0 with no stdout is closer to no-output than variance — do not retry.
+        if (!String(stdout || "").trim()) {
+          return { kind: "failed", failureReason: error.message };
+        }
+        return { kind: "parse_failure", failureReason: error.message };
+      }
+    }
+
+    function settleClassification(classification) {
+      if (classification.kind === "success") {
+        applySuccess(classification.parsed);
+        return;
+      }
+      if (classification.kind === "policy_violation") {
+        applyPolicyViolation(classification.statusAfter);
+        return;
+      }
+      status = classification.kind === "timeout" ? "timeout" : "failed";
+      failureReason = classification.failureReason;
+    }
+
+    let classification = classifyAttempt(runAdapterAttempt(laneBudgetMs));
+    if (classification.kind === "parse_failure") {
+      const remainingMs = laneBudgetMs - (Date.now() - laneStartedAt);
+      const minRetryMs = minAdvisoryRetryTimeoutSeconds(request.reviewerName) * 1000;
+      if (remainingMs >= minRetryMs) {
+        rawResponsePaths[0] = promoteRawResponseToAttempt(rawResponsePaths[0], 1);
+        classification = classifyAttempt(runAdapterAttempt(remainingMs));
+        if (classification.kind === "parse_failure") {
+          // Retry exhausted — surface as a normal failed result.
+          classification = {
+            kind: "failed",
+            failureReason: classification.failureReason,
+          };
+        }
+      } else {
+        const remainingSeconds = Math.max(0, Math.floor(remainingMs / 1000));
+        classification = {
+          kind: "failed",
+          failureReason: (
+            `${classification.failureReason}; retry skipped: remaining lane budget ` +
+            `${remainingSeconds}s below viable adapter minimum ${minRetryMs / 1000}s`
+          ),
+        };
+      }
+    }
+    settleClassification(classification);
   } catch (error) {
     status = "failed";
     failureReason = error.message;
@@ -497,6 +635,7 @@ function executeAdvisoryRequest(request) {
   const result = {
     artifactHash,
     artifactPath,
+    attemptCount,
     completed_at: new Date().toISOString(),
     failureReason,
     gating: request.gating === true,
@@ -504,6 +643,7 @@ function executeAdvisoryRequest(request) {
     model: request.reviewerModel || null,
     profile: request.profile,
     rawResponsePath,
+    rawResponsePaths: rawResponsePaths.slice(),
     reviewer: request.reviewerName,
     source: request.source || null,
     status,
@@ -537,6 +677,8 @@ function executeAdvisoryRequest(request) {
       artifact_path: artifactPath,
       advisory_artifact_hash: artifactHash,
       raw_response_path: rawResponsePath,
+      raw_response_paths: rawResponsePaths.slice(),
+      attempt_count: attemptCount,
       failure_reason: failureReason,
       ...counts,
       ...timingFields,

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -504,7 +504,7 @@ function executeAdvisoryRequest(request) {
       );
       rawResponsePaths.push(attemptRawPath);
       rawResponsePath = attemptRawPath;
-      return { stdout, stderr, outcome, rawPath: attemptRawPath };
+      return { stdout, stderr, outcome, rawResponsePath: attemptRawPath };
     }
 
     function applyPolicyViolation(statusAfter) {
@@ -548,7 +548,7 @@ function executeAdvisoryRequest(request) {
      * Returns { kind: "success"|"policy_violation"|"timeout"|"failed"|"parse_failure", ... }.
      * parse_failure is the only retryable class (model-output variance).
      */
-    function classifyAttempt({ stdout, stderr, outcome, rawPath }) {
+    function classifyAttempt({ stdout, stderr, outcome, rawResponsePath }) {
       const statusAfter = captureGitStatus(advisoryRepoPath);
       if (statusBefore !== statusAfter) {
         return { kind: "policy_violation", statusAfter };
@@ -558,7 +558,7 @@ function executeAdvisoryRequest(request) {
           kind: "timeout",
           failureReason: (
             `${request.reviewerName} reviewer advisory_review timed out after ${laneBudgetMs / 1000}s; ` +
-            `model=${request.reviewerModel || "default"}; raw_response=${rawPath}`
+            `model=${request.reviewerModel || "default"}; raw_response=${rawResponsePath}`
           ),
         };
       }

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -692,6 +692,272 @@ test("buildAdvisoryAdapterEnv only rewrites cline timeout env", () => {
   }
 });
 
+function writeStatefulParseRetryReviewer(repoRoot, {
+  counterPath,
+  failCalls = 1,
+  exitNonZeroOnParseFail = false,
+  mutateOnCall = null,
+  hangMs = 0,
+  emptyOnFail = false,
+  envLogPath = null,
+} = {}) {
+  const filePath = path.join(repoRoot, "stateful-parse-retry-reviewer.js");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require("fs");
+const counterPath = ${JSON.stringify(counterPath)};
+const envLogPath = ${JSON.stringify(envLogPath)};
+const failCalls = ${Number(failCalls)};
+const hangMs = ${Number(hangMs)};
+const emptyOnFail = ${emptyOnFail ? "true" : "false"};
+const exitNonZeroOnParseFail = ${exitNonZeroOnParseFail ? "true" : "false"};
+const mutateOnCall = ${mutateOnCall == null ? "null" : Number(mutateOnCall)};
+const call = Number(fs.existsSync(counterPath) ? fs.readFileSync(counterPath, "utf-8") : "0") + 1;
+fs.writeFileSync(counterPath, String(call), "utf-8");
+if (envLogPath) {
+  let prior = [];
+  try { prior = JSON.parse(fs.readFileSync(envLogPath, "utf-8")); } catch {}
+  prior.push({ call, RELAY_CLINE_REVIEW_TIMEOUT: process.env.RELAY_CLINE_REVIEW_TIMEOUT || null });
+  fs.writeFileSync(envLogPath, JSON.stringify(prior), "utf-8");
+}
+if (mutateOnCall === call) {
+  fs.writeFileSync(require("path").join(process.cwd(), "advisory-mutated.txt"), "bad\\n", "utf-8");
+}
+if (hangMs > 0) {
+  const end = Date.now() + hangMs;
+  while (Date.now() < end) {}
+}
+if (call <= failCalls) {
+  if (emptyOnFail) {
+    process.stderr.write("");
+    process.exit(1);
+  }
+  if (exitNonZeroOnParseFail) {
+    process.stderr.write("Error: Cline advisory review failed to parse any of 1 advisory candidate(s); first failure: bad json\\n");
+    process.stdout.write("not-valid-advisory-json\\n");
+    process.exit(1);
+  }
+  process.stdout.write("not-valid-advisory-json\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  profile: "blindspot",
+  summary: "recovered on retry",
+  required_findings: [],
+  advisory_findings: [],
+  duplicate_or_low_confidence: [],
+}));
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function executeParseRetryRequest({
+  reviewerFixture = {},
+  reviewerName = "opencode",
+  artifactReviewerName = "retry",
+  timeoutSeconds = 30,
+  profile = "blindspot",
+} = {}) {
+  const { repoRoot, runDir, runId } = setupRepo();
+  const resultPath = path.join(runDir, "parse-retry-result.json");
+  const promptPath = path.join(runDir, "parse-retry-prompt.md");
+  const decisionPath = path.join(runDir, "parse-retry-decision.json");
+  fs.writeFileSync(promptPath, "Advisory prompt\n", "utf-8");
+  const counterPath = path.join(runDir, "parse-retry-counter.txt");
+  const reviewerScript = writeStatefulParseRetryReviewer(repoRoot, {
+    counterPath,
+    ...reviewerFixture,
+  });
+
+  const result = executeAdvisoryRequest({
+    artifactReviewerName,
+    decisionPath,
+    gating: false,
+    headSha: "a".repeat(40),
+    laneIndex: 1,
+    profile,
+    promptPath,
+    requestPath: path.join(runDir, "parse-retry-request.json"),
+    resultPath,
+    reviewerModel: null,
+    reviewerName,
+    reviewerPolicy: null,
+    policyDecision: null,
+    modelResolution: null,
+    reviewerScript,
+    reviewRepoPath: repoRoot,
+    round: 1,
+    runDir,
+    runId,
+    runRepoPath: repoRoot,
+    source: null,
+    startedAt: Date.now(),
+    state: STATES.REVIEW_PENDING,
+    timeoutSeconds,
+    trigger: "every_round",
+  });
+
+  return { repoRoot, runDir, runId, result, resultPath, counterPath };
+}
+
+test("executeAdvisoryRequest retries once after exit-0 parse failure and succeeds", () => {
+  const { repoRoot, runDir, runId, result } = executeParseRetryRequest();
+  const attempt1 = path.join(runDir, "review-round-1-advisory-retry-raw-response-attempt-1.txt");
+  const attempt2 = path.join(runDir, "review-round-1-advisory-retry-raw-response.txt");
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === EVENTS.ADVISORY_REVIEW);
+
+  assert.equal(result.status, "success");
+  assert.equal(result.attemptCount, 2);
+  assert.equal(result.rawResponsePath, attempt2);
+  assert.deepEqual(result.rawResponsePaths, [attempt1, attempt2]);
+  assert.equal(fs.existsSync(attempt1), true);
+  assert.equal(fs.existsSync(attempt2), true);
+  assert.match(fs.readFileSync(attempt1, "utf-8"), /not-valid-advisory-json/);
+  assert.match(fs.readFileSync(attempt2, "utf-8"), /recovered on retry/);
+  assert.equal(event.attempt_count, 2);
+  assert.deepEqual(event.raw_response_paths, [attempt1, attempt2]);
+  assert.ok(result.artifactPath);
+  assert.ok(result.artifactHash);
+});
+
+test("executeAdvisoryRequest keeps both raw artifacts when parse retry also fails", () => {
+  const { repoRoot, runDir, runId, result } = executeParseRetryRequest({
+    reviewerFixture: { failCalls: 99 },
+    artifactReviewerName: "retry-fail",
+  });
+  const attempt1 = path.join(runDir, "review-round-1-advisory-retry-fail-raw-response-attempt-1.txt");
+  const attempt2 = path.join(runDir, "review-round-1-advisory-retry-fail-raw-response.txt");
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === EVENTS.ADVISORY_REVIEW);
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.attemptCount, 2);
+  assert.deepEqual(result.rawResponsePaths, [attempt1, attempt2]);
+  assert.equal(result.rawResponsePath, attempt2);
+  assert.equal(fs.existsSync(attempt1), true);
+  assert.equal(fs.existsSync(attempt2), true);
+  assert.match(fs.readFileSync(attempt1, "utf-8"), /not-valid-advisory-json/);
+  assert.match(fs.readFileSync(attempt2, "utf-8"), /not-valid-advisory-json/);
+  assert.equal(event.status, "failed");
+  assert.equal(event.attempt_count, 2);
+  assert.deepEqual(event.raw_response_paths, [attempt1, attempt2]);
+});
+
+test("executeAdvisoryRequest does not retry on timeout", () => {
+  const { repoRoot, runDir, runId, result, counterPath } = executeParseRetryRequest({
+    reviewerFixture: { hangMs: 2500, failCalls: 0 },
+    artifactReviewerName: "timeout",
+    timeoutSeconds: 1,
+  });
+
+  assert.equal(result.status, "timeout");
+  assert.equal(result.attemptCount, 1);
+  assert.equal(result.rawResponsePaths.length, 1);
+  assert.match(result.rawResponsePath, /raw-response\.txt$/);
+  assert.equal(fs.existsSync(path.join(runDir, "review-round-1-advisory-timeout-raw-response-attempt-1.txt")), false);
+  assert.equal(fs.readFileSync(counterPath, "utf-8").trim(), "1");
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === EVENTS.ADVISORY_REVIEW);
+  assert.equal(event.status, "timeout");
+  assert.equal(event.attempt_count, 1);
+});
+
+test("executeAdvisoryRequest does not retry on policy violation", () => {
+  const { repoRoot, runId, result, counterPath } = executeParseRetryRequest({
+    reviewerFixture: { mutateOnCall: 1, failCalls: 0 },
+    artifactReviewerName: "policy",
+  });
+
+  assert.equal(result.status, "policy_violation");
+  assert.equal(result.attemptCount, 1);
+  assert.equal(result.rawResponsePaths.length, 1);
+  assert.equal(fs.readFileSync(counterPath, "utf-8").trim(), "1");
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === EVENTS.ADVISORY_REVIEW);
+  assert.equal(event.status, "policy_violation");
+  assert.equal(event.attempt_count, 1);
+});
+
+test("executeAdvisoryRequest does not retry on no-output exec failure", () => {
+  const { repoRoot, runDir, runId, result, counterPath } = executeParseRetryRequest({
+    reviewerFixture: { emptyOnFail: true, failCalls: 1 },
+    artifactReviewerName: "no-output",
+  });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.attemptCount, 1);
+  assert.equal(result.rawResponsePaths.length, 1);
+  assert.equal(fs.readFileSync(counterPath, "utf-8").trim(), "1");
+  assert.equal(fs.existsSync(path.join(runDir, "review-round-1-advisory-no-output-raw-response-attempt-1.txt")), false);
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === EVENTS.ADVISORY_REVIEW);
+  assert.equal(event.attempt_count, 1);
+});
+
+test("executeAdvisoryRequest retries adapter-side parse-failure signal once", () => {
+  const { repoRoot, runId, result, counterPath } = executeParseRetryRequest({
+    reviewerFixture: { failCalls: 1, exitNonZeroOnParseFail: true },
+    artifactReviewerName: "adapter-signal",
+  });
+
+  assert.equal(result.status, "success");
+  assert.equal(result.attemptCount, 2);
+  assert.equal(result.rawResponsePaths.length, 2);
+  assert.equal(fs.readFileSync(counterPath, "utf-8").trim(), "2");
+  const event = readRunEvents(repoRoot, runId).find((record) => record.event === EVENTS.ADVISORY_REVIEW);
+  assert.equal(event.attempt_count, 2);
+});
+
+test("executeAdvisoryRequest exports remaining lane budget to cline env on parse retry", () => {
+  const { runDir, result } = (() => {
+    const setup = setupRepo();
+    const envLogPath = path.join(setup.runDir, "cline-retry-env.json");
+    const counterPath = path.join(setup.runDir, "cline-retry-counter.txt");
+    const reviewerScript = writeStatefulParseRetryReviewer(setup.repoRoot, {
+      counterPath,
+      failCalls: 1,
+      envLogPath,
+    });
+    const resultPath = path.join(setup.runDir, "cline-retry-result.json");
+    const promptPath = path.join(setup.runDir, "cline-retry-prompt.md");
+    fs.writeFileSync(promptPath, "Advisory prompt\n", "utf-8");
+    const result = executeAdvisoryRequest({
+      artifactReviewerName: "cline",
+      decisionPath: path.join(setup.runDir, "cline-retry-decision.json"),
+      gating: true,
+      headSha: "a".repeat(40),
+      laneIndex: 1,
+      profile: "blindspot",
+      promptPath,
+      requestPath: path.join(setup.runDir, "cline-retry-request.json"),
+      resultPath,
+      reviewerModel: null,
+      reviewerName: "cline",
+      reviewerPolicy: null,
+      policyDecision: null,
+      modelResolution: null,
+      reviewerScript,
+      reviewRepoPath: setup.repoRoot,
+      round: 1,
+      runDir: setup.runDir,
+      runId: setup.runId,
+      runRepoPath: setup.repoRoot,
+      source: null,
+      startedAt: Date.now(),
+      state: STATES.REVIEW_PENDING,
+      timeoutSeconds: 1800,
+      trigger: "on_pass",
+    });
+    return { runDir: setup.runDir, result };
+  })();
+
+  assert.equal(result.status, "success");
+  assert.equal(result.attemptCount, 2);
+  const envLog = JSON.parse(fs.readFileSync(path.join(runDir, "cline-retry-env.json"), "utf-8"));
+  assert.equal(envLog.length, 2);
+  assert.equal(envLog[0].RELAY_CLINE_REVIEW_TIMEOUT, "1800s");
+  assert.match(envLog[1].RELAY_CLINE_REVIEW_TIMEOUT, /^\d+s$/);
+  const retrySeconds = Number(envLog[1].RELAY_CLINE_REVIEW_TIMEOUT.replace(/s$/, ""));
+  assert.ok(retrySeconds <= 1800, `retry budget should not exceed lane total, got ${retrySeconds}s`);
+  assert.ok(retrySeconds >= 120, `retry budget must stay above cline minimum, got ${retrySeconds}s`);
+});
+
 function runReview({
   repoRoot,
   runId,
@@ -1482,11 +1748,20 @@ process.stderr.write("cline-provider-stderr-887\\n");
   });
 
   assert.equal(result.advisoryReview.status, "failed");
+  assert.equal(result.advisoryReview.attemptCount, 2);
   assert.equal(result.advisoryReview.rawResponsePath, path.join(runDir, "review-round-1-advisory-cline-raw-response.txt"));
+  assert.deepEqual(result.advisoryReview.rawResponsePaths, [
+    path.join(runDir, "review-round-1-advisory-cline-raw-response-attempt-1.txt"),
+    path.join(runDir, "review-round-1-advisory-cline-raw-response.txt"),
+  ]);
   const rawArtifact = fs.readFileSync(result.advisoryReview.rawResponsePath, "utf-8");
   assert.match(rawArtifact, /Error: Cline advisory review failed to parse any of 1 advisory candidate/);
   assert.match(rawArtifact, new RegExp(rawText));
   assert.match(rawArtifact, /cline-provider-stderr-887/);
+  assert.match(
+    fs.readFileSync(result.advisoryReview.rawResponsePaths[0], "utf-8"),
+    /Error: Cline advisory review failed to parse any of 1 advisory candidate/
+  );
 });
 
 test("review-runner denies pi advisory model before spawning advisory reviewer", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
`#932` 구현을 커밋했습니다: `61a5c39`.

### 변경 요약
- `executeAdvisoryRequest`가 **parse-class 실패**에만 어댑터를 **1회** 재시도합니다.
  - exit 0 + `parseAdvisoryReview` throw (stdout 있음)
  - 또는 non-zero + 안정 시그널 `failed to parse any of N advisory candidate`
- 재시도 timeout / `RELAY_CLINE_REVIEW_TIMEOUT`은 **잔여 lane budget**을 쓰고, 최소치 미만이면 재시도 skip + 사유 기록
- timeout / policy_violation / no-output은 재시도 없음
- attempt 1 raw → `-raw-response-attempt-1.txt`, 최종 → `-raw-response.txt` (#887 단일 시도 경로 유지)
- result/event에 `attemptCoun
```

## Score Log

- Run: issue-932-20260711052111749-1f0c84ce
- Executor: cursor
- Branch: issue-932