### PR TITLE
tests: cover fail-path branches shipped untested in the #949–#951 arc (#970)

### DIFF
--- a/skills/relay-review/scripts/review-runner/check-wait.js
+++ b/skills/relay-review/scripts/review-runner/check-wait.js
@@ -58,6 +58,10 @@ function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs 
   let ghErrors = 0;
   let polls = 0;
   let settled = false;
+  // Set only when the loop exits because the gh-error retry budget was exhausted —
+  // distinct from budgetExhausted (deadline reached). Lets callers tell "nothing was
+  // pending" (pending_checks: []) apart from "check state unknown due to gh failures".
+  let checksUnknown = false;
   while (true) {
     polls += 1;
     let fetchError = null;
@@ -71,7 +75,11 @@ function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs 
       settled = true;
       break;
     }
-    if (now() >= deadline || (fetchError && ghErrors > MAX_GH_RETRIES)) break;
+    if (fetchError && ghErrors > MAX_GH_RETRIES) {
+      checksUnknown = true;
+      break;
+    }
+    if (now() >= deadline) break;
     wait(Math.min(intervalMs, Math.max(0, deadline - now())));
   }
   const pendingChecks = classifyChecks(checks).pendingChecks;
@@ -84,6 +92,7 @@ function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs 
     waitedMs: Math.max(0, now() - start),
     polls,
     ghErrors,
+    checksUnknown,
   };
 }
 
@@ -98,6 +107,7 @@ function toResultSummary(outcome) {
     gh_errors: outcome.ghErrors,
     checks: outcome.checks,
     pending_checks: outcome.pendingCheckNames,
+    ...(outcome.checksUnknown ? { checks_unknown: true } : {}),
   };
 }
 

--- a/tests/relay-dispatch/scripts/recover-state.test.js
+++ b/tests/relay-dispatch/scripts/recover-state.test.js
@@ -207,6 +207,28 @@ process.exit(2);
   };
 }
 
