### PR TITLE
fix(relay-dispatch): validate salvage transition before row-6 side effects (#968)

### DIFF
--- a/skills/relay-dispatch/scripts/reconcile-run.js
+++ b/skills/relay-dispatch/scripts/reconcile-run.js
@@ -14,7 +14,12 @@ const {
   rebrandEvidence,
   writeExecutionEvidence,
 } = require("./execution-evidence");
-const { forceUpdateManifestState, STATES, updateManifestState } = require("./manifest/lifecycle");
+const {
+  forceUpdateManifestState,
+  STATES,
+  updateManifestState,
+  validateTransitionInvariants,
+} = require("./manifest/lifecycle");
 const { getRunDir, summarizeFailure, validateManifestPaths } = require("./manifest/paths");
 const { readManifest, writeManifest } = require("./manifest/store");
 const { classifyRepositoryDirt } = require("./runtime-dirt");
@@ -555,6 +560,27 @@ async function trySalvageEscalatedTimeout(
   const pushTarget = `origin/${branch}`;
   const evidencePlan = planSalvageEvidence(runDir, testResultFile);
   const reason = salvageAuditReason(runId);
+
+  // Validate escalated→review_pending invariants before any side effect (push,
+  // lease removal, evidence stamp). Mirrors reviewer-swap.js validate-first
+  // ordering so a max-1-swap rejection cannot leave a pushed-but-stuck run.
+  try {
+    validateTransitionInvariants(data, data.state, STATES.REVIEW_PENDING);
+  } catch (err) {
+    outputResult(salvageResult({
+      status: "invariant_blocked",
+      manifestPath,
+      runId,
+      data,
+      dryRun,
+      nextAction: "manual_close_run",
+      extra: {
+        branch,
+        invariantError: err.message,
+      },
+    }), jsonOut);
+    return true;
+  }
 
   if (dryRun) {
     outputResult(salvageResult({

--- a/tests/relay-dispatch/scripts/reconcile-run.test.js
+++ b/tests/relay-dispatch/scripts/reconcile-run.test.js
@@ -1036,3 +1036,74 @@ test("reconcile leaves an escalated-timeout run with nothing to salvage at the r
   assert.equal(result.state, STATES.ESCALATED);
   assert.equal(remoteBranchSha(fixture), null);
 });
+
+test("reconcile blocks escalated-timeout salvage when reviewer_swap_count invariant rejects", () => {
+  const fixture = setupRepo({
+    manifestState: STATES.ESCALATED,
+    committedWork: true,
+    dispatchResultFailureClass: "total_timeout",
+    executionEvidence: false,
+  });
+  const record = readManifest(fixture.manifestPath);
+  record.data.review = { ...(record.data.review || {}), reviewer_swap_count: 1 };
+  writeManifest(fixture.manifestPath, record.data, record.body);
+
+  const leasePath = writeLease(fixture, {
+    pid: 999999,
+    pgid: 999999,
+    startedAt: new Date().toISOString(),
+    timeoutS: 60,
+  });
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const remoteBefore = remoteBranchSha(fixture);
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 6);
+  assert.equal(result.status, "invariant_blocked");
+  assert.equal(result.nextAction, "manual_close_run");
+  assert.ok(result.invariantError && result.invariantError.length > 0);
+  assert.match(result.invariantError, /reviewer_swap_count/);
+
+  // No side effects: remote ref, lease, evidence, and manifest all untouched.
+  assert.equal(remoteBranchSha(fixture), remoteBefore);
+  assert.equal(fs.existsSync(leasePath), true);
+  assert.equal(fs.existsSync(evidencePath), false);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.ESCALATED);
+
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  assert.equal(events.some((event) => event.event === EVENTS.STATE_RECOVERY), false);
+});
+
+test("reconcile dry-run reports invariant_blocked without side effects when swap count rejects", () => {
+  const fixture = setupRepo({
+    manifestState: STATES.ESCALATED,
+    committedWork: true,
+    dispatchResultFailureClass: "total_timeout",
+    executionEvidence: false,
+  });
+  const record = readManifest(fixture.manifestPath);
+  record.data.review = { ...(record.data.review || {}), reviewer_swap_count: 1 };
+  writeManifest(fixture.manifestPath, record.data, record.body);
+
+  const leasePath = writeLease(fixture, {
+    pid: 999999,
+    pgid: 999999,
+    startedAt: new Date().toISOString(),
+    timeoutS: 60,
+  });
+  const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
+  const remoteBefore = remoteBranchSha(fixture);
+
+  const result = parseJsonResult(runReconcile(fixture, ["--dry-run"]));
+
+  assert.equal(result.row, 6);
+  assert.equal(result.status, "invariant_blocked");
+  assert.equal(result.nextAction, "manual_close_run");
+  assert.ok(result.invariantError && result.invariantError.length > 0);
+
+  assert.equal(remoteBranchSha(fixture), remoteBefore);
+  assert.equal(fs.existsSync(leasePath), true);
+  assert.equal(fs.existsSync(evidencePath), false);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.ESCALATED);
+});


### PR DESCRIPTION
## Summary
- Row-6 escalated-timeout salvage now evaluates `validateTransitionInvariants` for escalated→review_pending **before** any push, lease removal, or evidence stamp.
- When `reviewer_swap_count >= 1` rejects the transition, reconcile-run emits `status: invariant_blocked` / `nextAction: manual_close_run` (exit 0) with zero side effects — including under `--dry-run`.
- Invariant-clean salvage remains byte-identical; adds regression coverage for the blocked and dry-run-blocked paths.

Closes #968

## Test plan
- [x] `node --test tests/relay-dispatch/scripts/reconcile-run.test.js` (32 pass)
- [x] `node --test --test-concurrency=1 tests/relay-dispatch/scripts/*.test.js` (1046 pass, 2 skipped)
- [ ] Reviewer: confirm blocked path leaves bare-origin ref, lease, evidence, and manifest untouched

Made with [Cursor](https://cursor.com)