### PR TITLE
relay-orca: add fail-closed Orca capability probe and admission check

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -11,6 +11,7 @@ metadata:
 - Env: optional `RELAY_SKILL_ROOT` defaults to `skills`.
 - Files: an already-accepted program/epic contract as JSON (`--program-file`). Schema: [references/accepted-program-schema.md](references/accepted-program-schema.md).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js` (read-only wave-plan compiler).
+- Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js` (fail-closed Orca capability probe).
 
 # relay-orca
 
@@ -70,6 +71,14 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js" \
 ```
 
 `plan` is READ-ONLY: it creates no Orca task or terminal, no relay request/run/worktree, no PR, and no issue, and writes nothing outside stdout/stderr. On rejection it exits with a distinct non-zero code per reason. Rejection matrix and exit codes: [references/commands.md](references/commands.md).
+
+Admit a local Orca runtime before runtime intents (default read-only; optional `--smoke`):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json
+```
+
+Probe rationale, guarantees, and reason codes: [references/capability-probe.md](references/capability-probe.md).
 
 ## Ownership invariants
 

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -1,0 +1,82 @@
+# Orca capability probe
+
+The capability probe (`scripts/probe-orca.js`) is the **authoritative** admission gate for
+relay-orca runtime intents. A version string alone cannot prove that task creation, injected
+dispatch context, lifecycle IDs, or runtime readiness behave as relay-orca expects. The
+targeted mid-2026 Orca CLI also exposes **no version subcommand** (`orca version` → "Unknown
+command"; `orca --version` prints usage), so version is best-effort only and never blocks
+admission. The orchestration surface is experimental and evolving — **revalidate this probe
+on Orca upgrades**.
+
+## Why probe over minimum-version
+
+| Claim a version string cannot prove | What the probe verifies |
+| --- | --- |
+| Desktop app / runtime graph is ready | `orca status --json` readiness conjuncts |
+| Orchestration commands exist and are enabled | `orchestration task-list --json` |
+| Runtime-global state is empty for v0 | task-list + gate-list counts both `=== 0` |
+| Injected dispatch returns provenance IDs | Explicit `--smoke` create + `dispatch --inject` |
+
+## Targeted CLI surface (mid-2026)
+
+Read-only default:
+
+- `orca status --json`
+- `orca orchestration task-list --json`
+- `orca orchestration gate-list --json`
+
+Smoke-only (explicit `--smoke`):
+
+- `orca orchestration task-create --spec … --task-title … --json`
+- `orca orchestration dispatch --task … --to … --inject --json`
+- `orca orchestration task-update --id … --status … --json`
+
+**Never** invoked on any path: `orca orchestration reset`.
+
+## Check order (first failure wins)
+
+1. Binary resolution (`--orca-bin` → `PATH` → macOS bundle fallback)
+2. Runtime readiness (`status --json`)
+3. Orchestration availability (`task-list --json`)
+4. Existing global state (`task-list` + `gate-list` counts / runtimeId consistency)
+5. Optional smoke (only when `--smoke` and all prior checks passed)
+
+Checks after a failed check may be skipped and are recorded as `skipped` in `checks[]`.
+
+## Reason codes and exit codes
+
+| reason_code | exit | trigger |
+| --- | --- | --- |
+| `BINARY_NOT_FOUND` | 30 | All resolution branches miss |
+| `RUNTIME_NOT_READY` | 31 | Well-formed status fails a readiness conjunct |
+| `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent/disabled/`ok:false` |
+| `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
+| `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate `count > 0` (never adopted) |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Bad counts or `_meta.runtimeId` mismatch |
+| `SMOKE_FAILED` | 36 | Smoke provenance verification failed |
+| `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
+
+Usage errors (unknown flags, missing args) exit `64`.
+
+## Guarantees
+
+- **D1 read-only default** — without `--smoke`, the probe spawns only `status`,
+  `orchestration task-list`, and `orchestration gate-list`. It creates no Orca task,
+  terminal, worktree, relay request/run, PR, or tracker issue, and writes nothing to the
+  filesystem (stdout/stderr only).
+- **D2 no-reset** — no code path invokes `orca orchestration reset`, including error and
+  smoke-cleanup-failure paths.
+- **D9 smoke** — runs only under `--smoke`, only after default checks pass; creates exactly
+  one synthetic task whose title contains `relay-orca-probe-smoke`; requires non-empty
+  task / dispatch / assignee IDs; cleans up only IDs it created via `task-update` to a
+  terminal status; never touches pre-existing IDs and never calls reset.
+
+## Invocation
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json --smoke
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json --orca-bin /path/to/orca
+```
+
+See [commands.md](commands.md) for the flag table and JSON surface summary.

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -35,10 +35,11 @@ Smoke-only (explicit `--smoke`):
 
 ## Check order (first failure wins)
 
-1. Binary resolution (`--orca-bin` → `PATH` → macOS bundle fallback). First hit
-   wins; a `--orca-bin` override that does not exist is a **miss**, not a
-   short-circuit — resolution falls through to `PATH` and then the bundle, and
-   `BINARY_NOT_FOUND` is raised only when all three ordered branches miss.
+1. Binary resolution (`--orca-bin` → `PATH` → macOS bundle fallback). A candidate
+   is a hit only when it is a **regular, executable file**; anything that is not
+   (missing, a directory, or non-executable) is a **miss**, not a short-circuit —
+   resolution falls through to `PATH` and then the bundle, and `BINARY_NOT_FOUND`
+   is raised only when all three ordered branches miss.
 2. Runtime readiness (`status --json`)
 3. Orchestration availability (`task-list --json`)
 4. Existing global state (`task-list` + `gate-list` counts / runtimeId consistency)

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -56,7 +56,7 @@ Checks after a failed check may be skipped and are recorded as `skipped` in `che
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent/disabled/`ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
 | `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate `count > 0` (never adopted) |
-| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer `count`, a `count` that disagrees with its own array length, or a `_meta.runtimeId` that is missing/empty on any probed response or mismatched across them |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer `count`, a `count` that disagrees with its own array length, or a runtime id that is missing/empty on any probed response or disagrees across them — the status `runtime.runtimeId` and every `_meta.runtimeId` (status, task-list, gate-list) must all be present, non-empty, and identical |
 | `SMOKE_FAILED` | 36 | Smoke provenance verification failed |
 | `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
 

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -51,7 +51,7 @@ Checks after a failed check may be skipped and are recorded as `skipped` in `che
 | reason_code | exit | trigger |
 | --- | --- | --- |
 | `BINARY_NOT_FOUND` | 30 | All resolution branches miss |
-| `RUNTIME_NOT_READY` | 31 | Well-formed status fails a readiness conjunct |
+| `RUNTIME_NOT_READY` | 31 | Well-formed status fails a readiness conjunct, or `status` exits non-zero with shape-valid stdout |
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent/disabled/`ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
 | `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate `count > 0` (never adopted) |
@@ -82,10 +82,11 @@ Every subprocess-derived value that lands in a human-readable `message` or
 `remediation` string — readiness conjuncts (`runtime.state`, `runtimeId`,
 `graph.state`), `_meta.runtimeId` mismatch pairs, smoke task/dispatch/assignee
 IDs, the smoke leftover-cleanup ID, and any `stderr`/parse excerpt — is rendered
-through a single helper that truncates to 256 characters and appends a `…`
-marker when truncated. A hung or adversarial CLI therefore cannot inflate a
-blocking message or inject extra lines into it; the eleven top-level JSON keys,
-reason codes, and exit codes are unaffected.
+through a single helper that truncates so the returned excerpt is at most 256
+characters **total, including** the appended `…` marker (255 input chars + the
+marker). A hung or adversarial CLI therefore cannot inflate a blocking message
+or inject extra lines into it; the eleven top-level JSON keys, reason codes, and
+exit codes are unaffected.
 
 ## Guarantees
 
@@ -98,7 +99,10 @@ reason codes, and exit codes are unaffected.
 - **D9 smoke** — runs only under `--smoke`, only after default checks pass; creates exactly
   one synthetic task whose title contains `relay-orca-probe-smoke`; requires non-empty
   task / dispatch / assignee IDs; cleans up only IDs it created via `task-update` to a
-  terminal status; never touches pre-existing IDs and never calls reset.
+  terminal status; never touches pre-existing IDs and never calls reset. When `task-create`
+  returns ok but no task id, the probe fails `SMOKE_FAILED` with `cleaned_up:false` (no id
+  to clean) and its remediation names the `relay-orca-probe-smoke` title marker so the
+  operator can find any untracked synthetic task via `orca orchestration task-list`.
 
 ## Invocation
 

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -14,7 +14,7 @@ on Orca upgrades**.
 | --- | --- |
 | Desktop app / runtime graph is ready | `orca status --json` readiness conjuncts |
 | Orchestration commands exist and are enabled | `orchestration task-list --json` |
-| Runtime-global state is empty for v0 | task-list + gate-list counts both `=== 0` |
+| Runtime-global state is empty for v0 | task-list + gate-list counts both `=== 0` and each `count` equals its own array length |
 | Injected dispatch returns provenance IDs | Explicit `--smoke` create + `dispatch --inject` |
 
 ## Targeted CLI surface (mid-2026)
@@ -52,11 +52,26 @@ Checks after a failed check may be skipped and are recorded as `skipped` in `che
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent/disabled/`ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
 | `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate `count > 0` (never adopted) |
-| `AMBIGUOUS_GLOBAL_STATE` | 35 | Bad counts or `_meta.runtimeId` mismatch |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer `count`, a `count` that disagrees with its own array length, or `_meta.runtimeId` mismatch |
 | `SMOKE_FAILED` | 36 | Smoke provenance verification failed |
 | `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
 
 Usage errors (unknown flags, missing args) exit `64`.
+
+A `count` that contradicts its own array (e.g. `count:0` alongside a non-empty
+`tasks`/`gates`) is treated as ambiguous rather than trusted — the probe never
+adopts state the count claims is absent.
+
+## Bounded execution (no hangs)
+
+Every Orca invocation runs with a finite `timeout` (default 10000 ms) and a
+bounded `maxBuffer`, so a hung or wedged CLI cannot stall the probe forever. A
+timed-out command is killed and flows through the **same** per-check failure
+classification as any non-zero exit or spawn error of that command (a hung
+`status` → `MALFORMED_OUTPUT`; a hung `task-list`/`gate-list` →
+`ORCHESTRATION_UNAVAILABLE`), so the stable JSON envelope is still emitted with
+`admitted:false`. Set `RELAY_ORCA_PROBE_TIMEOUT_MS` (positive integer; invalid
+values are ignored and fall back to the default) to shorten the budget in tests.
 
 ## Guarantees
 

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -56,7 +56,7 @@ Checks after a failed check may be skipped and are recorded as `skipped` in `che
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent/disabled/`ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
 | `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate `count > 0` (never adopted) |
-| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer `count`, a `count` that disagrees with its own array length, or `_meta.runtimeId` mismatch |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer `count`, a `count` that disagrees with its own array length, or a `_meta.runtimeId` that is missing/empty on any probed response or mismatched across them |
 | `SMOKE_FAILED` | 36 | Smoke provenance verification failed |
 | `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
 

--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -35,7 +35,10 @@ Smoke-only (explicit `--smoke`):
 
 ## Check order (first failure wins)
 
-1. Binary resolution (`--orca-bin` → `PATH` → macOS bundle fallback)
+1. Binary resolution (`--orca-bin` → `PATH` → macOS bundle fallback). First hit
+   wins; a `--orca-bin` override that does not exist is a **miss**, not a
+   short-circuit — resolution falls through to `PATH` and then the bundle, and
+   `BINARY_NOT_FOUND` is raised only when all three ordered branches miss.
 2. Runtime readiness (`status --json`)
 3. Orchestration availability (`task-list --json`)
 4. Existing global state (`task-list` + `gate-list` counts / runtimeId consistency)
@@ -72,6 +75,17 @@ classification as any non-zero exit or spawn error of that command (a hung
 `ORCHESTRATION_UNAVAILABLE`), so the stable JSON envelope is still emitted with
 `admitted:false`. Set `RELAY_ORCA_PROBE_TIMEOUT_MS` (positive integer; invalid
 values are ignored and fall back to the default) to shorten the budget in tests.
+
+## Bounded message excerpts (D8)
+
+Every subprocess-derived value that lands in a human-readable `message` or
+`remediation` string — readiness conjuncts (`runtime.state`, `runtimeId`,
+`graph.state`), `_meta.runtimeId` mismatch pairs, smoke task/dispatch/assignee
+IDs, the smoke leftover-cleanup ID, and any `stderr`/parse excerpt — is rendered
+through a single helper that truncates to 256 characters and appends a `…`
+marker when truncated. A hung or adversarial CLI therefore cannot inflate a
+blocking message or inject extra lines into it; the eleven top-level JSON keys,
+reason codes, and exit codes are unaffected.
 
 ## Guarantees
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -54,8 +54,43 @@ Structural guards use their own codes: `INVALID_INPUT` (2), `DUPLICATE_OUTCOME_I
 `UNKNOWN_DEPENDENCY` (4), `INVALID_WAVE_DECLARATION` (5). Missing/unreadable program files or
 unknown flags exit `64` (usage).
 
