### PR TITLE
relay-orca: define explicit-only skill contract and compile accepted programs into bounded waves (#943)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
             tests/relay/scripts/*.test.js
             tests/relay-config/scripts/*.test.js
             tests/relay-fleet/scripts/*.test.js
+            tests/relay-orca/scripts/*.test.js
             tests/skills-lint/scripts/*.test.js
           )
           count=${#files[@]}
@@ -45,4 +46,5 @@ jobs:
           tests/relay/scripts/*.test.js
           tests/relay-config/scripts/*.test.js
           tests/relay-fleet/scripts/*.test.js
+          tests/relay-orca/scripts/*.test.js
           tests/skills-lint/scripts/*.test.js

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ For the full architecture, see [references/architecture.md](references/architect
 - Nested Codex executor runs may need `--network-access enabled` for networked quality gates or PR/API calls.
 - Antigravity dispatch has route-specific healthy live canary evidence for `google/antigravity-cli`; Antigravity primary and advisory review remain fail-safe experimental until healthy live reviewer canaries pass. Fake-bin tests alone do not prove live executor or reviewer success. See [docs/relay-operator-guide.md#antigravity-live-canary](docs/relay-operator-guide.md#antigravity-live-canary).
 - Sprint-file automation works, but some sprint status updates can still require manual intervention.
+- `relay-orca` is EXPERIMENTAL and opt-in. It is a supervised program-controller pilot, explicit-only, and not an implicit dependency of ordinary relay use; only its read-only `plan` mode is implemented today. See [skills/relay-orca/references/experimental-status.md](skills/relay-orca/references/experimental-status.md).
 
 ## Contributing
 

--- a/references/operator-surface.md
+++ b/references/operator-surface.md
@@ -9,6 +9,7 @@ dev-relay is a bundle-installed relay runtime exposed through thin skill command
 | Public operator surface | `relay-config`, `relay`, `relay-merge` | Normal day-to-day commands. These should read as stable product entrypoints and hide most phase internals. |
 | Internal phase surface | `relay-ready`, `relay-plan`, `relay-dispatch`, `relay-review` | Direct controls for advanced operation, debugging, recovery, and explicit manual phase work. They stay callable, but they are not the primary product surface. |
 | Optional/advanced surface | `relay-fleet` | Specialized fan-out for already-planned independent leaves. It should point to narrow references rather than expanding the core command surface. |
+| Optional/advanced surface | `relay-orca` | EXPERIMENTAL, opt-in, explicit-only program-altitude coordinator over relay/relay-fleet operators. Not part of ordinary relay use and never implicitly invoked; keep it thin and reference-heavy. |
 
 ## Placement Rules
 

--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: relay-orca
+description: EXPERIMENTAL, explicit-only program-altitude coordinator. On explicit operator request, compile an already-accepted program/epic contract into bounded, read-only Orca wave plans supervising relay and relay-fleet operators. NOT for ordinary relay, relay-fleet, delegation, implementation, or planning requests.
+compatibility: Requires Node.js 18+. Runtime modes (run/status/resume/stop) additionally require the experimental Orca orchestration surface and are gated on the capability probe.
+argument-hint: plan --program-file <accepted-program.json>
+metadata:
+  related-skills: relay, relay-fleet, relay-plan, relay-dispatch, relay-review, relay-merge, dev-backlog
+  keywords: relay-orca, orca program, program coordinator, accepted program, wave plan, program altitude
+---
+## Inputs
+- Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
+- Files: an already-accepted program/epic contract as JSON (`--program-file`). Schema: [references/accepted-program-schema.md](references/accepted-program-schema.md).
+- Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js` (read-only wave-plan compiler).
+
+# relay-orca
+
+> EXPERIMENTAL and opt-in. relay-orca is a supervised program controller pilot, not an autonomous software factory, and not an implicit dependency of ordinary relay use. See [references/experimental-status.md](references/experimental-status.md).
+
+## Use when
+
+- You have an **already-accepted** program/epic contract (stable id, tracker-backed accepted outcomes, program exit gates) and want it compiled into bounded, ordered operator waves — invoked explicitly.
+- You want a read-only preview of the wave plan, decision gates, and expected evidence before any dispatch.
+
+## Do not use when
+
+- Decomposing raw or ambiguous intent, authoring specs, or splitting an epic into issues — that is upstream product/planning work; relay-orca never brainstorms or mutates the tracker.
+- Completing one tracker-backed outcome — use `relay`.
+- Fanning out already-planned independent leaves — use `relay-fleet`.
+- Authoring a single rubric/dispatch prompt — use `relay-plan`.
+
+relay-orca is **explicit-only**. It must never be auto-selected from ordinary relay, relay-fleet, delegation, implementation, or planning requests; the OpenAI agent interface pins `allow_implicit_invocation: false`.
+
+## Intents
+
+relay-orca exposes exactly five intents. Only `plan` is implemented in this leaf; the runtime intents are contract-only here and are delivered in a later leaf (#944), gated on the Orca capability probe.
+
+| Intent | Status | Purpose |
+| --- | --- | --- |
+| `plan` | implemented (read-only) | Compile an accepted program into an immutable wave plan. |
+| `run` | contract-only (#944) | Dispatch provenance-injected relay/fleet operators for a plan. |
+| `status` | contract-only (#944) | Derive live status from Orca + relay + GitHub + exit-gate evidence. |
+| `resume` | contract-only (#944) | Resume a coordinator from a reconstructible receipt without resetting Orca. |
+| `stop` | contract-only (#944) | Stop the coordinator only; never kill relay runs or discard durable state. |
+
+Command tables and flag semantics: [references/commands.md](references/commands.md).
+
+## Input Contract
+
+`plan` reads one accepted-program JSON contract. The minimum contract is a stable program `id`, non-empty `exit_gates`, and a non-empty `outcomes[]` array where each outcome carries a stable `id`, a supported `task_kind`, non-empty `accepted_outcomes`, and optional `depends_on`/`wave`. The schema carries **no** agent-engine execution fields — executor/reviewer selection is relay route configuration (see [references/accepted-program-schema.md](references/accepted-program-schema.md) and [references/task-kinds.md](references/task-kinds.md)).
+
+Supported task kinds: `relay_run`, `relay_fleet`, `integration_gate`, `advisory_review`, `tracker_reconciliation`.
+
+## Commands
+
+Compile an accepted program into a wave plan (read-only; writes only to stdout):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js" \
+  --program-file /tmp/accepted-program.json \
+  --json
+```
+
+Override the coordinator concurrency ceiling (default 2, hard maximum 4):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js" \
+  --program-file /tmp/accepted-program.json \
+  --concurrency 3 \
+  --json
+```
+
+`plan` is READ-ONLY: it creates no Orca task or terminal, no relay request/run/worktree, no PR, and no issue, and writes nothing outside stdout/stderr. On rejection it exits with a distinct non-zero code per reason. Rejection matrix and exit codes: [references/commands.md](references/commands.md).
+
+## Ownership invariants
+
+- Orca workers are relay **operators**, not direct code workers; relay owns all implementation worktrees and durable run manifests.
+- Orca task status and `worker_done` are **lifecycle signals, not completion authority** — program completion is proven from live relay/GitHub/exit-gate evidence.
+- Maximum orchestration depth is coordinator → relay/fleet operator → relay executor/reviewer. Nested relay-orca and deeper delegation are rejected.
+
+Full operator contract, topology, and recovery detail: [references/task-kinds.md](references/task-kinds.md) and [references/experimental-status.md](references/experimental-status.md).

--- a/skills/relay-orca/agents/openai.yaml
+++ b/skills/relay-orca/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "relay-orca"
+  short_description: "EXPERIMENTAL, opt-in program-altitude coordinator. Explicit-only: supervises accepted programs as bounded Orca waves over relay/relay-fleet operators. Does NOT auto-trigger on ordinary relay, relay-fleet, delegation, implementation, or planning requests."
+  default_prompt: "Invoke relay-orca ONLY when the operator explicitly asks for relay-orca plan, run, status, resume, or stop on an already-accepted program contract."
+policy:
+  # Explicit-only routing (D5): relay-orca must never be selected implicitly.
+  # An engine may only enter it when the operator names a relay-orca intent.
+  allow_implicit_invocation: false

--- a/skills/relay-orca/references/accepted-program-schema.md
+++ b/skills/relay-orca/references/accepted-program-schema.md
@@ -1,0 +1,76 @@
+# Accepted-program schema (v0)
+
+`relay-orca plan` consumes exactly one **already-accepted** program/epic contract. The
+contract is the boundary: relay-orca does not brainstorm, author specs, decompose issues,
+or mutate the tracker. Input begins only after an operator has accepted a program with
+tracker-backed outcomes and program exit gates.
+
+The contract is engine-agnostic by construction. It carries **no** agent-engine execution
+fields (no `executor`, `reviewer`, `model`, `engine`, prompt variants, or CLI selection).
+Executor/reviewer selection is **relay route configuration**, resolved by `relay-config`
+at operator dispatch time — not part of this schema (D11).
+
+## Shape
+
+```jsonc
+{
+  "program": {
+    "id": "epic-941",                     // REQUIRED — stable program/epic identifier
+    "source": "https://.../issues/941",   // program source URL or file
+    "repo": "owner/name",                 // repository identity
+    "tracker": "github",                  // tracker identity
+    "concurrency": 2,                     // optional; default 2, hard maximum 4
+    "exit_gates": ["...", "..."],         // REQUIRED — >= 1 non-empty program exit gate
+    "decision_gates": [                    // optional program-level gates / auth boundaries
+      { "id": "signoff", "description": "operator approves completion", "authorization": "operator" }
+    ],
+    "outcomes": [                          // REQUIRED — >= 1 accepted outcome
+      {
+        "id": "942-probe",               // REQUIRED — stable, unique; yields a stable task id
+        "title": "Orca capability probe",
+        "issue": 942,                     // issue reference where implementation is required
+        "task_kind": "relay_run",         // REQUIRED — one of the five supported kinds
+        "accepted_outcomes": ["probe merged"],  // REQUIRED — >= 1 non-empty accepted outcome
+        "depends_on": [],                 // optional — outcome ids in THIS program
+        "wave": 1,                         // optional — author-pinned wave (all-or-nothing)
+        "decision_gate": null,             // optional per-outcome gate
+        "expected_evidence": ["PR merged", "issue 942 closed"],  // optional; defaults per kind
+        "leaves": []                       // relay_fleet ONLY — prepared leaf contracts
+      }
+    ]
+  }
+}
+```
+
+The root may be the program object directly or wrapped under a `program` key.
+
+## Field rules
+
+- `id` — required non-empty string. The stable task id is derived deterministically as
+  `orca-task-<slugified-id>`; duplicate outcome ids (or ids that collide after slugging)
+  are rejected.
+- `exit_gates` — required, at least one non-empty string. Missing → rejection (D7b).
+- `concurrency` — integer in `[1, 4]`; default `2`. Above `4` → rejection (D7g). `--concurrency`
+  overrides the program value.
+- `outcomes[].accepted_outcomes` — required, at least one non-empty string. Empty/absent means
+  raw/vague intent → rejection (D7a).
+- `outcomes[].task_kind` — one of `relay_run`, `relay_fleet`, `integration_gate`,
+  `advisory_review`, `tracker_reconciliation`. Anything else → rejection (D7f); `relay_orca`
+  specifically → nested-relay-orca rejection (D9).
+- `outcomes[].depends_on` — outcome ids declared in the same program. Unknown references and
+  self-references are rejected; a dependency cycle → rejection (D7d).
+- `outcomes[].wave` — optional author-pinned wave. If any outcome declares `wave`, all must
+  (positive integers). Every dependency must resolve to a strictly earlier declared wave;
+  a dependency in the same (or later) wave → rejection (D7e). When no waves are declared,
+  `plan` derives them by dependency leveling.
+- `relay_fleet` outcomes — must carry a non-empty `leaves[]`, each leaf with non-empty
+  `prompt_file`, `rubric_file`, and `done_criteria_file` (already prepared by `relay-plan` /
+  `relay-fleet`). Any unprepared leaf → rejection (D7c). relay-orca never prepares leaves.
+
+## Depth and nesting
+
+An outcome that declares sub-orchestration (`spawns_operators: true`, `sub_program`,
+`orchestrates[]`, or `depth > 1`) exceeds the allowed depth and is rejected (D9). A program
+that declares itself nested under another relay-orca program (`nested: true` or
+`parent_program_kind: "relay_orca"`) is rejected as nested relay-orca (D9). Maximum depth is
+coordinator → relay/fleet operator → relay executor/reviewer.

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -1,0 +1,61 @@
+# relay-orca commands
+
+## `plan` — read-only wave-plan compiler
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js" \
+  --program-file <accepted-program.json> [--json] [--concurrency N]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--program-file`, `-f` | Path to the accepted-program JSON contract (required). May also be passed positionally. |
+| `--json` | Emit the compiled plan (or the rejection object) as JSON on stdout. |
+| `--concurrency N` | Override the program's concurrency ceiling. Default 2, hard maximum 4. |
+| `--help`, `-h` | Print usage. |
+
+`plan` is **READ-ONLY** (D6): it reads only the program file and writes only to
+stdout/stderr. It creates no Orca task or terminal, no relay request/run/worktree, no pull
+request, and no tracker issue. It spawns no subprocess and imports no cross-skill module.
+
+### Plan output
+
+On success `plan` prints a stable, deterministic object:
+
+- `program_id`, `source`, `repo`, `tracker`, `concurrency`
+- `exit_gates`, `decision_gates` (echoed)
+- `invariants` — the ownership invariants (see [task-kinds.md](task-kinds.md))
+- `waves[]` — ordered, immutable waves `{ wave, task_ids }`; same-wave tasks are always
+  mutually independent
+- `tasks[]` — one per outcome: `task_id`, `outcome_id`, `kind`, `wave`, `depends_on`
+  (task ids), `recommended_route` (operator surface only), `decision_gate`,
+  `expected_evidence`
+
+The same input always yields byte-identical output (no timestamps, no randomness).
+
+## Rejection matrix
+
+Each rejection exits with a **distinct non-zero code** and, under `--json`, prints
+`{ "ok": false, "reason_code": "...", "message": "..." }`.
+
+| Done Criteria | reason_code | exit | Trigger |
+| --- | --- | --- | --- |
+| D7(a) | `VAGUE_INTENT` | 10 | An outcome lacks accepted outcomes (raw/vague intent). |
+| D7(b) | `MISSING_EXIT_GATES` | 11 | The program has no non-empty exit gate. |
+| D7(c) | `UNPREPARED_FLEET_LEAF` | 12 | A `relay_fleet` outcome has no prepared prompt/rubric/Done-Criteria leaf. |
+| D7(d) | `DEPENDENCY_CYCLE` | 13 | The dependency graph contains a cycle. |
+| D7(e) | `SAME_WAVE_DEPENDENCY` | 14 | A dependency does not resolve to a strictly earlier declared wave. |
+| D7(f) | `UNSUPPORTED_TASK_KIND` | 15 | A `task_kind` is outside the five supported kinds. |
+| D7(g) | `CONCURRENCY_EXCEEDED` | 16 | Concurrency exceeds the hard maximum of 4. |
+| D9 | `NESTED_RELAY_ORCA` | 20 | An outcome/program nests relay-orca. |
+| D9 | `EXCESSIVE_DEPTH` | 21 | An outcome declares sub-orchestration beyond one operator layer. |
+
+Structural guards use their own codes: `INVALID_INPUT` (2), `DUPLICATE_OUTCOME_ID` (3),
+`UNKNOWN_DEPENDENCY` (4), `INVALID_WAVE_DECLARATION` (5). Missing/unreadable program files or
+unknown flags exit `64` (usage).
+
+## Runtime intents (contract-only in this leaf)
+
+`run`, `status`, `resume`, and `stop` are defined by the skill contract but are **not
+implemented here**. They are delivered in a later leaf (#944) and gated on the Orca capability
+probe. See [experimental-status.md](experimental-status.md) for the pilot boundary.

--- a/skills/relay-orca/references/experimental-status.md
+++ b/skills/relay-orca/references/experimental-status.md
@@ -1,0 +1,36 @@
+# relay-orca is EXPERIMENTAL and opt-in
+
+relay-orca ships as an **experimental, opt-in** program-controller pilot (epic #941). It is
+**not** part of the ordinary relay workflow and **not** an implicit dependency of `relay`,
+`relay-fleet`, or any other relay skill. A fresh install can ignore it entirely; ordinary
+relay use never routes through relay-orca.
+
+## Installation and opt-in
+
+- The full bundle (`npx skills add sungjunlee/dev-relay`) installs relay-orca alongside the
+  other skills, but it stays dormant unless an operator **explicitly** invokes a relay-orca
+  intent (`plan`, `run`, `status`, `resume`, `stop`).
+- The OpenAI agent interface pins `allow_implicit_invocation: false` (see
+  [../agents/openai.yaml](../agents/openai.yaml)), so no agent may auto-select relay-orca from
+  ordinary relay, relay-fleet, delegation, implementation, or planning requests (D5).
+- `plan` requires only Node.js 18+ and is read-only. The runtime intents
+  (`run`/`status`/`resume`/`stop`) additionally require the experimental Orca orchestration
+  surface and remain gated on the Orca capability probe; they are contract-only until a later
+  leaf (#944) delivers them.
+
+## Pilot boundary
+
+The first release is a supervised program-controller pilot, not a general autonomous software
+factory. In v0:
+
+- One active relay-orca program per Orca runtime; fail closed on ambiguous runtime-global
+  state.
+- Default concurrency 2, hard maximum 4.
+- `stop` stops only the coordinator; it never kills relay runs or discards their durable
+  state.
+- Program truth stays in the tracker/dev-backlog plus relay manifests. relay-orca adds no new
+  durable lifecycle state machine.
+- `orca orchestration reset` is never run automatically.
+
+See [accepted-program-schema.md](accepted-program-schema.md) for the input contract and
+[task-kinds.md](task-kinds.md) for the operator/ownership invariants.

--- a/skills/relay-orca/references/task-kinds.md
+++ b/skills/relay-orca/references/task-kinds.md
@@ -1,0 +1,42 @@
+# Task kinds, routes, and ownership invariants
+
+relay-orca supervises a bounded Orca task graph whose workers are relay **operators**. Each
+task compiles to a recommended relay operator surface and a set of expected live evidence.
+The recommended route names the operator surface **only**; the executor/reviewer engine is
+relay route configuration (`relay-config`), never part of the program contract (D11).
+
+## The five supported task kinds
+
+| task_kind | Operator | recommended_route | read-only | Expected evidence (default) |
+| --- | --- | --- | --- | --- |
+| `relay_run` | `relay` | `{ operator: relay, mode: single_run }` | no | relay manifest merged; PR merged; issue closed |
+| `relay_fleet` | `relay-fleet` | `{ operator: relay-fleet, mode: prepared_leaves }` | no | every fleet child terminal; fleet manifest closed |
+| `integration_gate` | `relay-review` | `{ operator: relay-review, mode: integration_gate }` | yes | integration gate report; gate check passes live |
+| `advisory_review` | `relay-review` | `{ operator: relay-review, mode: advisory }` | yes | advisory evidence posted; blocking findings triaged |
+| `tracker_reconciliation` | `dev-backlog` | `{ operator: dev-backlog, mode: reconcile }` | yes | tracker/issue state reconciled against relay manifests |
+
+`relay_fleet` outcomes must arrive with already-prepared leaves (`prompt_file`,
+`rubric_file`, `done_criteria_file`). relay-orca never prepares leaves — that is `relay-plan`
+and `relay-fleet` work.
+
+## Ownership invariants (surfaced in every plan)
+
+- **Operators, not code workers.** Orca workers are relay operators. Relay is the only owner
+  of implementation worktrees and durable child run manifests. Orca never edits code directly.
+- **Lifecycle is not completion.** Orca task status and `worker_done` are lifecycle signals,
+  **not** completion authority. A program outcome is complete only when live relay manifests,
+  PRs, issues, and program exit gates confirm it. `worker_done` alone is never sufficient.
+- **Bounded depth.** Maximum orchestration depth is
+  coordinator → relay/fleet operator → relay executor/reviewer. Nested relay-orca is
+  forbidden, and any outcome that would add a deeper delegation layer is rejected (D9).
+- **Immutable waves.** Dependencies compile into ordered, immutable waves; same-wave tasks are
+  mutually independent. New or changed dependencies belong in a **later** wave — v0 never
+  rewrites an active wave in place.
+
+## Wave compilation
+
+`plan` compiles `depends_on` edges into ordered waves. When outcomes pin `wave` values, those
+declared waves are honored and validated (every dependency must sit in a strictly earlier
+wave). When no waves are declared, `plan` derives them by dependency leveling: an outcome's
+wave is `1 + max(wave of its dependencies)`. Either way, same-wave independence is guaranteed,
+which is why a same-wave dependency is a hard rejection (D7e) rather than a silent reorder.

--- a/skills/relay-orca/scripts/lib/compile-program.js
+++ b/skills/relay-orca/scripts/lib/compile-program.js
@@ -1,0 +1,165 @@
+"use strict";
+
+const { reject } = require("./reasons");
+const { assertSupportedKind, assertPreparedFleet, routeFor, defaultEvidenceFor } = require("./task-kinds");
+const { edgesFor, computeLevels, declaredLevels, groupIntoWaves } = require("./waves");
+
+const DEFAULT_CONCURRENCY = 2;
+const MAX_CONCURRENCY = 4;
+
+// Ownership invariants surfaced in every plan (D10): Orca supervises operators,
+// relay owns implementation, lifecycle signals are not completion authority.
+const INVARIANTS = Object.freeze({
+  orca_workers_are_operators: "Orca workers are relay OPERATORS, not direct code workers",
+  relay_owns_worktrees: "relay owns implementation worktrees and durable run manifests",
+  lifecycle_not_completion: "Orca task status and worker_done are lifecycle signals, NOT completion authority",
+  max_depth: "coordinator -> relay/fleet operator -> relay executor/reviewer",
+  nested_relay_orca: "forbidden",
+});
+
+function unwrapProgram(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    reject("INVALID_INPUT", "accepted program must be a JSON object");
+  }
+  const program = input.program && typeof input.program === "object" ? input.program : input;
+  if (typeof program.id !== "string" || program.id.trim() === "") {
+    reject("INVALID_INPUT", "program.id is required and must be a non-empty string");
+  }
+  if (program.nested === true || program.parent_program_kind === "relay_orca") {
+    reject("NESTED_RELAY_ORCA", "this program declares itself nested under another relay-orca program");
+  }
+  return program;
+}
+
+function resolveConcurrency(program, override) {
+  const raw = override !== undefined ? override : program.concurrency;
+  const value = raw === undefined || raw === null ? DEFAULT_CONCURRENCY : raw;
+  if (!Number.isInteger(value) || value < 1) {
+    reject("INVALID_INPUT", `concurrency must be an integer >= 1 (got ${JSON.stringify(value)})`);
+  }
+  if (value > MAX_CONCURRENCY) {
+    reject("CONCURRENCY_EXCEEDED", `concurrency ${value} exceeds the hard maximum of ${MAX_CONCURRENCY}`);
+  }
+  return value;
+}
+
+function assertExitGates(program) {
+  const gates = program.exit_gates;
+  if (!Array.isArray(gates) || gates.filter((gate) => typeof gate === "string" && gate.trim()).length === 0) {
+    reject("MISSING_EXIT_GATES", "program.exit_gates must list at least one non-empty exit gate");
+  }
+}
+
+function assertOutcomes(program) {
+  if (!Array.isArray(program.outcomes) || program.outcomes.length === 0) {
+    reject("INVALID_INPUT", "program.outcomes must be a non-empty array");
+  }
+}
+
+function slug(id) {
+  return String(id).trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function taskIdOf(outcomeId) {
+  const normalized = slug(outcomeId);
+  if (!normalized) reject("INVALID_INPUT", `outcome id ${JSON.stringify(outcomeId)} does not yield a stable task id`);
+  return `orca-task-${normalized}`;
+}
+
+function assertDepthAndNesting(outcome) {
+  const route = outcome.route || (outcome.recommended_route && outcome.recommended_route.operator);
+  if (route === "relay-orca" || route === "relay_orca") {
+    reject("NESTED_RELAY_ORCA", `outcome ${outcome.id} routes to relay-orca; nested relay-orca is forbidden`);
+  }
+  if (outcome.spawns_operators === true || outcome.sub_program || Array.isArray(outcome.orchestrates)) {
+    reject("EXCESSIVE_DEPTH", `outcome ${outcome.id} declares sub-orchestration; depth beyond coordinator -> operator -> executor/reviewer is forbidden`);
+  }
+  if (Number.isInteger(outcome.depth) && outcome.depth > 1) {
+    reject("EXCESSIVE_DEPTH", `outcome ${outcome.id} declares depth ${outcome.depth}; a single operator layer is the maximum`);
+  }
+}
+
+function assertAcceptedOutcomes(outcome) {
+  const accepted = outcome.accepted_outcomes;
+  const cleaned = Array.isArray(accepted) ? accepted.filter((item) => typeof item === "string" && item.trim()) : [];
+  if (cleaned.length === 0) {
+    reject("VAGUE_INTENT", `outcome ${outcome.id} has no accepted outcomes; raw/vague intent cannot be planned`);
+  }
+}
+
+function validateOutcome(outcome, seenIds, seenTaskIds) {
+  if (!outcome || typeof outcome !== "object" || typeof outcome.id !== "string" || outcome.id.trim() === "") {
+    reject("INVALID_INPUT", "each outcome must be an object with a non-empty string id");
+  }
+  if (seenIds.has(outcome.id)) reject("DUPLICATE_OUTCOME_ID", `duplicate outcome id ${outcome.id}`);
+  seenIds.add(outcome.id);
+  const taskId = taskIdOf(outcome.id);
+  if (seenTaskIds.has(taskId)) reject("DUPLICATE_OUTCOME_ID", `outcome ${outcome.id} collides on task id ${taskId}`);
+  seenTaskIds.add(taskId);
+  assertDepthAndNesting(outcome);
+  assertSupportedKind(outcome);
+  assertAcceptedOutcomes(outcome);
+  assertPreparedFleet(outcome);
+  return taskId;
+}
+
+function buildTask(outcome, taskId, waveIndex, taskIdByOutcome) {
+  const deps = Array.isArray(outcome.depends_on) ? outcome.depends_on : [];
+  const evidence = Array.isArray(outcome.expected_evidence) && outcome.expected_evidence.length
+    ? outcome.expected_evidence.slice()
+    : defaultEvidenceFor(outcome.task_kind);
+  return {
+    task_id: taskId,
+    outcome_id: outcome.id,
+    title: typeof outcome.title === "string" ? outcome.title : null,
+    issue: outcome.issue ?? null,
+    kind: outcome.task_kind,
+    wave: waveIndex,
+    depends_on: deps.map((dep) => taskIdByOutcome.get(dep)).sort(),
+    recommended_route: routeFor(outcome.task_kind),
+    decision_gate: outcome.decision_gate ?? null,
+    expected_evidence: evidence,
+  };
+}
+
+function compileProgram(input, options = {}) {
+  const program = unwrapProgram(input);
+  const concurrency = resolveConcurrency(program, options.concurrency);
+  assertExitGates(program);
+  assertOutcomes(program);
+
+  const seenIds = new Set();
+  const seenTaskIds = new Set();
+  const taskIdByOutcome = new Map();
+  program.outcomes.forEach((outcome) => taskIdByOutcome.set(outcome.id, validateOutcome(outcome, seenIds, seenTaskIds)));
+
+  const edges = edgesFor(program.outcomes);
+  const declared = declaredLevels(program.outcomes, edges);
+  const levels = declared || computeLevels(program.outcomes, edges);
+  const waves = groupIntoWaves(program.outcomes, (id) => levels.get(id), taskIdOf);
+  const waveByTaskId = new Map();
+  waves.forEach((entry) => entry.task_ids.forEach((taskId) => waveByTaskId.set(taskId, entry.wave)));
+
+  const tasks = program.outcomes
+    .map((outcome) => {
+      const taskId = taskIdByOutcome.get(outcome.id);
+      return buildTask(outcome, taskId, waveByTaskId.get(taskId), taskIdByOutcome);
+    })
+    .sort((a, b) => a.task_id.localeCompare(b.task_id));
+
+  return {
+    ok: true,
+    program_id: program.id,
+    source: program.source ?? null,
+    repo: program.repo ?? null,
+    tracker: program.tracker ?? null,
+    concurrency,
+    exit_gates: program.exit_gates.filter((gate) => typeof gate === "string" && gate.trim()),
+    decision_gates: Array.isArray(program.decision_gates) ? program.decision_gates : [],
+    invariants: INVARIANTS,
+    waves,
+    tasks,
+  };
+}
+
+module.exports = { compileProgram, DEFAULT_CONCURRENCY, MAX_CONCURRENCY, INVARIANTS };

--- a/skills/relay-orca/scripts/lib/compile-program.js
+++ b/skills/relay-orca/scripts/lib/compile-program.js
@@ -2,7 +2,7 @@
 
 const { reject } = require("./reasons");
 const { assertSupportedKind, assertPreparedFleet, routeFor, defaultEvidenceFor } = require("./task-kinds");
-const { edgesFor, computeLevels, declaredLevels, groupIntoWaves } = require("./waves");
+const { normalizeDependsOn, edgesFor, assertAcyclic, computeLevels, declaredLevels, groupIntoWaves } = require("./waves");
 
 const DEFAULT_CONCURRENCY = 2;
 const MAX_CONCURRENCY = 4;
@@ -74,8 +74,13 @@ function assertDepthAndNesting(outcome) {
   if (outcome.spawns_operators === true || outcome.sub_program || Array.isArray(outcome.orchestrates)) {
     reject("EXCESSIVE_DEPTH", `outcome ${outcome.id} declares sub-orchestration; depth beyond coordinator -> operator -> executor/reviewer is forbidden`);
   }
-  if (Number.isInteger(outcome.depth) && outcome.depth > 1) {
-    reject("EXCESSIVE_DEPTH", `outcome ${outcome.id} declares depth ${outcome.depth}; a single operator layer is the maximum`);
+  if (outcome.depth !== undefined && outcome.depth !== null) {
+    if (typeof outcome.depth !== "number" || !Number.isFinite(outcome.depth)) {
+      reject("INVALID_INPUT", `outcome ${outcome.id} has invalid depth ${JSON.stringify(outcome.depth)} (expected a finite number)`);
+    }
+    if (outcome.depth > 1) {
+      reject("EXCESSIVE_DEPTH", `outcome ${outcome.id} declares depth ${outcome.depth}; a single operator layer is the maximum`);
+    }
   }
 }
 
@@ -104,7 +109,7 @@ function validateOutcome(outcome, seenIds, seenTaskIds) {
 }
 
 function buildTask(outcome, taskId, waveIndex, taskIdByOutcome) {
-  const deps = Array.isArray(outcome.depends_on) ? outcome.depends_on : [];
+  const deps = normalizeDependsOn(outcome);
   const evidence = Array.isArray(outcome.expected_evidence) && outcome.expected_evidence.length
     ? outcome.expected_evidence.slice()
     : defaultEvidenceFor(outcome.task_kind);
@@ -134,6 +139,7 @@ function compileProgram(input, options = {}) {
   program.outcomes.forEach((outcome) => taskIdByOutcome.set(outcome.id, validateOutcome(outcome, seenIds, seenTaskIds)));
 
   const edges = edgesFor(program.outcomes);
+  assertAcyclic(program.outcomes, edges);
   const declared = declaredLevels(program.outcomes, edges);
   const levels = declared || computeLevels(program.outcomes, edges);
   const waves = groupIntoWaves(program.outcomes, (id) => levels.get(id), taskIdOf);

--- a/skills/relay-orca/scripts/lib/reasons.js
+++ b/skills/relay-orca/scripts/lib/reasons.js
@@ -1,0 +1,42 @@
+"use strict";
+
+// Every plan rejection maps to a DISTINCT non-zero exit code plus a stable
+// reason_code string. The seven Done-Criteria D7 cases are marked below; the
+// remaining codes are structural guards. Exit codes stay <= 125 so they never
+// collide with Node's own fatal/exec exit codes.
+const REASONS = {
+  // --- structural guards ---
+  INVALID_INPUT: 2,
+  DUPLICATE_OUTCOME_ID: 3,
+  UNKNOWN_DEPENDENCY: 4,
+  INVALID_WAVE_DECLARATION: 5,
+  // --- D7 enumerated rejection matrix ---
+  VAGUE_INTENT: 10, // D7(a) raw/vague intent lacking accepted outcomes
+  MISSING_EXIT_GATES: 11, // D7(b) program missing exit gates
+  UNPREPARED_FLEET_LEAF: 12, // D7(c) relay_fleet route without prepared prompt/rubric/DC
+  DEPENDENCY_CYCLE: 13, // D7(d) dependency cycle
+  SAME_WAVE_DEPENDENCY: 14, // D7(e) dependency does not resolve to a strictly earlier wave
+  UNSUPPORTED_TASK_KIND: 15, // D7(f) task kind outside the five supported
+  CONCURRENCY_EXCEEDED: 16, // D7(g) concurrency above the hard maximum of 4
+  // --- D9 depth / nesting rejections ---
+  NESTED_RELAY_ORCA: 20, // relay-orca nested inside a relay-orca program
+  EXCESSIVE_DEPTH: 21, // orchestration depth beyond coordinator -> operator -> executor/reviewer
+};
+
+class PlanError extends Error {
+  constructor(reasonCode, message) {
+    super(message);
+    this.name = "PlanError";
+    this.reasonCode = reasonCode;
+    this.exitCode = REASONS[reasonCode];
+    if (this.exitCode === undefined) {
+      throw new Error(`unknown plan reason code: ${reasonCode}`);
+    }
+  }
+}
+
+function reject(reasonCode, message) {
+  throw new PlanError(reasonCode, message);
+}
+
+module.exports = { REASONS, PlanError, reject };

--- a/skills/relay-orca/scripts/lib/task-kinds.js
+++ b/skills/relay-orca/scripts/lib/task-kinds.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const { reject } = require("./reasons");
+
+// The five supported task kinds. recommended_route names the relay OPERATOR
+// surface only; the executor/reviewer engine is deliberately absent — engine
+// selection is relay route configuration, not part of the program (D11).
+const TASK_KINDS = {
+  relay_run: {
+    route: { operator: "relay", mode: "single_run", read_only: false },
+    evidence: ["relay manifest reaches merged", "PR merged", "issue closed"],
+  },
+  relay_fleet: {
+    route: { operator: "relay-fleet", mode: "prepared_leaves", read_only: false },
+    evidence: ["every fleet child terminal (merged/closed)", "fleet manifest closed"],
+  },
+  integration_gate: {
+    route: { operator: "relay-review", mode: "integration_gate", read_only: true },
+    evidence: ["integration gate report produced", "gate check passes on live evidence"],
+  },
+  advisory_review: {
+    route: { operator: "relay-review", mode: "advisory", read_only: true },
+    evidence: ["advisory review evidence posted", "blocking findings triaged"],
+  },
+  tracker_reconciliation: {
+    route: { operator: "dev-backlog", mode: "reconcile", read_only: true },
+    evidence: ["tracker/issue state reconciled against relay manifests"],
+  },
+};
+
+const SUPPORTED_KINDS = Object.keys(TASK_KINDS);
+
+// relay-orca supervising a relay-orca program is forbidden (D9). Kept out of the
+// generic UNSUPPORTED_TASK_KIND bucket so it fails with its own reason code.
+const NESTED_ORCA_KINDS = new Set(["relay_orca", "relay-orca", "orca"]);
+
+function assertSupportedKind(outcome) {
+  const kind = outcome.task_kind;
+  if (NESTED_ORCA_KINDS.has(kind)) {
+    reject("NESTED_RELAY_ORCA", `outcome ${outcome.id} nests relay-orca (task_kind=${kind}); nested relay-orca is forbidden`);
+  }
+  if (!SUPPORTED_KINDS.includes(kind)) {
+    reject("UNSUPPORTED_TASK_KIND", `outcome ${outcome.id} has unsupported task_kind ${JSON.stringify(kind)}; supported: ${SUPPORTED_KINDS.join(", ")}`);
+  }
+}
+
+function assertPreparedFleet(outcome) {
+  if (outcome.task_kind !== "relay_fleet") return;
+  const leaves = Array.isArray(outcome.leaves) ? outcome.leaves : [];
+  if (leaves.length === 0) {
+    reject("UNPREPARED_FLEET_LEAF", `relay_fleet outcome ${outcome.id} has no prepared leaves`);
+  }
+  leaves.forEach((leaf, index) => assertPreparedLeaf(outcome, leaf, index));
+}
+
+function assertPreparedLeaf(outcome, leaf, index) {
+  for (const field of ["prompt_file", "rubric_file", "done_criteria_file"]) {
+    const value = leaf && leaf[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      reject("UNPREPARED_FLEET_LEAF", `relay_fleet outcome ${outcome.id} leaf #${index + 1} is missing prepared ${field}`);
+    }
+  }
+}
+
+function routeFor(kind) {
+  return { ...TASK_KINDS[kind].route };
+}
+
+function defaultEvidenceFor(kind) {
+  return [...TASK_KINDS[kind].evidence];
+}
+
+module.exports = {
+  TASK_KINDS,
+  SUPPORTED_KINDS,
+  assertSupportedKind,
+  assertPreparedFleet,
+  routeFor,
+  defaultEvidenceFor,
+};

--- a/skills/relay-orca/scripts/lib/waves.js
+++ b/skills/relay-orca/scripts/lib/waves.js
@@ -2,12 +2,30 @@
 
 const { reject } = require("./reasons");
 
+// Normalize + validate a single outcome's depends_on. Absent (undefined/null) is
+// an empty edge set; a present value MUST be an array of non-empty outcome-id
+// strings. A malformed depends_on fails closed rather than silently emptying,
+// which would otherwise let a task run before its prerequisite.
+function normalizeDependsOn(outcome) {
+  const raw = outcome.depends_on;
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    reject("INVALID_INPUT", `outcome ${outcome.id} depends_on must be an array of outcome ids (got ${JSON.stringify(raw)})`);
+  }
+  raw.forEach((dep) => {
+    if (typeof dep !== "string" || dep.trim() === "") {
+      reject("INVALID_INPUT", `outcome ${outcome.id} depends_on contains an invalid entry ${JSON.stringify(dep)}; each dependency must be a non-empty outcome id string`);
+    }
+  });
+  return raw;
+}
+
 // Resolve and validate each outcome's depends_on edges against the declared id set.
 function edgesFor(outcomes) {
   const ids = new Set(outcomes.map((outcome) => outcome.id));
   const edges = new Map();
   outcomes.forEach((outcome) => {
-    const deps = Array.isArray(outcome.depends_on) ? outcome.depends_on : [];
+    const deps = normalizeDependsOn(outcome);
     deps.forEach((dep) => {
       if (!ids.has(dep)) {
         reject("UNKNOWN_DEPENDENCY", `outcome ${outcome.id} depends on unknown outcome ${JSON.stringify(dep)}`);
@@ -19,6 +37,28 @@ function edgesFor(outcomes) {
     edges.set(outcome.id, deps);
   });
   return edges;
+}
+
+// Cycle detection that fires regardless of wave mode (D7d). Author-declared waves
+// take the declaredLevels path and skip computeLevels' own cycle guard, so a true
+// dependency cycle among declared-wave outcomes would otherwise surface as a
+// SAME_WAVE_DEPENDENCY. Running this first guarantees any cycle rejects as
+// DEPENDENCY_CYCLE before either leveling strategy runs.
+function assertAcyclic(outcomes, edges) {
+  const VISITING = 1;
+  const DONE = 2;
+  const state = new Map();
+  const visit = (id) => {
+    const seen = state.get(id);
+    if (seen === DONE) return;
+    if (seen === VISITING) {
+      reject("DEPENDENCY_CYCLE", `dependency cycle detected at outcome ${id}`);
+    }
+    state.set(id, VISITING);
+    for (const dep of edges.get(id)) visit(dep);
+    state.set(id, DONE);
+  };
+  outcomes.forEach((outcome) => visit(outcome.id));
 }
 
 // Longest-path leveling; a re-entered node on the active DFS stack is a cycle (D7d).
@@ -81,4 +121,4 @@ function groupIntoWaves(outcomes, keyOf, taskIdOf) {
     .map((key, index) => ({ wave: index + 1, task_ids: buckets.get(key).slice().sort() }));
 }
 
-module.exports = { edgesFor, computeLevels, declaredLevels, groupIntoWaves };
+module.exports = { normalizeDependsOn, edgesFor, assertAcyclic, computeLevels, declaredLevels, groupIntoWaves };

--- a/skills/relay-orca/scripts/lib/waves.js
+++ b/skills/relay-orca/scripts/lib/waves.js
@@ -1,0 +1,84 @@
+"use strict";
+
+const { reject } = require("./reasons");
+
+// Resolve and validate each outcome's depends_on edges against the declared id set.
+function edgesFor(outcomes) {
+  const ids = new Set(outcomes.map((outcome) => outcome.id));
+  const edges = new Map();
+  outcomes.forEach((outcome) => {
+    const deps = Array.isArray(outcome.depends_on) ? outcome.depends_on : [];
+    deps.forEach((dep) => {
+      if (!ids.has(dep)) {
+        reject("UNKNOWN_DEPENDENCY", `outcome ${outcome.id} depends on unknown outcome ${JSON.stringify(dep)}`);
+      }
+      if (dep === outcome.id) {
+        reject("DEPENDENCY_CYCLE", `outcome ${outcome.id} depends on itself`);
+      }
+    });
+    edges.set(outcome.id, deps);
+  });
+  return edges;
+}
+
+// Longest-path leveling; a re-entered node on the active DFS stack is a cycle (D7d).
+function computeLevels(outcomes, edges) {
+  const level = new Map();
+  const active = new Set();
+  const visit = (id) => {
+    if (level.has(id)) return level.get(id);
+    if (active.has(id)) {
+      reject("DEPENDENCY_CYCLE", `dependency cycle detected at outcome ${id}`);
+    }
+    active.add(id);
+    let lvl = 0;
+    for (const dep of edges.get(id)) lvl = Math.max(lvl, visit(dep) + 1);
+    active.delete(id);
+    level.set(id, lvl);
+    return lvl;
+  };
+  outcomes.forEach((outcome) => visit(outcome.id));
+  return level;
+}
+
+// Author-declared waves: all-or-nothing positive integers. Every dependency must
+// resolve to a strictly earlier declared wave, otherwise it is a same-wave (or
+// out-of-order) dependency (D7e).
+function declaredLevels(outcomes, edges) {
+  const declared = outcomes.filter((outcome) => outcome.wave !== undefined);
+  if (declared.length === 0) return null;
+  if (declared.length !== outcomes.length) {
+    reject("INVALID_WAVE_DECLARATION", "wave declarations must be all-or-nothing across outcomes");
+  }
+  const wave = new Map();
+  outcomes.forEach((outcome) => {
+    if (!Number.isInteger(outcome.wave) || outcome.wave < 1) {
+      reject("INVALID_WAVE_DECLARATION", `outcome ${outcome.id} has invalid wave ${JSON.stringify(outcome.wave)} (expected integer >= 1)`);
+    }
+    wave.set(outcome.id, outcome.wave);
+  });
+  outcomes.forEach((outcome) => {
+    for (const dep of edges.get(outcome.id)) {
+      if (wave.get(dep) >= wave.get(outcome.id)) {
+        reject("SAME_WAVE_DEPENDENCY", `outcome ${outcome.id} (wave ${wave.get(outcome.id)}) depends on ${dep} (wave ${wave.get(dep)}); dependencies must resolve to a strictly earlier wave`);
+      }
+    }
+  });
+  return wave;
+}
+
+// Group outcome ids into ordered, contiguous waves. keyOf maps an outcome id to
+// its raw level/declared value; groups are sorted ascending then re-indexed 1..k.
+function groupIntoWaves(outcomes, keyOf, taskIdOf) {
+  const buckets = new Map();
+  outcomes.forEach((outcome) => {
+    const key = keyOf(outcome.id);
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key).push(taskIdOf(outcome.id));
+  });
+  return [...buckets.keys()]
+    .sort((a, b) => a - b)
+    .map((key, index) => ({ wave: index + 1, task_ids: buckets.get(key).slice().sort() }));
+}
+
+module.exports = { edgesFor, computeLevels, declaredLevels, groupIntoWaves };

--- a/skills/relay-orca/scripts/plan.js
+++ b/skills/relay-orca/scripts/plan.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+"use strict";
+
+// relay-orca `plan` — a deterministic, READ-ONLY compiler (D6). It converts an
+// already-accepted program contract into an ordered, immutable wave plan. It only
+// ever reads its input file and writes to stdout/stderr: it creates no Orca
+// task/terminal, no relay request/run/worktree, no pull request, no tracker issue,
+// and no files. It deliberately avoids any subprocess or cross-skill module so it
+// structurally cannot mutate external state.
+const fs = require("node:fs");
+const { compileProgram } = require("./lib/compile-program");
+const { PlanError } = require("./lib/reasons");
+
+const USAGE_EXIT = 64;
+
+function parseArgs(argv) {
+  const opts = { programFile: null, json: false, concurrency: undefined };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--program-file" || arg === "-f") opts.programFile = argv[(i += 1)];
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--concurrency") opts.concurrency = Number(argv[(i += 1)]);
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else if (!arg.startsWith("-") && !opts.programFile) opts.programFile = arg;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+function usageError(message) {
+  process.stderr.write(`relay-orca plan: ${message}\n`);
+  process.stderr.write("usage: plan.js --program-file <accepted-program.json> [--json] [--concurrency N]\n");
+  process.exit(USAGE_EXIT);
+}
+
+function readProgram(programFile) {
+  if (!programFile) usageError("--program-file is required");
+  let text;
+  try {
+    text = fs.readFileSync(programFile, "utf-8");
+  } catch (error) {
+    usageError(`cannot read program file ${programFile}: ${error.message}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    usageError(`program file ${programFile} is not valid JSON: ${error.message}`);
+  }
+}
+
+function printPlan(plan, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`relay-orca plan for ${plan.program_id} (concurrency ${plan.concurrency})\n`);
+  plan.waves.forEach((wave) => {
+    process.stdout.write(`  wave ${wave.wave}: ${wave.task_ids.join(", ")}\n`);
+  });
+  process.stdout.write(`  exit gates: ${plan.exit_gates.length}\n`);
+}
+
+function fail(error, json) {
+  if (!(error instanceof PlanError)) throw error;
+  const body = { ok: false, reason_code: error.reasonCode, message: error.message };
+  if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  else process.stderr.write(`relay-orca plan rejected [${error.reasonCode}]: ${error.message}\n`);
+  process.exit(error.exitCode);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) usageError("read-only wave-plan compiler");
+  const program = readProgram(opts.programFile);
+  try {
+    printPlan(compileProgram(program, { concurrency: opts.concurrency }), opts.json);
+  } catch (error) {
+    fail(error, opts.json);
+  }
+}
+
+main();

--- a/tests/relay-orca/fixtures/advisory-gate.json
+++ b/tests/relay-orca/fixtures/advisory-gate.json
@@ -1,0 +1,38 @@
+{
+  "program": {
+    "id": "epic-demo-advisory",
+    "source": "https://github.com/example/repo/issues/3000",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 3,
+    "exit_gates": ["integration gate green", "advisory findings triaged", "tracker reconciled"],
+    "outcomes": [
+      {
+        "id": "impl",
+        "issue": 3001,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["feature merged"],
+        "depends_on": []
+      },
+      {
+        "id": "advisory",
+        "task_kind": "advisory_review",
+        "accepted_outcomes": ["security advisory posted"],
+        "depends_on": ["impl"],
+        "decision_gate": { "id": "sec-gate", "description": "no blocking findings", "authorization": "operator" }
+      },
+      {
+        "id": "gate",
+        "task_kind": "integration_gate",
+        "accepted_outcomes": ["integration suite passes on merged code"],
+        "depends_on": ["impl"]
+      },
+      {
+        "id": "reconcile",
+        "task_kind": "tracker_reconciliation",
+        "accepted_outcomes": ["issues reconciled with relay manifests"],
+        "depends_on": ["advisory", "gate"]
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/mixed-run-fleet.json
+++ b/tests/relay-orca/fixtures/mixed-run-fleet.json
@@ -1,0 +1,28 @@
+{
+  "program": {
+    "id": "epic-demo-mixed",
+    "source": "file:///tmp/epic-mixed.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all child issues merged", "milestone has zero open implementation issues"],
+    "outcomes": [
+      {
+        "id": "foundation",
+        "issue": 2001,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["shared substrate merged"],
+        "depends_on": []
+      },
+      {
+        "id": "fanout",
+        "task_kind": "relay_fleet",
+        "accepted_outcomes": ["three independent leaves merged"],
+        "depends_on": ["foundation"],
+        "leaves": [
+          { "leaf_ref": "l1", "prompt_file": "/tmp/p1.md", "rubric_file": "/tmp/r1.yaml", "done_criteria_file": "/tmp/dc1.md" },
+          { "leaf_ref": "l2", "prompt_file": "/tmp/p2.md", "rubric_file": "/tmp/r2.yaml", "done_criteria_file": "/tmp/dc2.md" }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-concurrency.json
+++ b/tests/relay-orca/fixtures/reject-concurrency.json
@@ -1,0 +1,13 @@
+{
+  "program": {
+    "id": "reject-concurrency",
+    "source": "file:///tmp/concurrency.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 5,
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "a", "task_kind": "relay_run", "accepted_outcomes": ["a merged"], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-cycle-declared.json
+++ b/tests/relay-orca/fixtures/reject-cycle-declared.json
@@ -1,0 +1,13 @@
+{
+  "program": {
+    "id": "reject-cycle-declared",
+    "source": "file:///tmp/cycle-declared.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "a", "task_kind": "relay_run", "accepted_outcomes": ["a merged"], "depends_on": ["b"], "wave": 2 },
+      { "id": "b", "task_kind": "relay_run", "accepted_outcomes": ["b merged"], "depends_on": ["a"], "wave": 1 }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-cycle.json
+++ b/tests/relay-orca/fixtures/reject-cycle.json
@@ -1,0 +1,13 @@
+{
+  "program": {
+    "id": "reject-cycle",
+    "source": "file:///tmp/cycle.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "a", "task_kind": "relay_run", "accepted_outcomes": ["a merged"], "depends_on": ["b"] },
+      { "id": "b", "task_kind": "relay_run", "accepted_outcomes": ["b merged"], "depends_on": ["a"] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-depends-on-nonstring.json
+++ b/tests/relay-orca/fixtures/reject-depends-on-nonstring.json
@@ -1,0 +1,13 @@
+{
+  "program": {
+    "id": "reject-depends-on-nonstring",
+    "source": "file:///tmp/dep-nonstring.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "foundation", "task_kind": "relay_run", "accepted_outcomes": ["foundation merged"], "depends_on": [] },
+      { "id": "consumer", "task_kind": "relay_run", "accepted_outcomes": ["consumer merged"], "depends_on": ["foundation", 42] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-depends-on-string.json
+++ b/tests/relay-orca/fixtures/reject-depends-on-string.json
@@ -1,0 +1,13 @@
+{
+  "program": {
+    "id": "reject-depends-on-string",
+    "source": "file:///tmp/dep-string.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "foundation", "task_kind": "relay_run", "accepted_outcomes": ["foundation merged"], "depends_on": [] },
+      { "id": "consumer", "task_kind": "relay_run", "accepted_outcomes": ["consumer merged"], "depends_on": "foundation" }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-depth-fractional.json
+++ b/tests/relay-orca/fixtures/reject-depth-fractional.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-depth-fractional",
+    "source": "file:///tmp/depth-fractional.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "layered", "task_kind": "relay_run", "accepted_outcomes": ["work merged"], "depends_on": [], "depth": 1.5 }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-depth-nan.json
+++ b/tests/relay-orca/fixtures/reject-depth-nan.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-depth-nan",
+    "source": "file:///tmp/depth-nan.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "layered", "task_kind": "relay_run", "accepted_outcomes": ["work merged"], "depends_on": [], "depth": "two" }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-depth-two.json
+++ b/tests/relay-orca/fixtures/reject-depth-two.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-depth-two",
+    "source": "file:///tmp/depth-two.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "layered", "task_kind": "relay_run", "accepted_outcomes": ["work merged"], "depends_on": [], "depth": 2 }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-excessive-depth.json
+++ b/tests/relay-orca/fixtures/reject-excessive-depth.json
@@ -1,0 +1,18 @@
+{
+  "program": {
+    "id": "reject-depth",
+    "source": "file:///tmp/depth.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      {
+        "id": "super-operator",
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["work merged"],
+        "depends_on": [],
+        "spawns_operators": true
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-missing-exit-gates.json
+++ b/tests/relay-orca/fixtures/reject-missing-exit-gates.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-no-gates",
+    "source": "file:///tmp/no-gates.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": [],
+    "outcomes": [
+      { "id": "a", "task_kind": "relay_run", "accepted_outcomes": ["a merged"], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-nested-orca.json
+++ b/tests/relay-orca/fixtures/reject-nested-orca.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-nested",
+    "source": "file:///tmp/nested.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "inner-program", "task_kind": "relay_orca", "accepted_outcomes": ["sub-program done"], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-same-wave.json
+++ b/tests/relay-orca/fixtures/reject-same-wave.json
@@ -1,0 +1,13 @@
+{
+  "program": {
+    "id": "reject-same-wave",
+    "source": "file:///tmp/same-wave.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "a", "task_kind": "relay_run", "accepted_outcomes": ["a merged"], "depends_on": [], "wave": 1 },
+      { "id": "b", "task_kind": "relay_run", "accepted_outcomes": ["b merged"], "depends_on": ["a"], "wave": 1 }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-unprepared-fleet.json
+++ b/tests/relay-orca/fixtures/reject-unprepared-fleet.json
@@ -1,0 +1,20 @@
+{
+  "program": {
+    "id": "reject-unprepared-fleet",
+    "source": "file:///tmp/unprepared.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all leaves merged"],
+    "outcomes": [
+      {
+        "id": "fanout",
+        "task_kind": "relay_fleet",
+        "accepted_outcomes": ["leaves merged"],
+        "depends_on": [],
+        "leaves": [
+          { "leaf_ref": "l1", "prompt_file": "/tmp/p1.md", "rubric_file": "", "done_criteria_file": "/tmp/dc1.md" }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-unsupported-kind.json
+++ b/tests/relay-orca/fixtures/reject-unsupported-kind.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-unsupported-kind",
+    "source": "file:///tmp/unsupported.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["deployed"],
+    "outcomes": [
+      { "id": "deploy", "task_kind": "deploy_prod", "accepted_outcomes": ["service live"], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/reject-vague.json
+++ b/tests/relay-orca/fixtures/reject-vague.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "reject-vague",
+    "source": "file:///tmp/vague.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["ship it"],
+    "outcomes": [
+      { "id": "make-it-good", "task_kind": "relay_run", "accepted_outcomes": [], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/valid-depth-one.json
+++ b/tests/relay-orca/fixtures/valid-depth-one.json
@@ -1,0 +1,12 @@
+{
+  "program": {
+    "id": "valid-depth-one",
+    "source": "file:///tmp/depth-one.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "exit_gates": ["all merged"],
+    "outcomes": [
+      { "id": "single-layer", "task_kind": "relay_run", "accepted_outcomes": ["work merged"], "depends_on": [], "depth": 1 }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/valid-single-relay-run.json
+++ b/tests/relay-orca/fixtures/valid-single-relay-run.json
@@ -1,0 +1,24 @@
+{
+  "program": {
+    "id": "epic-demo-single",
+    "source": "https://github.com/example/repo/issues/1000",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 2,
+    "exit_gates": ["issue 1001 merged and closed"],
+    "decision_gates": [
+      { "id": "signoff", "description": "operator approves program completion", "authorization": "operator" }
+    ],
+    "outcomes": [
+      {
+        "id": "outcome-a",
+        "title": "Implement widget",
+        "issue": 1001,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["widget merged with passing tests"],
+        "depends_on": [],
+        "expected_evidence": ["PR merged", "issue 1001 closed"]
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/scripts/plan.test.js
+++ b/tests/relay-orca/scripts/plan.test.js
@@ -169,6 +169,57 @@ test("D7/D9: every rejection reason maps to a DISTINCT non-zero exit code", () =
   assert.ok(codes.every((code) => Number.isInteger(code) && code > 0));
 });
 
+// Assert a fixture rejects with a specific reason both at the compile-program
+// boundary and through the plan.js CLI (exit code + --json reason_code).
+function assertRejects(fixture, reason) {
+  assert.throws(() => compileFixture(fixture), (error) => error.reasonCode === reason, `${fixture} must reject with ${reason}`);
+  const result = runPlanIsolated(fixture, ["--json"]);
+  assert.equal(result.status, REASONS[reason], `${fixture} CLI must exit with ${reason} code ${REASONS[reason]}`);
+  assert.equal(JSON.parse(result.stdout).reason_code, reason);
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1: cycle detection is independent of declared-wave mode (D7d)
+// ---------------------------------------------------------------------------
+
+test("D7(d): a dependency cycle whose outcomes ALSO declare waves rejects as DEPENDENCY_CYCLE (not SAME_WAVE_DEPENDENCY)", () => {
+  assertRejects("reject-cycle-declared", "DEPENDENCY_CYCLE");
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2: malformed depends_on fails closed instead of silently emptying
+// ---------------------------------------------------------------------------
+
+test("depends_on present as a non-array string fails closed as INVALID_INPUT (never dropped to independent)", () => {
+  assertRejects("reject-depends-on-string", "INVALID_INPUT");
+});
+
+test("depends_on array containing a non-string entry fails closed as INVALID_INPUT", () => {
+  assertRejects("reject-depends-on-nonstring", "INVALID_INPUT");
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3: every numeric depth above the max is rejected, not just integers (D9)
+// ---------------------------------------------------------------------------
+
+test("D9: fractional depth 1.5 above one operator layer rejects as EXCESSIVE_DEPTH", () => {
+  assertRejects("reject-depth-fractional", "EXCESSIVE_DEPTH");
+});
+
+test("D9: integer depth 2 rejects as EXCESSIVE_DEPTH", () => {
+  assertRejects("reject-depth-two", "EXCESSIVE_DEPTH");
+});
+
+test("D9: non-numeric depth fails closed as INVALID_INPUT", () => {
+  assertRejects("reject-depth-nan", "INVALID_INPUT");
+});
+
+test("D9: depth of exactly 1 (a single operator layer) still compiles", () => {
+  const plan = compileFixture("valid-depth-one");
+  assert.equal(plan.ok, true);
+  assert.equal(plan.tasks.length, 1);
+});
+
 // ---------------------------------------------------------------------------
 // D6 read-only proof
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/plan.test.js
+++ b/tests/relay-orca/scripts/plan.test.js
@@ -1,0 +1,235 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SKILL_DIR = path.join(REPO_ROOT, "skills", "relay-orca");
+const PLAN_JS = path.join(SKILL_DIR, "scripts", "plan.js");
+const FIXTURES = path.join(__dirname, "..", "fixtures");
+const { compileProgram } = require(path.join(SKILL_DIR, "scripts", "lib", "compile-program"));
+const { REASONS } = require(path.join(SKILL_DIR, "scripts", "lib", "reasons"));
+
+function fixturePath(name) {
+  return path.join(FIXTURES, `${name}.json`);
+}
+
+function compileFixture(name) {
+  return compileProgram(JSON.parse(fs.readFileSync(fixturePath(name), "utf-8")));
+}
+
+// Run plan.js in a throwaway cwd + HOME so any accidental write is observable.
+function runPlanIsolated(name, extraArgs = []) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "orca-cwd-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "orca-home-"));
+  const result = { status: 0, stdout: "", stderr: "" };
+  try {
+    result.stdout = execFileSync(process.execPath, [PLAN_JS, "--program-file", fixturePath(name), ...extraArgs], {
+      cwd,
+      encoding: "utf-8",
+      env: { ...process.env, HOME: home, RELAY_HOME: path.join(home, ".relay") },
+      stdio: "pipe",
+    });
+  } catch (error) {
+    result.status = error.status;
+    result.stdout = error.stdout ? String(error.stdout) : "";
+    result.stderr = error.stderr ? String(error.stderr) : "";
+  }
+  result.cwdEntries = fs.readdirSync(cwd);
+  result.homeEntries = fs.readdirSync(home);
+  fs.rmSync(cwd, { recursive: true, force: true });
+  fs.rmSync(home, { recursive: true, force: true });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// D12 fixture matrix + D8 valid-plan shape
+// ---------------------------------------------------------------------------
+
+test("D12: valid single relay_run compiles to a one-task, one-wave plan (D8)", () => {
+  const plan = compileFixture("valid-single-relay-run");
+  assert.equal(plan.ok, true);
+  assert.equal(plan.tasks.length, 1);
+  assert.equal(plan.concurrency, 2);
+  const [task] = plan.tasks;
+  assert.equal(task.task_id, "orca-task-outcome-a");
+  assert.equal(task.kind, "relay_run");
+  assert.deepEqual(task.recommended_route, { operator: "relay", mode: "single_run", read_only: false });
+  assert.deepEqual(task.expected_evidence, ["PR merged", "issue 1001 closed"]);
+  assert.deepEqual(plan.waves, [{ wave: 1, task_ids: ["orca-task-outcome-a"] }]);
+});
+
+test("D12: mixed relay_run + relay_fleet orders the fleet into a later wave", () => {
+  const plan = compileFixture("mixed-run-fleet");
+  assert.equal(plan.ok, true);
+  assert.equal(plan.concurrency, 2, "default concurrency must be 2 when unspecified (D8)");
+  const fleet = plan.tasks.find((task) => task.kind === "relay_fleet");
+  assert.deepEqual(fleet.recommended_route, { operator: "relay-fleet", mode: "prepared_leaves", read_only: false });
+  assert.deepEqual(fleet.depends_on, ["orca-task-foundation"]);
+  assert.deepEqual(plan.waves, [
+    { wave: 1, task_ids: ["orca-task-foundation"] },
+    { wave: 2, task_ids: ["orca-task-fanout"] },
+  ]);
+});
+
+test("D12: advisory-gate keeps independent advisory + integration tasks in the same wave", () => {
+  const plan = compileFixture("advisory-gate");
+  assert.equal(plan.ok, true);
+  assert.equal(plan.waves.length, 3);
+  assert.deepEqual(plan.waves[1].task_ids, ["orca-task-advisory", "orca-task-gate"]);
+  const advisory = plan.tasks.find((task) => task.outcome_id === "advisory");
+  assert.equal(advisory.recommended_route.read_only, true);
+  assert.deepEqual(advisory.decision_gate, { id: "sec-gate", description: "no blocking findings", authorization: "operator" });
+  const reconcile = plan.tasks.find((task) => task.outcome_id === "reconcile");
+  assert.equal(reconcile.kind, "tracker_reconciliation");
+  assert.deepEqual(reconcile.depends_on, ["orca-task-advisory", "orca-task-gate"]);
+});
+
+test("D8: task IDs and waves are deterministic across repeated compiles", () => {
+  assert.deepEqual(compileFixture("advisory-gate"), compileFixture("advisory-gate"));
+});
+
+test("D8: same-wave tasks are always mutually independent across every valid fixture", () => {
+  for (const name of ["valid-single-relay-run", "mixed-run-fleet", "advisory-gate"]) {
+    const plan = compileFixture(name);
+    const waveOf = new Map(plan.tasks.map((task) => [task.task_id, task.wave]));
+    plan.waves.forEach((wave) => {
+      wave.task_ids.forEach((taskId) => {
+        const task = plan.tasks.find((candidate) => candidate.task_id === taskId);
+        task.depends_on.forEach((dep) => {
+          assert.ok(waveOf.get(dep) < wave.wave, `${name}: ${taskId} depends on same-or-later-wave ${dep}`);
+        });
+      });
+    });
+  }
+});
+
+test("D8: every task kind stays within the five supported kinds", () => {
+  const supported = new Set(["relay_run", "relay_fleet", "integration_gate", "advisory_review", "tracker_reconciliation"]);
+  for (const name of ["valid-single-relay-run", "mixed-run-fleet", "advisory-gate"]) {
+    compileFixture(name).tasks.forEach((task) => assert.ok(supported.has(task.kind)));
+  }
+});
+
+test("D11: no engine-specific execution fields leak into the compiled plan", () => {
+  const serialized = JSON.stringify(compileFixture("advisory-gate"));
+  // "executor/reviewer" are allowed as relay ROLE names in the depth invariant;
+  // what must never appear is an agent-ENGINE selection (that is relay route config).
+  for (const forbidden of ["codex", "claude", "opencode", "gpt-", "gemini", "antigravity", '"model"', '"engine"']) {
+    assert.ok(!serialized.includes(forbidden), `plan output must not carry engine token ${forbidden}`);
+  }
+  compileFixture("advisory-gate").tasks.forEach((task) => {
+    assert.deepEqual(Object.keys(task.recommended_route).sort(), ["mode", "operator", "read_only"]);
+  });
+});
+
+test("D10: ownership invariants are stated in the plan output", () => {
+  const { invariants } = compileFixture("valid-single-relay-run");
+  assert.match(invariants.orca_workers_are_operators, /OPERATORS, not direct code workers/);
+  assert.match(invariants.relay_owns_worktrees, /relay owns implementation worktrees/);
+  assert.match(invariants.lifecycle_not_completion, /worker_done.*NOT completion authority/);
+  assert.equal(invariants.nested_relay_orca, "forbidden");
+});
+
+// ---------------------------------------------------------------------------
+// D7 seven-case rejection matrix + D9 depth/nesting — distinct reason + exit code
+// ---------------------------------------------------------------------------
+
+const REJECTIONS = [
+  { fixture: "reject-vague", reason: "VAGUE_INTENT" }, // D7(a)
+  { fixture: "reject-missing-exit-gates", reason: "MISSING_EXIT_GATES" }, // D7(b)
+  { fixture: "reject-unprepared-fleet", reason: "UNPREPARED_FLEET_LEAF" }, // D7(c)
+  { fixture: "reject-cycle", reason: "DEPENDENCY_CYCLE" }, // D7(d)
+  { fixture: "reject-same-wave", reason: "SAME_WAVE_DEPENDENCY" }, // D7(e)
+  { fixture: "reject-unsupported-kind", reason: "UNSUPPORTED_TASK_KIND" }, // D7(f)
+  { fixture: "reject-concurrency", reason: "CONCURRENCY_EXCEEDED" }, // D7(g)
+  { fixture: "reject-nested-orca", reason: "NESTED_RELAY_ORCA" }, // D9
+  { fixture: "reject-excessive-depth", reason: "EXCESSIVE_DEPTH" }, // D9
+];
+
+for (const { fixture, reason } of REJECTIONS) {
+  test(`plan rejects ${fixture} with ${reason} and a distinct non-zero exit code`, () => {
+    const result = runPlanIsolated(fixture, ["--json"]);
+    assert.equal(result.status, REASONS[reason], `${fixture} must exit with ${reason} code ${REASONS[reason]}`);
+    assert.notEqual(result.status, 0);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.ok, false);
+    assert.equal(body.reason_code, reason);
+    assert.ok(body.message && body.message.length > 0);
+  });
+}
+
+test("D7/D9: every rejection reason maps to a DISTINCT non-zero exit code", () => {
+  const codes = REJECTIONS.map(({ reason }) => REASONS[reason]);
+  assert.equal(new Set(codes).size, codes.length, "reason exit codes must be pairwise distinct");
+  assert.ok(codes.every((code) => Number.isInteger(code) && code > 0));
+});
+
+// ---------------------------------------------------------------------------
+// D6 read-only proof
+// ---------------------------------------------------------------------------
+
+test("D6: a valid plan run writes nothing to cwd or HOME", () => {
+  const result = runPlanIsolated("advisory-gate", ["--json"]);
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.cwdEntries, [], "plan must not create files in the working directory");
+  assert.deepEqual(result.homeEntries, [], "plan must not create ~/.relay or any HOME state");
+  JSON.parse(result.stdout); // stdout is the only output surface
+});
+
+test("D6: a rejecting plan run also writes nothing outside stdout/stderr", () => {
+  const result = runPlanIsolated("reject-cycle", ["--json"]);
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(result.cwdEntries, []);
+  assert.deepEqual(result.homeEntries, []);
+});
+
+test("D6: plan sources contain no write, subprocess, or network APIs", () => {
+  const sources = [PLAN_JS, ...fs.readdirSync(path.join(SKILL_DIR, "scripts", "lib")).map((file) => path.join(SKILL_DIR, "scripts", "lib", file))];
+  const forbidden = [
+    /child_process/, /execFileSync/, /execSync/, /spawnSync/, /spawn\s*\(/,
+    /writeFile/, /appendFile/, /mkdirSync/, /rmSync/, /rmdirSync/, /createWriteStream/,
+    /require\((['"])(node:)?(https?|net|dgram|dns)\1\)/,
+  ];
+  sources.forEach((source) => {
+    const text = fs.readFileSync(source, "utf-8");
+    forbidden.forEach((pattern) => assert.doesNotMatch(text, pattern, `${path.basename(source)} must not use ${pattern}`));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D5 explicit-only routing + CLI success contract
+// ---------------------------------------------------------------------------
+
+test("D5: agents/openai.yaml disables implicit invocation", () => {
+  const yaml = fs.readFileSync(path.join(SKILL_DIR, "agents", "openai.yaml"), "utf-8");
+  assert.match(yaml, /allow_implicit_invocation:\s*false/, "relay-orca must be explicit-only from the OpenAI agent surface");
+});
+
+test("D5: SKILL.md routing text is explicit-only and disclaims ordinary relay triggers", () => {
+  const skill = fs.readFileSync(path.join(SKILL_DIR, "SKILL.md"), "utf-8");
+  const front = skill.split(/\n---\n/)[0];
+  assert.match(front, /explicit-only/i, "description must declare explicit-only routing");
+  assert.match(front, /NOT for ordinary relay, relay-fleet, delegation, implementation, or planning/i);
+  // keywords must be relay-orca-specific, never bare generic triggers.
+  const keywords = (front.match(/keywords:\s*(.*)/) || [])[1] || "";
+  for (const bare of ["dispatch", "implement", "delegate", "review"]) {
+    assert.ok(!keywords.split(/[\s,]+/).includes(bare), `keyword "${bare}" would auto-trigger on ordinary requests`);
+  }
+});
+
+test("CLI: --json success emits a parseable plan and exits 0", () => {
+  const result = runPlanIsolated("valid-single-relay-run", ["--json"]);
+  assert.equal(result.status, 0);
+  const plan = JSON.parse(result.stdout);
+  assert.equal(plan.program_id, "epic-demo-single");
+});
+
+test("CLI: --concurrency override above 4 is rejected", () => {
+  const result = runPlanIsolated("valid-single-relay-run", ["--json", "--concurrency", "8"]);
+  assert.equal(result.status, REASONS.CONCURRENCY_EXCEEDED);
+});

--- a/tests/skills-lint/scripts/ci-test-coverage.test.js
+++ b/tests/skills-lint/scripts/ci-test-coverage.test.js
@@ -1,0 +1,120 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SKILLS_DIR = path.join(REPO_ROOT, "skills");
+const TESTS_DIR = path.join(REPO_ROOT, "tests");
+const WORKFLOW_PATH = path.join(REPO_ROOT, ".github", "workflows", "test.yml");
+
+function listSkillDirs(skillsDir = SKILLS_DIR) {
+  if (!fs.existsSync(skillsDir)) return [];
+  return fs.readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function hasTestSuite(skill, testsDir = TESTS_DIR) {
+  const scriptsDir = path.join(testsDir, skill, "scripts");
+  if (!fs.existsSync(scriptsDir)) return false;
+  return fs.readdirSync(scriptsDir).some((file) => file.endsWith(".test.js"));
+}
+
+// The workflow guards CI with two skill-glob lists: the empty-glob guard array
+// (files=( ... )) and the `node --test` run command. A skill's test glob must
+// appear in BOTH — omission from either lets a newly installed skill's tests be
+// silently skipped by CI.
+function workflowGlobRegions(content) {
+  const guardMatch = content.match(/files=\(([\s\S]*?)\)/);
+  assert.ok(guardMatch, "workflow must declare an empty-glob guard: files=( ... )");
+  const runMatch = content.match(/Run test suites[\s\S]*$/);
+  assert.ok(runMatch, "workflow must declare a 'Run test suites' step");
+  return { guard: guardMatch[1], run: runMatch[0] };
+}
+
+function findSkillSuitesMissingFromCi({ skillsDir = SKILLS_DIR, testsDir = TESTS_DIR, workflow } = {}) {
+  const { guard, run } = workflowGlobRegions(workflow);
+  const missing = [];
+  listSkillDirs(skillsDir).forEach((skill) => {
+    if (!hasTestSuite(skill, testsDir)) return;
+    const glob = `tests/${skill}/scripts/*.test.js`;
+    if (!guard.includes(glob)) missing.push(`${glob} (missing from empty-glob guard)`);
+    if (!run.includes(glob)) missing.push(`${glob} (missing from run command)`);
+  });
+  return missing.sort();
+}
+
+function assertSkillSuitesWiredIntoCi(options = {}) {
+  const missing = findSkillSuitesMissingFromCi(options);
+  assert.deepEqual(
+    missing,
+    [],
+    `skill test suites not referenced in .github/workflows/test.yml:\n${missing.map((entry) => `- ${entry}`).join("\n")}`,
+  );
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+function buildFixture({ wired }) {
+  const skillsDir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-coverage-skills-"));
+  const testsDir = fs.mkdtempSync(path.join(os.tmpdir(), "ci-coverage-tests-"));
+  writeFile(path.join(skillsDir, "newskill", "SKILL.md"), "fixture\n");
+  writeFile(path.join(testsDir, "newskill", "scripts", "example.test.js"), "// fixture\n");
+  const suiteGlob = wired ? "\n            tests/newskill/scripts/*.test.js" : "";
+  const runGlob = wired ? "\n          tests/newskill/scripts/*.test.js" : "";
+  const workflow = [
+    "      - name: Guard against empty test globs",
+    "        run: |",
+    "          files=(",
+    "            tests/skills-lint/scripts/*.test.js" + suiteGlob,
+    "          )",
+    "      - name: Run test suites",
+    "        run: >",
+    "          node --test --test-concurrency=1",
+    "          tests/skills-lint/scripts/*.test.js" + runGlob,
+    "",
+  ].join("\n");
+  return { skillsDir, testsDir, workflow };
+}
+
+test("every skill with a tests/<skill>/scripts suite is wired into the CI workflow (both lists)", () => {
+  assert.ok(fs.existsSync(WORKFLOW_PATH), ".github/workflows/test.yml is missing");
+  const workflow = fs.readFileSync(WORKFLOW_PATH, "utf-8");
+  assertSkillSuitesWiredIntoCi({ workflow });
+});
+
+test("guard passes when a skill's suite is present in both workflow lists", () => {
+  const { skillsDir, testsDir, workflow } = buildFixture({ wired: true });
+  try {
+    assertSkillSuitesWiredIntoCi({ skillsDir, testsDir, workflow });
+  } finally {
+    fs.rmSync(skillsDir, { recursive: true, force: true });
+    fs.rmSync(testsDir, { recursive: true, force: true });
+  }
+});
+
+test("guard flags a skill whose test suite is omitted from the workflow", () => {
+  const { skillsDir, testsDir, workflow } = buildFixture({ wired: false });
+  try {
+    assert.throws(
+      () => assertSkillSuitesWiredIntoCi({ skillsDir, testsDir, workflow }),
+      /tests\/newskill\/scripts\/\*\.test\.js/,
+    );
+    const missing = findSkillSuitesMissingFromCi({ skillsDir, testsDir, workflow });
+    assert.deepEqual(missing, [
+      "tests/newskill/scripts/*.test.js (missing from empty-glob guard)",
+      "tests/newskill/scripts/*.test.js (missing from run command)",
+    ]);
+  } finally {
+    fs.rmSync(skillsDir, { recursive: true, force: true });
+    fs.rmSync(testsDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-943-20260711100545688-56ff88ba
- Branch: issue-943-relay-orca-skill-contract
- Reason: Executor completed-uncommitted: claude/opus authored full relay-orca skill (SKILL.md 80L, agents/openai.yaml, 4 references, plan.js + 4 lib modules, 12 fixtures) but ended its turn waiting on its own background suite before committing. Work verified green: relay-orca 25/25, skills-lint 30/30.
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-943-20260711100545688-56ff88ba.md; orchestrator=unknown; executor=claude
- Recovered at (UTC): 2026-07-11T11:08:03.375Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 승인된 프로그램 계약을 읽기 전용 웨이브 계획으로 변환하는 실험적 `relay-orca plan` 기능을 추가했습니다.
  * JSON 및 사람이 읽기 쉬운 계획 출력, 동시성 설정, 단계별 작업과 의존성 정보를 제공합니다.
  * 지원되는 작업 유형과 준비된 fleet 작업을 검증합니다.

* **문서**
  * 실험적·옵트인 기능이며 명시적으로 호출해야 한다는 사용 조건을 문서화했습니다.
  * 입력 형식, 명령어, 거부 사유, 작업 유형 및 운영 제한을 추가했습니다.

* **버그 수정**
  * 잘못된 입력, 순환·중첩 의존성, 동시성 초과 등을 명확한 오류와 종료 코드로 거부합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->