### PR TITLE
fleet drive: surface stalled executors (live lease, zero stdout) as operator_attention (#931)

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -99,6 +99,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" \
 - Fleet issue locks are checked before each child spawn; `dispatch.js --fleet-id` performs the durable lock during the actual child run.
 - Re-runs reconcile both directions: they re-adopt child run manifests whose `fleet_id` points back to this fleet, mark no-manifest interrupted children as `dispatch_failed_pre_manifest`, skip still-running child subprocesses, and continue recoverable work.
 - `--status` is read-only and uses the relay-dispatch fleet summary derivation rules. Without `--fleet-id`, it lists repo-scoped fleets and their terminal/total child counts.
+- `--status` operator_attention may include `stalled_executor` when a child's run lease is live, `dispatch-stdout.log` is still 0 bytes, and lease age exceeds 15 minutes (`RELAY_FLEET_STALL_THRESHOLD_MS` override only). Visibility only — no kill. Mid-run stalls after the first stdout byte are not detected.
 
 ## SPOF
 

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -39,11 +39,18 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/fleet");
 const { getRequestPath, readRequestArtifact } = require("../../relay-ready/scripts/relay-request");
 const { runReconcile } = require("../../relay-dispatch/scripts/reconcile-advisory");
-const { getRunLeaseStatus } = require("../../relay-dispatch/scripts/run-runtime-state");
+const {
+  getRunArtifactPaths,
+  getRunLeaseStatus,
+} = require("../../relay-dispatch/scripts/run-runtime-state");
 const { EVENTS, readRunEvents } = require("../../relay-dispatch/scripts/relay-events");
 const { runMergeQueue } = require("./merge-queue");
 
 const DEFAULT_PARALLEL = 4;
+// #931: live lease + still-empty stdout past this age → stalled_executor attention.
+// Mid-run stalls AFTER the first stdout byte are NOT detected (accepted limitation).
+const DEFAULT_STALL_THRESHOLD_MS = 15 * 60 * 1000;
+const STALL_STDERR_TAIL_MAX_CHARS = 120;
 const FLEET_CHILD_LOCK_TIMEOUT_MS = 5000;
 const FLEET_CHILD_LOCK_WAIT_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 const FLEET_CHILD_TICKET_PATTERN = /^ticket-(\d+)\.(waiting|done)$/;
@@ -2065,6 +2072,71 @@ function legacyAttentionReason(child) {
   return null;
 }
 
+function resolveStallThresholdMs(env = process.env) {
+  const raw = env.RELAY_FLEET_STALL_THRESHOLD_MS;
+  if (raw == null || String(raw).trim() === "") return DEFAULT_STALL_THRESHOLD_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_STALL_THRESHOLD_MS;
+  return parsed;
+}
+
+function readLastNonEmptyStderrLine(stderrPath) {
+  try {
+    const text = fs.readFileSync(stderrPath, "utf-8");
+    const lines = text.split(/\r?\n/);
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      return line.length > STALL_STDERR_TAIL_MAX_CHARS
+        ? line.slice(0, STALL_STDERR_TAIL_MAX_CHARS)
+        : line;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Visibility only (#931 / #839 boundary): no kill, signal, or state mutation.
+// Stateless heuristic — live lease (#927 getRunLeaseStatus) AND 0-byte stdout
+// AND lease age over threshold. First-byte limitation: once stdout has any
+// bytes, mid-run silence is invisible here.
+function detectStalledExecutor(repoRoot, child, { thresholdMs = resolveStallThresholdMs() } = {}) {
+  if (!repoRoot || !child?.run_id) return null;
+  if (child.dispatch_status !== DISPATCH_STATUS.DISPATCHED) return null;
+  if (!KNOWN_RUN_STATES.has(child.run_state)) return null;
+  if (terminalForFleetReview(child.run_state)) return null;
+
+  let leaseStatus;
+  try {
+    leaseStatus = getRunLeaseStatus(repoRoot, child.run_id);
+  } catch {
+    return null;
+  }
+  if (!leaseStatus?.live || !leaseStatus.lease) return null;
+
+  const startedAtMs = Date.parse(leaseStatus.lease.started_at);
+  if (!Number.isFinite(startedAtMs)) return null;
+  const ageMs = Date.now() - startedAtMs;
+  if (ageMs <= thresholdMs) return null;
+
+  const { stdoutLog, stderrLog } = getRunArtifactPaths(repoRoot, child.run_id);
+  let stdoutStat;
+  try {
+    stdoutStat = fs.statSync(stdoutLog);
+  } catch {
+    // Missing or unreadable stdout path → fail open (no item, no crash).
+    return null;
+  }
+  if (!stdoutStat.isFile() || stdoutStat.size !== 0) return null;
+
+  const minutes = Math.floor(ageMs / 60000);
+  let detail = `stdout 0 bytes for ${minutes}m`;
+  const stderrTail = readLastNonEmptyStderrLine(stderrLog);
+  if (stderrTail) detail += `; stderr tail: ${stderrTail}`;
+  return { detail };
+}
+
 // New reasons are independent of each other and of the legacy reason above, so
 // a single child can surface more than one attention item.
 function additionalAttentionReasons(child, { repoRoot, fleetId, defaultBranchName }) {
@@ -2091,6 +2163,9 @@ function additionalAttentionReasons(child, { repoRoot, fleetId, defaultBranchNam
     && !childIsAlive(repoRoot, fleetId, child)
   ) {
     reasons.push("stuck_child");
+  }
+  if (detectStalledExecutor(repoRoot, child)) {
+    reasons.push("stalled_executor");
   }
 
   return reasons;
@@ -2148,6 +2223,9 @@ function buildOperatorAttention(summary, context = {}) {
       const item = { leaf_ref: child.leaf_ref, run_id: child.run_id, reason };
       if (reason === "stuck_child") {
         Object.assign(item, stuckChildPreflightEnrichment(repoRoot, child));
+      }
+      if (reason === "stalled_executor") {
+        Object.assign(item, detectStalledExecutor(repoRoot, child) || {});
       }
       items.push(item);
     }

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -203,14 +203,27 @@ function writeChildRun(repoRoot, {
 function writeRunLeaseFixture(repoRoot, runId, {
   pid = process.pid,
   host = os.hostname(),
+  startedAt = new Date().toISOString(),
+  timeoutS = 3600,
 } = {}) {
   writeJson(path.join(getRunDir(repoRoot, runId), "lease.json"), {
     pid,
     pgid: 2147483647,
     host,
-    started_at: new Date().toISOString(),
-    timeout_s: 3600,
+    started_at: startedAt,
+    timeout_s: timeoutS,
   });
+}
+
+function writeDispatchLogs(repoRoot, runId, { stdout = null, stderr = null } = {}) {
+  const runDir = getRunDir(repoRoot, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  if (stdout !== null) {
+    fs.writeFileSync(path.join(runDir, "dispatch-stdout.log"), stdout, "utf-8");
+  }
+  if (stderr !== null) {
+    fs.writeFileSync(path.join(runDir, "dispatch-stderr.log"), stderr, "utf-8");
+  }
 }
 
 function waitFor(predicate, { timeoutMs = 3000, intervalMs = 25 } = {}) {
@@ -4446,4 +4459,244 @@ test("relay-fleet stuck_child operator_attention derives next_action/detail from
   assert.match(plainOnly, /^  - leaf-a: stuck_child \(run-a\)$/m);
   assert.doesNotMatch(plainOnly, /→ next:/);
   assert.doesNotMatch(plainOnly, / — /);
+});
+
+test("relay-fleet stalled_executor operator_attention pins the six-row matrix (#931)", () => {
+  const { relayHome, repoRoot } = setupRepo("relay-fleet-stalled-executor-");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-stalled-fake-"));
+  const fleetId = "fleet-stalled-executor";
+  const {
+    formatStatusText: formatText,
+    parseArgs,
+  } = require(RELAY_FLEET_SCRIPT);
+
+  const agedStartedAt = new Date(Date.now() - 42 * 60 * 1000).toISOString();
+  const freshStartedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  const longStderr = `Connection lost, reconnecting to agentn.global.api5.cursor.sh ${"x".repeat(200)}`;
+  const expectedStderrTail = longStderr.slice(0, 120);
+
+  const runs = {
+    stalled: "issue-931-20260711010101000-a1b2c3d4",
+    stalledEmptyStderr: "issue-932-20260711010101000-a1b2c3d4",
+    underThreshold: "issue-933-20260711010101000-a1b2c3d4",
+    nonEmptyStdout: "issue-934-20260711010101000-a1b2c3d4",
+    deadLease: "issue-935-20260711010101000-a1b2c3d4",
+    missingLease: "issue-936-20260711010101000-a1b2c3d4",
+    unreadableStdout: "issue-937-20260711010101000-a1b2c3d4",
+    terminal: "issue-938-20260711010101000-a1b2c3d4",
+    compose: "issue-939-20260711010101000-a1b2c3d4",
+    healthy: "issue-940-20260711010101000-a1b2c3d4",
+  };
+
+  for (const [kind, runId] of Object.entries(runs)) {
+    const state = kind === "terminal"
+      ? RUN_STATES.READY_TO_MERGE
+      : (kind === "compose" || kind === "healthy")
+        ? RUN_STATES.REVIEW_PENDING
+        : RUN_STATES.DISPATCHED;
+    writeChildRun(repoRoot, {
+      runId,
+      branch: `issue-${runId.slice(6, 9)}-leaf-${kind}`,
+      issueNumber: Number(runId.slice(6, 9)),
+      leafId: `leaf-${kind}`,
+      fleetId,
+      state,
+    });
+    if (kind === "compose") {
+      const manifestPath = getManifestPath(repoRoot, runId);
+      const data = readManifest(manifestPath).data;
+      writeManifest(manifestPath, {
+        ...data,
+        review: { ...data.review, rounds: 3 },
+        git: { ...data.git, pr_number: 939 },
+      });
+    }
+    if (kind === "terminal" || kind === "healthy") {
+      const manifestPath = getManifestPath(repoRoot, runId);
+      const data = readManifest(manifestPath).data;
+      writeManifest(manifestPath, {
+        ...data,
+        git: { ...data.git, pr_number: kind === "terminal" ? 938 : 940 },
+      });
+    }
+  }
+
+  // Row 1: live + 0-byte + aged → stalled_executor with stderr tail (truncated 120).
+  writeRunLeaseFixture(repoRoot, runs.stalled, { startedAt: agedStartedAt });
+  writeDispatchLogs(repoRoot, runs.stalled, { stdout: "", stderr: `${longStderr}\n` });
+
+  // Row 1b: empty stderr omits the tail clause.
+  writeRunLeaseFixture(repoRoot, runs.stalledEmptyStderr, { startedAt: agedStartedAt });
+  writeDispatchLogs(repoRoot, runs.stalledEmptyStderr, { stdout: "", stderr: "" });
+
+  // Row 2: live + 0-byte + under threshold → none.
+  writeRunLeaseFixture(repoRoot, runs.underThreshold, { startedAt: freshStartedAt });
+  writeDispatchLogs(repoRoot, runs.underThreshold, { stdout: "" });
+
+  // Row 3: live + non-empty stdout → none regardless of age.
+  writeRunLeaseFixture(repoRoot, runs.nonEmptyStdout, { startedAt: agedStartedAt });
+  writeDispatchLogs(repoRoot, runs.nonEmptyStdout, { stdout: "hello\n" });
+
+  // Row 4: dead lease → stuck_child owns it; no stalled_executor.
+  writeRunLeaseFixture(repoRoot, runs.deadLease, { pid: 2147483647, startedAt: agedStartedAt });
+  writeDispatchLogs(repoRoot, runs.deadLease, { stdout: "" });
+
+  // Row 4b: missing lease → no stalled_executor.
+  writeDispatchLogs(repoRoot, runs.missingLease, { stdout: "" });
+
+  // Row 5: unreadable/unresolvable stdout (broken symlink) → fail-open, no crash.
+  writeRunLeaseFixture(repoRoot, runs.unreadableStdout, { startedAt: agedStartedAt });
+  fs.symlinkSync(
+    "/nonexistent/relay-fleet-stalled-stdout",
+    path.join(getRunDir(repoRoot, runs.unreadableStdout), "dispatch-stdout.log")
+  );
+
+  // Row 6: terminal run state → no stalled_executor even with live+0-byte+aged.
+  writeRunLeaseFixture(repoRoot, runs.terminal, { startedAt: agedStartedAt });
+  writeDispatchLogs(repoRoot, runs.terminal, { stdout: "" });
+
+  // Additive: stalled_executor composes with high_review_rounds.
+  writeRunLeaseFixture(repoRoot, runs.compose, { startedAt: agedStartedAt });
+  writeDispatchLogs(repoRoot, runs.compose, { stdout: "", stderr: "Connection lost\n" });
+
+  // Healthy busy child (live lease, recent, non-empty stdout) → no stall item.
+  writeRunLeaseFixture(repoRoot, runs.healthy, { startedAt: freshStartedAt });
+  writeDispatchLogs(repoRoot, runs.healthy, { stdout: "progress\n" });
+
+  createFleetManifest(repoRoot, {
+    fleetId,
+    children: Object.entries(runs).map(([kind, runId]) => ({
+      leaf_ref: `leaf-${kind}`,
+      run_id: runId,
+      dispatch_status: DISPATCH_STATUS.DISPATCHED,
+    })),
+  });
+
+  const fakeGh = writeFakeGhDefaultBranch(tmpDir, "main");
+  const leaseBefore = fs.readFileSync(
+    path.join(getRunDir(repoRoot, runs.stalled), "lease.json"),
+    "utf-8"
+  );
+  const fleetBefore = fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8");
+
+  const result = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--status",
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      RELAY_GH_BIN: fakeGh,
+      // Keep default 15m; fixtures use 42m / 5m wall ages.
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const payload = JSON.parse(result.stdout);
+  const attention = payload.operator_attention;
+
+  function item(leafRef, reason) {
+    return attention.find((entry) => entry.leaf_ref === leafRef && entry.reason === reason);
+  }
+  function reasonsFor(leafRef) {
+    return attention.filter((entry) => entry.leaf_ref === leafRef).map((entry) => entry.reason).sort();
+  }
+
+  // Row 1: exact detail format with truncated stderr tail.
+  const stalled = item("leaf-stalled", "stalled_executor");
+  assert.ok(stalled);
+  assert.equal(stalled.detail, `stdout 0 bytes for 42m; stderr tail: ${expectedStderrTail}`);
+  assert.equal(expectedStderrTail.length, 120);
+
+  // Empty stderr → no "; stderr tail:" clause.
+  const stalledEmpty = item("leaf-stalledEmptyStderr", "stalled_executor");
+  assert.ok(stalledEmpty);
+  assert.equal(stalledEmpty.detail, "stdout 0 bytes for 42m");
+  assert.equal(stalledEmpty.detail.includes("stderr"), false);
+
+  // Rows 2–6: no stalled_executor.
+  assert.equal(item("leaf-underThreshold", "stalled_executor"), undefined);
+  assert.equal(item("leaf-nonEmptyStdout", "stalled_executor"), undefined);
+  assert.equal(item("leaf-deadLease", "stalled_executor"), undefined);
+  assert.equal(item("leaf-missingLease", "stalled_executor"), undefined);
+  assert.equal(item("leaf-unreadableStdout", "stalled_executor"), undefined);
+  assert.equal(item("leaf-terminal", "stalled_executor"), undefined);
+  assert.equal(item("leaf-healthy", "stalled_executor"), undefined);
+
+  // Dead lease is owned by stuck_child, not stalled_executor.
+  assert.ok(item("leaf-deadLease", "stuck_child"));
+  assert.equal(reasonsFor("leaf-deadLease").includes("stalled_executor"), false);
+
+  // Additive composition.
+  assert.deepEqual(reasonsFor("leaf-compose"), ["high_review_rounds", "stalled_executor"]);
+  assert.equal(
+    item("leaf-compose", "stalled_executor").detail,
+    "stdout 0 bytes for 42m; stderr tail: Connection lost"
+  );
+  assert.deepEqual(item("leaf-compose", "high_review_rounds"), {
+    leaf_ref: "leaf-compose",
+    run_id: runs.compose,
+    reason: "high_review_rounds",
+  });
+
+  // Non-stall children keep attention byte-identical (no spurious stall items).
+  assert.equal(attention.some((entry) => entry.leaf_ref === "leaf-healthy"), false);
+  assert.equal(attention.some((entry) => entry.leaf_ref === "leaf-underThreshold"), false);
+  assert.equal(attention.some((entry) => entry.leaf_ref === "leaf-nonEmptyStdout"), false);
+
+  // formatStatusText: one-line enriched rendering (#901 style).
+  const text = formatText(payload.summary, attention);
+  const stalledLine = `  - leaf-stalled: stalled_executor (${runs.stalled}) — stdout 0 bytes for 42m; stderr tail: ${expectedStderrTail}`;
+  assert.match(text, new RegExp(`^${stalledLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  assert.match(
+    text,
+    new RegExp(
+      `^  - leaf-stalledEmptyStderr: stalled_executor \\(${runs.stalledEmptyStderr}\\) — stdout 0 bytes for 42m$`,
+      "m"
+    )
+  );
+
+  // Visibility only: --status mutates neither lease nor fleet manifest.
+  assert.equal(
+    fs.readFileSync(path.join(getRunDir(repoRoot, runs.stalled), "lease.json"), "utf-8"),
+    leaseBefore
+  );
+  assert.equal(fs.readFileSync(getFleetManifestPath(repoRoot, fleetId), "utf-8"), fleetBefore);
+
+  // No kill/signal path in the stall heuristic source.
+  const source = fs.readFileSync(RELAY_FLEET_SCRIPT, "utf-8");
+  const stallRegion = source.slice(
+    source.indexOf("// Visibility only (#931"),
+    source.indexOf("// New reasons are independent")
+  );
+  assert.match(stallRegion, /Visibility only/);
+  assert.doesNotMatch(stallRegion, /process\.kill|terminateProcessGroup|SIGTERM|SIGKILL/);
+
+  // Env-only threshold override; no CLI flag.
+  const help = runFleet(["--help"], { relayHome });
+  assert.doesNotMatch(help.stdout + help.stderr, /STALL|stall-threshold|stall_threshold/i);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(parseArgs(["--repo", ".", "--fleet-id", "x", "--status"]), "stallThreshold"),
+    false
+  );
+
+  // Threshold override: shrink so a 5m-old empty stdout becomes stalled.
+  const overrideResult = runFleet([
+    "--repo", repoRoot,
+    "--fleet-id", fleetId,
+    "--status",
+    "--json",
+  ], {
+    relayHome,
+    env: {
+      RELAY_GH_BIN: fakeGh,
+      RELAY_FLEET_STALL_THRESHOLD_MS: "60000",
+    },
+  });
+  assert.equal(overrideResult.status, 0, `${overrideResult.stderr}\n${overrideResult.stdout}`);
+  const overrideAttention = JSON.parse(overrideResult.stdout).operator_attention;
+  assert.ok(overrideAttention.some(
+    (entry) => entry.leaf_ref === "leaf-underThreshold" && entry.reason === "stalled_executor"
+  ));
 });


### PR DESCRIPTION
## Dispatch Summary

```text
커밋 `acf6f7a` — `stalled_executor` attention을 추가했습니다. push/PR는 오케스트레이터 담당입니다.

## 구현 요약

live lease + 0-byte `dispatch-stdout.log` + lease age > 15분일 때 `operator_attention`에 `stalled_executor`를 추가합니다. kill/signal/상태 변경 없음 (`#839` 경계 유지). liveness는 `#927`의 `getRunLeaseStatus`.

## Completion Audit

| DC / Rubric | Artifact |
|---|---|
| 6-row matrix | `detectStalledExecutor` in `relay-fleet.js` + test `stalled_executor … six-row matrix (#931)` |
| Threshold 15m / env-only | `DEFAULT_STALL_THRESHOL
```

## Score Log

- Run: issue-931-20260711100058671-cb1fc5c1
- Executor: cursor
- Branch: issue-931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 상태 조회에서 장시간 실행이 멈춘 실행기를 `operator_attention`으로 표시합니다.
  * 실행 lease, 출력 로그, 경과 시간을 기준으로 정체 여부를 판단합니다.
  * stderr 마지막 내용을 상세 정보로 제공하며, 감지 임계값을 환경 변수로 조정할 수 있습니다.
  * 정체 감지는 가시성 제공만 수행하며 실행을 종료하지 않습니다.
* **문서**
  * `--status` 결과의 정체 실행기 표시 조건과 제한 사항을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->