### PR TITLE
fix(relay-merge): skip freshness gate when remote PR head is unresolvable (#965)

### DIFF
--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -72,6 +72,7 @@ This script:
 - After fetching `origin`, finalize refuses behind-main PRs only when main and the PR touch overlapping files.
 - Refusal leaves state unchanged and reports `next_action: rebase_and_rerun`.
 - `--allow-behind-main --reason "..."` is the audited operator escape hatch.
+- If the remote PR head cannot be resolved (`ls-remote` fails), the gate is skipped fail-open and finalize records `freshness: { skipped: true, reason: "unresolvable_remote_head" }`.
 - Finalize never auto-rebases: a rebase changes the reviewed head and re-enters the existing stale-review path (#884).
 - Accepted residual risk: cross-file semantic coupling is not detected.
 

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -1054,28 +1054,45 @@ function main() {
     }
     if (!alreadyMerged) {
       const freshnessRemote = resolveRemoteName(repoPath, branch) || "origin";
-      const prHead = resolveRemoteBranchHead(repoPath, freshnessRemote, branch);
-      const assessment = evaluateMergeFreshness(repoPath, prHead);
-      if (assessment.status === "behind_disjoint") {
+      let prHead = null;
+      try {
+        prHead = resolveRemoteBranchHead(repoPath, freshnessRemote, branch);
+      } catch {
+        // Fail-OPEN on resolution: an unresolvable remote tip must not abort
+        // a legitimate merge. Stale detection stays strict when the tip resolves.
         freshness = {
-          behind_count: assessment.behindCount,
-          overlapping_files: [],
+          skipped: true,
+          reason: "unresolvable_remote_head",
+          remote: freshnessRemote,
+          branch,
         };
-      } else if (assessment.status === "overlap") {
-        if (!allowBehindMain) {
-          if (!dryRun) {
-            appendRunEvent(repoPath, safeData.run_id, {
-              event: EVENTS.MERGE_BLOCKED,
-              state_from: safeData.state,
-              state_to: safeData.state,
-              head_sha: currentHeadSha,
-              round: safeData.review?.rounds || null,
-              reason: "behind_main_overlap",
-            });
+        console.warn(
+          `freshness gate skipped: unresolvable remote PR head for ${freshnessRemote}/${branch}`,
+        );
+      }
+      if (prHead) {
+        const assessment = evaluateMergeFreshness(repoPath, prHead);
+        if (assessment.status === "behind_disjoint") {
+          freshness = {
+            behind_count: assessment.behindCount,
+            overlapping_files: [],
+          };
+        } else if (assessment.status === "overlap") {
+          if (!allowBehindMain) {
+            if (!dryRun) {
+              appendRunEvent(repoPath, safeData.run_id, {
+                event: EVENTS.MERGE_BLOCKED,
+                state_from: safeData.state,
+                state_to: safeData.state,
+                head_sha: currentHeadSha,
+                round: safeData.review?.rounds || null,
+                reason: "behind_main_overlap",
+              });
+            }
+            throw new MergeFreshnessRefusal(assessment);
           }
-          throw new MergeFreshnessRefusal(assessment);
+          freshnessOverrideRequired = true;
         }
-        freshnessOverrideRequired = true;
       }
     }
     if (alreadyMerged) {

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -530,6 +530,65 @@ test("finalize-run freshness gate passes an up-to-date head without informationa
   assert.equal("freshness" in finalized.result, false);
 });
 
+test("finalize-run freshness gate skips when remote PR head is unresolvable", () => {
+  const fixture = setupRepo();
+  execFileSync("git", ["-C", fixture.repoRoot, "push", "origin", "--delete", fixture.branch], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.equal(remoteBranchExists(fixture.repoRoot, fixture.branch), false);
+
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [DEFAULT_REVIEW_COMMENT],
+    commits: [{ oid: fixture.headSha, committedDate: DEFAULT_COMMIT_DATE }],
+  });
+  const result = spawnSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: { ...process.env, RELAY_GH_BIN: fakeGh },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.state, STATES.MERGED);
+  assert.equal(payload.mergePerformed, true);
+  assert.deepEqual(payload.freshness, {
+    skipped: true,
+    reason: "unresolvable_remote_head",
+    remote: "origin",
+    branch: fixture.branch,
+  });
+  assert.match(result.stderr, /freshness gate skipped: unresolvable remote PR head/);
+});
+
+test("finalize-run freshness gate still computes freshness for a resolvable remote head", () => {
+  // Resolvable-head regression control for the unresolvable skip path above.
+  const fixture = setupRepo();
+  advanceOriginMain(fixture, [{
+    files: { "main-only.txt": "disjoint\n" },
+    message: "Advance main disjointly",
+  }]);
+
+  const finalized = execFinalize(fixture, {
+    ghOptions: { comments: [DEFAULT_REVIEW_COMMENT] },
+  });
+
+  assert.equal(finalized.result.state, STATES.MERGED);
+  assert.equal(finalized.result.mergePerformed, true);
+  assert.deepEqual(finalized.result.freshness, {
+    behind_count: 1,
+    overlapping_files: [],
+  });
+});
+
 test("finalize-run freshness gate reports behind but disjoint main changes and merges", () => {
   const fixture = setupRepo();
   advanceOriginMain(fixture, [{


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. 원격 PR head를 해석할 수 없을 때 freshness gate가 머지를 막지 않고 skip 합니다.

**변경 요약**
- `finalize-run.js`: `resolveRemoteBranchHead`를 try/catch로 감쌈. 실패 시 머지 진행 + `freshness: { skipped: true, reason: "unresolvable_remote_head", remote, branch }` + stderr 경고.
- resolvable head 경로는 기존 5행 매트릭스와 동일.
- 테스트: unresolvable skip + resolvable regression control 추가.
- `SKILL.md`에 fail-open 한 줄 문서화.

**검증:** `node --test --test-concurrency=1 tests/relay-merge/scripts/*.test.js tests/skills-lint/scripts/*.test.js` → 
```

## Score Log

- Run: issue-965-20260712020117389-f01ed6a3
- Executor: codex
- Branch: issue-965