### PR TITLE
fix(run-full-gate): announce lock acquisition even when the sentinel beats the status poll (#975)

### DIFF
--- a/skills/relay-merge/scripts/run-full-gate.js
+++ b/skills/relay-merge/scripts/run-full-gate.js
@@ -370,7 +370,17 @@ function waitForDetached(config) {
   let announcedState = null;
   while (true) {
     const result = readJson(config.sentinelPath);
-    if (result) return result;
+    if (result) {
+      // The runner may acquire the lock and finish (fast suites) within a single
+      // SENTINEL_POLL_MS window, so the "running" status is never observed below.
+      // The sentinel proves the lock was actually acquired (as opposed to a
+      // lock_timeout, where acquisition never happened) whenever we already
+      // announced waiting_for_lock but never announced running.
+      if (!config.json && announcedState === "waiting_for_lock" && result.result !== "lock_timeout") {
+        console.log("Full-gate lock acquired; running suites serially...");
+      }
+      return result;
+    }
     const status = readJson(config.statusPath);
     if (!config.json && status?.state === "waiting_for_lock" && announcedState !== status.state) {
       const owner = status.lock_wait?.owner || {};
@@ -437,4 +447,5 @@ module.exports = {
   expandSuites,
   globToRegExp,
   isProcessAlive,
+  waitForDetached,
 };

--- a/tests/relay-merge/scripts/run-full-gate.test.js
+++ b/tests/relay-merge/scripts/run-full-gate.test.js
@@ -112,6 +112,76 @@ test("two invocations serialize and the second reports the live lock owner", asy
   assert.ok(secondSentinel.lock_wait.waited_ms > 0);
 });
 
+// Regression for #975: the detached runner can acquire the lock and finish
+// (fast suites) within a single SENTINEL_POLL_MS window, so waitForDetached's
+// poll loop finds the completion sentinel before it ever observes the
+// intermediate status.state === "running" transition. This drives
+// waitForDetached directly (via a throwaway child process that requires the
+// script and calls the export) so the "sentinel beats the status poll" skip
+// is deterministic instead of depending on real subprocess/suite timing.
+test("waitForDetached announces lock acquisition even when the sentinel beats the status poll", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-full-gate-skip-test-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const statusPath = path.join(root, "gate.status.json");
+  const sentinelPath = path.join(root, "gate.done");
+  const owner = { pid: 987654, pgid: 987654, host: "loaded-ci-host", started_at: new Date(0).toISOString() };
+
+  // Only ever write "waiting_for_lock" — the status file never flips to
+  // "running", modelling the skip from the invoker's point of view.
+  fs.writeFileSync(statusPath, `${JSON.stringify({
+    runner_pid: owner.pid,
+    runner_pgid: owner.pgid,
+    state: "waiting_for_lock",
+    lock_wait: { did_wait: true, waited_ms: 250, owner, stale_reclaimed: false },
+  })}\n`, "utf-8");
+
+  const driverSource = [
+    `const mod = require(${JSON.stringify(SCRIPT)});`,
+    `process.exitCode = 0;`,
+    `const result = mod.waitForDetached(${JSON.stringify({ statusPath, sentinelPath, json: false })});`,
+    `process.stdout.write("DRIVER_RESULT:" + JSON.stringify(result) + "\\n");`,
+  ].join("\n");
+  const driver = spawn(process.execPath, ["-e", driverSource], { stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  driver.stdout.on("data", (chunk) => { stdout += chunk; });
+  let stderr = "";
+  driver.stderr.on("data", (chunk) => { stderr += chunk; });
+
+  // Only write the sentinel once the driver has genuinely announced the wait
+  // itself, so the invariant this test relies on (announcedState already
+  // "waiting_for_lock" when the sentinel is discovered) is never racy.
+  await waitFor(() => stdout.includes("Waiting for full-gate lock owned by pid 987654"), "driver to announce waiting_for_lock");
+
+  const sentinelResult = {
+    result: "pass",
+    exit_code: 0,
+    duration_ms: 4242,
+    output: path.join(root, "gate.log"),
+    sentinel: sentinelPath,
+    total_files: 3,
+    total_failed_files: 0,
+    failed_files: [],
+    lock_wait: { did_wait: true, waited_ms: 250, owner, stale_reclaimed: false },
+  };
+  const sentinelTemp = `${sentinelPath}.tmp`;
+  fs.writeFileSync(sentinelTemp, `${JSON.stringify(sentinelResult)}\n`, "utf-8");
+  fs.renameSync(sentinelTemp, sentinelPath);
+
+  const completion = await new Promise((resolve, reject) => {
+    driver.once("error", reject);
+    driver.once("close", (code) => resolve({ code }));
+  });
+  assert.equal(completion.code, 0, stderr);
+  assert.match(stdout, /Waiting for full-gate lock owned by pid 987654 \(pgid 987654, host loaded-ci-host\)\.\.\./);
+  assert.match(stdout, /Full-gate lock acquired; running suites serially\.\.\./);
+  assert.ok(
+    stdout.indexOf("Waiting for full-gate lock") < stdout.indexOf("Full-gate lock acquired"),
+    "waiting announcement must precede the lock-acquired announcement",
+  );
+  // Status never flipped to "running" — the fix must not require it to.
+  assert.equal(readJson(statusPath).state, "waiting_for_lock");
+});
+
 test("a lock owned by a real exited process is reclaimed as stale", async (t) => {
   const fixture = makeFixture();
   t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));


### PR DESCRIPTION
Closes #975

## Root cause

`waitForDetached` in `skills/relay-merge/scripts/run-full-gate.js` polls the completion sentinel FIRST and returns immediately when the detached runner has finished — before checking `statusPath`. When the runner acquires the lock and completes the (fast) suites within one `SENTINEL_POLL_MS` (100 ms) window after the lock release, the invoker never observes the intermediate `status.state === "running"` transition, so the `"Full-gate lock acquired; running suites serially..."` line — printed only on the observed `waiting_for_lock` → `running` transition — is never printed. Fast local machines observe the transition; loaded CI runners skip it. This is a state-transition skip in the poll loop, not an output-flush race.

That is exactly the CI failure signature: `assert.match(secondResult.stdout, /Full-gate lock acquired/)` gets stdout containing only the `Waiting for full-gate lock owned by pid ...` line (CI runs 29176964052 / 29177037654, blocking PR #972 and PR #974).

## Fix

In `waitForDetached`, when the sentinel result is found and the invoker had already announced `waiting_for_lock` but never announced `running` (`announcedState === "waiting_for_lock"`), print the lock-acquired line before returning — the runner demonstrably acquired the lock if it produced a non-`lock_timeout` result after waiting. Guarded to non-json mode and `result.result !== "lock_timeout"`. All other paths (json mode, no-wait fast path where `announcedState` is null, normally observed transition) are byte-identical.

`waitForDetached` is now exported so the regression test can drive the skip path deterministically.

## Regression test

New test `waitForDetached announces lock acquisition even when the sentinel beats the status poll`: a status file frozen at `waiting_for_lock` (never flips to `running`), the driver announces the wait, then the sentinel (with `lock_wait.did_wait: true`) is atomically renamed into place. Asserts stdout contains BOTH `Waiting for full-gate lock owned by pid` AND `Full-gate lock acquired`, in that order, while the status file still reads `waiting_for_lock`.

Verified the test catches the bug: with the production fix disabled, it fails with exactly the CI symptom — stdout has the waiting line but no `Full-gate lock acquired` line.

## Evidence

- `node --test tests/relay-merge/scripts/run-full-gate.test.js` x10 foreground loop: 10/10 runs `# pass 6 / # fail 0` (plus an earlier 10/10 loop pre-commit — 20/20 total)
- `node --test --test-concurrency=1 tests/relay-merge/scripts/*.test.js`: 216 pass, 0 fail (214.9 s)
- Local repro of the original flake before the fix: did not fire in the two-invocation test locally (needs CI-load timing), but the skip path was reproduced deterministically via the new regression test with the fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
