### PR TITLE
fleet drive liveness uses the runtime registry, not the lease — operator-resumed runs flagged stuck_child and re-targeted for redispatch (#927)

### DIFF
--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -963,6 +963,12 @@ function runtimeChildIsAlive(repoRoot, fleetId, leafRef) {
   return child && processIsAlive(Number(child.pid));
 }
 
+function childIsAlive(repoRoot, fleetId, child) {
+  if (!child) return false;
+  if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) return true;
+  return Boolean(child.run_id && getRunLeaseStatus(repoRoot, child.run_id).live);
+}
+
 function cleanupDeadRuntimeChildren(repoRoot, fleetId) {
   const runtime = readRuntime(repoRoot, fleetId);
   let changed = false;
@@ -1118,7 +1124,7 @@ function reconcileFleet(repoRoot, fleetId, leaves) {
   fleet = readFleetManifest(repoRoot, fleetId).data;
   for (const child of fleet.children) {
     if (child.dispatch_status !== DISPATCH_STATUS.DISPATCHING || child.run_id) continue;
-    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) continue;
+    if (childIsAlive(repoRoot, fleetId, child)) continue;
     const leaf = leavesByRef.get(child.leaf_ref);
     if (leaf && issueLockHeld(repoRoot, fleetId, leaf)) continue;
     const updated = setFleetChild(repoRoot, fleetId, {
@@ -1238,8 +1244,12 @@ function reconcileMutating(repoRoot, runId) {
   }
 }
 
-function detachedSupervisorIsAlive(repoRoot, fleetId, leaf) {
-  return Boolean(fleetId && leaf?.leaf_ref && runtimeChildIsAlive(repoRoot, fleetId, leaf.leaf_ref));
+function detachedSupervisorIsAlive(repoRoot, fleetId, leaf, runId) {
+  if (!fleetId || !leaf?.leaf_ref) return false;
+  return childIsAlive(repoRoot, fleetId, {
+    leaf_ref: leaf.leaf_ref,
+    run_id: runId,
+  });
 }
 
 async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf, options, isInterrupted }) {
@@ -1263,7 +1273,7 @@ async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf,
           run_id: runId,
           run_state: runState,
           reconcile: lastReconcile,
-          keep_runtime: detachedSupervisorIsAlive(repoRoot, fleetId, leaf),
+          keep_runtime: detachedSupervisorIsAlive(repoRoot, fleetId, leaf, runId),
         };
       }
       if (lastReconcile.rowName === "lease_live_timed_out") {
@@ -1290,7 +1300,7 @@ async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf,
             run_id: runId,
             run_state: runState,
             reconcile: healed,
-            keep_runtime: detachedSupervisorIsAlive(repoRoot, fleetId, leaf),
+            keep_runtime: detachedSupervisorIsAlive(repoRoot, fleetId, leaf, runId),
           };
         }
         return {
@@ -1301,11 +1311,11 @@ async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf,
           run_state: healed.state,
           reconcile: healed,
           keep_runtime: healed.state === RUN_STATES.DISPATCHED
-            && detachedSupervisorIsAlive(repoRoot, fleetId, leaf),
+            && detachedSupervisorIsAlive(repoRoot, fleetId, leaf, runId),
         };
       }
       if (lastReconcile.rowName === "dead_no_result_no_work") {
-        if (detachedSupervisorIsAlive(repoRoot, fleetId, leaf)) {
+        if (detachedSupervisorIsAlive(repoRoot, fleetId, leaf, runId)) {
           return {
             status: "dispatch_poll_timeout",
             run_id: runId,
@@ -1347,7 +1357,7 @@ async function waitForDetachedDispatchProgress({ repoRoot, fleetId, runId, leaf,
     run_id: runId,
     run_state: finalRunState,
     reconcile: lastReconcile,
-    keep_runtime: liveLease || detachedSupervisorIsAlive(repoRoot, fleetId, leaf),
+    keep_runtime: liveLease || detachedSupervisorIsAlive(repoRoot, fleetId, leaf, runId),
   };
 }
 
@@ -1526,7 +1536,7 @@ function spawnReviewForChild({ repoRoot, fleetId, child, options, activeChildren
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_interrupted" });
       return;
     }
-    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) {
+    if (childIsAlive(repoRoot, fleetId, child)) {
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_running", run_state: child.run_state });
       return;
     }
@@ -1635,7 +1645,7 @@ function spawnPublishForChild({ repoRoot, fleetId, child, options, activeChildre
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_interrupted" });
       return;
     }
-    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) {
+    if (childIsAlive(repoRoot, fleetId, child)) {
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_running", run_state: child.run_state });
       return;
     }
@@ -1721,7 +1731,7 @@ function spawnRedispatchForChild({ repoRoot, fleetId, child, options, activeChil
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_interrupted" });
       return;
     }
-    if (runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)) {
+    if (childIsAlive(repoRoot, fleetId, child)) {
       resolve({ leaf_ref: child.leaf_ref, run_id: child.run_id, status: "skipped_running", run_state: child.run_state });
       return;
     }
@@ -2078,7 +2088,7 @@ function additionalAttentionReasons(child, { repoRoot, fleetId, defaultBranchNam
     && !terminalForFleetReview(child.run_state)
     && repoRoot
     && fleetId
-    && !runtimeChildIsAlive(repoRoot, fleetId, child.leaf_ref)
+    && !childIsAlive(repoRoot, fleetId, child)
   ) {
     reasons.push("stuck_child");
   }

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -200,6 +200,19 @@ function writeChildRun(repoRoot, {
   return runId;
 }
 
+function writeRunLeaseFixture(repoRoot, runId, {
+  pid = process.pid,
+  host = os.hostname(),
+} = {}) {
+  writeJson(path.join(getRunDir(repoRoot, runId), "lease.json"), {
+    pid,
+    pgid: 2147483647,
+    host,
+    started_at: new Date().toISOString(),
+    timeout_s: 3600,
+  });
+}
+
 function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
   const started = Date.now();
   return new Promise((resolve, reject) => {
@@ -3344,6 +3357,208 @@ test("relay-fleet --resume skips a still-running review subprocess", async () =>
   fs.writeFileSync(releasePath, "go\n", "utf-8");
   await new Promise((resolve) => first.on("close", resolve));
   assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
+});
+
+test("relay-fleet review drive treats live leases as running across review, publish, and redispatch guards", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-live-lease-guards-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-live-lease-guards-fake-"));
+  const fleetId = "fleet-live-lease-guards";
+  const dispatchScript = writeFakeDispatchScript(tmpDir);
+  const reviewScript = writeFakeReviewScript(tmpDir);
+  const dispatchLog = path.join(tmpDir, "dispatch.log");
+  const reviewLog = path.join(tmpDir, "review.log");
+  const missingPublishScript = path.join(tmpDir, "must-not-run-publish.js");
+  const liveReviewRun = "issue-927-20260711010101000-a1b2c3d4";
+  const livePublishRun = "issue-928-20260711010101000-a1b2c3d4";
+  const liveRedispatchRun = "issue-929-20260711010101000-a1b2c3d4";
+  const deadReviewRun = "issue-930-20260711010101000-a1b2c3d4";
+  const foreignRedispatchRun = "issue-931-20260711010101000-a1b2c3d4";
+
+  function createRun(runId, leafRef, issueNumber, state) {
+    const manifestPath = getManifestPath(repoRoot, runId);
+    const initialState = state === RUN_STATES.PUBLISH_PENDING
+      ? RUN_STATES.DISPATCHED
+      : RUN_STATES.REVIEW_PENDING;
+    writeChildRun(repoRoot, {
+      runId,
+      branch: `issue-${issueNumber}-${leafRef}`,
+      issueNumber,
+      leafId: leafRef,
+      fleetId,
+      state: initialState,
+    });
+    if (state === RUN_STATES.CHANGES_REQUESTED) {
+      const record = readManifest(manifestPath);
+      writeManifest(
+        manifestPath,
+        updateManifestState(record.data, RUN_STATES.CHANGES_REQUESTED, "retry"),
+        record.body
+      );
+    } else if (state === RUN_STATES.PUBLISH_PENDING) {
+      const record = readManifest(manifestPath);
+      let manifest = record.data;
+      manifest = updateManifestState(manifest, RUN_STATES.INTERNAL_REVIEW_PENDING, "await_internal_review");
+      manifest = updateManifestState(manifest, RUN_STATES.PUBLISH_PENDING, "await_publish");
+      writeManifest(manifestPath, manifest, record.body);
+    }
+  }
+
+  createRun(liveReviewRun, "leaf-live-review", 927, RUN_STATES.REVIEW_PENDING);
+  createRun(livePublishRun, "leaf-live-publish", 928, RUN_STATES.PUBLISH_PENDING);
+  createRun(liveRedispatchRun, "leaf-live-redispatch", 929, RUN_STATES.CHANGES_REQUESTED);
+  createRun(deadReviewRun, "leaf-dead-review", 930, RUN_STATES.REVIEW_PENDING);
+  createRun(foreignRedispatchRun, "leaf-foreign-redispatch", 931, RUN_STATES.CHANGES_REQUESTED);
+
+  writeRunLeaseFixture(repoRoot, liveReviewRun);
+  writeRunLeaseFixture(repoRoot, livePublishRun);
+  writeRunLeaseFixture(repoRoot, liveRedispatchRun);
+  writeRunLeaseFixture(repoRoot, deadReviewRun, { pid: 2147483647 });
+  writeRunLeaseFixture(repoRoot, foreignRedispatchRun, { host: "foreign.example.invalid" });
+
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [
+      { leaf_ref: "leaf-live-review", run_id: liveReviewRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-live-publish", run_id: livePublishRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      {
+        leaf_ref: "leaf-live-redispatch",
+        run_id: liveRedispatchRun,
+        dispatch_status: DISPATCH_STATUS.DISPATCHED,
+        last_error: "operator-resumed",
+      },
+      { leaf_ref: "leaf-dead-review", run_id: deadReviewRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+      { leaf_ref: "leaf-foreign-redispatch", run_id: foreignRedispatchRun, dispatch_status: DISPATCH_STATUS.DISPATCHED },
+    ],
+  });
+  advanceFleetManifestState(repoRoot, fleetId, FLEET_STATES.DISPATCHED);
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--review",
+    "--dispatch-script", dispatchScript,
+    "--publish-script", missingPublishScript,
+    "--review-script", reviewScript,
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      FAKE_DISPATCH_LOG: dispatchLog,
+      FAKE_REVIEW_LOG: reviewLog,
+    },
+  });
+
+  assert.notEqual(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  const byLeaf = new Map(payload.reviewed_children.map((child) => [child.leaf_ref, child]));
+  const guardedPhases = {
+    "leaf-live-review": "review",
+    "leaf-live-publish": "publish",
+    "leaf-live-redispatch": "redispatch",
+  };
+  for (const [leafRef, phase] of Object.entries(guardedPhases)) {
+    assert.equal(byLeaf.get(leafRef).status, "skipped_running");
+    assert.equal(byLeaf.get(leafRef).steps[0].status, "skipped_running");
+    assert.equal(byLeaf.get(leafRef).steps[0].phase, phase);
+  }
+  assert.equal(byLeaf.get("leaf-dead-review").status, "complete");
+  assert.equal(byLeaf.get("leaf-foreign-redispatch").status, "complete");
+  assert.deepEqual(readJsonLines(dispatchLog).map((entry) => entry.runId), [foreignRedispatchRun]);
+  assert.deepEqual(
+    readJsonLines(reviewLog).map((entry) => entry.runId).sort(),
+    [deadReviewRun, foreignRedispatchRun].sort()
+  );
+  assert.equal(
+    readFleetManifest(repoRoot, fleetId).data.children
+      .find((child) => child.leaf_ref === "leaf-live-redispatch").last_error,
+    "operator-resumed"
+  );
+});
+
+test("relay-fleet status uses live local leases while dead and foreign leases remain stuck", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-lease-attention-");
+  const fleetId = "fleet-lease-attention";
+  const runs = {
+    live: "issue-932-20260711010101000-a1b2c3d4",
+    dead: "issue-933-20260711010101000-a1b2c3d4",
+    foreign: "issue-934-20260711010101000-a1b2c3d4",
+    registry: "issue-935-20260711010101000-a1b2c3d4",
+  };
+
+  for (const [kind, runId] of Object.entries(runs)) {
+    writeChildRun(repoRoot, {
+      runId,
+      branch: `issue-${runId.slice(6, 9)}-leaf-${kind}`,
+      issueNumber: Number(runId.slice(6, 9)),
+      leafId: `leaf-${kind}`,
+      fleetId,
+      state: RUN_STATES.DISPATCHED,
+    });
+  }
+  writeRunLeaseFixture(repoRoot, runs.live);
+  writeRunLeaseFixture(repoRoot, runs.dead, { pid: 2147483647 });
+  writeRunLeaseFixture(repoRoot, runs.foreign, { host: "foreign.example.invalid" });
+  fs.mkdirSync(path.dirname(getFleetRuntimePath(repoRoot, fleetId)), { recursive: true });
+  writeJson(getFleetRuntimePath(repoRoot, fleetId), {
+    fleet_id: fleetId,
+    children: {
+      "leaf-registry": { pid: process.pid, phase: "dispatch", run_id: runs.registry },
+    },
+  });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: Object.entries(runs).map(([kind, runId]) => ({
+      leaf_ref: `leaf-${kind}`,
+      run_id: runId,
+      dispatch_status: DISPATCH_STATUS.DISPATCHED,
+    })),
+  });
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--status",
+    "--json",
+  ], { relayHome });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const attention = JSON.parse(result.stdout).operator_attention;
+  const stuckLeaves = attention
+    .filter((item) => item.reason === "stuck_child")
+    .map((item) => item.leaf_ref)
+    .sort();
+  assert.deepEqual(stuckLeaves, ["leaf-dead", "leaf-foreign"]);
+});
+
+test("relay-fleet pre-manifest fan-out liveness remains registry-only without a run id", () => {
+  const { repoRoot } = setupRepo("relay-fleet-pre-manifest-liveness-");
+  const fleetId = "fleet-pre-manifest-liveness";
+  const liveLeaf = makeLeaf(repoRoot, 1, { leaf_ref: "leaf-live-registry", issue_number: 936 });
+  const missingLeaf = makeLeaf(repoRoot, 2, { leaf_ref: "leaf-no-registry", issue_number: 937 });
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: [liveLeaf, missingLeaf].map((leaf) => ({
+      leaf_ref: leaf.leaf_ref,
+      run_id: null,
+      dispatch_status: DISPATCH_STATUS.DISPATCHING,
+    })),
+  });
+  fs.mkdirSync(path.dirname(getFleetRuntimePath(repoRoot, fleetId)), { recursive: true });
+  writeJson(getFleetRuntimePath(repoRoot, fleetId), {
+    fleet_id: fleetId,
+    children: {
+      [liveLeaf.leaf_ref]: { pid: process.pid, phase: "dispatch" },
+    },
+  });
+
+  const fleet = reconcileFleet(repoRoot, fleetId, [liveLeaf, missingLeaf]);
+  const byLeaf = new Map(fleet.children.map((child) => [child.leaf_ref, child]));
+  assert.equal(byLeaf.get(liveLeaf.leaf_ref).dispatch_status, DISPATCH_STATUS.DISPATCHING);
+  assert.equal(byLeaf.get(liveLeaf.leaf_ref).run_id, null);
+  assert.equal(
+    byLeaf.get(missingLeaf.leaf_ref).dispatch_status,
+    DISPATCH_STATUS.DISPATCH_FAILED_PRE_MANIFEST
+  );
 });
 
 test("relay-fleet --status without --fleet-id lists every repo fleet in deterministic text rows", () => {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-927-20260711031501147-5df21097
- Branch: issue-927
- Reason: salvage #927: executor completed lease-probe liveness work but escalated on total_timeout before commit; full DC gate clean 1180/0 exit 0 on worktree
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-927-20260711031501147-5df21097.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-11T09:50:00.371Z