+// Simulates a persistent gh failure (rate limit, network blip, auth error, ...): stdout
+// stays empty and the stderr message does not match the "no checks reported" contract,
+// so fetchChecks (skills/relay-dispatch/scripts/wait-for-check.js) cannot normalize the
+// failure into [] and must throw (#970).
+function writeGhPrChecksErrorScript(message = "gh: API rate limit exceeded (HTTP 403)") {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gh-checks-error-"));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "pr" && args[1] === "checks") {
+  process.stderr.write(${JSON.stringify(message)});
+  process.exit(1);
+}
+console.error("unexpected gh args: " + args.join(" "));
+process.exit(2);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return {
+    PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+  };
+}
+
 function stampPendingChecksMarker(manifestPath, marker) {
   const record = readManifest(manifestPath);
   const updated = {
@@ -830,6 +852,63 @@ test("checks-green refuses a marker anchored to a different head (stale marker)"
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /no pending-checks marker anchored to the reviewed head/);
   assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED);
+});
+
+test("checks-green re-entry refuses when the live PR reports zero checks (#970)", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksScript([]) };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "trying checks-green when the PR reports no live checks",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /PR #334 reports no live checks/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED, "no transition on refusal");
+  assert.ok(
+    readManifest(manifestPath).data.review.pending_checks_marker,
+    "refusal must not consume the marker"
+  );
+});
+
+test("checks-green re-entry refuses when the live gh pr checks call itself fails (#970)", () => {
+  const { repoRoot, manifestPath, runId, initialHead } = setupRepo({
+    state: STATES.CHANGES_REQUESTED,
+    prNumber: 334,
+  });
+  stampPendingChecksMarker(manifestPath, { head_sha: initialHead, round: 1, pending_checks: ["unit"] });
+  const env = { ...process.env, ...writeGhPrChecksErrorScript() };
+
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--to", STATES.REVIEW_PENDING,
+    "--reason", "trying checks-green while gh itself is failing",
+    "--allow-same-head",
+    "--require-checks-green",
+    "--json",
+  ], { encoding: "utf-8", env });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /cannot fetch live gh pr checks/);
+  assert.match(result.stderr, /API rate limit exceeded/);
+  assert.equal(readManifest(manifestPath).data.state, STATES.CHANGES_REQUESTED, "no transition on refusal");
+  assert.ok(
+    readManifest(manifestPath).data.review.pending_checks_marker,
+    "refusal must not consume the marker"
+  );
 });
 
 test("--allow-same-head rejects passing both evidence flags (mutually exclusive)", () => {

--- a/tests/relay-review/scripts/review-runner-detach.test.js
+++ b/tests/relay-review/scripts/review-runner-detach.test.js
@@ -129,6 +129,22 @@ function writeVerdictFile(repoRoot, name, verdict) {
   return filePath;
 }
 
+// A reviewer subprocess that fails instead of producing a verdict: it exits non-zero
+// with an unparseable stderr message, which makes invokeReviewer's execFileSync throw
+// and, in turn, makes the detached child's run() reject (#970).
+function writeFailingReviewerScript(repoRoot, name, { delayMs = 0, message = "reviewer crashed: unparseable output" } = {}) {
+  const filePath = path.join(repoRoot, name);
+  const body = `#!/usr/bin/env node
+setTimeout(() => {
+  process.stderr.write(${JSON.stringify(message)});
+  process.exit(1);
+}, ${Number(delayMs)});
+`;
+  fs.writeFileSync(filePath, body, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
 function detachEnv(relayHome) {
   return { ...process.env, RELAY_HOME: relayHome };
 }
@@ -310,6 +326,43 @@ test("a persisted verdict with no manifest apply is recoverable via the document
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.state, STATES.CHANGES_REQUESTED, "verdict applied to the manifest via recovery");
   assert.equal(manifest.review.manual_review_reason, "reapply persisted verdict after detached-round kill");
+});
+
+// ---- #970: failed-sentinel path (finishDetachSupervisor's status:"failed" branch) --
+
+test("--detach writes a failed sentinel and the supervisor exits when run() rejects (#970)", async () => {
+  const { repoRoot, relayHome, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const reviewerScript = writeFailingReviewerScript(repoRoot, "reviewer-fail.js", { delayMs: 200 });
+
+  const launched = spawnSync(process.execPath, [
+    SCRIPT, "--repo", repoRoot, "--run-id", runId, "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath, "--diff-file", diffPath,
+    "--reviewer-script", reviewerScript, "--no-comment", "--detach", "--json",
+  ], { encoding: "utf-8", env: detachEnv(relayHome), timeout: 15000 });
+
+  assert.equal(launched.status, 0, `${launched.stderr}\n${launched.stdout}`);
+  const receipt = JSON.parse(launched.stdout);
+  assert.equal(receipt.status, "detached");
+  assert.ok(pidAlive(receipt.pid), "detached supervisor alive right after the receipt");
+
+  // The reviewer subprocess fails (non-zero exit, unparseable stderr) so invokeReviewer's
+  // execFileSync throws inside run(), rejecting the promise dispatchReviewEntry awaits.
+  await waitFor(() => fs.existsSync(receipt.sentinelPath), { message: "failed sentinel" });
+  const sentinel = JSON.parse(fs.readFileSync(receipt.sentinelPath, "utf-8"));
+  assert.equal(sentinel.status, "failed");
+  assert.equal(sentinel.runId, runId);
+  assert.equal(sentinel.round, 1);
+  assert.equal(sentinel.exitCode, 1);
+  assert.equal(typeof sentinel.error, "string");
+  assert.ok(sentinel.error.length > 0, "sentinel carries a non-empty error");
+  assert.ok(sentinel.finishedAt && !Number.isNaN(Date.parse(sentinel.finishedAt)), "sentinel carries an ISO finishedAt");
+
+  // printFailureAndExit calls process.exit(1) after the sentinel is written — the
+  // supervisor must not hang around as a zombie/leaked process.
+  await waitFor(() => !pidAlive(receipt.pid), { message: "detached supervisor process to exit after failure" });
+
+  // The round never applied a verdict, so the manifest stays exactly where it was.
+  assert.equal(readManifest(manifestPath).data.state, STATES.REVIEW_PENDING, "no verdict applied on a failed round");
 });
 
 // ---- DC #5: incompatible-combination rejection ---------------------------

--- a/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
+++ b/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
@@ -21,8 +21,10 @@ const {
 } = require("../../relay-dispatch/scripts/test-support");
 const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 const {
+  MAX_GH_RETRIES,
   parseWaitForChecksSeconds,
   pollChecksUntilSettled,
+  toResultSummary,
 } = require("../../../skills/relay-review/scripts/review-runner/check-wait");
 const { writeFakeGhScript } = require("../fixtures/fake-gh");
 
@@ -218,6 +220,63 @@ test("pollChecksUntilSettled proceeds with pending states when the budget is exh
   assert.equal(outcome.budgetExhausted, true);
   assert.deepEqual(outcome.pendingCheckNames, ["unit"]);
   assert.equal(outcome.waitedMs, 2000);
+});
+
+// ---- #970: gh-error exhaustion is never exercised by DC #1/#2 above -------------
+
+test("pollChecksUntilSettled exhausts the gh-error retry budget and flags checks_unknown (#970)", () => {
+  const clock = { t: 0 };
+  let calls = 0;
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 600, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      fetchChecks: () => { calls += 1; throw new Error("gh pr checks failed: API unavailable"); },
+    }
+  );
+  assert.equal(outcome.pending, true, "never settles — proceeds with pending semantics");
+  assert.equal(calls, MAX_GH_RETRIES + 1, "gh is retried up to the named budget, then the loop gives up");
+  assert.equal(outcome.ghErrors, MAX_GH_RETRIES + 1);
+  assert.equal(outcome.budgetExhausted, false, "the gh-error path exits well short of the 600s budget");
+  assert.deepEqual(outcome.checks, [], "no checks payload was ever fetched");
+
+  const summary = toResultSummary(outcome);
+  assert.equal(summary.checks_unknown, true, "summary distinguishes state-unknown from nothing-pending");
+  assert.equal(summary.gh_errors, MAX_GH_RETRIES + 1);
+  assert.equal(summary.proceeded_with_pending, true);
+  assert.deepEqual(summary.pending_checks, [], "pending_checks alone would misread as nothing pending");
+});
+
+test("a normal settle summary does not carry checks_unknown (#970)", () => {
+  const clock = { t: 0 };
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 60, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      fetchChecks: () => [{ name: "unit", bucket: "pass" }],
+    }
+  );
+  assert.equal(outcome.pending, false);
+  const summary = toResultSummary(outcome);
+  assert.equal("checks_unknown" in summary, false, "settled rounds never carry the field");
+});
+
+test("a normal budget-exhausted summary (no gh errors) does not carry checks_unknown (#970)", () => {
+  const clock = { t: 0 };
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 2, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      fetchChecks: () => [{ name: "unit", bucket: "pending" }],
+    }
+  );
+  assert.equal(outcome.pending, true);
+  assert.equal(outcome.budgetExhausted, true);
+  const summary = toResultSummary(outcome);
+  assert.equal("checks_unknown" in summary, false, "a clean budget-exhaustion is not a gh-error exhaustion");
 });
 
 test("parseWaitForChecksSeconds: absent flag -> null, valid -> number, invalid -> throw", () => {


### PR DESCRIPTION
Closes #970

Post-ship review of the #949–#951 arc (PRs #960/#961/#962) found three fail-path branches unexercised by any test. This PR closes all three gaps; the only production change is one observability field.

## Gaps closed

### 1. review-runner `--detach` failed-sentinel branch (test-only)
`tests/relay-review/scripts/review-runner-detach.test.js` — all four existing detach tests exercised success paths (`sentinel.status === "complete"`). New test forces the detached child's `run()` to reject via a reviewer fixture that exits non-zero with unparseable output, then asserts:
- sentinel written with `status: "failed"`, a non-empty `error`, `exitCode: 1`, and an ISO `finishedAt`
- the detached supervisor process exits after writing the sentinel (no hang / leaked process)
- the manifest stays in `review_pending` (no verdict applied on a failed round)

### 2. check-wait gh-error exhaustion (test + one field)
`skills/relay-review/scripts/review-runner/check-wait.js` — `pollChecksUntilSettled` breaks out when `ghErrors > MAX_GH_RETRIES`, but no test exercised it, and the summary on that path reported `pending_checks: []`, which misreads as "nothing pending". Production change (minimal): the summary now emits `checks_unknown: true` ONLY when the loop exits via the gh-error path. New tests assert:
- fetchChecks throwing on every poll exits after `MAX_GH_RETRIES + 1` attempts with proceed-with-pending semantics, the `gh_errors` count, and `checks_unknown: true`
- a normal settle summary does NOT carry `checks_unknown`
- a normal budget-exhausted summary (no gh errors) does NOT carry `checks_unknown`

### 3. recover-state `requireChecksGreenEvidence` refusals (test-only)
`tests/relay-dispatch/scripts/recover-state.test.js` — two fail-closed branches now covered, reusing the suite's `writeGhPrChecksScript` helper plus a new erroring-gh variant:
- live `gh pr checks` returns zero checks → refusal "PR reports no live checks", no transition, marker not consumed
- fetchChecks throws (gh failure) → refusal "cannot fetch live gh pr checks", no transition, marker not consumed

## Verification

Serialized combo run (`node --test --test-concurrency=1 tests/relay-review/scripts/*.test.js tests/relay-dispatch/scripts/recover-state.test.js`):

```
# Subtest: checks-green re-entry refuses when the live PR reports zero checks (#970)
# Subtest: checks-green re-entry refuses when the live gh pr checks call itself fails (#970)
# Subtest: --detach writes a failed sentinel and the supervisor exits when run() rejects (#970)
# Subtest: pollChecksUntilSettled exhausts the gh-error retry budget and flags checks_unknown (#970)
# Subtest: a normal settle summary does not carry checks_unknown (#970)
# Subtest: a normal budget-exhausted summary (no gh errors) does not carry checks_unknown (#970)
# tests 615
# suites 0
# pass 615
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 430947.921042
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