+## `probe` — fail-closed Orca capability admission
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" \
+  [--json] [--smoke] [--orca-bin <path>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--json` | Emit the D8 admission envelope as JSON on stdout. |
+| `--smoke` | After default checks pass, run a self-cleaning synthetic injection smoke. |
+| `--orca-bin <path>` | Explicit Orca CLI override (wins over PATH and the macOS bundle fallback). |
+| `--help`, `-h` | Print usage. |
+
+Default mode is **READ-ONLY**: it spawns only `orca status --json`,
+`orca orchestration task-list --json`, and `orca orchestration gate-list --json`. It never
+invokes `orca orchestration reset`. Full rationale, check order, smoke semantics, and the
+reason-code table: [capability-probe.md](capability-probe.md).
+
+### Probe rejection matrix
+
+| reason_code | exit | Trigger |
+| --- | --- | --- |
+| `BINARY_NOT_FOUND` | 30 | `--orca-bin`, PATH, and macOS bundle fallback all miss |
+| `RUNTIME_NOT_READY` | 31 | Well-formed `status` fails a readiness conjunct |
+| `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent, disabled, or `ok:false` |
+| `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
+| `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate count `> 0` (never adopted) |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Bad counts or `_meta.runtimeId` mismatch |
+| `SMOKE_FAILED` | 36 | Smoke provenance (task/dispatch/assignee) failed |
+| `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
+
+Usage errors exit `64`.
+
 ## Runtime intents (contract-only in this leaf)
 
 `run`, `status`, `resume`, and `stop` are defined by the skill contract but are **not
 implemented here**. They are delivered in a later leaf (#944) and gated on the Orca capability
-probe. See [experimental-status.md](experimental-status.md) for the pilot boundary.
+probe (`probe-orca.js`). See [experimental-status.md](experimental-status.md) for the pilot
+boundary and [capability-probe.md](capability-probe.md) for admission details.

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -82,11 +82,16 @@ reason-code table: [capability-probe.md](capability-probe.md).
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent, disabled, or `ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
 | `EXISTING_ORCHESTRATION_STATE` | 34 | Task or gate count `> 0` (never adopted) |
-| `AMBIGUOUS_GLOBAL_STATE` | 35 | Bad counts or `_meta.runtimeId` mismatch |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer count, a count that disagrees with its own array length, or `_meta.runtimeId` mismatch |
 | `SMOKE_FAILED` | 36 | Smoke provenance (task/dispatch/assignee) failed |
 | `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
 
 Usage errors exit `64`.
+
+Every Orca invocation carries a finite timeout (default 10000 ms), so a hung CLI
+still classifies through the matrix above and emits the JSON envelope instead of
+hanging. `RELAY_ORCA_PROBE_TIMEOUT_MS` (positive integer; invalid values ignored)
+shortens the budget for tests.
 
 ## Runtime intents (contract-only in this leaf)
 

--- a/skills/relay-orca/scripts/lib/probe-reasons.js
+++ b/skills/relay-orca/scripts/lib/probe-reasons.js
@@ -1,0 +1,54 @@
+"use strict";
+
+// Probe rejection matrix (D7). Exit codes stay in 30–37 so they never collide with
+// plan.js's 2–21 range or Node's fatal/exec codes (<=125).
+const REASONS = {
+  BINARY_NOT_FOUND: 30,
+  RUNTIME_NOT_READY: 31,
+  ORCHESTRATION_UNAVAILABLE: 32,
+  MALFORMED_OUTPUT: 33,
+  EXISTING_ORCHESTRATION_STATE: 34,
+  AMBIGUOUS_GLOBAL_STATE: 35,
+  SMOKE_FAILED: 36,
+  SMOKE_CLEANUP_FAILED: 37,
+};
+
+const USAGE_EXIT = 64;
+
+const REMEDIATION = {
+  BINARY_NOT_FOUND:
+    "Install Orca, ensure `orca` is on PATH, or pass --orca-bin <path> to the CLI binary.",
+  RUNTIME_NOT_READY:
+    "Start the Orca desktop app and wait until status reports app running with runtime/graph ready.",
+  ORCHESTRATION_UNAVAILABLE:
+    "Enable the experimental Orca orchestration surface, then re-run the probe.",
+  MALFORMED_OUTPUT:
+    "Upgrade or reinstall Orca so status/orchestration --json responses match the mid-2026 CLI shape.",
+  EXISTING_ORCHESTRATION_STATE:
+    "Clear or finish the existing Orca tasks/gates manually (never via automated reset), then re-probe.",
+  AMBIGUOUS_GLOBAL_STATE:
+    "Inspect orca status and orchestration list outputs for inconsistent runtime IDs or counts; resolve manually.",
+  SMOKE_FAILED:
+    "Fix task-create/dispatch --inject so they return non-empty task, dispatch, and assignee IDs.",
+  SMOKE_CLEANUP_FAILED:
+    "Terminalize leftover smoke-created task IDs named in the message; do not run orchestration reset.",
+};
+
+class ProbeError extends Error {
+  constructor(reasonCode, message, remediation) {
+    super(message);
+    this.name = "ProbeError";
+    this.reasonCode = reasonCode;
+    this.exitCode = REASONS[reasonCode];
+    this.remediation = remediation || REMEDIATION[reasonCode] || "";
+    if (this.exitCode === undefined) {
+      throw new Error(`unknown probe reason code: ${reasonCode}`);
+    }
+  }
+}
+
+function reject(reasonCode, message, remediation) {
+  throw new ProbeError(reasonCode, message, remediation);
+}
+
+module.exports = { REASONS, REMEDIATION, USAGE_EXIT, ProbeError, reject };

--- a/skills/relay-orca/scripts/lib/resolve-orca-bin.js
+++ b/skills/relay-orca/scripts/lib/resolve-orca-bin.js
@@ -7,6 +7,19 @@ const path = require("node:path");
 // be embedded; never embed home-directory or user-specific absolute paths.
 const MACOS_BUNDLE_FALLBACK = "/Applications/Orca.app/Contents/Resources/bin/orca";
 
+// A candidate is a HIT only when it is a REGULAR FILE that is EXECUTABLE. A
+// directory, a missing path, or a non-executable file is a MISS: the resolver
+// must not hand the spawn a path it cannot run and then misclassify the failure.
+function isRunnableFile(candidate) {
+  try {
+    if (!fs.statSync(candidate).isFile()) return false;
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Resolve the Orca CLI binary.
  * Order (first hit wins): --orca-bin override → PATH → macOS bundle fallback.
@@ -15,35 +28,35 @@ const MACOS_BUNDLE_FALLBACK = "/Applications/Orca.app/Contents/Resources/bin/orc
  * @param {string|null} [options.orcaBinOverride]
  * @param {string} [options.pathEnv]
  * @param {string} [options.pathDelimiter]
- * @param {(p: string) => boolean} [options.existsSync]
+ * @param {(p: string) => boolean} [options.isRunnableFile]
  * @returns {{ path: string|null, source: "override"|"path"|"bundle"|null }}
  */
 function resolveOrcaBin(options = {}) {
-  const existsSync = options.existsSync || fs.existsSync;
+  const runnable = options.isRunnableFile || isRunnableFile;
   const pathEnv = options.pathEnv !== undefined ? options.pathEnv : process.env.PATH || "";
   const pathDelimiter = options.pathDelimiter || path.delimiter;
   const orcaBinOverride = options.orcaBinOverride || null;
 
-  // First hit wins (D3). A missing/non-executable override is a MISS, not a
-  // short-circuit: fall through to PATH and then the bundle so BINARY_NOT_FOUND
-  // is raised only when all three ordered branches miss.
-  if (orcaBinOverride && existsSync(orcaBinOverride)) {
+  // First hit wins (D3). A candidate that is not a regular executable file is a
+  // MISS, not a short-circuit: fall through to PATH and then the bundle so
+  // BINARY_NOT_FOUND is raised only when all three ordered branches miss.
+  if (orcaBinOverride && runnable(orcaBinOverride)) {
     return { path: orcaBinOverride, source: "override" };
   }
 
   const dirs = pathEnv.split(pathDelimiter).filter(Boolean);
   for (const dir of dirs) {
     const candidate = path.join(dir, "orca");
-    if (existsSync(candidate)) {
+    if (runnable(candidate)) {
       return { path: candidate, source: "path" };
     }
   }
 
-  if (existsSync(MACOS_BUNDLE_FALLBACK)) {
+  if (runnable(MACOS_BUNDLE_FALLBACK)) {
     return { path: MACOS_BUNDLE_FALLBACK, source: "bundle" };
   }
 
   return { path: null, source: null };
 }
 
-module.exports = { resolveOrcaBin, MACOS_BUNDLE_FALLBACK };
+module.exports = { resolveOrcaBin, isRunnableFile, MACOS_BUNDLE_FALLBACK };

--- a/skills/relay-orca/scripts/lib/resolve-orca-bin.js
+++ b/skills/relay-orca/scripts/lib/resolve-orca-bin.js
@@ -24,12 +24,11 @@ function resolveOrcaBin(options = {}) {
   const pathDelimiter = options.pathDelimiter || path.delimiter;
   const orcaBinOverride = options.orcaBinOverride || null;
 
-  if (orcaBinOverride) {
-    if (existsSync(orcaBinOverride)) {
-      return { path: orcaBinOverride, source: "override" };
-    }
-    // Explicit override was requested but missing — do not silently fall through.
-    return { path: null, source: null };
+  // First hit wins (D3). A missing/non-executable override is a MISS, not a
+  // short-circuit: fall through to PATH and then the bundle so BINARY_NOT_FOUND
+  // is raised only when all three ordered branches miss.
+  if (orcaBinOverride && existsSync(orcaBinOverride)) {
+    return { path: orcaBinOverride, source: "override" };
   }
 
   const dirs = pathEnv.split(pathDelimiter).filter(Boolean);

--- a/skills/relay-orca/scripts/lib/resolve-orca-bin.js
+++ b/skills/relay-orca/scripts/lib/resolve-orca-bin.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Documented macOS application-bundle fallback (D3). No other absolute path may
+// be embedded; never embed home-directory or user-specific absolute paths.
+const MACOS_BUNDLE_FALLBACK = "/Applications/Orca.app/Contents/Resources/bin/orca";
+
+/**
+ * Resolve the Orca CLI binary.
+ * Order (first hit wins): --orca-bin override → PATH → macOS bundle fallback.
+ *
+ * @param {object} [options]
+ * @param {string|null} [options.orcaBinOverride]
+ * @param {string} [options.pathEnv]
+ * @param {string} [options.pathDelimiter]
+ * @param {(p: string) => boolean} [options.existsSync]
+ * @returns {{ path: string|null, source: "override"|"path"|"bundle"|null }}
+ */
+function resolveOrcaBin(options = {}) {
+  const existsSync = options.existsSync || fs.existsSync;
+  const pathEnv = options.pathEnv !== undefined ? options.pathEnv : process.env.PATH || "";
+  const pathDelimiter = options.pathDelimiter || path.delimiter;
+  const orcaBinOverride = options.orcaBinOverride || null;
+
+  if (orcaBinOverride) {
+    if (existsSync(orcaBinOverride)) {
+      return { path: orcaBinOverride, source: "override" };
+    }
+    // Explicit override was requested but missing — do not silently fall through.
+    return { path: null, source: null };
+  }
+
+  const dirs = pathEnv.split(pathDelimiter).filter(Boolean);
+  for (const dir of dirs) {
+    const candidate = path.join(dir, "orca");
+    if (existsSync(candidate)) {
+      return { path: candidate, source: "path" };
+    }
+  }
+
+  if (existsSync(MACOS_BUNDLE_FALLBACK)) {
+    return { path: MACOS_BUNDLE_FALLBACK, source: "bundle" };
+  }
+
+  return { path: null, source: null };
+}
+
+module.exports = { resolveOrcaBin, MACOS_BUNDLE_FALLBACK };

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -35,10 +35,14 @@ const JSON_KEYS = Object.freeze([
   "smoke",
 ]);
 
-function truncateExcerpt(text) {
-  const value = String(text || "").replace(/\s+/g, " ").trim();
-  if (value.length <= EXCERPT_LIMIT) return value;
-  return value.slice(0, EXCERPT_LIMIT);
+// Single bounded-rendering helper (D8). EVERY subprocess-derived value embedded
+// in a human-readable message/remediation must pass through this so an adversarial
+// or wedged CLI cannot inflate or line-inject a blocking message. Collapses
+// whitespace, truncates to EXCERPT_LIMIT, and appends a marker when truncated.
+function boundedExcerpt(value) {
+  const text = String(value).replace(/\s+/g, " ").trim();
+  if (text.length <= EXCERPT_LIMIT) return text;
+  return `${text.slice(0, EXCERPT_LIMIT)}…`;
 }
 
 function resolveProbeTimeoutMs(env) {
@@ -82,7 +86,7 @@ function parseJsonOutput(stdout) {
   try {
     return { ok: true, value: JSON.parse(text) };
   } catch (error) {
-    return { ok: false, error: error.message, excerpt: truncateExcerpt(text) };
+    return { ok: false, error: error.message, excerpt: boundedExcerpt(text) };
   }
 }
 
@@ -344,7 +348,7 @@ function runSmoke(result, orcaBin, run, options) {
       smokeError = new ProbeError(
         "SMOKE_FAILED",
         `smoke task-create failed` +
-          (createProc.stderr ? `: ${truncateExcerpt(createProc.stderr)}` : ""),
+          (createProc.stderr ? `: ${boundedExcerpt(createProc.stderr)}` : ""),
       );
     } else {
       taskId = extractCreatedId(createParsed.value, ["task_id", "taskId", "id"]);
@@ -382,7 +386,7 @@ function runSmoke(result, orcaBin, run, options) {
         smokeError = new ProbeError(
           "SMOKE_FAILED",
           `smoke dispatch --inject failed` +
-            (dispatchProc.stderr ? `: ${truncateExcerpt(dispatchProc.stderr)}` : ""),
+            (dispatchProc.stderr ? `: ${boundedExcerpt(dispatchProc.stderr)}` : ""),
         );
       } else {
         dispatchId = extractCreatedId(dispatchParsed.value, [
@@ -397,8 +401,8 @@ function runSmoke(result, orcaBin, run, options) {
           smokeError = new ProbeError(
             "SMOKE_FAILED",
             "smoke dispatch provenance incomplete " +
-              `(task_id=${JSON.stringify(taskId)}, dispatch_id=${JSON.stringify(dispatchId)}, ` +
-              `assignee=${JSON.stringify(assignee)})`,
+              `(task_id=${boundedExcerpt(taskId)}, dispatch_id=${boundedExcerpt(dispatchId)}, ` +
+              `assignee=${boundedExcerpt(assignee)})`,
           );
         }
       }
@@ -408,7 +412,7 @@ function runSmoke(result, orcaBin, run, options) {
     else {
       smokeError = new ProbeError(
         "SMOKE_FAILED",
-        `smoke failed: ${truncateExcerpt(error.message)}`,
+        `smoke failed: ${boundedExcerpt(error.message)}`,
       );
     }
   }
@@ -441,8 +445,8 @@ function runSmoke(result, orcaBin, run, options) {
       recordCheck(result.checks, "smoke", "failed");
       reject(
         "SMOKE_CLEANUP_FAILED",
-        `failed to terminalize smoke-created task leftover id=${taskId}` +
-          (updateProc.stderr ? `: ${truncateExcerpt(updateProc.stderr)}` : ""),
+        `failed to terminalize smoke-created task leftover id=${boundedExcerpt(taskId)}` +
+          (updateProc.stderr ? `: ${boundedExcerpt(updateProc.stderr)}` : ""),
       );
     }
   } else {
@@ -531,9 +535,9 @@ function probe(options = {}) {
       "orca status --json did not report a ready runtime " +
         `(ok=${statusShape.payload.ok}, app.running=${statusShape.payload.result.app.running}, ` +
         `runtime.reachable=${statusShape.payload.result.runtime.reachable}, ` +
-        `runtime.state=${JSON.stringify(statusShape.payload.result.runtime.state)}, ` +
-        `runtimeId=${JSON.stringify(statusShape.payload.result.runtime.runtimeId)}, ` +
-        `graph.state=${JSON.stringify(statusShape.payload.result.graph.state)})`,
+        `runtime.state=${boundedExcerpt(statusShape.payload.result.runtime.state)}, ` +
+        `runtimeId=${boundedExcerpt(statusShape.payload.result.runtime.runtimeId)}, ` +
+        `graph.state=${boundedExcerpt(statusShape.payload.result.graph.state)})`,
     );
   }
   recordCheck(result.checks, "runtime_ready", "ok");
@@ -555,7 +559,7 @@ function probe(options = {}) {
       "ORCHESTRATION_UNAVAILABLE",
       `orca orchestration task-list failed or is unknown` +
         (taskListProc.stderr
-          ? `: ${truncateExcerpt(taskListProc.stderr)}`
+          ? `: ${boundedExcerpt(taskListProc.stderr)}`
           : ` (exit ${taskListProc.status})`),
     );
   }
@@ -614,7 +618,7 @@ function probe(options = {}) {
       "ORCHESTRATION_UNAVAILABLE",
       `orca orchestration gate-list failed or is unknown` +
         (gateListProc.stderr
-          ? `: ${truncateExcerpt(gateListProc.stderr)}`
+          ? `: ${boundedExcerpt(gateListProc.stderr)}`
           : ` (exit ${gateListProc.status})`),
     );
   }
@@ -664,7 +668,8 @@ function probe(options = {}) {
     reject(
       "AMBIGUOUS_GLOBAL_STATE",
       `orchestration _meta.runtimeId does not match status runtimeId ` +
-        `(status=${statusRuntimeId}, task-list=${taskMetaId}, gate-list=${gateMetaId})`,
+        `(status=${boundedExcerpt(statusRuntimeId)}, task-list=${boundedExcerpt(taskMetaId)}, ` +
+        `gate-list=${boundedExcerpt(gateMetaId)})`,
     );
   }
 

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -15,6 +15,11 @@ const SMOKE_SPEC = "relay-orca capability probe synthetic smoke (self-cleaning)"
 const SMOKE_TO_HANDLE = "relay-orca-probe-smoke";
 const SMOKE_TERMINAL_STATUS = "cancelled";
 const EXCERPT_LIMIT = 256;
+// Every Orca invocation is bounded so a hung CLI still reaches the rejection
+// matrix instead of hanging the probe forever. Tests may shorten the wall-clock
+// budget via RELAY_ORCA_PROBE_TIMEOUT_MS (positive integer; invalid → default).
+const DEFAULT_PROBE_TIMEOUT_MS = 10000;
+const PROBE_MAX_BUFFER = 4 * 1024 * 1024;
 
 const JSON_KEYS = Object.freeze([
   "ok",
@@ -36,20 +41,33 @@ function truncateExcerpt(text) {
   return value.slice(0, EXCERPT_LIMIT);
 }
 
+function resolveProbeTimeoutMs(env) {
+  const raw = (env || process.env).RELAY_ORCA_PROBE_TIMEOUT_MS;
+  if (raw === undefined || raw === null || raw === "") return DEFAULT_PROBE_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  return DEFAULT_PROBE_TIMEOUT_MS;
+}
+
 function runOrca(orcaBin, args, options = {}) {
   const argv = Array.isArray(args) ? args.map(String) : [];
   if (argv.includes("reset")) {
     throw new Error("probe-orca must never invoke orca orchestration reset (D2)");
   }
   const exec = options.execFileSync || execFileSync;
+  const env = options.env || process.env;
   try {
     const stdout = exec(orcaBin, argv, {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
-      env: options.env || process.env,
+      env,
+      timeout: resolveProbeTimeoutMs(env),
+      maxBuffer: PROBE_MAX_BUFFER,
     });
     return { status: 0, stdout: String(stdout || ""), stderr: "" };
   } catch (error) {
+    // A timed-out command is killed by signal (status null) → status 1 here, so
+    // it flows through the same per-check classification as any spawn failure.
     return {
       status: typeof error.status === "number" ? error.status : 1,
       stdout: error.stdout ? String(error.stdout) : "",
@@ -219,6 +237,16 @@ function extractListCount(payload, listKey, arrayKey) {
   }
   if (!isIntegerCount(result.count)) {
     return { ambiguous: true, message: `${listKey}.result.count must be a non-negative integer` };
+  }
+  // A count that contradicts its own array admits pre-existing state the D6 gate
+  // must reject (e.g. count:0 alongside a non-empty array). Fail closed.
+  if (result.count !== result[arrayKey].length) {
+    return {
+      ambiguous: true,
+      message:
+        `${listKey}.result.count (${result.count}) does not match ` +
+        `${arrayKey}.length (${result[arrayKey].length})`,
+    };
   }
   return { count: result.count, items: result[arrayKey] };
 }

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -685,10 +685,30 @@ function probe(options = {}) {
 
   const taskMetaId = metaRuntimeId(taskListShape.payload);
   const gateMetaId = metaRuntimeId(gateListShape.payload);
-  if (
-    (taskMetaId && taskMetaId !== statusRuntimeId) ||
-    (gateMetaId && gateMetaId !== statusRuntimeId)
-  ) {
+  // Cross-runtime consistency: all three responses MUST carry a non-empty
+  // runtime id (status sources the D4-validated runtime.runtimeId; the
+  // orchestration responses source _meta.runtimeId) and every id must be
+  // identical. A missing, empty, or non-string id on any response means the
+  // probe cannot establish that the responses came from one runtime — the SAME
+  // failure as a mismatch → AMBIGUOUS_GLOBAL_STATE, never a silent pass.
+  const runtimeIdSources = [
+    ["status", statusRuntimeId],
+    ["task-list", taskMetaId],
+    ["gate-list", gateMetaId],
+  ];
+  const missingIdSource = runtimeIdSources.find(([, id]) => !isNonEmptyString(id));
+  if (missingIdSource) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject(
+      "AMBIGUOUS_GLOBAL_STATE",
+      `${missingIdSource[0]} response lacked a non-empty runtime id; ` +
+        `cross-runtime consistency cannot be established ` +
+        `(status=${boundedExcerpt(statusRuntimeId)}, task-list=${boundedExcerpt(taskMetaId)}, ` +
+        `gate-list=${boundedExcerpt(gateMetaId)})`,
+    );
+  }
+  if (taskMetaId !== statusRuntimeId || gateMetaId !== statusRuntimeId) {
     recordCheck(result.checks, "existing_state", "failed");
     skipRemaining(result.checks, ["smoke"]);
     reject(

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -7,7 +7,7 @@
 // Subprocess helpers live HERE (not under scripts/lib/) so plan.js's frozen
 // D6 source scan — which forbids child_process across every lib module — stays green.
 const { execFileSync } = require("node:child_process");
-const { resolveOrcaBin, MACOS_BUNDLE_FALLBACK } = require("./lib/resolve-orca-bin");
+const { resolveOrcaBin, isRunnableFile, MACOS_BUNDLE_FALLBACK } = require("./lib/resolve-orca-bin");
 const { REASONS, USAGE_EXIT, ProbeError, reject } = require("./lib/probe-reasons");
 
 const SMOKE_TITLE_MARKER = "relay-orca-probe-smoke";
@@ -499,7 +499,7 @@ function probe(options = {}) {
   const resolved = resolveOrcaBin({
     orcaBinOverride: options.orcaBin || null,
     pathEnv: options.pathEnv,
-    existsSync: options.existsSync,
+    isRunnableFile: options.isRunnableFile,
     pathDelimiter: options.pathDelimiter,
   });
 
@@ -730,7 +730,7 @@ function runMain(argv = process.argv.slice(2), runtime = {}) {
       smoke: opts.smoke,
       orcaBin: opts.orcaBin,
       pathEnv: runtime.pathEnv,
-      existsSync: runtime.existsSync,
+      isRunnableFile: runtime.isRunnableFile,
       pathDelimiter: runtime.pathDelimiter,
       runOrca: runtime.runOrca,
       runOptions: runtime.runOptions,
@@ -764,5 +764,6 @@ module.exports = {
   SMOKE_TITLE_MARKER,
   REASONS,
   resolveOrcaBin,
+  isRunnableFile,
   MACOS_BUNDLE_FALLBACK,
 };

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -38,11 +38,12 @@ const JSON_KEYS = Object.freeze([
 // Single bounded-rendering helper (D8). EVERY subprocess-derived value embedded
 // in a human-readable message/remediation must pass through this so an adversarial
 // or wedged CLI cannot inflate or line-inject a blocking message. Collapses
-// whitespace, truncates to EXCERPT_LIMIT, and appends a marker when truncated.
+// whitespace and truncates so the RETURNED excerpt — the `…` marker included — is
+// at most EXCERPT_LIMIT characters total (EXCERPT_LIMIT-1 input chars + marker).
 function boundedExcerpt(value) {
   const text = String(value).replace(/\s+/g, " ").trim();
   if (text.length <= EXCERPT_LIMIT) return text;
-  return `${text.slice(0, EXCERPT_LIMIT)}…`;
+  return `${text.slice(0, EXCERPT_LIMIT - 1)}…`;
 }
 
 function resolveProbeTimeoutMs(env) {
@@ -323,6 +324,7 @@ function runSmoke(result, orcaBin, run, options) {
   let dispatchId = null;
   let assignee = null;
   let smokeError = null;
+  let syntheticTaskMaybeCreated = false;
 
   try {
     const createProc = run(
@@ -354,9 +356,16 @@ function runSmoke(result, orcaBin, run, options) {
       taskId = extractCreatedId(createParsed.value, ["task_id", "taskId", "id"]);
       result.smoke.task_id = taskId;
       if (!isNonEmptyString(taskId)) {
+        // task-create reported ok but returned no id: a synthetic task may have been
+        // created that we can neither reference nor clean up. Fail closed and hand the
+        // operator the title marker so they can find and terminalize it manually.
+        syntheticTaskMaybeCreated = true;
         smokeError = new ProbeError(
           "SMOKE_FAILED",
-          "smoke task-create did not return a non-empty task id",
+          "smoke task-create returned ok without a non-empty task id; a synthetic task " +
+            "may have been created without a returned id",
+          `Locate any untracked synthetic task by its "${SMOKE_TITLE_MARKER}" title marker ` +
+            "via `orca orchestration task-list`, then terminalize it manually (never run reset).",
         );
       }
     }
@@ -449,6 +458,10 @@ function runSmoke(result, orcaBin, run, options) {
           (updateProc.stderr ? `: ${boundedExcerpt(updateProc.stderr)}` : ""),
       );
     }
+  } else if (syntheticTaskMaybeCreated) {
+    // No id came back, so there is nothing to reference and no cleanup is attempted.
+    // Report cleaned_up=false truthfully because an untracked synthetic task may exist.
+    cleanedUp = false;
   } else {
     cleanedUp = true;
   }
@@ -523,6 +536,19 @@ function probe(options = {}) {
     recordCheck(result.checks, "runtime_ready", "failed");
     skipRemaining(result.checks, checkOrder.slice(2));
     reject("MALFORMED_OUTPUT", `orca status --json shape invalid: ${statusShape.message}`);
+  }
+  // A failed readiness command must never admit, even when its (possibly cached or
+  // partial) stdout is shape-valid and claims readiness. Unparseable/empty stdout
+  // already stayed MALFORMED_OUTPUT above; only shape-valid stdout reaches here, so a
+  // non-zero (or signal-killed → status 1) exit is a runtime failure, not malformed.
+  if (statusProc.status !== 0) {
+    recordCheck(result.checks, "runtime_ready", "failed");
+    skipRemaining(result.checks, checkOrder.slice(2));
+    reject(
+      "RUNTIME_NOT_READY",
+      `orca status --json exited non-zero (exit ${statusProc.status})` +
+        (statusProc.stderr ? `: ${boundedExcerpt(statusProc.stderr)}` : ""),
+    );
   }
   const readiness = evaluateReadiness(statusShape.payload);
   result.runtime_id = readiness.runtimeId;

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -683,19 +683,27 @@ function probe(options = {}) {
 
   result.existing_state = { tasks: taskCountInfo.count, gates: gateCountInfo.count };
 
+  const statusMetaId = metaRuntimeId(statusShape.payload);
   const taskMetaId = metaRuntimeId(taskListShape.payload);
   const gateMetaId = metaRuntimeId(gateListShape.payload);
-  // Cross-runtime consistency: all three responses MUST carry a non-empty
-  // runtime id (status sources the D4-validated runtime.runtimeId; the
-  // orchestration responses source _meta.runtimeId) and every id must be
-  // identical. A missing, empty, or non-string id on any response means the
-  // probe cannot establish that the responses came from one runtime — the SAME
-  // failure as a mismatch → AMBIGUOUS_GLOBAL_STATE, never a silent pass.
+  // Cross-runtime consistency: all FOUR runtime-id observations MUST be present,
+  // non-empty, and identical — the D4-validated status runtime.runtimeId AND the
+  // _meta.runtimeId echoed by the status, task-list, and gate-list responses. A
+  // missing, empty, or non-string id on any response, or any disagreement among
+  // the four, means the probe cannot establish that the responses came from one
+  // runtime — the SAME failure as a mismatch → AMBIGUOUS_GLOBAL_STATE, never a
+  // silent pass. The status response is observed twice on purpose: its D4 runtime
+  // id and its own _meta.runtimeId must BOTH be present and agree.
   const runtimeIdSources = [
     ["status", statusRuntimeId],
+    ["status", statusMetaId],
     ["task-list", taskMetaId],
     ["gate-list", gateMetaId],
   ];
+  const idExcerpts =
+    `status.runtime=${boundedExcerpt(statusRuntimeId)}, ` +
+    `status._meta=${boundedExcerpt(statusMetaId)}, ` +
+    `task-list=${boundedExcerpt(taskMetaId)}, gate-list=${boundedExcerpt(gateMetaId)}`;
   const missingIdSource = runtimeIdSources.find(([, id]) => !isNonEmptyString(id));
   if (missingIdSource) {
     recordCheck(result.checks, "existing_state", "failed");
@@ -703,19 +711,17 @@ function probe(options = {}) {
     reject(
       "AMBIGUOUS_GLOBAL_STATE",
       `${missingIdSource[0]} response lacked a non-empty runtime id; ` +
-        `cross-runtime consistency cannot be established ` +
-        `(status=${boundedExcerpt(statusRuntimeId)}, task-list=${boundedExcerpt(taskMetaId)}, ` +
-        `gate-list=${boundedExcerpt(gateMetaId)})`,
+        `cross-runtime consistency cannot be established (${idExcerpts})`,
     );
   }
-  if (taskMetaId !== statusRuntimeId || gateMetaId !== statusRuntimeId) {
+  const mismatchedIdSource = runtimeIdSources.find(([, id]) => id !== statusRuntimeId);
+  if (mismatchedIdSource) {
     recordCheck(result.checks, "existing_state", "failed");
     skipRemaining(result.checks, ["smoke"]);
     reject(
       "AMBIGUOUS_GLOBAL_STATE",
-      `orchestration _meta.runtimeId does not match status runtimeId ` +
-        `(status=${boundedExcerpt(statusRuntimeId)}, task-list=${boundedExcerpt(taskMetaId)}, ` +
-        `gate-list=${boundedExcerpt(gateMetaId)})`,
+      `${mismatchedIdSource[0]} runtime id does not match the status runtime id; ` +
+        `cross-runtime consistency cannot be established (${idExcerpts})`,
     );
   }
 

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -1,0 +1,709 @@
+"use strict";
+
+// relay-orca capability probe — fail-closed runtime admission (issue #942).
+// Default mode is strictly READ-ONLY (D1). Explicit --smoke performs a
+// self-cleaning synthetic injection check (D9). Never invokes orchestration reset (D2).
+//
+// Subprocess helpers live HERE (not under scripts/lib/) so plan.js's frozen
+// D6 source scan — which forbids child_process across every lib module — stays green.
+const { execFileSync } = require("node:child_process");
+const { resolveOrcaBin, MACOS_BUNDLE_FALLBACK } = require("./lib/resolve-orca-bin");
+const { REASONS, USAGE_EXIT, ProbeError, reject } = require("./lib/probe-reasons");
+
+const SMOKE_TITLE_MARKER = "relay-orca-probe-smoke";
+const SMOKE_SPEC = "relay-orca capability probe synthetic smoke (self-cleaning)";
+const SMOKE_TO_HANDLE = "relay-orca-probe-smoke";
+const SMOKE_TERMINAL_STATUS = "cancelled";
+const EXCERPT_LIMIT = 256;
+
+const JSON_KEYS = Object.freeze([
+  "ok",
+  "admitted",
+  "orca_bin",
+  "orca_version",
+  "runtime_id",
+  "runtime_ready",
+  "orchestration_available",
+  "existing_state",
+  "checks",
+  "blocking_reasons",
+  "smoke",
+]);
+
+function truncateExcerpt(text) {
+  const value = String(text || "").replace(/\s+/g, " ").trim();
+  if (value.length <= EXCERPT_LIMIT) return value;
+  return value.slice(0, EXCERPT_LIMIT);
+}
+
+function runOrca(orcaBin, args, options = {}) {
+  const argv = Array.isArray(args) ? args.map(String) : [];
+  if (argv.includes("reset")) {
+    throw new Error("probe-orca must never invoke orca orchestration reset (D2)");
+  }
+  const exec = options.execFileSync || execFileSync;
+  try {
+    const stdout = exec(orcaBin, argv, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: options.env || process.env,
+    });
+    return { status: 0, stdout: String(stdout || ""), stderr: "" };
+  } catch (error) {
+    return {
+      status: typeof error.status === "number" ? error.status : 1,
+      stdout: error.stdout ? String(error.stdout) : "",
+      stderr: error.stderr ? String(error.stderr) : "",
+    };
+  }
+}
+
+function parseJsonOutput(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return { ok: false, error: "empty stdout" };
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (error) {
+    return { ok: false, error: error.message, excerpt: truncateExcerpt(text) };
+  }
+}
+
+function parseArgs(argv) {
+  const opts = {
+    json: false,
+    smoke: false,
+    orcaBin: null,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") opts.json = true;
+    else if (arg === "--smoke") opts.smoke = true;
+    else if (arg === "--orca-bin") {
+      const value = argv[(i += 1)];
+      if (!value || value.startsWith("-")) usageError("--orca-bin requires a path");
+      opts.orcaBin = value;
+    } else if (arg === "--help" || arg === "-h") opts.help = true;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+function usageError(message) {
+  process.stderr.write(`relay-orca probe: ${message}\n`);
+  process.stderr.write(
+    "usage: probe-orca.js [--json] [--smoke] [--orca-bin <path>]\n",
+  );
+  process.exit(USAGE_EXIT);
+}
+
+function emptyResult(smokeRequested) {
+  return {
+    ok: false,
+    admitted: false,
+    orca_bin: null,
+    orca_version: null,
+    runtime_id: null,
+    runtime_ready: false,
+    orchestration_available: false,
+    existing_state: { tasks: null, gates: null },
+    checks: [],
+    blocking_reasons: [],
+    smoke: {
+      requested: Boolean(smokeRequested),
+      ran: false,
+      cleaned_up: null,
+      task_id: null,
+      dispatch_id: null,
+      assignee: null,
+    },
+  };
+}
+
+function recordCheck(checks, name, status) {
+  checks.push({ name, status });
+}
+
+function skipRemaining(checks, names) {
+  names.forEach((name) => {
+    if (!checks.some((entry) => entry.name === name)) {
+      recordCheck(checks, name, "skipped");
+    }
+  });
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isIntegerCount(value) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function looksLikeUnknownCommand(stderr, stdout) {
+  const text = `${stderr || ""}\n${stdout || ""}`.toLowerCase();
+  return text.includes("unknown command") || text.includes("unrecognized");
+}
+
+function assertStatusShape(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { malformed: true, message: "status JSON is not an object" };
+  }
+  if (typeof payload.ok !== "boolean") {
+    return { malformed: true, message: "status.ok must be a boolean" };
+  }
+  const result = payload.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return { malformed: true, message: "status.result must be an object" };
+  }
+  const app = result.app;
+  const runtime = result.runtime;
+  const graph = result.graph;
+  if (!app || typeof app !== "object" || typeof app.running !== "boolean") {
+    return { malformed: true, message: "status.result.app.running must be a boolean" };
+  }
+  if (!runtime || typeof runtime !== "object") {
+    return { malformed: true, message: "status.result.runtime must be an object" };
+  }
+  if (typeof runtime.reachable !== "boolean") {
+    return { malformed: true, message: "status.result.runtime.reachable must be a boolean" };
+  }
+  if (typeof runtime.state !== "string") {
+    return { malformed: true, message: "status.result.runtime.state must be a string" };
+  }
+  if (!("runtimeId" in runtime) || (runtime.runtimeId !== null && typeof runtime.runtimeId !== "string")) {
+    return { malformed: true, message: "status.result.runtime.runtimeId must be a string" };
+  }
+  if (!graph || typeof graph !== "object" || typeof graph.state !== "string") {
+    return { malformed: true, message: "status.result.graph.state must be a string" };
+  }
+  return { malformed: false, payload };
+}
+
+function evaluateReadiness(payload) {
+  const ready =
+    payload.ok === true &&
+    payload.result.app.running === true &&
+    payload.result.runtime.reachable === true &&
+    payload.result.runtime.state === "ready" &&
+    isNonEmptyString(payload.result.runtime.runtimeId) &&
+    payload.result.graph.state === "ready";
+  return {
+    ready,
+    runtimeId: isNonEmptyString(payload.result.runtime.runtimeId)
+      ? payload.result.runtime.runtimeId
+      : null,
+  };
+}
+
+function parseListPayload(payload, listKey) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { malformed: true, message: `${listKey} JSON is not an object` };
+  }
+  if (typeof payload.ok !== "boolean") {
+    return { malformed: true, message: `${listKey}.ok must be a boolean` };
+  }
+  return { malformed: false, payload };
+}
+
+function extractListCount(payload, listKey, arrayKey) {
+  const result = payload.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return { malformed: true, message: `${listKey}.result must be an object` };
+  }
+  if (!(arrayKey in result) || !Array.isArray(result[arrayKey])) {
+    return { malformed: true, message: `${listKey}.result.${arrayKey} must be an array` };
+  }
+  if (!("count" in result)) {
+    return { malformed: true, message: `${listKey}.result.count is missing` };
+  }
+  if (!isIntegerCount(result.count)) {
+    return { ambiguous: true, message: `${listKey}.result.count must be a non-negative integer` };
+  }
+  return { count: result.count, items: result[arrayKey] };
+}
+
+function metaRuntimeId(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  const meta = payload._meta;
+  if (!meta || typeof meta !== "object") return null;
+  return typeof meta.runtimeId === "string" ? meta.runtimeId : null;
+}
+
+function extractCreatedId(payload, keys) {
+  if (!payload || typeof payload !== "object") return null;
+  const result = payload.result;
+  if (!result || typeof result !== "object") return null;
+  for (const key of keys) {
+    if (isNonEmptyString(result[key])) return result[key];
+  }
+  if (result.task && isNonEmptyString(result.task.id)) return result.task.id;
+  if (result.dispatch && isNonEmptyString(result.dispatch.id)) return result.dispatch.id;
+  return null;
+}
+
+function extractAssignee(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  const result = payload.result;
+  if (!result || typeof result !== "object") return null;
+  if (isNonEmptyString(result.assignee)) return result.assignee;
+  if (result.dispatch && isNonEmptyString(result.dispatch.assignee)) {
+    return result.dispatch.assignee;
+  }
+  if (isNonEmptyString(result.to)) return result.to;
+  return null;
+}
+
+function blockingReason(error) {
+  return {
+    reason_code: error.reasonCode,
+    message: error.message,
+    remediation: error.remediation || "",
+  };
+}
+
+function printResult(result, json) {
+  if (json) {
+    const ordered = {};
+    JSON_KEYS.forEach((key) => {
+      ordered[key] = result[key];
+    });
+    process.stdout.write(`${JSON.stringify(ordered, null, 2)}\n`);
+    return;
+  }
+  if (result.admitted) {
+    process.stdout.write(
+      `relay-orca probe: admitted (orca_bin=${result.orca_bin}, runtime_id=${result.runtime_id})\n`,
+    );
+  } else {
+    const reason = result.blocking_reasons[0];
+    process.stderr.write(
+      `relay-orca probe rejected [${reason ? reason.reason_code : "UNKNOWN"}]: ` +
+        `${reason ? reason.message : "not admitted"}\n`,
+    );
+  }
+}
+
+function runSmoke(result, orcaBin, run, options) {
+  result.smoke.ran = true;
+  let cleanedUp = false;
+  let taskId = null;
+  let dispatchId = null;
+  let assignee = null;
+  let smokeError = null;
+
+  try {
+    const createProc = run(
+      orcaBin,
+      [
+        "orchestration",
+        "task-create",
+        "--spec",
+        SMOKE_SPEC,
+        "--task-title",
+        `${SMOKE_TITLE_MARKER} admission check`,
+        "--json",
+      ],
+      options.runOptions,
+    );
+    const createParsed = parseJsonOutput(createProc.stdout);
+    if (
+      createProc.status !== 0 ||
+      !createParsed.ok ||
+      !createParsed.value ||
+      createParsed.value.ok !== true
+    ) {
+      smokeError = new ProbeError(
+        "SMOKE_FAILED",
+        `smoke task-create failed` +
+          (createProc.stderr ? `: ${truncateExcerpt(createProc.stderr)}` : ""),
+      );
+    } else {
+      taskId = extractCreatedId(createParsed.value, ["task_id", "taskId", "id"]);
+      result.smoke.task_id = taskId;
+      if (!isNonEmptyString(taskId)) {
+        smokeError = new ProbeError(
+          "SMOKE_FAILED",
+          "smoke task-create did not return a non-empty task id",
+        );
+      }
+    }
+
+    if (!smokeError) {
+      const dispatchProc = run(
+        orcaBin,
+        [
+          "orchestration",
+          "dispatch",
+          "--task",
+          taskId,
+          "--to",
+          SMOKE_TO_HANDLE,
+          "--inject",
+          "--json",
+        ],
+        options.runOptions,
+      );
+      const dispatchParsed = parseJsonOutput(dispatchProc.stdout);
+      if (
+        dispatchProc.status !== 0 ||
+        !dispatchParsed.ok ||
+        !dispatchParsed.value ||
+        dispatchParsed.value.ok !== true
+      ) {
+        smokeError = new ProbeError(
+          "SMOKE_FAILED",
+          `smoke dispatch --inject failed` +
+            (dispatchProc.stderr ? `: ${truncateExcerpt(dispatchProc.stderr)}` : ""),
+        );
+      } else {
+        dispatchId = extractCreatedId(dispatchParsed.value, [
+          "dispatch_id",
+          "dispatchId",
+          "id",
+        ]);
+        assignee = extractAssignee(dispatchParsed.value);
+        result.smoke.dispatch_id = dispatchId;
+        result.smoke.assignee = assignee;
+        if (!isNonEmptyString(dispatchId) || !isNonEmptyString(assignee)) {
+          smokeError = new ProbeError(
+            "SMOKE_FAILED",
+            "smoke dispatch provenance incomplete " +
+              `(task_id=${JSON.stringify(taskId)}, dispatch_id=${JSON.stringify(dispatchId)}, ` +
+              `assignee=${JSON.stringify(assignee)})`,
+          );
+        }
+      }
+    }
+  } catch (error) {
+    if (error instanceof ProbeError) smokeError = error;
+    else {
+      smokeError = new ProbeError(
+        "SMOKE_FAILED",
+        `smoke failed: ${truncateExcerpt(error.message)}`,
+      );
+    }
+  }
+
+  // Cleanup ONLY smoke-created ids; never reset (D2/D9).
+  if (isNonEmptyString(taskId)) {
+    const updateProc = run(
+      orcaBin,
+      [
+        "orchestration",
+        "task-update",
+        "--id",
+        taskId,
+        "--status",
+        SMOKE_TERMINAL_STATUS,
+        "--json",
+      ],
+      options.runOptions,
+    );
+    const updateParsed = parseJsonOutput(updateProc.stdout);
+    const updateOk =
+      updateProc.status === 0 &&
+      updateParsed.ok &&
+      updateParsed.value &&
+      updateParsed.value.ok === true;
+    if (updateOk) {
+      cleanedUp = true;
+    } else {
+      result.smoke.cleaned_up = false;
+      recordCheck(result.checks, "smoke", "failed");
+      reject(
+        "SMOKE_CLEANUP_FAILED",
+        `failed to terminalize smoke-created task leftover id=${taskId}` +
+          (updateProc.stderr ? `: ${truncateExcerpt(updateProc.stderr)}` : ""),
+      );
+    }
+  } else {
+    cleanedUp = true;
+  }
+
+  result.smoke.cleaned_up = cleanedUp;
+
+  if (smokeError) {
+    recordCheck(result.checks, "smoke", "failed");
+    throw smokeError;
+  }
+
+  recordCheck(result.checks, "smoke", "ok");
+  result.ok = true;
+  result.admitted = true;
+  return result;
+}
+
+/**
+ * Run the capability probe. Mutates options._result when provided so callers
+ * can still emit the D8 JSON envelope after a thrown ProbeError.
+ */
+function probe(options = {}) {
+  const smokeRequested = Boolean(options.smoke);
+  const result = options._result || emptyResult(smokeRequested);
+  result.smoke.requested = smokeRequested;
+
+  const checkOrder = [
+    "binary",
+    "runtime_ready",
+    "orchestration_available",
+    "existing_state",
+    "smoke",
+  ];
+
+  const resolved = resolveOrcaBin({
+    orcaBinOverride: options.orcaBin || null,
+    pathEnv: options.pathEnv,
+    existsSync: options.existsSync,
+    pathDelimiter: options.pathDelimiter,
+  });
+
+  if (!resolved.path) {
+    recordCheck(result.checks, "binary", "failed");
+    skipRemaining(result.checks, checkOrder.slice(1));
+    reject(
+      "BINARY_NOT_FOUND",
+      `Orca CLI not found (checked --orca-bin, PATH, and ${MACOS_BUNDLE_FALLBACK})`,
+    );
+  }
+
+  result.orca_bin = resolved.path;
+  recordCheck(result.checks, "binary", "ok");
+  // Version is best-effort only; the mid-2026 CLI has no version subcommand (D8).
+  result.orca_version = null;
+
+  const run = options.runOrca || runOrca;
+
+  // --- D4 runtime readiness ---
+  const statusProc = run(resolved.path, ["status", "--json"], options.runOptions);
+  const statusParsed = parseJsonOutput(statusProc.stdout);
+  if (!statusParsed.ok) {
+    recordCheck(result.checks, "runtime_ready", "failed");
+    skipRemaining(result.checks, checkOrder.slice(2));
+    reject(
+      "MALFORMED_OUTPUT",
+      `orca status --json is not parseable JSON: ${statusParsed.error}` +
+        (statusParsed.excerpt ? ` (excerpt: ${statusParsed.excerpt})` : ""),
+    );
+  }
+  const statusShape = assertStatusShape(statusParsed.value);
+  if (statusShape.malformed) {
+    recordCheck(result.checks, "runtime_ready", "failed");
+    skipRemaining(result.checks, checkOrder.slice(2));
+    reject("MALFORMED_OUTPUT", `orca status --json shape invalid: ${statusShape.message}`);
+  }
+  const readiness = evaluateReadiness(statusShape.payload);
+  result.runtime_id = readiness.runtimeId;
+  result.runtime_ready = readiness.ready;
+  if (!readiness.ready) {
+    recordCheck(result.checks, "runtime_ready", "failed");
+    skipRemaining(result.checks, checkOrder.slice(2));
+    reject(
+      "RUNTIME_NOT_READY",
+      "orca status --json did not report a ready runtime " +
+        `(ok=${statusShape.payload.ok}, app.running=${statusShape.payload.result.app.running}, ` +
+        `runtime.reachable=${statusShape.payload.result.runtime.reachable}, ` +
+        `runtime.state=${JSON.stringify(statusShape.payload.result.runtime.state)}, ` +
+        `runtimeId=${JSON.stringify(statusShape.payload.result.runtime.runtimeId)}, ` +
+        `graph.state=${JSON.stringify(statusShape.payload.result.graph.state)})`,
+    );
+  }
+  recordCheck(result.checks, "runtime_ready", "ok");
+  const statusRuntimeId = readiness.runtimeId;
+
+  // --- D5 orchestration availability ---
+  const taskListProc = run(
+    resolved.path,
+    ["orchestration", "task-list", "--json"],
+    options.runOptions,
+  );
+  if (
+    taskListProc.status !== 0 ||
+    looksLikeUnknownCommand(taskListProc.stderr, taskListProc.stdout)
+  ) {
+    recordCheck(result.checks, "orchestration_available", "failed");
+    skipRemaining(result.checks, checkOrder.slice(3));
+    reject(
+      "ORCHESTRATION_UNAVAILABLE",
+      `orca orchestration task-list failed or is unknown` +
+        (taskListProc.stderr
+          ? `: ${truncateExcerpt(taskListProc.stderr)}`
+          : ` (exit ${taskListProc.status})`),
+    );
+  }
+  const taskListParsed = parseJsonOutput(taskListProc.stdout);
+  if (!taskListParsed.ok) {
+    recordCheck(result.checks, "orchestration_available", "failed");
+    skipRemaining(result.checks, checkOrder.slice(3));
+    reject(
+      "MALFORMED_OUTPUT",
+      `orca orchestration task-list --json is not parseable JSON: ${taskListParsed.error}` +
+        (taskListParsed.excerpt ? ` (excerpt: ${taskListParsed.excerpt})` : ""),
+    );
+  }
+  const taskListShape = parseListPayload(taskListParsed.value, "task-list");
+  if (taskListShape.malformed) {
+    recordCheck(result.checks, "orchestration_available", "failed");
+    skipRemaining(result.checks, checkOrder.slice(3));
+    reject("MALFORMED_OUTPUT", taskListShape.message);
+  }
+  if (taskListShape.payload.ok === false) {
+    result.orchestration_available = false;
+    recordCheck(result.checks, "orchestration_available", "failed");
+    skipRemaining(result.checks, checkOrder.slice(3));
+    reject("ORCHESTRATION_UNAVAILABLE", "orca orchestration task-list returned ok:false");
+  }
+  const taskCountInfo = extractListCount(taskListShape.payload, "task-list", "tasks");
+  if (taskCountInfo.malformed) {
+    recordCheck(result.checks, "orchestration_available", "failed");
+    skipRemaining(result.checks, checkOrder.slice(3));
+    reject("MALFORMED_OUTPUT", taskCountInfo.message);
+  }
+  if (taskCountInfo.ambiguous) {
+    recordCheck(result.checks, "orchestration_available", "ok");
+    result.orchestration_available = true;
+    result.existing_state.tasks = null;
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject("AMBIGUOUS_GLOBAL_STATE", taskCountInfo.message);
+  }
+  result.orchestration_available = true;
+  recordCheck(result.checks, "orchestration_available", "ok");
+
+  // --- D6 existing global state ---
+  const gateListProc = run(
+    resolved.path,
+    ["orchestration", "gate-list", "--json"],
+    options.runOptions,
+  );
+  if (
+    gateListProc.status !== 0 ||
+    looksLikeUnknownCommand(gateListProc.stderr, gateListProc.stdout)
+  ) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject(
+      "ORCHESTRATION_UNAVAILABLE",
+      `orca orchestration gate-list failed or is unknown` +
+        (gateListProc.stderr
+          ? `: ${truncateExcerpt(gateListProc.stderr)}`
+          : ` (exit ${gateListProc.status})`),
+    );
+  }
+  const gateListParsed = parseJsonOutput(gateListProc.stdout);
+  if (!gateListParsed.ok) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject(
+      "MALFORMED_OUTPUT",
+      `orca orchestration gate-list --json is not parseable JSON: ${gateListParsed.error}` +
+        (gateListParsed.excerpt ? ` (excerpt: ${gateListParsed.excerpt})` : ""),
+    );
+  }
+  const gateListShape = parseListPayload(gateListParsed.value, "gate-list");
+  if (gateListShape.malformed) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject("MALFORMED_OUTPUT", gateListShape.message);
+  }
+  if (gateListShape.payload.ok === false) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject("ORCHESTRATION_UNAVAILABLE", "orca orchestration gate-list returned ok:false");
+  }
+  const gateCountInfo = extractListCount(gateListShape.payload, "gate-list", "gates");
+  if (gateCountInfo.malformed) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject("MALFORMED_OUTPUT", gateCountInfo.message);
+  }
+  if (gateCountInfo.ambiguous) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject("AMBIGUOUS_GLOBAL_STATE", gateCountInfo.message);
+  }
+
+  result.existing_state = { tasks: taskCountInfo.count, gates: gateCountInfo.count };
+
+  const taskMetaId = metaRuntimeId(taskListShape.payload);
+  const gateMetaId = metaRuntimeId(gateListShape.payload);
+  if (
+    (taskMetaId && taskMetaId !== statusRuntimeId) ||
+    (gateMetaId && gateMetaId !== statusRuntimeId)
+  ) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject(
+      "AMBIGUOUS_GLOBAL_STATE",
+      `orchestration _meta.runtimeId does not match status runtimeId ` +
+        `(status=${statusRuntimeId}, task-list=${taskMetaId}, gate-list=${gateMetaId})`,
+    );
+  }
+
+  if (taskCountInfo.count > 0 || gateCountInfo.count > 0) {
+    recordCheck(result.checks, "existing_state", "failed");
+    skipRemaining(result.checks, ["smoke"]);
+    reject(
+      "EXISTING_ORCHESTRATION_STATE",
+      `existing orchestration state rejected (tasks=${taskCountInfo.count}, gates=${gateCountInfo.count}); ` +
+        "v0 admits only one active program per runtime and never adopts pre-existing state",
+    );
+  }
+  recordCheck(result.checks, "existing_state", "ok");
+
+  if (!smokeRequested) {
+    recordCheck(result.checks, "smoke", "skipped");
+    result.ok = true;
+    result.admitted = true;
+    return result;
+  }
+
+  return runSmoke(result, resolved.path, run, options);
+}
+
+function runMain(argv = process.argv.slice(2), runtime = {}) {
+  const opts = parseArgs(argv);
+  if (opts.help) usageError("fail-closed Orca capability probe");
+
+  const result = emptyResult(opts.smoke);
+  try {
+    probe({
+      smoke: opts.smoke,
+      orcaBin: opts.orcaBin,
+      pathEnv: runtime.pathEnv,
+      existsSync: runtime.existsSync,
+      pathDelimiter: runtime.pathDelimiter,
+      runOrca: runtime.runOrca,
+      runOptions: runtime.runOptions,
+      _result: result,
+    });
+  } catch (error) {
+    if (!(error instanceof ProbeError)) throw error;
+    result.blocking_reasons = [blockingReason(error)];
+    result.ok = false;
+    result.admitted = false;
+    printResult(result, opts.json);
+    process.exitCode = error.exitCode;
+    return result;
+  }
+
+  printResult(result, opts.json);
+  process.exitCode = 0;
+  return result;
+}
+
+if (require.main === module) {
+  runMain();
+}
+
+module.exports = {
+  probe,
+  runMain,
+  parseArgs,
+  emptyResult,
+  JSON_KEYS,
+  SMOKE_TITLE_MARKER,
+  REASONS,
+  resolveOrcaBin,
+  MACOS_BUNDLE_FALLBACK,
+};

--- a/tests/relay-orca/fixtures/fake-orca.js
+++ b/tests/relay-orca/fixtures/fake-orca.js
@@ -1,0 +1,227 @@
+"use strict";
+
+/**
+ * Fake Orca CLI fixture for relay-orca probe tests.
+ *
+ * Installs an executable `orca` on PATH (or at a chosen path). Behavior is
+ * driven by a scenario JSON file pointed to by RELAY_FAKE_ORCA_SCENARIO.
+ * Every invocation is appended to RELAY_FAKE_ORCA_LOG. Invoking `reset` writes
+ * a poison marker and exits non-zero so tests hard-fail (D2).
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const DEFAULT_RUNTIME_ID = "00000000-0000-4000-8000-000000000001";
+
+function readyStatus(runtimeId = DEFAULT_RUNTIME_ID) {
+  return {
+    id: "status-1",
+    ok: true,
+    result: {
+      app: { running: true, pid: 4242 },
+      runtime: { state: "ready", reachable: true, runtimeId },
+      graph: { state: "ready" },
+    },
+    _meta: { runtimeId },
+  };
+}
+
+function emptyTaskList(runtimeId = DEFAULT_RUNTIME_ID) {
+  return {
+    id: "task-list-1",
+    ok: true,
+    result: { tasks: [], count: 0 },
+    _meta: { runtimeId },
+  };
+}
+
+function emptyGateList(runtimeId = DEFAULT_RUNTIME_ID) {
+  return {
+    id: "gate-list-1",
+    ok: true,
+    result: { gates: [], count: 0 },
+    _meta: { runtimeId },
+  };
+}
+
+function defaultScenario(overrides = {}) {
+  const runtimeId = overrides.runtimeId || DEFAULT_RUNTIME_ID;
+  return {
+    runtimeId,
+    status: overrides.status !== undefined ? overrides.status : readyStatus(runtimeId),
+    statusExit: overrides.statusExit !== undefined ? overrides.statusExit : 0,
+    statusStdout: overrides.statusStdout,
+    taskList: overrides.taskList !== undefined ? overrides.taskList : emptyTaskList(runtimeId),
+    taskListExit: overrides.taskListExit !== undefined ? overrides.taskListExit : 0,
+    taskListStdout: overrides.taskListStdout,
+    taskListStderr: overrides.taskListStderr || "",
+    gateList: overrides.gateList !== undefined ? overrides.gateList : emptyGateList(runtimeId),
+    gateListExit: overrides.gateListExit !== undefined ? overrides.gateListExit : 0,
+    gateListStdout: overrides.gateListStdout,
+    gateListStderr: overrides.gateListStderr || "",
+    taskCreate: overrides.taskCreate !== undefined
+      ? overrides.taskCreate
+      : {
+          id: "task-create-1",
+          ok: true,
+          result: { id: "smoke-task-1", task_id: "smoke-task-1" },
+          _meta: { runtimeId },
+        },
+    taskCreateExit: overrides.taskCreateExit !== undefined ? overrides.taskCreateExit : 0,
+    dispatch: overrides.dispatch !== undefined
+      ? overrides.dispatch
+      : {
+          id: "dispatch-1",
+          ok: true,
+          result: {
+            id: "smoke-dispatch-1",
+            dispatch_id: "smoke-dispatch-1",
+            assignee: "relay-orca-probe-smoke",
+          },
+          _meta: { runtimeId },
+        },
+    dispatchExit: overrides.dispatchExit !== undefined ? overrides.dispatchExit : 0,
+    taskUpdate: overrides.taskUpdate !== undefined
+      ? overrides.taskUpdate
+      : {
+          id: "task-update-1",
+          ok: true,
+          result: { id: "smoke-task-1", status: "cancelled" },
+          _meta: { runtimeId },
+        },
+    taskUpdateExit: overrides.taskUpdateExit !== undefined ? overrides.taskUpdateExit : 0,
+    taskUpdateStderr: overrides.taskUpdateStderr || "",
+  };
+}
+
+function writeFakeOrcaScript({ orcaPath, scenarioPath, logPath, poisonPath }) {
+  const script = `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+
+function appendLog(line) {
+  if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8");
+}
+
+appendLog(args.join(" "));
+
+function loadScenario() {
+  return JSON.parse(fs.readFileSync(scenarioPath, "utf-8"));
+}
+
+function writeJson(value) {
+  process.stdout.write(JSON.stringify(value));
+}
+
+function emit(payload, exitCode, stdoutOverride, stderrText) {
+  if (stderrText) process.stderr.write(String(stderrText));
+  if (stdoutOverride !== undefined && stdoutOverride !== null) {
+    process.stdout.write(String(stdoutOverride));
+  } else if (payload !== undefined && payload !== null) {
+    writeJson(payload);
+  }
+  process.exit(typeof exitCode === "number" ? exitCode : 0);
+}
+
+// D2 poison: any reset invocation hard-fails the fixture (and thus the test).
+if (args.includes("reset")) {
+  if (poisonPath) fs.writeFileSync(poisonPath, "RESET_INVOKED:" + args.join(" "), "utf-8");
+  process.stderr.write("POISON: orca orchestration reset must never be invoked\\n");
+  process.exit(99);
+}
+
+const scenario = loadScenario();
+
+if (args[0] === "status") {
+  emit(scenario.status, scenario.statusExit, scenario.statusStdout, scenario.statusStderr);
+}
+
+if (args[0] === "orchestration" && args[1] === "task-list") {
+  emit(scenario.taskList, scenario.taskListExit, scenario.taskListStdout, scenario.taskListStderr);
+}
+
+if (args[0] === "orchestration" && args[1] === "gate-list") {
+  emit(scenario.gateList, scenario.gateListExit, scenario.gateListStdout, scenario.gateListStderr);
+}
+
+if (args[0] === "orchestration" && args[1] === "task-create") {
+  emit(scenario.taskCreate, scenario.taskCreateExit, scenario.taskCreateStdout, scenario.taskCreateStderr);
+}
+
+if (args[0] === "orchestration" && args[1] === "dispatch") {
+  emit(scenario.dispatch, scenario.dispatchExit, scenario.dispatchStdout, scenario.dispatchStderr);
+}
+
+if (args[0] === "orchestration" && args[1] === "task-update") {
+  emit(scenario.taskUpdate, scenario.taskUpdateExit, scenario.taskUpdateStdout, scenario.taskUpdateStderr);
+}
+
+process.stderr.write("Unsupported fake orca invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+
+  fs.writeFileSync(orcaPath, script, "utf-8");
+  fs.chmodSync(orcaPath, 0o755);
+  return orcaPath;
+}
+
+function installFakeOrca(scenarioOverrides = {}, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-orca-"));
+  const orcaPath = path.join(dir, options.binName || "orca");
+  const scenarioPath = path.join(dir, "scenario.json");
+  const logPath = path.join(dir, "invocations.log");
+  const poisonPath = path.join(dir, "poison.txt");
+  const scenario = defaultScenario(scenarioOverrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
+  writeFakeOrcaScript({ orcaPath, scenarioPath, logPath, poisonPath });
+
+  const originalPath = process.env.PATH;
+  if (options.prependPath !== false) {
+    process.env.PATH = `${dir}${path.delimiter}${process.env.PATH || ""}`;
+  }
+
+  let restored = false;
+  const restore = () => {
+    if (restored) return;
+    if (options.prependPath !== false) process.env.PATH = originalPath;
+    restored = true;
+  };
+
+  return {
+    dir,
+    orcaPath,
+    scenarioPath,
+    logPath,
+    poisonPath,
+    scenario,
+    restore,
+    readLog() {
+      if (!fs.existsSync(logPath)) return [];
+      return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readPoison() {
+      if (!fs.existsSync(poisonPath)) return null;
+      return fs.readFileSync(poisonPath, "utf-8");
+    },
+    writeScenario(next) {
+      const merged = defaultScenario(next);
+      fs.writeFileSync(scenarioPath, JSON.stringify(merged, null, 2), "utf-8");
+      return merged;
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_RUNTIME_ID,
+  readyStatus,
+  emptyTaskList,
+  emptyGateList,
+  defaultScenario,
+  writeFakeOrcaScript,
+  installFakeOrca,
+};

--- a/tests/relay-orca/fixtures/fake-orca.js
+++ b/tests/relay-orca/fixtures/fake-orca.js
@@ -135,6 +135,15 @@ if (args.includes("reset")) {
   process.exit(99);
 }
 
+// Deterministic stall mode: when RELAY_FAKE_ORCA_STALL_MS is a positive integer
+// and the invocation matches RELAY_FAKE_ORCA_STALL_CMD (default "status"), block
+// synchronously so the probe's finite timeout must fire. SIGTERM still kills us.
+const stallMs = Number(process.env.RELAY_FAKE_ORCA_STALL_MS);
+const stallCmd = process.env.RELAY_FAKE_ORCA_STALL_CMD || "status";
+if (Number.isInteger(stallMs) && stallMs > 0 && args[0] === stallCmd) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, stallMs);
+}
+
 const scenario = loadScenario();
 
 if (args[0] === "status") {

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -1,0 +1,482 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const PROBE_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "probe-orca.js");
+const {
+  resolveOrcaBin,
+  MACOS_BUNDLE_FALLBACK,
+  JSON_KEYS,
+  SMOKE_TITLE_MARKER,
+  REASONS,
+} = require(PROBE_JS);
+const {
+  installFakeOrca,
+  readyStatus,
+  emptyTaskList,
+  emptyGateList,
+  DEFAULT_RUNTIME_ID,
+} = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+const READ_ONLY_SUBCOMMANDS = new Set(["status", "task-list", "gate-list"]);
+const FORBIDDEN_DEFAULT = ["task-create", "task-update", "dispatch", "run", "reset"];
+
+function runProbe(args, env = {}) {
+  const result = { status: 0, stdout: "", stderr: "" };
+  try {
+    result.stdout = execFileSync(process.execPath, [PROBE_JS, ...args], {
+      encoding: "utf-8",
+      env: { ...process.env, ...env },
+      stdio: "pipe",
+    });
+  } catch (error) {
+    result.status = error.status;
+    result.stdout = error.stdout ? String(error.stdout) : "";
+    result.stderr = error.stderr ? String(error.stderr) : "";
+  }
+  return result;
+}
+
+function parseJson(stdout) {
+  return JSON.parse(String(stdout));
+}
+
+function assertExactKeys(body) {
+  assert.deepEqual(Object.keys(body).sort(), [...JSON_KEYS].sort());
+}
+
+function assertNoPoison(fake) {
+  assert.equal(fake.readPoison(), null, "reset poison marker must never be written");
+}
+
+function assertReadOnlyLog(logLines) {
+  const tokens = logLines.join(" ");
+  for (const forbidden of FORBIDDEN_DEFAULT) {
+    assert.equal(
+      tokens.includes(forbidden),
+      false,
+      `default mode must not invoke ${forbidden}; log=${JSON.stringify(logLines)}`,
+    );
+  }
+  for (const line of logLines) {
+    const parts = line.split(" ");
+    // status | orchestration task-list | orchestration gate-list
+    if (parts[0] === "status") continue;
+    if (parts[0] === "orchestration" && READ_ONLY_SUBCOMMANDS.has(parts[1])) continue;
+    assert.fail(`unexpected default-mode invocation: ${line}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// D3 binary resolution
+// ---------------------------------------------------------------------------
+
+test("D3: PATH lookup resolves the fixture orca", () => {
+  const fake = installFakeOrca();
+  try {
+    const resolved = resolveOrcaBin({ pathEnv: process.env.PATH });
+    assert.equal(resolved.path, fake.orcaPath);
+    assert.equal(resolved.source, "path");
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D3: --orca-bin override wins over PATH", () => {
+  const onPath = installFakeOrca({}, { prefix: "orca-path-" });
+  const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "orca-override-"));
+  const overrideBin = path.join(overrideDir, "orca-override");
+  fs.copyFileSync(onPath.orcaPath, overrideBin);
+  fs.chmodSync(overrideBin, 0o755);
+  // Point override fake at its own scenario/log via rewriting — simpler: use
+  // resolveOrcaBin unit path + CLI with --orca-bin.
+  try {
+    const resolved = resolveOrcaBin({
+      orcaBinOverride: overrideBin,
+      pathEnv: process.env.PATH,
+    });
+    assert.equal(resolved.path, overrideBin);
+    assert.equal(resolved.source, "override");
+
+    const result = runProbe(["--json", "--orca-bin", overrideBin], {
+      PATH: process.env.PATH,
+    });
+    // Override binary is a copy without scenario env — the script embeds absolute
+    // scenario path from install time, so the copied binary still works if we
+    // copy from a second install that shares... Actually copyFileSync of the
+    // script keeps the original scenarioPath constants, so it still works.
+    assert.equal(result.status, 0);
+    const body = parseJson(result.stdout);
+    assert.equal(body.orca_bin, overrideBin);
+    assert.equal(body.admitted, true);
+    assertNoPoison(onPath);
+  } finally {
+    onPath.restore();
+    fs.rmSync(overrideDir, { recursive: true, force: true });
+  }
+});
+
+test("D3: bundle-fallback branch without a real /Applications install", () => {
+  const seen = [];
+  const bundlePath = MACOS_BUNDLE_FALLBACK;
+  const resolved = resolveOrcaBin({
+    orcaBinOverride: null,
+    pathEnv: "",
+    existsSync: (candidate) => {
+      seen.push(candidate);
+      return candidate === bundlePath;
+    },
+  });
+  assert.equal(resolved.path, bundlePath);
+  assert.equal(resolved.source, "bundle");
+  assert.ok(seen.includes(bundlePath));
+});
+
+test("D3: all resolution branches miss → BINARY_NOT_FOUND exit 30", () => {
+  const result = runProbe(["--json", "--orca-bin", "/tmp/definitely-missing-orca-bin"], {
+    PATH: "/tmp/empty-orca-path-dir-that-does-not-provide-orca",
+  });
+  assert.equal(result.status, REASONS.BINARY_NOT_FOUND);
+  const body = parseJson(result.stdout);
+  assertExactKeys(body);
+  assert.equal(body.admitted, false);
+  assert.equal(body.orca_bin, null);
+  assert.equal(body.blocking_reasons[0].reason_code, "BINARY_NOT_FOUND");
+});
+
+// ---------------------------------------------------------------------------
+// D4 readiness
+// ---------------------------------------------------------------------------
+
+test("D4: app.running false → RUNTIME_NOT_READY exit 31", () => {
+  const status = readyStatus();
+  status.result.app.running = false;
+  const fake = installFakeOrca({ status });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.RUNTIME_NOT_READY);
+    const body = parseJson(result.stdout);
+    assert.equal(body.blocking_reasons[0].reason_code, "RUNTIME_NOT_READY");
+    assert.equal(body.runtime_ready, false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test('D4: runtime.state ≠ "ready" → RUNTIME_NOT_READY exit 31', () => {
+  const status = readyStatus();
+  status.result.runtime.state = "starting";
+  const fake = installFakeOrca({ status });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.RUNTIME_NOT_READY);
+    assert.equal(parseJson(result.stdout).blocking_reasons[0].reason_code, "RUNTIME_NOT_READY");
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D4: missing/empty runtimeId → RUNTIME_NOT_READY exit 31", () => {
+  const status = readyStatus();
+  status.result.runtime.runtimeId = "";
+  const fake = installFakeOrca({ status });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.RUNTIME_NOT_READY);
+    assert.equal(parseJson(result.stdout).blocking_reasons[0].reason_code, "RUNTIME_NOT_READY");
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D5 orchestration availability
+// ---------------------------------------------------------------------------
+
+test("D5: orchestration unknown/non-zero/ok:false → ORCHESTRATION_UNAVAILABLE exit 32", () => {
+  const cases = [
+    { taskListExit: 1, taskListStderr: "Unknown command: orchestration" },
+    { taskList: { id: "x", ok: false, result: { tasks: [], count: 0 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } } },
+  ];
+  for (const overrides of cases) {
+    const fake = installFakeOrca(overrides);
+    try {
+      const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+      assert.equal(result.status, REASONS.ORCHESTRATION_UNAVAILABLE);
+      assert.equal(
+        parseJson(result.stdout).blocking_reasons[0].reason_code,
+        "ORCHESTRATION_UNAVAILABLE",
+      );
+      assertNoPoison(fake);
+    } finally {
+      fake.restore();
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D4/D5 malformed
+// ---------------------------------------------------------------------------
+
+test("D4/D5: unparseable status AND shape-invalid task-list → MALFORMED_OUTPUT exit 33", () => {
+  const fakeUnparseable = installFakeOrca({ statusStdout: "NOT-JSON{{{", status: null });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fakeUnparseable.orcaPath]);
+    assert.equal(result.status, REASONS.MALFORMED_OUTPUT);
+    assert.equal(parseJson(result.stdout).blocking_reasons[0].reason_code, "MALFORMED_OUTPUT");
+    assertNoPoison(fakeUnparseable);
+  } finally {
+    fakeUnparseable.restore();
+  }
+
+  const badTaskList = {
+    id: "x",
+    ok: true,
+    result: { tasks: "not-an-array", count: 0 },
+    _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+  };
+  const fakeShape = installFakeOrca({ taskList: badTaskList });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fakeShape.orcaPath]);
+    assert.equal(result.status, REASONS.MALFORMED_OUTPUT);
+    assert.equal(parseJson(result.stdout).blocking_reasons[0].reason_code, "MALFORMED_OUTPUT");
+    assertNoPoison(fakeShape);
+  } finally {
+    fakeShape.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D6 existing state / ambiguous
+// ---------------------------------------------------------------------------
+
+test("D6: tasks count > 0 → EXISTING_ORCHESTRATION_STATE exit 34", () => {
+  const fake = installFakeOrca({
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [{ id: "pre" }], count: 1 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.EXISTING_ORCHESTRATION_STATE);
+    const body = parseJson(result.stdout);
+    assert.equal(body.blocking_reasons[0].reason_code, "EXISTING_ORCHESTRATION_STATE");
+    assert.match(body.blocking_reasons[0].message, /tasks=1/);
+    assert.match(body.blocking_reasons[0].message, /gates=0/);
+    assert.equal(body.admitted, false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D6: gates count > 0 → EXISTING_ORCHESTRATION_STATE exit 34", () => {
+  const fake = installFakeOrca({
+    gateList: {
+      id: "x",
+      ok: true,
+      result: { gates: [{ id: "g1" }], count: 2 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.EXISTING_ORCHESTRATION_STATE);
+    const body = parseJson(result.stdout);
+    assert.equal(body.blocking_reasons[0].reason_code, "EXISTING_ORCHESTRATION_STATE");
+    assert.match(body.blocking_reasons[0].message, /tasks=0/);
+    assert.match(body.blocking_reasons[0].message, /gates=2/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D6: _meta.runtimeId mismatch → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
+  const fake = installFakeOrca({
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [], count: 0 },
+      _meta: { runtimeId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    assert.equal(
+      parseJson(result.stdout).blocking_reasons[0].reason_code,
+      "AMBIGUOUS_GLOBAL_STATE",
+    );
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D1/D8 all green
+// ---------------------------------------------------------------------------
+
+test("D1/D8: all green → admitted true, exact JSON keys, read-only invocation set", () => {
+  const fake = installFakeOrca();
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, 0);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.ok, true);
+    assert.equal(body.admitted, true);
+    assert.equal(body.orca_bin, fake.orcaPath);
+    assert.equal(body.orca_version, null);
+    assert.equal(body.runtime_id, DEFAULT_RUNTIME_ID);
+    assert.equal(body.runtime_ready, true);
+    assert.equal(body.orchestration_available, true);
+    assert.deepEqual(body.existing_state, { tasks: 0, gates: 0 });
+    assert.deepEqual(body.blocking_reasons, []);
+    assert.equal(body.smoke.requested, false);
+    assert.equal(body.smoke.ran, false);
+    assert.equal(body.smoke.cleaned_up, null);
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D1/D14: default mode never invokes smoke subcommands", () => {
+  const fake = installFakeOrca();
+  try {
+    runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    const log = fake.readLog().join("\n");
+    assert.equal(log.includes("task-create"), false);
+    assert.equal(log.includes("dispatch"), false);
+    assert.equal(log.includes("task-update"), false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9 smoke
+// ---------------------------------------------------------------------------
+
+test("D9: smoke success — marker, provenance trio, self-only cleanup", () => {
+  const fake = installFakeOrca();
+  try {
+    const result = runProbe(["--json", "--smoke", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, 0);
+    const body = parseJson(result.stdout);
+    assert.equal(body.admitted, true);
+    assert.equal(body.smoke.requested, true);
+    assert.equal(body.smoke.ran, true);
+    assert.equal(body.smoke.cleaned_up, true);
+    assert.equal(body.smoke.task_id, "smoke-task-1");
+    assert.equal(body.smoke.dispatch_id, "smoke-dispatch-1");
+    assert.equal(body.smoke.assignee, "relay-orca-probe-smoke");
+
+    const log = fake.readLog();
+    const createLine = log.find((line) => line.includes("task-create"));
+    assert.ok(createLine, "task-create must be recorded");
+    assert.ok(createLine.includes(SMOKE_TITLE_MARKER), "task-title must contain smoke marker");
+    assert.ok(log.some((line) => line.includes("dispatch") && line.includes("--inject")));
+    const updateLines = log.filter((line) => line.includes("task-update"));
+    assert.equal(updateLines.length, 1);
+    assert.ok(updateLines[0].includes("smoke-task-1"));
+    assert.equal(log.some((line) => line.includes("reset")), false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D9: smoke provenance failure (null assignee) → SMOKE_FAILED exit 36, cleanup still attempted", () => {
+  const fake = installFakeOrca({
+    dispatch: {
+      id: "dispatch-1",
+      ok: true,
+      result: {
+        id: "smoke-dispatch-1",
+        dispatch_id: "smoke-dispatch-1",
+        assignee: null,
+      },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--smoke", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.SMOKE_FAILED);
+    const body = parseJson(result.stdout);
+    assert.equal(body.blocking_reasons[0].reason_code, "SMOKE_FAILED");
+    assert.equal(body.smoke.ran, true);
+    assert.equal(body.smoke.cleaned_up, true);
+    const log = fake.readLog();
+    assert.ok(log.some((line) => line.includes("task-update") && line.includes("smoke-task-1")));
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("D9: smoke cleanup failure → SMOKE_CLEANUP_FAILED exit 37, leftover id named, no reset", () => {
+  const fake = installFakeOrca({
+    taskUpdateExit: 1,
+    taskUpdate: { ok: false, result: {} },
+    taskUpdateStderr: "cannot update task",
+  });
+  try {
+    const result = runProbe(["--json", "--smoke", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.SMOKE_CLEANUP_FAILED);
+    const body = parseJson(result.stdout);
+    assert.equal(body.blocking_reasons[0].reason_code, "SMOKE_CLEANUP_FAILED");
+    assert.match(body.blocking_reasons[0].message, /smoke-task-1/);
+    assert.equal(body.smoke.cleaned_up, false);
+    assert.equal(fake.readLog().some((line) => line.includes("reset")), false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("usage errors exit 64", () => {
+  const result = runProbe(["--json", "--not-a-real-flag"]);
+  assert.equal(result.status, 64);
+});
+
+test("blocking_reasons carry remediation; excerpts stay bounded", () => {
+  const long = "x".repeat(500);
+  const fake = installFakeOrca({
+    taskListExit: 1,
+    taskListStderr: long,
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    const body = parseJson(result.stdout);
+    const reason = body.blocking_reasons[0];
+    assert.equal(reason.reason_code, "ORCHESTRATION_UNAVAILABLE");
+    assert.ok(typeof reason.remediation === "string" && reason.remediation.length > 0);
+    assert.ok(reason.message.length <= 400);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// Keep helpers referenced so lint/coverage-style unused import checks stay quiet.
+void readyStatus;
+void emptyTaskList;
+void emptyGateList;

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -288,7 +288,7 @@ test("D6: gates count > 0 → EXISTING_ORCHESTRATION_STATE exit 34", () => {
     gateList: {
       id: "x",
       ok: true,
-      result: { gates: [{ id: "g1" }], count: 2 },
+      result: { gates: [{ id: "g1" }, { id: "g2" }], count: 2 },
       _meta: { runtimeId: DEFAULT_RUNTIME_ID },
     },
   });
@@ -321,6 +321,80 @@ test("D6: _meta.runtimeId mismatch → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
       parseJson(result.stdout).blocking_reasons[0].reason_code,
       "AMBIGUOUS_GLOBAL_STATE",
     );
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Finding 1: contradictory list count vs array length → AMBIGUOUS_GLOBAL_STATE
+// ---------------------------------------------------------------------------
+
+test("Finding 1: task-list count contradicts array length → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
+  const fake = installFakeOrca({
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [{ id: "existing" }], count: 0 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "AMBIGUOUS_GLOBAL_STATE");
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("Finding 1: gate-list count contradicts array length → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
+  const fake = installFakeOrca({
+    gateList: {
+      id: "x",
+      ok: true,
+      result: { gates: [{ id: "g1" }, { id: "g2" }], count: 5 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "AMBIGUOUS_GLOBAL_STATE");
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2: a hung Orca subprocess must time out into the rejection matrix
+// ---------------------------------------------------------------------------
+
+test("Finding 2: hung status call times out → MALFORMED_OUTPUT exit 33, envelope emitted", () => {
+  const fake = installFakeOrca();
+  const started = Date.now();
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath], {
+      RELAY_ORCA_PROBE_TIMEOUT_MS: "200",
+      RELAY_FAKE_ORCA_STALL_MS: "5000",
+      RELAY_FAKE_ORCA_STALL_CMD: "status",
+    });
+    assert.ok(Date.now() - started < 4000, "probe must not hang for the full stall duration");
+    assert.equal(result.status, REASONS.MALFORMED_OUTPUT);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "MALFORMED_OUTPUT");
+    assert.equal(body.runtime_ready, false);
     assertNoPoison(fake);
   } finally {
     fake.restore();

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -490,6 +490,49 @@ test('Finding 5: gate-list empty-string _meta.runtimeId → AMBIGUOUS_GLOBAL_STA
   }
 });
 
+test("Finding 6: status response missing _meta.runtimeId → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
+  // status is otherwise ready (runtime.runtimeId present so D4 passes) but its
+  // _meta block is absent. The consistency check requires status._meta.runtimeId
+  // too, so a missing one classifies exactly like a task-list/gate-list miss and
+  // names the status source.
+  const status = readyStatus();
+  delete status._meta;
+  const fake = installFakeOrca({ status });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "AMBIGUOUS_GLOBAL_STATE");
+    assert.match(body.blocking_reasons[0].message, /status/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("Finding 6: status _meta.runtimeId disagrees with runtime.runtimeId → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
+  // status carries a _meta.runtimeId that differs from the D4-validated
+  // runtime.runtimeId. All four observed ids must agree, so the disagreement
+  // fails closed and the message names the status source.
+  const status = readyStatus();
+  status._meta.runtimeId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const fake = installFakeOrca({ status });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "AMBIGUOUS_GLOBAL_STATE");
+    assert.match(body.blocking_reasons[0].message, /status/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Finding 1: contradictory list count vs array length → AMBIGUOUS_GLOBAL_STATE
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -11,6 +11,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const PROBE_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "probe-orca.js");
 const {
   resolveOrcaBin,
+  runMain,
   MACOS_BUNDLE_FALLBACK,
   JSON_KEYS,
   SMOKE_TITLE_MARKER,
@@ -140,15 +141,50 @@ test("D3: bundle-fallback branch without a real /Applications install", () => {
 });
 
 test("D3: all resolution branches miss → BINARY_NOT_FOUND exit 30", () => {
-  const result = runProbe(["--json", "--orca-bin", "/tmp/definitely-missing-orca-bin"], {
-    PATH: "/tmp/empty-orca-path-dir-that-does-not-provide-orca",
-  });
-  assert.equal(result.status, REASONS.BINARY_NOT_FOUND);
-  const body = parseJson(result.stdout);
-  assertExactKeys(body);
-  assert.equal(body.admitted, false);
-  assert.equal(body.orca_bin, null);
-  assert.equal(body.blocking_reasons[0].reason_code, "BINARY_NOT_FOUND");
+  // Driven in-process with an injected existsSync so the macOS bundle fallback
+  // deterministically misses even on a host that has a real Orca install — a
+  // missing --orca-bin override now falls through, so the bundle must be stubbed.
+  const prevExit = process.exitCode;
+  try {
+    const result = runMain(["--json", "--orca-bin", "/tmp/definitely-missing-orca-bin"], {
+      existsSync: () => false,
+      pathEnv: "/tmp/empty-orca-path-dir-that-does-not-provide-orca",
+    });
+    assert.equal(process.exitCode, REASONS.BINARY_NOT_FOUND);
+    assertExactKeys(result);
+    assert.equal(result.admitted, false);
+    assert.equal(result.orca_bin, null);
+    assert.equal(result.blocking_reasons[0].reason_code, "BINARY_NOT_FOUND");
+  } finally {
+    process.exitCode = prevExit;
+  }
+});
+
+test("Finding 1: missing --orca-bin override falls through to a PATH orca (first-hit order)", () => {
+  const fake = installFakeOrca();
+  try {
+    // Unit: a missing override is a miss, not a short-circuit → resolves via PATH.
+    const resolved = resolveOrcaBin({
+      orcaBinOverride: "/tmp/definitely-missing-orca-override",
+      pathEnv: process.env.PATH,
+    });
+    assert.equal(resolved.path, fake.orcaPath);
+    assert.equal(resolved.source, "path");
+
+    // End-to-end: probe admits using the PATH binary and reports it as orca_bin.
+    const result = runProbe(
+      ["--json", "--orca-bin", "/tmp/definitely-missing-orca-override"],
+      { PATH: process.env.PATH },
+    );
+    assert.equal(result.status, 0);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, true);
+    assert.equal(body.orca_bin, fake.orcaPath);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -395,6 +431,34 @@ test("Finding 2: hung status call times out → MALFORMED_OUTPUT exit 33, envelo
     assert.equal(body.admitted, false);
     assert.equal(body.blocking_reasons[0].reason_code, "MALFORMED_OUTPUT");
     assert.equal(body.runtime_ready, false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2 (D8): subprocess-derived values embedded in messages stay bounded
+// ---------------------------------------------------------------------------
+
+test("Finding 2: oversized runtime.state is truncated in the RUNTIME_NOT_READY message", () => {
+  const status = readyStatus();
+  status.result.runtime.state = "x".repeat(10000); // shape-valid string, but not "ready"
+  const fake = installFakeOrca({ status });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.RUNTIME_NOT_READY);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.runtime_ready, false);
+    const reason = body.blocking_reasons[0];
+    assert.equal(reason.reason_code, "RUNTIME_NOT_READY");
+    // The interpolated runtime.state was truncated to <=256 chars: no 257-run of x.
+    assert.equal(reason.message.includes("x".repeat(257)), false);
+    assert.ok(reason.message.includes("…"), "truncation marker must be present");
+    // Whole message stays under a sane cap despite the 10k-char subprocess value.
+    assert.ok(reason.message.length <= 512, `message too long: ${reason.message.length}`);
     assertNoPoison(fake);
   } finally {
     fake.restore();

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -235,6 +235,26 @@ test("D4: missing/empty runtimeId → RUNTIME_NOT_READY exit 31", () => {
   }
 });
 
+test("Finding 1: non-zero status exit with ready-shaped stdout → RUNTIME_NOT_READY exit 31", () => {
+  // status prints a fully ready-shaped JSON body but exits 3: a failed readiness
+  // command must never admit, regardless of what its (possibly cached) stdout claims.
+  const fake = installFakeOrca({ statusExit: 3 });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.RUNTIME_NOT_READY);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.runtime_ready, false);
+    const reason = body.blocking_reasons[0];
+    assert.equal(reason.reason_code, "RUNTIME_NOT_READY");
+    assert.match(reason.message, /exit 3/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // D5 orchestration availability
 // ---------------------------------------------------------------------------
@@ -454,8 +474,16 @@ test("Finding 2: oversized runtime.state is truncated in the RUNTIME_NOT_READY m
     assert.equal(body.runtime_ready, false);
     const reason = body.blocking_reasons[0];
     assert.equal(reason.reason_code, "RUNTIME_NOT_READY");
-    // The interpolated runtime.state was truncated to <=256 chars: no 257-run of x.
-    assert.equal(reason.message.includes("x".repeat(257)), false);
+    // The embedded excerpt is bounded to <=256 chars TOTAL, marker included
+    // (255 filler chars + the single `…` marker).
+    const excerptMatch = reason.message.match(/x+…/);
+    assert.ok(excerptMatch, "bounded excerpt with truncation marker must be present");
+    assert.ok(
+      excerptMatch[0].length <= 256,
+      `embedded excerpt too long: ${excerptMatch[0].length}`,
+    );
+    // No 256-char run of the original filler survives the bound.
+    assert.equal(reason.message.includes("x".repeat(256)), false);
     assert.ok(reason.message.includes("…"), "truncation marker must be present");
     // Whole message stays under a sane cap despite the 10k-char subprocess value.
     assert.ok(reason.message.length <= 512, `message too long: ${reason.message.length}`);
@@ -583,6 +611,40 @@ test("D9: smoke cleanup failure → SMOKE_CLEANUP_FAILED exit 37, leftover id na
     assert.equal(body.blocking_reasons[0].reason_code, "SMOKE_CLEANUP_FAILED");
     assert.match(body.blocking_reasons[0].message, /smoke-task-1/);
     assert.equal(body.smoke.cleaned_up, false);
+    assert.equal(fake.readLog().some((line) => line.includes("reset")), false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test("Finding 3: smoke task-create ok without a task id → SMOKE_FAILED exit 36, cleaned_up=false, no cleanup", () => {
+  // task-create reports ok but returns no id: an untracked synthetic task may exist and
+  // there is no id to clean, so cleaned_up must be false and no task-update may run.
+  const fake = installFakeOrca({
+    taskCreate: {
+      id: "task-create-1",
+      ok: true,
+      result: {},
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--smoke", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.SMOKE_FAILED);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "SMOKE_FAILED");
+    assert.equal(body.smoke.cleaned_up, false);
+    // No id came back → no task-update cleanup may be attempted.
+    assert.equal(
+      fake.readLog().some((line) => line.includes("task-update")),
+      false,
+      "no task-update may run when no task id was returned",
+    );
+    // Remediation points the operator at the smoke title marker + task-list.
+    assert.match(body.blocking_reasons[0].remediation, /relay-orca-probe-smoke/);
     assert.equal(fake.readLog().some((line) => line.includes("reset")), false);
     assertNoPoison(fake);
   } finally {

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -440,6 +440,56 @@ test("D6: _meta.runtimeId mismatch → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
   }
 });
 
+test("Finding 5: task-list missing _meta.runtimeId → AMBIGUOUS_GLOBAL_STATE exit 35", () => {
+  // Otherwise clean/empty state, but the task-list response carries no
+  // _meta.runtimeId. Cross-runtime consistency cannot be established, so a
+  // missing id must classify exactly like a mismatch, never a silent pass.
+  const fake = installFakeOrca({
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [], count: 0 },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "AMBIGUOUS_GLOBAL_STATE");
+    assert.match(body.blocking_reasons[0].message, /task-list/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
+test('Finding 5: gate-list empty-string _meta.runtimeId → AMBIGUOUS_GLOBAL_STATE exit 35', () => {
+  // An empty-string runtime id is as unusable as a missing one for establishing
+  // that the three responses came from a single runtime.
+  const fake = installFakeOrca({
+    gateList: {
+      id: "x",
+      ok: true,
+      result: { gates: [], count: 0 },
+      _meta: { runtimeId: "" },
+    },
+  });
+  try {
+    const result = runProbe(["--json", "--orca-bin", fake.orcaPath]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "AMBIGUOUS_GLOBAL_STATE");
+    assert.match(body.blocking_reasons[0].message, /gate-list/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Finding 1: contradictory list count vs array length → AMBIGUOUS_GLOBAL_STATE
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -11,6 +11,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const PROBE_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "probe-orca.js");
 const {
   resolveOrcaBin,
+  isRunnableFile,
   runMain,
   MACOS_BUNDLE_FALLBACK,
   JSON_KEYS,
@@ -130,7 +131,7 @@ test("D3: bundle-fallback branch without a real /Applications install", () => {
   const resolved = resolveOrcaBin({
     orcaBinOverride: null,
     pathEnv: "",
-    existsSync: (candidate) => {
+    isRunnableFile: (candidate) => {
       seen.push(candidate);
       return candidate === bundlePath;
     },
@@ -147,7 +148,7 @@ test("D3: all resolution branches miss → BINARY_NOT_FOUND exit 30", () => {
   const prevExit = process.exitCode;
   try {
     const result = runMain(["--json", "--orca-bin", "/tmp/definitely-missing-orca-bin"], {
-      existsSync: () => false,
+      isRunnableFile: () => false,
       pathEnv: "/tmp/empty-orca-path-dir-that-does-not-provide-orca",
     });
     assert.equal(process.exitCode, REASONS.BINARY_NOT_FOUND);
@@ -184,6 +185,62 @@ test("Finding 1: missing --orca-bin override falls through to a PATH orca (first
     assertNoPoison(fake);
   } finally {
     fake.restore();
+  }
+});
+
+test("Finding 4: --orca-bin override at a DIRECTORY falls through to a runnable PATH orca; probe admits", () => {
+  const fake = installFakeOrca(); // real chmod 0o755 orca prepended to PATH
+  const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "orca-override-dir-"));
+  try {
+    // Unit: a directory is not a regular executable file → override MISS → PATH wins.
+    const resolved = resolveOrcaBin({
+      orcaBinOverride: overrideDir,
+      pathEnv: process.env.PATH,
+    });
+    assert.equal(resolved.path, fake.orcaPath);
+    assert.equal(resolved.source, "path");
+
+    // End-to-end: probe resolves the PATH binary and admits.
+    const result = runProbe(["--json", "--orca-bin", overrideDir], {
+      PATH: process.env.PATH,
+    });
+    assert.equal(result.status, 0);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, true);
+    assert.equal(body.orca_bin, fake.orcaPath);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(overrideDir, { recursive: true, force: true });
+  }
+});
+
+test("Finding 4: non-executable regular orca on PATH, nothing else → BINARY_NOT_FOUND exit 30", () => {
+  // A regular file that is not executable is a MISS. The real isRunnableFile
+  // predicate rejects it; the bundle fallback is stubbed to miss so the result
+  // is deterministic even on a host with a real /Applications Orca install.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orca-nonexec-"));
+  const nonExec = path.join(dir, "orca");
+  fs.writeFileSync(nonExec, "#!/bin/sh\necho hi\n", "utf-8");
+  fs.chmodSync(nonExec, 0o644); // regular file, NOT executable
+  const prevExit = process.exitCode;
+  try {
+    // Unit: the real predicate treats a non-executable regular file as a miss.
+    assert.equal(isRunnableFile(nonExec), false);
+
+    const result = runMain(["--json"], {
+      pathEnv: dir,
+      isRunnableFile: (p) => (p === MACOS_BUNDLE_FALLBACK ? false : isRunnableFile(p)),
+    });
+    assert.equal(process.exitCode, REASONS.BINARY_NOT_FOUND);
+    assertExactKeys(result);
+    assert.equal(result.admitted, false);
+    assert.equal(result.orca_bin, null);
+    assert.equal(result.blocking_reasons[0].reason_code, "BINARY_NOT_FOUND");
+  } finally {
+    process.exitCode = prevExit;
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Dispatch Summary

```text
이슈 #942 구현을 완료했고 커밋했습니다 (`d765bf9`).

## 요약

`skills/relay-orca/scripts/probe-orca.js` — fail-closed Orca capability probe:
- 기본 모드: `status` / `task-list` / `gate-list`만 (읽기 전용)
- `--smoke`: 합성 task + `dispatch --inject` 후 자체 정리 (`reset` 절대 호출 안 함)
- reason codes 30–37, D8 JSON 표면

## Score Log

| Factor | Target | Baseline | Iter 1 | Final | Status |
|--------|--------|----------|--------|-------|--------|
| Read-only default probe | met | fail | pass | pass | pass |
| No-reset poison fixture 
```

## Score Log

- Run: issue-942-20260712104958225-f2fd591e
- Executor: cursor
- Branch: issue-942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * Orca 런타임 사용 가능 여부를 자동으로 점검하는 capability probe를 추가했습니다.
  * 기본 점검은 읽기 전용이며, `--smoke`로 안전한 smoke 테스트를 선택 실행할 수 있습니다.
  * 결과를 JSON으로 제공하고, 실패 사유에 따른 종료 코드/안내를 표준화했습니다.
  * Orca 실행 파일을 환경 변수, 직접 지정 경로, macOS 앱 경로에서 자동 탐색합니다.
* **문서**
  * probe 사용 방법, 점검 순서, 실패 사유 매핑, 안전 보장 사항을 상세히 문서화했습니다.
* **테스트**
  * 다양한 성공/실패/오류/상태 혼선/smoke 정리 흐름을 검증하는 통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #942
