### PR TITLE
review-runner: stop burning rounds on CI-in-progress — --wait-for-checks + same-head re-entry after checks turn green (#950)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -95,6 +95,7 @@ const FLAGS = [
   { flag: "--repeated-issue-count", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Numeric review field; flag-like following tokens should mean the value is missing." },
   { flag: "--repo", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied repository path; keep the literal argv token." },
   { flag: "--request-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay-ready identifier; flag-like following tokens should mean the value is missing." },
+  { flag: "--require-checks-green", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Require a same-HEAD pending-checks marker plus all-green live checks for same-HEAD recovery; no value is consumed." },
   { flag: "--require-pr-body-change", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Require audited PR body evidence for same-HEAD recovery; no value is consumed." },
   { flag: "--review-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied verdict path; keep the literal argv token." },
   { flag: "--review-assurance", kind: VALUE, mode: MODE_PARSED, valueName: "<level>", allowedValues: ["standard", "hardened"], rationale: "Run-level review assurance policy; closed selector independent of agent identity." },
@@ -129,6 +130,7 @@ const FLAGS = [
   { flag: "--to", kind: VALUE, mode: MODE_PARSED, valueName: "<state>", rationale: "Closed recovery state selector; flag-like following tokens should mean the value is missing." },
   { flag: "--topic", kind: VALUE, mode: MODE_VERBATIM, valueName: "<name>", rationale: "Operator-supplied topic text used to derive a branch; keep the literal argv token." },
   { flag: "--verdict", kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed review verdict selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--wait-for-checks", kind: VALUE, mode: MODE_PARSED, valueName: "<seconds>", rationale: "Pre-review check-settle budget in seconds; flag-like following tokens should mean the value is missing." },
   { flag: "--window-days", kind: VALUE, mode: MODE_PARSED, valueName: "<N>", rationale: "Numeric scan window; flag-like following tokens should mean the value is missing." },
   { flag: "--worktree-path", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied worktree path; keep the literal argv token." },
   { flag: "--writer-pr", kind: VALUE, mode: MODE_PARSED, valueName: "<number>", rationale: "Numeric PR selector for the writer PR; flag-like following tokens should mean the value is missing." },
@@ -196,7 +198,7 @@ const COMMAND_FLAGS = {
   ],
   "recover-state": [
     "--repo", "--run-id", "--manifest", "--to", "--reason", "--force", "--dry-run", "--json", "--help",
-    "--allow-same-head", "--require-pr-body-change",
+    "--allow-same-head", "--require-pr-body-change", "--require-checks-green",
   ],
   "recover-commit": [
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",
@@ -228,7 +230,7 @@ const COMMAND_FLAGS = {
     "--diff-file", "--review-file", "--reviewer", "--reviewer-script",
     "--reviewer-model", "--advisory-reviewer", "--advisory-profile",
     "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--prepare-only",
-    "--manual-review-reason", "--independent-review-reason", "--allow-behind-base", "--no-comment", "--json", "--help",
+    "--manual-review-reason", "--independent-review-reason", "--allow-behind-base", "--wait-for-checks", "--no-comment", "--json", "--help",
   ],
   "run-full-gate": [
     "--repo", "--suites", "--output", "--lock-timeout", "--json", "--help",

--- a/skills/relay-dispatch/scripts/recover-state.js
+++ b/skills/relay-dispatch/scripts/recover-state.js
@@ -14,6 +14,14 @@
 //   Q3 (external verifier): `git rev-parse` against the working branch's HEAD SHA.
 //     The claim (`review.last_reviewed_sha`) does not self-attest; the gate reads an
 //     independent artifact (git's object db for the branch).
+//
+// Same-head checks-green route (#950): re-enters review at the exact reviewed head
+// after post-publication CI turns green. The manifest `review.pending_checks_marker`
+// only proves the prior round's block was procedural (it proceeded on pending checks);
+// it does NOT self-attest that checks flipped green. The gate therefore verifies TWO
+// independent artifacts — git HEAD (still equals the marker's anchored head) and a live
+// `gh pr checks` re-poll (every check in a non-pending, non-failed bucket) — before it
+// force-transitions changes_requested -> review_pending.
 
 const path = require("path");
 const fs = require("fs");
@@ -31,6 +39,7 @@ const { readTextFileWithoutFollowingSymlinks } = require("./manifest/rubric");
 const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { resolveManifestRecord } = require("./relay-resolver");
 const { appendEventLineToPath, appendRunEvent, EVENTS } = require("./relay-events");
+const { classifyChecks, fetchChecks } = require("./wait-for-check");
 const CLI_ARG_OPTIONS = { commandName: "recover-state", reservedFlags: ["-h"] };
 const PR_BODY_FETCH_TIMEOUT_MS = 15000;
 
@@ -141,8 +150,9 @@ function printUsage(stream = console.log) {
     `  --to <state>      ${modeLabel("--to")} Recovery target state\n` +
     `  --reason <text>   ${modeLabel("--reason")} Audit reason\n` +
     `  --force           ${modeLabel("--force")} Confirm selected recovery transitions\n` +
-    `  --allow-same-head ${modeLabel("--allow-same-head")} Allow same-HEAD review recovery when PR-body evidence changed\n` +
+    `  --allow-same-head ${modeLabel("--allow-same-head")} Allow same-HEAD review recovery with exactly one same-HEAD evidence flag\n` +
     `  --require-pr-body-change ${modeLabel("--require-pr-body-change")} Require current PR body to differ from the latest review snapshot\n` +
+    `  --require-checks-green ${modeLabel("--require-checks-green")} Require the pending-checks marker at HEAD and all-green live gh pr checks\n` +
     `  --dry-run         ${modeLabel("--dry-run")} Print result without writing\n` +
     `  --json            ${modeLabel("--json")} Output JSON\n` +
     "\n" +
@@ -150,7 +160,7 @@ function printUsage(stream = console.log) {
     RECOVERY_TRANSITIONS.map((t) => {
       const forceFlag = t.requireForce ? " (--force required)" : "";
       const freshFlag = t.requireFreshCommit
-        ? " (fresh commit required on branch; same-HEAD PR-body-only recovery requires both same-HEAD flags)"
+        ? " (fresh commit required on branch; same-HEAD recovery requires --allow-same-head plus exactly one of --require-pr-body-change or --require-checks-green)"
         : "";
       const driftFlag = t.requireReadyHeadDrift
         ? " (live PR HEAD drift required)"
@@ -433,6 +443,76 @@ function requirePrBodyOnlyEvidence({ repoRoot, manifestData, currentHead, lastRe
   };
 }
 
+// Same-head checks-green re-entry (#950). Accepts changes_requested -> review_pending
+// at the exact reviewed head only when (a) git HEAD still equals review.last_reviewed_sha,
+// (b) review.pending_checks_marker is present and anchored to that same head (proving the
+// prior round's block was procedural), and (c) a live gh pr checks re-poll shows no check
+// in the fail or pending bucket. The marker alone never suffices — the live re-poll is the
+// independent artifact that proves checks actually flipped green.
+function requireChecksGreenEvidence({ repoRoot, manifestData, currentHead, lastReviewedSha }) {
+  const branch = manifestData?.git?.working_branch;
+  if (!lastReviewedSha || currentHead !== lastReviewedSha) {
+    throw new Error(
+      `Refusing same-HEAD checks-green recovery: git HEAD for '${branch}' (${currentHead}) ` +
+      `does not equal review.last_reviewed_sha (${lastReviewedSha || "none"}). ` +
+      "The checks-green route only re-enters review at the exact reviewed head; " +
+      "use the fresh-commit route when a new commit has landed."
+    );
+  }
+
+  const marker = manifestData?.review?.pending_checks_marker || null;
+  if (!marker || marker.head_sha !== currentHead) {
+    throw new Error(
+      "Refusing same-HEAD checks-green recovery: no pending-checks marker anchored to the reviewed head " +
+      `(${currentHead}). The prior round did not proceed on pending checks — ` +
+      "use the fresh-commit or --require-pr-body-change route instead."
+    );
+  }
+
+  const prNumber = getManifestPrNumber(manifestData);
+  if (!prNumber) {
+    throw new Error(
+      "Refusing same-HEAD checks-green recovery: manifest has no PR number " +
+      "(expected git.pr_number or github.pr_number)."
+    );
+  }
+
+  let checks;
+  try {
+    checks = fetchChecks(repoRoot, prNumber);
+  } catch (error) {
+    throw new Error(
+      `Refusing same-HEAD checks-green recovery: cannot fetch live gh pr checks for PR #${prNumber}: ` +
+      `${summarizeCommandFailure(error)}`
+    );
+  }
+
+  const { failedChecks, pendingChecks } = classifyChecks(checks);
+  if (failedChecks.length || pendingChecks.length) {
+    const failedNames = failedChecks.map((check) => check.name).join(", ") || "none";
+    const pendingNames = pendingChecks.map((check) => check.name).join(", ") || "none";
+    throw new Error(
+      `Refusing same-HEAD checks-green recovery: live gh pr checks for PR #${prNumber} are not all green ` +
+      `(failed: ${failedNames}; pending: ${pendingNames}). Wait for CI to finish and pass before re-entering review.`
+    );
+  }
+  if (checks.length === 0) {
+    throw new Error(
+      `Refusing same-HEAD checks-green recovery: PR #${prNumber} reports no live checks, but the ` +
+      "pending-checks marker implies checks were pending at review time. Re-verify the PR's CI state."
+    );
+  }
+
+  return {
+    checksGreen: true,
+    currentHead,
+    lastReviewedSha,
+    prNumber,
+    markerRound: Number.isInteger(marker.round) ? marker.round : null,
+    checkNames: checks.map((check) => check.name),
+  };
+}
+
 function main() {
   const args = process.argv.slice(2);
   const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
@@ -454,6 +534,7 @@ function main() {
   const force = hasCliFlag("--force");
   const allowSameHead = hasCliFlag("--allow-same-head");
   const requirePrBodyChange = hasCliFlag("--require-pr-body-change");
+  const requireChecksGreen = hasCliFlag("--require-checks-green");
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
 
@@ -466,10 +547,18 @@ function main() {
   if (!reason) {
     throw new Error("--reason <text> is required (audit trail)");
   }
-  if (allowSameHead !== requirePrBodyChange) {
+  const sameHeadEvidenceFlagCount = [requirePrBodyChange, requireChecksGreen].filter(Boolean).length;
+  if (allowSameHead && sameHeadEvidenceFlagCount !== 1) {
     throw new Error(
-      "--allow-same-head and --require-pr-body-change must be passed together. " +
-      "Same-HEAD recovery is only supported for audited PR-body-only evidence changes."
+      "--allow-same-head requires exactly one same-HEAD evidence flag: " +
+      "--require-pr-body-change (audited PR-body change) or --require-checks-green (marker + all-green live checks). " +
+      "The two evidence flags are mutually exclusive."
+    );
+  }
+  if (!allowSameHead && sameHeadEvidenceFlagCount > 0) {
+    throw new Error(
+      "--require-pr-body-change and --require-checks-green require --allow-same-head. " +
+      "Same-HEAD recovery is only supported for audited same-HEAD evidence changes."
     );
   }
 
@@ -513,6 +602,7 @@ function main() {
 
   let commitContext = null;
   let prBodyOnlyContext = null;
+  let checksGreenContext = null;
   let readyHeadDriftContext = null;
   if (recovery.requireFreshCommit) {
     const headContext = getBranchHeadContext({
@@ -521,7 +611,16 @@ function main() {
     });
     const sameReviewedHead = headContext.lastReviewedSha
       && headContext.currentHead === headContext.lastReviewedSha;
-    if (sameReviewedHead && allowSameHead && requirePrBodyChange) {
+    if (allowSameHead && requireChecksGreen) {
+      // The operator explicitly opted into same-HEAD checks-green re-entry; this
+      // route verifies same head, marker, and live checks itself (never falls back
+      // to the fresh-commit route — a moved head is a refusal, not a silent switch).
+      checksGreenContext = requireChecksGreenEvidence({
+        repoRoot: validatedPaths.repoRoot,
+        manifestData: safeData,
+        ...headContext,
+      });
+    } else if (sameReviewedHead && allowSameHead && requirePrBodyChange) {
       prBodyOnlyContext = requirePrBodyOnlyEvidence({
         repoRoot: validatedPaths.repoRoot,
         manifestData: safeData,
@@ -554,6 +653,12 @@ function main() {
   if (recovery.resetLastReviewedSha) {
     updated.review = { ...(updated.review || {}), last_reviewed_sha: null };
   }
+  if (checksGreenContext) {
+    // Consume the pending-checks marker so the same-head route is single-use: a later
+    // changes_requested at this head (e.g. a real finding) cannot replay the re-entry.
+    updated = { ...updated, review: { ...(updated.review || {}) } };
+    delete updated.review.pending_checks_marker;
+  }
   if (readyHeadDriftContext) {
     updated = {
       ...updated,
@@ -574,12 +679,14 @@ function main() {
       head_sha: readyHeadDriftContext?.newSha
         || commitContext?.currentHead
         || prBodyOnlyContext?.currentHead
+        || checksGreenContext?.currentHead
         || updated.git?.head_sha
         || null,
-      round: prBodyOnlyContext?.previousSnapshotRound || updated.review?.rounds || null,
+      round: prBodyOnlyContext?.previousSnapshotRound || checksGreenContext?.markerRound || updated.review?.rounds || null,
       reason,
       last_reviewed_sha: commitContext?.lastReviewedSha
         ?? prBodyOnlyContext?.lastReviewedSha
+        ?? checksGreenContext?.lastReviewedSha
         ?? readyHeadDriftContext?.lastReviewedSha
         ?? (safeData.review?.last_reviewed_sha || null),
       ...(validatedPaths.worktreeMissing ? { worktree_missing: true } : {}),
@@ -596,6 +703,11 @@ function main() {
             pr_number: prBodyOnlyContext.prNumber,
           }
         : {}),
+      ...(checksGreenContext
+        ? {
+            pr_number: checksGreenContext.prNumber,
+          }
+        : {}),
     });
   }
 
@@ -609,6 +721,7 @@ function main() {
     force,
     freshCommit: commitContext,
     prBodyOnly: prBodyOnlyContext,
+    checksGreen: checksGreenContext,
     readyHeadDrift: readyHeadDriftContext,
     dryRun,
   };
@@ -630,6 +743,13 @@ function main() {
       console.log(`  Prev reviewed: ${prBodyOnlyContext.lastReviewedSha || "(none)"}`);
       console.log(`  PR number:    ${prBodyOnlyContext.prNumber}`);
       console.log(`  Snapshot:     ${prBodyOnlyContext.previousSnapshotPath}`);
+    }
+    if (checksGreenContext) {
+      console.log("  Checks green: true");
+      console.log(`  HEAD sha:     ${checksGreenContext.currentHead}`);
+      console.log(`  Prev reviewed: ${checksGreenContext.lastReviewedSha || "(none)"}`);
+      console.log(`  PR number:    ${checksGreenContext.prNumber}`);
+      console.log(`  Checks:       ${checksGreenContext.checkNames.join(", ") || "(none)"}`);
     }
     if (readyHeadDriftContext) {
       console.log("  Ready drift:  true");

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -27,6 +27,7 @@ const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { appendAdvisoryRunsForTrigger, resolveAdvisoryConfig } = require("./review-runner/advisory-orchestration");
 const { settleAdvisoryGatesForRound } = require("./review-runner/advisory-gates");
 const { printResult, printUsage } = require("./review-runner/output");
+const { applyPendingChecksMarker, maybeWaitForChecks } = require("./review-runner/check-wait");
 const { assertKnownReviewRunnerFlags, parseReviewRunnerCliArgs } = require("./review-runner/cli");
 const { args, cliArgs, options } = parseReviewRunnerCliArgs(process.argv.slice(2));
 if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]))) {
@@ -39,7 +40,7 @@ async function run() {
     advisoryGraceArg, advisoryProfileArg, advisoryReviewerArg, advisoryReviewerModel, allowBehindBase,
     advisoryTimeoutArg, branchArg, diffFile, doneCriteriaFile, independentReviewReason,
     jsonOut, manifestPathArg, manualReviewReason, noComment, prArg, prepareOnly, repoArg,
-    repoPath, reviewFile, reviewerArg, reviewerModel, reviewerScriptArg, runIdArg,
+    repoPath, reviewFile, reviewerArg, reviewerModel, reviewerScriptArg, runIdArg, waitForChecksArg,
   } = options;
   if (manualReviewReason && !reviewFile) throw new Error("--manual-review-reason requires --review-file");
   const { branch, issueNumber, manifest, prNumber, reviewRepoPath, runRepoPath } = resolveContext(repoPath, repoArg, manifestPathArg, runIdArg, branchArg, prArg, doneCriteriaFile);
@@ -78,6 +79,8 @@ async function run() {
   } catch {}
 
   enforceRoundCap({ body, data, manifestPath, prNumber, reviewedHeadSha, round, runRepoPath });
+
+  const checkWait = maybeWaitForChecks({ internalReview, prepareOnly, prNumber, round, runDir, runRepoPath, waitForChecksArg });
 
   const {
     diffPath,
@@ -144,6 +147,7 @@ async function run() {
     runId: data.run_id,
     state: data.state, convergenceSummary: null, verdictPath: null,
   };
+  if (checkWait) result.checkWait = checkWait.summary;
   let advisoryRuns = [], advisoryResult = null, advisoryResults = [], gateResult = null, primaryReviewerPreflight = null;
 
   if (prepareOnly) {
@@ -321,6 +325,7 @@ async function run() {
         : {}),
     },
   };
+  updatedManifest.review = applyPendingChecksMarker(updatedManifest.review, { appliedVerdict, checkWait, reviewedHeadSha, round });
   updatedManifest = applyReviewerIdentity(updatedManifest, noComment || internalReview, runRepoPath);
   writeManifest(manifestPath, updatedManifest, body);
   appendRunEvent(runRepoPath, data.run_id, { event: EVENTS.ESCALATION_DECISION, state_from: data.state, state_to: updatedManifest.state, head_sha: reviewedHeadSha, ...escalationDecision });

--- a/skills/relay-review/scripts/review-runner/check-wait.js
+++ b/skills/relay-review/scripts/review-runner/check-wait.js
@@ -1,0 +1,160 @@
+"use strict";
+
+// Pre-review check-wait for review-runner `--wait-for-checks <seconds>` (#950).
+//
+// Two rounds in the 2026-07-11 arc were spent purely on pending post-publication
+// CI checks with every Done Criterion already verified. This helper lets a review
+// round WAIT for checks to leave the `pending` bucket before the primary reviewer
+// is invoked (and before the check states are baked into the reviewer prompt),
+// proceeding anyway once the budget is exhausted (proceeding-with-pending is the
+// legal floor — never a hard block).
+//
+// When such a round proceeds with checks still pending AND its applied verdict is
+// `changes_requested`, it stamps a machine-readable pending-checks marker anchored
+// to the reviewed head into the manifest `review` section. Its sole consumer is
+// recover-state's same-head checks-green re-entry route (Half 2). Without the flag
+// this module is never engaged, so review output stays byte-identical to today.
+
+const path = require("path");
+const { classifyChecks, fetchChecks } = require("../../../relay-dispatch/scripts/wait-for-check");
+const { writeText } = require("./common");
+
+const DEFAULT_POLL_INTERVAL_MS = 12000;
+const MAX_GH_RETRIES = 3;
+const PENDING_CHECKS_MARKER_KEY = "pending_checks_marker";
+
+function resolvePollIntervalMs() {
+  const raw = Number(process.env.RELAY_REVIEW_CHECK_POLL_INTERVAL_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_POLL_INTERVAL_MS;
+}
+
+// Returns null when the flag is absent; the parsed seconds otherwise. Throws on a
+// malformed value so the round fails loudly rather than silently skipping the wait.
+function parseWaitForChecksSeconds(rawValue) {
+  if (rawValue === undefined || rawValue === null) return null;
+  const seconds = Number(rawValue);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new Error("--wait-for-checks requires a non-negative number of seconds");
+  }
+  return seconds;
+}
+
+function blockingSleep(ms) {
+  if (ms <= 0) return;
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+// Poll a PR's checks until none are pending, or the budget is exhausted. Transient
+// gh failures are tolerated (never abort the round); a persistent gh failure past
+// the retry budget just proceeds with the checks state unknown.
+function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs }, deps = {}) {
+  const now = deps.now || Date.now;
+  const wait = deps.sleep || blockingSleep;
+  const getChecks = deps.fetchChecks || fetchChecks;
+  const start = now();
+  const deadline = start + Math.max(0, budgetSeconds) * 1000;
+  let checks = [];
+  let ghErrors = 0;
+  let polls = 0;
+  let settled = false;
+  while (true) {
+    polls += 1;
+    let fetchError = null;
+    try {
+      checks = getChecks(repoPath, prNumber);
+    } catch (error) {
+      fetchError = error;
+      ghErrors += 1;
+    }
+    if (!fetchError && classifyChecks(checks).pendingChecks.length === 0) {
+      settled = true;
+      break;
+    }
+    if (now() >= deadline || (fetchError && ghErrors > MAX_GH_RETRIES)) break;
+    wait(Math.min(intervalMs, Math.max(0, deadline - now())));
+  }
+  const pendingChecks = classifyChecks(checks).pendingChecks;
+  return {
+    checks,
+    pendingCheckNames: pendingChecks.map((check) => check.name),
+    pending: !settled,
+    budgetSeconds: Math.max(0, budgetSeconds),
+    budgetExhausted: !settled && now() >= deadline,
+    waitedMs: Math.max(0, now() - start),
+    polls,
+    ghErrors,
+  };
+}
+
+function toResultSummary(outcome) {
+  return {
+    budget_seconds: outcome.budgetSeconds,
+    waited_ms: outcome.waitedMs,
+    waited_seconds: Math.round(outcome.waitedMs / 1000),
+    budget_exhausted: outcome.budgetExhausted,
+    proceeded_with_pending: outcome.pending,
+    polls: outcome.polls,
+    gh_errors: outcome.ghErrors,
+    checks: outcome.checks,
+    pending_checks: outcome.pendingCheckNames,
+  };
+}
+
+// Runs the pre-review check wait when `--wait-for-checks` was supplied and a PR is
+// available (post-publication rounds only). Returns null — a byte-identical no-op —
+// otherwise. On engagement it records a round artifact and returns { outcome, summary }.
+function maybeWaitForChecks({ internalReview, prepareOnly, prNumber, round, runDir, runRepoPath, waitForChecksArg }, deps = {}) {
+  const budgetSeconds = parseWaitForChecksSeconds(waitForChecksArg);
+  if (budgetSeconds === null) return null;
+  if (prepareOnly || internalReview || !prNumber) return null;
+
+  const outcome = pollChecksUntilSettled({
+    repoPath: runRepoPath,
+    prNumber,
+    budgetSeconds,
+    intervalMs: resolvePollIntervalMs(),
+  }, deps);
+  const summary = toResultSummary(outcome);
+  writeText(
+    path.join(runDir, `review-round-${round}-check-wait.json`),
+    `${JSON.stringify(summary, null, 2)}\n`
+  );
+  return { outcome, summary };
+}
+
+// Set or clear the pending-checks marker on a manifest `review` section. When the
+// flag is inactive (checkWait === null) the section is returned untouched, keeping
+// flagless behavior byte-identical. When active, the marker is a fresh per-round
+// signal: present only while checks were still pending AND the applied verdict is
+// changes_requested, cleared otherwise so the same-head route cannot be replayed.
+function applyPendingChecksMarker(reviewSection, { appliedVerdict, checkWait, reviewedHeadSha, round }) {
+  if (!checkWait) return reviewSection;
+  const next = { ...(reviewSection || {}) };
+  const shouldMark = checkWait.outcome.pending
+    && appliedVerdict === "changes_requested"
+    && Boolean(reviewedHeadSha);
+  if (shouldMark) {
+    next[PENDING_CHECKS_MARKER_KEY] = {
+      head_sha: reviewedHeadSha,
+      round,
+      pending_checks: checkWait.outcome.pendingCheckNames,
+      budget_seconds: checkWait.outcome.budgetSeconds,
+      budget_exhausted: checkWait.outcome.budgetExhausted,
+    };
+  } else {
+    delete next[PENDING_CHECKS_MARKER_KEY];
+  }
+  return next;
+}
+
+module.exports = {
+  DEFAULT_POLL_INTERVAL_MS,
+  MAX_GH_RETRIES,
+  PENDING_CHECKS_MARKER_KEY,
+  applyPendingChecksMarker,
+  maybeWaitForChecks,
+  parseWaitForChecksSeconds,
+  pollChecksUntilSettled,
+  toResultSummary,
+};

--- a/skills/relay-review/scripts/review-runner/check-wait.js
+++ b/skills/relay-review/scripts/review-runner/check-wait.js
@@ -123,17 +123,30 @@ function maybeWaitForChecks({ internalReview, prepareOnly, prNumber, round, runD
   return { outcome, summary };
 }
 
-// Set or clear the pending-checks marker on a manifest `review` section. When the
-// flag is inactive (checkWait === null) the section is returned untouched, keeping
-// flagless behavior byte-identical. When active, the marker is a fresh per-round
-// signal: present only while checks were still pending AND the applied verdict is
-// changes_requested, cleared otherwise so the same-head route cannot be replayed.
+// Reconcile the pending-checks marker for the head this round reviewed so its
+// presence at a head always means "the most recent review round at this head blocked
+// procedurally (proceeded with checks still pending)". A round WRITES the marker only
+// when it proceeded with pending checks AND applied changes_requested; EVERY other
+// round at that head — settled/green checks, a flagless round (checkWait === null), or
+// any non-changes_requested verdict — CLEARS a stale marker anchored to the same head.
+// That closes the replay where a marker stamped by a `--wait-for-checks` round could
+// survive a later real changes_requested at the same head and let recover-state's
+// checks-green route bypass the finding. Markers anchored to a DIFFERENT head are left
+// untouched (they can never be consumed at that head unless HEAD returns to it, and a
+// future round there reconciles them). When there is nothing to write and no same-head
+// marker to clear, the section is returned untouched, keeping flagless output
+// byte-identical to today.
 function applyPendingChecksMarker(reviewSection, { appliedVerdict, checkWait, reviewedHeadSha, round }) {
-  if (!checkWait) return reviewSection;
-  const next = { ...(reviewSection || {}) };
-  const shouldMark = checkWait.outcome.pending
+  const shouldMark = Boolean(checkWait)
+    && checkWait.outcome.pending
     && appliedVerdict === "changes_requested"
     && Boolean(reviewedHeadSha);
+  const existingMarker = reviewSection ? reviewSection[PENDING_CHECKS_MARKER_KEY] : undefined;
+  const hasStaleSameHeadMarker = Boolean(existingMarker)
+    && Boolean(reviewedHeadSha)
+    && existingMarker.head_sha === reviewedHeadSha;
+  if (!shouldMark && !hasStaleSameHeadMarker) return reviewSection;
+  const next = { ...(reviewSection || {}) };
   if (shouldMark) {
     next[PENDING_CHECKS_MARKER_KEY] = {
       head_sha: reviewedHeadSha,

--- a/skills/relay-review/scripts/review-runner/cli.js
+++ b/skills/relay-review/scripts/review-runner/cli.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const { bindCliArgs, findUnknownFlags } = require("../../../relay-dispatch/scripts/cli-args");
 
-const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--allow-behind-base", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--allow-behind-base", "--wait-for-checks", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
 
 function parseReviewRunnerCliArgs(args) {
   const cliArgs = bindCliArgs(args, {
@@ -36,6 +36,7 @@ function parseReviewRunnerCliArgs(args) {
       reviewerModel: cliArgs.getArg("--reviewer-model"),
       reviewerScriptArg: cliArgs.getArg("--reviewer-script"),
       runIdArg: cliArgs.getArg("--run-id"),
+      waitForChecksArg: cliArgs.getArg("--wait-for-checks"),
     },
   };
 }

--- a/skills/relay-review/scripts/review-runner/output.js
+++ b/skills/relay-review/scripts/review-runner/output.js
@@ -23,6 +23,7 @@ function printUsage() {
   console.log(`  --advisory-timeout <seconds> ${modeLabel("--advisory-timeout")} Advisory timeout`);
   console.log(`  --advisory-grace <seconds>   ${modeLabel("--advisory-grace")} Standard-mode critical-path wait window`);
   console.log(`  --allow-behind-base          ${modeLabel("--allow-behind-base")} Proceed despite a behind-base warning`);
+  console.log(`  --wait-for-checks <seconds>  ${modeLabel("--wait-for-checks")} Wait up to N seconds for PR checks to leave the pending bucket before reviewing`);
   console.log(`  --prepare-only               ${modeLabel("--prepare-only")} Emit prompt bundle only; do not apply verdict`);
   console.log(`  --no-comment                 ${modeLabel("--no-comment")} Do not post a PR comment`);
   console.log(`  --json                       ${modeLabel("--json")} Output JSON`);

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -178,6 +178,44 @@ process.exit(2);
   };
 }
 
+function writeGhPrChecksScript(checks, { branch = "issue-211" } = {}) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-checks-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "checks") {
+  const checks = ${JSON.stringify(checks)};
+  const FAIL = new Set(["fail","failed","failure","cancel","cancelled","canceled","timed_out","action_required","startup_failure","stale"]);
+  const SUCCESS = new Set(["pass","success","skipping","skipped","neutral"]);
+  if (checks.length === 0) {
+    // Real gh (cli/cli#9390): zero checks -> stderr message, empty stdout, exit 1.
+    process.stderr.write("no checks reported on '${branch}'\\n");
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(checks));
+  const buckets = checks.map((c) => String(c.bucket || "").toLowerCase());
+  const hasPending = buckets.some((b) => !SUCCESS.has(b) && !FAIL.has(b));
+  const hasFail = buckets.some((b) => FAIL.has(b));
+  process.exit(hasPending ? 8 : hasFail ? 1 : 0);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return {
+    PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+  };
+}
+
+function stampPendingChecksMarker(manifestPath, marker) {
+  const record = readManifest(manifestPath);
+  const updated = {
+    ...record.data,
+    review: { ...(record.data.review || {}), pending_checks_marker: marker },
+  };
+  writeManifest(manifestPath, updated, record.body);
+}
+
 test("changes_requested -> review_pending succeeds after a fresh commit", () => {
   const { repoRoot, manifestPath, runId, worktreePath, branch, initialHead } = setupRepo({ state: STATES.CHANGES_REQUESTED });
   const newHead = addCommitOnBranch(worktreePath, branch);
@@ -586,7 +624,253 @@ test("same-HEAD PR-body-only recovery requires both explicit opt-in flags", () =
   ], { encoding: "utf-8", env });
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /must be passed together/);
+  assert.match(result.stderr, /exactly one same-HEAD evidence flag/);
+});
+
+test("changes_requested -> review_pending accepts same-HEAD checks-green re-entry (marker present, all checks pass)", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksScript([
+    { name: "unit", bucket: "pass" },
+    { name: "lint", bucket: "skipping" },
+  ]) };
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "CI turned green at the reviewed head",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.previousState, STATES.CHANGES_REQUESTED);
+  assert.equal(result.nextAction, "run_review");
+  assert.equal(result.freshCommit, null);
+  assert.equal(result.prBodyOnly, null);
+  assert.equal(result.checksGreen.checksGreen, true);
+  assert.equal(result.checksGreen.currentHead, initialHead);
+  assert.equal(result.checksGreen.lastReviewedSha, initialHead);
+  assert.equal(result.checksGreen.prNumber, 334);
+  assert.deepEqual(result.checksGreen.checkNames, ["lint", "unit"], "fetchChecks normalizes/sorts check names");
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.next_action, "run_review");
+  assert.equal(manifest.review.last_reviewed_sha, initialHead, "recovery must NOT auto-reset last_reviewed_sha");
+  assert.equal(manifest.review.pending_checks_marker, undefined, "marker consumed on accept (single-use)");
+
+  // The STATE_RECOVERY event records only allowlisted fields; the checks-green
+  // decision is captured via the audit reason + pr_number + anchored head_sha.
+  const event = readRunEvents(repoRoot, runId).find((entry) => entry.event === "state_recovery");
+  assert.equal(event?.state_from, STATES.CHANGES_REQUESTED);
+  assert.equal(event?.state_to, STATES.REVIEW_PENDING);
+  assert.equal(event?.pr_number, 334);
+  assert.equal(event?.head_sha, initialHead);
+  assert.equal(event?.last_reviewed_sha, initialHead);
+  assert.equal(event?.reason, "CI turned green at the reviewed head");
+});
+
+test("checks-green re-entry honors --dry-run: reports the decision without writing", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksScript([{ name: "unit", bucket: "pass" }]) };
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "dry-run checks-green preview",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--dry-run",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  const result = JSON.parse(stdout);
+  assert.equal(result.state, STATES.REVIEW_PENDING);
+  assert.equal(result.dryRun, true);
+  assert.equal(result.checksGreen.checksGreen, true);
+
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED, "dry-run must not transition");
+  assert.ok(manifest.review.pending_checks_marker, "dry-run must not consume the marker");
+  assert.equal(readRunEvents(repoRoot, runId).some((entry) => entry.event === "state_recovery"), false);
+});
+
+test("checks-green re-entry refuses when a live check failed", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksScript([{ name: "unit", bucket: "fail" }]) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "trying while CI is red",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /not all green/);
+  assert.match(result.stderr, /failed: unit/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("checks-green re-entry refuses when a live check is still pending", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksScript([{ name: "unit", bucket: "pending" }]) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "trying while CI still running",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /not all green/);
+  assert.match(result.stderr, /pending: unit/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("checks-green re-entry refuses when the head has moved off the reviewed sha", () => {
+  const { repoRoot, manifestPath, runId, worktreePath, branch, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  addCommitOnBranch(worktreePath, branch, "moved.txt");
+  const env = { ...process.env, ...writeGhPrChecksScript([{ name: "unit", bucket: "pass" }]) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "head moved but trying checks-green route",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not equal review\.last_reviewed_sha/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("checks-green re-entry refuses when the pending-checks marker is absent", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  // No marker stamped: the prior round did not proceed on pending checks.
+  const env = { ...process.env, ...writeGhPrChecksScript([{ name: "unit", bucket: "pass" }]) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "trying checks-green without a marker",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /no pending-checks marker/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("checks-green refuses a marker anchored to a different head (stale marker)", () => {
+  const { repoRoot, manifestPath, runId } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: "b".repeat(40), round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksScript([{ name: "unit", bucket: "pass" }]) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "stale marker anchored elsewhere",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /no pending-checks marker anchored to the reviewed head/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("--allow-same-head rejects passing both evidence flags (mutually exclusive)", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "both evidence flags is invalid",
+    "--allow-same-head",
+    "--require-pr-body-change",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /exactly one same-HEAD evidence flag/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("--require-checks-green without --allow-same-head is rejected", () => {
+  const { repoRoot, runId } = setupRepo({ state: STATES.CHANGES_REQUESTED, prNumber: 334 });
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "checks-green without opt-in",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /require --allow-same-head/);
 });
 
 test("escalated -> review_pending requires --force; succeeds with --force", () => {

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -77,6 +77,7 @@ function writeFakeGhScript({
   capturePath = null,
   logPath = null,
   statePath = null,
+  checksStatePath = null,
   merge = null,
 } = {}) {
   if (!ghPath) {
@@ -95,7 +96,31 @@ const fixture = ${JSON.stringify(fixture)};
 const capturePath = ${JSON.stringify(capturePath)};
 const logPath = ${JSON.stringify(logPath)};
 const statePath = ${JSON.stringify(statePath)};
+const checksStatePath = ${JSON.stringify(checksStatePath)};
 const merge = ${JSON.stringify(merge)};
+
+// gh pr checks --json name,bucket exit-code contract mirrored for the fake:
+// exit 8 while any check is pending, exit 1 on any failure, exit 0 when all pass.
+const CHECKS_FAILURE_BUCKETS = new Set([
+  "fail", "failed", "failure", "cancel", "cancelled", "canceled",
+  "timed_out", "action_required", "startup_failure", "stale",
+]);
+const CHECKS_SUCCESS_BUCKETS = new Set([
+  "pass", "success", "skipping", "skipped", "neutral",
+]);
+
+function loadChecksIndex() {
+  if (checksStatePath && fs.existsSync(checksStatePath)) {
+    return JSON.parse(fs.readFileSync(checksStatePath, "utf-8")).index || 0;
+  }
+  return 0;
+}
+
+function saveChecksIndex(next) {
+  if (checksStatePath) {
+    fs.writeFileSync(checksStatePath, JSON.stringify({ index: next }), "utf-8");
+  }
+}
 const prViewJsonRegistry = {
 ${serializedPrViewRegistry}
 };
@@ -127,6 +152,38 @@ function saveState(next) {
 if (fixture.failOnCall) {
   process.stderr.write("gh should not have been called");
   process.exit(91);
+}
+
+if (args[0] === "pr" && args[1] === "checks") {
+  // Optional stateful timeline so a check can transition pending -> pass across
+  // successive polls; falls back to a static fixture.checks array otherwise.
+  const timeline = Array.isArray(fixture.checksTimeline) ? fixture.checksTimeline : null;
+  let entry;
+  if (timeline) {
+    const idx = loadChecksIndex();
+    entry = timeline[Math.min(idx, timeline.length - 1)] || {};
+    saveChecksIndex(idx + 1);
+  } else {
+    entry = { checks: fixture.checks || [] };
+  }
+  if (entry.type === "error") {
+    process.stderr.write(entry.message || "transient gh error");
+    process.exit(entry.status || 1);
+  }
+  const checks = Array.isArray(entry.checks) ? entry.checks : [];
+  if (checks.length === 0) {
+    // Real gh (cli/cli#9390): zero checks -> stderr message, empty stdout, exit 1.
+    process.stderr.write(entry.message || "no checks reported on 'fixture-branch'\\n");
+    process.exit(typeof entry.status === "number" ? entry.status : 1);
+  }
+  writeJson(checks);
+  if (typeof entry.status === "number") process.exit(entry.status);
+  const buckets = checks.map((check) => String(check.bucket || "").toLowerCase());
+  const hasPending = buckets.some((bucket) => (
+    !CHECKS_SUCCESS_BUCKETS.has(bucket) && !CHECKS_FAILURE_BUCKETS.has(bucket)
+  ));
+  const hasFailure = buckets.some((bucket) => CHECKS_FAILURE_BUCKETS.has(bucket));
+  process.exit(hasPending ? 8 : hasFailure ? 1 : 0);
 }
 
 if (args[0] === "pr" && args[1] === "view") {

--- a/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
+++ b/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
@@ -1,7 +1,7 @@
 // Issue #950 Half 1: review-runner --wait-for-checks + pending-checks marker.
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -27,6 +27,7 @@ const {
 const { writeFakeGhScript } = require("../fixtures/fake-gh");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+const RECOVER_STATE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-state.js");
 const POLL_INTERVAL_MS = "3";
 
 function defaultRubricScores() {
@@ -314,4 +315,78 @@ test("review-runner without --wait-for-checks is byte-identical: no poll, no art
   assert.equal(manifest.review.pending_checks_marker, undefined, "no marker without the flag");
   const pollCalls = readGhCalls(logPath).filter((line) => line.startsWith("pr checks"));
   assert.equal(pollCalls.length, 0, "gh pr checks never polled without the flag");
+});
+
+// Simulate the same-head re-entry that the recover-state --require-pr-body-change route
+// performs after a pending round: land back in review_pending at the same head WITHOUT
+// consuming the pending-checks marker (that route never touches it).
+function reenterReviewPendingPreservingMarker(manifestPath) {
+  const record = readManifest(manifestPath);
+  writeManifest(manifestPath, {
+    ...record.data,
+    state: STATES.REVIEW_PENDING,
+    next_action: "run_review",
+  }, record.body);
+}
+
+// The marker must be single-use / always-current: once a real changes_requested lands at
+// the same head with settled (green) checks, the stale marker is cleared so the
+// checks-green recovery route can no longer replay the earlier procedural block (#950 R2).
+test("pending-checks marker is single-use: a later green changes_requested at the same head clears it and recover-state then refuses", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath, headSha } = setupRepo();
+
+  // Round 1: proceed with a pending check + changes_requested -> marker stamped at head H.
+  const round1Gh = installGh(repoRoot, { checks: [{ name: "unit", bucket: "pending" }] });
+  const round1 = runReview({
+    repoRoot, runId, doneCriteriaPath, diffPath,
+    reviewFile: changesRequestedVerdict(repoRoot), ghBinDir: round1Gh.binDir, waitForChecks: 0,
+  });
+  assert.equal(round1.checkWait.proceeded_with_pending, true);
+  const afterRound1 = readManifest(manifestPath).data;
+  assert.ok(afterRound1.review.pending_checks_marker, "round 1 stamps the pending-checks marker");
+  assert.equal(afterRound1.review.pending_checks_marker.head_sha, headSha);
+
+  // Same-head re-entry (PR-body route) preserves the marker without consuming it.
+  reenterReviewPendingPreservingMarker(manifestPath);
+  assert.ok(
+    readManifest(manifestPath).data.review.pending_checks_marker,
+    "same-head re-entry does not consume the marker"
+  );
+
+  // Round 2: same head H, but checks are now green and a REAL changes_requested lands.
+  // The stale marker must be cleared because this round did NOT proceed on pending checks.
+  const round2Gh = installGh(repoRoot, { checks: [{ name: "unit", bucket: "pass" }] });
+  const round2 = runReview({
+    repoRoot, runId, doneCriteriaPath, diffPath,
+    reviewFile: changesRequestedVerdict(repoRoot), ghBinDir: round2Gh.binDir, waitForChecks: 5,
+  });
+  assert.equal(round2.checkWait.proceeded_with_pending, false, "round 2 saw settled green checks");
+  assert.equal(round2.nextState, STATES.CHANGES_REQUESTED, "round 2 applies a real changes_requested");
+  const afterRound2 = readManifest(manifestPath).data;
+  assert.equal(
+    afterRound2.review.pending_checks_marker, undefined,
+    "the green changes_requested round clears the stale marker (single-use)"
+  );
+
+  // With the marker cleared, the checks-green recovery route can no longer replay: it
+  // refuses because no pending-checks marker is anchored to the reviewed head.
+  const recover = spawnSync("node", [
+    RECOVER_STATE_SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "attempting checks-green replay after the marker was cleared",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, PATH: `${round2Gh.binDir}${path.delimiter}${process.env.PATH || ""}` },
+  });
+  assert.notEqual(recover.status, 0, "recover-state refuses without a marker");
+  assert.match(recover.stderr, /no pending-checks marker/);
+  assert.equal(
+    readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED,
+    "refused recovery leaves the run in changes_requested"
+  );
 });

--- a/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
+++ b/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
@@ -1,0 +1,317 @@
+// Issue #950 Half 1: review-runner --wait-for-checks + pending-checks marker.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+  readManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
+const {
+  DEFAULT_ENFORCEMENT_RUBRIC,
+  createEnforcementFixture,
+} = require("../../relay-dispatch/scripts/test-support");
+const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+const {
+  parseWaitForChecksSeconds,
+  pollChecksUntilSettled,
+} = require("../../../skills/relay-review/scripts/review-runner/check-wait");
+const { writeFakeGhScript } = require("../fixtures/fake-gh");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+const POLL_INTERVAL_MS = "3";
+
+function defaultRubricScores() {
+  return [{
+    factor: "Default enforcement rubric",
+    target: ">= 1/1",
+    observed: "1/1",
+    status: "pass",
+    tier: "contract",
+    notes: "The enforcement fixture rubric remained satisfied.",
+  }];
+}
+
+function writeExecutionEvidence(runDir, headSha) {
+  fs.writeFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), `${JSON.stringify({
+    schema_version: 1,
+    head_sha: headSha,
+    test_command: "unspecified",
+    test_result_hash: "unspecified",
+    test_result_summary: "unspecified",
+    recorded_at: "2026-07-11T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  }, null, 2)}\n`, "utf-8");
+}
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-wait-checks-"));
+  const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-wait-checks-origin-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["init", "--bare", remoteRoot], { stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Wait Test"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-wait@example.com"], { cwd: repoRoot, stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", remoteRoot], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, stdio: "pipe" });
+
+  const runId = "issue-950-20260711010000000";
+  const worktreePath = path.join(repoRoot, "wt", "issue-950");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", "issue-950"], { cwd: repoRoot, stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, "marker.txt"), "worktree\n", "utf-8");
+
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot, runId, branch: "issue-950", baseBranch: "main", issueNumber: 950,
+    worktreePath, orchestrator: "codex", executor: "codex", reviewer: "claude",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor = createEnforcementFixture({
+    repoRoot, runId, state: "loaded", rubricContent: DEFAULT_ENFORCEMENT_RUBRIC,
+  }).anchor;
+  const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  manifest = { ...manifest, git: { ...(manifest.git || {}), pr_number: 123, head_sha: headSha } };
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(manifestPath, manifest);
+  writeExecutionEvidence(runDir, headSha);
+
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const diffPath = path.join(repoRoot, "pr.diff");
+  fs.writeFileSync(doneCriteriaPath, "# Done Criteria\n\n- Add smoke.txt\n", "utf-8");
+  fs.writeFileSync(diffPath, "diff --git a/smoke.txt b/smoke.txt\n+ok\n", "utf-8");
+  return { repoRoot, worktreePath, manifestPath, runId, runDir, doneCriteriaPath, diffPath, headSha };
+}
+
+function writeVerdict(repoRoot, name, verdict) {
+  const filePath = path.join(repoRoot, name);
+  fs.writeFileSync(filePath, `${JSON.stringify(verdict, null, 2)}\n`, "utf-8");
+  return filePath;
+}
+
+function changesRequestedVerdict(repoRoot) {
+  return writeVerdict(repoRoot, "changes.json", {
+    verdict: "changes_requested",
+    summary: "Contract drift found.",
+    contract_status: "fail",
+    quality_review_status: "not_run",
+    quality_execution_status: "pass",
+    next_action: "changes_requested",
+    issues: [{
+      title: "Missing contract item", body: "smoke.txt not present.",
+      file: "src/index.js", line: 10, category: "contract", severity: "high", confidence: "high",
+    }],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  });
+}
+
+function passVerdict(repoRoot) {
+  return writeVerdict(repoRoot, "pass.json", {
+    verdict: "pass",
+    summary: "All done criteria are satisfied.",
+    contract_status: "pass",
+    quality_review_status: "pass",
+    quality_execution_status: "pass",
+    next_action: "ready_to_merge",
+    issues: [],
+    rubric_scores: defaultRubricScores(),
+    scope_drift: { creep: [], missing: [] },
+  });
+}
+
+function installGh(repoRoot, { checksTimeline, checks } = {}) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-wait-gh-bin-"));
+  const ghPath = path.join(binDir, "gh");
+  const logPath = path.join(binDir, "gh-calls.log");
+  const checksStatePath = path.join(binDir, "checks-state.json");
+  writeFakeGhScript({
+    ghPath,
+    logPath,
+    checksStatePath,
+    fixture: {
+      body: "## Test PR\n\nFixture body.\n",
+      headRefOid: "a".repeat(40),
+      headRefName: "issue-950",
+      number: 123,
+      title: "Wait-for-checks PR",
+      statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
+      checksTimeline,
+      checks,
+    },
+  });
+  return { binDir, ghPath, logPath };
+}
+
+function runReview({ repoRoot, runId, doneCriteriaPath, diffPath, reviewFile, ghBinDir, waitForChecks }) {
+  const args = [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--review-file", reviewFile, "--no-comment",
+  ];
+  if (waitForChecks !== undefined) args.push("--wait-for-checks", String(waitForChecks));
+  args.push("--json");
+  const stdout = execFileSync("node", args, {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${ghBinDir}${path.delimiter}${process.env.PATH || ""}`,
+      RELAY_REVIEW_CHECK_POLL_INTERVAL_MS: POLL_INTERVAL_MS,
+    },
+  });
+  return JSON.parse(stdout);
+}
+
+function readGhCalls(logPath) {
+  return fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf-8").trim().split("\n") : [];
+}
+
+// ---- Helper unit test: deterministic durations/states without spawning processes ----
+
+test("pollChecksUntilSettled waits while pending then settles when the check flips (DC #1)", () => {
+  const clock = { t: 0 };
+  const timeline = [
+    [{ name: "unit", bucket: "pending" }],
+    [{ name: "unit", bucket: "pending" }],
+    [{ name: "unit", bucket: "pass" }],
+  ];
+  let call = 0;
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 60, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      fetchChecks: () => timeline[Math.min(call++, timeline.length - 1)],
+    }
+  );
+  assert.equal(outcome.pending, false, "settled once the check leaves pending");
+  assert.equal(outcome.polls, 3);
+  assert.deepEqual(outcome.checks, [{ name: "unit", bucket: "pass" }]);
+  assert.equal(outcome.pendingCheckNames.length, 0);
+  assert.equal(outcome.waitedMs, 2000, "two 1s sleeps between three polls");
+  assert.equal(outcome.budgetExhausted, false);
+});
+
+test("pollChecksUntilSettled proceeds with pending states when the budget is exhausted (DC #2)", () => {
+  const clock = { t: 0 };
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 2, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      fetchChecks: () => [{ name: "unit", bucket: "pending" }, { name: "lint", bucket: "pass" }],
+    }
+  );
+  assert.equal(outcome.pending, true, "still pending at budget exhaustion");
+  assert.equal(outcome.budgetExhausted, true);
+  assert.deepEqual(outcome.pendingCheckNames, ["unit"]);
+  assert.equal(outcome.waitedMs, 2000);
+});
+
+test("parseWaitForChecksSeconds: absent flag -> null, valid -> number, invalid -> throw", () => {
+  assert.equal(parseWaitForChecksSeconds(undefined), null);
+  assert.equal(parseWaitForChecksSeconds(null), null);
+  assert.equal(parseWaitForChecksSeconds("30"), 30);
+  assert.equal(parseWaitForChecksSeconds("0"), 0);
+  assert.throws(() => parseWaitForChecksSeconds("soon"), /non-negative number of seconds/);
+  assert.throws(() => parseWaitForChecksSeconds("-5"), /non-negative number of seconds/);
+});
+
+// ---- End-to-end review-runner rounds through the fake gh ----
+
+test("review-runner --wait-for-checks waits then proceeds when the check flips to pass (DC #1, #8a)", () => {
+  const { repoRoot, manifestPath, runId, runDir, doneCriteriaPath, diffPath, headSha } = setupRepo();
+  const reviewFile = passVerdict(repoRoot);
+  const { binDir, logPath } = installGh(repoRoot, {
+    checksTimeline: [
+      { checks: [{ name: "unit", bucket: "pending" }] },
+      { checks: [{ name: "unit", bucket: "pending" }] },
+      { checks: [{ name: "unit", bucket: "pass" }] },
+    ],
+  });
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, reviewFile, ghBinDir: binDir, waitForChecks: 60 });
+
+  assert.ok(result.checkWait, "checkWait recorded in round output");
+  assert.equal(result.checkWait.proceeded_with_pending, false, "settled before proceeding");
+  assert.equal(result.checkWait.budget_exhausted, false);
+  assert.deepEqual(result.checkWait.checks, [{ name: "unit", bucket: "pass" }]);
+  assert.ok(result.checkWait.polls >= 3, `polled until the check flipped (got ${result.checkWait.polls})`);
+  assert.equal(typeof result.checkWait.waited_ms, "number");
+  assert.equal(result.reviewHeadSha, headSha);
+
+  const artifact = JSON.parse(fs.readFileSync(path.join(runDir, "review-round-1-check-wait.json"), "utf-8"));
+  assert.deepEqual(artifact.checks, [{ name: "unit", bucket: "pass" }]);
+
+  const pollCalls = readGhCalls(logPath).filter((line) => line.startsWith("pr checks 123 --json name,bucket"));
+  assert.ok(pollCalls.length >= 3, "gh pr checks polled repeatedly");
+
+  // Settled (not pending) -> no pending-checks marker even though the verdict is a pass round.
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.review.pending_checks_marker, undefined, "no marker when checks settled green");
+});
+
+test("review-runner --wait-for-checks records still-pending states and no new failure when the budget is exhausted (DC #2, #8b)", () => {
+  const { repoRoot, manifestPath, runId, runDir, doneCriteriaPath, diffPath, headSha } = setupRepo();
+  const reviewFile = changesRequestedVerdict(repoRoot);
+  const { binDir } = installGh(repoRoot, {
+    checks: [{ name: "unit", bucket: "pending" }],
+  });
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, reviewFile, ghBinDir: binDir, waitForChecks: 0 });
+
+  assert.equal(result.checkWait.proceeded_with_pending, true);
+  assert.equal(result.checkWait.budget_exhausted, true);
+  assert.deepEqual(result.checkWait.pending_checks, ["unit"]);
+  assert.equal(result.nextState, STATES.CHANGES_REQUESTED, "round still applies its verdict (no new failure mode)");
+
+  const artifact = JSON.parse(fs.readFileSync(path.join(runDir, "review-round-1-check-wait.json"), "utf-8"));
+  assert.equal(artifact.proceeded_with_pending, true);
+  assert.deepEqual(artifact.pending_checks, ["unit"]);
+
+  // DC #3: changes_requested + proceeded-with-pending -> marker anchored to reviewed head.
+  const manifest = readManifest(manifestPath).data;
+  const marker = manifest.review.pending_checks_marker;
+  assert.ok(marker, "pending-checks marker written");
+  assert.equal(marker.head_sha, headSha, "marker anchored to the reviewed head");
+  assert.deepEqual(marker.pending_checks, ["unit"]);
+  assert.equal(marker.round, 1);
+});
+
+test("review-runner --wait-for-checks does NOT write the marker when checks settle green (DC #3)", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewFile = changesRequestedVerdict(repoRoot);
+  const { binDir } = installGh(repoRoot, { checks: [{ name: "unit", bucket: "pass" }] });
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, reviewFile, ghBinDir: binDir, waitForChecks: 5 });
+
+  assert.equal(result.checkWait.proceeded_with_pending, false);
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.review.pending_checks_marker, undefined, "no marker when checks are green");
+});
+
+test("review-runner without --wait-for-checks is byte-identical: no poll, no artifact, no marker, no field (DC #4, #8c)", () => {
+  const { repoRoot, manifestPath, runId, runDir, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewFile = changesRequestedVerdict(repoRoot);
+  const { binDir, logPath } = installGh(repoRoot, { checks: [{ name: "unit", bucket: "pending" }] });
+
+  const result = runReview({ repoRoot, runId, doneCriteriaPath, diffPath, reviewFile, ghBinDir: binDir });
+
+  assert.equal("checkWait" in result, false, "no checkWait field without the flag");
+  assert.equal(fs.existsSync(path.join(runDir, "review-round-1-check-wait.json")), false, "no check-wait artifact");
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.review.pending_checks_marker, undefined, "no marker without the flag");
+  const pollCalls = readGhCalls(logPath).filter((line) => line.startsWith("pr checks"));
+  assert.equal(pollCalls.length, 0, "gh pr checks never polled without the flag");
+});

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -35,7 +35,7 @@ const {
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
 const DISPATCH_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js");
 const RECOVER_STATE_SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-state.js");
-const REVIEW_RUNNER_LINE_CAP = 390;
+const REVIEW_RUNNER_LINE_CAP = 400;
 const REVIEW_RUNNER_FUNCTION_CAP = 12;
 
 function installDefaultGhFixture() {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-950-20260711105248679-359cf80f
- Branch: issue-950
- Reason: claude executor completed #950 two-half impl (check-wait module, --wait-for-checks, recover-state --require-checks-green + marker; 41/41 targeted tests) but total_timeout before commit/push/PR
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-950-20260711105248679-359cf80f.md; orchestrator=unknown; executor=cursor
- Recovered at (UTC): 2026-07-11T15:11:08.698Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - PR 검토 중 상태 확인이 완료될 때까지 대기하는 `--wait-for-checks <seconds>` 옵션을 추가했습니다.
  - 모든 검사가 성공한 동일 커밋에서 검토 상태를 안전하게 재진입할 수 있는 `--require-checks-green` 옵션을 지원합니다.
  - 체크 대기 결과와 진행 상태를 검토 결과 및 아티팩트에 표시합니다.

- **버그 수정**
  - 실패하거나 아직 진행 중인 체크를 통과한 것으로 잘못 처리하는 상태 복구를 방지합니다.
  - 오래되었거나 이미 사용된 체크 상태 정보의 재사용을 차단합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->