### PR TITLE
relay-orca: implement the run intent — provenance-injected operator dispatch (#944)

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -12,6 +12,7 @@ metadata:
 - Files: an already-accepted program/epic contract as JSON (`--program-file`). Schema: [references/accepted-program-schema.md](references/accepted-program-schema.md).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js` (read-only wave-plan compiler).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js` (fail-closed Orca capability probe).
+- Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js` (admission-gated provenance-injected operator dispatch).
 
 # relay-orca
 
@@ -33,15 +34,15 @@ relay-orca is **explicit-only**. It must never be auto-selected from ordinary re
 
 ## Intents
 
-relay-orca exposes exactly five intents. Only `plan` is implemented in this leaf; the runtime intents are contract-only here and are delivered in a later leaf (#944), gated on the Orca capability probe.
+relay-orca exposes exactly five intents. `plan` (read-only) and `run` (admission-gated operator dispatch) are implemented; the remaining runtime intents are contract-only here and delivered in later leaves, gated on the Orca capability probe.
 
 | Intent | Status | Purpose |
 | --- | --- | --- |
 | `plan` | implemented (read-only) | Compile an accepted program into an immutable wave plan. |
-| `run` | contract-only (#944) | Dispatch provenance-injected relay/fleet operators for a plan. |
-| `status` | contract-only (#944) | Derive live status from Orca + relay + GitHub + exit-gate evidence. |
-| `resume` | contract-only (#944) | Resume a coordinator from a reconstructible receipt without resetting Orca. |
-| `stop` | contract-only (#944) | Stop the coordinator only; never kill relay runs or discard durable state. |
+| `run` | implemented (#944) | Dispatch provenance-injected relay/fleet operators for a plan. |
+| `status` | contract-only (#945) | Derive live status from Orca + relay + GitHub + exit-gate evidence. |
+| `resume` | contract-only (#946) | Resume a coordinator from a reconstructible receipt without resetting Orca. |
+| `stop` | contract-only (#946) | Stop the coordinator only; never kill relay runs or discard durable state. |
 
 Command tables and flag semantics: [references/commands.md](references/commands.md).
 
@@ -79,6 +80,17 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json
 ```
 
 Probe rationale, guarantees, and reason codes: [references/capability-probe.md](references/capability-probe.md).
+
+Dispatch provenance-injected operators for an accepted program (admission-gated; never creates an Orca worktree or invokes reset):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
+  --program-file /tmp/accepted-program.json \
+  --operator-handle term-a --operator-handle term-b \
+  --json
+```
+
+`run` compiles through the frozen plan library, requires probe admission before any mutation, materializes wave-1 tasks, and dispatches with fail-closed provenance verification. Flags, run report shape, partial-wave semantics, and reason codes 40–44: [references/commands.md](references/commands.md) and [references/operator-dispatch.md](references/operator-dispatch.md).
 
 ## Ownership invariants
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -93,9 +93,69 @@ still classifies through the matrix above and emits the JSON envelope instead of
 hanging. `RELAY_ORCA_PROBE_TIMEOUT_MS` (positive integer; invalid values ignored)
 shortens the budget for tests.
 
+## `run` — admission-gated provenance-injected operator dispatch
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
+  --program-file <accepted-program.json> [--json] [--concurrency N] \
+  [--operator-handle <handle> ...] [--orca-bin <path>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--program-file`, `-f` | Accepted-program JSON contract (required) — the SAME input as `plan`. A precompiled plan JSON is NOT accepted (prevents tampered-plan injection). May be passed positionally. |
+| `--json` | Emit the machine-readable run report as JSON on stdout. |
+| `--concurrency N` | Override the concurrency ceiling. Default 2, hard maximum 4 (rejected via the plan library). |
+| `--operator-handle <handle>` | Repeatable. An explicit operator terminal handle to dispatch to. With none, `run` creates its own terminals via `orca terminal create` and records them. |
+| `--orca-bin <path>` | Explicit Orca CLI override — passed to the capability probe and used for all orchestration calls. |
+| `--help`, `-h` | Print usage. |
+
+`run` compiles the program through the FROZEN plan library, then requires capability
+admission from the FROZEN #942 probe **before any mutation**. Only after admission does it
+materialize the wave plan as `orca orchestration task-create` tasks (dependency order, deps
+carried as real Orca task ids), dispatch provenance-injected operators, verify each dispatch
+via `orca orchestration dispatch-show`, and deliver the operator prompt. It **never** invokes
+`orca orchestration reset` (D2) or any `orca worktree` subcommand (D5) — relay owns every
+implementation worktree. Plan-library rejections (`VAGUE_INTENT` … `EXCESSIVE_DEPTH`,
+`UNPREPARED_FLEET_LEAF`, `CONCURRENCY_EXCEEDED`, `NESTED_RELAY_ORCA`, structural guards)
+re-raise verbatim with their existing reason codes and exit codes.
+
+### Run report (`--json`)
+
+Exactly these top-level keys: `ok`, `program_id`, `admission`, `concurrency`, `tasks`,
+`terminals_created`, `blocking_reasons`, `reconciliation_required`. Each `tasks[]` entry is
+`{ task_id, outcome_id, kind, wave, orca_task_id, dispatch_id, assignee, status }` where
+`status` is `dispatched | pending | escalated`; a `dispatched` entry always carries the full
+non-null provenance trio. `reconciliation_required` is literally `true` in every report — run
+NEVER claims completion (live reconciliation is #945).
+
+### Partial-wave semantics
+
+Only wave-1 tasks (all dependency-satisfied) are dispatch-eligible in v0; later waves are
+materialized but reported `pending`. At most `concurrency` tasks are dispatched at once — excess
+eligible tasks stay `pending` with **no error** (exit 0). A handle carries at most one active
+task; an explicit-handle shortfall also leaves the remaining eligible tasks `pending`.
+Completion-driven wave advancement is #945/#947 scope.
+
+### Run rejection matrix
+
+| reason_code | exit | Trigger |
+| --- | --- | --- |
+| `ADMISSION_REJECTED` | 40 | The capability probe rejected or reported `admitted:false` (no mutation ran). |
+| `TASK_MATERIALIZE_FAILED` | 41 | An `orca orchestration task-create` failed; earlier tasks are left in place and listed. |
+| `INJECTION_UNDELIVERED` | 42 | An `orca orchestration dispatch --inject` failed (or the post-verification prompt hand-off failed). |
+| `PROVENANCE_MISMATCH` | 43 | `dispatch-show` returned a null/empty/mismatched task id, dispatch id, or assignee. |
+| `OPERATOR_DISPATCH_FAILED` | 44 | No valid operator target remained for an eligible task (terminal create yielded no usable handle). |
+
+A `42`/`43` failure records the failing task `escalated`, dispatches no further pending task,
+and does not touch already-verified running operators (stop semantics are #946). Plan-library
+rejections re-raise codes `2`–`21`; usage errors exit `64`. Full operator prompt contract and
+provenance rules: [operator-dispatch.md](operator-dispatch.md).
+
 ## Runtime intents (contract-only in this leaf)
 
-`run`, `status`, `resume`, and `stop` are defined by the skill contract but are **not
-implemented here**. They are delivered in a later leaf (#944) and gated on the Orca capability
-probe (`probe-orca.js`). See [experimental-status.md](experimental-status.md) for the pilot
-boundary and [capability-probe.md](capability-probe.md) for admission details.
+`run` is implemented (#944). `status`, `resume`, and `stop` remain defined by the skill
+contract but **not implemented here** — they are delivered in later leaves (#945/#946) and
+gated on the same Orca capability probe (`probe-orca.js`). See
+[experimental-status.md](experimental-status.md) for the pilot boundary and
+[capability-probe.md](capability-probe.md) for admission details.

--- a/skills/relay-orca/references/experimental-status.md
+++ b/skills/relay-orca/references/experimental-status.md
@@ -13,10 +13,10 @@ relay use never routes through relay-orca.
 - The OpenAI agent interface pins `allow_implicit_invocation: false` (see
   [../agents/openai.yaml](../agents/openai.yaml)), so no agent may auto-select relay-orca from
   ordinary relay, relay-fleet, delegation, implementation, or planning requests (D5).
-- `plan` requires only Node.js 18+ and is read-only. The runtime intents
-  (`run`/`status`/`resume`/`stop`) additionally require the experimental Orca orchestration
-  surface and remain gated on the Orca capability probe; they are contract-only until a later
-  leaf (#944) delivers them.
+- `plan` requires only Node.js 18+ and is read-only. `run` (#944) additionally requires the
+  experimental Orca orchestration surface and is gated on the Orca capability probe; the
+  remaining runtime intents (`status`/`resume`/`stop`) stay contract-only until later leaves
+  (#945/#946) deliver them.
 
 ## Pilot boundary
 

--- a/skills/relay-orca/references/operator-dispatch.md
+++ b/skills/relay-orca/references/operator-dispatch.md
@@ -1,0 +1,84 @@
+# Operator dispatch contract (`run` intent)
+
+`run` materializes an accepted program's wave plan into Orca orchestration tasks and dispatches
+**provenance-injected relay operators**. This reference pins the operator prompt contract per
+task kind, the completion payload every operator returns, the fail-closed provenance rules, and
+the ownership boundary. It is the reviewer's anchor for the `run` operator surface (#944).
+
+## Ownership boundary (binding)
+
+- Orca workers are relay **operators**, not direct code workers. The coordinator and Orca
+  terminals never edit implementation code directly. **Relay is the only creator of
+  implementation worktrees and durable run manifests** — `run` never invokes any
+  `orca worktree` subcommand.
+- `orca orchestration reset` is never invoked on any path.
+- Orca `worker_done` and task status are **lifecycle signals, never completion authority**. A
+  program outcome is complete only when live relay manifests, PRs/issues, and program exit gates
+  confirm it. `run` always reports `reconciliation_required: true`; live reconciliation is #945.
+
+## Prompt contract per task kind
+
+Each prompt sources its operator surface from the plan's `recommended_route` (operator name and
+mode **only**). No executor/reviewer engine name, model name, or engine-specific flag ever
+appears in a prompt — engine selection is `relay-config`, resolved at relay dispatch time.
+
+| task_kind | Operator | Prompt body |
+| --- | --- | --- |
+| `relay_run` | `relay` | Drive the normal relay path: readiness → plan → dispatch → review → merge. Coordinator/terminals never edit code directly. |
+| `relay_fleet` | `relay-fleet` | Same relay path, plus the **already-prepared** leaf artifacts (prompt/rubric/done-criteria paths from the program contract). A fleet outcome lacking prepared leaves never reaches prompt building (the plan rejects `UNPREPARED_FLEET_LEAF`). |
+| `integration_gate` | `relay-review` | **read-only** integration-gate evidence; findings become tracker follow-ups. Review completion does not authorize coordinator file edits or silent fixes. |
+| `advisory_review` | `relay-review` | **read-only** advisory evidence; blocking findings triaged into tracker follow-ups. No file edits or fixes. |
+| `tracker_reconciliation` | `dev-backlog` | Reconcile tracker/issue state against live relay manifests. |
+
+`integration_gate` and `advisory_review` prompts always contain the literal token `read-only`
+and never instruct file edits.
+
+## Completion payload contract
+
+Every operator prompt embeds the completion payload contract — the operator returns ALL of:
+
+`program_id`, `task_id`, `outcome_id`, `orca_task_id`, `dispatch_id`, `assignee`, `relay_ids`
+(request/run/fleet ids when applicable), `issue_url`, `pr_url`, `verification`,
+`observed_state`, `follow_ups`.
+
+The prompt closes with the literal sentence:
+
+> Live reconciliation is still required; this payload is not completion evidence.
+
+and the lifecycle note that Orca `worker_done` and task status are lifecycle signals, never
+completion authority.
+
+## Provenance verification (fail closed)
+
+For each dispatched task, in order:
+
+1. `orca orchestration dispatch --task <orca_task_id> --to <handle> --inject --json`. Non-zero
+   exit or `ok:false` → `INJECTION_UNDELIVERED` (exit 42).
+2. `orca orchestration dispatch-show --task <orca_task_id> --json` MUST carry a task id equal to
+   the dispatched id, a non-null non-empty dispatch id, and a non-null non-empty assignee
+   handle. Any null/empty/mismatched value → `PROVENANCE_MISMATCH` (exit 43).
+3. **Only after** verification succeeds is the operator prompt delivered (via `orca terminal
+   send`, prompt on stdin). It is never delivered before verification.
+
+An unverified task is never reported `dispatched`. A step 1–2 failure records the task
+`escalated`, dispatches no further pending task, and leaves already-verified running operators
+untouched (stop semantics are #946).
+
+## Terminal acquisition
+
+`run` dispatches only to handles it (a) received via a repeatable `--operator-handle`, or (b)
+created itself via `orca terminal create` this invocation (each created handle recorded in the
+report's `terminals_created`). A handle carries at most one active dispatched task; when ready
+tasks exceed available handles, remaining tasks stay `pending` (partial wave dispatch).
+
+## Reason codes
+
+| reason_code | exit | Trigger |
+| --- | --- | --- |
+| `ADMISSION_REJECTED` | 40 | Probe rejected or reported `admitted:false` (no mutation ran). |
+| `TASK_MATERIALIZE_FAILED` | 41 | An `orca orchestration task-create` failed; earlier tasks left in place and listed. |
+| `INJECTION_UNDELIVERED` | 42 | A `dispatch --inject` step failed (or the post-verification prompt hand-off failed). |
+| `PROVENANCE_MISMATCH` | 43 | `dispatch-show` returned null/empty/mismatched provenance. |
+| `OPERATOR_DISPATCH_FAILED` | 44 | No valid operator target remained for an eligible task. |
+
+Plan-library rejections (`2`–`21`) re-raise verbatim; usage errors exit `64`.

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -1,0 +1,100 @@
+"use strict";
+
+// Engine-agnostic operator prompt builder (D8). One prompt per task kind. The
+// operator SURFACE is sourced from the plan's recommended_route (operator name +
+// mode only). NO executor/reviewer engine name, model name, or engine-specific
+// flag ever appears here — engine selection is relay-config, resolved at relay
+// dispatch time, never named in a program-altitude operator prompt.
+
+// The operator completion payload contract (D8): every prompt lists these fields
+// verbatim so an operator returns machine-checkable provenance, not prose.
+const PAYLOAD_FIELDS = Object.freeze([
+  "program_id",
+  "task_id",
+  "outcome_id",
+  "orca_task_id",
+  "dispatch_id",
+  "assignee",
+  "relay_ids", // request/run/fleet ids when applicable
+  "issue_url",
+  "pr_url",
+  "verification",
+  "observed_state",
+  "follow_ups",
+]);
+
+// Pinned literals — the reviewer greps generated prompts for these exact strings.
+const RECONCILIATION_SENTENCE =
+  "Live reconciliation is still required; this payload is not completion evidence.";
+const LIFECYCLE_NOTE =
+  "Orca worker_done and task status are lifecycle signals, never completion authority.";
+const OWNERSHIP_NOTE =
+  "The coordinator and Orca terminals never edit implementation code directly; relay owns every implementation worktree and durable run manifest.";
+const READ_ONLY_MARKER = "read-only";
+const NO_EDIT_CLAUSE =
+  "This is a read-only task: review completion does not authorize coordinator file edits or silent fixes; findings become tracker follow-ups.";
+const RELAY_PATH =
+  "Drive the normal relay path: readiness -> plan -> dispatch -> review -> merge.";
+
+function payloadContractBlock() {
+  return [
+    "Completion payload contract (return ALL fields):",
+    ...PAYLOAD_FIELDS.map((field) => `  - ${field}`),
+    RECONCILIATION_SENTENCE,
+    LIFECYCLE_NOTE,
+  ].join("\n");
+}
+
+function headerBlock(task, program, outcome) {
+  const route = task.recommended_route || {};
+  return [
+    `relay-orca operator task for program ${program.id}`,
+    `outcome: ${task.outcome_id} (kind ${task.kind}, wave ${task.wave})`,
+    `operator surface: ${route.operator} (mode ${route.mode})`,
+    `accepted outcomes: ${(outcome.accepted_outcomes || []).join("; ")}`,
+    `expected evidence: ${(task.expected_evidence || []).join("; ")}`,
+  ].join("\n");
+}
+
+// relay_fleet prompts embed ONLY already-prepared leaf artifacts (D8). The plan
+// already rejects UNPREPARED_FLEET_LEAF, so leaves arrive prepared; no second check.
+function fleetLeavesBlock(outcome) {
+  const leaves = Array.isArray(outcome.leaves) ? outcome.leaves : [];
+  const lines = leaves.map(
+    (leaf, index) =>
+      `  leaf ${index + 1}: prompt=${leaf.prompt_file} rubric=${leaf.rubric_file} done_criteria=${leaf.done_criteria_file}`,
+  );
+  return ["prepared fleet leaves:", ...lines].join("\n");
+}
+
+function bodyBlock(task, outcome) {
+  const route = task.recommended_route || {};
+  if (route.read_only) {
+    return [NO_EDIT_CLAUSE, `Deliver the ${route.mode} evidence, then triage blocking findings into tracker follow-ups.`].join("\n");
+  }
+  if (task.kind === "relay_fleet") {
+    return [RELAY_PATH, fleetLeavesBlock(outcome), OWNERSHIP_NOTE].join("\n");
+  }
+  return [RELAY_PATH, OWNERSHIP_NOTE].join("\n");
+}
+
+// Build the full operator prompt for a single task. `outcome` is the original
+// program outcome (carries relay_fleet leaves); `task` is the compiled plan task.
+function buildOperatorPrompt(task, program, outcome = {}) {
+  return [
+    headerBlock(task, program, outcome),
+    bodyBlock(task, outcome),
+    payloadContractBlock(),
+  ].join("\n\n");
+}
+
+module.exports = {
+  PAYLOAD_FIELDS,
+  RECONCILIATION_SENTENCE,
+  LIFECYCLE_NOTE,
+  OWNERSHIP_NOTE,
+  READ_ONLY_MARKER,
+  NO_EDIT_CLAUSE,
+  RELAY_PATH,
+  buildOperatorPrompt,
+};

--- a/skills/relay-orca/scripts/lib/run-orca.js
+++ b/skills/relay-orca/scripts/lib/run-orca.js
@@ -1,0 +1,140 @@
+"use strict";
+
+// Orca CLI adapter for relay-orca `run` — PURE argv builders + response parsers.
+// It never touches the Node subprocess module: the CLI-invocation boundary
+// (timeout, poison guards, stdin) lives in run.js, mirroring how the frozen probe
+// keeps its spawn helpers out of scripts/lib/ so plan.js's D6 source scan stays
+// green. Every step function receives an injected `run(orcaBin, args, options)`.
+//
+// Every CLI-derived value embedded in a message passes through boundedExcerpt so a
+// wedged or adversarial CLI cannot inflate the run report.
+const EXCERPT_LIMIT = 256;
+
+// Collapse whitespace and truncate so the returned excerpt — the `…` marker
+// included — is at most EXCERPT_LIMIT characters total.
+function boundedExcerpt(value) {
+  const text = String(value).replace(/\s+/g, " ").trim();
+  if (text.length <= EXCERPT_LIMIT) return text;
+  return `${text.slice(0, EXCERPT_LIMIT - 1)}…`;
+}
+
+function parseJson(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return { ok: false, error: "empty stdout" };
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (error) {
+    return { ok: false, error: error.message, excerpt: boundedExcerpt(text) };
+  }
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function pickString(result, keys) {
+  if (!result || typeof result !== "object") return null;
+  for (const key of keys) {
+    if (isNonEmptyString(result[key])) return result[key];
+  }
+  return null;
+}
+
+function extractTaskId(payload) {
+  const result = payload && payload.result;
+  const direct = pickString(result, ["task_id", "taskId", "id"]);
+  if (direct) return direct;
+  if (result && result.task) return pickString(result.task, ["id", "task_id"]);
+  return null;
+}
+
+function extractDispatchId(payload) {
+  const result = payload && payload.result;
+  const direct = pickString(result, ["dispatch_id", "dispatchId", "id"]);
+  if (direct) return direct;
+  if (result && result.dispatch) return pickString(result.dispatch, ["id", "dispatch_id"]);
+  return null;
+}
+
+function extractAssignee(payload) {
+  const result = payload && payload.result;
+  const direct = pickString(result, ["assignee", "to", "handle"]);
+  if (direct) return direct;
+  if (result && result.dispatch) return pickString(result.dispatch, ["assignee", "to"]);
+  return null;
+}
+
+function extractHandle(payload) {
+  const result = payload && payload.result;
+  const direct = pickString(result, ["handle", "terminal_id", "terminalId", "id"]);
+  if (direct) return direct;
+  if (result && result.terminal) return pickString(result.terminal, ["handle", "id"]);
+  return null;
+}
+
+// A subprocess is "ok" only when it exited 0, produced parseable JSON, and that
+// JSON's top-level ok is exactly true — the same fail-closed test the probe uses.
+function envelopeOk(proc, parsed) {
+  return proc.status === 0 && parsed.ok && parsed.value && parsed.value.ok === true;
+}
+
+function createTask(run, orcaBin, { title, spec, deps }, options = {}) {
+  const args = ["orchestration", "task-create", "--spec", spec, "--task-title", title];
+  if (Array.isArray(deps) && deps.length) args.push("--deps", JSON.stringify(deps));
+  args.push("--json");
+  const proc = run(orcaBin, args, options);
+  const parsed = parseJson(proc.stdout);
+  const taskId = envelopeOk(proc, parsed) ? extractTaskId(parsed.value) : null;
+  return { ok: envelopeOk(proc, parsed) && isNonEmptyString(taskId), taskId, proc, parsed };
+}
+
+function dispatchTask(run, orcaBin, { orcaTaskId, handle }, options = {}) {
+  const args = ["orchestration", "dispatch", "--task", orcaTaskId, "--to", handle, "--inject", "--json"];
+  const proc = run(orcaBin, args, options);
+  const parsed = parseJson(proc.stdout);
+  return { ok: envelopeOk(proc, parsed), proc, parsed };
+}
+
+function showDispatch(run, orcaBin, { orcaTaskId }, options = {}) {
+  const args = ["orchestration", "dispatch-show", "--task", orcaTaskId, "--json"];
+  const proc = run(orcaBin, args, options);
+  const parsed = parseJson(proc.stdout);
+  if (!envelopeOk(proc, parsed)) return { ok: false, proc, parsed };
+  return {
+    ok: true,
+    taskId: extractTaskId(parsed.value),
+    dispatchId: extractDispatchId(parsed.value),
+    assignee: extractAssignee(parsed.value),
+    proc,
+    parsed,
+  };
+}
+
+function createTerminal(run, orcaBin, options = {}) {
+  const proc = run(orcaBin, ["terminal", "create", "--json"], options);
+  const parsed = parseJson(proc.stdout);
+  const handle = envelopeOk(proc, parsed) ? extractHandle(parsed.value) : null;
+  return { ok: envelopeOk(proc, parsed) && isNonEmptyString(handle), handle, proc, parsed };
+}
+
+// Prompt delivery (D6 step 3). Called ONLY after provenance verification. The
+// prompt is passed on stdin (via options.input) so a multi-line operator prompt
+// never lands in argv (and never corrupts the invocation log used by tests).
+function sendPrompt(run, orcaBin, { orcaTaskId, handle, prompt }, options = {}) {
+  const args = ["terminal", "send", "--to", handle, "--task", orcaTaskId, "--json"];
+  const proc = run(orcaBin, args, { ...options, input: prompt });
+  const parsed = parseJson(proc.stdout);
+  return { ok: envelopeOk(proc, parsed), proc, parsed };
+}
+
+module.exports = {
+  EXCERPT_LIMIT,
+  boundedExcerpt,
+  parseJson,
+  isNonEmptyString,
+  createTask,
+  dispatchTask,
+  showDispatch,
+  createTerminal,
+  sendPrompt,
+};

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -1,0 +1,233 @@
+"use strict";
+
+// Core `run` flow: compile (frozen plan lib) -> admit (frozen #942 probe) ->
+// materialize tasks -> dispatch provenance-injected operators. The report is
+// mutated in place throughout so it is truthful on every early-exit path. All
+// fail-closed transitions go through run-reasons; plan-library rejections
+// propagate as PlanError untouched (D1) and are re-raised by the caller.
+const { compileProgram } = require("./compile-program");
+const { probe, emptyResult } = require("../probe-orca");
+const { ProbeError } = require("./probe-reasons");
+const { RunError, reject } = require("./run-reasons");
+const { initReport, blockingReason, STATUS } = require("./run-report");
+const {
+  boundedExcerpt,
+  isNonEmptyString,
+  createTask,
+  dispatchTask,
+  showDispatch,
+  createTerminal,
+  sendPrompt,
+} = require("./run-orca");
+const { buildOperatorPrompt } = require("./operator-prompt");
+
+// The CLI-invocation boundary is injected by run.js (the Node subprocess module
+// may not live under scripts/lib/ — plan.js's frozen D6 source scan forbids it).
+// Every Orca call below threads options.runOrca into the pure adapter functions.
+
+// The accepted-program root may be the program object directly or wrapped under
+// a `program` key (accepted-program-schema.md). compileProgram unwraps the same
+// way internally; run needs the unwrapped object for the original outcomes
+// (relay_fleet leaves, accepted_outcomes) that the compiled plan does not carry.
+function unwrapProgram(raw) {
+  return raw && raw.program && typeof raw.program === "object" ? raw.program : raw;
+}
+
+function procDetail(proc, note) {
+  if (proc && proc.stderr) return `: ${boundedExcerpt(proc.stderr)}`;
+  if (proc && proc.status !== 0) return ` (exit ${proc.status})`;
+  return note ? `: ${note}` : "";
+}
+
+// D3 admission gate: every mutation is preceded by capability admission from the
+// FROZEN #942 probe (imported, never modified). Any probe rejection or
+// admitted:false fails closed as ADMISSION_REJECTED, before any task/terminal.
+function admit(report, options) {
+  const result = emptyResult(false);
+  try {
+    probe({ orcaBin: options.orcaBin, _result: result });
+  } catch (error) {
+    if (!(error instanceof ProbeError)) throw error;
+    report.admission = { admitted: false, runtime_id: result.runtime_id };
+    reject(
+      "ADMISSION_REJECTED",
+      `Orca capability probe rejected admission [${error.reasonCode}]: ${boundedExcerpt(error.message)}`,
+    );
+  }
+  if (!result.admitted) {
+    report.admission = { admitted: false, runtime_id: result.runtime_id };
+    reject("ADMISSION_REJECTED", "Orca capability probe returned admitted:false");
+  }
+  report.admission = { admitted: true, runtime_id: result.runtime_id };
+  return result.orca_bin;
+}
+
+function taskTitle(program, task) {
+  // Literal marker `relay-orca:` followed by `<program_id>/<outcome_id>` (D4).
+  return `relay-orca: ${program.id}/${task.outcome_id}`;
+}
+
+function taskSpec(program, task) {
+  // Machine-readable task metadata embedded in --spec (D4). No operator prompt is
+  // embedded here: the prompt is delivered only AFTER provenance verification (D6).
+  return JSON.stringify({
+    marker: "relay-orca",
+    program_id: program.id,
+    outcome_id: task.outcome_id,
+    task_kind: task.kind,
+    wave: task.wave,
+    depends_on: task.depends_on,
+  });
+}
+
+// D4 materialization. Waves are ordered and dependencies resolve to strictly
+// earlier waves, so iterating waves in order guarantees a task's dependency Orca
+// ids already exist when its --deps array is built.
+function materialize(plan, program, report, orcaBin, options) {
+  const taskByPlanId = new Map(plan.tasks.map((task) => [task.task_id, task]));
+  const entryByPlanId = new Map(report.tasks.map((entry) => [entry.task_id, entry]));
+  const orcaIdByPlanId = new Map();
+  for (const wave of plan.waves) {
+    for (const planId of wave.task_ids) {
+      const task = taskByPlanId.get(planId);
+      const deps = task.depends_on.map((dep) => orcaIdByPlanId.get(dep));
+      const res = createTask(options.runOrca, orcaBin, {
+        title: taskTitle(program, task),
+        spec: taskSpec(program, task),
+        deps,
+      });
+      if (!res.ok) {
+        reject(
+          "TASK_MATERIALIZE_FAILED",
+          `orca orchestration task-create failed for outcome ${task.outcome_id}` +
+            procDetail(res.proc, "response reported ok:false or returned no task id"),
+        );
+      }
+      orcaIdByPlanId.set(planId, res.taskId);
+      entryByPlanId.get(planId).orca_task_id = res.taskId;
+    }
+  }
+  return { taskByPlanId, entryByPlanId, orcaIdByPlanId };
+}
+
+// D5 terminal acquisition. A handle is either (a) an explicit --operator-handle
+// or (b) one created via `orca terminal create` this invocation. When explicit
+// handles are provided, run uses only those: exhausting them leaves the remaining
+// eligible tasks pending (handle-shortfall, no error). With no explicit handles,
+// run creates a fresh terminal per dispatch; a create that yields no usable
+// handle is OPERATOR_DISPATCH_FAILED. Every created handle is recorded (D10).
+function makeHandlePool(orcaBin, report, options) {
+  const explicit = Array.isArray(options.operatorHandles) ? options.operatorHandles.slice() : [];
+  const hasExplicit = explicit.length > 0;
+  let index = 0;
+  return {
+    acquire() {
+      if (hasExplicit) return index < explicit.length ? explicit[index++] : null;
+      const term = createTerminal(options.runOrca, orcaBin);
+      if (!term.ok) {
+        reject(
+          "OPERATOR_DISPATCH_FAILED",
+          "no valid operator target: orca terminal create yielded no usable handle" +
+            procDetail(term.proc, "response reported ok:false or returned no handle"),
+        );
+      }
+      report.terminals_created.push(term.handle);
+      return term.handle;
+    },
+  };
+}
+
+// D6.2 provenance trio verification. Returns a bounded description of the first
+// null/empty/mismatched value, or null when the task/dispatch/assignee trio is
+// fully verified.
+function provenanceMismatch(show, orcaTaskId) {
+  if (!show.ok) return "dispatch-show did not return ok" + procDetail(show.proc);
+  if (show.taskId !== orcaTaskId) {
+    return `task id ${boundedExcerpt(show.taskId)} does not match dispatched ${boundedExcerpt(orcaTaskId)}`;
+  }
+  if (!isNonEmptyString(show.dispatchId)) return "dispatch id is null or empty";
+  if (!isNonEmptyString(show.assignee)) return "assignee handle is null or empty";
+  return null;
+}
+
+// D6 per-task dispatch: inject, verify, then (only after verification) deliver the
+// operator prompt. Any failure records the task `escalated` and re-raises so no
+// further pending task is dispatched; already-verified operators are not touched.
+function dispatchOne(ctx) {
+  const { orcaBin, entry, orcaTaskId, handle, task, program, outcome, options } = ctx;
+  const disp = dispatchTask(options.runOrca, orcaBin, { orcaTaskId, handle });
+  if (!disp.ok) {
+    entry.status = STATUS.ESCALATED;
+    reject(
+      "INJECTION_UNDELIVERED",
+      `orca orchestration dispatch --inject failed for outcome ${task.outcome_id}` + procDetail(disp.proc),
+    );
+  }
+  const show = showDispatch(options.runOrca, orcaBin, { orcaTaskId });
+  const mismatch = provenanceMismatch(show, orcaTaskId);
+  if (mismatch) {
+    entry.status = STATUS.ESCALATED;
+    reject("PROVENANCE_MISMATCH", `dispatch-show provenance verification failed for outcome ${task.outcome_id}: ${mismatch}`);
+  }
+  entry.dispatch_id = show.dispatchId;
+  entry.assignee = show.assignee;
+  const prompt = buildOperatorPrompt(task, program, outcome);
+  const sent = sendPrompt(options.runOrca, orcaBin, { orcaTaskId, handle, prompt });
+  if (!sent.ok) {
+    entry.status = STATUS.ESCALATED;
+    reject(
+      "INJECTION_UNDELIVERED",
+      `operator prompt hand-off failed for outcome ${task.outcome_id}` + procDetail(sent.proc),
+    );
+  }
+  entry.status = STATUS.DISPATCHED;
+}
+
+// D7 dispatch scope: only wave-1 tasks (all dependency-satisfied) are eligible in
+// v0; later waves stay pending. At most `concurrency` are dispatched; excess
+// eligible tasks stay pending with no error (partial wave dispatch).
+function dispatchWave(plan, program, report, orcaBin, maps, options) {
+  const wave1 = plan.waves.length ? plan.waves[0].task_ids : [];
+  const target = Math.min(wave1.length, plan.concurrency);
+  const handles = makeHandlePool(orcaBin, report, options);
+  const outcomeById = new Map(program.outcomes.map((outcome) => [outcome.id, outcome]));
+  for (let i = 0; i < target; i += 1) {
+    const planId = wave1[i];
+    const handle = handles.acquire();
+    if (!handle) break; // explicit-handle shortfall → remaining eligible stay pending (D5)
+    const task = maps.taskByPlanId.get(planId);
+    dispatchOne({
+      orcaBin,
+      task,
+      entry: maps.entryByPlanId.get(planId),
+      orcaTaskId: maps.orcaIdByPlanId.get(planId),
+      handle,
+      program,
+      outcome: outcomeById.get(task.outcome_id) || {},
+      options,
+    });
+  }
+}
+
+// Compile through the frozen plan library, admit through the frozen probe, then
+// materialize and dispatch. PlanError propagates untouched (D1); RunError is
+// captured into the report's blocking_reasons with its fail-closed exit code.
+function orchestrate(rawProgram, options = {}) {
+  const plan = compileProgram(rawProgram, { concurrency: options.concurrency });
+  const program = unwrapProgram(rawProgram);
+  const report = initReport(plan);
+  try {
+    const orcaBin = admit(report, options);
+    const maps = materialize(plan, program, report, orcaBin, options);
+    dispatchWave(plan, program, report, orcaBin, maps, options);
+    report.ok = true;
+    return { report, exitCode: 0 };
+  } catch (error) {
+    if (!(error instanceof RunError)) throw error;
+    report.ok = false;
+    report.blocking_reasons = [blockingReason(error)];
+    return { report, exitCode: error.exitCode };
+  }
+}
+
+module.exports = { orchestrate };

--- a/skills/relay-orca/scripts/lib/run-reasons.js
+++ b/skills/relay-orca/scripts/lib/run-reasons.js
@@ -1,0 +1,46 @@
+"use strict";
+
+// relay-orca `run` rejection matrix (D9). Each fail-closed reason maps to a
+// DISTINCT non-zero exit code plus a stable reason_code string. Codes stay in
+// 40–44 so they never collide with plan.js's 2–21 range, the probe's 30–37
+// range, or Node's own fatal/exec codes (<=125). This is a NEW module: plan's
+// lib/reasons.js and the probe's lib/probe-reasons.js are frozen and untouched.
+const REASONS = {
+  ADMISSION_REJECTED: 40, // D3 probe rejected or admitted:false
+  TASK_MATERIALIZE_FAILED: 41, // D4 orchestration task-create failure
+  INJECTION_UNDELIVERED: 42, // D6 dispatch --inject step failed / prompt hand-off failed
+  PROVENANCE_MISMATCH: 43, // D6 dispatch-show null/empty/mismatched provenance
+  OPERATOR_DISPATCH_FAILED: 44, // D7 no valid operator target for an eligible task
+};
+
+const REMEDIATION = {
+  ADMISSION_REJECTED:
+    "Resolve the Orca capability probe rejection (run probe-orca.js --json) before dispatching operators.",
+  TASK_MATERIALIZE_FAILED:
+    "Inspect the failing orca orchestration task-create response; already-created tasks are listed and left in place.",
+  INJECTION_UNDELIVERED:
+    "Re-run once the Orca dispatch surface delivers the injected operator context; the task is left escalated.",
+  PROVENANCE_MISMATCH:
+    "Reconcile the dispatch-show provenance (task id, dispatch id, assignee); never advance a program on unverified provenance.",
+  OPERATOR_DISPATCH_FAILED:
+    "Provide an --operator-handle or ensure orca terminal create yields a usable handle for the eligible task.",
+};
+
+class RunError extends Error {
+  constructor(reasonCode, message, remediation) {
+    super(message);
+    this.name = "RunError";
+    this.reasonCode = reasonCode;
+    this.exitCode = REASONS[reasonCode];
+    this.remediation = remediation || REMEDIATION[reasonCode] || "";
+    if (this.exitCode === undefined) {
+      throw new Error(`unknown run reason code: ${reasonCode}`);
+    }
+  }
+}
+
+function reject(reasonCode, message, remediation) {
+  throw new RunError(reasonCode, message, remediation);
+}
+
+module.exports = { REASONS, REMEDIATION, RunError, reject };

--- a/skills/relay-orca/scripts/lib/run-report.js
+++ b/skills/relay-orca/scripts/lib/run-report.js
@@ -1,0 +1,76 @@
+"use strict";
+
+// Stable machine-readable run report (D10). EXACTLY these eight top-level keys,
+// verbatim and in this order. The report is built once from the compiled plan and
+// mutated in place as the run progresses so it stays truthful on EVERY early-exit
+// path: an admission rejection, a mid-materialization failure, and an escalation
+// all emit the same key set with truthful per-task statuses.
+const REPORT_KEYS = Object.freeze([
+  "ok",
+  "program_id",
+  "admission",
+  "concurrency",
+  "tasks",
+  "terminals_created",
+  "blocking_reasons",
+  "reconciliation_required",
+]);
+
+const STATUS = Object.freeze({
+  PENDING: "pending",
+  DISPATCHED: "dispatched",
+  ESCALATED: "escalated",
+});
+
+// One report task entry per plan task. Provenance starts null; a task only ever
+// reaches "dispatched" after its dispatch-show provenance trio is verified (D6).
+function initTaskEntry(task) {
+  return {
+    task_id: task.task_id,
+    outcome_id: task.outcome_id,
+    kind: task.kind,
+    wave: task.wave,
+    orca_task_id: null,
+    dispatch_id: null,
+    assignee: null,
+    status: STATUS.PENDING,
+  };
+}
+
+function initReport(plan) {
+  return {
+    ok: false,
+    program_id: plan.program_id,
+    admission: { admitted: false, runtime_id: null },
+    concurrency: plan.concurrency,
+    tasks: plan.tasks.map(initTaskEntry),
+    terminals_created: [],
+    blocking_reasons: [],
+    reconciliation_required: true, // literal true in EVERY report (live reconcile is #945)
+  };
+}
+
+function blockingReason(error) {
+  return {
+    reason_code: error.reasonCode,
+    message: error.message,
+    remediation: error.remediation || "",
+  };
+}
+
+// Emit exactly REPORT_KEYS, in order, regardless of insertion order above.
+function orderedReport(report) {
+  const ordered = {};
+  REPORT_KEYS.forEach((key) => {
+    ordered[key] = report[key];
+  });
+  return ordered;
+}
+
+module.exports = {
+  REPORT_KEYS,
+  STATUS,
+  initReport,
+  blockingReason,
+  orderedReport,
+};

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+"use strict";
+
+// relay-orca `run` — admission-gated materialization and provenance-injected
+// operator dispatch for an already-accepted program (issue #944). It compiles
+// the program through the FROZEN plan library, requires capability admission
+// through the FROZEN #942 probe, materializes the wave plan as Orca
+// orchestration tasks, dispatches provenance-injected relay/fleet operators, and
+// emits a stable machine-readable run report. It never creates an Orca worktree
+// (D5) and never invokes orchestration reset (D2). Relay remains the sole creator
+// of implementation worktrees and manifests.
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+const { PlanError } = require("./lib/reasons");
+const { orchestrate } = require("./lib/run-orchestrator");
+const { orderedReport } = require("./lib/run-report");
+
+const USAGE_EXIT = 64;
+const RUN_MAX_BUFFER = 4 * 1024 * 1024;
+const DEFAULT_RUN_TIMEOUT_MS = 30000;
+
+// The ONE subprocess boundary for run. lib/ modules stay child_process-free
+// (plan.js's frozen D6 source scan forbids it there); the pure adapter step
+// functions call back into this injected runner. Two surfaces are structurally
+// refused here, independent of any fixture poison: `orca orchestration reset`
+// (D2) and any `orca worktree` subcommand (D5) — no run code path builds either.
+function resolveRunTimeoutMs() {
+  const raw = process.env.RELAY_ORCA_RUN_TIMEOUT_MS;
+  if (raw === undefined || raw === null || raw === "") return DEFAULT_RUN_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_RUN_TIMEOUT_MS;
+}
+
+function runOrca(orcaBin, args, options = {}) {
+  const argv = Array.isArray(args) ? args.map(String) : [];
+  if (argv.includes("reset")) throw new Error("relay-orca run must never invoke orca orchestration reset (D2)");
+  if (argv.includes("worktree")) throw new Error("relay-orca run must never invoke any orca worktree subcommand (D5)");
+  const hasInput = options.input !== undefined && options.input !== null;
+  try {
+    const stdout = execFileSync(orcaBin, argv, {
+      encoding: "utf-8",
+      stdio: hasInput ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+      timeout: resolveRunTimeoutMs(),
+      maxBuffer: RUN_MAX_BUFFER,
+      ...(hasInput ? { input: String(options.input) } : {}),
+    });
+    return { status: 0, stdout: String(stdout || ""), stderr: "" };
+  } catch (error) {
+    return {
+      status: typeof error.status === "number" ? error.status : 1,
+      stdout: error.stdout ? String(error.stdout) : "",
+      stderr: error.stderr ? String(error.stderr) : "",
+    };
+  }
+}
+
+function usageError(message) {
+  process.stderr.write(`relay-orca run: ${message}\n`);
+  process.stderr.write(
+    "usage: run.js --program-file <accepted-program.json> [--json] [--concurrency N] " +
+      "[--operator-handle <handle> ...] [--orca-bin <path>]\n",
+  );
+  process.exit(USAGE_EXIT);
+}
+
+function parseArgs(argv) {
+  const opts = { programFile: null, json: false, concurrency: undefined, operatorHandles: [], orcaBin: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--program-file" || arg === "-f") opts.programFile = argv[(i += 1)];
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--concurrency") opts.concurrency = Number(argv[(i += 1)]);
+    else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
+    else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else if (!arg.startsWith("-") && !opts.programFile) opts.programFile = arg;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+function requireValue(value, flag) {
+  if (!value || value.startsWith("-")) usageError(`${flag} requires a value`);
+  return value;
+}
+
+function readProgram(programFile) {
+  if (!programFile) usageError("--program-file is required");
+  let text;
+  try {
+    text = fs.readFileSync(programFile, "utf-8");
+  } catch (error) {
+    usageError(`cannot read program file ${programFile}: ${error.message}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    usageError(`program file ${programFile} is not valid JSON: ${error.message}`);
+  }
+}
+
+function printReport(report, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(orderedReport(report), null, 2)}\n`);
+    return;
+  }
+  const stream = report.ok ? process.stdout : process.stderr;
+  stream.write(`relay-orca run for ${report.program_id} (admitted=${report.admission.admitted}, ok=${report.ok})\n`);
+  report.tasks.forEach((task) => {
+    stream.write(`  ${task.task_id} [${task.status}] orca=${task.orca_task_id} assignee=${task.assignee}\n`);
+  });
+  report.blocking_reasons.forEach((reason) => {
+    stream.write(`  blocked [${reason.reason_code}]: ${reason.message}\n`);
+  });
+}
+
+// Plan-library rejections re-raise unchanged (D1): same reason_code, same exit
+// code, same JSON rejection object shape as `plan`.
+function failPlan(error, json) {
+  const body = { ok: false, reason_code: error.reasonCode, message: error.message };
+  if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  else process.stderr.write(`relay-orca run rejected [${error.reasonCode}]: ${error.message}\n`);
+  process.exit(error.exitCode);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) usageError("admission-gated operator dispatch for an accepted program");
+  const program = readProgram(opts.programFile);
+  let result;
+  try {
+    result = orchestrate(program, {
+      concurrency: opts.concurrency,
+      operatorHandles: opts.operatorHandles,
+      orcaBin: opts.orcaBin,
+      runOrca,
+    });
+  } catch (error) {
+    if (error instanceof PlanError) failPlan(error, opts.json);
+    throw error;
+  }
+  printReport(result.report, opts.json);
+  process.exitCode = result.exitCode;
+}
+
+main();

--- a/tests/relay-orca/fixtures/fake-orca-run.js
+++ b/tests/relay-orca/fixtures/fake-orca-run.js
@@ -1,0 +1,190 @@
+"use strict";
+
+/**
+ * Run-capable fake Orca CLI fixture for relay-orca `run` tests.
+ *
+ * Extends the #942 read-only fake (which stays untouched) with the mutating
+ * orchestration/terminal surface `run` drives: task-create, dispatch,
+ * dispatch-show, terminal create, terminal send. Behavior is scenario-driven via
+ * a JSON file; every invocation is appended to a shared log. Two surfaces are
+ * POISONED on EVERY path (they write a poison marker and exit non-zero so the
+ * test hard-fails): `orca orchestration reset` (D2) and any `orca worktree`
+ * subcommand (D5).
+ *
+ * Dispatch provenance is stateful: `dispatch` writes a per-task state file so a
+ * following `dispatch-show` returns the same dispatch id and assignee handle,
+ * making happy-path provenance verifiable. Scenario overrides force
+ * null/empty/mismatched provenance for the fail-closed tests.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  DEFAULT_RUNTIME_ID,
+  readyStatus,
+  emptyTaskList,
+  emptyGateList,
+} = require("./fake-orca");
+
+function defaultRunScenario(overrides = {}) {
+  const runtimeId = overrides.runtimeId || DEFAULT_RUNTIME_ID;
+  return {
+    runtimeId,
+    // Admission surface (consumed by the frozen probe).
+    status: overrides.status !== undefined ? overrides.status : readyStatus(runtimeId),
+    statusExit: overrides.statusExit !== undefined ? overrides.statusExit : 0,
+    statusStdout: overrides.statusStdout,
+    taskList: overrides.taskList !== undefined ? overrides.taskList : emptyTaskList(runtimeId),
+    taskListExit: overrides.taskListExit !== undefined ? overrides.taskListExit : 0,
+    gateList: overrides.gateList !== undefined ? overrides.gateList : emptyGateList(runtimeId),
+    gateListExit: overrides.gateListExit !== undefined ? overrides.gateListExit : 0,
+    // Run surface knobs.
+    taskCreateFailFor: overrides.taskCreateFailFor || null, // outcome id whose task-create fails
+    taskCreateFailMode: overrides.taskCreateFailMode || "ok_false", // ok_false | nonzero | empty_id
+    dispatchFailFor: overrides.dispatchFailFor || null, // orca task id whose dispatch returns ok:false
+    provenanceOverride: overrides.provenanceOverride || null, // merged over dispatch-show result
+    provenanceOverrideFor: overrides.provenanceOverrideFor || null, // limit override to one orca task id
+    terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
+    terminalCreateEmptyHandle: overrides.terminalCreateEmptyHandle || false,
+    terminalSendOkFalse: overrides.terminalSendOkFalse || false,
+  };
+}
+
+function fakeOrcaRunScript({ scenarioPath, logPath, poisonPath, stateDir }) {
+  return `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+const stateDir = ${JSON.stringify(stateDir)};
+
+function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
+appendLog(args.join(" "));
+
+function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
+function writeJson(value) { process.stdout.write(JSON.stringify(value)); }
+function emit(payload, exitCode, stdoutOverride) {
+  if (stdoutOverride !== undefined && stdoutOverride !== null) process.stdout.write(String(stdoutOverride));
+  else if (payload !== undefined && payload !== null) writeJson(payload);
+  process.exit(typeof exitCode === "number" ? exitCode : 0);
+}
+function argValue(flag) { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : undefined; }
+function drainStdin() { try { fs.readFileSync(0); } catch (e) { /* no stdin */ } }
+function stateFile(taskId) { return path.join(stateDir, "disp-" + String(taskId).replace(/[^a-zA-Z0-9._-]/g, "_") + ".json"); }
+
+// D2 poison: reset must never be invoked.
+if (args.includes("reset")) {
+  if (poisonPath) fs.writeFileSync(poisonPath, "RESET_INVOKED:" + args.join(" "), "utf-8");
+  process.stderr.write("POISON: orca orchestration reset must never be invoked\\n");
+  process.exit(99);
+}
+// D5 poison: relay owns implementation worktrees; run never touches orca worktree.
+if (args.includes("worktree")) {
+  if (poisonPath) fs.writeFileSync(poisonPath, "WORKTREE_INVOKED:" + args.join(" "), "utf-8");
+  process.stderr.write("POISON: orca worktree must never be invoked by run\\n");
+  process.exit(98);
+}
+
+const scenario = loadScenario();
+
+if (args[0] === "status") emit(scenario.status, scenario.statusExit, scenario.statusStdout);
+if (args[0] === "orchestration" && args[1] === "task-list") emit(scenario.taskList, scenario.taskListExit);
+if (args[0] === "orchestration" && args[1] === "gate-list") emit(scenario.gateList, scenario.gateListExit);
+
+if (args[0] === "orchestration" && args[1] === "task-create") {
+  const title = argValue("--task-title") || "";
+  const outcome = title.split("/").pop();
+  const orcaId = "orca-live-" + outcome;
+  if (scenario.taskCreateFailFor && scenario.taskCreateFailFor === outcome) {
+    if (scenario.taskCreateFailMode === "nonzero") emit({ ok: false, error: "task-create failed" }, 1);
+    if (scenario.taskCreateFailMode === "empty_id") emit({ ok: true, result: {} }, 0);
+    emit({ ok: false, error: "task-create rejected" }, 0);
+  }
+  emit({ id: "tc-" + orcaId, ok: true, result: { id: orcaId, task_id: orcaId }, _meta: { runtimeId: scenario.runtimeId } }, 0);
+}
+
+if (args[0] === "orchestration" && args[1] === "dispatch") {
+  const task = argValue("--task");
+  const handle = argValue("--to");
+  if (scenario.dispatchFailFor && scenario.dispatchFailFor === task) {
+    emit({ ok: false, error: "dispatch inject undelivered" }, 0);
+  }
+  const record = { task_id: task, dispatch_id: "disp-" + task, assignee: handle };
+  try { fs.writeFileSync(stateFile(task), JSON.stringify(record), "utf-8"); } catch (e) { /* ignore */ }
+  emit({ id: "d-" + task, ok: true, result: { id: record.dispatch_id, dispatch_id: record.dispatch_id, assignee: handle }, _meta: { runtimeId: scenario.runtimeId } }, 0);
+}
+
+if (args[0] === "orchestration" && args[1] === "dispatch-show") {
+  const task = argValue("--task");
+  let base = { task_id: task, dispatch_id: "disp-" + task, assignee: "assignee-" + task };
+  try { base = JSON.parse(fs.readFileSync(stateFile(task), "utf-8")); } catch (e) { /* no prior dispatch */ }
+  if (scenario.provenanceOverride && (!scenario.provenanceOverrideFor || scenario.provenanceOverrideFor === task)) {
+    Object.assign(base, scenario.provenanceOverride);
+  }
+  emit({ id: "ds-" + task, ok: true, result: base, _meta: { runtimeId: scenario.runtimeId } }, 0);
+}
+
+if (args[0] === "terminal" && args[1] === "create") {
+  if (scenario.terminalCreateOkFalse) emit({ ok: false, error: "terminal create failed" }, 1);
+  if (scenario.terminalCreateEmptyHandle) emit({ ok: true, result: {} }, 0);
+  let n = 0;
+  const counter = path.join(stateDir, "term-counter");
+  try { n = Number(fs.readFileSync(counter, "utf-8")) || 0; } catch (e) { n = 0; }
+  n += 1;
+  try { fs.writeFileSync(counter, String(n), "utf-8"); } catch (e) { /* ignore */ }
+  emit({ ok: true, result: { handle: "orca-term-" + n, id: "orca-term-" + n }, _meta: { runtimeId: scenario.runtimeId } }, 0);
+}
+
+if (args[0] === "terminal" && args[1] === "send") {
+  drainStdin();
+  if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
+  emit({ ok: true, result: { delivered: true } }, 0);
+}
+
+process.stderr.write("Unsupported fake orca invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+}
+
+function installFakeOrcaRun(scenarioOverrides = {}, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-orca-run-"));
+  const orcaPath = path.join(dir, options.binName || "orca");
+  const scenarioPath = path.join(dir, "scenario.json");
+  const logPath = path.join(dir, "invocations.log");
+  const poisonPath = path.join(dir, "poison.txt");
+  const stateDir = path.join(dir, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const scenario = defaultRunScenario(scenarioOverrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
+  fs.writeFileSync(orcaPath, fakeOrcaRunScript({ scenarioPath, logPath, poisonPath, stateDir }), "utf-8");
+  fs.chmodSync(orcaPath, 0o755);
+
+  return {
+    dir,
+    orcaPath,
+    scenarioPath,
+    logPath,
+    poisonPath,
+    stateDir,
+    scenario,
+    restore() {
+      /* PATH is never mutated: tests pass --orca-bin explicitly. */
+    },
+    readLog() {
+      if (!fs.existsSync(logPath)) return [];
+      return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readPoison() {
+      if (!fs.existsSync(poisonPath)) return null;
+      return fs.readFileSync(poisonPath, "utf-8");
+    },
+    cleanup() {
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+module.exports = { defaultRunScenario, fakeOrcaRunScript, installFakeOrcaRun };

--- a/tests/relay-orca/fixtures/run-all-kinds.json
+++ b/tests/relay-orca/fixtures/run-all-kinds.json
@@ -1,0 +1,25 @@
+{
+  "program": {
+    "id": "epic-all-kinds",
+    "source": "file:///tmp/epic-all-kinds.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 4,
+    "exit_gates": ["every accepted outcome reconciled against live evidence"],
+    "outcomes": [
+      { "id": "run-outcome", "issue": 5001, "task_kind": "relay_run", "accepted_outcomes": ["run merged"], "depends_on": [] },
+      {
+        "id": "fleet-outcome",
+        "task_kind": "relay_fleet",
+        "accepted_outcomes": ["all leaves merged"],
+        "depends_on": [],
+        "leaves": [
+          { "leaf_ref": "l1", "prompt_file": "/tmp/leaf1-prompt.md", "rubric_file": "/tmp/leaf1-rubric.yaml", "done_criteria_file": "/tmp/leaf1-dc.md" }
+        ]
+      },
+      { "id": "gate-outcome", "task_kind": "integration_gate", "accepted_outcomes": ["integration gate green"], "depends_on": [] },
+      { "id": "advisory-outcome", "task_kind": "advisory_review", "accepted_outcomes": ["advisory findings triaged"], "depends_on": [] },
+      { "id": "tracker-outcome", "task_kind": "tracker_reconciliation", "accepted_outcomes": ["tracker reconciled"], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/run-three-wave1.json
+++ b/tests/relay-orca/fixtures/run-three-wave1.json
@@ -1,0 +1,15 @@
+{
+  "program": {
+    "id": "epic-run-three",
+    "source": "file:///tmp/epic-run-three.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 2,
+    "exit_gates": ["all three issues merged and closed"],
+    "outcomes": [
+      { "id": "alpha", "issue": 4001, "task_kind": "relay_run", "accepted_outcomes": ["alpha merged"], "depends_on": [] },
+      { "id": "bravo", "issue": 4002, "task_kind": "relay_run", "accepted_outcomes": ["bravo merged"], "depends_on": [] },
+      { "id": "charlie", "issue": 4003, "task_kind": "relay_run", "accepted_outcomes": ["charlie merged"], "depends_on": [] }
+    ]
+  }
+}

--- a/tests/relay-orca/fixtures/run-two-wave1.json
+++ b/tests/relay-orca/fixtures/run-two-wave1.json
@@ -1,0 +1,26 @@
+{
+  "program": {
+    "id": "epic-run-two",
+    "source": "file:///tmp/epic-run-two.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 2,
+    "exit_gates": ["both issues merged and closed"],
+    "outcomes": [
+      {
+        "id": "alpha",
+        "issue": 3001,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["alpha merged"],
+        "depends_on": []
+      },
+      {
+        "id": "bravo",
+        "issue": 3002,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["bravo merged"],
+        "depends_on": []
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -1,0 +1,486 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
+const RUN_JS = path.join(SCRIPTS, "run.js");
+
+const { REASONS } = require(path.join(SCRIPTS, "lib", "run-reasons.js"));
+const { REPORT_KEYS } = require(path.join(SCRIPTS, "lib", "run-report.js"));
+const { compileProgram } = require(path.join(SCRIPTS, "lib", "compile-program.js"));
+const {
+  buildOperatorPrompt,
+  PAYLOAD_FIELDS,
+  RECONCILIATION_SENTENCE,
+  LIFECYCLE_NOTE,
+  READ_ONLY_MARKER,
+  NO_EDIT_CLAUSE,
+} = require(path.join(SCRIPTS, "lib", "operator-prompt.js"));
+const { installFakeOrcaRun } = require(path.join(__dirname, "..", "fixtures", "fake-orca-run.js"));
+const { readyStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+// Plan-library codes re-raised verbatim by run (D1/D9).
+const PLAN_CODES = { UNPREPARED_FLEET_LEAF: 12, CONCURRENCY_EXCEEDED: 16, NESTED_RELAY_ORCA: 20 };
+
+const MUTATING_TOKENS = ["task-create", "dispatch", "terminal", "task-update"];
+const FORBIDDEN_ENGINE_TOKENS = [
+  "codex",
+  "claude",
+  "gpt",
+  "opus",
+  "sonnet",
+  "haiku",
+  "gemini",
+  "cursor",
+  "cline",
+  "grok",
+  "glm",
+  "opencode",
+  "engine",
+  "model",
+];
+
+function fixture(name) {
+  return path.join(REPO_ROOT, "tests", "relay-orca", "fixtures", name);
+}
+
+function runRun(args, env = {}) {
+  const result = { status: 0, stdout: "", stderr: "" };
+  try {
+    result.stdout = execFileSync(process.execPath, [RUN_JS, ...args], {
+      encoding: "utf-8",
+      env: { ...process.env, ...env },
+      stdio: "pipe",
+    });
+  } catch (error) {
+    result.status = error.status;
+    result.stdout = error.stdout ? String(error.stdout) : "";
+    result.stderr = error.stderr ? String(error.stderr) : "";
+  }
+  return result;
+}
+
+function runProgram(fixtureName, extraArgs, scenario, options = {}) {
+  const fake = installFakeOrcaRun(scenario || {});
+  const args = ["--json", "--orca-bin", fake.orcaPath, "--program-file", fixture(fixtureName), ...(extraArgs || [])];
+  const result = runRun(args, options.env);
+  result.fake = fake;
+  result.body = result.stdout ? JSON.parse(result.stdout) : null;
+  return result;
+}
+
+function parse(stdout) {
+  return JSON.parse(String(stdout));
+}
+
+function assertReportKeys(body) {
+  assert.deepEqual(Object.keys(body).sort(), [...REPORT_KEYS].sort());
+}
+
+function assertNoPoison(fake) {
+  assert.equal(fake.readPoison(), null, "reset/worktree poison marker must never be written");
+}
+
+function assertNoMutations(fake) {
+  const tokens = fake.readLog().join(" ");
+  MUTATING_TOKENS.forEach((forbidden) => {
+    assert.equal(tokens.includes(forbidden), false, `no mutating subcommand ${forbidden} allowed; log=${tokens}`);
+  });
+}
+
+function taskByOutcome(body, outcomeId) {
+  return body.tasks.find((task) => task.outcome_id === outcomeId);
+}
+
+// ---------------------------------------------------------------------------
+// D11.1 Successful injection — 2-task wave, provenance verified
+// ---------------------------------------------------------------------------
+
+test("D11.1: 2-task wave dispatches, provenance verified, exact D10 report", () => {
+  const r = runProgram("run-two-wave1.json", ["--operator-handle", "h1", "--operator-handle", "h2"]);
+  try {
+    assert.equal(r.status, 0);
+    assertReportKeys(r.body);
+    assert.equal(r.body.ok, true);
+    assert.equal(r.body.reconciliation_required, true);
+    assert.equal(r.body.program_id, "epic-run-two");
+    assert.equal(r.body.concurrency, 2);
+    assert.equal(r.body.admission.admitted, true);
+    assert.ok(r.body.admission.runtime_id, "admission echoes the probe runtime_id");
+    assert.deepEqual(r.body.terminals_created, []);
+    assert.deepEqual(r.body.blocking_reasons, []);
+    for (const outcome of ["alpha", "bravo"]) {
+      const task = taskByOutcome(r.body, outcome);
+      assert.equal(task.status, "dispatched");
+      // A dispatched task MUST carry the full non-null provenance trio (D6/D10).
+      assert.ok(task.orca_task_id && task.dispatch_id && task.assignee);
+    }
+    assert.equal(taskByOutcome(r.body, "alpha").assignee, "h1");
+    assert.equal(taskByOutcome(r.body, "bravo").assignee, "h2");
+    // Prompt (terminal send) is delivered ONLY after dispatch-show verification.
+    const log = r.fake.readLog();
+    const showIdx = log.findIndex((l) => l.includes("dispatch-show --task orca-live-alpha"));
+    const sendIdx = log.findIndex((l) => l.includes("terminal send --to h1"));
+    assert.ok(showIdx >= 0 && sendIdx > showIdx, "prompt must be sent after verification");
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.2 Admission rejection — exit 40, zero mutating subcommands
+// ---------------------------------------------------------------------------
+
+test("D11.2: probe rejects admission → ADMISSION_REJECTED exit 40, zero mutations", () => {
+  const status = readyStatus();
+  status.result.app.running = false;
+  const r = runProgram("run-two-wave1.json", ["--operator-handle", "h1"], { status });
+  try {
+    assert.equal(r.status, REASONS.ADMISSION_REJECTED);
+    assertReportKeys(r.body);
+    assert.equal(r.body.ok, false);
+    assert.equal(r.body.admission.admitted, false);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "ADMISSION_REJECTED");
+    assert.equal(r.body.reconciliation_required, true);
+    // Every plan task stays pending; NO mutating subcommand ever ran.
+    r.body.tasks.forEach((task) => assert.equal(task.status, "pending"));
+    assertNoMutations(r.fake);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.3 Undelivered injection — exit 42, escalated, no further dispatch
+// ---------------------------------------------------------------------------
+
+test("D11.3: dispatch ok:false → INJECTION_UNDELIVERED exit 42, escalated, prior stays dispatched", () => {
+  const r = runProgram(
+    "run-two-wave1.json",
+    ["--operator-handle", "h1", "--operator-handle", "h2"],
+    { dispatchFailFor: "orca-live-bravo" },
+  );
+  try {
+    assert.equal(r.status, REASONS.INJECTION_UNDELIVERED);
+    assertReportKeys(r.body);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "INJECTION_UNDELIVERED");
+    assert.equal(taskByOutcome(r.body, "alpha").status, "dispatched");
+    assert.equal(taskByOutcome(r.body, "bravo").status, "escalated");
+    // bravo never advances: no dispatch-show, no prompt hand-off after the failure.
+    const log = r.fake.readLog().join(" ");
+    assert.equal(log.includes("dispatch-show --task orca-live-bravo"), false);
+    assert.equal(log.includes("terminal send --to h2"), false);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.4 Mismatched provenance — wrong task id AND null assignee → exit 43
+// ---------------------------------------------------------------------------
+
+test("D11.4a: dispatch-show wrong task id → PROVENANCE_MISMATCH exit 43, escalated, never dispatched", () => {
+  const r = runProgram(
+    "valid-single-relay-run.json",
+    ["--operator-handle", "h1"],
+    { provenanceOverride: { task_id: "orca-live-WRONG" } },
+  );
+  try {
+    assert.equal(r.status, REASONS.PROVENANCE_MISMATCH);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "PROVENANCE_MISMATCH");
+    const task = taskByOutcome(r.body, "outcome-a");
+    assert.equal(task.status, "escalated");
+    assert.notEqual(task.status, "dispatched");
+    // Prompt never handed off on an unverified task.
+    assert.equal(r.fake.readLog().join(" ").includes("terminal send"), false);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+test("D11.4b: dispatch-show null assignee → PROVENANCE_MISMATCH exit 43, escalated", () => {
+  const r = runProgram(
+    "valid-single-relay-run.json",
+    ["--operator-handle", "h1"],
+    { provenanceOverride: { assignee: null } },
+  );
+  try {
+    assert.equal(r.status, REASONS.PROVENANCE_MISMATCH);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "PROVENANCE_MISMATCH");
+    assert.equal(taskByOutcome(r.body, "outcome-a").status, "escalated");
+    assert.equal(r.fake.readLog().join(" ").includes("terminal send"), false);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.5 Partial wave dispatch — 3 eligible, concurrency 2 → 2 dispatched, 1 pending
+// ---------------------------------------------------------------------------
+
+test("D11.5: 3 eligible with concurrency 2 → 2 dispatched, 1 pending, exit 0", () => {
+  const r = runProgram("run-three-wave1.json", [
+    "--operator-handle",
+    "h1",
+    "--operator-handle",
+    "h2",
+    "--operator-handle",
+    "h3",
+  ]);
+  try {
+    assert.equal(r.status, 0);
+    assert.equal(r.body.ok, true);
+    assert.equal(r.body.concurrency, 2);
+    const dispatched = r.body.tasks.filter((t) => t.status === "dispatched");
+    const pending = r.body.tasks.filter((t) => t.status === "pending");
+    assert.equal(dispatched.length, 2);
+    assert.equal(pending.length, 1);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.6 Duplicate active guard — busy handle never reused
+// ---------------------------------------------------------------------------
+
+test("D11.6: single handle for two eligible tasks → busy handle never reused, task never dispatched twice", () => {
+  const r = runProgram("run-two-wave1.json", ["--operator-handle", "h1"]);
+  try {
+    assert.equal(r.status, 0);
+    const dispatched = r.body.tasks.filter((t) => t.status === "dispatched");
+    const pending = r.body.tasks.filter((t) => t.status === "pending");
+    assert.equal(dispatched.length, 1);
+    assert.equal(pending.length, 1);
+    assert.equal(dispatched[0].assignee, "h1");
+    // h1 is targeted by exactly one dispatch; the pending task is never dispatched.
+    const dispatchLines = r.fake.readLog().filter((l) => l.startsWith("orchestration dispatch --task"));
+    assert.equal(dispatchLines.length, 1);
+    assert.ok(dispatchLines[0].includes("--to h1"));
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.7 task-create failure mid-materialization — exit 41, earlier tasks listed
+// ---------------------------------------------------------------------------
+
+test("D11.7: task-create failure → TASK_MATERIALIZE_FAILED exit 41, earlier task listed, nothing cleaned", () => {
+  const r = runProgram(
+    "run-two-wave1.json",
+    ["--operator-handle", "h1", "--operator-handle", "h2"],
+    { taskCreateFailFor: "bravo" },
+  );
+  try {
+    assert.equal(r.status, REASONS.TASK_MATERIALIZE_FAILED);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "TASK_MATERIALIZE_FAILED");
+    // alpha materialized first and is left in place (listed with its Orca id).
+    assert.equal(taskByOutcome(r.body, "alpha").orca_task_id, "orca-live-alpha");
+    assert.equal(taskByOutcome(r.body, "bravo").orca_task_id, null);
+    const log = r.fake.readLog().join(" ");
+    assert.equal(log.includes("dispatch"), false, "no dispatch after materialize failure");
+    assert.equal(log.includes("task-update"), false, "nothing is cleaned up (cleanup is #946)");
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.8 / D11.9 / D11.12 — plan-library codes re-raised verbatim
+// ---------------------------------------------------------------------------
+
+test("D11.8: fleet leaf without prepared artifacts → UNPREPARED_FLEET_LEAF re-raised (exit 12)", () => {
+  const r = runProgram("reject-unprepared-fleet.json", []);
+  try {
+    assert.equal(r.status, PLAN_CODES.UNPREPARED_FLEET_LEAF);
+    assert.equal(r.body.reason_code, "UNPREPARED_FLEET_LEAF");
+    assert.equal(r.body.ok, false);
+    // Plan rejects before admission: no Orca invocation at all.
+    assert.deepEqual(r.fake.readLog(), []);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+test("D11.9: concurrency > 4 → CONCURRENCY_EXCEEDED re-raised (exit 16)", () => {
+  const r = runProgram("valid-single-relay-run.json", ["--concurrency", "9"]);
+  try {
+    assert.equal(r.status, PLAN_CODES.CONCURRENCY_EXCEEDED);
+    assert.equal(r.body.reason_code, "CONCURRENCY_EXCEEDED");
+    assert.deepEqual(r.fake.readLog(), []);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+test("D11.12: nested relay-orca program → NESTED_RELAY_ORCA re-raised (exit 20)", () => {
+  const r = runProgram("reject-nested-orca.json", []);
+  try {
+    assert.equal(r.status, PLAN_CODES.NESTED_RELAY_ORCA);
+    assert.equal(r.body.reason_code, "NESTED_RELAY_ORCA");
+    assert.deepEqual(r.fake.readLog(), []);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11.10 Prompt content — engine-agnostic, read-only, payload contract
+// ---------------------------------------------------------------------------
+
+test("D11.10: operator prompts carry the pinned literals and never name an engine/model", () => {
+  const raw = JSON.parse(fs.readFileSync(fixture("run-all-kinds.json"), "utf-8"));
+  const program = raw.program;
+  const plan = compileProgram(raw);
+  const outcomeById = new Map(program.outcomes.map((o) => [o.id, o]));
+
+  const kinds = new Set();
+  for (const task of plan.tasks) {
+    const prompt = buildOperatorPrompt(task, program, outcomeById.get(task.outcome_id));
+    kinds.add(task.kind);
+    // Every prompt: full payload contract + reconciliation + lifecycle literals (D8).
+    PAYLOAD_FIELDS.forEach((field) => assert.ok(prompt.includes(field), `${task.kind} prompt missing payload field ${field}`));
+    assert.ok(prompt.includes(RECONCILIATION_SENTENCE), `${task.kind} prompt missing reconciliation sentence`);
+    assert.ok(prompt.includes(LIFECYCLE_NOTE), `${task.kind} prompt missing lifecycle note`);
+    // No executor/reviewer engine or model name anywhere.
+    const lowered = prompt.toLowerCase();
+    FORBIDDEN_ENGINE_TOKENS.forEach((token) =>
+      assert.equal(lowered.includes(token), false, `${task.kind} prompt leaked engine/model token ${token}`),
+    );
+    if (task.recommended_route.read_only) {
+      assert.ok(prompt.includes(READ_ONLY_MARKER), `${task.kind} read-only prompt missing read-only marker`);
+      assert.ok(prompt.includes(NO_EDIT_CLAUSE), `${task.kind} read-only prompt missing no-edit clause`);
+      assert.ok(prompt.includes("tracker follow-ups"), `${task.kind} read-only prompt must route findings to tracker`);
+    }
+    if (task.kind === "relay_fleet") {
+      // Fleet prompts embed already-prepared leaf artifacts (D8).
+      assert.ok(prompt.includes("/tmp/leaf1-prompt.md"));
+      assert.ok(prompt.includes("/tmp/leaf1-rubric.yaml"));
+      assert.ok(prompt.includes("/tmp/leaf1-dc.md"));
+    }
+  }
+  // All five kinds were exercised.
+  assert.deepEqual(
+    [...kinds].sort(),
+    ["advisory_review", "integration_gate", "relay_fleet", "relay_run", "tracker_reconciliation"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// D11.11 Poison guards — reset AND worktree hard-fail the fixture
+// ---------------------------------------------------------------------------
+
+test("D11.11: reset AND worktree subcommands poison the fixture", () => {
+  const fake = installFakeOrcaRun();
+  try {
+    let resetStatus = 0;
+    try {
+      execFileSync(fake.orcaPath, ["orchestration", "reset"], { stdio: "pipe" });
+    } catch (error) {
+      resetStatus = error.status;
+    }
+    assert.equal(resetStatus, 99);
+    assert.match(fake.readPoison(), /RESET_INVOKED/);
+    fs.rmSync(fake.poisonPath, { force: true });
+
+    let worktreeStatus = 0;
+    try {
+      execFileSync(fake.orcaPath, ["worktree", "create"], { stdio: "pipe" });
+    } catch (error) {
+      worktreeStatus = error.status;
+    }
+    assert.equal(worktreeStatus, 98);
+    assert.match(fake.readPoison(), /WORKTREE_INVOKED/);
+  } finally {
+    fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D4/D7 — dependency-ordered materialization + later-wave pending
+// ---------------------------------------------------------------------------
+
+test("D4/D7: deps carry real Orca ids in dependency order; later-wave task stays pending", () => {
+  const r = runProgram("mixed-run-fleet.json", ["--operator-handle", "h1"]);
+  try {
+    assert.equal(r.status, 0);
+    assert.equal(taskByOutcome(r.body, "foundation").status, "dispatched");
+    // fanout is wave 2 → materialized but not dispatched in this invocation.
+    assert.equal(taskByOutcome(r.body, "fanout").status, "pending");
+    assert.equal(taskByOutcome(r.body, "fanout").orca_task_id, "orca-live-fanout");
+    // The fanout task-create passes the real Orca id of its dependency via --deps.
+    const fanoutCreate = r.fake
+      .readLog()
+      .find((l) => l.includes("task-create") && l.includes("epic-demo-mixed/fanout"));
+    assert.ok(fanoutCreate.includes('--deps ["orca-live-foundation"]'), `deps missing: ${fanoutCreate}`);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D5 — self-created terminals recorded; D7 — OPERATOR_DISPATCH_FAILED
+// ---------------------------------------------------------------------------
+
+test("D5: no explicit handle → run creates terminals and records them", () => {
+  const r = runProgram("run-two-wave1.json", []);
+  try {
+    assert.equal(r.status, 0);
+    assert.equal(r.body.terminals_created.length, 2);
+    r.body.tasks.forEach((task) => {
+      assert.equal(task.status, "dispatched");
+      assert.ok(r.body.terminals_created.includes(task.assignee));
+    });
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+test("D7: terminal create yields no usable handle → OPERATOR_DISPATCH_FAILED exit 44", () => {
+  const r = runProgram("run-two-wave1.json", [], { terminalCreateEmptyHandle: true });
+  try {
+    assert.equal(r.status, REASONS.OPERATOR_DISPATCH_FAILED);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "OPERATOR_DISPATCH_FAILED");
+    // No task ever became dispatched.
+    assert.equal(r.body.tasks.every((t) => t.status !== "dispatched"), true);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Usage errors exit 64
+// ---------------------------------------------------------------------------
+
+test("usage: unknown flag exits 64", () => {
+  const r = runRun(["--program-file", fixture("run-two-wave1.json"), "--not-a-flag"]);
+  assert.equal(r.status, 64);
+});
+
+test("usage: missing --program-file exits 64", () => {
+  const r = runRun(["--json"]);
+  assert.equal(r.status, 64);
+});
+
+// Keep the imported parse helper referenced.
+void parse;


### PR DESCRIPTION
## Dispatch Summary

```text
Done. Here's the final report for **#944 — relay-orca `run` intent**.

## Summary

Implemented the admission-gated, provenance-injected operator dispatch (`run` intent) and committed to branch `issue-944` (`cf685b0`, 15 files, +1652/−13). The orchestrator will handle push + PR.

## What shipped

**`skills/relay-orca/scripts/run.js`** + 5 new pure lib modules:
- `run-reasons.js` — reason codes 40–44 + typed `RunError`
- `operator-prompt.js` — engine-agnostic per-kind prompts, completion-payload c
```

## Score Log

- Run: issue-944-20260712195259758-2d960ad4
- Executor: claude
- Branch: issue-944


Fixes #944
