### PR TITLE
review-runner: --detach for crash-only review rounds (dispatch.js symmetry) (#951)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -37,7 +37,7 @@ const FLAGS = [
   { flag: "--copy", kind: VALUE, mode: MODE_VERBATIM, valueName: "<file,...>", rationale: "Operator-supplied file list; keep the literal argv token." },
   { flag: "--diff-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied fixture path; keep the literal argv token." },
   { flag: "--dispatch", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
-  { flag: "--detach", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Launch dispatch under a detached supervisor and return a receipt; no value is consumed." },
+  { flag: "--detach", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Launch the run (dispatch or review round) under a detached supervisor and return a receipt; no value is consumed." },
   { flag: "--done-criteria-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied anchor path; keep the literal argv token." },
   { flag: "--dry-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--effective", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
@@ -230,7 +230,7 @@ const COMMAND_FLAGS = {
     "--diff-file", "--review-file", "--reviewer", "--reviewer-script",
     "--reviewer-model", "--advisory-reviewer", "--advisory-profile",
     "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--prepare-only",
-    "--manual-review-reason", "--independent-review-reason", "--allow-behind-base", "--wait-for-checks", "--no-comment", "--json", "--help",
+    "--manual-review-reason", "--independent-review-reason", "--allow-behind-base", "--wait-for-checks", "--detach", "--no-comment", "--json", "--help",
   ],
   "run-full-gate": [
     "--repo", "--suites", "--output", "--lock-timeout", "--json", "--help",

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -99,6 +99,35 @@ Codex-only operation is covered as a regression for `policy.review_assurance=har
 
 Escalated runs may be reopened for one independent review attempt. A different `--reviewer` records a `reviewer_swap` event with `reason=different_reviewer:<from>-><to>`. Reusing the same adapter requires `--independent-review-reason <text>` so the audit trail explains how the attempt is independent, such as a fresh ephemeral context, different model hint, or materially different prompt bundle.
 
+## Detached Review Rounds (`--detach`)
+
+A review round is the last long-running foreground-fragile step in the pipeline. `--detach` runs the round under a crash-only detached supervisor — the same pattern `dispatch.js` ships (`--detach`, #799–#802) and `run-full-gate.js` ships for gates (#930) — so the round survives the death of the invoking shell.
+
+```bash
+node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --reviewer codex --detach --json
+```
+
+The parent re-execs `review-runner.js` (same argv minus `--detach`, with a receipt env var) in a new process group, waits for the child's receipt, prints it, and exits. The child runs the existing `run()` end-to-end. The receipt carries at least `{ runId, round, pid, pgid, logPath, sentinelPath }` plus `leasePath`, `manifestPath`, and a `recoverCommand`.
+
+Run-dir artifacts the detached round adds (foreground rounds write none of these, staying byte-identical):
+
+- `lease.json` — the run-dir lease written via `run-runtime-state.js` `writeRunLease` (`pid`, `pgid`, `host`, `started_at`, `timeout_s`). Operators identify and kill only this owned `pgid` (`kill -TERM -<pgid>`); the lease is left in place after the round so its shape stays inspectable, and the next detached round overwrites it.
+- `review-round-N.done` — the completion sentinel (`{ status: "complete" | "failed", exitCode, finishedAt }`), analogous to the gate `.done` sentinel.
+
+`--detach` composes with the normal round flags (`--reviewer`, `--reviewer-model`, `--advisory-reviewer` and lanes, `--wait-for-checks`, `--no-comment`). It is rejected — with a clear error, not silently ignored — when combined with `--prepare-only` (only emits the prompt bundle) or with a `--review-file` apply (applies an already-produced verdict without invoking the reviewer), because detaching adds nothing there.
+
+### Recovery: killed between verdict persistence and manifest apply
+
+If the detached supervisor is killed after the round persisted its verdict (`review-round-N-verdict.json` / `review-round-N-raw-response.txt` written) but before the manifest apply completed, re-apply the persisted verdict without re-invoking the reviewer using the existing `--review-file` semantics (unchanged by `--detach`):
+
+```bash
+node skills/relay-review/scripts/review-runner.js --repo . --run-id <id> --pr <pr> \
+  --review-file ~/.relay/runs/<repo-slug>/<id>/review-round-N-raw-response.txt \
+  --manual-review-reason "reapply persisted verdict after detached-round kill"
+```
+
+`loadReviewText` short-circuits to the on-disk review text when `--review-file` is passed, so this re-runs the round with the persisted verdict and applies it (`--manual-review-reason` records the provenance in `review.manual_review_reason`). The receipt's `recoverCommand` field spells out this same command for the current run.
+
 ## Backward Compatibility
 
 Pre-261 runs do not have `execution-evidence.json`. In that case the runner computes `quality_execution_status=missing`, a reviewer PASS cannot be applied, and operators should use `finalize-run --force-finalize-nonready --reason "pre-261 run, no artifact"` only after independent verification.

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -29,6 +29,7 @@ const { settleAdvisoryGatesForRound } = require("./review-runner/advisory-gates"
 const { printResult, printUsage } = require("./review-runner/output");
 const { applyPendingChecksMarker, maybeWaitForChecks } = require("./review-runner/check-wait");
 const { assertKnownReviewRunnerFlags, parseReviewRunnerCliArgs } = require("./review-runner/cli");
+const { beginDetachSupervisorIfRequested, dispatchReviewEntry } = require("./review-runner/detach");
 const { args, cliArgs, options } = parseReviewRunnerCliArgs(process.argv.slice(2));
 if (require.main === module && (!args.length || cliArgs.hasFlag(["--help", "-h"]))) {
   printUsage();
@@ -60,6 +61,10 @@ async function run() {
   const round = Number(data.review?.rounds || 0) + 1;
   const runDir = getRunDir(runRepoPath, data.run_id);
   ensureRunLayout(runRepoPath, data.run_id);
+  // Detached child only (no-op in the foreground): write the run-dir lease + receipt
+  // before the long-running reviewer invocation so the parent can return and the round
+  // survives the invoker's death.
+  beginDetachSupervisorIfRequested({ runRepoPath, runId: data.run_id, round, runDir, manifestPath });
   const runRoutePlan = loadRunRoutePlan(runRepoPath, data.run_id).plan;
   const resolvedAdvisoryConfig = resolveAdvisoryConfig({
     advisoryGraceArg,
@@ -388,8 +393,6 @@ async function run() {
 }
 
 if (require.main === module) {
-  Promise.resolve(run()).catch((error) => {
-    printFailureAndExit(error, { jsonOut: cliArgs.hasFlag("--json") });
-  });
+  dispatchReviewEntry({ options, args, entryPath: __filename, jsonOut: cliArgs.hasFlag("--json"), run, printFailureAndExit });
 }
 module.exports = { applyVerdictToManifest, buildCommentBody, buildPrompt, buildRedispatchPrompt, buildReviewRunnerRubricGateFailure, detectChurnGrowth, formatIssueList, formatPriorVerdictSummary, formatScopeDrift, getGhLogin, loadRubricFromRunDir, parseRemoteHost, parseReviewVerdict, parseScoreLog, resolveIssueNumber, resolveRemoteHost, validateReviewVerdict, validateScopeDrift };

--- a/skills/relay-review/scripts/review-runner/cli.js
+++ b/skills/relay-review/scripts/review-runner/cli.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const { bindCliArgs, findUnknownFlags } = require("../../../relay-dispatch/scripts/cli-args");
 
-const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--allow-behind-base", "--wait-for-checks", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
+const KNOWN_FLAGS = ["--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file", "--diff-file", "--review-file", "--manual-review-reason", "--reviewer", "--reviewer-script", "--reviewer-model", "--independent-review-reason", "--advisory-reviewer", "--advisory-profile", "--advisory-reviewer-model", "--advisory-timeout", "--advisory-grace", "--allow-behind-base", "--wait-for-checks", "--detach", "--prepare-only", "--no-comment", "--json", "--help", "-h"];
 
 function parseReviewRunnerCliArgs(args) {
   const cliArgs = bindCliArgs(args, {
@@ -14,6 +14,7 @@ function parseReviewRunnerCliArgs(args) {
     cliArgs,
     options: {
       allowBehindBase: cliArgs.hasFlag("--allow-behind-base"),
+      detach: cliArgs.hasFlag("--detach"),
       advisoryGraceArg: cliArgs.getArg("--advisory-grace"),
       advisoryProfileArg: cliArgs.getArg("--advisory-profile"),
       advisoryReviewerArg: cliArgs.getArg("--advisory-reviewer"),

--- a/skills/relay-review/scripts/review-runner/detach.js
+++ b/skills/relay-review/scripts/review-runner/detach.js
@@ -71,10 +71,10 @@ function sentinelPathFor(runDir, round) {
   return path.join(runDir, `review-round-${round}.done`);
 }
 
-function recoverCommandForReceipt(runRepoPath, runId, round) {
+function recoverCommandForReceipt(runRepoPath, runId, round, runDir) {
   return (
     `node skills/relay-review/scripts/review-runner.js --repo ${shellQuote(runRepoPath)} --run-id ${runId} ` +
-    `--review-file ${shellQuote(path.join("<runDir>", `review-round-${round}-raw-response.txt`))} ` +
+    `--review-file ${shellQuote(path.join(runDir, `review-round-${round}-raw-response.txt`))} ` +
     `--manual-review-reason "reapply persisted verdict after detached-round kill"`
   );
 }
@@ -112,7 +112,7 @@ function beginDetachSupervisorIfRequested({ runRepoPath, runId, round, runDir, m
     sentinelPath,
     leasePath,
     manifestPath: manifestPath || null,
-    recoverCommand: recoverCommandForReceipt(runRepoPath, runId, round),
+    recoverCommand: recoverCommandForReceipt(runRepoPath, runId, round, runDir),
   };
   writeJsonFileAtomically(receiptPath, receipt);
   // Don't let the receipt env leak into any nested child processes (e.g. the

--- a/skills/relay-review/scripts/review-runner/detach.js
+++ b/skills/relay-review/scripts/review-runner/detach.js
@@ -1,0 +1,269 @@
+"use strict";
+
+// Crash-only review rounds. Mirrors the dispatch.js detach scaffold
+// (skills/relay-dispatch/scripts/dispatch.js: --detach, DETACH_RECEIPT_ENV,
+// launchDetachedAndExit/waitForDetachReceipt/writeDetachReceiptIfRequested) so a
+// review round survives the death of the invoking shell. The child re-execs
+// review-runner.js with the receipt env var set, writes a run-dir lease using the
+// shared run-runtime-state.js conventions, prints a receipt, and runs the existing
+// round end-to-end; on settle it writes a completion sentinel.
+//
+// The lease/receipt/sentinel are ONLY produced when the receipt env var is set
+// (i.e. inside the detached child). Foreground review-runner never enters this
+// code path, keeping the no-detach behavior byte-identical.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawn: nodeSpawn } = require("child_process");
+const { writeRunLease } = require("../../../relay-dispatch/scripts/run-runtime-state");
+
+const DETACH_RECEIPT_ENV = "RELAY_REVIEW_DETACH_RECEIPT_PATH";
+const DETACH_STDOUT_LOG_ENV = "RELAY_REVIEW_DETACH_STDOUT_LOG";
+const DETACH_STDERR_LOG_ENV = "RELAY_REVIEW_DETACH_STDERR_LOG";
+// Review rounds have no fixed --timeout; the lease timeout only feeds remaining_s
+// for staleness reporting. Operators identify/kill the owned pgid regardless.
+const DEFAULT_REVIEW_LEASE_TIMEOUT_S = 3600;
+const RECEIPT_WAIT_TIMEOUT_MS = 60000;
+
+// Child-side supervisor handle, set by beginDetachSupervisorIfRequested and
+// consumed by finishDetachSupervisor. Null in the foreground/parent, so both
+// functions are no-ops outside a detached child.
+let activeSupervisor = null;
+
+function sleepAsync(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shellQuote(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
+function removeDetachFlag(argv) {
+  return argv.filter((arg) => arg !== "--detach" && !String(arg).startsWith("--detach="));
+}
+
+function tailFile(filePath, maxBytes = 8192) {
+  try {
+    const stat = fs.statSync(filePath);
+    const start = Math.max(0, stat.size - maxBytes);
+    const fd = fs.openSync(filePath, "r");
+    try {
+      const buffer = Buffer.alloc(stat.size - start);
+      fs.readSync(fd, buffer, 0, buffer.length, start);
+      return buffer.toString("utf-8").trim();
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return "";
+  }
+}
+
+function writeJsonFileAtomically(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+function sentinelPathFor(runDir, round) {
+  return path.join(runDir, `review-round-${round}.done`);
+}
+
+function recoverCommandForReceipt(runRepoPath, runId, round) {
+  return (
+    `node skills/relay-review/scripts/review-runner.js --repo ${shellQuote(runRepoPath)} --run-id ${runId} ` +
+    `--review-file ${shellQuote(path.join("<runDir>", `review-round-${round}-raw-response.txt`))} ` +
+    `--manual-review-reason "reapply persisted verdict after detached-round kill"`
+  );
+}
+
+// ---- Child side: lease + receipt + sentinel ------------------------------
+
+function isDetachChild() {
+  return Boolean(process.env[DETACH_RECEIPT_ENV]);
+}
+
+// Called inside run() once runId/round/runDir are known (after ensureRunLayout).
+// In the foreground (no receipt env) this is a no-op and returns null, so no
+// lease/receipt/sentinel file is written and behavior stays byte-identical.
+function beginDetachSupervisorIfRequested({ runRepoPath, runId, round, runDir, manifestPath, leaseTimeoutS }) {
+  const receiptPath = process.env[DETACH_RECEIPT_ENV];
+  if (!receiptPath) return null;
+  if (activeSupervisor) return activeSupervisor;
+
+  // Spawned with detached:true, so the child is its own process-group leader:
+  // process.pid == pgid. Operators kill only this owned pgid.
+  const pgid = process.pid;
+  const { lease, leasePath } = writeRunLease(runRepoPath, runId, {
+    pid: process.pid,
+    pgid,
+    timeoutS: leaseTimeoutS || DEFAULT_REVIEW_LEASE_TIMEOUT_S,
+  });
+  const sentinelPath = sentinelPathFor(runDir, round);
+  const receipt = {
+    runId,
+    round,
+    pid: process.pid,
+    pgid,
+    logPath: process.env[DETACH_STDOUT_LOG_ENV] || null,
+    stderrPath: process.env[DETACH_STDERR_LOG_ENV] || null,
+    sentinelPath,
+    leasePath,
+    manifestPath: manifestPath || null,
+    recoverCommand: recoverCommandForReceipt(runRepoPath, runId, round),
+  };
+  writeJsonFileAtomically(receiptPath, receipt);
+  // Don't let the receipt env leak into any nested child processes (e.g. the
+  // reviewer adapter) that must not think they are the detached supervisor.
+  delete process.env[DETACH_RECEIPT_ENV];
+  activeSupervisor = { runRepoPath, runId, round, runDir, sentinelPath, leasePath, lease, receipt };
+  return activeSupervisor;
+}
+
+// Called from the module entry after run() settles. Writes the completion
+// sentinel (success or failure). No-op in the foreground/parent.
+function finishDetachSupervisor(outcome = {}) {
+  if (!activeSupervisor) return null;
+  const { runId, round, sentinelPath } = activeSupervisor;
+  const status = outcome.status === "failed" ? "failed" : "complete";
+  const sentinel = {
+    runId,
+    round,
+    status,
+    exitCode: Number.isInteger(outcome.exitCode) ? outcome.exitCode : status === "complete" ? 0 : 1,
+    finishedAt: new Date().toISOString(),
+    ...(outcome.error ? { error: String(outcome.error) } : {}),
+  };
+  writeJsonFileAtomically(sentinelPath, sentinel);
+  const finished = { ...activeSupervisor, sentinel };
+  activeSupervisor = null;
+  return finished;
+}
+
+// ---- Parent side: launch the detached supervisor -------------------------
+
+function assertDetachCompatible(options) {
+  if (options.prepareOnly) {
+    throw new Error(
+      "--detach cannot be combined with --prepare-only: --prepare-only only emits the prompt bundle, so there is nothing long-running to supervise."
+    );
+  }
+  if (options.reviewFile) {
+    throw new Error(
+      "--detach cannot be combined with --review-file: a --review-file invocation applies an already-produced verdict without invoking the reviewer, so detaching adds nothing. Run the apply in the foreground."
+    );
+  }
+}
+
+async function waitForDetachReceipt({ receiptPath, stderrPath, stdoutPath, child, timeoutMs = RECEIPT_WAIT_TIMEOUT_MS }) {
+  const deadline = Date.now() + timeoutMs;
+  let childExit = null;
+  child.once("exit", (code, signal) => {
+    childExit = { code, signal };
+  });
+  while (true) {
+    if (fs.existsSync(receiptPath)) {
+      let receipt;
+      try {
+        receipt = JSON.parse(fs.readFileSync(receiptPath, "utf-8"));
+      } catch {
+        await sleepAsync(25);
+        continue;
+      }
+      if (!receipt.runId) {
+        throw new Error(`detached review wrote an invalid receipt without runId: ${receiptPath}`);
+      }
+      return receipt;
+    }
+    if (childExit) {
+      const detail = tailFile(stderrPath) || tailFile(stdoutPath) || `child exited code=${childExit.code} signal=${childExit.signal || "none"}`;
+      throw new Error(`detached review exited before receipt: ${detail}`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `detached review did not write a receipt within ${Math.round(timeoutMs / 1000)}s; ` +
+        `the supervisor may still be resolving context (logs: ${stdoutPath}, ${stderrPath}).`
+      );
+    }
+    await sleepAsync(50);
+  }
+}
+
+async function launchDetachedReviewAndExit({ entryPath, args, options, jsonOut }) {
+  assertDetachCompatible(options);
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-detach-"));
+  const receiptPath = path.join(tmpDir, "receipt.json");
+  const stdoutPath = path.join(tmpDir, "supervisor-stdout.log");
+  const stderrPath = path.join(tmpDir, "supervisor-stderr.log");
+  const childArgs = removeDetachFlag(args);
+  const stdoutFd = fs.openSync(stdoutPath, "w");
+  const stderrFd = fs.openSync(stderrPath, "w");
+  let child;
+  try {
+    child = nodeSpawn(process.execPath, [entryPath, ...childArgs], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        [DETACH_RECEIPT_ENV]: receiptPath,
+        [DETACH_STDOUT_LOG_ENV]: stdoutPath,
+        [DETACH_STDERR_LOG_ENV]: stderrPath,
+      },
+      detached: true,
+      stdio: ["ignore", stdoutFd, stderrFd],
+    });
+  } finally {
+    try { fs.closeSync(stdoutFd); } catch {}
+    try { fs.closeSync(stderrFd); } catch {}
+  }
+  child.unref();
+  const receipt = await waitForDetachReceipt({ receiptPath, stderrPath, stdoutPath, child });
+  const output = { status: "detached", ...receipt, supervisorPid: child.pid };
+  if (jsonOut) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    console.log(`Detached review round launched: ${output.runId} (round ${output.round})`);
+    console.log(`  PID/PGID:  ${output.pid}/${output.pgid}`);
+    console.log(`  Log:       ${output.logPath}`);
+    console.log(`  Sentinel:  ${output.sentinelPath}`);
+    console.log(`  Lease:     ${output.leasePath}`);
+    console.log(`  Recover:   ${output.recoverCommand}`);
+  }
+  return output;
+}
+
+// Module entry dispatcher. Parent side of --detach (no receipt env yet) launches a
+// detached supervisor and exits; otherwise (foreground or the detached child) run()
+// executes and, when a supervisor is active, writes the completion sentinel on settle.
+function dispatchReviewEntry({ options, args, entryPath, jsonOut, run, printFailureAndExit }) {
+  if (options.detach && !process.env[DETACH_RECEIPT_ENV]) {
+    launchDetachedReviewAndExit({ entryPath, args, options, jsonOut }).catch((error) => {
+      printFailureAndExit(error, { jsonOut });
+    });
+    return;
+  }
+  Promise.resolve(run())
+    .then(() => { finishDetachSupervisor({ status: "complete" }); })
+    .catch((error) => {
+      finishDetachSupervisor({ status: "failed", error: error.message });
+      printFailureAndExit(error, { jsonOut });
+    });
+}
+
+module.exports = {
+  DEFAULT_REVIEW_LEASE_TIMEOUT_S,
+  DETACH_RECEIPT_ENV,
+  DETACH_STDERR_LOG_ENV,
+  DETACH_STDOUT_LOG_ENV,
+  assertDetachCompatible,
+  beginDetachSupervisorIfRequested,
+  dispatchReviewEntry,
+  finishDetachSupervisor,
+  isDetachChild,
+  launchDetachedReviewAndExit,
+  removeDetachFlag,
+  sentinelPathFor,
+  waitForDetachReceipt,
+};

--- a/skills/relay-review/scripts/review-runner/output.js
+++ b/skills/relay-review/scripts/review-runner/output.js
@@ -24,6 +24,7 @@ function printUsage() {
   console.log(`  --advisory-grace <seconds>   ${modeLabel("--advisory-grace")} Standard-mode critical-path wait window`);
   console.log(`  --allow-behind-base          ${modeLabel("--allow-behind-base")} Proceed despite a behind-base warning`);
   console.log(`  --wait-for-checks <seconds>  ${modeLabel("--wait-for-checks")} Wait up to N seconds for PR checks to leave the pending bucket before reviewing`);
+  console.log(`  --detach                     ${modeLabel("--detach")} Run the round in a detached supervisor (crash-only) and print a receipt`);
   console.log(`  --prepare-only               ${modeLabel("--prepare-only")} Emit prompt bundle only; do not apply verdict`);
   console.log(`  --no-comment                 ${modeLabel("--no-comment")} Do not post a PR comment`);
   console.log(`  --json                       ${modeLabel("--json")} Output JSON`);

--- a/tests/relay-review/scripts/review-runner-detach.test.js
+++ b/tests/relay-review/scripts/review-runner-detach.test.js
@@ -183,6 +183,16 @@ test("--detach prints a receipt and returns before the round finishes (DC #6a)",
   assert.equal(typeof receipt.logPath, "string");
   assert.match(receipt.recoverCommand, /--review-file/);
   assert.match(receipt.recoverCommand, /--manual-review-reason/);
+  // recoverCommand must be directly copy-pasteable for THIS run: it spells out the
+  // absolute persisted-verdict path, not an unusable <runDir> placeholder.
+  assert.ok(
+    receipt.recoverCommand.includes(path.join(runDir, "review-round-1-raw-response.txt")),
+    `recoverCommand embeds the real run-dir path (got: ${receipt.recoverCommand})`,
+  );
+  assert.ok(
+    !receipt.recoverCommand.includes("<runDir>"),
+    `recoverCommand carries no <runDir> placeholder (got: ${receipt.recoverCommand})`,
+  );
 
   // The round still completes end-to-end after the parent returned.
   await waitFor(() => fs.existsSync(receipt.sentinelPath), { message: "completion sentinel" });

--- a/tests/relay-review/scripts/review-runner-detach.test.js
+++ b/tests/relay-review/scripts/review-runner-detach.test.js
@@ -1,0 +1,326 @@
+// Issue #951: review-runner --detach (crash-only review rounds, dispatch.js symmetry).
+// Covers DC #6: (a) receipt shape + prompt return, (b) invoker-kill survival,
+// (c) lease shape + sentinel, (d) verdict-persisted/apply-missing --review-file recovery.
+// Every flavor asserts real run-dir files and the final manifest state, not mocked spawns.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawn, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+  readManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const {
+  DEFAULT_ENFORCEMENT_RUBRIC,
+  createEnforcementFixture,
+} = require("../../relay-dispatch/scripts/test-support");
+const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+
+function defaultRubricScores() {
+  return [{
+    factor: "Default enforcement rubric",
+    target: ">= 1/1",
+    observed: "1/1",
+    status: "pass",
+    tier: "contract",
+    notes: "The enforcement fixture rubric remained satisfied.",
+  }];
+}
+
+function writeExecutionEvidence(runDir, headSha) {
+  fs.writeFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), `${JSON.stringify({
+    schema_version: 1,
+    head_sha: headSha,
+    test_command: "unspecified",
+    test_result_hash: "unspecified",
+    test_result_summary: "unspecified",
+    recorded_at: "2026-07-12T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  }, null, 2)}\n`, "utf-8");
+}
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-detach-"));
+  const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-detach-origin-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["init", "--bare", remoteRoot], { stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Detach Test"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-detach@example.com"], { cwd: repoRoot, stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", remoteRoot], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, stdio: "pipe" });
+
+  const runId = "issue-951-20260712010000000";
+  const worktreePath = path.join(repoRoot, "wt", "issue-951");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", "issue-951"], { cwd: repoRoot, stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, "marker.txt"), "worktree\n", "utf-8");
+
+  // ensureRunLayout + getRunDir resolve under RELAY_HOME, so set it before laying the run out.
+  const priorRelayHome = process.env.RELAY_HOME;
+  process.env.RELAY_HOME = relayHome;
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot, runId, branch: "issue-951", baseBranch: "main", issueNumber: 951,
+    worktreePath, orchestrator: "codex", executor: "codex", reviewer: "claude",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor = createEnforcementFixture({
+    repoRoot, runId, state: "loaded", rubricContent: DEFAULT_ENFORCEMENT_RUBRIC,
+  }).anchor;
+  const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  manifest = { ...manifest, git: { ...(manifest.git || {}), pr_number: 123, head_sha: headSha } };
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(manifestPath, manifest);
+  writeExecutionEvidence(runDir, headSha);
+  if (priorRelayHome === undefined) delete process.env.RELAY_HOME; else process.env.RELAY_HOME = priorRelayHome;
+
+  const doneCriteriaPath = path.join(repoRoot, "done-criteria.md");
+  const diffPath = path.join(repoRoot, "pr.diff");
+  fs.writeFileSync(doneCriteriaPath, "# Done Criteria\n\n- Add smoke.txt\n", "utf-8");
+  fs.writeFileSync(diffPath, "diff --git a/smoke.txt b/smoke.txt\n+ok\n", "utf-8");
+  return { repoRoot, relayHome, worktreePath, manifestPath, runId, runDir, doneCriteriaPath, diffPath, headSha };
+}
+
+const CHANGES_REQUESTED_VERDICT = {
+  verdict: "changes_requested",
+  summary: "Contract drift found.",
+  contract_status: "fail",
+  quality_review_status: "not_run",
+  quality_execution_status: "pass",
+  next_action: "changes_requested",
+  issues: [{
+    title: "Missing contract item", body: "smoke.txt not present.",
+    file: "src/index.js", line: 10, category: "contract", severity: "high", confidence: "high",
+  }],
+  rubric_scores: defaultRubricScores(),
+  scope_drift: { creep: [], missing: [] },
+};
+
+// A real reviewer subprocess (not --review-file): sleeps `delayMs`, then emits the verdict
+// on stdout. The delay keeps the detached round in-flight while the invoker is killed.
+function writeReviewerScript(repoRoot, name, verdict, { delayMs = 0 } = {}) {
+  const filePath = path.join(repoRoot, name);
+  const body = `#!/usr/bin/env node
+setTimeout(() => {
+  process.stdout.write(${JSON.stringify(JSON.stringify(verdict))});
+}, ${Number(delayMs)});
+`;
+  fs.writeFileSync(filePath, body, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function writeVerdictFile(repoRoot, name, verdict) {
+  const filePath = path.join(repoRoot, name);
+  fs.writeFileSync(filePath, `${JSON.stringify(verdict, null, 2)}\n`, "utf-8");
+  return filePath;
+}
+
+function detachEnv(relayHome) {
+  return { ...process.env, RELAY_HOME: relayHome };
+}
+
+async function waitFor(predicate, { timeoutMs = 15000, intervalMs = 50, message = "condition" } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let done = false;
+    try { done = await predicate(); } catch { done = false; }
+    if (done) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${message}`);
+}
+
+function pidAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch (error) { return error.code === "EPERM"; }
+}
+
+function killPgidQuietly(pgid) {
+  if (!pgid) return;
+  try { process.kill(-pgid, "SIGKILL"); } catch {}
+}
+
+// ---- DC #6a: receipt shape + prompt return -------------------------------
+
+test("--detach prints a receipt and returns before the round finishes (DC #6a)", async () => {
+  const { repoRoot, relayHome, manifestPath, runId, runDir, doneCriteriaPath, diffPath } = setupRepo();
+  // 2.5s reviewer delay: the parent must return long before the round applies its verdict.
+  const reviewerScript = writeReviewerScript(repoRoot, "reviewer-slow.js", CHANGES_REQUESTED_VERDICT, { delayMs: 2500 });
+
+  const started = Date.now();
+  const launched = spawnSync(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript, "--no-comment", "--detach", "--json",
+  ], { encoding: "utf-8", env: detachEnv(relayHome), timeout: 15000 });
+  const elapsedMs = Date.now() - started;
+
+  assert.equal(launched.status, 0, `${launched.stderr}\n${launched.stdout}`);
+  assert.ok(elapsedMs < 2500, `parent returned before the reviewer delay elapsed (got ${elapsedMs}ms)`);
+
+  const receipt = JSON.parse(launched.stdout);
+  assert.equal(receipt.status, "detached");
+  assert.equal(receipt.runId, runId);
+  assert.equal(receipt.round, 1);
+  assert.equal(Number.isInteger(receipt.pid) && receipt.pid > 0, true, "receipt carries a pid");
+  assert.equal(Number.isInteger(receipt.pgid) && receipt.pgid > 0, true, "receipt carries a pgid");
+  assert.equal(receipt.sentinelPath, path.join(runDir, "review-round-1.done"));
+  assert.equal(receipt.leasePath, path.join(runDir, "lease.json"));
+  assert.equal(receipt.manifestPath, manifestPath);
+  assert.equal(typeof receipt.logPath, "string");
+  assert.match(receipt.recoverCommand, /--review-file/);
+  assert.match(receipt.recoverCommand, /--manual-review-reason/);
+
+  // The round still completes end-to-end after the parent returned.
+  await waitFor(() => fs.existsSync(receipt.sentinelPath), { message: "completion sentinel" });
+  await waitFor(() => readManifest(manifestPath).data.state === STATES.CHANGES_REQUESTED, {
+    message: "manifest verdict applied by the detached round",
+  });
+  const sentinel = JSON.parse(fs.readFileSync(receipt.sentinelPath, "utf-8"));
+  assert.equal(sentinel.status, "complete");
+  assert.equal(sentinel.round, 1);
+  assert.ok(fs.existsSync(path.join(runDir, "review-round-1-verdict.json")), "verdict artifact persisted");
+});
+
+// ---- DC #6b: invoker-kill survival ---------------------------------------
+
+test("the round applies the verdict even when the invoker is SIGKILLed right after the receipt (DC #6b)", async () => {
+  const { repoRoot, relayHome, manifestPath, runId, runDir, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewerScript = writeReviewerScript(repoRoot, "reviewer-kill.js", CHANGES_REQUESTED_VERDICT, { delayMs: 2500 });
+
+  const parent = spawn(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript, "--no-comment", "--detach", "--json",
+  ], { env: detachEnv(relayHome) });
+
+  let stdout = "";
+  parent.stdout.on("data", (chunk) => { stdout += chunk; });
+  let receipt = null;
+  try {
+    await waitFor(() => {
+      try { receipt = JSON.parse(stdout); return Boolean(receipt.runId); } catch { return false; }
+    }, { message: "detach receipt on the parent's stdout" });
+
+    // The detached supervisor is its own process-group leader, so killing the invoker
+    // (parent) does not touch it. The round must still be running (2.5s reviewer delay).
+    assert.equal(receipt.status, "detached");
+    assert.ok(pidAlive(receipt.pid), "detached supervisor alive before the invoker dies");
+    parent.kill("SIGKILL");
+    await waitFor(() => !pidAlive(parent.pid), { message: "invoker process to die" });
+    assert.ok(pidAlive(receipt.pid), "detached supervisor outlives the SIGKILLed invoker");
+
+    // Despite the invoker crash, the round persists the verdict and applies it to the manifest.
+    await waitFor(() => fs.existsSync(receipt.sentinelPath), { message: "completion sentinel after invoker kill" });
+    await waitFor(() => readManifest(manifestPath).data.state === STATES.CHANGES_REQUESTED, {
+      message: "manifest verdict applied after invoker kill",
+    });
+    const manifest = readManifest(manifestPath).data;
+    assert.equal(manifest.state, STATES.CHANGES_REQUESTED);
+    assert.ok(fs.existsSync(path.join(runDir, "review-round-1-verdict.json")), "verdict artifact persisted");
+  } finally {
+    try { parent.kill("SIGKILL"); } catch {}
+    killPgidQuietly(receipt?.pgid);
+  }
+});
+
+// ---- DC #6c: lease shape + completion sentinel ---------------------------
+
+test("the detached round writes a run-dir lease (pid/pgid/host/started_at) and a completion sentinel (DC #6c)", async () => {
+  const { repoRoot, relayHome, manifestPath, runId, runDir, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewerScript = writeReviewerScript(repoRoot, "reviewer-lease.js", CHANGES_REQUESTED_VERDICT, { delayMs: 1500 });
+
+  const launched = spawnSync(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript, "--no-comment", "--detach", "--json",
+  ], { encoding: "utf-8", env: detachEnv(relayHome), timeout: 15000 });
+  assert.equal(launched.status, 0, `${launched.stderr}\n${launched.stdout}`);
+  const receipt = JSON.parse(launched.stdout);
+
+  // The receipt is written after the lease, so the lease file is present the moment the
+  // parent returns. Read the absolute leasePath from the receipt (the run dir resolves
+  // under the child's RELAY_HOME, not this test process's).
+  assert.equal(receipt.leasePath, path.join(runDir, "lease.json"));
+  assert.ok(fs.existsSync(receipt.leasePath), "lease.json present in the run dir");
+  const lease = JSON.parse(fs.readFileSync(receipt.leasePath, "utf-8"));
+  assert.equal(Number.isInteger(lease.pid) && lease.pid > 0, true, "lease carries pid");
+  assert.equal(Number.isInteger(lease.pgid) && lease.pgid > 0, true, "lease carries pgid");
+  assert.equal(lease.pgid, receipt.pgid, "lease pgid matches the receipt's owned pgid");
+  assert.equal(lease.host, os.hostname(), "lease carries host");
+  assert.ok(lease.started_at && !Number.isNaN(Date.parse(lease.started_at)), "lease carries an ISO started_at");
+
+  // A sentinel appears on completion (analogous to the gate .done sentinel).
+  await waitFor(() => fs.existsSync(receipt.sentinelPath), { message: "completion sentinel" });
+  const sentinel = JSON.parse(fs.readFileSync(receipt.sentinelPath, "utf-8"));
+  assert.equal(sentinel.status, "complete");
+  assert.equal(sentinel.runId, runId);
+  assert.equal(sentinel.round, 1);
+  assert.equal(sentinel.exitCode, 0);
+  await waitFor(() => readManifest(manifestPath).data.state === STATES.CHANGES_REQUESTED, {
+    message: "manifest verdict applied",
+  });
+});
+
+// ---- DC #6d: verdict-persisted / apply-missing recovery via --review-file --
+
+test("a persisted verdict with no manifest apply is recoverable via the documented --review-file path (DC #6d)", () => {
+  const { repoRoot, relayHome, manifestPath, runId, runDir, doneCriteriaPath, diffPath } = setupRepo();
+
+  // Simulate a kill between verdict persistence and manifest apply: the raw reviewer
+  // response is on disk (review-round-1-raw-response.txt) but the manifest is untouched.
+  const persistedResponse = path.join(runDir, "review-round-1-raw-response.txt");
+  fs.writeFileSync(persistedResponse, `${JSON.stringify(CHANGES_REQUESTED_VERDICT, null, 2)}\n`, "utf-8");
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING, "manifest apply did not happen yet");
+
+  // Documented one-command recovery: re-run the round with the persisted verdict + provenance.
+  const recovered = JSON.parse(execFileSync(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--review-file", persistedResponse,
+    "--manual-review-reason", "reapply persisted verdict after detached-round kill",
+    "--no-comment", "--json",
+  ], { encoding: "utf-8", env: detachEnv(relayHome) }));
+
+  assert.equal(recovered.appliedVerdict, "changes_requested");
+  assert.equal(recovered.nextState, STATES.CHANGES_REQUESTED);
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.state, STATES.CHANGES_REQUESTED, "verdict applied to the manifest via recovery");
+  assert.equal(manifest.review.manual_review_reason, "reapply persisted verdict after detached-round kill");
+});
+
+// ---- DC #5: incompatible-combination rejection ---------------------------
+
+test("--detach is rejected with --prepare-only and with --review-file (DC #5)", () => {
+  const { repoRoot, relayHome, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const verdictFile = writeVerdictFile(repoRoot, "verdict.json", CHANGES_REQUESTED_VERDICT);
+
+  const prepareOnly = spawnSync(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--detach", "--prepare-only", "--json",
+  ], { encoding: "utf-8", env: detachEnv(relayHome) });
+  assert.notEqual(prepareOnly.status, 0, "--detach + --prepare-only is rejected");
+  assert.match(prepareOnly.stderr, /--detach cannot be combined with --prepare-only/);
+
+  const reviewFile = spawnSync(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--review-file", verdictFile, "--detach", "--json",
+  ], { encoding: "utf-8", env: detachEnv(relayHome) });
+  assert.notEqual(reviewFile.status, 0, "--detach + --review-file is rejected");
+  assert.match(reviewFile.stderr, /--detach cannot be combined with --review-file/);
+});


### PR DESCRIPTION
## Summary

Review rounds were the last long-running foreground-fragile step in the pipeline. In the 2026-07-11 arc, cross-session `TaskStop` kills terminated three in-flight review rounds; one landed between verdict persistence and manifest apply, needing manual `--review-file` recovery. Operators hand-wrote `spawn({detached:true})` + sentinel wrappers per round — the pattern `dispatch.js` already ships natively (#799–#802) and `run-full-gate` ships for gates (#930).

`--detach` makes that native, mirroring the dispatch crash-only scaffold.

## What changed

- **`review-runner/detach.js`** (new): reuses the dispatch detach scaffold + `run-runtime-state.js` `writeRunLease`. The parent re-execs `review-runner.js` (same argv minus `--detach`, with a receipt env var) in a new process group, waits for the child's receipt, prints it, and exits. The child runs the existing `run()` end-to-end.
  - Run-dir **lease** (`lease.json`, `pid`/`pgid`/`host`/`started_at`) so operators identify and kill only the owned pgid.
  - Completion **sentinel** (`review-round-N.done`, success or failure), analogous to the gate `.done` sentinel.
  - **Receipt** carries `{ runId, round, pid, pgid, logPath, sentinelPath }` + `leasePath`, `manifestPath`, `recoverCommand`.
- **`review-runner.js`**: writes the lease/receipt after `ensureRunLayout` (detached child only — no-op + byte-identical in the foreground) and delegates the module entry to `dispatchReviewEntry`. Facade stays under the 400-line cap.
- **Incompatible combos**: `--detach` rejects `--prepare-only` and `--review-file`-only applies with a clear error instead of silently ignoring the flag (DC #5).
- **Recovery**: a kill between verdict persistence and manifest apply reuses the existing `--review-file` apply semantics (unchanged) — documented in `relay-review/references/runner-notes.md` and echoed in the receipt's `recoverCommand`.
- **`cli.js` / `cli-schema.js`**: register `--detach` for `review-runner` (same mechanical registration `--wait-for-checks` used in #950); usage line added.

## Scope boundary

Confined to `review-runner.js`, `review-runner/cli.js`, the new `review-runner/detach.js`, `output.js` (usage line), the `cli-schema.js` flag registration, the references doc, and tests. Review logic, verdict schema, advisory lanes, escalation, the EVENTS enum, `--review-file` semantics, lifecycle transitions, and dispatch/merge scripts are untouched.

## Testing

`tests/relay-review/scripts/review-runner-detach.test.js` spawns the **real** detached process and asserts run-dir files + final manifest state (not mocked spawns), covering DC #6:
- **(a)** receipt shape + prompt return (parent returns before the 2.5s reviewer delay);
- **(b)** invoker-kill survival — SIGKILL the parent right after the receipt, verdict still applies to the manifest;
- **(c)** lease shape (`pid`/`pgid`/`host`/`started_at`) + completion sentinel;
- **(d)** verdict-persisted / apply-missing recovery via the documented `--review-file` path;
- plus the DC #5 incompatible-combo rejections.

Full serialized repo gate green: relay-review 575 pass, remaining 8 suites 1572 pass (2 skipped), 0 fail. Re-ran skills-lint (incl. main's new `ci-test-coverage.test.js`) + the detach suite after merging origin/main — 38 pass.

Closes #951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 리뷰 라운드를 `--detach` 옵션으로 실행할 수 있습니다.
  - 호출이 중단되거나 셸이 종료되어도 리뷰 라운드가 계속 진행됩니다.
  - 실행 영수증, 로그 경로, 복구 명령 및 완료 상태를 확인할 수 있습니다.
  - 저장된 리뷰 결과를 다시 적용해 중단된 매니페스트 반영을 복구할 수 있습니다.

- **문서**
  - 분리 실행, 장애 복구 및 지원되지 않는 옵션 조합에 대한 안내를 추가했습니다.

- **버그 수정**
  - `--detach`와 호환되지 않는 옵션 조합을 명확히 거부합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->