### PR TITLE
fix(cleanup-worktrees): ownership validation across multi-checkout topologies (#969)

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -23,10 +23,15 @@ const {
   CLEANUP_STATUSES,
   runCleanup,
 } = require("./manifest/cleanup");
+const { execGit } = require("./exec");
 const {
   getRelayWorktreeBase,
+  getRunDir,
+  getWorktreeGitCommonDir,
   isPathContainedWithin,
   listManifestPaths,
+  sameFilesystemLocation,
+  summarizeFailure,
   validateManifestPaths,
 } = require("./manifest/paths");
 const {
@@ -46,6 +51,12 @@ const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "cleanup-worktrees" };
 const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
 const OS_DETRITUS = new Set([".DS_Store", "Thumbs.db"]);
+
+const VALIDATE_MANIFEST_CLEANUP_OPTS = {
+  acceptPrunedRelayOwned: true,
+  acceptVanishedRepoRootForCleanup: true,
+  caller: "cleanup-worktrees",
+};
 
 function parseHours(value, label) {
   const parsed = Number(value);
@@ -116,6 +127,165 @@ function sweepOrphanedWorktreeShells({ dryRun }) {
   return result;
 }
 
+function isRealpathContainedWithin(basePath, candidatePath) {
+  try {
+    const realBase = fs.realpathSync.native(basePath);
+    const realCandidate = fs.realpathSync.native(candidatePath);
+    return isPathContainedWithin(realBase, realCandidate);
+  } catch {
+    return false;
+  }
+}
+
+function removeAdvisoryWorktreeDirectory(candidatePath, runDir) {
+  if (!fs.existsSync(candidatePath)) {
+    return true;
+  }
+  if (!isRealpathContainedWithin(runDir, candidatePath)) {
+    throw new Error(`refusing rm fallback outside run advisory root: ${candidatePath}`);
+  }
+  fs.rmSync(candidatePath, { recursive: true, force: true });
+  return !fs.existsSync(candidatePath);
+}
+
+/**
+ * Prune stale advisory-lane worktrees under a terminal run's run dir.
+ * Candidates must be realpath-contained under the run dir; when the checkout
+ * still resolves, its git common dir must match the trust root.
+ */
+function pruneAdvisoryWorktreesForRun({
+  repoRoot,
+  runId,
+  dryRun,
+  expectedGitCommonDir,
+}) {
+  const runDir = getRunDir(repoRoot, runId);
+  const advisoryRoot = path.join(runDir, "advisory-worktrees");
+  const results = [];
+  if (!fs.existsSync(advisoryRoot)) {
+    return results;
+  }
+
+  let entries;
+  try {
+    entries = fs.readdirSync(advisoryRoot, { withFileTypes: true });
+  } catch (error) {
+    results.push({
+      runId,
+      path: advisoryRoot,
+      classification: "refused",
+      reason: "advisory_root_unreadable",
+      error: summarizeFailure(error),
+    });
+    return results;
+  }
+
+  for (const entry of entries) {
+    const candidate = path.join(advisoryRoot, entry.name);
+    if (!isPathContainedWithin(runDir, candidate)) {
+      results.push({
+        runId,
+        path: candidate,
+        classification: "refused",
+        reason: "outside_run_dir_advisory_root",
+      });
+      continue;
+    }
+
+    const candidateExists = fs.existsSync(candidate);
+    if (candidateExists) {
+      if (!isRealpathContainedWithin(runDir, candidate)) {
+        results.push({
+          runId,
+          path: candidate,
+          classification: "refused",
+          reason: "realpath_outside_run_dir_advisory_root",
+        });
+        continue;
+      }
+      const candidateCommonDir = getWorktreeGitCommonDir(candidate);
+      if (!candidateCommonDir) {
+        results.push({
+          runId,
+          path: candidate,
+          classification: "refused",
+          reason: "unverifiable_git_common_dir",
+        });
+        continue;
+      }
+      const matchesTrustRoot = candidateCommonDir === expectedGitCommonDir
+        || sameFilesystemLocation(candidateCommonDir, expectedGitCommonDir);
+      if (!matchesTrustRoot) {
+        results.push({
+          runId,
+          path: candidate,
+          classification: "refused",
+          reason: "foreign_git_common_dir",
+        });
+        continue;
+      }
+    }
+
+    if (dryRun) {
+      results.push({
+        runId,
+        path: candidate,
+        classification: "pruned-planned",
+        reason: "terminal_advisory_worktree",
+      });
+      continue;
+    }
+
+    let removed = !candidateExists;
+    const errors = [];
+    if (candidateExists) {
+      try {
+        execGit(repoRoot, ["worktree", "remove", "--force", candidate]);
+        removed = !fs.existsSync(candidate);
+      } catch (error) {
+        try {
+          execGit(repoRoot, ["worktree", "prune"]);
+          removed = removeAdvisoryWorktreeDirectory(candidate, runDir);
+          if (!removed) {
+            errors.push(`advisory worktree still exists after fallback: ${candidate}`);
+          }
+        } catch (fallbackError) {
+          errors.push(
+            `worktree remove failed: ${summarizeFailure(error)}; ` +
+            `rm fallback failed: ${summarizeFailure(fallbackError)}`
+          );
+        }
+      }
+    } else {
+      try {
+        execGit(repoRoot, ["worktree", "prune"]);
+      } catch (error) {
+        errors.push(`worktree prune failed: ${summarizeFailure(error)}`);
+      }
+    }
+
+    if (errors.length || (candidateExists && fs.existsSync(candidate))) {
+      results.push({
+        runId,
+        path: candidate,
+        classification: "refused",
+        reason: "advisory_prune_failed",
+        error: errors.join("; ") || `advisory worktree still exists: ${candidate}`,
+      });
+      continue;
+    }
+
+    results.push({
+      runId,
+      path: candidate,
+      classification: "owned",
+      reason: "terminal_advisory_worktree_pruned",
+    });
+  }
+
+  return results;
+}
+
 if (hasCliFlag(["--help", "-h"])) {
   console.log("Usage: cleanup-worktrees.js [options]");
   console.log("\nManifest-aware relay janitor for stale worktrees.");
@@ -151,6 +321,7 @@ function run() {
   const olderThanHours = all ? 0 : parseHours(readArg(args, "--older-than", "24", CLI_ARG_OPTIONS), "--older-than");
   const now = Date.now();
   const cutoff = now - olderThanHours * 60 * 60 * 1000;
+  const expectedGitCommonDir = getWorktreeGitCommonDir(repoRoot) || path.join(repoRoot, ".git");
 
   const result = {
     repoRoot,
@@ -170,6 +341,8 @@ function run() {
     inventory: [],
     reapedShells: [],
     skippedShells: [],
+    advisoryPruned: [],
+    advisoryRefused: [],
   };
 
   const manifestPaths = listManifestPaths(repoRoot);
@@ -201,11 +374,10 @@ function run() {
         expectedRepoRoot: repoRoot,
         manifestPath,
         runId: data.run_id,
-        acceptPrunedRelayOwned: true,
         allowMissingWorktree: terminalState,
         acceptMissingRelayContainedForCleanup: terminalState,
         acceptUnverifiableRelayContainedForCleanup: terminalState && forceTerminal,
-        caller: "cleanup-worktrees",
+        ...VALIDATE_MANIFEST_CLEANUP_OPTS,
       });
       forcedTerminalUnverifiable = Boolean(validatedPaths.unverifiableRelayContainedForCleanup);
       normalizedData = {
@@ -224,11 +396,10 @@ function run() {
             expectedRepoRoot: repoRoot,
             manifestPath,
             runId: data.run_id,
-            acceptPrunedRelayOwned: true,
             allowMissingWorktree: true,
             acceptMissingRelayContainedForCleanup: true,
             acceptUnverifiableRelayContainedForCleanup: true,
-            caller: "cleanup-worktrees",
+            ...VALIDATE_MANIFEST_CLEANUP_OPTS,
           });
           terminalForceEligible = Boolean(forceValidatedPaths.unverifiableRelayContainedForCleanup);
         } catch {
@@ -329,6 +500,7 @@ function run() {
         dryRun,
         deleteMergedBranch: true,
         acceptPrunedRelayOwned: true,
+        acceptVanishedRepoRootForCleanup: true,
       });
 
       const item = {
@@ -380,6 +552,22 @@ function run() {
       continue;
     }
 
+    // Terminal + age-eligible: prune advisory-lane worktrees even when the
+    // executor worktree was already cleaned (they are not recorded in paths.worktree).
+    const advisoryResults = pruneAdvisoryWorktreesForRun({
+      repoRoot,
+      runId: normalizedData.run_id,
+      dryRun,
+      expectedGitCommonDir,
+    });
+    for (const advisory of advisoryResults) {
+      if (advisory.classification === "refused") {
+        result.advisoryRefused.push(advisory);
+      } else {
+        result.advisoryPruned.push(advisory);
+      }
+    }
+
     if (cleanupStatus === CLEANUP_STATUSES.SUCCEEDED) {
       result.skipped.push({ ...enrichedBaseInfo, reason: "already_cleaned" });
       continue;
@@ -417,6 +605,7 @@ function run() {
       allowMissingWorktree: true,
       acceptMissingRelayContainedForCleanup: true,
       acceptUnverifiableRelayContainedForCleanup: forcedTerminalUnverifiable,
+      acceptVanishedRepoRootForCleanup: true,
     });
 
     const item = {
@@ -428,12 +617,16 @@ function run() {
       branchDeleted: cleanupResult.summary.branchDeleted,
       pruneRan: cleanupResult.summary.pruneRan,
       error: cleanupResult.summary.error,
+      classification: forcedTerminalUnverifiable
+        ? "cleanable_terminal_unverifiable_path"
+        : "owned",
       ...(forcedTerminalUnverifiable
         ? {
           reason: "forced_terminal_unverifiable_path",
-          classification: "cleanable_terminal_unverifiable_path",
         }
-        : {}),
+        : {
+          reason: "owned_relay_worktree",
+        }),
     };
 
     if (!dryRun) {
@@ -475,6 +668,7 @@ function run() {
     console.log(`  failed:     ${result.failed.length}`);
     console.log(`  stale open: ${result.staleOpen.length}`);
     console.log(`  skipped:    ${result.skipped.length}`);
+    console.log(`  advisory:   ${result.advisoryPruned.length} pruned, ${result.advisoryRefused.length} refused`);
     if (result.failed.length) {
       console.log("  failures:");
       result.failed.forEach((entry) => console.log(`    ${entry.runId}: ${entry.error}`));
@@ -490,6 +684,18 @@ function run() {
       console.log("  inventory:");
       result.inventory.forEach((entry) => {
         console.log(`    ${entry.runId} (${entry.state}, ${entry.health.finishPath}) -> ${entry.health.recommendedAction}`);
+      });
+    }
+    if (result.advisoryPruned.length) {
+      console.log("  advisory pruned:");
+      result.advisoryPruned.forEach((entry) => {
+        console.log(`    ${entry.runId}: ${entry.classification} ${entry.path} (${entry.reason})`);
+      });
+    }
+    if (result.advisoryRefused.length) {
+      console.log("  advisory refused:");
+      result.advisoryRefused.forEach((entry) => {
+        console.log(`    ${entry.runId}: ${entry.classification} ${entry.path} (${entry.reason})`);
       });
     }
     if (dryRun) {

--- a/skills/relay-dispatch/scripts/manifest/cleanup.js
+++ b/skills/relay-dispatch/scripts/manifest/cleanup.js
@@ -113,6 +113,7 @@ function runCleanup({
   allowMissingWorktree = false,
   acceptMissingRelayContainedForCleanup = false,
   acceptUnverifiableRelayContainedForCleanup = false,
+  acceptVanishedRepoRootForCleanup = false,
 }) {
   const validatedPaths = validateManifestPaths(data?.paths, {
     expectedRepoRoot: repoRoot,
@@ -121,6 +122,7 @@ function runCleanup({
     allowMissingWorktree,
     acceptMissingRelayContainedForCleanup,
     acceptUnverifiableRelayContainedForCleanup,
+    acceptVanishedRepoRootForCleanup,
     caller: "runCleanup",
   });
   const normalizedData = {

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -425,6 +425,26 @@ function sameGitCommonDir(leftPath, rightPath) {
   return leftCommonDir === rightCommonDir || sameFilesystemLocation(leftCommonDir, rightCommonDir);
 }
 
+/**
+ * Basename of the main working tree that owns a git common dir.
+ * For `<dir>/.git` → `basename(<dir>)`. Bare common-dir shapes fall back to the
+ * common-dir basename (with a trailing `.git` suffix stripped when present).
+ */
+function getTrustRootRepoBasename(expectedGitCommonDir) {
+  if (!expectedGitCommonDir || typeof expectedGitCommonDir !== "string") {
+    return null;
+  }
+  const resolved = path.resolve(expectedGitCommonDir);
+  const leaf = path.basename(resolved);
+  if (leaf === ".git") {
+    const parent = path.basename(path.dirname(resolved));
+    return parent || null;
+  }
+  // Bare / non-standard common-dir: use the directory name, drop a trailing `.git`.
+  const bareName = leaf.replace(/\.git$/i, "");
+  return bareName || leaf || null;
+}
+
 function validateManifestPaths(paths, {
   expectedRepoRoot,
   manifestPath,
@@ -434,6 +454,7 @@ function validateManifestPaths(paths, {
   acceptPrunedRelayOwned = false,
   acceptMissingRelayContainedForCleanup = false,
   acceptUnverifiableRelayContainedForCleanup = false,
+  acceptVanishedRepoRootForCleanup = false,
   caller = "relay manifest consumer",
 } = {}) {
   if (!paths || typeof paths !== "object" || Array.isArray(paths)) {
@@ -449,11 +470,21 @@ function validateManifestPaths(paths, {
   const normalizedExpectedRepoRoot = typeof expectedRepoRoot === "string" && expectedRepoRoot.trim() !== ""
     ? path.resolve(expectedRepoRoot)
     : null;
+  const recordedRepoRootExists = fs.existsSync(repoRoot);
   const repoRootEquivalentToExpected = normalizedExpectedRepoRoot
     && repoRoot !== normalizedExpectedRepoRoot
     && !sameFilesystemLocation(repoRoot, normalizedExpectedRepoRoot)
     && sameGitCommonDir(repoRoot, normalizedExpectedRepoRoot);
-  const effectiveRepoRoot = repoRootEquivalentToExpected ? normalizedExpectedRepoRoot : repoRoot;
+  // Cleanup-only: a deleted dispatch-time checkout cannot prove common-dir
+  // equivalence. Fall through to the invoking checkout and let worktree rules decide.
+  const vanishedRepoRootAccepted = Boolean(
+    acceptVanishedRepoRootForCleanup
+    && normalizedExpectedRepoRoot
+    && !recordedRepoRootExists
+  );
+  const effectiveRepoRoot = (repoRootEquivalentToExpected || vanishedRepoRootAccepted)
+    ? normalizedExpectedRepoRoot
+    : repoRoot;
   const normalizedManifestPath = typeof manifestPath === "string" && manifestPath.trim() !== ""
     ? path.resolve(manifestPath)
     : null;
@@ -468,6 +499,7 @@ function validateManifestPaths(paths, {
     && repoRoot !== normalizedExpectedRepoRoot
     && !sameFilesystemLocation(repoRoot, normalizedExpectedRepoRoot)
     && !repoRootEquivalentToExpected
+    && !vanishedRepoRootAccepted
   ) {
     throw new Error(
       `${caller}: manifest paths.repo_root ${JSON.stringify(repoRoot)} does not match the expected repo root ` +
@@ -507,14 +539,16 @@ function validateManifestPaths(paths, {
   const worktree = path.resolve(worktreeRaw);
   const relayWorktreeBase = getRelayWorktreeBase();
   const repoContainedWorktree = isPathContainedWithin(effectiveRepoRoot, worktree);
+  const expectedGitCommonDir = getWorktreeGitCommonDir(effectiveRepoRoot) || path.join(effectiveRepoRoot, ".git");
+  const trustRootRepoBasename = getTrustRootRepoBasename(expectedGitCommonDir);
   const relayOwnedRepoRootBasenames = [
     path.basename(effectiveRepoRoot),
     path.basename(repoRoot),
-  ];
+    trustRootRepoBasename,
+  ].filter(Boolean);
   const relayOwnedWorktreeCandidate = isPathContainedWithin(relayWorktreeBase, worktree)
     && relayOwnedRepoRootBasenames.includes(path.basename(worktree));
   const relayContainedWorktreeCandidateForCleanup = isPathContainedWithin(relayWorktreeBase, worktree);
-  const expectedGitCommonDir = getWorktreeGitCommonDir(effectiveRepoRoot) || path.join(effectiveRepoRoot, ".git");
   const worktreeExists = fs.existsSync(worktree);
   if (!worktreeExists) {
     if (
@@ -622,6 +656,7 @@ module.exports = {
   getRunDir,
   getRunsBase,
   getRunsDir,
+  getTrustRootRepoBasename,
   getWorktreeGitCommonDir,
   inferIssueNumber,
   isPathContainedWithin,

--- a/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -971,3 +971,238 @@ test("cleanup-worktrees rejects tampered paths.repo_root before cleanup side eff
   const manifest = readManifest(manifestPath).data;
   assert.equal(manifest.cleanup.status, "pending");
 });
+
+function setupNamedMainRepo(repoName = "dev-relay") {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-janitor-969-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-969-"));
+  const repoRoot = path.join(fixtureRoot, repoName);
+  fs.mkdirSync(repoRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Janitor 969"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-janitor-969@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  return { fixtureRoot, repoRoot };
+}
+
+function writeMultiCheckoutMissingWorktreeRun(repoRoot, {
+  branch,
+  updatedAt,
+  recordedRepoRoot,
+  worktreeBasename,
+}) {
+  const runId = createRunId({
+    branch,
+    timestamp: new Date(updatedAt),
+  });
+  const worktreePath = path.join(getRelayWorktreeBase(), `969-${branch}`, worktreeBasename);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  fs.rmSync(worktreePath, { recursive: true, force: true });
+
+  const layout = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot: recordedRepoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 969,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor.rubric_path = "rubric.yaml";
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: multi-checkout\n", "utf-8");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+  manifest = updateManifestState(manifest, STATES.MERGED, "manual_cleanup_required");
+  manifest.timestamps.created_at = updatedAt;
+  manifest.timestamps.updated_at = updatedAt;
+  // Skeleton may canonicalize repo_root; force the recorded dispatch-time path.
+  manifest.paths.repo_root = recordedRepoRoot;
+  writeManifest(layout.manifestPath, manifest);
+  return { manifestPath: layout.manifestPath, runId, worktreePath, runDir: layout.runDir };
+}
+
+test("cleanup-worktrees #969 cleans missing trust-root-named worktree from differently-named checkout", () => {
+  const { repoRoot } = setupNamedMainRepo("dev-relay");
+  const krillCheckout = path.join(path.dirname(repoRoot), "krill");
+  execFileSync("git", ["worktree", "add", krillCheckout, "-b", "checkout-krill"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const stale = writeMultiCheckoutMissingWorktreeRun(repoRoot, {
+    branch: "issue-969-a",
+    updatedAt,
+    recordedRepoRoot: krillCheckout,
+    worktreeBasename: "dev-relay",
+  });
+  assert.notEqual(path.basename(krillCheckout), "dev-relay");
+  assert.equal(path.basename(stale.worktreePath), "dev-relay");
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", krillCheckout,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+
+  const result = JSON.parse(stdout);
+  const cleaned = result.cleaned.find((entry) => entry.runId === stale.runId);
+  assert.ok(cleaned, `expected cleanable run, got: ${JSON.stringify(result.failed, null, 2)}`);
+  assert.equal(result.failed.length, 0);
+  assert.equal(cleaned.classification, "owned");
+  assert.equal(cleaned.worktreeRemoved, true);
+  assert.equal(branchExists(repoRoot, "issue-969-a"), false);
+  assert.equal(readManifest(stale.manifestPath).data.cleanup.status, "succeeded");
+});
+
+test("cleanup-worktrees #969 accepts vanished repo_root and still refuses foreign existing repo_root", () => {
+  const { repoRoot } = setupNamedMainRepo("dev-relay");
+  const krillCheckout = path.join(path.dirname(repoRoot), "krill-vanish");
+  execFileSync("git", ["worktree", "add", krillCheckout, "-b", "checkout-krill-vanish"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const vanishedCheckout = path.join(path.dirname(repoRoot), "codex-ephemeral-checkout");
+  execFileSync("git", ["worktree", "add", vanishedCheckout, "-b", "checkout-vanished"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const stale = writeMultiCheckoutMissingWorktreeRun(repoRoot, {
+    branch: "issue-969-b",
+    updatedAt,
+    recordedRepoRoot: vanishedCheckout,
+    worktreeBasename: "dev-relay",
+  });
+  // Delete the dispatch-time checkout after recording it.
+  execFileSync("git", ["worktree", "remove", "--force", vanishedCheckout], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.equal(fs.existsSync(vanishedCheckout), false);
+
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", krillCheckout,
+    "--all",
+    "--json",
+  ], { encoding: "utf-8" });
+  const result = JSON.parse(stdout);
+  const cleaned = result.cleaned.find((entry) => entry.runId === stale.runId);
+  assert.ok(cleaned, `vanished repo_root must fall through: ${JSON.stringify(result.failed, null, 2)}`);
+  assert.equal(cleaned.classification, "owned");
+  assert.equal(readManifest(stale.manifestPath).data.cleanup.status, "succeeded");
+
+  // Existing foreign repo_root still refused.
+  const foreign = createUnrelatedRelayOwnedWorktree(repoRoot, "issue-969-foreign-root");
+  const foreignRun = writeRun(repoRoot, {
+    branch: "issue-969-foreign-root-run",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const record = readManifest(foreignRun.manifestPath);
+  writeManifest(foreignRun.manifestPath, {
+    ...record.data,
+    paths: {
+      ...record.data.paths,
+      repo_root: foreign.attackerRoot,
+    },
+  }, record.body);
+  const refused = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", krillCheckout, "--all", "--json",
+  ], { encoding: "utf-8" }));
+  const foreignFailure = refused.failed.find((entry) => entry.runId === readManifest(foreignRun.manifestPath).data.run_id
+    || entry.manifestPath === foreignRun.manifestPath);
+  assert.ok(foreignFailure, "foreign existing repo_root must be refused");
+  assert.match(foreignFailure.error, /Refusing to trust manifest-owned repo paths|manifest paths\.repo_root/);
+  assert.equal(fs.existsSync(foreignRun.worktreePath), true);
+});
+
+test("cleanup-worktrees #969 prunes advisory worktrees of merged runs and leaves non-terminal untouched", () => {
+  const { repoRoot } = setupNamedMainRepo("dev-relay");
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+
+  const merged = writeRun(repoRoot, {
+    branch: "issue-969-adv-merged",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const mergedRunId = readManifest(merged.manifestPath).data.run_id;
+  const mergedRunDir = ensureRunLayout(repoRoot, mergedRunId).runDir;
+  const mergedAdvisory = path.join(mergedRunDir, "advisory-worktrees", `codex-${process.pid}-merged`);
+  fs.mkdirSync(path.dirname(mergedAdvisory), { recursive: true });
+  execFileSync("git", ["worktree", "add", "--detach", mergedAdvisory, "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.match(
+    execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf-8" }),
+    new RegExp(mergedAdvisory.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  );
+
+  const open = writeRun(repoRoot, {
+    branch: "issue-969-adv-open",
+    state: STATES.REVIEW_PENDING,
+    updatedAt,
+  });
+  const openRunId = readManifest(open.manifestPath).data.run_id;
+  const openRunDir = ensureRunLayout(repoRoot, openRunId).runDir;
+  const openAdvisory = path.join(openRunDir, "advisory-worktrees", `codex-${process.pid}-open`);
+  fs.mkdirSync(path.dirname(openAdvisory), { recursive: true });
+  execFileSync("git", ["worktree", "add", "--detach", openAdvisory, "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  const dryRun = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", repoRoot, "--all", "--dry-run", "--json",
+  ], { encoding: "utf-8" }));
+  const planned = dryRun.advisoryPruned.find((entry) => entry.path === mergedAdvisory);
+  assert.ok(planned, `dry-run must plan advisory prune: ${JSON.stringify(dryRun.advisoryPruned, null, 2)}`);
+  assert.equal(planned.classification, "pruned-planned");
+  assert.equal(fs.existsSync(mergedAdvisory), true, "dry-run must not delete advisory worktree");
+  assert.equal(fs.existsSync(openAdvisory), true);
+  assert.equal(
+    dryRun.advisoryPruned.some((entry) => entry.path === openAdvisory),
+    false,
+    "non-terminal advisory must not be planned"
+  );
+  assert.match(
+    execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf-8" }),
+    new RegExp(mergedAdvisory.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    "dry-run must not deregister advisory worktree"
+  );
+
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", repoRoot, "--all", "--json",
+  ], { encoding: "utf-8" }));
+  const pruned = result.advisoryPruned.find((entry) => entry.path === mergedAdvisory);
+  assert.ok(pruned, `must prune merged advisory: ${JSON.stringify(result.advisoryPruned, null, 2)}`);
+  assert.equal(pruned.classification, "owned");
+  assert.equal(fs.existsSync(mergedAdvisory), false);
+  assert.doesNotMatch(
+    execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf-8" }),
+    new RegExp(mergedAdvisory.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  );
+  assert.equal(fs.existsSync(openAdvisory), true, "non-terminal advisory must remain on disk");
+  assert.match(
+    execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf-8" }),
+    new RegExp(openAdvisory.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  );
+});

--- a/tests/relay-dispatch/scripts/manifest/paths.test.js
+++ b/tests/relay-dispatch/scripts/manifest/paths.test.js
@@ -469,3 +469,97 @@ test("manifest/paths rejects missing worktrees outside repo and relay-owned root
     /is not contained under the expected repo root/
   );
 });
+
+test("manifest/paths missing worktree accepts trust-root repo basename from differently-named checkout (#969)", () => {
+  const runId = "issue-969-20260712010101000-a1b2c3d4";
+  const { repoRoot, linkedRoot, manifestPath, relayWorktreeBase } = createLinkedDispatchFixture(runId);
+  // Worktree named after the main repo (dev-relay), not the invoking checkout (floofy-seeking-music).
+  const missingWorktree = path.join(relayWorktreeBase, "969-trust-root", path.basename(repoRoot));
+  fs.mkdirSync(path.dirname(missingWorktree), { recursive: true });
+  assert.equal(fs.existsSync(missingWorktree), false);
+  assert.notEqual(path.basename(linkedRoot), path.basename(repoRoot));
+
+  const result = validateManifestPaths({
+    repo_root: linkedRoot,
+    worktree: missingWorktree,
+  }, {
+    expectedRepoRoot: linkedRoot,
+    manifestPath: getManifestPath(linkedRoot, runId),
+    runId,
+    allowMissingWorktree: true,
+    caller: "manifest/paths.test #969 trust-root basename",
+  });
+
+  assert.equal(result.worktreeLocation, "relay_worktree");
+  assert.equal(result.worktreeMissing, true);
+  assert.equal(path.basename(result.worktree), "dev-relay");
+});
+
+test("manifest/paths acceptVanishedRepoRootForCleanup falls through; default still refuses (#969)", () => {
+  const runId = "issue-969-20260712010102000-a1b2c3d4";
+  const { repoRoot, linkedRoot, relayWorktreeBase } = createLinkedDispatchFixture(runId);
+  const vanishedRepoRoot = path.join(
+    os.tmpdir(),
+    `relay-vanished-checkout-${process.pid}-${Date.now()}`
+  );
+  assert.equal(fs.existsSync(vanishedRepoRoot), false);
+  const missingWorktree = path.join(relayWorktreeBase, "969-vanished", path.basename(repoRoot));
+  fs.mkdirSync(path.dirname(missingWorktree), { recursive: true });
+  const manifestPath = getManifestPath(linkedRoot, runId);
+
+  assert.throws(
+    () => validateManifestPaths({
+      repo_root: vanishedRepoRoot,
+      worktree: missingWorktree,
+    }, {
+      expectedRepoRoot: linkedRoot,
+      manifestPath,
+      runId,
+      allowMissingWorktree: true,
+      caller: "manifest/paths.test #969 vanished default",
+    }),
+    /Refusing to trust manifest-owned repo paths/
+  );
+
+  const accepted = validateManifestPaths({
+    repo_root: vanishedRepoRoot,
+    worktree: missingWorktree,
+  }, {
+    expectedRepoRoot: linkedRoot,
+    manifestPath,
+    runId,
+    allowMissingWorktree: true,
+    acceptVanishedRepoRootForCleanup: true,
+    caller: "manifest/paths.test #969 vanished opt-in",
+  });
+  assert.equal(accepted.repoRoot, path.resolve(linkedRoot));
+  assert.equal(accepted.worktreeLocation, "relay_worktree");
+  assert.equal(accepted.worktreeMissing, true);
+});
+
+test("manifest/paths existing foreign repo_root still refuses with or without vanish option (#969)", () => {
+  const runId = "issue-969-20260712010103000-a1b2c3d4";
+  const { repoRoot, linkedRoot } = createLinkedDispatchFixture(runId);
+  const foreignRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-paths-foreign-root-"));
+  initGitRepo(foreignRoot);
+  commitBaseFile(foreignRoot);
+  const worktreePath = path.join(repoRoot, "wt", "issue-969-foreign-root");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  const manifestPath = getManifestPath(linkedRoot, runId);
+
+  for (const acceptVanished of [false, true]) {
+    assert.throws(
+      () => validateManifestPaths({
+        repo_root: foreignRoot,
+        worktree: worktreePath,
+      }, {
+        expectedRepoRoot: linkedRoot,
+        manifestPath,
+        runId,
+        acceptVanishedRepoRootForCleanup: acceptVanished,
+        caller: `manifest/paths.test #969 foreign root vanish=${acceptVanished}`,
+      }),
+      /Refusing to trust manifest-owned repo paths/
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Fix `validateManifestPaths` so missing relay worktrees named after the trust-root repo validate from any linked checkout, and so vanished dispatch-time `repo_root` falls through to worktree-based trust for cleanup callers only (`acceptVanishedRepoRootForCleanup`).
- Teach `cleanup-worktrees` to prune stale `advisory-worktrees/*` of terminal (merged/closed) runs past the age threshold, with dry-run reporting and fail-closed foreign/ambiguous refusal.
- Add real-git fixture coverage for trust-root basename, vanished/foreign repo_root, foreign relay-base worktrees, advisory prune vs non-terminal retain, and dry-run zero-mutation.

Closes #969

## Test plan
- [x] `node --test tests/relay-dispatch/scripts/cleanup-worktrees.test.js`
- [x] `node --test tests/relay-dispatch/scripts/manifest/paths.test.js`
- [x] `node --test --test-concurrency=1 tests/relay-dispatch/scripts/*.test.js` (1050 pass, 2 skipped)
- [ ] Manual: `node skills/relay-dispatch/scripts/cleanup-worktrees.js --repo <linked-checkout> --dry-run --json` against a multi-checkout machine with stale manifests


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 종료된 릴레이 작업에 남아 있는 불필요한 advisory 작업 공간을 자동으로 정리합니다.
  * 실제 저장소 위치와 신뢰 가능한 작업 공간을 확인해 안전하지 않은 외부 경로는 정리 대상에서 제외합니다.
  * 저장소 경로나 체크아웃이 사라진 경우에도 안전 조건을 충족하면 작업 정리를 계속할 수 있습니다.
  * 정리된 항목, 보류된 항목, 거부된 항목과 사유를 JSON 및 콘솔 결과에서 확인할 수 있습니다.

* **버그 수정**
  * 저장소 이름이나 위치가 변경된 환경에서 누락된 작업 공간이 잘못 거부되던 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Review reconciliation (2026-07-12):** R1/R2 verdicts were DC-VERIFIED on content; blocks were (a) unrelated run-full-gate flake #975 (fixed in PR #978) and (b) fresh-push check-registration race #979. CI is green on the current head e34b681 (run 29177980597) after two clean rebases (#968/#976, then sprint-log). Same-head re-entry via --require-pr-body-change.
