### PR TITLE
relay-orca #945: harden status classification + receipt path (self-review fixes)

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js` (read-only wave-plan compiler).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js` (fail-closed Orca capability probe).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js` (admission-gated provenance-injected operator dispatch).
+- Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js` (read-only live reconciler over receipt + relay + GitHub + Orca).
 
 # relay-orca
 
@@ -34,13 +35,13 @@ relay-orca is **explicit-only**. It must never be auto-selected from ordinary re
 
 ## Intents
 
-relay-orca exposes exactly five intents. `plan` (read-only) and `run` (admission-gated operator dispatch) are implemented; the remaining runtime intents are contract-only here and delivered in later leaves, gated on the Orca capability probe.
+relay-orca exposes exactly five intents. `plan` (read-only), `run` (admission-gated operator dispatch), and `status` (read-only live reconciler) are implemented; the remaining runtime intents are contract-only here and delivered in a later leaf, gated on the Orca capability probe.
 
 | Intent | Status | Purpose |
 | --- | --- | --- |
 | `plan` | implemented (read-only) | Compile an accepted program into an immutable wave plan. |
 | `run` | implemented (#944) | Dispatch provenance-injected relay/fleet operators for a plan. |
-| `status` | contract-only (#945) | Derive live status from Orca + relay + GitHub + exit-gate evidence. |
+| `status` | implemented (#945) | Derive a read-only live program view from receipt + relay + GitHub + Orca. |
 | `resume` | contract-only (#946) | Resume a coordinator from a reconstructible receipt without resetting Orca. |
 | `stop` | contract-only (#946) | Stop the coordinator only; never kill relay runs or discard durable state. |
 
@@ -90,7 +91,17 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
   --json
 ```
 
-`run` compiles through the frozen plan library, requires probe admission before any mutation, materializes wave-1 tasks, and dispatches with fail-closed provenance verification. Flags, run report shape, partial-wave semantics, and reason codes 40–44: [references/commands.md](references/commands.md) and [references/operator-dispatch.md](references/operator-dispatch.md).
+`run` compiles through the frozen plan library, requires probe admission before any mutation, materializes wave-1 tasks, and dispatches with fail-closed provenance verification. `run` also persists a minimal, versioned, atomically-written **receipt** (identity/mapping only) under `~/.relay/programs/<repo-slug>/<program-id>/`. Flags, run report shape, partial-wave semantics, and reason codes 40–44: [references/commands.md](references/commands.md) and [references/operator-dispatch.md](references/operator-dispatch.md).
+
+Derive a read-only live program view from the receipt + relay manifests + GitHub + Orca (no mutation of any kind):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
+  --program-id epic-941 \
+  --json
+```
+
+`status` reconciles durable truth (relay manifests, PRs/issues) against Orca runtime signals — `worker_done` is never completion evidence. Report shape, the state taxonomy, the nine detector codes, and reason codes 50–52: [references/commands.md](references/commands.md) and [references/receipt-and-status.md](references/receipt-and-status.md).
 
 ## Ownership invariants
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -151,8 +151,10 @@ Completion-driven wave advancement is #945/#947 scope.
 
 A `42`/`43` failure records the failing task `escalated`, dispatches no further pending task,
 and does not touch already-verified running operators (stop semantics are #946). Plan-library
-rejections re-raise codes `2`–`21`; usage errors exit `64`. Full operator prompt contract and
-provenance rules: [operator-dispatch.md](operator-dispatch.md).
+rejections re-raise codes `2`–`21`; usage errors exit `64`. A repo root that cannot be
+git-canonicalized fails closed with `RECEIPT_REPO_MISMATCH` (exit `52`) — there is **no**
+realpath fallback (A24). Full operator prompt contract and provenance rules:
+[operator-dispatch.md](operator-dispatch.md).
 
 ## `status` — read-only live reconciler
 
@@ -190,7 +192,7 @@ and the read-only guarantee: [receipt-and-status.md](receipt-and-status.md).
 | --- | --- | --- |
 | `RECEIPT_NOT_FOUND` | 50 | No receipt for `--program-id` under the programs root. |
 | `RECEIPT_CORRUPT` | 51 | Unparseable JSON, wrong `schema`, or missing required keys. |
-| `RECEIPT_REPO_MISMATCH` | 52 | The receipt `repo.slug` does not match the current repo. |
+| `RECEIPT_REPO_MISMATCH` | 52 | The receipt `repo.slug` does not match the current repo, **or** the repo root could not be git-canonicalized (fail-closed, no realpath fallback — A24). |
 
 Usage errors exit `64`. A successfully derived view exits `0` even when it is full of
 `inconsistent`/`stale_missing` outcomes; runtime mismatch and unreachable Orca/GitHub degrade

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -123,11 +123,13 @@ re-raise verbatim with their existing reason codes and exit codes.
 ### Run report (`--json`)
 
 Exactly these top-level keys: `ok`, `program_id`, `admission`, `concurrency`, `tasks`,
-`terminals_created`, `blocking_reasons`, `reconciliation_required`. Each `tasks[]` entry is
-`{ task_id, outcome_id, kind, wave, orca_task_id, dispatch_id, assignee, status }` where
-`status` is `dispatched | pending | escalated`; a `dispatched` entry always carries the full
-non-null provenance trio. `reconciliation_required` is literally `true` in every report — run
-NEVER claims completion (live reconciliation is #945).
+`terminals_created`, `blocking_reasons`, `reconciliation_required`, `receipt_path`. Each
+`tasks[]` entry is `{ task_id, outcome_id, kind, wave, orca_task_id, dispatch_id, assignee,
+status }` where `status` is `dispatched | pending | escalated`; a `dispatched` entry always
+carries the full non-null provenance trio. `reconciliation_required` is literally `true` in
+every report — run NEVER claims completion. `receipt_path` (#945) is the path of the
+atomically-written reconstructible receipt (or `null` on paths that never materialize tasks);
+see [receipt-and-status.md](receipt-and-status.md).
 
 ### Partial-wave semantics
 
@@ -152,10 +154,51 @@ and does not touch already-verified running operators (stop semantics are #946).
 rejections re-raise codes `2`–`21`; usage errors exit `64`. Full operator prompt contract and
 provenance rules: [operator-dispatch.md](operator-dispatch.md).
 
+## `status` — read-only live reconciler
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
+  --program-id <program-id> [--json] [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--program-id`, `-p` | The accepted program's stable id (required). Resolves the receipt under the programs root. |
+| `--json` | Emit the machine-readable status report as JSON on stdout. |
+| `--orca-bin <path>` | Explicit Orca CLI override for the read-only runtime queries. |
+| `--gh-bin <path>` | Explicit `gh` CLI override (or env `RELAY_ORCA_GH_BIN`). |
+| `--repo-root <path>` | Explicit repo root for slug derivation (defaults to the git repo of the cwd). |
+| `--help`, `-h` | Print usage. |
+
+`status` loads the reconstructible receipt, then queries relay manifests, GitHub, and Orca
+**live** to derive a normalized program view. It is strictly **READ-ONLY**: no GitHub write,
+no relay manifest write, no Orca mutating subcommand or `reset`/`worktree`, and no receipt
+write. Durable truth outranks runtime signals and `worker_done` is never completion evidence.
+
+### Status report (`--json`)
+
+Exactly these top-level keys: `ok`, `program_id`, `receipt_path`, `runtime`, `program_state`,
+`outcomes`, `diagnostics`, `repair_candidates`, `evidence_checked`. `runtime` is
+`ok | mismatch | foreign_state | unreachable`; `evidence_checked` is literally `true`. Each
+`outcomes[]` entry is `{ outcome_id, kind, wave, state, orca_task_id, dispatch_id, relay_ids,
+issue_url, pr_url, evidence }`. State taxonomy, the nine detector codes, the authority order,
+and the read-only guarantee: [receipt-and-status.md](receipt-and-status.md).
+
+### Status rejection matrix
+
+| reason_code | exit | Trigger |
+| --- | --- | --- |
+| `RECEIPT_NOT_FOUND` | 50 | No receipt for `--program-id` under the programs root. |
+| `RECEIPT_CORRUPT` | 51 | Unparseable JSON, wrong `schema`, or missing required keys. |
+| `RECEIPT_REPO_MISMATCH` | 52 | The receipt `repo.slug` does not match the current repo. |
+
+Usage errors exit `64`. A successfully derived view exits `0` even when it is full of
+`inconsistent`/`stale_missing` outcomes; runtime mismatch and unreachable Orca/GitHub degrade
+to diagnostics rather than failing.
+
 ## Runtime intents (contract-only in this leaf)
 
-`run` is implemented (#944). `status`, `resume`, and `stop` remain defined by the skill
-contract but **not implemented here** — they are delivered in later leaves (#945/#946) and
-gated on the same Orca capability probe (`probe-orca.js`). See
-[experimental-status.md](experimental-status.md) for the pilot boundary and
-[capability-probe.md](capability-probe.md) for admission details.
+`run` (#944) and `status` (#945) are implemented. `resume` and `stop` remain defined by the
+skill contract but **not implemented here** — they are delivered in #946 and gated on the same
+Orca capability probe (`probe-orca.js`). See [experimental-status.md](experimental-status.md)
+for the pilot boundary and [capability-probe.md](capability-probe.md) for admission details.

--- a/skills/relay-orca/references/experimental-status.md
+++ b/skills/relay-orca/references/experimental-status.md
@@ -14,9 +14,9 @@ relay use never routes through relay-orca.
   [../agents/openai.yaml](../agents/openai.yaml)), so no agent may auto-select relay-orca from
   ordinary relay, relay-fleet, delegation, implementation, or planning requests (D5).
 - `plan` requires only Node.js 18+ and is read-only. `run` (#944) additionally requires the
-  experimental Orca orchestration surface and is gated on the Orca capability probe; the
-  remaining runtime intents (`status`/`resume`/`stop`) stay contract-only until later leaves
-  (#945/#946) deliver them.
+  experimental Orca orchestration surface and is gated on the Orca capability probe; `status`
+  (#945) is read-only but reads the same live runtime signals; the remaining runtime intents
+  (`resume`/`stop`) stay contract-only until #946 delivers them.
 
 ## Pilot boundary
 

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -19,9 +19,18 @@ That exact sentence is carried verbatim in every receipt's top-level `note` fiel
 `skills/relay-dispatch/scripts/manifest/paths.js` `getRepoSlug`): the lowercased,
 dash-sanitized basename of the **canonicalized repo root** joined to the first 8 hex chars
 of its `sha256`. relay-orca replicates the algorithm in `scripts/lib/repo-slug.js` — it does
-**not** import cross-skill code. The canonical root is resolved the same way relay does (git
-common dir → `realpath` of its parent), so a receipt lands under the same slug relay uses for
-its run manifests. The programs root is overridable for tests via `RELAY_ORCA_PROGRAMS_ROOT`
+**not** import cross-skill code. The canonical root is resolved the same way relay's
+`getCanonicalRepoRoot` does (A22): `git rev-parse --git-common-dir` at the input path, take
+that common dir's **parent**, and `realpath` it. This collapses a **linked worktree** to the
+**primary checkout** root, so a receipt lands under the same slug relay uses for its run
+manifests. The `--repo-root` override is canonicalized through git **identically** — it is
+**not** `realpath`'d directly — so pointing `run` or `status` at a linked worktree still
+derives the primary slug, and because both scripts resolve `--repo-root` through the same
+`resolveRepoContext`, a `run`-written receipt always resolves back for `status` on the same
+input. On **any** git failure (not a repo, git missing, timeout) the resolver falls back to a
+plain `realpath` of the provided root — the hermetic behavior the non-git path tests rely on.
+The subprocess lives in the top-level `receipt-io.js` script (the pure `lib/` modules stay
+subprocess-free). The programs root is overridable for tests via `RELAY_ORCA_PROGRAMS_ROOT`
 (validated absolute path; invalid → ignored, default used).
 
 ### Program-segment encoding + identity check (collision-resistant)
@@ -243,7 +252,18 @@ Outcome `state` is exactly one of: `running`, `awaiting_decision`, `complete_wit
 
 Program `state` is one of those six or `ready_for_next_wave` (every outcome in the preceding
 waves of the lowest incomplete wave is `complete_with_evidence`, no outcome is
-`escalated`/`inconsistent`, and the next wave is not yet started). Pinned decisions:
+`escalated`/`inconsistent`, and the next wave is not yet started).
+
+**Started-ness (A23).** An outcome counts as **started** when it carries a `dispatch_id`, a
+`relay_ids.run`, a **`relay_ids.fleet`** mapping, a live fleet manifest resolved for it, **or**
+a PR. The fleet mapping is decisive: a `relay_fleet` outcome whose fleet is already dispatched
+has no per-run `dispatch_id`/`relay_ids.run`/PR of its own yet, so without counting the fleet
+mapping the wave would be mis-derived as an **unstarted** next wave and the program would
+falsely report `ready_for_next_wave` while the fleet is actually running. Such an outcome is
+`running` (or whatever state its own facts dictate — e.g. `escalated` for an escalated child),
+never treated as unstarted by program-state derivation.
+
+Pinned decisions:
 
 - Orca task completed/`worker_done` BUT (open PR OR non-terminal relay manifest) →
   `inconsistent` (stale-`worker_done` rule; never complete).

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -1,0 +1,125 @@
+# Reconstructible receipt + read-only `status`
+
+`run` persists a minimal, versioned **bridge receipt**; `status` is a strictly read-only
+reconciler that derives a normalized program view from that receipt plus live relay
+manifests, GitHub, and Orca runtime signals. Neither introduces a second program state
+machine. This reference is the reviewer anchor for #945.
+
+> This receipt is reconstructible coordination metadata, not a source of truth.
+
+That exact sentence is carried verbatim in every receipt's top-level `note` field.
+
+## Receipt path and slug derivation
+
+```
+~/.relay/programs/<repo-slug>/<program-id>/receipt.json
+```
+
+`<repo-slug>` is derived **identically** to relay's run-dir slug (see
+`skills/relay-dispatch/scripts/manifest/paths.js` `getRepoSlug`): the lowercased,
+dash-sanitized basename of the **canonicalized repo root** joined to the first 8 hex chars
+of its `sha256`. relay-orca replicates the algorithm in `scripts/lib/repo-slug.js` — it does
+**not** import cross-skill code. The canonical root is resolved the same way relay does (git
+common dir → `realpath` of its parent), so a receipt lands under the same slug relay uses for
+its run manifests. The programs root is overridable for tests via `RELAY_ORCA_PROGRAMS_ROOT`
+(validated absolute path; invalid → ignored, default used).
+
+## Receipt schema (v0)
+
+Top-level keys, verbatim: `schema` (literal `1`), `program_id`, `source` (program file path),
+`repo` (`{ slug, root }`), `runtime_id`, `tasks`, `terminals_created`, `created_at`,
+`updated_at` (ISO-8601), `note` (the authority-disclaimer sentence above). Each `tasks[]`
+entry: `outcome_id`, `task_id`, `kind`, `wave`, `orca_task_id`, `dispatch_id`, `assignee`,
+`relay_ids` (`{ request, run, fleet }`, each `null` or a string).
+
+The receipt records **only identity and mapping**. It MUST NOT contain child lifecycle
+states, PR/issue status, Done Criteria text, completion flags, prompts, or terminal output.
+
+- **Atomic write:** a temp file in the same directory + `rename`. Partial/torn receipts are
+  impossible by construction.
+- **Write points (bounded edit to `run`):** after task materialization, and after each
+  successful dispatch verification (mapping-changing steps only). `run`'s report grows by
+  exactly one key, `receipt_path`.
+
+## `status` authority order (durable truth outranks runtime signals)
+
+1. **Relay manifests** — read from `~/.relay/runs/<repo-slug>/` (overridable via
+   `RELAY_ORCA_RUNS_ROOT`). The manifest `state` is the relay lifecycle truth.
+2. **GitHub** — `gh issue view <n> --json state,stateReason` and read-only `gh pr view`
+   queries (merge state + head), via an injectable gh binary (`--gh-bin` / env).
+3. **Orca (runtime signals only)** — `status --json`, `orchestration task-list --json`,
+   `gate-list --json`, `dispatch-show --task <id> --json`, all read-only, all through the
+   probe's binary-resolution rules.
+
+Orca task status and `worker_done` are lifecycle signals, **never** completion authority. An
+outcome is `complete_with_evidence` ONLY when its live durable evidence holds — relay
+manifest terminal AND expected PR merged AND tracker issue closed when closure is part of the
+outcome (per the task kind's expected-evidence defaults in [task-kinds.md](task-kinds.md)).
+
+## Foreign / ambiguous runtime is never adopted
+
+If the live Orca `_meta.runtimeId` differs from the receipt's `runtime_id`, or the runtime
+carries orchestration tasks whose titles lack this program's `relay-orca:<program_id>/`
+marker, Orca-derived facts are **not** adopted (they degrade to `stale_missing`); the report
+sets `runtime` to `"mismatch"` or `"foreign_state"` and durable truth still renders. Foreign
+tasks are never listed as this program's tasks.
+
+## State taxonomy
+
+Outcome `state` is exactly one of: `running`, `awaiting_decision`, `complete_with_evidence`,
+`escalated`, `stale_missing`, `inconsistent`.
+
+Program `state` is one of those six or `ready_for_next_wave` (every outcome in the preceding
+waves of the lowest incomplete wave is `complete_with_evidence`, no outcome is
+`escalated`/`inconsistent`, and the next wave is not yet started). Pinned decisions:
+
+- Orca task completed/`worker_done` BUT (open PR OR non-terminal relay manifest) →
+  `inconsistent` (stale-`worker_done` rule; never complete).
+- Live durable evidence complete BUT Orca terminal/task gone → `complete_with_evidence`
+  (durable truth wins; the vanished runtime signal is a diagnostic only).
+- Mapping present but the referenced Orca task/dispatch/terminal is missing AND durable
+  evidence is not terminal → `stale_missing`.
+- A pending decision gate blocking the outcome's task → `awaiting_decision`.
+
+## Detector matrix (verbatim diagnostic codes)
+
+Each diagnostic is `{ code, outcome_id | null, message, ids }` with `code` one of:
+
+| code | condition |
+| --- | --- |
+| `RUNTIME_MISMATCH` | live runtime id differs from the receipt, or the runtime carries unmarked foreign tasks |
+| `MISSING_TERMINAL` | a mapped operator terminal is gone |
+| `MISSING_TASK` | a mapped Orca task is absent from the live task-list |
+| `MISSING_DISPATCH` | a mapped dispatch is no longer reported |
+| `DUPLICATE_MAPPING` | two receipt entries share an `orca_task_id` or a relay run id |
+| `MISSING_RELAY_RUN` | a mapped relay run has no manifest |
+| `PR_CHANGED` | the PR head moved or its state regressed relative to durable evidence |
+| `ISSUE_REOPENED` | the issue is open though the outcome's evidence contract requires closure |
+| `STALE_WORKER_DONE` | an Orca task reports done but durable evidence is incomplete |
+
+Diagnostics carry stable IDs (task/dispatch/run/PR numbers) and remediation hints but NEVER
+terminal output, secrets, or env values; every subprocess-derived excerpt is bounded to
+≤ 256 chars, the same rule the probe uses. `repair_candidates` (`{ kind, outcome_id,
+proposal }`) are emitted for receipt→live gaps and live→receipt back-pointer discoveries.
+**Repair is out of scope in this leaf** — `status` proposes text and performs NO mutation.
+
+## Fail-closed exit codes (50-range)
+
+| reason_code | exit | trigger |
+| --- | --- | --- |
+| `RECEIPT_NOT_FOUND` | 50 | no receipt for `--program-id` under the programs root |
+| `RECEIPT_CORRUPT` | 51 | unparseable JSON, wrong `schema`, or missing required keys |
+| `RECEIPT_REPO_MISMATCH` | 52 | receipt `repo.slug` does not match the current repo |
+
+Usage errors exit `64`. `status` exits `0` whenever it successfully derives a view — even a
+view full of `inconsistent`/`stale_missing` outcomes. Runtime mismatch and unreachable
+Orca/GitHub do NOT fail the command; they degrade to diagnostics + `stale_missing`.
+
+## Read-only guarantee
+
+`status` performs NO mutation of any kind: no GitHub write, no relay manifest write, no Orca
+mutating subcommand (`task-create`, `task-update`, `dispatch`, `terminal`, any `worktree`
+subcommand, `reset`), and no receipt write. The tests prove it: the fake Orca fixture poisons
+`reset`, `worktree`, and every mutating orchestration subcommand; the fake `gh` fixture
+hard-fails on any non-read subcommand; and a test asserts the receipt bytes are identical
+before and after `status`.

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -336,7 +336,12 @@ Orca/GitHub do NOT fail the command; they degrade to diagnostics + `stale_missin
 
 `status` performs NO mutation of any kind: no GitHub write, no relay manifest write, no Orca
 mutating subcommand (`task-create`, `task-update`, `dispatch`, `terminal`, any `worktree`
-subcommand, `reset`), and no receipt write. The tests prove it: the fake Orca fixture poisons
-`reset`, `worktree`, and every mutating orchestration subcommand; the fake `gh` fixture
-hard-fails on any non-read subcommand; and a test asserts the receipt bytes are identical
-before and after `status`.
+subcommand, `reset`), and no receipt write. Only `gh issue view`, `gh pr view`, and
+**read-shaped** `gh api` GETs are permitted. A `gh api` call is read-shaped only when it
+carries **no** body/field option (`-f`, `--field`, `-F`, `--raw-field`, `--input`) and **no**
+explicit non-GET method — any of those makes `gh api` default to a mutating `POST`/`PATCH`/
+`PUT`/`DELETE`, so `assertGhReadOnly` (and the fake-`gh` poison) refuse it even without a
+literal `-X` (A28). The tests prove it: the fake Orca fixture poisons `reset`, `worktree`, and
+every mutating orchestration subcommand; the fake `gh` fixture hard-fails on any non-read
+subcommand — including a mutation-shaped `gh api`; and a test asserts the receipt bytes are
+identical before and after `status`.

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -27,10 +27,13 @@ manifests. The `--repo-root` override is canonicalized through git **identically
 **not** `realpath`'d directly — so pointing `run` or `status` at a linked worktree still
 derives the primary slug, and because both scripts resolve `--repo-root` through the same
 `resolveRepoContext`, a `run`-written receipt always resolves back for `status` on the same
-input. On **any** git failure (not a repo, git missing, timeout) the resolver falls back to a
-plain `realpath` of the provided root — the hermetic behavior the non-git path tests rely on.
-The subprocess lives in the top-level `receipt-io.js` script (the pure `lib/` modules stay
-subprocess-free). The programs root is overridable for tests via `RELAY_ORCA_PROGRAMS_ROOT`
+input. On **any** git failure (not a repo, git missing, timeout) the resolver **fails closed**
+(A24): there is **no** realpath fallback. Deriving a slug from a plain `realpath` of an
+arbitrary directory could silently point `run`/`status` at **another** repository's receipts,
+so both commands reject with `RECEIPT_REPO_MISMATCH` (exit `52`) and a message carrying a
+bounded excerpt of the git error. Hermetic tests therefore init a tiny real git fixture repo
+(or assert the exit-`52` failure path). The subprocess lives in the top-level `receipt-io.js`
+script (the pure `lib/` modules stay subprocess-free). The programs root is overridable for tests via `RELAY_ORCA_PROGRAMS_ROOT`
 (validated absolute path; invalid → ignored, default used).
 
 ### Program-segment encoding + identity check (collision-resistant)
@@ -233,17 +236,27 @@ required** (A20): if EITHER the merge read or the head read fails or returns inv
 the whole PR source is `unreachable` (`ok:false`) → the outcome degrades to `stale_missing`.
 The head read is **never** substituted with `{}` while keeping the PR source `ok:true`,
 because a resulting `null` `headRefOid` silently disables the `PR_CHANGED` head-moved detector
-and could complete a `merged` outcome whose head actually moved. A merged manifest with a
-closed issue therefore never false-completes when the live head could not be fetched — it
-degrades to `stale_missing` (A11/A20).
+and could complete a `merged` outcome whose head actually moved. **A25:** the same rule
+applies to a head read that **succeeds** (status 0, valid JSON) but whose `headRefOid` is
+missing, empty, or non-string — a real `gh pr view` on an existing PR always returns a
+non-empty head OID, so an absent one means the live head could not be established. That case
+is `unreachable` too: the head comparison is skipped exactly as when the read failed, and
+`pr_merged` never counts as completion evidence when the head comparison was skipped. A merged
+manifest with a closed issue therefore never false-completes when the live head could not be
+fetched **or was absent from the read** — it degrades to `stale_missing` (A11/A20/A25).
 
 ## Foreign / ambiguous runtime is never adopted
 
 If the live Orca `_meta.runtimeId` differs from the receipt's `runtime_id`, or the runtime
-carries orchestration tasks whose titles lack this program's `relay-orca:<program_id>/`
+carries orchestration tasks whose titles lack this program's `relay-orca: <program-segment>/`
 marker, Orca-derived facts are **not** adopted (they degrade to `stale_missing`); the report
 sets `runtime` to `"mismatch"` or `"foreign_state"` and durable truth still renders. Foreign
-tasks are never listed as this program's tasks.
+tasks are never listed as this program's tasks. **A26:** the marker embeds the SAME
+collision-resistant `<program-segment>` used for the receipt path (sanitized ≤64 prefix +
+8-hex `sha256`), **not** the raw id. A raw id can contain `/`, so a marker built from the raw
+id would let program `alpha` adopt a task titled for `alpha/child`; the slash-free segment
+keeps distinct programs on distinct markers. `run.js` materializes task titles and `status`
+detects foreign tasks through the SAME injected pure segment encoder.
 
 ## State taxonomy
 

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -68,10 +68,12 @@ states, PR/issue status, Done Criteria text, completion flags, prompts, or termi
 
 ## `status` authority order (durable truth outranks runtime signals)
 
-1. **Relay manifests** — read from `<runs-root>/<repo-slug>/`. The manifest `state` is the
-   relay lifecycle truth. `<runs-root>` follows relay's own resolution precedence (first hit
-   wins, each candidate must be an **absolute** path; a non-absolute value falls through to
-   the next):
+1. **Relay manifests** — child run manifests are read from `<runs-root>/<repo-slug>/`; fleet
+   manifests are read from a **separate** `<fleets-root>/<repo-slug>/` (see
+   [Fleets-root resolution](#fleets-root-resolution)). The manifest `state` is the relay
+   lifecycle truth. `<runs-root>` follows relay's own resolution precedence (first hit wins,
+   each candidate must be an **absolute** path; a non-absolute value falls through to the
+   next):
    1. `RELAY_ORCA_RUNS_ROOT` (relay-orca-specific override; tests use this)
    2. `RELAY_RUNS_BASE` (relay's runs-base override)
    3. `RELAY_HOME` + `/runs` (relay's home override)
@@ -102,12 +104,15 @@ unclassifiable.
 | `advisory_review` | `advisory_evidence_posted`, `blocking_findings_triaged` | live Orca advisory gate mapped to the outcome's `orca_task_id` |
 | `tracker_reconciliation` | `tracker_reconciled` | mapped relay run manifest terminal AND its tracker issue closed |
 
-- **`relay_fleet`** resolves the fleet manifest via `relay_ids.fleet`. For this leaf, fleet
-  manifests live under the **same runs root** as run manifests. The fleet manifest carries a
+- **`relay_fleet`** resolves the fleet manifest via `relay_ids.fleet`. Fleet manifests live
+  under a **separate fleets root** — `<fleets-root>/<repo-slug>/<fleet-id>.md` — NOT the runs
+  root that holds child run manifests (this mirrors relay-fleet's own layout; see
+  [Fleets-root resolution](#fleets-root-resolution) below). The fleet manifest carries a
   single-line JSON `children` array — `[{"leaf_ref":"…","run_id":"…","dispatch_status":"…"}]`
   (the real relay-fleet shape) — and `fleet_state`. `fleet_manifest_closed` is
   `fleet_state ∈ {merged, closed}`; `fleet_children_terminal` requires ≥1 child and every
-  child `run_id` to resolve to a **terminal** run manifest.
+  child `run_id` to resolve to a **terminal** run manifest **under the runs root** (children
+  are ordinary relay runs; only the fleet manifest itself lives under the fleets root).
 - **Read-only gate kinds** (`integration_gate`, `advisory_review`) are receipt-referenced
   through the outcome's `orca_task_id`: the evidence source is the live decision/review gate
   mapped to that task. A gate "passes"/"triaged" when its live status ∈ `{passed, approved,
@@ -115,6 +120,25 @@ unclassifiable.
   untrusted (mismatch / foreign / unreachable), both checks degrade to `null`.
 - **`tracker_reconciliation`** reconciles the mapped relay run's tracker issue against its
   durable manifest: reconciled = terminal manifest **and** the live issue `CLOSED`.
+
+### Fleets-root resolution
+
+Production relay-fleet manifests do **not** live beside child run manifests. relay-fleet
+writes them to `<fleets-root>/<repo-slug>/<fleet-id>.md`, a directory **separate** from the
+runs root (confirmed in relay-dispatch's `manifest/paths.js`: `getFleetsBase()` returns
+`RELAY_HOME + "/fleets"`, default `~/.relay/fleets`). `status` therefore resolves the two
+roots independently: a `relay_fleet` outcome's `relay_ids.fleet` loads the fleet manifest
+from the **fleets root**, while its children (ordinary relay runs) continue to load from the
+**runs root**. `<fleets-root>` uses the same first-hit-wins, absolute-validated fall-through
+as `<runs-root>`, adapted to relay-fleet's convention:
+
+1. `RELAY_ORCA_FLEETS_ROOT` (relay-orca-specific override; tests use this)
+2. `RELAY_FLEETS_BASE` (the `RELAY_RUNS_BASE` parallel; honored if it is ever set)
+3. `RELAY_HOME` + `/fleets` (relay-fleet's actual convention)
+4. `~/.relay/fleets` (default)
+
+A fleet manifest that is *not* present under the fleets root leaves the outcome's fleet
+evidence `null` (unknown) — it is never silently resolved from the runs root.
 
 ### Failed required Orca reads = unreachable (never fabricated empty state)
 
@@ -126,6 +150,13 @@ fabricated. A failed task-list must never forge a `MISSING_TASK` against a recei
 simply could not be listed, and a failed gate-list must never be treated as "no pending gate"
 (which would silently suppress `awaiting_decision`). A per-task `dispatch-show` failure marks
 only that task's Orca facts **unknown** — never `MISSING_TASK` / `MISSING_DISPATCH`.
+
+The same honesty applies to **GitHub**: a failed **required** live GitHub read for an
+outcome's evidence contract (`gh pr view` feeding `pr_merged`, `gh issue view` feeding
+`issue_closed` / `tracker_reconciled`) leaves that fact `null` and degrades the outcome to
+`stale_missing` rather than reporting a false-clean `running`. The command still exits `0`
+(durable-complete evidence, if any, still wins), and the read never fabricates a fact it
+could not fetch.
 
 ## Foreign / ambiguous runtime is never adopted
 

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -12,7 +12,7 @@ That exact sentence is carried verbatim in every receipt's top-level `note` fiel
 ## Receipt path and slug derivation
 
 ```
-~/.relay/programs/<repo-slug>/<program-id>/receipt.json
+~/.relay/programs/<repo-slug>/<program-segment>/receipt.json
 ```
 
 `<repo-slug>` is derived **identically** to relay's run-dir slug (see
@@ -23,6 +23,28 @@ of its `sha256`. relay-orca replicates the algorithm in `scripts/lib/repo-slug.j
 common dir → `realpath` of its parent), so a receipt lands under the same slug relay uses for
 its run manifests. The programs root is overridable for tests via `RELAY_ORCA_PROGRAMS_ROOT`
 (validated absolute path; invalid → ignored, default used).
+
+### Program-segment encoding + identity check (collision-resistant)
+
+`<program-segment>` is **not** the raw program id. A pure sanitize is lossy — `"a b"` and
+`"a+b"` both collapse to `"a-b"`, which would silently point two distinct programs at ONE
+receipt. So the segment is the sanitized base (`[^A-Za-z0-9._-]+` → `-`, trimmed of leading/
+trailing dashes; empty / `.` / `..` collapse to `program`) joined to the first 8 hex chars of
+`sha256(<raw program id>)`:
+
+```
+<sanitized-base>-<sha256(raw id)[0:8]>
+```
+
+The hash disambiguates ids that sanitize identically while the readable prefix keeps the path
+scannable, and it also keeps `.`/`..` (and any other traversal attempt) on **distinct**,
+non-escaping segments. `run.js` and `status.js` apply `programSegment` identically, so a
+`run`-written receipt resolves back for `status`.
+
+On load, `status` also enforces an **identity check**: the receipt's `program_id` MUST equal
+the requested `--program-id`. A mismatch (hand-edit, misplaced write, or a sanitized-segment
+collision the hash is meant to prevent) fails closed as `RECEIPT_CORRUPT` (exit 51) with a
+bounded message naming **both** ids — never a silent reconcile of the wrong program.
 
 ## Receipt schema (v0)
 
@@ -37,14 +59,23 @@ states, PR/issue status, Done Criteria text, completion flags, prompts, or termi
 
 - **Atomic write:** a temp file in the same directory + `rename`. Partial/torn receipts are
   impossible by construction.
-- **Write points (bounded edit to `run`):** after task materialization, and after each
-  successful dispatch verification (mapping-changing steps only). `run`'s report grows by
+- **Write points (bounded edit to `run`):** after task materialization, and immediately after
+  each dispatch-show provenance verification — **before** the operator prompt is delivered
+  (mapping-changing steps only). A prompt-delivery failure therefore leaves the receipt
+  already carrying the verified `(orca_task_id, dispatch_id, assignee)` trio, so a later
+  reconcile recovers the dispatch instead of re-materializing it. `run`'s report grows by
   exactly one key, `receipt_path`.
 
 ## `status` authority order (durable truth outranks runtime signals)
 
-1. **Relay manifests** — read from `~/.relay/runs/<repo-slug>/` (overridable via
-   `RELAY_ORCA_RUNS_ROOT`). The manifest `state` is the relay lifecycle truth.
+1. **Relay manifests** — read from `<runs-root>/<repo-slug>/`. The manifest `state` is the
+   relay lifecycle truth. `<runs-root>` follows relay's own resolution precedence (first hit
+   wins, each candidate must be an **absolute** path; a non-absolute value falls through to
+   the next):
+   1. `RELAY_ORCA_RUNS_ROOT` (relay-orca-specific override; tests use this)
+   2. `RELAY_RUNS_BASE` (relay's runs-base override)
+   3. `RELAY_HOME` + `/runs` (relay's home override)
+   4. `~/.relay/runs` (default)
 2. **GitHub** — `gh issue view <n> --json state,stateReason` and read-only `gh pr view`
    queries (merge state + head), via an injectable gh binary (`--gh-bin` / env).
 3. **Orca (runtime signals only)** — `status --json`, `orchestration task-list --json`,
@@ -52,9 +83,49 @@ states, PR/issue status, Done Criteria text, completion flags, prompts, or termi
    probe's binary-resolution rules.
 
 Orca task status and `worker_done` are lifecycle signals, **never** completion authority. An
-outcome is `complete_with_evidence` ONLY when its live durable evidence holds — relay
-manifest terminal AND expected PR merged AND tracker issue closed when closure is part of the
-outcome (per the task kind's expected-evidence defaults in [task-kinds.md](task-kinds.md)).
+outcome is `complete_with_evidence` ONLY when its live durable evidence holds — per the task
+kind's expected-evidence defaults in [task-kinds.md](task-kinds.md), enumerated below.
+
+### Per-task-kind evidence contracts
+
+Each task kind names its **own** live evidence checks (`status-classify.js`). An outcome is
+`complete_with_evidence` only when EVERY named check for its kind holds `true`; a `null` check
+is "unknown" (source not yet resolvable — e.g. Orca untrusted) and never completes. The report
+surfaces these checks verbatim in each outcome's `evidence` object, so no kind is
+unclassifiable.
+
+| task_kind | evidence keys (all must be `true`) | source |
+| --- | --- | --- |
+| `relay_run` | `manifest_terminal`, `pr_merged`, `issue_closed` | mapped relay run manifest + PR/issue |
+| `relay_fleet` | `fleet_children_terminal`, `fleet_manifest_closed` | fleet manifest via `relay_ids.fleet` + each child run manifest |
+| `integration_gate` | `gate_report_present`, `gate_check_passes` | live Orca gate mapped to the outcome's `orca_task_id` |
+| `advisory_review` | `advisory_evidence_posted`, `blocking_findings_triaged` | live Orca advisory gate mapped to the outcome's `orca_task_id` |
+| `tracker_reconciliation` | `tracker_reconciled` | mapped relay run manifest terminal AND its tracker issue closed |
+
+- **`relay_fleet`** resolves the fleet manifest via `relay_ids.fleet`. For this leaf, fleet
+  manifests live under the **same runs root** as run manifests. The fleet manifest carries a
+  single-line JSON `children` array — `[{"leaf_ref":"…","run_id":"…","dispatch_status":"…"}]`
+  (the real relay-fleet shape) — and `fleet_state`. `fleet_manifest_closed` is
+  `fleet_state ∈ {merged, closed}`; `fleet_children_terminal` requires ≥1 child and every
+  child `run_id` to resolve to a **terminal** run manifest.
+- **Read-only gate kinds** (`integration_gate`, `advisory_review`) are receipt-referenced
+  through the outcome's `orca_task_id`: the evidence source is the live decision/review gate
+  mapped to that task. A gate "passes"/"triaged" when its live status ∈ `{passed, approved,
+  resolved}`; a pending gate leaves the outcome `awaiting_decision`. When the runtime is
+  untrusted (mismatch / foreign / unreachable), both checks degrade to `null`.
+- **`tracker_reconciliation`** reconciles the mapped relay run's tracker issue against its
+  durable manifest: reconciled = terminal manifest **and** the live issue `CLOSED`.
+
+### Failed required Orca reads = unreachable (never fabricated empty state)
+
+The runtime is `ok` (Orca facts adopted) **only** when `status` AND `task-list` AND `gate-list`
+all succeed and attribute to this program. A failed **required** read (task-list or gate-list)
+degrades the runtime to `unreachable`: Orca-derived facts are **withheld** (outcomes degrade
+per D5 — `stale_missing` while durable evidence still renders), and NO diagnostics are
+fabricated. A failed task-list must never forge a `MISSING_TASK` against a receipt whose task
+simply could not be listed, and a failed gate-list must never be treated as "no pending gate"
+(which would silently suppress `awaiting_decision`). A per-task `dispatch-show` failure marks
+only that task's Orca facts **unknown** — never `MISSING_TASK` / `MISSING_DISPATCH`.
 
 ## Foreign / ambiguous runtime is never adopted
 
@@ -98,17 +169,22 @@ Each diagnostic is `{ code, outcome_id | null, message, ids }` with `code` one o
 | `STALE_WORKER_DONE` | an Orca task reports done but durable evidence is incomplete |
 
 Diagnostics carry stable IDs (task/dispatch/run/PR numbers) and remediation hints but NEVER
-terminal output, secrets, or env values; every subprocess-derived excerpt is bounded to
-≤ 256 chars, the same rule the probe uses. `repair_candidates` (`{ kind, outcome_id,
-proposal }`) are emitted for receipt→live gaps and live→receipt back-pointer discoveries.
-**Repair is out of scope in this leaf** — `status` proposes text and performs NO mutation.
+terminal output, secrets, or env values. **Every** subprocess-derived value that reaches a
+diagnostic is bounded to ≤ 256 chars (marker included), the same rule the probe uses — and
+this holds for values inside the `ids` object, not only inside `message`. `ids` values are
+restricted to normalized stable identifiers; each is passed through the shared bounded-excerpt
+helper (`boundedIds` in `lib/bounded-excerpt.js`) so a wedged or adversarial CLI returning,
+say, a 10,000-char `headRefOid` or `state` cannot inflate or line-inject the report through
+`ids.live_head` / `ids.live`. `repair_candidates` (`{ kind, outcome_id, proposal }`) are
+emitted for receipt→live gaps and live→receipt back-pointer discoveries. **Repair is out of
+scope in this leaf** — `status` proposes text and performs NO mutation.
 
 ## Fail-closed exit codes (50-range)
 
 | reason_code | exit | trigger |
 | --- | --- | --- |
 | `RECEIPT_NOT_FOUND` | 50 | no receipt for `--program-id` under the programs root |
-| `RECEIPT_CORRUPT` | 51 | unparseable JSON, wrong `schema`, or missing required keys |
+| `RECEIPT_CORRUPT` | 51 | unparseable JSON, wrong `schema`, missing required keys, or `program_id` ≠ requested `--program-id` |
 | `RECEIPT_REPO_MISMATCH` | 52 | receipt `repo.slug` does not match the current repo |
 
 Usage errors exit `64`. `status` exits `0` whenever it successfully derives a view — even a

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -29,17 +29,22 @@ its run manifests. The programs root is overridable for tests via `RELAY_ORCA_PR
 `<program-segment>` is **not** the raw program id. A pure sanitize is lossy — `"a b"` and
 `"a+b"` both collapse to `"a-b"`, which would silently point two distinct programs at ONE
 receipt. So the segment is the sanitized base (`[^A-Za-z0-9._-]+` → `-`, trimmed of leading/
-trailing dashes; empty / `.` / `..` collapse to `program`) joined to the first 8 hex chars of
+trailing dashes; empty / `.` / `..` collapse to `program`; then **truncated to at most 64
+chars**, re-trimming any trailing dash the cut exposes) joined to the first 8 hex chars of
 `sha256(<raw program id>)`:
 
 ```
-<sanitized-base>-<sha256(raw id)[0:8]>
+<sanitized-base (≤ 64 chars)>-<sha256(raw id)[0:8]>
 ```
 
-The hash disambiguates ids that sanitize identically while the readable prefix keeps the path
-scannable, and it also keeps `.`/`..` (and any other traversal attempt) on **distinct**,
-non-escaping segments. `run.js` and `status.js` apply `programSegment` identically, so a
-`run`-written receipt resolves back for `status`.
+The hash disambiguates ids that sanitize identically **or that share a 64-char prefix** — it
+is computed over the **full raw id**, never the truncated prefix — while the readable prefix
+keeps the path scannable, and it also keeps `.`/`..` (and any other traversal attempt) on
+**distinct**, non-escaping segments. Bounding the readable prefix (A15) keeps a pathologically
+long program id from overflowing the filesystem per-segment name limit (NAME_MAX, typically
+255) so the receipt still writes and loads; the appended hash guarantees two long ids sharing
+the same 64-char prefix stay on distinct paths. `run.js` and `status.js` apply `programSegment`
+identically, so a `run`-written receipt resolves back for `status`.
 
 On load, `status` also enforces an **identity check**: the receipt's `program_id` MUST equal
 the requested `--program-id`. A mismatch (hand-edit, misplaced write, or a sanitized-segment
@@ -59,12 +64,16 @@ states, PR/issue status, Done Criteria text, completion flags, prompts, or termi
 
 - **Atomic write:** a temp file in the same directory + `rename`. Partial/torn receipts are
   impossible by construction.
-- **Write points (bounded edit to `run`):** after task materialization, and immediately after
-  each dispatch-show provenance verification — **before** the operator prompt is delivered
-  (mapping-changing steps only). A prompt-delivery failure therefore leaves the receipt
-  already carrying the verified `(orca_task_id, dispatch_id, assignee)` trio, so a later
-  reconcile recovers the dispatch instead of re-materializing it. `run`'s report grows by
-  exactly one key, `receipt_path`.
+- **Write points (bounded edit to `run`):** after **each** successful task-create (A12), and
+  immediately after each dispatch-show provenance verification — **before** the operator
+  prompt is delivered (mapping-changing steps only). Persisting after every task-create means
+  a `TASK_MATERIALIZE_FAILED` (exit 41) raised mid-wave still leaves every earlier outcome's
+  `orca_task_id` durably on disk — the partial mapping is never lost — before the failure
+  propagates. Likewise a prompt-delivery failure leaves the receipt already carrying the
+  verified `(orca_task_id, dispatch_id, assignee)` trio, so a later reconcile recovers the
+  created tasks / dispatch instead of re-materializing them. (There is no separate
+  post-materialization write — the last per-create write already covers it.) `run`'s report
+  grows by exactly one key, `receipt_path`.
 
 ## `status` authority order (durable truth outranks runtime signals)
 
@@ -98,7 +107,7 @@ unclassifiable.
 
 | task_kind | evidence keys (all must be `true`) | source |
 | --- | --- | --- |
-| `relay_run` | `manifest_terminal`, `pr_merged`, `issue_closed` | mapped relay run manifest + PR/issue |
+| `relay_run` | `manifest_terminal` (manifest `merged` **only**, A14), `pr_merged`, `issue_closed` | mapped relay run manifest + PR/issue |
 | `relay_fleet` | `fleet_children_terminal`, `fleet_manifest_closed` | fleet manifest via `relay_ids.fleet` + each child run manifest |
 | `integration_gate` | `gate_report_present`, `gate_check_passes` | live Orca gate mapped to the outcome's `orca_task_id` |
 | `advisory_review` | `advisory_evidence_posted`, `blocking_findings_triaged` | live Orca advisory gate mapped to the outcome's `orca_task_id` |
@@ -118,6 +127,13 @@ unclassifiable.
   mapped to that task. A gate "passes"/"triaged" when its live status ∈ `{passed, approved,
   resolved}`; a pending gate leaves the outcome `awaiting_decision`. When the runtime is
   untrusted (mismatch / foreign / unreachable), both checks degrade to `null`.
+- **`relay_run`** completion is **`merged`-only** (A14): `manifest_terminal` holds `true` only
+  when the mapped run manifest reached `merged` — **not** merely any terminal state. A
+  terminal-but-`closed` (force-closed / abandoned) manifest can never yield completion
+  evidence again, so `manifest_terminal` stays `false` and the outcome surfaces as
+  `escalated` — never `complete_with_evidence` — even if the PR shows merged and the issue
+  shows closed. (`relay_fleet` and `tracker_reconciliation` keep their existing terminal-state
+  contracts.)
 - **`tracker_reconciliation`** reconciles the mapped relay run's tracker issue against its
   durable manifest: reconciled = terminal manifest **and** the live issue `CLOSED`.
 
@@ -146,7 +162,11 @@ The runtime is `ok` (Orca facts adopted) **only** when `status` AND `task-list` 
 all succeed and attribute to this program. A failed **required** read (task-list or gate-list)
 degrades the runtime to `unreachable`: Orca-derived facts are **withheld** (outcomes degrade
 per D5 — `stale_missing` while durable evidence still renders), and NO diagnostics are
-fabricated. A failed task-list must never forge a `MISSING_TASK` against a receipt whose task
+fabricated. A `status` read that **succeeds** but carries **no usable live runtime id**
+(missing, empty, or non-string) is equally unattributable (A13) — the live runtime cannot be
+proven to be the one the receipt mapped — so it too degrades to `unreachable`, withholding
+Orca facts rather than silently trusting an unidentified runtime (this is the same withholding
+as A4, not a fabricated `RUNTIME_MISMATCH`). A failed task-list must never forge a `MISSING_TASK` against a receipt whose task
 simply could not be listed, and a failed gate-list must never be treated as "no pending gate"
 (which would silently suppress `awaiting_decision`). A per-task `dispatch-show` failure marks
 only that task's Orca facts **unknown** — never `MISSING_TASK` / `MISSING_DISPATCH`.
@@ -181,6 +201,9 @@ waves of the lowest incomplete wave is `complete_with_evidence`, no outcome is
   (durable truth wins; the vanished runtime signal is a diagnostic only).
 - Mapping present but the referenced Orca task/dispatch/terminal is missing AND durable
   evidence is not terminal → `stale_missing`.
+- A `relay_run` whose manifest is terminal-but-`closed` (force-closed / abandoned) →
+  `escalated`, never `complete_with_evidence`, regardless of a merged PR or closed issue
+  (relay_run completion is manifest `merged` only, A14).
 - A pending decision gate blocking the outcome's task → `awaiting_decision`.
 
 ## Detector matrix (verbatim diagnostic codes)

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -64,14 +64,19 @@ states, PR/issue status, Done Criteria text, completion flags, prompts, or termi
 
 - **Atomic write:** a temp file in the same directory + `rename`. Partial/torn receipts are
   impossible by construction.
-- **Write points (bounded edit to `run`):** after **each** successful task-create (A12), and
-  immediately after each dispatch-show provenance verification — **before** the operator
-  prompt is delivered (mapping-changing steps only). Persisting after every task-create means
-  a `TASK_MATERIALIZE_FAILED` (exit 41) raised mid-wave still leaves every earlier outcome's
+- **Write points (bounded edit to `run`):** after **each** successful task-create (A12),
+  immediately after **each auto-created operator terminal** is recorded (A16), and immediately
+  after each dispatch-show provenance verification — **before** the operator prompt is
+  delivered (mapping-changing steps only). Persisting after every task-create means a
+  `TASK_MATERIALIZE_FAILED` (exit 41) raised mid-wave still leaves every earlier outcome's
   `orca_task_id` durably on disk — the partial mapping is never lost — before the failure
-  propagates. Likewise a prompt-delivery failure leaves the receipt already carrying the
-  verified `(orca_task_id, dispatch_id, assignee)` trio, so a later reconcile recovers the
-  created tasks / dispatch instead of re-materializing them. (There is no separate
+  propagates. Persisting immediately after an auto-created terminal (A16) means a dispatch (or
+  provenance) failure right after terminal creation leaves the receipt already carrying the
+  handle in `terminals_created`, so a reconcile can **adopt** (not re-create) that terminal
+  instead of leaking it — the receipt is written **before** the dispatch that may fail, not
+  only after dispatch-show. Likewise a prompt-delivery failure leaves the receipt already
+  carrying the verified `(orca_task_id, dispatch_id, assignee)` trio, so a later reconcile
+  recovers the created tasks / dispatch instead of re-materializing them. (There is no separate
   post-materialization write — the last per-create write already covers it.) `run`'s report
   grows by exactly one key, `receipt_path`.
 
@@ -88,7 +93,11 @@ states, PR/issue status, Done Criteria text, completion flags, prompts, or termi
    3. `RELAY_HOME` + `/runs` (relay's home override)
    4. `~/.relay/runs` (default)
 2. **GitHub** — `gh issue view <n> --json state,stateReason` and read-only `gh pr view`
-   queries (merge state + head), via an injectable gh binary (`--gh-bin` / env).
+   queries, via an injectable gh binary (`--gh-bin` / env). The PR evidence is fetched with
+   **two required** `gh pr view` sub-reads whose `--json` field lists are literals registered
+   in the repo-wide pr-view field-list contract: a merge read (`mergedAt,state`) and a head
+   read (`number,headRefName,headRefOid`). Both are required (A20) — see
+   [Failed required reads](#failed-required-orca-reads--unreachable-never-fabricated-empty-state).
 3. **Orca (runtime signals only)** — `status --json`, `orchestration task-list --json`,
    `gate-list --json`, `dispatch-show --task <id> --json`, all read-only, all through the
    probe's binary-resolution rules.
@@ -108,9 +117,9 @@ unclassifiable.
 | task_kind | evidence keys (all must be `true`) | source |
 | --- | --- | --- |
 | `relay_run` | `manifest_terminal` (manifest `merged` **only**, A14), `pr_merged`, `issue_closed` | mapped relay run manifest + PR/issue |
-| `relay_fleet` | `fleet_children_terminal`, `fleet_manifest_closed` | fleet manifest via `relay_ids.fleet` + each child run manifest |
-| `integration_gate` | `gate_report_present`, `gate_check_passes` | live Orca gate mapped to the outcome's `orca_task_id` |
-| `advisory_review` | `advisory_evidence_posted`, `blocking_findings_triaged` | live Orca advisory gate mapped to the outcome's `orca_task_id` |
+| `relay_fleet` | `fleet_children_terminal` (child terminal set = `{merged, closed, escalated}`, A18), `fleet_manifest_closed` | fleet manifest via `relay_ids.fleet` + each child run manifest |
+| `integration_gate` | `gate_report_present`, `gate_check_passes` | live Orca gate (`kind` `"integration"` or untyped) mapped to the outcome's `orca_task_id` |
+| `advisory_review` | `advisory_evidence_posted`, `blocking_findings_triaged` | live Orca gate **explicitly** `kind: "advisory"` (A19) mapped to the outcome's `orca_task_id` |
 | `tracker_reconciliation` | `tracker_reconciled` | mapped relay run manifest terminal AND its tracker issue closed |
 
 - **`relay_fleet`** resolves the fleet manifest via `relay_ids.fleet`. Fleet manifests live
@@ -122,11 +131,26 @@ unclassifiable.
   `fleet_state ∈ {merged, closed}`; `fleet_children_terminal` requires ≥1 child and every
   child `run_id` to resolve to a **terminal** run manifest **under the runs root** (children
   are ordinary relay runs; only the fleet manifest itself lives under the fleets root).
+  A child is **terminal** when its state ∈ `{merged, closed, escalated}` (A18) — an escalated
+  child is terminal (it will not progress on its own) but NOT *complete*. Fleet **completion**
+  still requires every child at `merged`/`closed`, so an escalated child in a closed fleet
+  makes `fleet_children_terminal` `true` (the fleet reached a terminal configuration) yet the
+  outcome is `escalated`, never `complete_with_evidence` (terminal ≠ complete — see the State
+  taxonomy pinned decision below).
 - **Read-only gate kinds** (`integration_gate`, `advisory_review`) are receipt-referenced
   through the outcome's `orca_task_id`: the evidence source is the live decision/review gate
   mapped to that task. A gate "passes"/"triaged" when its live status ∈ `{passed, approved,
   resolved}`; a pending gate leaves the outcome `awaiting_decision`. When the runtime is
-  untrusted (mismatch / foreign / unreachable), both checks degrade to `null`.
+  untrusted (mismatch / foreign / unreachable), both checks degrade to `null`. The modeled
+  gate shape is `{ id, task_id, status, kind }`; a gate is matched to an outcome when its
+  `task_id`/`task` equals the outcome's `orca_task_id` (or it lists that id in `blocks`).
+  **Gate-kind markers:** `integration_gate` evidence is satisfied by a gate whose `kind` is
+  `"integration"` **or is absent/untyped** (an untyped gate defaults to integration).
+  `advisory_review` evidence (A19) requires a gate **explicitly** marked advisory — its `kind`
+  is exactly `"advisory"`. There is **no** "first gate" fallback: a non-advisory or untyped
+  gate mapped to an `advisory_review` task is **never** advisory evidence, so a passed
+  integration/untyped gate can never forge advisory completion; none present →
+  `advisory_evidence_posted` `false` → not complete.
 - **`relay_run`** completion is **`merged`-only** (A14): `manifest_terminal` holds `true` only
   when the mapped run manifest reached `merged` — **not** merely any terminal state. A
   terminal-but-`closed` (force-closed / abandoned) manifest can never yield completion
@@ -171,12 +195,38 @@ simply could not be listed, and a failed gate-list must never be treated as "no 
 (which would silently suppress `awaiting_decision`). A per-task `dispatch-show` failure marks
 only that task's Orca facts **unknown** — never `MISSING_TASK` / `MISSING_DISPATCH`.
 
+**Per-read runtime-id attribution (A17).** Adopting a read is not just about it succeeding —
+it must be proven to come from the runtime the receipt mapped. The `status` read establishes
+the reference runtime id (A13 guarantees it is a non-empty string). **Every** adopted read
+then carries `_meta.runtimeId` and is validated against that reference before its data is
+used:
+
+- **Whole-runtime reads** (`task-list`, `gate-list`): a mismatched or missing-where-expected
+  `_meta.runtimeId` degrades the runtime to `unreachable` — Orca facts are **withheld**
+  exactly like a failed required read (A4), never adopted from an unverifiable runtime, and no
+  diagnostic is fabricated.
+- **Per-task `dispatch-show`**: a reachable read whose `_meta.runtimeId` is mismatched or
+  missing-where-expected makes **only that task's** runtime facts **unknown** — its dispatch
+  facts are withheld (so no false `MISSING_DISPATCH` / `MISSING_TERMINAL` is forged) and that
+  outcome degrades to `stale_missing`, leaving every other outcome unaffected. (A transiently
+  failed/unreachable `dispatch-show` has no id to check and keeps its existing pass-through
+  handling — it never forges a diagnostic.)
+
 The same honesty applies to **GitHub**: a failed **required** live GitHub read for an
 outcome's evidence contract (`gh pr view` feeding `pr_merged`, `gh issue view` feeding
 `issue_closed` / `tracker_reconciled`) leaves that fact `null` and degrades the outcome to
 `stale_missing` rather than reporting a false-clean `running`. The command still exits `0`
 (durable-complete evidence, if any, still wins), and the read never fabricates a fact it
 could not fetch.
+
+The PR read is fetched via **two required sub-reads** (merge state + head), and **both are
+required** (A20): if EITHER the merge read or the head read fails or returns invalid JSON,
+the whole PR source is `unreachable` (`ok:false`) → the outcome degrades to `stale_missing`.
+The head read is **never** substituted with `{}` while keeping the PR source `ok:true`,
+because a resulting `null` `headRefOid` silently disables the `PR_CHANGED` head-moved detector
+and could complete a `merged` outcome whose head actually moved. A merged manifest with a
+closed issue therefore never false-completes when the live head could not be fetched — it
+degrades to `stale_missing` (A11/A20).
 
 ## Foreign / ambiguous runtime is never adopted
 
@@ -204,6 +254,10 @@ waves of the lowest incomplete wave is `complete_with_evidence`, no outcome is
 - A `relay_run` whose manifest is terminal-but-`closed` (force-closed / abandoned) →
   `escalated`, never `complete_with_evidence`, regardless of a merged PR or closed issue
   (relay_run completion is manifest `merged` only, A14).
+- A `relay_fleet` with an **escalated** child (child terminal set = `{merged, closed,
+  escalated}`, A18) → `escalated`, never `complete_with_evidence`, even in a closed fleet
+  where every child is terminal — terminal ≠ complete, and completion requires every child
+  `merged`/`closed`. The all-`merged` fleet still completes.
 - A pending decision gate blocking the outcome's task → `awaiting_decision`.
 
 ## Detector matrix (verbatim diagnostic codes)

--- a/skills/relay-orca/scripts/lib/bounded-excerpt.js
+++ b/skills/relay-orca/scripts/lib/bounded-excerpt.js
@@ -1,0 +1,30 @@
+"use strict";
+
+// Shared bounded-rendering + JSON-parse helpers for the read-only `status` adapters
+// (#945 D7). Every subprocess-derived value embedded in a diagnostic message passes
+// through boundedExcerpt so a wedged or adversarial CLI cannot inflate or line-inject
+// the status report — the SAME ≤256-char rule the probe uses. Pure: no subprocess, no
+// fs mutation.
+const EXCERPT_LIMIT = 256;
+
+function boundedExcerpt(value) {
+  const text = String(value).replace(/\s+/g, " ").trim();
+  if (text.length <= EXCERPT_LIMIT) return text;
+  return `${text.slice(0, EXCERPT_LIMIT - 1)}…`;
+}
+
+function parseJson(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return { ok: false, error: "empty stdout" };
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (error) {
+    return { ok: false, error: error.message, excerpt: boundedExcerpt(text) };
+  }
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+module.exports = { EXCERPT_LIMIT, boundedExcerpt, parseJson, isNonEmptyString };

--- a/skills/relay-orca/scripts/lib/bounded-excerpt.js
+++ b/skills/relay-orca/scripts/lib/bounded-excerpt.js
@@ -27,4 +27,24 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
 }
 
-module.exports = { EXCERPT_LIMIT, boundedExcerpt, parseJson, isNonEmptyString };
+// Bound a single diagnostic-`ids` value (#945 D7). Every string is passed through
+// boundedExcerpt so a wedged/adversarial CLI cannot inflate or line-inject a value
+// that reaches the report inside `ids` (not only inside `message`). Numbers, nulls,
+// and booleans are inherently bounded stable identifiers and pass through; arrays are
+// bounded element-wise (e.g. the `outcomes` id list on DUPLICATE_MAPPING).
+function boundIdValue(value) {
+  if (typeof value === "string") return boundedExcerpt(value);
+  if (Array.isArray(value)) return value.map(boundIdValue);
+  return value;
+}
+
+// Bound EVERY value of a diagnostic `ids` object. Diagnostic ids must be normalized
+// stable identifiers; any subprocess-derived value routed through here can never
+// exceed the ≤256-char excerpt limit (marker included).
+function boundedIds(ids) {
+  const out = {};
+  for (const [key, value] of Object.entries(ids || {})) out[key] = boundIdValue(value);
+  return out;
+}
+
+module.exports = { EXCERPT_LIMIT, boundedExcerpt, parseJson, isNonEmptyString, boundIdValue, boundedIds };

--- a/skills/relay-orca/scripts/lib/gh-reads.js
+++ b/skills/relay-orca/scripts/lib/gh-reads.js
@@ -35,6 +35,12 @@ function ghIssueView(run, ghBin, number, options = {}) {
 // merge evidence (mergedAt,state); the second recovers the live head (headRefOid) for
 // the PR_CHANGED head-moved detector. Both are read-only; the results are merged so
 // callers see one `{ state, mergedAt, headRefOid }` fact.
+//
+// A20: BOTH sub-reads are REQUIRED. If EITHER fails or returns invalid JSON, the PR
+// source is unreachable (ok:false) — it must NEVER substitute `{}` for the head read
+// and keep ok:true, because a resulting null `headRefOid` silently disables the
+// PR_CHANGED head-moved detector and can complete a merged outcome whose head actually
+// moved. An unreachable PR source degrades the outcome to stale_missing (A11/A20).
 function ghPrView(run, ghBin, number, options = {}) {
   const mergeArgs = ["pr", "view", String(number), "--json", "mergedAt,state"];
   const mergeProc = run(ghBin, mergeArgs, options);
@@ -46,7 +52,10 @@ function ghPrView(run, ghBin, number, options = {}) {
   const headArgs = ["pr", "view", String(number), "--json", "number,headRefName,headRefOid"];
   const headProc = run(ghBin, headArgs, options);
   const headParsed = parseJson(headProc.stdout);
-  const head = headProc.status === 0 && headParsed.ok && headParsed.value ? headParsed.value : {};
+  if (headProc.status !== 0 || !headParsed.ok || !headParsed.value) {
+    return { ok: false, reachable: false, proc: headProc };
+  }
+  const head = headParsed.value;
   return {
     ok: true,
     reachable: true,

--- a/skills/relay-orca/scripts/lib/gh-reads.js
+++ b/skills/relay-orca/scripts/lib/gh-reads.js
@@ -36,11 +36,19 @@ function ghIssueView(run, ghBin, number, options = {}) {
 // the PR_CHANGED head-moved detector. Both are read-only; the results are merged so
 // callers see one `{ state, mergedAt, headRefOid }` fact.
 //
-// A20: BOTH sub-reads are REQUIRED. If EITHER fails or returns invalid JSON, the PR
+// A20/A25: BOTH sub-reads are REQUIRED. If EITHER fails or returns invalid JSON, the PR
 // source is unreachable (ok:false) — it must NEVER substitute `{}` for the head read
 // and keep ok:true, because a resulting null `headRefOid` silently disables the
 // PR_CHANGED head-moved detector and can complete a merged outcome whose head actually
 // moved. An unreachable PR source degrades the outcome to stale_missing (A11/A20).
+//
+// A25: a head read that SUCCEEDS (status 0, valid JSON) but whose `headRefOid` is
+// missing, empty, or non-string is ALSO unreachable — the live head could not be
+// established, so the head comparison is skipped exactly as when the read failed. A
+// real `gh pr view` on an existing PR always returns a non-empty head OID; anything
+// else means the head fact is absent, and `pr_merged` must NEVER count as completion
+// evidence when the head comparison was skipped. So the whole PR source degrades to
+// stale_missing rather than false-completing a merged outcome off a null head.
 function ghPrView(run, ghBin, number, options = {}) {
   const mergeArgs = ["pr", "view", String(number), "--json", "mergedAt,state"];
   const mergeProc = run(ghBin, mergeArgs, options);
@@ -56,12 +64,15 @@ function ghPrView(run, ghBin, number, options = {}) {
     return { ok: false, reachable: false, proc: headProc };
   }
   const head = headParsed.value;
+  if (typeof head.headRefOid !== "string" || head.headRefOid.trim() === "") {
+    return { ok: false, reachable: false, proc: headProc };
+  }
   return {
     ok: true,
     reachable: true,
     state: typeof merge.state === "string" ? merge.state : null,
     mergedAt: merge.mergedAt ?? null,
-    headRefOid: typeof head.headRefOid === "string" ? head.headRefOid : null,
+    headRefOid: head.headRefOid,
     proc: mergeProc,
   };
 }

--- a/skills/relay-orca/scripts/lib/gh-reads.js
+++ b/skills/relay-orca/scripts/lib/gh-reads.js
@@ -1,0 +1,60 @@
+"use strict";
+
+// Pure GitHub read adapters for `status` (#945 D4). ONLY read-only `gh` subcommands
+// are ever built here: `gh issue view <n> --json state,stateReason` and
+// `gh pr view <n> --json state,mergedAt,headRefOid`. No write subcommand is
+// reachable. Every builder receives an injected `run(ghBin, args, options)` so the
+// subprocess boundary stays in the top-level script and plan.js's frozen lib
+// source-scan keeps passing.
+const { parseJson } = require("./bounded-excerpt");
+
+// Read-only field list for `gh issue view` (D4). `gh issue view` is not covered by the
+// repo-wide pr-view field-list contract, so a named constant is fine here.
+const ISSUE_FIELDS = "state,stateReason";
+
+function ghIssueView(run, ghBin, number, options = {}) {
+  const args = ["issue", "view", String(number), "--json", ISSUE_FIELDS];
+  const proc = run(ghBin, args, options);
+  const parsed = parseJson(proc.stdout);
+  if (proc.status !== 0 || !parsed.ok || !parsed.value) {
+    return { ok: false, reachable: false, proc };
+  }
+  const value = parsed.value;
+  return {
+    ok: true,
+    reachable: true,
+    state: typeof value.state === "string" ? value.state : null,
+    stateReason: typeof value.stateReason === "string" ? value.stateReason : null,
+    proc,
+  };
+}
+
+// The full D4 PR evidence (state, mergedAt, headRefOid) is fetched via two read-only
+// `gh pr view` calls whose --json field lists are LITERAL strings already registered
+// in the repo-wide pr-view field-list contract (tests/skills-lint). The first covers
+// merge evidence (mergedAt,state); the second recovers the live head (headRefOid) for
+// the PR_CHANGED head-moved detector. Both are read-only; the results are merged so
+// callers see one `{ state, mergedAt, headRefOid }` fact.
+function ghPrView(run, ghBin, number, options = {}) {
+  const mergeArgs = ["pr", "view", String(number), "--json", "mergedAt,state"];
+  const mergeProc = run(ghBin, mergeArgs, options);
+  const mergeParsed = parseJson(mergeProc.stdout);
+  if (mergeProc.status !== 0 || !mergeParsed.ok || !mergeParsed.value) {
+    return { ok: false, reachable: false, proc: mergeProc };
+  }
+  const merge = mergeParsed.value;
+  const headArgs = ["pr", "view", String(number), "--json", "number,headRefName,headRefOid"];
+  const headProc = run(ghBin, headArgs, options);
+  const headParsed = parseJson(headProc.stdout);
+  const head = headProc.status === 0 && headParsed.ok && headParsed.value ? headParsed.value : {};
+  return {
+    ok: true,
+    reachable: true,
+    state: typeof merge.state === "string" ? merge.state : null,
+    mergedAt: merge.mergedAt ?? null,
+    headRefOid: typeof head.headRefOid === "string" ? head.headRefOid : null,
+    proc: mergeProc,
+  };
+}
+
+module.exports = { ISSUE_FIELDS, ghIssueView, ghPrView };

--- a/skills/relay-orca/scripts/lib/manifest-parse.js
+++ b/skills/relay-orca/scripts/lib/manifest-parse.js
@@ -64,8 +64,33 @@ function asObject(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
 }
 
+// Parse a relay-fleet manifest's `children:` frontmatter value (#945 D4 relay_fleet).
+// Real fleet manifests store the child references as a single-line JSON array, e.g.
+// `children: [{"leaf_ref":"...","run_id":"...","dispatch_status":"dispatched"}]`.
+// parseFrontmatter keeps that value as a raw scalar string, so we JSON.parse it here
+// and normalize each child to `{ leaf_ref, run_id }`. Anything unparseable → []
+// (a run manifest with no `children` key yields [] and never throws).
+function parseFleetChildren(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .filter((child) => child && typeof child === "object")
+    .map((child) => ({
+      leaf_ref: typeof child.leaf_ref === "string" ? child.leaf_ref : null,
+      run_id: typeof child.run_id === "string" ? child.run_id : null,
+    }));
+}
+
 // Extract the durable lifecycle facts `status` reconciles against. Every field is
 // null when absent so the classifier can distinguish "unknown" from a real value.
+// Fleet-only fields (`fleet_state`, `fleet_children`) are populated for relay-fleet
+// manifests and stay null/[] for ordinary relay run manifests.
 function parseManifest(text) {
   const frontmatter = parseFrontmatter(text);
   const git = asObject(frontmatter.git);
@@ -78,6 +103,9 @@ function parseManifest(text) {
     base_branch: typeof git.base_branch === "string" ? git.base_branch : null,
     head_sha: typeof git.head_sha === "string" ? git.head_sha : null,
     issue_number: typeof issue.number === "number" ? issue.number : null,
+    fleet_id: typeof frontmatter.fleet_id === "string" ? frontmatter.fleet_id : null,
+    fleet_state: typeof frontmatter.fleet_state === "string" ? frontmatter.fleet_state : null,
+    fleet_children: parseFleetChildren(frontmatter.children),
   };
 }
 
@@ -93,6 +121,7 @@ module.exports = {
   TERMINAL_MANIFEST_STATES,
   ESCALATED_MANIFEST_STATES,
   parseFrontmatter,
+  parseFleetChildren,
   parseManifest,
   isTerminalManifestState,
   isEscalatedManifestState,

--- a/skills/relay-orca/scripts/lib/manifest-parse.js
+++ b/skills/relay-orca/scripts/lib/manifest-parse.js
@@ -1,0 +1,99 @@
+"use strict";
+
+// Pure relay-manifest reader (#945 D4). Relay manifests are YAML-frontmatter `.md`
+// files; `status` reads ONLY the durable lifecycle facts it needs — the manifest
+// `state`, the git PR number, and the tracker issue number — from the frontmatter.
+// The top-level script reads the file bytes; this module parses the text and never
+// touches the filesystem, so plan.js's frozen lib source-scan keeps passing.
+//
+// The frontmatter is walked with a small indentation-stack scanner (not a general
+// YAML engine): it captures scalar leaves and nested maps, which is sufficient for
+// the pinned `state` / `git.pr_number` / `issue.number` lookups against both the
+// real relay manifest shape and the self-contained test fixtures.
+
+// Relay lifecycle states that count as a durable terminal for completion evidence
+// (D4/D5): a run reaches `merged` (or `closed` as the contract requires). Everything
+// else (draft/dispatched/review_pending/ready_to_merge/changes_requested) is
+// non-terminal. `escalated` is treated separately as an escalation signal.
+const TERMINAL_MANIFEST_STATES = new Set(["merged", "closed"]);
+const ESCALATED_MANIFEST_STATES = new Set(["escalated"]);
+
+function parseScalar(raw) {
+  const value = raw.trim();
+  if (value === "" || value === "null" || value === "~") return null;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  const unquoted = value.replace(/^['"]/, "").replace(/['"]$/, "");
+  if (/^-?\d+$/.test(unquoted)) return Number(unquoted);
+  return unquoted;
+}
+
+function frontmatterBlock(text) {
+  const match = String(text || "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return match ? match[1] : "";
+}
+
+// Build a nested object from the frontmatter by tracking indentation depth. List
+// items and comments are skipped — `status` never reads list-valued manifest fields.
+function parseFrontmatter(text) {
+  const root = {};
+  const stack = [{ indent: -1, node: root }];
+  for (const line of frontmatterBlock(text).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("- ")) continue;
+    const indent = line.match(/^ */)[0].length;
+    const rest = line.slice(indent);
+    const colon = rest.indexOf(":");
+    if (colon < 0) continue;
+    const key = rest.slice(0, colon).trim();
+    const valuePart = rest.slice(colon + 1);
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop();
+    const parent = stack[stack.length - 1].node;
+    if (valuePart.trim() === "") {
+      const child = {};
+      parent[key] = child;
+      stack.push({ indent, node: child });
+    } else {
+      parent[key] = parseScalar(valuePart);
+    }
+  }
+  return root;
+}
+
+function asObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+// Extract the durable lifecycle facts `status` reconciles against. Every field is
+// null when absent so the classifier can distinguish "unknown" from a real value.
+function parseManifest(text) {
+  const frontmatter = parseFrontmatter(text);
+  const git = asObject(frontmatter.git);
+  const issue = asObject(frontmatter.issue);
+  return {
+    run_id: typeof frontmatter.run_id === "string" ? frontmatter.run_id : null,
+    state: typeof frontmatter.state === "string" ? frontmatter.state : null,
+    pr_number: typeof git.pr_number === "number" ? git.pr_number : null,
+    working_branch: typeof git.working_branch === "string" ? git.working_branch : null,
+    base_branch: typeof git.base_branch === "string" ? git.base_branch : null,
+    head_sha: typeof git.head_sha === "string" ? git.head_sha : null,
+    issue_number: typeof issue.number === "number" ? issue.number : null,
+  };
+}
+
+function isTerminalManifestState(state) {
+  return typeof state === "string" && TERMINAL_MANIFEST_STATES.has(state);
+}
+
+function isEscalatedManifestState(state) {
+  return typeof state === "string" && ESCALATED_MANIFEST_STATES.has(state);
+}
+
+module.exports = {
+  TERMINAL_MANIFEST_STATES,
+  ESCALATED_MANIFEST_STATES,
+  parseFrontmatter,
+  parseManifest,
+  isTerminalManifestState,
+  isEscalatedManifestState,
+};

--- a/skills/relay-orca/scripts/lib/orca-reads.js
+++ b/skills/relay-orca/scripts/lib/orca-reads.js
@@ -44,10 +44,12 @@ function orcaTaskList(run, orcaBin, options = {}) {
 function orcaGateList(run, orcaBin, options = {}) {
   const proc = run(orcaBin, ["orchestration", "gate-list", "--json"], options);
   const { ok, value } = envelope(proc);
-  if (!ok) return { ok: false, reachable: false, gates: [], proc };
+  if (!ok) return { ok: false, reachable: false, gates: [], runtimeId: null, proc };
   const result = value.result || {};
   const gates = Array.isArray(result.gates) ? result.gates : [];
-  return { ok: true, reachable: true, gates, proc };
+  // A17: expose the read's `_meta.runtimeId` so the caller can prove this whole-runtime
+  // read came from the SAME runtime the status read established before adopting its data.
+  return { ok: true, reachable: true, gates, runtimeId: metaRuntimeId(value), proc };
 }
 
 function orcaDispatchShow(run, orcaBin, taskId, options = {}) {
@@ -66,6 +68,9 @@ function orcaDispatchShow(run, orcaBin, taskId, options = {}) {
     dispatchId: isNonEmptyString(result.dispatch_id) ? result.dispatch_id : null,
     assignee,
     terminalPresent,
+    // A17: expose the per-task read's `_meta.runtimeId` so the caller can prove THIS
+    // task's dispatch-show came from the receipt's runtime before adopting its facts.
+    runtimeId: metaRuntimeId(value),
     proc,
   };
 }

--- a/skills/relay-orca/scripts/lib/orca-reads.js
+++ b/skills/relay-orca/scripts/lib/orca-reads.js
@@ -1,0 +1,73 @@
+"use strict";
+
+// Pure Orca READ-ONLY adapters for `status` (#945 D4). ONLY read subcommands are
+// built here: `status --json`, `orchestration task-list --json`,
+// `orchestration gate-list --json`, and `orchestration dispatch-show --task <id>
+// --json`. No mutating orchestration subcommand (task-create/task-update/dispatch/
+// terminal), no `reset`, and no `worktree` subcommand is reachable from this module.
+// Every builder receives an injected `run(orcaBin, args, options)` so the subprocess
+// boundary stays in the top-level script and plan.js's frozen lib source-scan keeps
+// passing.
+const { parseJson, isNonEmptyString } = require("./bounded-excerpt");
+
+function envelope(proc) {
+  const parsed = parseJson(proc.stdout);
+  const ok = proc.status === 0 && parsed.ok && parsed.value && parsed.value.ok === true;
+  return { ok, value: ok ? parsed.value : null };
+}
+
+function metaRuntimeId(value) {
+  const meta = value && value._meta;
+  return meta && isNonEmptyString(meta.runtimeId) ? meta.runtimeId : null;
+}
+
+function orcaStatus(run, orcaBin, options = {}) {
+  const proc = run(orcaBin, ["status", "--json"], options);
+  const { ok, value } = envelope(proc);
+  if (!ok) return { ok: false, reachable: false, runtimeId: null, proc };
+  const runtime = value.result && value.result.runtime;
+  const runtimeId = runtime && isNonEmptyString(runtime.runtimeId)
+    ? runtime.runtimeId
+    : metaRuntimeId(value);
+  return { ok: true, reachable: true, runtimeId, proc };
+}
+
+function orcaTaskList(run, orcaBin, options = {}) {
+  const proc = run(orcaBin, ["orchestration", "task-list", "--json"], options);
+  const { ok, value } = envelope(proc);
+  if (!ok) return { ok: false, reachable: false, tasks: [], runtimeId: null, proc };
+  const result = value.result || {};
+  const tasks = Array.isArray(result.tasks) ? result.tasks : [];
+  return { ok: true, reachable: true, tasks, runtimeId: metaRuntimeId(value), proc };
+}
+
+function orcaGateList(run, orcaBin, options = {}) {
+  const proc = run(orcaBin, ["orchestration", "gate-list", "--json"], options);
+  const { ok, value } = envelope(proc);
+  if (!ok) return { ok: false, reachable: false, gates: [], proc };
+  const result = value.result || {};
+  const gates = Array.isArray(result.gates) ? result.gates : [];
+  return { ok: true, reachable: true, gates, proc };
+}
+
+function orcaDispatchShow(run, orcaBin, taskId, options = {}) {
+  const proc = run(orcaBin, ["orchestration", "dispatch-show", "--task", String(taskId), "--json"], options);
+  const { ok, value } = envelope(proc);
+  if (!ok) return { ok: false, reachable: false, proc };
+  const result = value.result || {};
+  const assignee = isNonEmptyString(result.assignee) ? result.assignee : null;
+  // Terminal presence: an explicit `terminal_present:false` (or a null assignee)
+  // means the dispatched operator terminal is gone (feeds MISSING_TERMINAL, D7).
+  const terminalPresent = result.terminal_present === false ? false : Boolean(assignee);
+  return {
+    ok: true,
+    reachable: true,
+    taskId: isNonEmptyString(result.task_id) ? result.task_id : null,
+    dispatchId: isNonEmptyString(result.dispatch_id) ? result.dispatch_id : null,
+    assignee,
+    terminalPresent,
+    proc,
+  };
+}
+
+module.exports = { orcaStatus, orcaTaskList, orcaGateList, orcaDispatchShow };

--- a/skills/relay-orca/scripts/lib/receipt.js
+++ b/skills/relay-orca/scripts/lib/receipt.js
@@ -1,0 +1,170 @@
+"use strict";
+
+// relay-orca reconstructible bridge receipt (#945 D1). A minimal, versioned
+// identity/mapping record — NOT a second state machine. It carries ONLY the program
+// identity and the outcome→Orca/relay mapping; it must never record child lifecycle
+// states, PR/issue status, Done Criteria text, completion flags, prompts, or terminal
+// output. Atomic persistence (a temp file in the same directory, then rename) is
+// performed by the top-level script; this module stays pure (no subprocess, no fs
+// mutation) so plan.js's frozen lib source-scan keeps passing. It only shapes,
+// orders, validates, and parses the receipt object.
+
+const SCHEMA_VERSION = 1;
+
+// The authority disclaimer carried verbatim in the receipt's `note` field AND in
+// references/receipt-and-status.md (D1). This exact sentence is the reviewer anchor.
+const RECEIPT_NOTE = "This receipt is reconstructible coordination metadata, not a source of truth.";
+
+// Verbatim top-level key set (D1). `note` is included per D1.
+const RECEIPT_KEYS = Object.freeze([
+  "schema",
+  "program_id",
+  "source",
+  "repo",
+  "runtime_id",
+  "tasks",
+  "terminals_created",
+  "created_at",
+  "updated_at",
+  "note",
+]);
+
+const TASK_KEYS = Object.freeze([
+  "outcome_id",
+  "task_id",
+  "kind",
+  "wave",
+  "orca_task_id",
+  "dispatch_id",
+  "assignee",
+  "relay_ids",
+]);
+
+const RELAY_ID_KEYS = Object.freeze(["request", "run", "fleet"]);
+
+function relayIds(source) {
+  const raw = source && typeof source === "object" ? source : {};
+  const normalizeId = (value) => (typeof value === "string" && value.length > 0 ? value : null);
+  return {
+    request: normalizeId(raw.request),
+    run: normalizeId(raw.run),
+    fleet: normalizeId(raw.fleet),
+  };
+}
+
+// Map one run-report task entry into a receipt task entry. Identity + mapping only.
+function receiptTaskEntry(reportTask) {
+  return {
+    outcome_id: reportTask.outcome_id,
+    task_id: reportTask.task_id,
+    kind: reportTask.kind,
+    wave: reportTask.wave,
+    orca_task_id: reportTask.orca_task_id ?? null,
+    dispatch_id: reportTask.dispatch_id ?? null,
+    assignee: reportTask.assignee ?? null,
+    relay_ids: relayIds(reportTask.relay_ids),
+  };
+}
+
+// Build the receipt mapping from the live run report. Timestamps are stamped by the
+// top-level persistence step (created_at preserved across writes), so they start null.
+function buildReceiptMapping({ program_id, source, repo, runtimeId, tasks, terminalsCreated }) {
+  if (!repo || typeof repo.slug !== "string" || typeof repo.root !== "string") {
+    throw new Error("buildReceiptMapping requires repo { slug, root } strings");
+  }
+  return {
+    schema: SCHEMA_VERSION,
+    program_id,
+    source: source ?? null,
+    repo: { slug: repo.slug, root: repo.root },
+    runtime_id: runtimeId ?? null,
+    tasks: (tasks || []).map(receiptTaskEntry),
+    terminals_created: Array.isArray(terminalsCreated) ? terminalsCreated.slice() : [],
+    created_at: null,
+    updated_at: null,
+    note: RECEIPT_NOTE,
+  };
+}
+
+// Emit the receipt with EXACTLY RECEIPT_KEYS in order, each task with TASK_KEYS in
+// order, so the serialized bytes are deterministic regardless of build order.
+function orderReceipt(receipt) {
+  const ordered = {};
+  RECEIPT_KEYS.forEach((key) => {
+    ordered[key] = receipt[key];
+  });
+  ordered.repo = { slug: receipt.repo.slug, root: receipt.repo.root };
+  ordered.tasks = (receipt.tasks || []).map((task) => {
+    const entry = {};
+    TASK_KEYS.forEach((key) => {
+      entry[key] = task[key];
+    });
+    entry.relay_ids = relayIds(task.relay_ids);
+    return entry;
+  });
+  return ordered;
+}
+
+function serializeReceipt(receipt) {
+  return `${JSON.stringify(orderReceipt(receipt), null, 2)}\n`;
+}
+
+function validateTask(task) {
+  if (!task || typeof task !== "object") return "a task entry is not an object";
+  for (const key of TASK_KEYS) {
+    if (!(key in task)) return `task entry missing required key ${key}`;
+  }
+  const ids = task.relay_ids;
+  if (!ids || typeof ids !== "object") return "task relay_ids must be an object";
+  for (const key of RELAY_ID_KEYS) {
+    if (!(key in ids)) return `task relay_ids missing required key ${key}`;
+  }
+  return null;
+}
+
+// Structural validation for a parsed receipt (D8 RECEIPT_CORRUPT). Returns null when
+// valid, or a short reason string when the schema is wrong or a required key is absent.
+function validateReceipt(receipt) {
+  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) return "receipt is not a JSON object";
+  if (receipt.schema !== SCHEMA_VERSION) return `receipt schema must be ${SCHEMA_VERSION}, got ${JSON.stringify(receipt.schema)}`;
+  for (const key of RECEIPT_KEYS) {
+    if (!(key in receipt)) return `receipt missing required key ${key}`;
+  }
+  if (!receipt.repo || typeof receipt.repo !== "object" || typeof receipt.repo.slug !== "string") {
+    return "receipt.repo.slug must be a string";
+  }
+  if (typeof receipt.repo.root !== "string") return "receipt.repo.root must be a string";
+  if (!Array.isArray(receipt.tasks)) return "receipt.tasks must be an array";
+  for (const task of receipt.tasks) {
+    const taskError = validateTask(task);
+    if (taskError) return taskError;
+  }
+  return null;
+}
+
+// Parse + validate receipt text. Returns { ok, receipt } or { ok:false, reason }.
+function parseReceipt(text) {
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    return { ok: false, reason: `receipt is not valid JSON: ${error.message}` };
+  }
+  const structuralError = validateReceipt(value);
+  if (structuralError) return { ok: false, reason: structuralError };
+  return { ok: true, receipt: value };
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  RECEIPT_NOTE,
+  RECEIPT_KEYS,
+  TASK_KEYS,
+  RELAY_ID_KEYS,
+  buildReceiptMapping,
+  receiptTaskEntry,
+  orderReceipt,
+  serializeReceipt,
+  validateReceipt,
+  parseReceipt,
+};

--- a/skills/relay-orca/scripts/lib/repo-slug.js
+++ b/skills/relay-orca/scripts/lib/repo-slug.js
@@ -1,0 +1,28 @@
+"use strict";
+
+// Repo-slug derivation REPLICATED (never imported) from relay's manifest/paths.js
+// getRepoSlug (#945 D1): the lowercased, dash-sanitized basename of the
+// canonicalized repo root joined to the first 8 hex chars of its sha256. relay-orca
+// receipts live under <programs-root>/<repo-slug>/<program-id>/ so a receipt
+// resolves to the SAME slug relay uses for its run manifests under <runs-root>/.
+//
+// Canonicalization of the repo root (git common dir + realpath) is performed by the
+// top-level script and the resolved absolute path is passed in here. This module
+// stays pure — no subprocess, no fs mutation — so plan.js's frozen lib source-scan
+// keeps passing.
+const crypto = require("node:crypto");
+const path = require("node:path");
+
+function computeRepoSlug(canonicalRepoRoot) {
+  if (typeof canonicalRepoRoot !== "string" || canonicalRepoRoot.trim() === "") {
+    throw new Error(
+      `computeRepoSlug requires a non-empty canonical repo root, got: ${JSON.stringify(canonicalRepoRoot)}`,
+    );
+  }
+  const base =
+    path.basename(canonicalRepoRoot).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "repo";
+  const hash = crypto.createHash("sha256").update(canonicalRepoRoot).digest("hex").slice(0, 8);
+  return `${base}-${hash}`;
+}
+
+module.exports = { computeRepoSlug };

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -140,6 +140,11 @@ function makeHandlePool(orcaBin, report, options) {
         );
       }
       report.terminals_created.push(term.handle);
+      // A16: persist the receipt IMMEDIATELY after recording the created terminal handle —
+      // before the dispatch that may fail. A dispatch (or provenance) failure right after
+      // auto terminal creation must leave the on-disk receipt already carrying the handle,
+      // so a reconcile can adopt (not re-create) the terminal instead of leaking it.
+      persistReceipt(report, options);
       return term.handle;
     },
   };

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -187,6 +187,12 @@ function dispatchOne(ctx) {
   }
   entry.dispatch_id = show.dispatchId;
   entry.assignee = show.assignee;
+  // D2/A2: the provenance trio (orca_task_id, dispatch_id, assignee) is now VERIFIED,
+  // so persist the receipt mapping HERE — before prompt delivery. A prompt hand-off
+  // failure below must leave the receipt already carrying the verified provenance (it
+  // is durable coordination metadata, independent of whether the operator prompt lands),
+  // so a later reconcile can recover the dispatch instead of re-materializing it.
+  persistReceipt(report, options);
   const prompt = buildOperatorPrompt(task, program, outcome);
   const sent = sendPrompt(options.runOrca, orcaBin, { orcaTaskId, handle, prompt });
   if (!sent.ok) {
@@ -197,9 +203,6 @@ function dispatchOne(ctx) {
     );
   }
   entry.status = STATUS.DISPATCHED;
-  // D2: the provenance trio (orca_task_id, dispatch_id, assignee) just changed —
-  // re-persist the receipt mapping after this verified dispatch.
-  persistReceipt(report, options);
 }
 
 // D7 dispatch scope: only wave-1 tasks (all dependency-satisfied) are eligible in

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -62,9 +62,14 @@ function admit(report, options) {
   return result.orca_bin;
 }
 
-function taskTitle(program, task) {
-  // Literal marker `relay-orca:` followed by `<program_id>/<outcome_id>` (D4).
-  return `relay-orca: ${program.id}/${task.outcome_id}`;
+function taskTitle(program, task, programSegment) {
+  // A26: the marker embeds the SAME collision-resistant program SEGMENT used for the
+  // receipt path (sanitized ≤64 prefix + 8-hex sha256), NOT the raw id. A raw id can
+  // contain `/`, so a marker built from `program.id` would let program `alpha` match a
+  // task titled for `alpha/child`. The segment is slash-free, so `status`'s
+  // `title.includes("relay-orca: <segment>/")` foreign-task check can never confuse two
+  // distinct programs. `programSegment` is injected (pure) so lib/ stays subprocess-free.
+  return `relay-orca: ${programSegment(program.id)}/${task.outcome_id}`;
 }
 
 function taskSpec(program, task) {
@@ -92,7 +97,7 @@ function materialize(plan, program, report, orcaBin, options) {
       const task = taskByPlanId.get(planId);
       const deps = task.depends_on.map((dep) => orcaIdByPlanId.get(dep));
       const res = createTask(options.runOrca, orcaBin, {
-        title: taskTitle(program, task),
+        title: taskTitle(program, task, options.programSegment),
         spec: taskSpec(program, task),
         deps,
       });

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -97,6 +97,10 @@ function materialize(plan, program, report, orcaBin, options) {
         deps,
       });
       if (!res.ok) {
+        // A12: a mid-wave task-create failure raises TASK_MATERIALIZE_FAILED (exit 41)
+        // ONLY after the mappings recorded by earlier successful creates (persisted just
+        // below) are already durable — a later failure never drops an earlier outcome's
+        // orca_task_id.
         reject(
           "TASK_MATERIALIZE_FAILED",
           `orca orchestration task-create failed for outcome ${task.outcome_id}` +
@@ -105,6 +109,10 @@ function materialize(plan, program, report, orcaBin, options) {
       }
       orcaIdByPlanId.set(planId, res.taskId);
       entryByPlanId.get(planId).orca_task_id = res.taskId;
+      // A12: persist the receipt after EACH successful task-create so the mapping is on
+      // disk before the next (possibly failing) create runs. A reconcile can then adopt
+      // the already-created tasks instead of re-materializing them.
+      persistReceipt(report, options);
     }
   }
   return { taskByPlanId, entryByPlanId, orcaIdByPlanId };
@@ -151,8 +159,8 @@ function provenanceMismatch(show, orcaTaskId) {
 }
 
 // D2 receipt persistence. The receipt is a minimal, versioned identity/mapping
-// record; it is (re)written after task materialization and after each successful
-// dispatch verification — the mapping-changing steps. The atomic write itself lives
+// record; it is (re)written after EACH successful task-create (A12) and after each
+// successful dispatch verification — the mapping-changing steps. The atomic write itself lives
 // in the top-level script (options.persistReceipt); this pure module only assembles
 // the mapping-changing "core" from the live report and threads back the resulting
 // path. When no writer is injected (direct-orchestrator unit tests) it is a no-op.
@@ -241,8 +249,11 @@ function orchestrate(rawProgram, options = {}) {
   const report = initReport(plan);
   try {
     const orcaBin = admit(report, options);
+    // materialize persists the receipt after EACH successful task-create (A12), so the
+    // full outcome→orca_task_id mapping is already durable here; dispatchWave then
+    // re-persists after each provenance verification (A2). No separate post-materialize
+    // write is needed.
     const maps = materialize(plan, program, report, orcaBin, options);
-    persistReceipt(report, options); // D2: persist after task materialization
     dispatchWave(plan, program, report, orcaBin, maps, options);
     report.ok = true;
     return { report, exitCode: 0 };

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -150,11 +150,27 @@ function provenanceMismatch(show, orcaTaskId) {
   return null;
 }
 
+// D2 receipt persistence. The receipt is a minimal, versioned identity/mapping
+// record; it is (re)written after task materialization and after each successful
+// dispatch verification — the mapping-changing steps. The atomic write itself lives
+// in the top-level script (options.persistReceipt); this pure module only assembles
+// the mapping-changing "core" from the live report and threads back the resulting
+// path. When no writer is injected (direct-orchestrator unit tests) it is a no-op.
+function persistReceipt(report, options) {
+  if (typeof options.persistReceipt !== "function") return;
+  report.receipt_path = options.persistReceipt({
+    program_id: report.program_id,
+    runtime_id: report.admission.runtime_id,
+    tasks: report.tasks,
+    terminals_created: report.terminals_created,
+  });
+}
+
 // D6 per-task dispatch: inject, verify, then (only after verification) deliver the
 // operator prompt. Any failure records the task `escalated` and re-raises so no
 // further pending task is dispatched; already-verified operators are not touched.
 function dispatchOne(ctx) {
-  const { orcaBin, entry, orcaTaskId, handle, task, program, outcome, options } = ctx;
+  const { orcaBin, entry, orcaTaskId, handle, task, program, outcome, options, report } = ctx;
   const disp = dispatchTask(options.runOrca, orcaBin, { orcaTaskId, handle });
   if (!disp.ok) {
     entry.status = STATUS.ESCALATED;
@@ -181,6 +197,9 @@ function dispatchOne(ctx) {
     );
   }
   entry.status = STATUS.DISPATCHED;
+  // D2: the provenance trio (orca_task_id, dispatch_id, assignee) just changed —
+  // re-persist the receipt mapping after this verified dispatch.
+  persistReceipt(report, options);
 }
 
 // D7 dispatch scope: only wave-1 tasks (all dependency-satisfied) are eligible in
@@ -205,6 +224,7 @@ function dispatchWave(plan, program, report, orcaBin, maps, options) {
       program,
       outcome: outcomeById.get(task.outcome_id) || {},
       options,
+      report,
     });
   }
 }
@@ -219,6 +239,7 @@ function orchestrate(rawProgram, options = {}) {
   try {
     const orcaBin = admit(report, options);
     const maps = materialize(plan, program, report, orcaBin, options);
+    persistReceipt(report, options); // D2: persist after task materialization
     dispatchWave(plan, program, report, orcaBin, maps, options);
     report.ok = true;
     return { report, exitCode: 0 };

--- a/skills/relay-orca/scripts/lib/run-report.js
+++ b/skills/relay-orca/scripts/lib/run-report.js
@@ -1,10 +1,12 @@
 "use strict";
 
-// Stable machine-readable run report (D10). EXACTLY these eight top-level keys,
-// verbatim and in this order. The report is built once from the compiled plan and
-// mutated in place as the run progresses so it stays truthful on EVERY early-exit
-// path: an admission rejection, a mid-materialization failure, and an escalation
-// all emit the same key set with truthful per-task statuses.
+// Stable machine-readable run report (D10). EXACTLY these top-level keys, verbatim
+// and in this order. The report is built once from the compiled plan and mutated in
+// place as the run progresses so it stays truthful on EVERY early-exit path: an
+// admission rejection, a mid-materialization failure, and an escalation all emit the
+// same key set with truthful per-task statuses. `receipt_path` (#945 D2) is the ONE
+// key the run intent grows for reconstructible receipt persistence — it is the path
+// of the atomically-written receipt, or null on paths that never materialize tasks.
 const REPORT_KEYS = Object.freeze([
   "ok",
   "program_id",
@@ -14,6 +16,7 @@ const REPORT_KEYS = Object.freeze([
   "terminals_created",
   "blocking_reasons",
   "reconciliation_required",
+  "receipt_path",
 ]);
 
 const STATUS = Object.freeze({
@@ -47,6 +50,7 @@ function initReport(plan) {
     terminals_created: [],
     blocking_reasons: [],
     reconciliation_required: true, // literal true in EVERY report (live reconcile is #945)
+    receipt_path: null, // set once the receipt is atomically persisted (#945 D2)
   };
 }
 

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -81,7 +81,12 @@ function integrationGateEvidence(facts, orcaTrusted) {
 function advisoryReviewEvidence(facts, orcaTrusted) {
   if (!orcaTrusted) return { advisory_evidence_posted: null, blocking_findings_triaged: null };
   const gates = Array.isArray(facts.outcomeGates) ? facts.outcomeGates : [];
-  const gate = gates.find((candidate) => candidate.kind === "advisory") || gates[0] || null;
+  // A19: ONLY a gate explicitly marked advisory — its `kind` is exactly "advisory", the
+  // advisory marker in the modeled gate shape { id, task_id, status, kind } — satisfies
+  // advisory evidence. There is NO gates[0] fallback: a non-advisory (e.g. integration) or
+  // untyped gate mapped to the task is NOT advisory evidence, so a passed unmarked gate can
+  // never forge advisory completion. None present → advisory_evidence_posted false → not complete.
+  const gate = gates.find((candidate) => candidate.kind === "advisory") || null;
   return { advisory_evidence_posted: Boolean(gate), blocking_findings_triaged: gate ? gatePasses(gate) : false };
 }
 
@@ -211,8 +216,12 @@ function isAbandonedManifest(manifest) {
 }
 
 function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate) {
-  const { manifest, receiptTask, orcaTaskMissing, dispatch, mappedRunMissing, gateBlocking, githubUnreachable } = facts;
+  const { manifest, receiptTask, orcaTaskMissing, dispatch, mappedRunMissing, gateBlocking, githubUnreachable, dispatchRuntimeUnknown, fleetChildEscalated } = facts;
   if (flags.staleWorkerDone || flags.issueReopened || flags.prChanged || isDuplicate) return "inconsistent";
+  // A18: an escalated fleet child is TERMINAL but NOT complete — the fleet reached a
+  // terminal configuration it cannot complete from, so it surfaces as escalated BEFORE
+  // the completion check (which would otherwise pass off the all-terminal evidence).
+  if (fleetChildEscalated) return "escalated";
   if (complete) return "complete_with_evidence";
   if (manifest && (isEscalatedManifestState(manifest.state) || isAbandonedManifest(manifest))) return "escalated";
   if (gateBlocking) return "awaiting_decision";
@@ -222,7 +231,9 @@ function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate
   // A failed REQUIRED live GitHub read (#945 A11) leaves the outcome's evidence
   // unknown, so it degrades to stale_missing instead of a false-clean `running`.
   // Durable-complete already returned above, so it still wins over an unreachable read.
-  if (mappedRunMissing || runtimeMappingBroken || orcaUnavailable || githubUnreachable) return "stale_missing";
+  // A17: a per-task dispatch-show that could not be attributed to the receipt's runtime
+  // (`dispatchRuntimeUnknown`) leaves that task's runtime facts unknown → stale_missing.
+  if (mappedRunMissing || runtimeMappingBroken || orcaUnavailable || githubUnreachable || dispatchRuntimeUnknown) return "stale_missing";
   return "running";
 }
 

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -41,6 +41,15 @@ function diag(code, outcomeId, message, ids) {
   return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: ids || {} };
 }
 
+// A dispatch is "missing" only when dispatch-show actually REPORTED (reachable) yet
+// returned no dispatch id — never when the read itself failed transiently. A failed
+// dispatch-show leaves `dispatchId` undefined AND `reachable` false, so gating on
+// `reachable` avoids a false MISSING_DISPATCH on a flaky/timed-out read (mirrors the
+// strict `terminalPresent === false` check used for MISSING_TERMINAL).
+function dispatchMissing(orcaTrusted, receiptTask, dispatch) {
+  return Boolean(orcaTrusted && receiptTask.dispatch_id && dispatch && dispatch.reachable && !dispatch.dispatchId);
+}
+
 // Emit the receipt↔live detector diagnostics for one outcome (D7). Returns the
 // diagnostics plus the contradiction flags that drive the `inconsistent` state.
 function detectOutcome(facts, evidence, orcaTrusted, complete) {
@@ -53,8 +62,7 @@ function detectOutcome(facts, evidence, orcaTrusted, complete) {
   if (orcaTrusted && orcaTaskId && orcaTaskMissing) {
     diagnostics.push(diag("MISSING_TASK", outcomeId, `Orca task ${orcaTaskId} is absent from the live task-list`, { orca_task_id: orcaTaskId }));
   }
-  const missingDispatch = orcaTrusted && receiptTask.dispatch_id && dispatch && !dispatch.dispatchId;
-  if (missingDispatch) {
+  if (dispatchMissing(orcaTrusted, receiptTask, dispatch)) {
     diagnostics.push(diag("MISSING_DISPATCH", outcomeId, `dispatch ${receiptTask.dispatch_id} for task ${orcaTaskId} is no longer reported`, { orca_task_id: orcaTaskId, dispatch_id: receiptTask.dispatch_id }));
   }
   if (orcaTrusted && receiptTask.assignee && dispatch && dispatch.terminalPresent === false) {
@@ -93,15 +101,22 @@ function detectOutcome(facts, evidence, orcaTrusted, complete) {
   return { diagnostics, flags };
 }
 
+// A relay manifest in a terminal state that is NOT a merge (`closed`) is a
+// force-closed / abandoned run. It can never yield completion evidence again, so it
+// must surface as `escalated` rather than falling through to `running` (D5). The
+// merge-happy terminal (`merged`) is handled by the completion + PR/issue detectors.
+function isAbandonedManifest(manifest) {
+  return Boolean(manifest && manifest.state === "closed");
+}
+
 function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate) {
   const { manifest, receiptTask, orcaTaskMissing, dispatch, mappedRunMissing, gateBlocking } = facts;
   if (flags.staleWorkerDone || flags.issueReopened || flags.prChanged || isDuplicate) return "inconsistent";
   if (complete) return "complete_with_evidence";
-  if (manifest && isEscalatedManifestState(manifest.state)) return "escalated";
+  if (manifest && (isEscalatedManifestState(manifest.state) || isAbandonedManifest(manifest))) return "escalated";
   if (gateBlocking) return "awaiting_decision";
-  const missingDispatch = orcaTrusted && receiptTask.dispatch_id && dispatch && !dispatch.dispatchId;
   const terminalMissing = orcaTrusted && receiptTask.assignee && dispatch && dispatch.terminalPresent === false;
-  const runtimeMappingBroken = orcaTrusted && (orcaTaskMissing || missingDispatch || terminalMissing);
+  const runtimeMappingBroken = orcaTrusted && (orcaTaskMissing || dispatchMissing(orcaTrusted, receiptTask, dispatch) || terminalMissing);
   const orcaUnavailable = !orcaTrusted && Boolean(receiptTask.orca_task_id);
   if (mappedRunMissing || runtimeMappingBroken || orcaUnavailable) return "stale_missing";
   return "running";

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -246,7 +246,16 @@ function classifyOutcome(facts, { orcaTrusted, isDuplicate }) {
   const complete = isComplete(evidence);
   const { diagnostics, flags } = detectOutcome(facts, evidence, orcaTrusted, complete);
   const state = outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate);
-  const started = Boolean(receiptTask.dispatch_id || (receiptTask.relay_ids && receiptTask.relay_ids.run) || facts.pr);
+  // A23: a durable fleet mapping counts as started, exactly like a per-run dispatch, a
+  // relay run mapping, or a PR. `relay_ids.fleet` (or a live fleet manifest resolved for
+  // this outcome) means the wave's work is under way even before any child run has its own
+  // dispatch_id / relay_ids.run / PR. Without this, a wave whose only in-progress outcome is
+  // a relay_fleet would be mis-derived as an UNSTARTED next wave and deriveProgramState would
+  // falsely report `ready_for_next_wave` while the fleet is actually running.
+  const relayIds = receiptTask.relay_ids || {};
+  const started = Boolean(
+    receiptTask.dispatch_id || relayIds.run || relayIds.fleet || facts.fleetManifest || facts.pr,
+  );
   return {
     outcome: {
       outcome_id: receiptTask.outcome_id,

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -1,0 +1,168 @@
+"use strict";
+
+// Pure per-outcome classification + program-state derivation for `status`
+// (#945 D4/D5/D7). Given already-gathered live facts (durable relay manifest, live
+// GitHub, live Orca runtime signals), this module computes each outcome's evidence
+// checks, its detector diagnostics, and its D5 state, then derives the program-level
+// state. It performs NO I/O — the top-level script and status-derive.js do the
+// subprocess/fs work — so plan.js's frozen lib source-scan keeps passing.
+//
+// Completion authority is durable-only: an outcome is `complete_with_evidence` ONLY
+// when its required live durable evidence holds. Orca task status and `worker_done`
+// are lifecycle signals, NEVER completion authority.
+const { boundedExcerpt } = require("./bounded-excerpt");
+const { isTerminalManifestState, isEscalatedManifestState } = require("./manifest-parse");
+
+// Required durable evidence per task kind (D4). Evidence expectations mirror the
+// task kind's expected-evidence defaults: a relay_run is complete only when its
+// manifest is terminal AND its PR merged AND its tracker issue closed.
+const REQUIRED_EVIDENCE = Object.freeze({
+  relay_run: ["manifest_terminal", "pr_merged", "issue_closed"],
+  relay_fleet: ["manifest_terminal", "pr_merged"],
+  integration_gate: ["manifest_terminal"],
+  advisory_review: ["manifest_terminal"],
+  tracker_reconciliation: ["manifest_terminal"],
+});
+
+function requiredEvidenceFor(kind) {
+  return REQUIRED_EVIDENCE[kind] || ["manifest_terminal"];
+}
+
+function computeEvidence(facts) {
+  const { manifest, pr, issue } = facts;
+  return {
+    manifest_terminal: manifest ? isTerminalManifestState(manifest.state) : null,
+    pr_merged: pr ? pr.state === "MERGED" || Boolean(pr.mergedAt) : null,
+    issue_closed: issue ? issue.state === "CLOSED" : null,
+  };
+}
+
+function diag(code, outcomeId, message, ids) {
+  return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: ids || {} };
+}
+
+// Emit the receipt↔live detector diagnostics for one outcome (D7). Returns the
+// diagnostics plus the contradiction flags that drive the `inconsistent` state.
+function detectOutcome(facts, evidence, orcaTrusted, complete) {
+  const { receiptTask, manifest, orcaTask, orcaTaskMissing, dispatch, mappedRunMissing, mappedRunId, pr } = facts;
+  const outcomeId = receiptTask.outcome_id;
+  const orcaTaskId = receiptTask.orca_task_id;
+  const diagnostics = [];
+  const flags = { staleWorkerDone: false, issueReopened: false, prChanged: false };
+
+  if (orcaTrusted && orcaTaskId && orcaTaskMissing) {
+    diagnostics.push(diag("MISSING_TASK", outcomeId, `Orca task ${orcaTaskId} is absent from the live task-list`, { orca_task_id: orcaTaskId }));
+  }
+  const missingDispatch = orcaTrusted && receiptTask.dispatch_id && dispatch && !dispatch.dispatchId;
+  if (missingDispatch) {
+    diagnostics.push(diag("MISSING_DISPATCH", outcomeId, `dispatch ${receiptTask.dispatch_id} for task ${orcaTaskId} is no longer reported`, { orca_task_id: orcaTaskId, dispatch_id: receiptTask.dispatch_id }));
+  }
+  if (orcaTrusted && receiptTask.assignee && dispatch && dispatch.terminalPresent === false) {
+    diagnostics.push(diag("MISSING_TERMINAL", outcomeId, `operator terminal ${receiptTask.assignee} for task ${orcaTaskId} is gone`, { orca_task_id: orcaTaskId, assignee: receiptTask.assignee }));
+  }
+  if (mappedRunMissing) {
+    diagnostics.push(diag("MISSING_RELAY_RUN", outcomeId, `mapped relay run ${mappedRunId} has no manifest`, { run: mappedRunId }));
+  }
+
+  const taskCompleted = Boolean(orcaTask && (orcaTask.status === "completed" || orcaTask.worker_done === true));
+  if (taskCompleted && !complete) {
+    const prOpen = pr && pr.state !== "MERGED" && !pr.mergedAt;
+    const manifestNonTerminal = manifest && !isTerminalManifestState(manifest.state);
+    if (prOpen || manifestNonTerminal) {
+      flags.staleWorkerDone = true;
+      diagnostics.push(diag("STALE_WORKER_DONE", outcomeId, `Orca task ${orcaTaskId} reports done but durable evidence is incomplete`, { orca_task_id: orcaTaskId, pr: manifest ? manifest.pr_number : null, run: mappedRunId }));
+    }
+  }
+
+  const requiresClosure = requiredEvidenceFor(receiptTask.kind).includes("issue_closed");
+  if (requiresClosure && facts.issue && facts.issue.state === "OPEN" && evidence.pr_merged === true && evidence.manifest_terminal === true) {
+    flags.issueReopened = true;
+    diagnostics.push(diag("ISSUE_REOPENED", outcomeId, `issue ${manifest ? manifest.issue_number : ""} is open though the outcome's evidence contract requires closure`, { issue: manifest ? manifest.issue_number : null }));
+  }
+
+  if (manifest && manifest.state === "merged" && pr) {
+    if (pr.state !== "MERGED") {
+      flags.prChanged = true;
+      diagnostics.push(diag("PR_CHANGED", outcomeId, `PR ${manifest.pr_number} state regressed to ${pr.state} though the relay manifest merged it`, { pr: manifest.pr_number, expected: "MERGED", live: pr.state }));
+    } else if (manifest.head_sha && pr.headRefOid && manifest.head_sha !== pr.headRefOid) {
+      flags.prChanged = true;
+      diagnostics.push(diag("PR_CHANGED", outcomeId, `PR ${manifest.pr_number} head moved after merge`, { pr: manifest.pr_number, expected_head: manifest.head_sha, live_head: pr.headRefOid }));
+    }
+  }
+
+  return { diagnostics, flags };
+}
+
+function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate) {
+  const { manifest, receiptTask, orcaTaskMissing, dispatch, mappedRunMissing, gateBlocking } = facts;
+  if (flags.staleWorkerDone || flags.issueReopened || flags.prChanged || isDuplicate) return "inconsistent";
+  if (complete) return "complete_with_evidence";
+  if (manifest && isEscalatedManifestState(manifest.state)) return "escalated";
+  if (gateBlocking) return "awaiting_decision";
+  const missingDispatch = orcaTrusted && receiptTask.dispatch_id && dispatch && !dispatch.dispatchId;
+  const terminalMissing = orcaTrusted && receiptTask.assignee && dispatch && dispatch.terminalPresent === false;
+  const runtimeMappingBroken = orcaTrusted && (orcaTaskMissing || missingDispatch || terminalMissing);
+  const orcaUnavailable = !orcaTrusted && Boolean(receiptTask.orca_task_id);
+  if (mappedRunMissing || runtimeMappingBroken || orcaUnavailable) return "stale_missing";
+  return "running";
+}
+
+// Classify one outcome. `facts` is the gathered fact bundle; `orcaTrusted` is false
+// when the runtime is a mismatch / foreign / unreachable (Orca facts degrade to
+// stale_missing per D6). `isDuplicate` marks outcomes sharing a mapping (D7).
+function classifyOutcome(facts, { orcaTrusted, isDuplicate }) {
+  const { receiptTask } = facts;
+  const evidence = computeEvidence(facts);
+  const complete = requiredEvidenceFor(receiptTask.kind).every((key) => evidence[key] === true);
+  const { diagnostics, flags } = detectOutcome(facts, evidence, orcaTrusted, complete);
+  const state = outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate);
+  const started = Boolean(receiptTask.dispatch_id || (receiptTask.relay_ids && receiptTask.relay_ids.run) || facts.pr);
+  return {
+    outcome: {
+      outcome_id: receiptTask.outcome_id,
+      kind: receiptTask.kind,
+      wave: receiptTask.wave,
+      state,
+      orca_task_id: receiptTask.orca_task_id ?? null,
+      dispatch_id: receiptTask.dispatch_id ?? null,
+      relay_ids: receiptTask.relay_ids,
+      issue_url: facts.issueUrl ?? null,
+      pr_url: facts.prUrl ?? null,
+      evidence,
+    },
+    diagnostics,
+    started,
+    complete,
+  };
+}
+
+// Derive the program-level state (D5). `ready_for_next_wave` requires every outcome
+// in the preceding waves of the lowest incomplete wave to be complete_with_evidence,
+// no outcome escalated/inconsistent, and the next wave not yet started.
+function deriveProgramState(entries) {
+  const states = entries.map((entry) => entry.outcome.state);
+  if (states.includes("inconsistent")) return "inconsistent";
+  if (states.includes("escalated")) return "escalated";
+  if (states.length > 0 && states.every((state) => state === "complete_with_evidence")) return "complete_with_evidence";
+  if (states.includes("awaiting_decision")) return "awaiting_decision";
+  const nonComplete = entries.filter((entry) => entry.outcome.state !== "complete_with_evidence");
+  if (nonComplete.length === 0) return "running";
+  const lowestIncompleteWave = Math.min(...nonComplete.map((entry) => entry.outcome.wave));
+  const precedingComplete = entries
+    .filter((entry) => entry.outcome.wave < lowestIncompleteWave)
+    .every((entry) => entry.outcome.state === "complete_with_evidence");
+  const waveStarted = nonComplete
+    .filter((entry) => entry.outcome.wave === lowestIncompleteWave)
+    .some((entry) => entry.started);
+  if (lowestIncompleteWave > 1 && precedingComplete && !waveStarted) return "ready_for_next_wave";
+  if (states.includes("stale_missing")) return "stale_missing";
+  return "running";
+}
+
+module.exports = {
+  REQUIRED_EVIDENCE,
+  requiredEvidenceFor,
+  computeEvidence,
+  classifyOutcome,
+  deriveProgramState,
+};

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -117,13 +117,23 @@ function diag(code, outcomeId, message, ids) {
   return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: boundedIds(ids) };
 }
 
-// A dispatch is "missing" only when dispatch-show actually REPORTED (reachable) yet
-// returned no dispatch id — never when the read itself failed transiently. A failed
-// dispatch-show leaves `dispatchId` undefined AND `reachable` false, so gating on
-// `reachable` avoids a false MISSING_DISPATCH on a flaky/timed-out read (mirrors the
-// strict `terminalPresent === false` check used for MISSING_TERMINAL).
+// The live dispatch id reported by dispatch-show (a non-empty string) or null.
+function liveDispatchId(dispatch) {
+  return dispatch && typeof dispatch.dispatchId === "string" && dispatch.dispatchId ? dispatch.dispatchId : null;
+}
+
+// A dispatch mapping is "missing/stale" only when dispatch-show actually REPORTED
+// (reachable) AND either returned NO dispatch id (the mapping vanished) OR returned a
+// non-empty id DIFFERENT from the receipt's (the mapping drifted — the task was
+// re-dispatched, so the recorded dispatch id no longer points at the live dispatch,
+// #945 A10). It never fires when the read itself failed transiently: a failed
+// dispatch-show leaves `reachable` false, so gating on `reachable` avoids a false
+// MISSING_DISPATCH on a flaky/timed-out read (mirrors the strict `terminalPresent ===
+// false` check used for MISSING_TERMINAL).
 function dispatchMissing(orcaTrusted, receiptTask, dispatch) {
-  return Boolean(orcaTrusted && receiptTask.dispatch_id && dispatch && dispatch.reachable && !dispatch.dispatchId);
+  if (!(orcaTrusted && receiptTask.dispatch_id && dispatch && dispatch.reachable)) return false;
+  const live = liveDispatchId(dispatch);
+  return !live || live !== receiptTask.dispatch_id;
 }
 
 // Emit the receipt↔live detector diagnostics for one outcome (D7). Returns the
@@ -139,7 +149,16 @@ function detectOutcome(facts, evidence, orcaTrusted, complete) {
     diagnostics.push(diag("MISSING_TASK", outcomeId, `Orca task ${orcaTaskId} is absent from the live task-list`, { orca_task_id: orcaTaskId }));
   }
   if (dispatchMissing(orcaTrusted, receiptTask, dispatch)) {
-    diagnostics.push(diag("MISSING_DISPATCH", outcomeId, `dispatch ${receiptTask.dispatch_id} for task ${orcaTaskId} is no longer reported`, { orca_task_id: orcaTaskId, dispatch_id: receiptTask.dispatch_id }));
+    const live = liveDispatchId(dispatch);
+    const drifted = Boolean(live && live !== receiptTask.dispatch_id);
+    const ids = { orca_task_id: orcaTaskId, dispatch_id: receiptTask.dispatch_id };
+    // Carry BOTH the receipt id and the changed live id when the mapping drifted, so a
+    // reconcile can see what it drifted to (both bounded via boundedIds in `diag`).
+    if (drifted) ids.live_dispatch_id = live;
+    const message = drifted
+      ? `dispatch ${receiptTask.dispatch_id} for task ${orcaTaskId} changed to ${live}`
+      : `dispatch ${receiptTask.dispatch_id} for task ${orcaTaskId} is no longer reported`;
+    diagnostics.push(diag("MISSING_DISPATCH", outcomeId, message, ids));
   }
   if (orcaTrusted && receiptTask.assignee && dispatch && dispatch.terminalPresent === false) {
     diagnostics.push(diag("MISSING_TERMINAL", outcomeId, `operator terminal ${receiptTask.assignee} for task ${orcaTaskId} is gone`, { orca_task_id: orcaTaskId, assignee: receiptTask.assignee }));
@@ -186,7 +205,7 @@ function isAbandonedManifest(manifest) {
 }
 
 function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate) {
-  const { manifest, receiptTask, orcaTaskMissing, dispatch, mappedRunMissing, gateBlocking } = facts;
+  const { manifest, receiptTask, orcaTaskMissing, dispatch, mappedRunMissing, gateBlocking, githubUnreachable } = facts;
   if (flags.staleWorkerDone || flags.issueReopened || flags.prChanged || isDuplicate) return "inconsistent";
   if (complete) return "complete_with_evidence";
   if (manifest && (isEscalatedManifestState(manifest.state) || isAbandonedManifest(manifest))) return "escalated";
@@ -194,7 +213,10 @@ function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate
   const terminalMissing = orcaTrusted && receiptTask.assignee && dispatch && dispatch.terminalPresent === false;
   const runtimeMappingBroken = orcaTrusted && (orcaTaskMissing || dispatchMissing(orcaTrusted, receiptTask, dispatch) || terminalMissing);
   const orcaUnavailable = !orcaTrusted && Boolean(receiptTask.orca_task_id);
-  if (mappedRunMissing || runtimeMappingBroken || orcaUnavailable) return "stale_missing";
+  // A failed REQUIRED live GitHub read (#945 A11) leaves the outcome's evidence
+  // unknown, so it degrades to stale_missing instead of a false-clean `running`.
+  // Durable-complete already returned above, so it still wins over an unreachable read.
+  if (mappedRunMissing || runtimeMappingBroken || orcaUnavailable || githubUnreachable) return "stale_missing";
   return "running";
 }
 

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -10,25 +10,29 @@
 // Completion authority is durable-only: an outcome is `complete_with_evidence` ONLY
 // when its required live durable evidence holds. Orca task status and `worker_done`
 // are lifecycle signals, NEVER completion authority.
-const { boundedExcerpt } = require("./bounded-excerpt");
+const { boundedExcerpt, boundedIds } = require("./bounded-excerpt");
 const { isTerminalManifestState, isEscalatedManifestState } = require("./manifest-parse");
 
-// Required durable evidence per task kind (D4). Evidence expectations mirror the
-// task kind's expected-evidence defaults: a relay_run is complete only when its
-// manifest is terminal AND its PR merged AND its tracker issue closed.
-const REQUIRED_EVIDENCE = Object.freeze({
+// Named live-evidence checks per task kind (D4). Each kind carries its OWN evidence
+// contract mirroring the FROZEN expected-evidence defaults in references/task-kinds.md
+// (relay manifest merged; every fleet child terminal; gate check passes live; etc.).
+// An outcome is `complete_with_evidence` ONLY when every check in its kind's contract
+// holds `true`; a null check is "unknown" (source not yet resolvable) and never
+// completes. No kind is left unclassifiable — every kind names ≥1 concrete check.
+const EVIDENCE_CONTRACTS = Object.freeze({
   relay_run: ["manifest_terminal", "pr_merged", "issue_closed"],
-  relay_fleet: ["manifest_terminal", "pr_merged"],
-  integration_gate: ["manifest_terminal"],
-  advisory_review: ["manifest_terminal"],
-  tracker_reconciliation: ["manifest_terminal"],
+  relay_fleet: ["fleet_children_terminal", "fleet_manifest_closed"],
+  integration_gate: ["gate_report_present", "gate_check_passes"],
+  advisory_review: ["advisory_evidence_posted", "blocking_findings_triaged"],
+  tracker_reconciliation: ["tracker_reconciled"],
 });
 
 function requiredEvidenceFor(kind) {
-  return REQUIRED_EVIDENCE[kind] || ["manifest_terminal"];
+  return EVIDENCE_CONTRACTS[kind] || EVIDENCE_CONTRACTS.relay_run;
 }
 
-function computeEvidence(facts) {
+// relay_run: relay manifest merged AND PR merged AND tracker issue closed.
+function relayRunEvidence(facts) {
   const { manifest, pr, issue } = facts;
   return {
     manifest_terminal: manifest ? isTerminalManifestState(manifest.state) : null,
@@ -37,8 +41,80 @@ function computeEvidence(facts) {
   };
 }
 
+// relay_fleet: EVERY fleet child terminal AND the fleet manifest closed. The fleet
+// manifest is resolved via relay_ids.fleet in status-derive.js, and each child's
+// terminal flag is resolved there against the same runs root.
+function relayFleetEvidence(facts) {
+  const { fleetManifest, fleetChildren } = facts;
+  const children = Array.isArray(fleetChildren) ? fleetChildren : [];
+  let childrenTerminal = null;
+  if (fleetManifest) childrenTerminal = children.length > 0 && children.every((child) => child.terminal === true);
+  return {
+    fleet_children_terminal: childrenTerminal,
+    fleet_manifest_closed: fleetManifest ? isTerminalManifestState(fleetManifest.fleet_state) : null,
+  };
+}
+
+// A decision/review gate "passes" when its live status is an explicit pass token.
+function gatePasses(gate) {
+  return Boolean(gate && ["passed", "approved", "resolved"].includes(gate.status));
+}
+
+// integration_gate (read-only): the outcome's live integration gate exists AND its
+// check passes. The gate is receipt-referenced via the outcome's orca_task_id (see
+// receipt-and-status.md). When Orca is untrusted the checks degrade to null.
+function integrationGateEvidence(facts, orcaTrusted) {
+  if (!orcaTrusted) return { gate_report_present: null, gate_check_passes: null };
+  const gates = Array.isArray(facts.outcomeGates) ? facts.outcomeGates : [];
+  const gate = gates.find((candidate) => !candidate.kind || candidate.kind === "integration") || null;
+  return { gate_report_present: Boolean(gate), gate_check_passes: gate ? gatePasses(gate) : false };
+}
+
+// advisory_review (read-only): advisory evidence posted AND every blocking finding
+// triaged (the advisory gate resolved). Same receipt-referenced gate source.
+function advisoryReviewEvidence(facts, orcaTrusted) {
+  if (!orcaTrusted) return { advisory_evidence_posted: null, blocking_findings_triaged: null };
+  const gates = Array.isArray(facts.outcomeGates) ? facts.outcomeGates : [];
+  const gate = gates.find((candidate) => candidate.kind === "advisory") || gates[0] || null;
+  return { advisory_evidence_posted: Boolean(gate), blocking_findings_triaged: gate ? gatePasses(gate) : false };
+}
+
+// tracker_reconciliation (read-only): the mapped relay run's tracker issue state is
+// reconciled against the durable manifest — a terminal manifest with its issue closed.
+function trackerReconciliationEvidence(facts) {
+  const { manifest, issue } = facts;
+  if (!manifest || !issue) return { tracker_reconciled: null };
+  return { tracker_reconciled: isTerminalManifestState(manifest.state) && issue.state === "CLOSED" };
+}
+
+// Dispatch to the kind's evidence contract. Unknown kinds fall back to relay_run so
+// no outcome is ever unclassifiable (plan already rejects unsupported kinds).
+function computeEvidence(facts, orcaTrusted) {
+  switch (facts.receiptTask.kind) {
+    case "relay_fleet":
+      return relayFleetEvidence(facts);
+    case "integration_gate":
+      return integrationGateEvidence(facts, orcaTrusted);
+    case "advisory_review":
+      return advisoryReviewEvidence(facts, orcaTrusted);
+    case "tracker_reconciliation":
+      return trackerReconciliationEvidence(facts);
+    case "relay_run":
+    default:
+      return relayRunEvidence(facts);
+  }
+}
+
+function isComplete(evidence) {
+  const keys = Object.keys(evidence);
+  return keys.length > 0 && keys.every((key) => evidence[key] === true);
+}
+
+// Every subprocess-derived value that reaches a diagnostic — inside `message` AND
+// inside `ids` — is bounded (≤256 chars, marker included) so a wedged/adversarial CLI
+// can never inflate or line-inject the status report (D7).
 function diag(code, outcomeId, message, ids) {
-  return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: ids || {} };
+  return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: boundedIds(ids) };
 }
 
 // A dispatch is "missing" only when dispatch-show actually REPORTED (reachable) yet
@@ -127,8 +203,8 @@ function outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate
 // stale_missing per D6). `isDuplicate` marks outcomes sharing a mapping (D7).
 function classifyOutcome(facts, { orcaTrusted, isDuplicate }) {
   const { receiptTask } = facts;
-  const evidence = computeEvidence(facts);
-  const complete = requiredEvidenceFor(receiptTask.kind).every((key) => evidence[key] === true);
+  const evidence = computeEvidence(facts, orcaTrusted);
+  const complete = isComplete(evidence);
   const { diagnostics, flags } = detectOutcome(facts, evidence, orcaTrusted, complete);
   const state = outcomeState(facts, evidence, complete, flags, orcaTrusted, isDuplicate);
   const started = Boolean(receiptTask.dispatch_id || (receiptTask.relay_ids && receiptTask.relay_ids.run) || facts.pr);
@@ -175,7 +251,7 @@ function deriveProgramState(entries) {
 }
 
 module.exports = {
-  REQUIRED_EVIDENCE,
+  EVIDENCE_CONTRACTS,
   requiredEvidenceFor,
   computeEvidence,
   classifyOutcome,

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -35,7 +35,13 @@ function requiredEvidenceFor(kind) {
 function relayRunEvidence(facts) {
   const { manifest, pr, issue } = facts;
   return {
-    manifest_terminal: manifest ? isTerminalManifestState(manifest.state) : null,
+    // A14: relay_run completion requires the manifest to have reached `merged`
+    // SPECIFICALLY — not merely any terminal state. A terminal-but-`closed`
+    // (force-closed / abandoned) manifest can never yield completion evidence again, so
+    // `manifest_terminal` stays false and the outcome surfaces as `escalated` (via
+    // isAbandonedManifest in outcomeState) rather than completing off a stray merged PR
+    // or closed issue.
+    manifest_terminal: manifest ? manifest.state === "merged" : null,
     pr_merged: pr ? pr.state === "MERGED" || Boolean(pr.mergedAt) : null,
     issue_closed: issue ? issue.state === "CLOSED" : null,
   };

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -10,14 +10,18 @@
 // Durable truth outranks runtime signals (D4). When the runtime is a mismatch,
 // foreign, or unreachable, Orca-derived facts are NOT adopted for this program (D6):
 // they degrade to `stale_missing` while durable evidence still renders.
-const { boundedExcerpt } = require("./bounded-excerpt");
+const { boundedExcerpt, boundedIds } = require("./bounded-excerpt");
 const { orcaStatus, orcaTaskList, orcaGateList, orcaDispatchShow } = require("./orca-reads");
 const { ghIssueView, ghPrView } = require("./gh-reads");
 const { classifyOutcome, deriveProgramState } = require("./status-classify");
+const { isTerminalManifestState } = require("./manifest-parse");
 const { orderReport } = require("./status-report");
 
+// Every subprocess-derived value that reaches a diagnostic — inside `message` AND
+// inside `ids` — is bounded (≤256 chars, marker included) so a wedged/adversarial CLI
+// can never inflate or line-inject the status report (D7).
 function diag(code, outcomeId, message, ids) {
-  return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: ids || {} };
+  return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: boundedIds(ids) };
 }
 
 function programMarker(programId) {
@@ -33,13 +37,21 @@ function referencesProgram(text, programId) {
 // Attribute the live runtime (D6). Orca facts are trusted ONLY when the live runtime
 // id matches the receipt AND every live orchestration task is marked for this program.
 function attributeRuntime({ receipt, programId, orca }) {
-  if (!orca) return { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
+  const unreachable = { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
+  if (!orca) return unreachable;
   const status = orcaStatus(orca, null, {});
-  if (!status.ok) return { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
+  if (!status.ok) return unreachable;
+  // Runtime is "ok" (Orca facts adopted) ONLY when status AND task-list AND gate-list
+  // all succeed. A failed REQUIRED read is unreachable — never an empty array with a
+  // runtime of "ok" (D4). Fabricating [] would hide awaiting_decision and forge a false
+  // MISSING_TASK against a receipt whose task simply could not be listed. On unreachable,
+  // Orca-derived facts are withheld and each outcome's Orca facts degrade per D5/D6.
   const taskList = orcaTaskList(orca, null, {});
+  if (!taskList.ok) return unreachable;
   const gateList = orcaGateList(orca, null, {});
-  const tasks = taskList.ok ? taskList.tasks : [];
-  const gates = gateList.ok ? gateList.gates : [];
+  if (!gateList.ok) return unreachable;
+  const tasks = taskList.tasks;
+  const gates = gateList.gates;
   const marker = programMarker(programId);
   const foreignTasks = tasks.filter((task) => !(typeof task.title === "string" && task.title.includes(marker)));
   // The live runtime id is subprocess-derived, so it is bounded (≤256 chars, marker
@@ -98,6 +110,33 @@ function gatherOutcomeFacts(task, ctx) {
   const gateBlocking = Boolean(
     runtime.orcaTrusted && task.orca_task_id && runtime.gates.some((gate) => isPendingGate(gate) && gateBlocksTask(gate, task.orca_task_id)),
   );
+  // The live decision/review gates mapped to this outcome's orca_task_id feed the
+  // integration_gate / advisory_review evidence contracts. Gates are runtime signals,
+  // so they are only gathered when the runtime is trusted (untrusted → [] → the gate
+  // evidence checks degrade to null in the classifier).
+  const outcomeGates = runtime.orcaTrusted && task.orca_task_id
+    ? runtime.gates.filter((gate) => gateBlocksTask(gate, task.orca_task_id))
+    : [];
+
+  // relay_fleet outcomes map via relay_ids.fleet to a fleet manifest under the SAME
+  // runs root (see receipt-and-status.md). Its `children` list resolves each child run
+  // to the same manifest set so the classifier can require every child terminal.
+  const mappedFleetId = task.relay_ids && task.relay_ids.fleet ? task.relay_ids.fleet : null;
+  let fleetManifest = null;
+  let fleetChildren = [];
+  if (mappedFleetId) {
+    fleetManifest = manifestByRunId.get(mappedFleetId) || null;
+    if (fleetManifest && Array.isArray(fleetManifest.fleet_children)) {
+      fleetChildren = fleetManifest.fleet_children.map((child) => {
+        const childManifest = child.run_id ? manifestByRunId.get(child.run_id) || null : null;
+        return {
+          leaf_ref: child.leaf_ref ?? null,
+          run_id: child.run_id ?? null,
+          terminal: childManifest ? isTerminalManifestState(childManifest.state) : false,
+        };
+      });
+    }
+  }
 
   let pr = null;
   let issue = null;
@@ -120,7 +159,24 @@ function gatherOutcomeFacts(task, ctx) {
     }
   }
 
-  return { receiptTask: task, manifest, mappedRunId, mappedRunMissing, orcaTask, orcaTaskMissing, dispatch, gateBlocking, pr, issue, prUrl, issueUrl };
+  return {
+    receiptTask: task,
+    manifest,
+    mappedRunId,
+    mappedRunMissing,
+    orcaTask,
+    orcaTaskMissing,
+    dispatch,
+    gateBlocking,
+    outcomeGates,
+    fleetManifest,
+    mappedFleetId,
+    fleetChildren,
+    pr,
+    issue,
+    prUrl,
+    issueUrl,
+  };
 }
 
 // Program-level duplicate-mapping detector (D7): two receipt entries sharing an

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -13,7 +13,7 @@
 const { boundedExcerpt, boundedIds } = require("./bounded-excerpt");
 const { orcaStatus, orcaTaskList, orcaGateList, orcaDispatchShow } = require("./orca-reads");
 const { ghIssueView, ghPrView } = require("./gh-reads");
-const { classifyOutcome, deriveProgramState } = require("./status-classify");
+const { classifyOutcome, deriveProgramState, requiredEvidenceFor } = require("./status-classify");
 const { isTerminalManifestState } = require("./manifest-parse");
 const { orderReport } = require("./status-report");
 
@@ -90,7 +90,7 @@ function gateBlocksTask(gate, orcaTaskId) {
 
 // Build the gathered fact bundle for one receipt task.
 function gatherOutcomeFacts(task, ctx) {
-  const { manifestByRunId, runtime, gh, orca, urlFor } = ctx;
+  const { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor } = ctx;
   const mappedRunId = task.relay_ids && task.relay_ids.run ? task.relay_ids.run : null;
   let manifest = null;
   let mappedRunMissing = false;
@@ -118,14 +118,15 @@ function gatherOutcomeFacts(task, ctx) {
     ? runtime.gates.filter((gate) => gateBlocksTask(gate, task.orca_task_id))
     : [];
 
-  // relay_fleet outcomes map via relay_ids.fleet to a fleet manifest under the SAME
-  // runs root (see receipt-and-status.md). Its `children` list resolves each child run
-  // to the same manifest set so the classifier can require every child terminal.
+  // relay_fleet outcomes map via relay_ids.fleet to a fleet manifest under the SEPARATE
+  // FLEETS root (see receipt-and-status.md § A8) — NOT the runs root. Its `children`
+  // list still resolves each child run against the runs-root manifest map so the
+  // classifier can require every child terminal.
   const mappedFleetId = task.relay_ids && task.relay_ids.fleet ? task.relay_ids.fleet : null;
   let fleetManifest = null;
   let fleetChildren = [];
   if (mappedFleetId) {
-    fleetManifest = manifestByRunId.get(mappedFleetId) || null;
+    fleetManifest = fleetManifestById.get(mappedFleetId) || null;
     if (fleetManifest && Array.isArray(fleetManifest.fleet_children)) {
       fleetChildren = fleetManifest.fleet_children.map((child) => {
         const childManifest = child.run_id ? manifestByRunId.get(child.run_id) || null : null;
@@ -138,16 +139,27 @@ function gatherOutcomeFacts(task, ctx) {
     }
   }
 
+  // GitHub reachability (#945 A11): a REQUIRED live GitHub read is one whose result
+  // feeds this outcome's evidence contract. `pr_merged` needs `gh pr view`;
+  // `issue_closed` / `tracker_reconciled` need `gh issue view`. When such a read is
+  // attempted (the manifest names the PR/issue AND a gh runner exists) but FAILS,
+  // the fact stays null AND we flag the outcome so it degrades to `stale_missing`
+  // rather than silently classifying `running` on a null fact.
+  const contract = requiredEvidenceFor(task.kind);
+  const prRequired = contract.includes("pr_merged");
+  const issueRequired = contract.includes("issue_closed") || contract.includes("tracker_reconciled");
   let pr = null;
   let issue = null;
   let prUrl = null;
   let issueUrl = null;
+  let githubUnreachable = false;
   if (manifest) {
     if (manifest.pr_number != null) {
       prUrl = urlFor("pull", manifest.pr_number);
       if (gh) {
         const prView = ghPrView(gh, null, manifest.pr_number, {});
         if (prView.ok) pr = prView;
+        else if (prRequired) githubUnreachable = true;
       }
     }
     if (manifest.issue_number != null) {
@@ -155,6 +167,7 @@ function gatherOutcomeFacts(task, ctx) {
       if (gh) {
         const issueView = ghIssueView(gh, null, manifest.issue_number, {});
         if (issueView.ok) issue = issueView;
+        else if (issueRequired) githubUnreachable = true;
       }
     }
   }
@@ -176,6 +189,7 @@ function gatherOutcomeFacts(task, ctx) {
     issue,
     prUrl,
     issueUrl,
+    githubUnreachable,
   };
 }
 
@@ -234,15 +248,18 @@ function repairForOutcome(entry) {
   return repairs;
 }
 
-// Assemble the full D9 report from the receipt + injected read adapters.
-function deriveStatusReport({ receipt, programId, receiptPath, manifests, orca, gh, urlFor }) {
+// Assemble the full D9 report from the receipt + injected read adapters. `manifests`
+// are the child run manifests (runs root); `fleetManifests` are the fleet manifests
+// from the SEPARATE fleets root (#945 A8), keyed by fleet id.
+function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor }) {
   const resolvedUrlFor = typeof urlFor === "function" ? urlFor : () => null;
   const manifestByRunId = new Map(manifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
+  const fleetManifestById = new Map(fleetManifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
   const runtime = attributeRuntime({ receipt, programId, orca });
   const { diagnostics: duplicateDiagnostics, duplicateOutcomeIds } = detectDuplicateMappings(receipt.tasks);
 
   const entries = receipt.tasks.map((task) => {
-    const facts = gatherOutcomeFacts(task, { manifestByRunId, runtime, gh, orca, urlFor: resolvedUrlFor });
+    const facts = gatherOutcomeFacts(task, { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor: resolvedUrlFor });
     return classifyOutcome(facts, { orcaTrusted: runtime.orcaTrusted, isDuplicate: duplicateOutcomeIds.has(task.outcome_id) });
   });
 

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -14,8 +14,15 @@ const { boundedExcerpt, boundedIds, isNonEmptyString } = require("./bounded-exce
 const { orcaStatus, orcaTaskList, orcaGateList, orcaDispatchShow } = require("./orca-reads");
 const { ghIssueView, ghPrView } = require("./gh-reads");
 const { classifyOutcome, deriveProgramState, requiredEvidenceFor } = require("./status-classify");
-const { isTerminalManifestState } = require("./manifest-parse");
+const { isTerminalManifestState, isEscalatedManifestState } = require("./manifest-parse");
 const { orderReport } = require("./status-report");
+
+// A17: two runtime ids attribute to the SAME runtime only when both are non-empty
+// strings AND identical. Used to prove every adopted read (task-list, gate-list, and
+// per-task dispatch-show) came from the runtime the status read established.
+function runtimeIdMatches(candidate, reference) {
+  return isNonEmptyString(candidate) && isNonEmptyString(reference) && candidate === reference;
+}
 
 // Every subprocess-derived value that reaches a diagnostic — inside `message` AND
 // inside `ids` — is bounded (≤256 chars, marker included) so a wedged/adversarial CLI
@@ -82,7 +89,16 @@ function attributeRuntime({ receipt, programId, orca }) {
       diagnostic: diag("RUNTIME_MISMATCH", null, "live runtime carries orchestration tasks not marked for this program; runtime signals are not adopted", { foreign_task_count: foreignTasks.length, live_runtime: liveRuntime }),
     };
   }
-  return { runtime: "ok", orcaTrusted: true, tasks, gates, diagnostic: null };
+  // A17: every adopted WHOLE-RUNTIME read must prove it came from the SAME runtime the
+  // status read established. task-list / gate-list carry `_meta.runtimeId`; a mismatched
+  // or missing-where-expected id means the read cannot be attributed to the receipt's
+  // runtime, so Orca facts are WITHHELD (unreachable) exactly like a failed required read
+  // (A4) — never adopted from an unverifiable runtime. The status read already proved a
+  // non-empty runtime id (A13), so it is the authoritative reference here.
+  if (!runtimeIdMatches(taskList.runtimeId, status.runtimeId) || !runtimeIdMatches(gateList.runtimeId, status.runtimeId)) {
+    return unreachable;
+  }
+  return { runtime: "ok", orcaTrusted: true, tasks, gates, runtimeId: status.runtimeId, diagnostic: null };
 }
 
 function isPendingGate(gate) {
@@ -109,10 +125,24 @@ function gatherOutcomeFacts(task, ctx) {
   let orcaTask = null;
   let orcaTaskMissing = false;
   let dispatch = null;
+  let dispatchRuntimeUnknown = false;
   if (runtime.orcaTrusted && task.orca_task_id) {
     orcaTask = runtime.tasks.find((candidate) => candidate.id === task.orca_task_id) || null;
     orcaTaskMissing = !orcaTask;
-    if (orcaTask) dispatch = orcaDispatchShow(orca, null, task.orca_task_id, {});
+    if (orcaTask) {
+      const shown = orcaDispatchShow(orca, null, task.orca_task_id, {});
+      // A17: the per-task dispatch-show must ALSO prove it came from the receipt's runtime.
+      // A reachable read whose `_meta.runtimeId` is mismatched or missing-where-expected
+      // makes THIS task's runtime facts UNKNOWN — the dispatch facts are withheld (so no
+      // false MISSING_DISPATCH / MISSING_TERMINAL is forged) and the outcome degrades to
+      // stale_missing, leaving every other outcome unaffected. A transiently-failed
+      // (unreachable) read has no id to check and keeps its existing pass-through handling.
+      if (shown.reachable && !runtimeIdMatches(shown.runtimeId, runtime.runtimeId)) {
+        dispatchRuntimeUnknown = true;
+      } else {
+        dispatch = shown;
+      }
+    }
   }
   const gateBlocking = Boolean(
     runtime.orcaTrusted && task.orca_task_id && runtime.gates.some((gate) => isPendingGate(gate) && gateBlocksTask(gate, task.orca_task_id)),
@@ -137,14 +167,27 @@ function gatherOutcomeFacts(task, ctx) {
     if (fleetManifest && Array.isArray(fleetManifest.fleet_children)) {
       fleetChildren = fleetManifest.fleet_children.map((child) => {
         const childManifest = child.run_id ? manifestByRunId.get(child.run_id) || null : null;
+        const state = childManifest ? childManifest.state : null;
+        // A18: a child is COMPLETE only at merged/closed, but TERMINAL at merged/closed OR
+        // escalated — an escalated child will not progress on its own, so the fleet has
+        // reached a terminal configuration it cannot complete from. Completion still
+        // requires every child complete; an escalated terminal child surfaces the fleet as
+        // escalated (never complete) via `fleetChildEscalated` below.
+        const complete = isTerminalManifestState(state);
+        const escalated = isEscalatedManifestState(state);
         return {
           leaf_ref: child.leaf_ref ?? null,
           run_id: child.run_id ?? null,
-          terminal: childManifest ? isTerminalManifestState(childManifest.state) : false,
+          terminal: complete || escalated,
+          complete,
+          escalated,
         };
       });
     }
   }
+  // A18: any escalated fleet child (with a resolvable fleet manifest) makes the fleet
+  // outcome escalated — terminal ≠ complete.
+  const fleetChildEscalated = Boolean(fleetManifest) && fleetChildren.some((child) => child.escalated === true);
 
   // GitHub reachability (#945 A11): a REQUIRED live GitHub read is one whose result
   // feeds this outcome's evidence contract. `pr_merged` needs `gh pr view`;
@@ -187,11 +230,13 @@ function gatherOutcomeFacts(task, ctx) {
     orcaTask,
     orcaTaskMissing,
     dispatch,
+    dispatchRuntimeUnknown,
     gateBlocking,
     outcomeGates,
     fleetManifest,
     mappedFleetId,
     fleetChildren,
+    fleetChildEscalated,
     pr,
     issue,
     prUrl,

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -10,7 +10,7 @@
 // Durable truth outranks runtime signals (D4). When the runtime is a mismatch,
 // foreign, or unreachable, Orca-derived facts are NOT adopted for this program (D6):
 // they degrade to `stale_missing` while durable evidence still renders.
-const { boundedExcerpt, boundedIds } = require("./bounded-excerpt");
+const { boundedExcerpt, boundedIds, isNonEmptyString } = require("./bounded-excerpt");
 const { orcaStatus, orcaTaskList, orcaGateList, orcaDispatchShow } = require("./orca-reads");
 const { ghIssueView, ghPrView } = require("./gh-reads");
 const { classifyOutcome, deriveProgramState, requiredEvidenceFor } = require("./status-classify");
@@ -41,6 +41,13 @@ function attributeRuntime({ receipt, programId, orca }) {
   if (!orca) return unreachable;
   const status = orcaStatus(orca, null, {});
   if (!status.ok) return unreachable;
+  // A13: a status read that SUCCEEDS but yields no usable live runtime id (missing,
+  // empty, or non-string) is unattributable — the live runtime cannot be proven to be
+  // the one the receipt mapped. Trusting Orca facts here would silently adopt an
+  // unidentified runtime and forge false MISSING_* diagnostics, so it degrades to
+  // "unreachable" (Orca facts withheld) exactly like a failed required read (A4) — never
+  // a silent pass through the mismatch check below.
+  if (!isNonEmptyString(status.runtimeId)) return unreachable;
   // Runtime is "ok" (Orca facts adopted) ONLY when status AND task-list AND gate-list
   // all succeed. A failed REQUIRED read is unreachable — never an empty array with a
   // runtime of "ok" (D4). Fabricating [] would hide awaiting_decision and forge a false

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -1,0 +1,216 @@
+"use strict";
+
+// `status` gather + assembly (#945 D4/D6/D9). Given the parsed receipt and injected
+// read-only adapters (Orca reads, GitHub reads, already-parsed relay manifests), this
+// module gathers live facts, threads them through the pure classifier, and assembles
+// the stable D9 report. All subprocess/fs work happens in the top-level script via
+// the injected adapters; this module performs no I/O itself, so plan.js's frozen lib
+// source-scan keeps passing.
+//
+// Durable truth outranks runtime signals (D4). When the runtime is a mismatch,
+// foreign, or unreachable, Orca-derived facts are NOT adopted for this program (D6):
+// they degrade to `stale_missing` while durable evidence still renders.
+const { boundedExcerpt } = require("./bounded-excerpt");
+const { orcaStatus, orcaTaskList, orcaGateList, orcaDispatchShow } = require("./orca-reads");
+const { ghIssueView, ghPrView } = require("./gh-reads");
+const { classifyOutcome, deriveProgramState } = require("./status-classify");
+const { orderReport } = require("./status-report");
+
+function diag(code, outcomeId, message, ids) {
+  return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: ids || {} };
+}
+
+function programMarker(programId) {
+  // Literal task-title marker run.js injects: `relay-orca: <program_id>/<outcome_id>`.
+  return `relay-orca: ${programId}/`;
+}
+
+function referencesProgram(text, programId) {
+  const body = String(text || "");
+  return body.includes("relay-orca") && body.includes(programId);
+}
+
+// Attribute the live runtime (D6). Orca facts are trusted ONLY when the live runtime
+// id matches the receipt AND every live orchestration task is marked for this program.
+function attributeRuntime({ receipt, programId, orca }) {
+  if (!orca) return { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
+  const status = orcaStatus(orca, null, {});
+  if (!status.ok) return { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
+  const taskList = orcaTaskList(orca, null, {});
+  const gateList = orcaGateList(orca, null, {});
+  const tasks = taskList.ok ? taskList.tasks : [];
+  const gates = gateList.ok ? gateList.gates : [];
+  const marker = programMarker(programId);
+  const foreignTasks = tasks.filter((task) => !(typeof task.title === "string" && task.title.includes(marker)));
+  // The live runtime id is subprocess-derived, so it is bounded (≤256 chars, marker
+  // included) before it enters a diagnostic — the same rule the probe uses (D7).
+  const liveRuntime = boundedExcerpt(status.runtimeId);
+  if (receipt.runtime_id && status.runtimeId && status.runtimeId !== receipt.runtime_id) {
+    return {
+      runtime: "mismatch",
+      orcaTrusted: false,
+      tasks: [],
+      gates: [],
+      diagnostic: diag("RUNTIME_MISMATCH", null, "live Orca runtime id does not match the receipt; runtime signals are not adopted", { receipt_runtime: receipt.runtime_id, live_runtime: liveRuntime }),
+    };
+  }
+  if (foreignTasks.length > 0) {
+    return {
+      runtime: "foreign_state",
+      orcaTrusted: false,
+      tasks: [],
+      gates: [],
+      diagnostic: diag("RUNTIME_MISMATCH", null, "live runtime carries orchestration tasks not marked for this program; runtime signals are not adopted", { foreign_task_count: foreignTasks.length, live_runtime: liveRuntime }),
+    };
+  }
+  return { runtime: "ok", orcaTrusted: true, tasks, gates, diagnostic: null };
+}
+
+function isPendingGate(gate) {
+  return gate && (gate.status === "pending" || gate.pending === true);
+}
+
+function gateBlocksTask(gate, orcaTaskId) {
+  if (!gate) return false;
+  if (gate.task_id === orcaTaskId || gate.task === orcaTaskId) return true;
+  return Array.isArray(gate.blocks) && gate.blocks.includes(orcaTaskId);
+}
+
+// Build the gathered fact bundle for one receipt task.
+function gatherOutcomeFacts(task, ctx) {
+  const { manifestByRunId, runtime, gh, orca, urlFor } = ctx;
+  const mappedRunId = task.relay_ids && task.relay_ids.run ? task.relay_ids.run : null;
+  let manifest = null;
+  let mappedRunMissing = false;
+  if (mappedRunId) {
+    manifest = manifestByRunId.get(mappedRunId) || null;
+    mappedRunMissing = !manifest;
+  }
+
+  let orcaTask = null;
+  let orcaTaskMissing = false;
+  let dispatch = null;
+  if (runtime.orcaTrusted && task.orca_task_id) {
+    orcaTask = runtime.tasks.find((candidate) => candidate.id === task.orca_task_id) || null;
+    orcaTaskMissing = !orcaTask;
+    if (orcaTask) dispatch = orcaDispatchShow(orca, null, task.orca_task_id, {});
+  }
+  const gateBlocking = Boolean(
+    runtime.orcaTrusted && task.orca_task_id && runtime.gates.some((gate) => isPendingGate(gate) && gateBlocksTask(gate, task.orca_task_id)),
+  );
+
+  let pr = null;
+  let issue = null;
+  let prUrl = null;
+  let issueUrl = null;
+  if (manifest) {
+    if (manifest.pr_number != null) {
+      prUrl = urlFor("pull", manifest.pr_number);
+      if (gh) {
+        const prView = ghPrView(gh, null, manifest.pr_number, {});
+        if (prView.ok) pr = prView;
+      }
+    }
+    if (manifest.issue_number != null) {
+      issueUrl = urlFor("issues", manifest.issue_number);
+      if (gh) {
+        const issueView = ghIssueView(gh, null, manifest.issue_number, {});
+        if (issueView.ok) issue = issueView;
+      }
+    }
+  }
+
+  return { receiptTask: task, manifest, mappedRunId, mappedRunMissing, orcaTask, orcaTaskMissing, dispatch, gateBlocking, pr, issue, prUrl, issueUrl };
+}
+
+// Program-level duplicate-mapping detector (D7): two receipt entries sharing an
+// orca_task_id or a relay run id. Returns diagnostics plus the involved outcome ids.
+function detectDuplicateMappings(tasks) {
+  const diagnostics = [];
+  const duplicateOutcomeIds = new Set();
+  const group = (keyOf, label, idKey) => {
+    const byKey = new Map();
+    tasks.forEach((task) => {
+      const key = keyOf(task);
+      if (!key) return;
+      if (!byKey.has(key)) byKey.set(key, []);
+      byKey.get(key).push(task.outcome_id);
+    });
+    for (const [key, outcomes] of byKey) {
+      if (outcomes.length > 1) {
+        outcomes.forEach((id) => duplicateOutcomeIds.add(id));
+        diagnostics.push(diag("DUPLICATE_MAPPING", null, `${label} ${key} is mapped by ${outcomes.length} outcomes`, { [idKey]: key, outcomes }));
+      }
+    }
+  };
+  group((task) => task.orca_task_id, "Orca task", "orca_task_id");
+  group((task) => (task.relay_ids && task.relay_ids.run) || null, "relay run", "run");
+  return { diagnostics, duplicateOutcomeIds };
+}
+
+// live→receipt back-pointer discovery (D7): a relay manifest referencing this program
+// but absent from the receipt's mappings. Text only; NO mutation is performed.
+function discoverBackPointers({ manifests, tasks, programId }) {
+  const knownRunIds = new Set(tasks.map((task) => task.relay_ids && task.relay_ids.run).filter(Boolean));
+  const candidates = [];
+  manifests.forEach((entry) => {
+    if (!entry.run_id || knownRunIds.has(entry.run_id)) return;
+    if (!referencesProgram(entry.text, programId)) return;
+    candidates.push({
+      kind: "adopt_relay_run",
+      outcome_id: null,
+      proposal: boundedExcerpt(`relay run ${entry.run_id} references program ${programId} but is absent from the receipt; reconcile it into the receipt mapping (no mutation performed)`),
+    });
+  });
+  return candidates;
+}
+
+function repairForOutcome(entry) {
+  const repairs = [];
+  entry.diagnostics.forEach((diagnostic) => {
+    if (diagnostic.code === "MISSING_RELAY_RUN") {
+      repairs.push({ kind: "reconcile_relay_run", outcome_id: diagnostic.outcome_id, proposal: boundedExcerpt(`mapped relay run for outcome ${diagnostic.outcome_id} is absent; re-establish or clear the mapping via a supervised reconcile (no mutation performed)`) });
+    }
+    if (diagnostic.code === "MISSING_TASK" || diagnostic.code === "MISSING_DISPATCH" || diagnostic.code === "MISSING_TERMINAL") {
+      repairs.push({ kind: "reconcile_runtime_mapping", outcome_id: diagnostic.outcome_id, proposal: boundedExcerpt(`runtime mapping for outcome ${diagnostic.outcome_id} is stale (${diagnostic.code}); reconcile against durable evidence (no mutation performed)`) });
+    }
+  });
+  return repairs;
+}
+
+// Assemble the full D9 report from the receipt + injected read adapters.
+function deriveStatusReport({ receipt, programId, receiptPath, manifests, orca, gh, urlFor }) {
+  const resolvedUrlFor = typeof urlFor === "function" ? urlFor : () => null;
+  const manifestByRunId = new Map(manifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
+  const runtime = attributeRuntime({ receipt, programId, orca });
+  const { diagnostics: duplicateDiagnostics, duplicateOutcomeIds } = detectDuplicateMappings(receipt.tasks);
+
+  const entries = receipt.tasks.map((task) => {
+    const facts = gatherOutcomeFacts(task, { manifestByRunId, runtime, gh, orca, urlFor: resolvedUrlFor });
+    return classifyOutcome(facts, { orcaTrusted: runtime.orcaTrusted, isDuplicate: duplicateOutcomeIds.has(task.outcome_id) });
+  });
+
+  const diagnostics = [];
+  if (runtime.diagnostic) diagnostics.push(runtime.diagnostic);
+  entries.forEach((entry) => entry.diagnostics.forEach((entryDiag) => diagnostics.push(entryDiag)));
+  duplicateDiagnostics.forEach((duplicateDiag) => diagnostics.push(duplicateDiag));
+
+  const repairCandidates = [];
+  entries.forEach((entry) => repairForOutcome(entry).forEach((repair) => repairCandidates.push(repair)));
+  discoverBackPointers({ manifests, tasks: receipt.tasks, programId }).forEach((candidate) => repairCandidates.push(candidate));
+
+  const report = {
+    ok: true,
+    program_id: programId,
+    receipt_path: receiptPath,
+    runtime: runtime.runtime,
+    program_state: deriveProgramState(entries),
+    outcomes: entries.map((entry) => entry.outcome),
+    diagnostics,
+    repair_candidates: repairCandidates,
+    evidence_checked: true,
+  };
+  return orderReport(report);
+}
+
+module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers };

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -31,9 +31,14 @@ function diag(code, outcomeId, message, ids) {
   return { code, outcome_id: outcomeId ?? null, message: boundedExcerpt(message), ids: boundedIds(ids) };
 }
 
-function programMarker(programId) {
-  // Literal task-title marker run.js injects: `relay-orca: <program_id>/<outcome_id>`.
-  return `relay-orca: ${programId}/`;
+function programMarker(programId, programSegment) {
+  // A26: the task-title marker run.js injects embeds the collision-resistant program
+  // SEGMENT (sanitized ≤64 prefix + 8-hex sha256), NOT the raw id — the SAME encoder used
+  // for the receipt path. Detecting foreign tasks off the raw id would let program `alpha`
+  // adopt a task titled for `alpha/child` (the raw id can contain `/`); the slash-free
+  // segment keeps distinct programs on distinct markers. `programSegment` is injected
+  // (pure) so this lib module stays subprocess-free.
+  return `relay-orca: ${programSegment(programId)}/`;
 }
 
 function referencesProgram(text, programId) {
@@ -43,7 +48,7 @@ function referencesProgram(text, programId) {
 
 // Attribute the live runtime (D6). Orca facts are trusted ONLY when the live runtime
 // id matches the receipt AND every live orchestration task is marked for this program.
-function attributeRuntime({ receipt, programId, orca }) {
+function attributeRuntime({ receipt, programId, orca, programSegment }) {
   const unreachable = { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
   if (!orca) return unreachable;
   const status = orcaStatus(orca, null, {});
@@ -66,7 +71,7 @@ function attributeRuntime({ receipt, programId, orca }) {
   if (!gateList.ok) return unreachable;
   const tasks = taskList.tasks;
   const gates = gateList.gates;
-  const marker = programMarker(programId);
+  const marker = programMarker(programId, programSegment);
   const foreignTasks = tasks.filter((task) => !(typeof task.title === "string" && task.title.includes(marker)));
   // The live runtime id is subprocess-derived, so it is bounded (≤256 chars, marker
   // included) before it enters a diagnostic — the same rule the probe uses (D7).
@@ -303,11 +308,11 @@ function repairForOutcome(entry) {
 // Assemble the full D9 report from the receipt + injected read adapters. `manifests`
 // are the child run manifests (runs root); `fleetManifests` are the fleet manifests
 // from the SEPARATE fleets root (#945 A8), keyed by fleet id.
-function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor }) {
+function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment }) {
   const resolvedUrlFor = typeof urlFor === "function" ? urlFor : () => null;
   const manifestByRunId = new Map(manifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
   const fleetManifestById = new Map(fleetManifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
-  const runtime = attributeRuntime({ receipt, programId, orca });
+  const runtime = attributeRuntime({ receipt, programId, orca, programSegment });
   const { diagnostics: duplicateDiagnostics, duplicateOutcomeIds } = detectDuplicateMappings(receipt.tasks);
 
   const entries = receipt.tasks.map((task) => {

--- a/skills/relay-orca/scripts/lib/status-reasons.js
+++ b/skills/relay-orca/scripts/lib/status-reasons.js
@@ -1,0 +1,45 @@
+"use strict";
+
+// relay-orca `status` fail-closed reason matrix (#945 D8). A NEW module in the
+// 50-range so it never collides with plan.js's 2–21 codes, the probe's 30–37, run's
+// 40–44, or Node's own fatal/exec codes (<=125). Existing reason modules
+// (lib/reasons.js, lib/probe-reasons.js, lib/run-reasons.js) stay untouched.
+//
+// These three are the ONLY conditions that fail the command. A successfully derived
+// view — even one full of `inconsistent`/`stale_missing` outcomes, a runtime
+// mismatch, or an unreachable Orca/GitHub — exits 0 (the information is the product).
+const REASONS = Object.freeze({
+  RECEIPT_NOT_FOUND: 50, // no receipt for --program-id under the programs root
+  RECEIPT_CORRUPT: 51, // unparseable JSON, wrong schema, or missing required keys
+  RECEIPT_REPO_MISMATCH: 52, // receipt repo.slug does not match the current repo
+});
+
+const REMEDIATION = Object.freeze({
+  RECEIPT_NOT_FOUND:
+    "Run relay-orca `run` for this program first, or pass the correct --program-id; the receipt is written under the relay-owned programs root.",
+  RECEIPT_CORRUPT:
+    "The receipt is unparseable or schema-invalid; re-run relay-orca `run` to rewrite a fresh atomic receipt (never hand-edit it).",
+  RECEIPT_REPO_MISMATCH:
+    "The receipt was written for a different repository; invoke `status` from the same repo (or pass --repo-root) that produced the receipt.",
+});
+
+const USAGE_EXIT = 64;
+
+class StatusError extends Error {
+  constructor(reasonCode, message, remediation) {
+    super(message);
+    this.name = "StatusError";
+    this.reasonCode = reasonCode;
+    this.exitCode = REASONS[reasonCode];
+    this.remediation = remediation || REMEDIATION[reasonCode] || "";
+    if (this.exitCode === undefined) {
+      throw new Error(`unknown status reason code: ${reasonCode}`);
+    }
+  }
+}
+
+function reject(reasonCode, message, remediation) {
+  throw new StatusError(reasonCode, message, remediation);
+}
+
+module.exports = { REASONS, REMEDIATION, USAGE_EXIT, StatusError, reject };

--- a/skills/relay-orca/scripts/lib/status-report.js
+++ b/skills/relay-orca/scripts/lib/status-report.js
@@ -1,0 +1,91 @@
+"use strict";
+
+// Stable machine-readable `status` report shape (#945 D9). EXACTLY these nine
+// top-level keys, verbatim and in order, on EVERY path — success, degraded, or
+// runtime-mismatch. `evidence_checked` is literally `true` (status always checks
+// live durable evidence). No timestamps or randomness are generated in the report
+// body; receipt timestamps pass through the caller verbatim. Pure: no subprocess,
+// no fs mutation.
+
+const REPORT_KEYS = Object.freeze([
+  "ok",
+  "program_id",
+  "receipt_path",
+  "runtime",
+  "program_state",
+  "outcomes",
+  "diagnostics",
+  "repair_candidates",
+  "evidence_checked",
+]);
+
+// Per-outcome entry shape (D9). Deterministic key set on every path.
+const OUTCOME_KEYS = Object.freeze([
+  "outcome_id",
+  "kind",
+  "wave",
+  "state",
+  "orca_task_id",
+  "dispatch_id",
+  "relay_ids",
+  "issue_url",
+  "pr_url",
+  "evidence",
+]);
+
+// D5 outcome-level taxonomy — exactly these six tokens.
+const OUTCOME_STATES = Object.freeze([
+  "running",
+  "awaiting_decision",
+  "complete_with_evidence",
+  "escalated",
+  "stale_missing",
+  "inconsistent",
+]);
+
+// D5 program-level taxonomy — the six outcome tokens plus `ready_for_next_wave`.
+const PROGRAM_STATES = Object.freeze([...OUTCOME_STATES, "ready_for_next_wave"]);
+
+// D6/D9 runtime attribution.
+const RUNTIME_STATES = Object.freeze(["ok", "mismatch", "foreign_state", "unreachable"]);
+
+// D7 detector matrix — the nine verbatim diagnostic codes.
+const DIAGNOSTIC_CODES = Object.freeze([
+  "RUNTIME_MISMATCH",
+  "MISSING_TERMINAL",
+  "MISSING_TASK",
+  "MISSING_DISPATCH",
+  "DUPLICATE_MAPPING",
+  "MISSING_RELAY_RUN",
+  "PR_CHANGED",
+  "ISSUE_REOPENED",
+  "STALE_WORKER_DONE",
+]);
+
+function orderOutcome(outcome) {
+  const ordered = {};
+  OUTCOME_KEYS.forEach((key) => {
+    ordered[key] = outcome[key];
+  });
+  return ordered;
+}
+
+function orderReport(report) {
+  const ordered = {};
+  REPORT_KEYS.forEach((key) => {
+    ordered[key] = report[key];
+  });
+  ordered.outcomes = (report.outcomes || []).map(orderOutcome);
+  return ordered;
+}
+
+module.exports = {
+  REPORT_KEYS,
+  OUTCOME_KEYS,
+  OUTCOME_STATES,
+  PROGRAM_STATES,
+  RUNTIME_STATES,
+  DIAGNOSTIC_CODES,
+  orderOutcome,
+  orderReport,
+};

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -8,6 +8,7 @@
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const crypto = require("node:crypto");
 const { execFileSync } = require("node:child_process");
 const { computeRepoSlug } = require("./lib/repo-slug");
 
@@ -46,20 +47,39 @@ function programsRoot() {
   return absoluteEnvDir(process.env.RELAY_ORCA_PROGRAMS_ROOT) || path.join(os.homedir(), ".relay", "programs");
 }
 
-// Runs root is overridable for tests via RELAY_ORCA_RUNS_ROOT (same rule) — D4.
+// Relay manifests root resolution (#945 D4/A5). First hit wins; each candidate must be
+// an ABSOLUTE path (invalid → fall through to the next). This mirrors relay's own
+// resolution precedence so `status` reconciles against the same runs directory relay
+// wrote its manifests to:
+//   1. RELAY_ORCA_RUNS_ROOT   (relay-orca-specific override; tests use this)
+//   2. RELAY_RUNS_BASE        (relay's runs-base override)
+//   3. RELAY_HOME + "/runs"   (relay's home override)
+//   4. ~/.relay/runs          (default)
 function runsRoot() {
-  return absoluteEnvDir(process.env.RELAY_ORCA_RUNS_ROOT) || path.join(os.homedir(), ".relay", "runs");
+  const orcaRoot = absoluteEnvDir(process.env.RELAY_ORCA_RUNS_ROOT);
+  if (orcaRoot) return orcaRoot;
+  const runsBase = absoluteEnvDir(process.env.RELAY_RUNS_BASE);
+  if (runsBase) return runsBase;
+  const relayHome = absoluteEnvDir(process.env.RELAY_HOME);
+  if (relayHome) return path.join(relayHome, "runs");
+  return path.join(os.homedir(), ".relay", "runs");
 }
 
-// Program id → a single safe path segment (never traverses). run.js and status.js
-// apply this identically so a `run`-written receipt resolves back for `status`. `.`
-// and `..` are neutralized so a pathological program id can never escape the intended
-// <programs-root>/<repo-slug>/<program-id>/ directory (same guard relay's paths.js
-// applies to run/fleet ids).
+// Program id → a single safe path segment (never traverses) that is ALSO
+// collision-resistant (#945 A6). A pure sanitize is lossy — `"a b"` and `"a+b"` both
+// collapse to `"a-b"`, which would silently point two distinct programs at ONE receipt.
+// So the segment is the sanitized base joined to the first 8 hex of sha256(raw id): the
+// hash disambiguates ids that sanitize identically while the sanitized prefix keeps the
+// path human-readable. run.js and status.js apply this identically, so a `run`-written
+// receipt resolves back for `status`. `.` and `..` (and empty) collapse to `program`
+// so a pathological id can never escape <programs-root>/<repo-slug>/<segment>/, and the
+// hash still keeps `.` and `..` on distinct paths.
 function programSegment(programId) {
-  const safe = String(programId == null ? "" : programId).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  if (safe === "" || safe === "." || safe === "..") return "program";
-  return safe;
+  const raw = String(programId == null ? "" : programId);
+  const sanitized = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  const base = sanitized === "" || sanitized === "." || sanitized === ".." ? "program" : sanitized;
+  const hash = crypto.createHash("sha256").update(raw).digest("hex").slice(0, 8);
+  return `${base}-${hash}`;
 }
 
 function receiptPathFor(slug, programId) {

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -65,6 +65,28 @@ function runsRoot() {
   return path.join(os.homedir(), ".relay", "runs");
 }
 
+// Fleet manifests root resolution (#945 A8). relay-fleet manifests live UNDER RELAY'S
+// FLEETS ROOT — a directory SEPARATE from the runs root that holds child run manifests
+// (confirmed in relay-dispatch's manifest/paths.js: `getFleetsBase()` returns
+// `RELAY_HOME + "/fleets"`, defaulting to `~/.relay/fleets`, with NO dedicated
+// fleets-base env of its own). This resolver mirrors the runsRoot precedence pattern
+// (first hit wins; each candidate must be an ABSOLUTE path or it falls through to the
+// next), adapted to that convention so `status` reads fleet manifests from the same
+// place relay-fleet wrote them:
+//   1. RELAY_ORCA_FLEETS_ROOT (relay-orca-specific override; tests use this)
+//   2. RELAY_FLEETS_BASE      (the RELAY_RUNS_BASE parallel; honored if it is ever set)
+//   3. RELAY_HOME + "/fleets" (relay-fleet's actual convention)
+//   4. ~/.relay/fleets        (default)
+function fleetsRoot() {
+  const orcaRoot = absoluteEnvDir(process.env.RELAY_ORCA_FLEETS_ROOT);
+  if (orcaRoot) return orcaRoot;
+  const fleetsBase = absoluteEnvDir(process.env.RELAY_FLEETS_BASE);
+  if (fleetsBase) return fleetsBase;
+  const relayHome = absoluteEnvDir(process.env.RELAY_HOME);
+  if (relayHome) return path.join(relayHome, "fleets");
+  return path.join(os.homedir(), ".relay", "fleets");
+}
+
 // Program id → a single safe path segment (never traverses) that is ALSO
 // collision-resistant (#945 A6). A pure sanitize is lossy — `"a b"` and `"a+b"` both
 // collapse to `"a-b"`, which would silently point two distinct programs at ONE receipt.
@@ -106,10 +128,11 @@ function receiptExists(finalPath) {
   return fs.existsSync(finalPath);
 }
 
-// List relay manifests for a repo slug as { run_id, file, text }. run_id is the
-// manifest filename stem; text is the raw bytes (parsing happens in the pure lib).
-function listManifestFiles(slug) {
-  const dir = path.join(runsRoot(), slug);
+// List relay manifest `.md` files under a root/<slug> directory as
+// { run_id, file, text }. `run_id` is the manifest filename stem (for fleet manifests
+// this stem is the fleet id); text is the raw bytes (parsing happens in the pure lib).
+function listManifestFilesUnder(root, slug) {
+  const dir = path.join(root, slug);
   if (!fs.existsSync(dir)) return [];
   return fs
     .readdirSync(dir)
@@ -119,6 +142,16 @@ function listManifestFiles(slug) {
       file: path.join(dir, name),
       text: fs.readFileSync(path.join(dir, name), "utf-8"),
     }));
+}
+
+// Child run manifests live under the runs root.
+function listManifestFiles(slug) {
+  return listManifestFilesUnder(runsRoot(), slug);
+}
+
+// Fleet manifests live under the SEPARATE fleets root (#945 A8), keyed by fleet id.
+function listFleetManifestFiles(slug) {
+  return listManifestFilesUnder(fleetsRoot(), slug);
 }
 
 // Best-effort GitHub URL construction from the repo's origin remote — read-only and
@@ -145,11 +178,13 @@ module.exports = {
   resolveRepoContext,
   programsRoot,
   runsRoot,
+  fleetsRoot,
   programSegment,
   receiptPathFor,
   writeReceiptAtomic,
   readReceiptFile,
   receiptExists,
   listManifestFiles,
+  listFleetManifestFiles,
   makeUrlResolver,
 };

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -96,10 +96,19 @@ function fleetsRoot() {
 // receipt resolves back for `status`. `.` and `..` (and empty) collapse to `program`
 // so a pathological id can never escape <programs-root>/<repo-slug>/<segment>/, and the
 // hash still keeps `.` and `..` on distinct paths.
+// A15: the readable prefix is bounded to at most 64 chars so a very long program id can
+// never overflow the filesystem per-segment name limit (NAME_MAX, typically 255). The
+// 8-hex hash is ALWAYS appended and is computed over the FULL raw id, so two long ids
+// that share a 64-char prefix still resolve to DISTINCT segments.
+const MAX_SEGMENT_PREFIX = 64;
+
 function programSegment(programId) {
   const raw = String(programId == null ? "" : programId);
   const sanitized = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  const base = sanitized === "" || sanitized === "." || sanitized === ".." ? "program" : sanitized;
+  const readable = sanitized === "" || sanitized === "." || sanitized === ".." ? "program" : sanitized;
+  // Truncate to the readable-prefix bound, re-trimming any trailing dash the cut exposes
+  // (the first char is always non-dash, so the result is never empty).
+  const base = readable.slice(0, MAX_SEGMENT_PREFIX).replace(/-+$/, "");
   const hash = crypto.createHash("sha256").update(raw).digest("hex").slice(0, 8);
   return `${base}-${hash}`;
 }

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -14,20 +14,29 @@ const { computeRepoSlug } = require("./lib/repo-slug");
 
 const GIT_TIMEOUT_MS = 10000;
 
-// Canonicalize the repo root the SAME way relay's manifest/paths.js does: resolve the
-// git common dir and realpath its parent (collapsing a linked worktree to the main
-// checkout). A --repo-root override skips git and realpaths the given path directly —
-// the hermetic path tests use. The slug is then computed by the replicated algorithm.
+// Canonicalize the repo root the SAME way relay's manifest/paths.js `getCanonicalRepoRoot`
+// does: run `git rev-parse --git-common-dir` at the provided root (or cwd), take that common
+// dir's PARENT, and realpath it. This collapses a LINKED WORKTREE to the PRIMARY checkout
+// root, so a receipt written from a worktree resolves back to the same slug relay used for
+// the primary checkout — and `run` and `status` derive the same slug from the same input.
+// The `--repo-root` override (A22) is canonicalized through git identically — it is NOT
+// realpath'd directly — so pointing status/run at a linked worktree still derives the
+// primary slug. On ANY git failure (not a repo, git missing, timeout) it falls back to a
+// plain realpath of the provided root, which keeps the hermetic non-git path tests stable.
+// The slug is then computed from this canonical root by the replicated algorithm.
 function resolveCanonicalRepoRoot({ repoRootOverride, cwd } = {}) {
-  if (repoRootOverride) return fs.realpathSync(repoRootOverride);
-  const dir = cwd || process.cwd();
-  const commonDirText = execFileSync("git", ["-C", dir, "rev-parse", "--git-common-dir"], {
-    encoding: "utf-8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: GIT_TIMEOUT_MS,
-  }).trim();
-  const commonDir = path.isAbsolute(commonDirText) ? commonDirText : path.resolve(dir, commonDirText);
-  return fs.realpathSync(path.dirname(commonDir));
+  const startDir = repoRootOverride || cwd || process.cwd();
+  try {
+    const commonDirText = execFileSync("git", ["-C", startDir, "rev-parse", "--git-common-dir"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: GIT_TIMEOUT_MS,
+    }).trim();
+    const commonDir = path.isAbsolute(commonDirText) ? commonDirText : path.resolve(startDir, commonDirText);
+    return fs.realpathSync(path.dirname(commonDir));
+  } catch {
+    return fs.realpathSync(startDir);
+  }
 }
 
 function resolveRepoContext(options = {}) {

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -1,0 +1,131 @@
+"use strict";
+
+// Top-level (NON-lib) filesystem + subprocess helpers shared by run.js and status.js
+// (#945). Per the architectural constraint, ALL subprocess and filesystem mutation
+// lives in top-level scripts; the pure lib/ modules receive injected I/O. This file
+// sits directly under scripts/ (not scripts/lib/), so plan.js's frozen lib
+// source-scan never touches it.
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const { computeRepoSlug } = require("./lib/repo-slug");
+
+const GIT_TIMEOUT_MS = 10000;
+
+// Canonicalize the repo root the SAME way relay's manifest/paths.js does: resolve the
+// git common dir and realpath its parent (collapsing a linked worktree to the main
+// checkout). A --repo-root override skips git and realpaths the given path directly —
+// the hermetic path tests use. The slug is then computed by the replicated algorithm.
+function resolveCanonicalRepoRoot({ repoRootOverride, cwd } = {}) {
+  if (repoRootOverride) return fs.realpathSync(repoRootOverride);
+  const dir = cwd || process.cwd();
+  const commonDirText = execFileSync("git", ["-C", dir, "rev-parse", "--git-common-dir"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: GIT_TIMEOUT_MS,
+  }).trim();
+  const commonDir = path.isAbsolute(commonDirText) ? commonDirText : path.resolve(dir, commonDirText);
+  return fs.realpathSync(path.dirname(commonDir));
+}
+
+function resolveRepoContext(options = {}) {
+  const root = resolveCanonicalRepoRoot(options);
+  return { root, slug: computeRepoSlug(root) };
+}
+
+function absoluteEnvDir(envValue) {
+  return typeof envValue === "string" && envValue.trim() !== "" && path.isAbsolute(envValue.trim())
+    ? envValue.trim()
+    : null;
+}
+
+// Programs root is overridable for tests via RELAY_ORCA_PROGRAMS_ROOT (must be an
+// absolute path; invalid values are ignored and the default is used) — D1.
+function programsRoot() {
+  return absoluteEnvDir(process.env.RELAY_ORCA_PROGRAMS_ROOT) || path.join(os.homedir(), ".relay", "programs");
+}
+
+// Runs root is overridable for tests via RELAY_ORCA_RUNS_ROOT (same rule) — D4.
+function runsRoot() {
+  return absoluteEnvDir(process.env.RELAY_ORCA_RUNS_ROOT) || path.join(os.homedir(), ".relay", "runs");
+}
+
+// Program id → a single safe path segment (never traverses). run.js and status.js
+// apply this identically so a `run`-written receipt resolves back for `status`.
+function programSegment(programId) {
+  const safe = String(programId == null ? "" : programId).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return safe || "program";
+}
+
+function receiptPathFor(slug, programId) {
+  return path.join(programsRoot(), slug, programSegment(programId), "receipt.json");
+}
+
+// Atomic write: a temp file in the SAME directory, then rename. A partial/torn
+// receipt is impossible by construction — the rename is the only publish step (D1).
+// The low-level fs primitives are injectable so the atomicity is unit-testable.
+function writeReceiptAtomic(finalPath, text, io = fs) {
+  const dir = path.dirname(finalPath);
+  io.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.receipt.${process.pid}.${Date.now()}.tmp`);
+  io.writeFileSync(tmp, text, "utf-8");
+  io.renameSync(tmp, finalPath);
+  return finalPath;
+}
+
+function readReceiptFile(finalPath) {
+  return fs.readFileSync(finalPath, "utf-8");
+}
+
+function receiptExists(finalPath) {
+  return fs.existsSync(finalPath);
+}
+
+// List relay manifests for a repo slug as { run_id, file, text }. run_id is the
+// manifest filename stem; text is the raw bytes (parsing happens in the pure lib).
+function listManifestFiles(slug) {
+  const dir = path.join(runsRoot(), slug);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => ({
+      run_id: name.replace(/\.md$/, ""),
+      file: path.join(dir, name),
+      text: fs.readFileSync(path.join(dir, name), "utf-8"),
+    }));
+}
+
+// Best-effort GitHub URL construction from the repo's origin remote — read-only and
+// never a `gh` call (the fake gh poisons non-read subcommands). Returns null when the
+// remote/owner cannot be resolved (tests run in a bare temp repo-root → null).
+function makeUrlResolver(repoRoot) {
+  let ownerRepo = null;
+  try {
+    const remote = execFileSync("git", ["-C", repoRoot, "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: GIT_TIMEOUT_MS,
+    }).trim();
+    const match = remote.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+    if (match) ownerRepo = `${match[1]}/${match[2]}`;
+  } catch {
+    ownerRepo = null;
+  }
+  return (kind, number) => (ownerRepo && number != null ? `https://github.com/${ownerRepo}/${kind}/${number}` : null);
+}
+
+module.exports = {
+  resolveCanonicalRepoRoot,
+  resolveRepoContext,
+  programsRoot,
+  runsRoot,
+  programSegment,
+  receiptPathFor,
+  writeReceiptAtomic,
+  readReceiptFile,
+  receiptExists,
+  listManifestFiles,
+  makeUrlResolver,
+};

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -11,8 +11,26 @@ const path = require("node:path");
 const crypto = require("node:crypto");
 const { execFileSync } = require("node:child_process");
 const { computeRepoSlug } = require("./lib/repo-slug");
+const { boundedExcerpt } = require("./lib/bounded-excerpt");
 
 const GIT_TIMEOUT_MS = 10000;
+
+// A24: a repo root that cannot be git-canonicalized FAILS CLOSED. Both `run` and
+// `status` catch this and reject with `RECEIPT_REPO_MISMATCH` (exit 52) — the SAME
+// fail-closed reason `status` already uses for a cross-repo receipt — rather than
+// deriving a slug from a plain realpath of an arbitrary directory, which could silently
+// point run/status at ANOTHER repository's receipts. It carries the reason_code/exitCode
+// shape both top-level scripts' rejection paths expect.
+class CanonicalizationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CanonicalizationError";
+    this.reasonCode = "RECEIPT_REPO_MISMATCH";
+    this.exitCode = 52;
+    this.remediation =
+      "Invoke relay-orca `run`/`status` from inside the git repository (or pass a --repo-root that is a git checkout); the repo root must be git-canonicalizable — there is no realpath fallback.";
+  }
+}
 
 // Canonicalize the repo root the SAME way relay's manifest/paths.js `getCanonicalRepoRoot`
 // does: run `git rev-parse --git-common-dir` at the provided root (or cwd), take that common
@@ -21,9 +39,12 @@ const GIT_TIMEOUT_MS = 10000;
 // the primary checkout — and `run` and `status` derive the same slug from the same input.
 // The `--repo-root` override (A22) is canonicalized through git identically — it is NOT
 // realpath'd directly — so pointing status/run at a linked worktree still derives the
-// primary slug. On ANY git failure (not a repo, git missing, timeout) it falls back to a
-// plain realpath of the provided root, which keeps the hermetic non-git path tests stable.
-// The slug is then computed from this canonical root by the replicated algorithm.
+// primary slug. On ANY git failure (not a repo, git missing, timeout) it FAILS CLOSED
+// (A24): there is NO realpath fallback, because deriving a slug from a plain realpath of
+// an arbitrary directory could silently read/write ANOTHER repo's receipts. It throws a
+// CanonicalizationError (RECEIPT_REPO_MISMATCH, exit 52) carrying a bounded excerpt of
+// the git error. The slug is then computed from this canonical root by the replicated
+// algorithm.
 function resolveCanonicalRepoRoot({ repoRootOverride, cwd } = {}) {
   const startDir = repoRootOverride || cwd || process.cwd();
   try {
@@ -34,8 +55,11 @@ function resolveCanonicalRepoRoot({ repoRootOverride, cwd } = {}) {
     }).trim();
     const commonDir = path.isAbsolute(commonDirText) ? commonDirText : path.resolve(startDir, commonDirText);
     return fs.realpathSync(path.dirname(commonDir));
-  } catch {
-    return fs.realpathSync(startDir);
+  } catch (error) {
+    const detail = boundedExcerpt(error && error.stderr ? String(error.stderr) : (error && error.message) || String(error));
+    throw new CanonicalizationError(
+      `repo root could not be canonicalized via git rev-parse at ${startDir}: ${detail}`,
+    );
   }
 }
 
@@ -192,6 +216,7 @@ function makeUrlResolver(repoRoot) {
 }
 
 module.exports = {
+  CanonicalizationError,
   resolveCanonicalRepoRoot,
   resolveRepoContext,
   programsRoot,

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -52,10 +52,14 @@ function runsRoot() {
 }
 
 // Program id → a single safe path segment (never traverses). run.js and status.js
-// apply this identically so a `run`-written receipt resolves back for `status`.
+// apply this identically so a `run`-written receipt resolves back for `status`. `.`
+// and `..` are neutralized so a pathological program id can never escape the intended
+// <programs-root>/<repo-slug>/<program-id>/ directory (same guard relay's paths.js
+// applies to run/fleet ids).
 function programSegment(programId) {
   const safe = String(programId == null ? "" : programId).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  return safe || "program";
+  if (safe === "" || safe === "." || safe === "..") return "program";
+  return safe;
 }
 
 function receiptPathFor(slug, programId) {

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -16,11 +16,13 @@ const { orchestrate } = require("./lib/run-orchestrator");
 const { orderedReport } = require("./lib/run-report");
 const { buildReceiptMapping, serializeReceipt } = require("./lib/receipt");
 const {
+  CanonicalizationError,
   resolveRepoContext,
   receiptPathFor,
   writeReceiptAtomic,
   readReceiptFile,
   receiptExists,
+  programSegment,
 } = require("./receipt-io");
 
 const USAGE_EXIT = 64;
@@ -158,9 +160,11 @@ function printReport(report, json) {
   });
 }
 
-// Plan-library rejections re-raise unchanged (D1): same reason_code, same exit
-// code, same JSON rejection object shape as `plan`.
-function failPlan(error, json) {
+// Fail-closed rejection: plan-library rejections re-raise unchanged (D1) — same
+// reason_code, exit code, and JSON shape as `plan` — and a repo root that cannot be
+// git-canonicalized (A24) rejects with RECEIPT_REPO_MISMATCH (exit 52) through the same
+// path. Every carrier exposes reasonCode / message / exitCode.
+function failReject(error, json) {
   const body = { ok: false, reason_code: error.reasonCode, message: error.message };
   if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
   else process.stderr.write(`relay-orca run rejected [${error.reasonCode}]: ${error.message}\n`);
@@ -179,9 +183,12 @@ function main() {
       orcaBin: opts.orcaBin,
       runOrca,
       persistReceipt: makeReceiptPersistor(opts),
+      // A26: the task-title program marker embeds the SAME collision-resistant segment
+      // used for the receipt path, injected as a pure function (lib/ stays subprocess-free).
+      programSegment,
     });
   } catch (error) {
-    if (error instanceof PlanError) failPlan(error, opts.json);
+    if (error instanceof PlanError || error instanceof CanonicalizationError) failReject(error, opts.json);
     throw error;
   }
   printReport(result.report, opts.json);

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -90,15 +90,17 @@ function parseArgs(argv) {
   return opts;
 }
 
-// D2 receipt persistence closure. Repo context (canonical root + slug) is resolved
-// lazily on first write, so plan-library rejections and admission rejections never
-// touch the filesystem. created_at is preserved across the materialize/dispatch
-// rewrites; only the atomic write + timestamps live here (top-level), while the pure
-// mapping is built by lib/receipt.js.
+// D2 receipt persistence closure. A27: repo context (canonical root + slug) is resolved
+// EAGERLY when this factory runs — at run startup, BEFORE orchestrate performs any
+// admission/materialization mutation. A git-canonicalization failure (A24) therefore
+// throws CanonicalizationError NOW, so `run` exits 52 with ZERO mutating Orca invocations
+// instead of after the first successful task-create had already mutated Orca (the exact
+// receipt-loss condition A12 forbids: the created task's mapping would never be persisted).
+// created_at is preserved across the materialize/dispatch rewrites; only the atomic write +
+// timestamps live here (top-level), while the pure mapping is built by lib/receipt.js.
 function makeReceiptPersistor(opts) {
-  let repo = null;
+  const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
   return function persistReceipt(core) {
-    if (!repo) repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
     const finalPath = receiptPathFor(repo.slug, core.program_id);
     const nowIso = new Date().toISOString();
     let createdAt = nowIso;
@@ -177,12 +179,17 @@ function main() {
   const program = readProgram(opts.programFile);
   let result;
   try {
+    // A27: build the persistor FIRST. This eagerly canonicalizes the repo and resolves the
+    // receipt path before orchestrate runs ANY admission/materialization mutation — a
+    // git-canonicalization failure exits 52 here (CanonicalizationError, caught below) with
+    // zero mutating Orca invocations.
+    const persistReceipt = makeReceiptPersistor(opts);
     result = orchestrate(program, {
       concurrency: opts.concurrency,
       operatorHandles: opts.operatorHandles,
       orcaBin: opts.orcaBin,
       runOrca,
-      persistReceipt: makeReceiptPersistor(opts),
+      persistReceipt,
       // A26: the task-title program marker embeds the SAME collision-resistant segment
       // used for the receipt path, injected as a pure function (lib/ stays subprocess-free).
       programSegment,

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -14,6 +14,14 @@ const { execFileSync } = require("node:child_process");
 const { PlanError } = require("./lib/reasons");
 const { orchestrate } = require("./lib/run-orchestrator");
 const { orderedReport } = require("./lib/run-report");
+const { buildReceiptMapping, serializeReceipt } = require("./lib/receipt");
+const {
+  resolveRepoContext,
+  receiptPathFor,
+  writeReceiptAtomic,
+  readReceiptFile,
+  receiptExists,
+} = require("./receipt-io");
 
 const USAGE_EXIT = 64;
 const RUN_MAX_BUFFER = 4 * 1024 * 1024;
@@ -64,7 +72,7 @@ function usageError(message) {
 }
 
 function parseArgs(argv) {
-  const opts = { programFile: null, json: false, concurrency: undefined, operatorHandles: [], orcaBin: null };
+  const opts = { programFile: null, json: false, concurrency: undefined, operatorHandles: [], orcaBin: null, repoRoot: null };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--program-file" || arg === "-f") opts.programFile = argv[(i += 1)];
@@ -72,11 +80,47 @@ function parseArgs(argv) {
     else if (arg === "--concurrency") opts.concurrency = Number(argv[(i += 1)]);
     else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
     else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
+    else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
     else if (arg === "--help" || arg === "-h") opts.help = true;
     else if (!arg.startsWith("-") && !opts.programFile) opts.programFile = arg;
     else usageError(`unrecognized argument: ${arg}`);
   }
   return opts;
+}
+
+// D2 receipt persistence closure. Repo context (canonical root + slug) is resolved
+// lazily on first write, so plan-library rejections and admission rejections never
+// touch the filesystem. created_at is preserved across the materialize/dispatch
+// rewrites; only the atomic write + timestamps live here (top-level), while the pure
+// mapping is built by lib/receipt.js.
+function makeReceiptPersistor(opts) {
+  let repo = null;
+  return function persistReceipt(core) {
+    if (!repo) repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+    const finalPath = receiptPathFor(repo.slug, core.program_id);
+    const nowIso = new Date().toISOString();
+    let createdAt = nowIso;
+    if (receiptExists(finalPath)) {
+      try {
+        const prior = JSON.parse(readReceiptFile(finalPath));
+        if (typeof prior.created_at === "string" && prior.created_at) createdAt = prior.created_at;
+      } catch {
+        createdAt = nowIso;
+      }
+    }
+    const mapping = buildReceiptMapping({
+      program_id: core.program_id,
+      source: opts.programFile,
+      repo: { slug: repo.slug, root: repo.root },
+      runtimeId: core.runtime_id,
+      tasks: core.tasks,
+      terminalsCreated: core.terminals_created,
+    });
+    mapping.created_at = createdAt;
+    mapping.updated_at = nowIso;
+    writeReceiptAtomic(finalPath, serializeReceipt(mapping));
+    return finalPath;
+  };
 }
 
 function requireValue(value, flag) {
@@ -105,7 +149,7 @@ function printReport(report, json) {
     return;
   }
   const stream = report.ok ? process.stdout : process.stderr;
-  stream.write(`relay-orca run for ${report.program_id} (admitted=${report.admission.admitted}, ok=${report.ok})\n`);
+  stream.write(`relay-orca run for ${report.program_id} (admitted=${report.admission.admitted}, ok=${report.ok}, receipt=${report.receipt_path || "none"})\n`);
   report.tasks.forEach((task) => {
     stream.write(`  ${task.task_id} [${task.status}] orca=${task.orca_task_id} assignee=${task.assignee}\n`);
   });
@@ -134,6 +178,7 @@ function main() {
       operatorHandles: opts.operatorHandles,
       orcaBin: opts.orcaBin,
       runOrca,
+      persistReceipt: makeReceiptPersistor(opts),
     });
   } catch (error) {
     if (error instanceof PlanError) failPlan(error, opts.json);

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -74,13 +74,41 @@ function assertOrcaReadOnly(argv) {
   }
 }
 
+// A28: `gh api` body/field options that make the request default to a mutating POST.
+// Present in ANY of these forms, an `api` call is a write even without a literal `-X`.
+const GH_API_BODY_OPTS = new Set(["-f", "--field", "-F", "--raw-field", "--input"]);
+
+// Extract an explicit `gh api` method, handling both separated (`-X POST`, `--method POST`)
+// and attached (`-XPOST`, `--method=POST`) forms. Returns null when no method is specified
+// (a bare `gh api` defaults to GET).
+function ghApiMethod(argv) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "-X" || token === "--method") return String(argv[i + 1] || "");
+    if (token.startsWith("--method=")) return token.slice("--method=".length);
+    if (token.startsWith("-X") && token.length > 2) return token.slice(2);
+  }
+  return null;
+}
+
+// A28: a `gh api` invocation is mutation-shaped (defaults to POST/PATCH/PUT/DELETE) when it
+// carries any body/field option OR an explicit non-GET method. A bare `gh api <path>` (no
+// method, no body/field) is a read-only GET.
+function isMutatingGhApi(argv) {
+  if (argv[0] !== "api") return false;
+  if (argv.some((token) => GH_API_BODY_OPTS.has(token))) return true;
+  const method = ghApiMethod(argv);
+  if (method !== null && method.trim().toUpperCase() !== "GET") return true;
+  return argv.some((token) => /^(POST|PATCH|PUT|DELETE)$/i.test(token));
+}
+
 // Structural read-only refusal for gh: only `issue view`, `pr view`, and read-shaped
-// `api` GETs are permitted (D3). Any write subcommand is refused before it runs.
+// `api` GETs are permitted (D3). Any write subcommand — including a mutation-shaped `gh api`
+// carrying body/field options or an explicit non-GET method (A28) — is refused before it runs.
 function assertGhReadOnly(argv) {
   const isIssueView = argv[0] === "issue" && argv[1] === "view";
   const isPrView = argv[0] === "pr" && argv[1] === "view";
-  const isApiRead = argv[0] === "api" && !argv.some((token) => /^(-X|--method)$/.test(token))
-    && !argv.some((token) => /^(POST|PATCH|PUT|DELETE)$/i.test(token));
+  const isApiRead = argv[0] === "api" && !isMutatingGhApi(argv);
   if (!isIssueView && !isPrView && !isApiRead) {
     throw new Error(`relay-orca status must never invoke a non-read gh subcommand (got: ${argv.join(" ")})`);
   }
@@ -218,4 +246,8 @@ function main() {
   process.exitCode = 0;
 }
 
-main();
+// Run as a CLI only when invoked directly; importing this module (e.g. the A28 read-only
+// boundary unit tests) exercises the guard functions without triggering a real status run.
+if (require.main === module) main();
+
+module.exports = { assertGhReadOnly, assertOrcaReadOnly, isMutatingGhApi };

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -17,6 +17,7 @@ const {
   readReceiptFile,
   receiptExists,
   listManifestFiles,
+  listFleetManifestFiles,
   makeUrlResolver,
 } = require("./receipt-io");
 const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
@@ -83,7 +84,13 @@ function assertGhReadOnly(argv) {
   }
 }
 
-function makeRunner(bin, assertReadOnly) {
+// Every read runner is pinned to the selected repository's root via `cwd` (#945 A9).
+// A repo-scoped `gh` invocation resolves the PR/issue against THIS repo's origin
+// remote, so running `status` from an unrelated directory can never read a different
+// repository's GitHub state. `cwd` is the slug-verified canonical repo root (the
+// receipt's repo, guaranteed on disk and matched against the receipt slug before any
+// read runs).
+function makeRunner(bin, assertReadOnly, cwd) {
   if (!bin) return null;
   return (_bin, args) => {
     const argv = (Array.isArray(args) ? args : []).map(String);
@@ -92,6 +99,7 @@ function makeRunner(bin, assertReadOnly) {
       const stdout = execFileSync(bin, argv, {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "pipe"],
+        cwd: cwd || undefined,
         timeout: READ_TIMEOUT_MS,
         maxBuffer: READ_MAX_BUFFER,
       });
@@ -171,7 +179,15 @@ function main() {
     if (receipt.repo && receipt.repo.slug !== repo.slug) {
       reject("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
     }
+    // Child run manifests come from the runs root; fleet manifests come from the
+    // SEPARATE fleets root (#945 A8). A fleet outcome's `relay_ids.fleet` resolves to a
+    // fleet manifest here, while its children still resolve against the runs-root map.
     const manifests = listManifestFiles(repo.slug).map((entry) => ({
+      run_id: entry.run_id,
+      text: entry.text,
+      parsed: parseManifest(entry.text),
+    }));
+    const fleetManifests = listFleetManifestFiles(repo.slug).map((entry) => ({
       run_id: entry.run_id,
       text: entry.text,
       parsed: parseManifest(entry.text),
@@ -181,8 +197,9 @@ function main() {
       programId: opts.programId,
       receiptPath,
       manifests,
-      orca: makeRunner(resolveOrca(opts), assertOrcaReadOnly),
-      gh: makeRunner(resolveGhBin(opts), assertGhReadOnly),
+      fleetManifests,
+      orca: makeRunner(resolveOrca(opts), assertOrcaReadOnly, repo.root),
+      gh: makeRunner(resolveGhBin(opts), assertGhReadOnly, repo.root),
       urlFor: makeUrlResolver(repo.root),
     });
   } catch (error) {

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -12,6 +12,7 @@
 // in receipt-io.js; the pure scripts/lib/ modules receive injected read adapters.
 const { execFileSync } = require("node:child_process");
 const {
+  CanonicalizationError,
   resolveRepoContext,
   receiptPathFor,
   readReceiptFile,
@@ -19,6 +20,7 @@ const {
   listManifestFiles,
   listFleetManifestFiles,
   makeUrlResolver,
+  programSegment,
 } = require("./receipt-io");
 const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
 const { parseReceipt } = require("./lib/receipt");
@@ -201,9 +203,14 @@ function main() {
       orca: makeRunner(resolveOrca(opts), assertOrcaReadOnly, repo.root),
       gh: makeRunner(resolveGhBin(opts), assertGhReadOnly, repo.root),
       urlFor: makeUrlResolver(repo.root),
+      // A26: the foreign-task marker embeds the SAME collision-resistant segment used for
+      // the receipt path, injected as a pure function (lib/ stays subprocess-free).
+      programSegment,
     });
   } catch (error) {
-    if (error instanceof StatusError) failStatus(error, opts.json);
+    // A24: a repo root that cannot be git-canonicalized fails closed with the same
+    // RECEIPT_REPO_MISMATCH (exit 52) contract as a cross-repo receipt.
+    if (error instanceof StatusError || error instanceof CanonicalizationError) failStatus(error, opts.json);
     throw error;
   }
 

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -21,6 +21,7 @@ const {
 } = require("./receipt-io");
 const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
 const { parseReceipt } = require("./lib/receipt");
+const { boundedExcerpt } = require("./lib/bounded-excerpt");
 const { parseManifest } = require("./lib/manifest-parse");
 const { deriveStatusReport } = require("./lib/status-derive");
 const { StatusError, USAGE_EXIT, reject } = require("./lib/status-reasons");
@@ -105,12 +106,23 @@ function makeRunner(bin, assertReadOnly) {
   };
 }
 
-function loadReceipt(receiptPath) {
+function loadReceipt(receiptPath, requestedProgramId) {
   if (!receiptExists(receiptPath)) {
     reject("RECEIPT_NOT_FOUND", `no receipt found at ${receiptPath}`);
   }
   const parsed = parseReceipt(readReceiptFile(receiptPath));
   if (!parsed.ok) reject("RECEIPT_CORRUPT", parsed.reason);
+  // Identity check (#945 A6): the receipt loaded from the requested program's path MUST
+  // carry the same program_id. A mismatch means the file at this path belongs to a
+  // different program (hand-edit, misplaced write, or a sanitized-segment collision that
+  // the stable hash is meant to prevent) — fail closed rather than reconcile the wrong
+  // program. Both ids are bounded so a pathological receipt id cannot inflate the error.
+  if (parsed.receipt.program_id !== requestedProgramId) {
+    reject(
+      "RECEIPT_CORRUPT",
+      `receipt program_id ${boundedExcerpt(parsed.receipt.program_id)} does not match the requested --program-id ${boundedExcerpt(requestedProgramId)}`,
+    );
+  }
   return parsed.receipt;
 }
 
@@ -155,7 +167,7 @@ function main() {
   try {
     const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
     const receiptPath = receiptPathFor(repo.slug, opts.programId);
-    const receipt = loadReceipt(receiptPath);
+    const receipt = loadReceipt(receiptPath, opts.programId);
     if (receipt.repo && receipt.repo.slug !== repo.slug) {
       reject("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
     }

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+"use strict";
+
+// relay-orca `status` — strictly READ-ONLY live reconciler (issue #945). It derives a
+// normalized program view from the reconstructible receipt, relay manifests, GitHub,
+// and Orca runtime signals. Durable truth outranks runtime signals; `worker_done` is
+// NEVER completion evidence. It performs NO mutation of any kind: no GitHub write, no
+// relay manifest write, no Orca mutating subcommand, no receipt write. Repair is out
+// of scope in this leaf — `status` emits `repair_candidates` diagnostics only.
+//
+// Per the architectural constraint, ALL subprocess and filesystem I/O lives HERE and
+// in receipt-io.js; the pure scripts/lib/ modules receive injected read adapters.
+const { execFileSync } = require("node:child_process");
+const {
+  resolveRepoContext,
+  receiptPathFor,
+  readReceiptFile,
+  receiptExists,
+  listManifestFiles,
+  makeUrlResolver,
+} = require("./receipt-io");
+const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
+const { parseReceipt } = require("./lib/receipt");
+const { parseManifest } = require("./lib/manifest-parse");
+const { deriveStatusReport } = require("./lib/status-derive");
+const { StatusError, USAGE_EXIT, reject } = require("./lib/status-reasons");
+
+const READ_TIMEOUT_MS = 15000;
+const READ_MAX_BUFFER = 4 * 1024 * 1024;
+
+function usageError(message) {
+  process.stderr.write(`relay-orca status: ${message}\n`);
+  process.stderr.write(
+    "usage: status.js --program-id <id> [--json] [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
+  );
+  process.exit(USAGE_EXIT);
+}
+
+function requireValue(value, flag) {
+  if (!value || value.startsWith("-")) usageError(`${flag} requires a value`);
+  return value;
+}
+
+function parseArgs(argv) {
+  const opts = { programId: null, json: false, orcaBin: null, ghBin: null, repoRoot: null, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--program-id" || arg === "-p") opts.programId = requireValue(argv[(i += 1)], "--program-id");
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
+    else if (arg === "--gh-bin") opts.ghBin = requireValue(argv[(i += 1)], "--gh-bin");
+    else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+// Structural read-only refusal for Orca (belt-and-suspenders alongside the fixture
+// poisons): no mutating orchestration subcommand, no reset, no worktree ever runs.
+function assertOrcaReadOnly(argv) {
+  const mutating = argv.includes("reset")
+    || argv.includes("worktree")
+    || argv.includes("task-create")
+    || argv.includes("task-update")
+    || (argv[0] === "orchestration" && argv[1] === "dispatch")
+    || argv[0] === "terminal";
+  if (mutating) {
+    throw new Error(`relay-orca status must never invoke a mutating Orca subcommand (got: ${argv.join(" ")})`);
+  }
+}
+
+// Structural read-only refusal for gh: only `issue view`, `pr view`, and read-shaped
+// `api` GETs are permitted (D3). Any write subcommand is refused before it runs.
+function assertGhReadOnly(argv) {
+  const isIssueView = argv[0] === "issue" && argv[1] === "view";
+  const isPrView = argv[0] === "pr" && argv[1] === "view";
+  const isApiRead = argv[0] === "api" && !argv.some((token) => /^(-X|--method)$/.test(token))
+    && !argv.some((token) => /^(POST|PATCH|PUT|DELETE)$/i.test(token));
+  if (!isIssueView && !isPrView && !isApiRead) {
+    throw new Error(`relay-orca status must never invoke a non-read gh subcommand (got: ${argv.join(" ")})`);
+  }
+}
+
+function makeRunner(bin, assertReadOnly) {
+  if (!bin) return null;
+  return (_bin, args) => {
+    const argv = (Array.isArray(args) ? args : []).map(String);
+    assertReadOnly(argv);
+    try {
+      const stdout = execFileSync(bin, argv, {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: READ_TIMEOUT_MS,
+        maxBuffer: READ_MAX_BUFFER,
+      });
+      return { status: 0, stdout: String(stdout || ""), stderr: "" };
+    } catch (error) {
+      return {
+        status: typeof error.status === "number" ? error.status : 1,
+        stdout: error.stdout ? String(error.stdout) : "",
+        stderr: error.stderr ? String(error.stderr) : "",
+      };
+    }
+  };
+}
+
+function loadReceipt(receiptPath) {
+  if (!receiptExists(receiptPath)) {
+    reject("RECEIPT_NOT_FOUND", `no receipt found at ${receiptPath}`);
+  }
+  const parsed = parseReceipt(readReceiptFile(receiptPath));
+  if (!parsed.ok) reject("RECEIPT_CORRUPT", parsed.reason);
+  return parsed.receipt;
+}
+
+function resolveGhBin(opts) {
+  if (opts.ghBin) return opts.ghBin;
+  const env = process.env.RELAY_ORCA_GH_BIN;
+  return env && env.trim() !== "" ? env.trim() : "gh";
+}
+
+function resolveOrca(opts) {
+  const resolved = resolveOrcaBin({ orcaBinOverride: opts.orcaBin || null });
+  return resolved.path || null;
+}
+
+function printReport(report, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`relay-orca status for ${report.program_id} (runtime=${report.runtime}, program_state=${report.program_state})\n`);
+  report.outcomes.forEach((outcome) => {
+    process.stdout.write(`  ${outcome.outcome_id} [${outcome.state}] kind=${outcome.kind} wave=${outcome.wave}\n`);
+  });
+  report.diagnostics.forEach((diagnostic) => {
+    process.stdout.write(`  diagnostic [${diagnostic.code}] ${diagnostic.outcome_id || "-"}: ${diagnostic.message}\n`);
+  });
+}
+
+function failStatus(error, json) {
+  const body = { ok: false, reason_code: error.reasonCode, message: error.message, remediation: error.remediation || "" };
+  if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  else process.stderr.write(`relay-orca status rejected [${error.reasonCode}]: ${error.message}\n`);
+  process.exit(error.exitCode);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) usageError("read-only live reconciler for an accepted program");
+  if (!opts.programId) usageError("--program-id is required");
+
+  let report;
+  try {
+    const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+    const receiptPath = receiptPathFor(repo.slug, opts.programId);
+    const receipt = loadReceipt(receiptPath);
+    if (receipt.repo && receipt.repo.slug !== repo.slug) {
+      reject("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
+    }
+    const manifests = listManifestFiles(repo.slug).map((entry) => ({
+      run_id: entry.run_id,
+      text: entry.text,
+      parsed: parseManifest(entry.text),
+    }));
+    report = deriveStatusReport({
+      receipt,
+      programId: opts.programId,
+      receiptPath,
+      manifests,
+      orca: makeRunner(resolveOrca(opts), assertOrcaReadOnly),
+      gh: makeRunner(resolveGhBin(opts), assertGhReadOnly),
+      urlFor: makeUrlResolver(repo.root),
+    });
+  } catch (error) {
+    if (error instanceof StatusError) failStatus(error, opts.json);
+    throw error;
+  }
+
+  printReport(report, opts.json);
+  process.exitCode = 0;
+}
+
+main();

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -45,7 +45,25 @@ function poison(code) { if (poisonPath) fs.writeFileSync(poisonPath, "GH_WRITE_I
 
 const isIssueView = args[0] === "issue" && args[1] === "view";
 const isPrView = args[0] === "pr" && args[1] === "view";
-const isApiWrite = args[0] === "api" && (args.some(function (t) { return t === "-X" || t === "--method"; }) || args.some(function (t) { return /^(POST|PATCH|PUT|DELETE)$/i.test(t); }));
+// A28: body/field options make \`gh api\` default to a mutating POST even without \`-X\`;
+// an explicit non-GET method (separated or attached) is likewise a write. Mirror the
+// status.js assertGhReadOnly boundary so this poison layer rejects the same shapes.
+const GH_API_BODY_OPTS = ["-f", "--field", "-F", "--raw-field", "--input"];
+function ghApiMethod(a) {
+  for (var i = 0; i < a.length; i++) {
+    var t = a[i];
+    if (t === "-X" || t === "--method") return String(a[i + 1] || "");
+    if (t.indexOf("--method=") === 0) return t.slice(9);
+    if (t.indexOf("-X") === 0 && t.length > 2) return t.slice(2);
+  }
+  return null;
+}
+var apiMethod = args[0] === "api" ? ghApiMethod(args) : null;
+const isApiWrite = args[0] === "api" && (
+  args.some(function (t) { return GH_API_BODY_OPTS.indexOf(t) >= 0; })
+  || (apiMethod !== null && apiMethod.trim().toUpperCase() !== "GET")
+  || args.some(function (t) { return /^(POST|PATCH|PUT|DELETE)$/i.test(t); })
+);
 const isApiRead = args[0] === "api" && !isApiWrite;
 
 if (!isIssueView && !isPrView && !isApiRead) poison(92);

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -1,0 +1,101 @@
+"use strict";
+
+/**
+ * Read-only fake `gh` CLI fixture for relay-orca `status` tests (#945 D3/D10),
+ * following the tests/relay-review/fixtures/fake-gh.js house pattern but hardened for
+ * the read-only contract: it serves ONLY `gh issue view` and `gh pr view` reads (and
+ * read-shaped `gh api` GETs). ANY other subcommand — pr merge, pr comment, issue
+ * close, an `api` with a write method, etc. — writes a poison marker and exits
+ * non-zero so the test hard-fails.
+ *
+ * Behavior is scenario-driven: `issues[<n>]` and `prs[<n>]` supply the JSON the pinned
+ * D4 field lists (`state,stateReason` and `state,mergedAt,headRefOid`) return. Every
+ * invocation is appended to a shared log.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function defaultGhScenario(overrides = {}) {
+  return {
+    issues: overrides.issues || {},
+    prs: overrides.prs || {},
+  };
+}
+
+function fakeGhScript({ scenarioPath, logPath, poisonPath }) {
+  return `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+
+function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
+appendLog(args.join(" "));
+function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
+function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
+function poison(code) { if (poisonPath) fs.writeFileSync(poisonPath, "GH_WRITE_INVOKED:" + args.join(" "), "utf-8"); process.stderr.write("POISON: gh non-read subcommand must never run\\n"); process.exit(code); }
+
+const isIssueView = args[0] === "issue" && args[1] === "view";
+const isPrView = args[0] === "pr" && args[1] === "view";
+const isApiWrite = args[0] === "api" && (args.some(function (t) { return t === "-X" || t === "--method"; }) || args.some(function (t) { return /^(POST|PATCH|PUT|DELETE)$/i.test(t); }));
+const isApiRead = args[0] === "api" && !isApiWrite;
+
+if (!isIssueView && !isPrView && !isApiRead) poison(92);
+
+const scenario = loadScenario();
+
+if (isIssueView) {
+  const number = args[2];
+  const issue = scenario.issues && scenario.issues[number];
+  if (!issue) { process.stderr.write("issue not found\\n"); process.exit(1); }
+  emit({ state: issue.state, stateReason: issue.stateReason === undefined ? null : issue.stateReason }, 0);
+}
+if (isPrView) {
+  const number = args[2];
+  const pr = scenario.prs && scenario.prs[number];
+  if (!pr) { process.stderr.write("pr not found\\n"); process.exit(1); }
+  emit({ state: pr.state, mergedAt: pr.mergedAt === undefined ? null : pr.mergedAt, headRefOid: pr.headRefOid === undefined ? null : pr.headRefOid }, 0);
+}
+if (isApiRead) emit({}, 0);
+
+process.stderr.write("Unsupported fake gh invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+}
+
+function installFakeGh(scenarioOverrides = {}, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-orca-fake-gh-"));
+  const ghPath = path.join(dir, options.binName || "gh");
+  const scenarioPath = path.join(dir, "scenario.json");
+  const logPath = path.join(dir, "invocations.log");
+  const poisonPath = path.join(dir, "poison.txt");
+  const scenario = defaultGhScenario(scenarioOverrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
+  fs.writeFileSync(ghPath, fakeGhScript({ scenarioPath, logPath, poisonPath }), "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+
+  return {
+    dir,
+    ghPath,
+    scenarioPath,
+    logPath,
+    poisonPath,
+    scenario,
+    readLog() {
+      if (!fs.existsSync(logPath)) return [];
+      return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readPoison() {
+      if (!fs.existsSync(poisonPath)) return null;
+      return fs.readFileSync(poisonPath, "utf-8");
+    },
+    cleanup() {
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+module.exports = { defaultGhScenario, fakeGhScript, installFakeGh };

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -23,7 +23,7 @@ function defaultGhScenario(overrides = {}) {
   };
 }
 
-function fakeGhScript({ scenarioPath, logPath, poisonPath }) {
+function fakeGhScript({ scenarioPath, logPath, poisonPath, cwdLogPath }) {
   return `#!/usr/bin/env node
 "use strict";
 const fs = require("fs");
@@ -31,9 +31,14 @@ const args = process.argv.slice(2);
 const scenarioPath = ${JSON.stringify(scenarioPath)};
 const logPath = ${JSON.stringify(logPath)};
 const poisonPath = ${JSON.stringify(poisonPath)};
+const cwdLogPath = ${JSON.stringify(cwdLogPath)};
 
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
+// Record the cwd each invocation ran under so a test can prove every gh read is
+// scoped to the selected repository root (#945 A9), independent of the caller's cwd.
+function appendCwd() { if (cwdLogPath) fs.appendFileSync(cwdLogPath, process.cwd() + "\\n", "utf-8"); }
 appendLog(args.join(" "));
+appendCwd();
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
 function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
 function poison(code) { if (poisonPath) fs.writeFileSync(poisonPath, "GH_WRITE_INVOKED:" + args.join(" "), "utf-8"); process.stderr.write("POISON: gh non-read subcommand must never run\\n"); process.exit(code); }
@@ -72,9 +77,10 @@ function installFakeGh(scenarioOverrides = {}, options = {}) {
   const scenarioPath = path.join(dir, "scenario.json");
   const logPath = path.join(dir, "invocations.log");
   const poisonPath = path.join(dir, "poison.txt");
+  const cwdLogPath = path.join(dir, "cwd.log");
   const scenario = defaultGhScenario(scenarioOverrides);
   fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
-  fs.writeFileSync(ghPath, fakeGhScript({ scenarioPath, logPath, poisonPath }), "utf-8");
+  fs.writeFileSync(ghPath, fakeGhScript({ scenarioPath, logPath, poisonPath, cwdLogPath }), "utf-8");
   fs.chmodSync(ghPath, 0o755);
 
   return {
@@ -83,10 +89,15 @@ function installFakeGh(scenarioOverrides = {}, options = {}) {
     scenarioPath,
     logPath,
     poisonPath,
+    cwdLogPath,
     scenario,
     readLog() {
       if (!fs.existsSync(logPath)) return [];
       return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readCwdLog() {
+      if (!fs.existsSync(cwdLogPath)) return [];
+      return fs.readFileSync(cwdLogPath, "utf-8").split("\n").filter(Boolean);
     },
     readPoison() {
       if (!fs.existsSync(poisonPath)) return null;

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -62,6 +62,16 @@ if (isPrView) {
   const number = args[2];
   const pr = scenario.prs && scenario.prs[number];
   if (!pr) { process.stderr.write("pr not found\\n"); process.exit(1); }
+  // A20: gh pr view evidence is fetched via TWO required sub-reads — the merge read
+  // (--json mergedAt,state) and the head read (--json ...headRefOid). Distinguish them by
+  // the requested field list so a scenario can fail EITHER sub-read independently and
+  // prove a partial PR read degrades to unreachable (never substitutes a null head into a
+  // false complete).
+  const jsonIdx = args.indexOf("--json");
+  const fields = jsonIdx >= 0 ? String(args[jsonIdx + 1] || "") : "";
+  const isHeadRead = fields.indexOf("headRefOid") >= 0;
+  if (isHeadRead && pr.headReadFails) { process.stderr.write("pr head read failed\\n"); process.exit(1); }
+  if (!isHeadRead && pr.mergeReadFails) { process.stderr.write("pr merge read failed\\n"); process.exit(1); }
   emit({ state: pr.state, mergedAt: pr.mergedAt === undefined ? null : pr.mergedAt, headRefOid: pr.headRefOid === undefined ? null : pr.headRefOid }, 0);
 }
 if (isApiRead) emit({}, 0);

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -72,7 +72,14 @@ if (isPrView) {
   const isHeadRead = fields.indexOf("headRefOid") >= 0;
   if (isHeadRead && pr.headReadFails) { process.stderr.write("pr head read failed\\n"); process.exit(1); }
   if (!isHeadRead && pr.mergeReadFails) { process.stderr.write("pr merge read failed\\n"); process.exit(1); }
-  emit({ state: pr.state, mergedAt: pr.mergedAt === undefined ? null : pr.mergedAt, headRefOid: pr.headRefOid === undefined ? null : pr.headRefOid }, 0);
+  // A25: a real \`gh pr view\` on an existing PR ALWAYS returns a non-empty head OID, so
+  // default a stable non-empty \`headRefOid\` when a scenario does not pin one — otherwise a
+  // reachable merged PR would be mistaken for a head-missing degradation. A scenario models
+  // the MISSING-head case by setting \`headOmitted:true\` (key absent from the successful
+  // read) or \`headRefOid:null\`/\`""\` (present but empty).
+  const payload = { state: pr.state, mergedAt: pr.mergedAt === undefined ? null : pr.mergedAt };
+  if (!pr.headOmitted) payload.headRefOid = pr.headRefOid === undefined ? ("head-" + number) : pr.headRefOid;
+  emit(payload, 0);
 }
 if (isApiRead) emit({}, 0);
 

--- a/tests/relay-orca/fixtures/fake-orca-status.js
+++ b/tests/relay-orca/fixtures/fake-orca-status.js
@@ -29,6 +29,10 @@ function defaultStatusScenario(overrides = {}) {
     // the runtime to "unreachable" instead of fabricating an empty [] with runtime "ok".
     taskListOk: overrides.taskListOk !== undefined ? overrides.taskListOk : true,
     gateListOk: overrides.gateListOk !== undefined ? overrides.gateListOk : true,
+    // A13 knob: when true, the `status` read SUCCEEDS (ok:true) but carries NO live
+    // runtime id — neither `result.runtime.runtimeId` nor `_meta.runtimeId` — so the
+    // derive path can prove a missing runtime id degrades the runtime to "unreachable".
+    omitRuntimeId: overrides.omitRuntimeId === true,
     tasks: overrides.tasks || [],
     gates: overrides.gates || [],
     dispatch: overrides.dispatch || {},
@@ -61,7 +65,12 @@ const meta = { runtimeId: scenario.runtimeId };
 
 if (args[0] === "status") {
   if (!scenario.statusOk) { process.stderr.write("orca status unreachable\\n"); process.exit(1); }
-  emit({ id: "status-1", ok: true, result: { app: { running: true, pid: 1 }, runtime: { state: "ready", reachable: true, runtimeId: scenario.runtimeId }, graph: { state: "ready" } }, _meta: meta }, 0);
+  // A13: omitRuntimeId emits a SUCCESSFUL status whose runtime block AND _meta both lack
+  // a runtimeId, so orcaStatus normalizes runtimeId to null (missing live runtime id).
+  const runtime = { state: "ready", reachable: true };
+  if (!scenario.omitRuntimeId) runtime.runtimeId = scenario.runtimeId;
+  const statusMeta = scenario.omitRuntimeId ? {} : meta;
+  emit({ id: "status-1", ok: true, result: { app: { running: true, pid: 1 }, runtime, graph: { state: "ready" } }, _meta: statusMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "task-list") {
   if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }

--- a/tests/relay-orca/fixtures/fake-orca-status.js
+++ b/tests/relay-orca/fixtures/fake-orca-status.js
@@ -1,0 +1,113 @@
+"use strict";
+
+/**
+ * Read-only fake Orca CLI fixture for relay-orca `status` tests (#945 D3/D10).
+ *
+ * Supports ONLY the read subcommands `status` needs: `status`,
+ * `orchestration task-list`, `orchestration gate-list`, and
+ * `orchestration dispatch-show`. EVERY mutating surface is POISONED on every path —
+ * it writes a poison marker and exits non-zero so the test hard-fails: `reset`, any
+ * `worktree` subcommand, and the mutating orchestration subcommands
+ * `task-create`, `task-update`, and `dispatch` (note: `dispatch-show` is a read and
+ * is NOT poisoned), plus any `terminal` subcommand.
+ *
+ * Behavior is scenario-driven via a JSON file; every invocation is appended to a
+ * shared log.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { DEFAULT_RUNTIME_ID } = require("./fake-orca");
+
+function defaultStatusScenario(overrides = {}) {
+  const runtimeId = overrides.runtimeId || DEFAULT_RUNTIME_ID;
+  return {
+    runtimeId,
+    statusOk: overrides.statusOk !== undefined ? overrides.statusOk : true,
+    tasks: overrides.tasks || [],
+    gates: overrides.gates || [],
+    dispatch: overrides.dispatch || {},
+  };
+}
+
+function fakeOrcaStatusScript({ scenarioPath, logPath, poisonPath }) {
+  return `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+
+function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
+appendLog(args.join(" "));
+function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
+function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
+function argValue(flag) { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : undefined; }
+function poison(marker, code) { if (poisonPath) fs.writeFileSync(poisonPath, marker + ":" + args.join(" "), "utf-8"); process.stderr.write("POISON: " + marker + "\\n"); process.exit(code); }
+
+if (args.includes("reset")) poison("RESET_INVOKED", 99);
+if (args.includes("worktree")) poison("WORKTREE_INVOKED", 98);
+if (args[0] === "orchestration" && (args[1] === "task-create" || args[1] === "task-update" || args[1] === "dispatch")) poison("MUTATION_INVOKED", 97);
+if (args[0] === "terminal") poison("TERMINAL_INVOKED", 96);
+
+const scenario = loadScenario();
+const meta = { runtimeId: scenario.runtimeId };
+
+if (args[0] === "status") {
+  if (!scenario.statusOk) { process.stderr.write("orca status unreachable\\n"); process.exit(1); }
+  emit({ id: "status-1", ok: true, result: { app: { running: true, pid: 1 }, runtime: { state: "ready", reachable: true, runtimeId: scenario.runtimeId }, graph: { state: "ready" } }, _meta: meta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "task-list") {
+  const tasks = Array.isArray(scenario.tasks) ? scenario.tasks : [];
+  emit({ id: "task-list-1", ok: true, result: { tasks, count: tasks.length }, _meta: meta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "gate-list") {
+  const gates = Array.isArray(scenario.gates) ? scenario.gates : [];
+  emit({ id: "gate-list-1", ok: true, result: { gates, count: gates.length }, _meta: meta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "dispatch-show") {
+  const task = argValue("--task");
+  const override = (scenario.dispatch && scenario.dispatch[task]) || {};
+  const result = Object.assign({ task_id: task, dispatch_id: "disp-" + task, assignee: "term-" + task, terminal_present: true }, override);
+  emit({ id: "ds-" + task, ok: true, result, _meta: meta }, 0);
+}
+
+process.stderr.write("Unsupported fake orca (status) invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+}
+
+function installFakeOrcaStatus(scenarioOverrides = {}, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-orca-status-"));
+  const orcaPath = path.join(dir, options.binName || "orca");
+  const scenarioPath = path.join(dir, "scenario.json");
+  const logPath = path.join(dir, "invocations.log");
+  const poisonPath = path.join(dir, "poison.txt");
+  const scenario = defaultStatusScenario(scenarioOverrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
+  fs.writeFileSync(orcaPath, fakeOrcaStatusScript({ scenarioPath, logPath, poisonPath }), "utf-8");
+  fs.chmodSync(orcaPath, 0o755);
+
+  return {
+    dir,
+    orcaPath,
+    scenarioPath,
+    logPath,
+    poisonPath,
+    scenario,
+    readLog() {
+      if (!fs.existsSync(logPath)) return [];
+      return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readPoison() {
+      if (!fs.existsSync(poisonPath)) return null;
+      return fs.readFileSync(poisonPath, "utf-8");
+    },
+    cleanup() {
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+module.exports = { defaultStatusScenario, fakeOrcaStatusScript, installFakeOrcaStatus };

--- a/tests/relay-orca/fixtures/fake-orca-status.js
+++ b/tests/relay-orca/fixtures/fake-orca-status.js
@@ -24,6 +24,11 @@ function defaultStatusScenario(overrides = {}) {
   return {
     runtimeId,
     statusOk: overrides.statusOk !== undefined ? overrides.statusOk : true,
+    // Required-read failure knobs (#945 A4): when false, the read subcommand exits
+    // non-zero so the derive path can prove a failed task-list/gate-list read degrades
+    // the runtime to "unreachable" instead of fabricating an empty [] with runtime "ok".
+    taskListOk: overrides.taskListOk !== undefined ? overrides.taskListOk : true,
+    gateListOk: overrides.gateListOk !== undefined ? overrides.gateListOk : true,
     tasks: overrides.tasks || [],
     gates: overrides.gates || [],
     dispatch: overrides.dispatch || {},
@@ -59,10 +64,12 @@ if (args[0] === "status") {
   emit({ id: "status-1", ok: true, result: { app: { running: true, pid: 1 }, runtime: { state: "ready", reachable: true, runtimeId: scenario.runtimeId }, graph: { state: "ready" } }, _meta: meta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "task-list") {
+  if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }
   const tasks = Array.isArray(scenario.tasks) ? scenario.tasks : [];
   emit({ id: "task-list-1", ok: true, result: { tasks, count: tasks.length }, _meta: meta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "gate-list") {
+  if (scenario.gateListOk === false) { process.stderr.write("orca gate-list unreachable\\n"); process.exit(1); }
   const gates = Array.isArray(scenario.gates) ? scenario.gates : [];
   emit({ id: "gate-list-1", ok: true, result: { gates, count: gates.length }, _meta: meta }, 0);
 }

--- a/tests/relay-orca/fixtures/fake-orca-status.js
+++ b/tests/relay-orca/fixtures/fake-orca-status.js
@@ -33,8 +33,16 @@ function defaultStatusScenario(overrides = {}) {
     // runtime id — neither `result.runtime.runtimeId` nor `_meta.runtimeId` — so the
     // derive path can prove a missing runtime id degrades the runtime to "unreachable".
     omitRuntimeId: overrides.omitRuntimeId === true,
+    // A17 per-read runtime-id knobs: when set, the whole-runtime read emits THIS
+    // `_meta.runtimeId` instead of the shared runtimeId, so a test can prove a task-list
+    // or gate-list read from a DIFFERENT runtime degrades the runtime to "unreachable".
+    taskListRuntimeId: overrides.taskListRuntimeId,
+    gateListRuntimeId: overrides.gateListRuntimeId,
     tasks: overrides.tasks || [],
     gates: overrides.gates || [],
+    // A17 per-task knob: a dispatch override may carry `runtimeId`, which becomes THAT
+    // task's dispatch-show `_meta.runtimeId` (never a result-payload field), so a test can
+    // prove a mismatched per-task read marks only that task's facts unknown.
     dispatch: overrides.dispatch || {},
   };
 }
@@ -75,18 +83,25 @@ if (args[0] === "status") {
 if (args[0] === "orchestration" && args[1] === "task-list") {
   if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }
   const tasks = Array.isArray(scenario.tasks) ? scenario.tasks : [];
-  emit({ id: "task-list-1", ok: true, result: { tasks, count: tasks.length }, _meta: meta }, 0);
+  const taskMeta = scenario.taskListRuntimeId !== undefined ? { runtimeId: scenario.taskListRuntimeId } : meta;
+  emit({ id: "task-list-1", ok: true, result: { tasks, count: tasks.length }, _meta: taskMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "gate-list") {
   if (scenario.gateListOk === false) { process.stderr.write("orca gate-list unreachable\\n"); process.exit(1); }
   const gates = Array.isArray(scenario.gates) ? scenario.gates : [];
-  emit({ id: "gate-list-1", ok: true, result: { gates, count: gates.length }, _meta: meta }, 0);
+  const gateMeta = scenario.gateListRuntimeId !== undefined ? { runtimeId: scenario.gateListRuntimeId } : meta;
+  emit({ id: "gate-list-1", ok: true, result: { gates, count: gates.length }, _meta: gateMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   const task = argValue("--task");
   const override = (scenario.dispatch && scenario.dispatch[task]) || {};
-  const result = Object.assign({ task_id: task, dispatch_id: "disp-" + task, assignee: "term-" + task, terminal_present: true }, override);
-  emit({ id: "ds-" + task, ok: true, result, _meta: meta }, 0);
+  // A17: a per-task runtimeId override rides in _meta, never the result payload, so it
+  // mirrors the real per-read runtime id without polluting the dispatch fields.
+  const dispatchMeta = override.runtimeId !== undefined ? { runtimeId: override.runtimeId } : meta;
+  const resultOverride = Object.assign({}, override);
+  delete resultOverride.runtimeId;
+  const result = Object.assign({ task_id: task, dispatch_id: "disp-" + task, assignee: "term-" + task, terminal_present: true }, resultOverride);
+  emit({ id: "ds-" + task, ok: true, result, _meta: dispatchMeta }, 0);
 }
 
 process.stderr.write("Unsupported fake orca (status) invocation: " + args.join(" ") + "\\n");

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -16,7 +16,7 @@ const { REPORT_KEYS } = require(path.join(SCRIPTS, "lib", "run-report.js"));
 const { compileProgram } = require(path.join(SCRIPTS, "lib", "compile-program.js"));
 const { RECEIPT_KEYS, TASK_KEYS, RECEIPT_NOTE, parseReceipt } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
-const { writeReceiptAtomic } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { writeReceiptAtomic, programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
 const {
   buildOperatorPrompt,
   PAYLOAD_FIELDS,
@@ -601,6 +601,16 @@ test("D10.12: writeReceiptAtomic is temp+rename — a crash during rename leaves
   assert.equal(published, finalPath);
   assert.equal(fs.readFileSync(finalPath, "utf-8"), '{"schema":1}\n');
   fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("D1: programSegment neutralizes path-traversal program ids so a receipt cannot escape its dir", () => {
+  assert.equal(programSegment(".."), "program");
+  assert.equal(programSegment("."), "program");
+  // separators collapse to a dash → a single safe segment that cannot traverse.
+  assert.equal(programSegment("../../etc/passwd"), "..-..-etc-passwd");
+  assert.ok(!programSegment("../../etc/passwd").includes("/"));
+  assert.equal(programSegment("epic-941"), "epic-941");
+  assert.equal(programSegment("epic.941_v2"), "epic.941_v2");
 });
 
 // Keep the imported parse helper referenced.

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -4,6 +4,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
@@ -13,6 +14,9 @@ const RUN_JS = path.join(SCRIPTS, "run.js");
 const { REASONS } = require(path.join(SCRIPTS, "lib", "run-reasons.js"));
 const { REPORT_KEYS } = require(path.join(SCRIPTS, "lib", "run-report.js"));
 const { compileProgram } = require(path.join(SCRIPTS, "lib", "compile-program.js"));
+const { RECEIPT_KEYS, TASK_KEYS, RECEIPT_NOTE, parseReceipt } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
+const { writeReceiptAtomic } = require(path.join(SCRIPTS, "receipt-io.js"));
 const {
   buildOperatorPrompt,
   PAYLOAD_FIELDS,
@@ -65,11 +69,44 @@ function runRun(args, env = {}) {
   return result;
 }
 
+// Isolate receipt persistence (#945 D2) into temp roots so run tests never touch the
+// real ~/.relay: a temp programs root + a temp --repo-root (realpath'd for a stable
+// slug). fake.cleanup() is extended to remove them.
+function makeReceiptWorld() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-run-receipt-"));
+  const programsRoot = path.join(base, "programs");
+  const repoRoot = path.join(base, "repo");
+  fs.mkdirSync(programsRoot, { recursive: true });
+  fs.mkdirSync(repoRoot, { recursive: true });
+  return { base, programsRoot, repoRoot, slug: computeRepoSlug(fs.realpathSync(repoRoot)) };
+}
+
+function receiptPathForWorld(world, programId) {
+  const segment = String(programId).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "program";
+  return path.join(world.programsRoot, world.slug, segment, "receipt.json");
+}
+
 function runProgram(fixtureName, extraArgs, scenario, options = {}) {
   const fake = installFakeOrcaRun(scenario || {});
-  const args = ["--json", "--orca-bin", fake.orcaPath, "--program-file", fixture(fixtureName), ...(extraArgs || [])];
-  const result = runRun(args, options.env);
+  const world = makeReceiptWorld();
+  const args = [
+    "--json",
+    "--orca-bin",
+    fake.orcaPath,
+    "--repo-root",
+    world.repoRoot,
+    "--program-file",
+    fixture(fixtureName),
+    ...(extraArgs || []),
+  ];
+  const result = runRun(args, { RELAY_ORCA_PROGRAMS_ROOT: world.programsRoot, ...options.env });
   result.fake = fake;
+  result.world = world;
+  const origCleanup = fake.cleanup;
+  fake.cleanup = () => {
+    origCleanup();
+    fs.rmSync(world.base, { recursive: true, force: true });
+  };
   result.body = result.stdout ? JSON.parse(result.stdout) : null;
   return result;
 }
@@ -480,6 +517,90 @@ test("usage: unknown flag exits 64", () => {
 test("usage: missing --program-file exits 64", () => {
   const r = runRun(["--json"]);
   assert.equal(r.status, 64);
+});
+
+// ---------------------------------------------------------------------------
+// #945 D1/D2 — receipt persistence wired into the run intent
+// ---------------------------------------------------------------------------
+
+test("D2: a successful run persists a schema-1 receipt (identity/mapping only) and reports receipt_path", () => {
+  const r = runProgram("run-two-wave1.json", ["--operator-handle", "h1", "--operator-handle", "h2"]);
+  try {
+    assert.equal(r.status, 0);
+    const receiptPath = receiptPathForWorld(r.world, "epic-run-two");
+    assert.equal(r.body.receipt_path, receiptPath, "receipt_path echoes the atomically-written receipt");
+    assert.ok(fs.existsSync(receiptPath), "receipt file exists on disk");
+
+    const parsed = parseReceipt(fs.readFileSync(receiptPath, "utf-8"));
+    assert.equal(parsed.ok, true, `receipt must parse+validate: ${parsed.reason || ""}`);
+    const receipt = parsed.receipt;
+    assert.deepEqual(Object.keys(receipt).sort(), [...RECEIPT_KEYS].sort());
+    assert.equal(receipt.schema, 1);
+    assert.equal(receipt.note, RECEIPT_NOTE, "verbatim authority-disclaimer note");
+    assert.equal(receipt.program_id, "epic-run-two");
+    assert.equal(receipt.repo.slug, r.world.slug);
+    assert.equal(receipt.repo.root, fs.realpathSync(r.world.repoRoot));
+    assert.ok(receipt.runtime_id, "runtime_id captured from admission");
+    assert.match(receipt.created_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.match(receipt.updated_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.deepEqual(receipt.terminals_created, []);
+
+    // Each task entry carries EXACTLY the identity/mapping keys — never lifecycle
+    // state, PR/issue status, completion flags, prompts, or terminal output.
+    assert.equal(receipt.tasks.length, 2);
+    receipt.tasks.forEach((task) => {
+      assert.deepEqual(Object.keys(task).sort(), [...TASK_KEYS].sort());
+      assert.ok(task.orca_task_id, "materialized orca id recorded");
+      assert.ok(task.dispatch_id, "dispatch id recorded after verification");
+      assert.deepEqual(task.relay_ids, { request: null, run: null, fleet: null });
+    });
+    assert.equal(taskByOutcome(receipt, "alpha").assignee, "h1");
+    assert.equal(taskByOutcome(receipt, "bravo").assignee, "h2");
+
+    // D11-style engine-agnostic proof over the written receipt bytes.
+    const lowered = fs.readFileSync(receiptPath, "utf-8").toLowerCase();
+    FORBIDDEN_ENGINE_TOKENS.forEach((token) =>
+      assert.equal(lowered.includes(token), false, `receipt leaked engine/model token ${token}`),
+    );
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+test("D2: an admission rejection never writes a receipt (persist happens after materialization)", () => {
+  const status = readyStatus();
+  status.result.app.running = false;
+  const r = runProgram("run-two-wave1.json", ["--operator-handle", "h1"], { status });
+  try {
+    assert.equal(r.status, REASONS.ADMISSION_REJECTED);
+    assert.equal(r.body.receipt_path, null);
+    assert.equal(fs.existsSync(receiptPathForWorld(r.world, "epic-run-two")), false);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+test("D10.12: writeReceiptAtomic is temp+rename — a crash during rename leaves no partial receipt", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-atomic-"));
+  const finalPath = path.join(dir, "nested", "receipt.json");
+  const crashingIo = {
+    mkdirSync: fs.mkdirSync,
+    writeFileSync: fs.writeFileSync,
+    renameSync: () => {
+      throw new Error("crash during publish");
+    },
+  };
+  assert.throws(() => writeReceiptAtomic(finalPath, '{"schema":1}\n', crashingIo));
+  assert.equal(fs.existsSync(finalPath), false, "the published receipt never appears when rename crashes");
+  const leftovers = fs.readdirSync(path.dirname(finalPath));
+  assert.ok(leftovers.some((name) => name.startsWith(".receipt.")), "the temp file lives in the SAME directory");
+  assert.ok(leftovers.every((name) => name !== "receipt.json"), "no torn receipt.json is published");
+
+  // Happy path: rename publishes exactly the final file with the full contents.
+  const published = writeReceiptAtomic(finalPath, '{"schema":1}\n');
+  assert.equal(published, finalPath);
+  assert.equal(fs.readFileSync(finalPath, "utf-8"), '{"schema":1}\n');
+  fs.rmSync(dir, { recursive: true, force: true });
 });
 
 // Keep the imported parse helper referenced.

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -87,6 +87,35 @@ function receiptPathForWorld(world, programId) {
   return path.join(world.programsRoot, world.slug, programSegment(programId), "receipt.json");
 }
 
+// A22 harness: a REAL primary git checkout plus a LINKED WORKTREE whose `.git` FILE points
+// at the primary's git-common-dir. `--repo-root` is pointed at the worktree; run.js must
+// canonicalize it through git to the PRIMARY root so the receipt lands under the primary
+// slug (`primarySlug`), NOT the worktree-directory slug (`worktreeSlug`).
+function makeGitWorktreeReceiptWorld() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-run-worktree-"));
+  const programsRoot = path.join(base, "programs");
+  const primary = path.join(base, "primary");
+  const worktree = path.join(base, "wt");
+  fs.mkdirSync(programsRoot, { recursive: true });
+  fs.mkdirSync(primary, { recursive: true });
+  const git = (args, cwd) => execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"], primary);
+  git(["config", "user.email", "t@t.com"], primary);
+  git(["config", "user.name", "t"], primary);
+  git(["commit", "-q", "--allow-empty", "-m", "init"], primary);
+  git(["worktree", "add", "-q", "--detach", worktree, "HEAD"], primary);
+  const primaryRoot = fs.realpathSync(primary);
+  return {
+    base,
+    programsRoot,
+    primary,
+    worktree,
+    primaryRoot,
+    primarySlug: computeRepoSlug(primaryRoot),
+    worktreeSlug: computeRepoSlug(fs.realpathSync(worktree)),
+  };
+}
+
 function runProgram(fixtureName, extraArgs, scenario, options = {}) {
   const fake = installFakeOrcaRun(scenario || {});
   const world = makeReceiptWorld();
@@ -596,6 +625,49 @@ test("D2: a successful run persists a schema-1 receipt (identity/mapping only) a
     );
   } finally {
     r.fake.cleanup();
+  }
+});
+
+test("A22: run --repo-root pointed at a LINKED WORKTREE writes the receipt under the PRIMARY slug (git-canonical repo root)", () => {
+  // The provided --repo-root is a linked worktree whose `.git` FILE points at the primary
+  // checkout's git-common-dir. run.js canonicalizes it through git to the PRIMARY root, so the
+  // receipt lands under the primary slug — the SAME slug status derives from the same worktree
+  // input (both call resolveRepoContext). A plain-realpath resolver would have used the
+  // worktree-directory slug and written the receipt somewhere status could never find it.
+  const world = makeGitWorktreeReceiptWorld();
+  const fake = installFakeOrcaRun({});
+  try {
+    assert.notEqual(world.primarySlug, world.worktreeSlug, "the worktree dir slug differs from the primary slug");
+    const r = runRun(
+      [
+        "--json",
+        "--orca-bin",
+        fake.orcaPath,
+        "--repo-root",
+        world.worktree,
+        "--program-file",
+        fixture("run-two-wave1.json"),
+        "--operator-handle",
+        "h1",
+        "--operator-handle",
+        "h2",
+      ],
+      { RELAY_ORCA_PROGRAMS_ROOT: world.programsRoot },
+    );
+    assert.equal(r.status, 0);
+    const body = JSON.parse(r.stdout);
+    // The receipt is written under the PRIMARY slug, never the worktree-directory slug.
+    const primaryPath = path.join(world.programsRoot, world.primarySlug, programSegment("epic-run-two"), "receipt.json");
+    const worktreePath = path.join(world.programsRoot, world.worktreeSlug, programSegment("epic-run-two"), "receipt.json");
+    assert.equal(body.receipt_path, primaryPath, "receipt_path is under the canonical PRIMARY slug");
+    assert.ok(fs.existsSync(primaryPath), "receipt exists under the primary slug");
+    assert.equal(fs.existsSync(worktreePath), false, "no receipt is written under the worktree-directory slug");
+    const receipt = parseReceipt(fs.readFileSync(primaryPath, "utf-8")).receipt;
+    assert.equal(receipt.repo.slug, world.primarySlug, "receipt records the primary slug");
+    assert.equal(receipt.repo.root, world.primaryRoot, "receipt records the canonical primary root");
+  } finally {
+    fake.cleanup();
+    fs.rmSync(world.base, { recursive: true, force: true });
   }
 });
 

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -640,6 +640,34 @@ test("A2: a prompt-delivery failure still leaves the receipt carrying the verifi
   }
 });
 
+test("A16: a dispatch failure right after an AUTO-created terminal leaves the on-disk receipt already carrying the handle", () => {
+  // No explicit --operator-handle → run auto-creates a terminal ("orca-term-1"), records
+  // it, and (A16) persists the receipt IMMEDIATELY — BEFORE the dispatch. The dispatch then
+  // fails (INJECTION_UNDELIVERED, exit 42) before any provenance-verification write could run.
+  // Without the immediate persist the mapping-changing writes only happen after dispatch-show,
+  // so the handle would be lost from disk; A16 makes the created terminal durable so a
+  // reconcile can adopt (not re-create) it.
+  const r = runProgram("valid-single-relay-run.json", [], { dispatchFailFor: "orca-live-outcome-a" });
+  try {
+    assert.equal(r.status, REASONS.INJECTION_UNDELIVERED);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "INJECTION_UNDELIVERED");
+    assert.equal(taskByOutcome(r.body, "outcome-a").status, "escalated");
+    // The in-memory report is truthful about the auto-created terminal...
+    assert.deepEqual(r.body.terminals_created, ["orca-term-1"]);
+
+    // ...and so is the receipt ON DISK, written before the failing dispatch.
+    const receiptPath = receiptPathForWorld(r.world, "epic-demo-single");
+    assert.ok(fs.existsSync(receiptPath), "receipt persisted right after the terminal was created");
+    assert.equal(r.body.receipt_path, receiptPath, "the report echoes the persisted receipt path");
+    const parsed = parseReceipt(fs.readFileSync(receiptPath, "utf-8"));
+    assert.equal(parsed.ok, true, `receipt must parse+validate: ${parsed.reason || ""}`);
+    assert.deepEqual(parsed.receipt.terminals_created, ["orca-term-1"], "the created terminal handle is durable despite the dispatch failure");
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
 test("D10.12: writeReceiptAtomic is temp+rename — a crash during rename leaves no partial receipt", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-atomic-"));
   const finalPath = path.join(dir, "nested", "receipt.json");

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -717,6 +717,14 @@ test("A24: run --repo-root pointed at a NON-git dir fails closed with RECEIPT_RE
     assert.match(body.message, /could not be canonicalized/i);
     // No receipt is written anywhere under the programs root when canonicalization fails.
     assert.deepEqual(fs.readdirSync(programsRoot), [], "no receipt directory is created on a fail-closed canonicalization");
+    // A27: canonicalization is EAGER — it runs before any admission/materialization mutation,
+    // so exit 52 leaves ZERO mutating Orca invocations in the fixture log (no task-create,
+    // terminal, or dispatch). Before A27 the first task-create ran before the receipt path was
+    // resolved, so a canon failure mutated Orca before failing (dropping that task's mapping).
+    const orcaLog = fake.readLog().join(" ");
+    ["task-create", "terminal", "dispatch"].forEach((mutating) =>
+      assert.equal(orcaLog.includes(mutating), false, `no ${mutating} may run before a fail-closed canonicalization; log=${orcaLog}`),
+    );
   } finally {
     fake.cleanup();
     fs.rmSync(nonGit, { recursive: true, force: true });

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -82,8 +82,9 @@ function makeReceiptWorld() {
 }
 
 function receiptPathForWorld(world, programId) {
-  const segment = String(programId).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "program";
-  return path.join(world.programsRoot, world.slug, segment, "receipt.json");
+  // Use the SAME collision-resistant segment encoder run.js/status.js use (#945 A6),
+  // so the expected path stays in lock-step with the production path derivation.
+  return path.join(world.programsRoot, world.slug, programSegment(programId), "receipt.json");
 }
 
 function runProgram(fixtureName, extraArgs, scenario, options = {}) {
@@ -580,6 +581,34 @@ test("D2: an admission rejection never writes a receipt (persist happens after m
   }
 });
 
+test("A2: a prompt-delivery failure still leaves the receipt carrying the verified provenance trio", () => {
+  // sendPrompt (terminal send) fails AFTER dispatch-show verifies the provenance trio.
+  // The receipt must already carry the non-null (orca_task_id, dispatch_id, assignee)
+  // for the escalated outcome — provenance persists BEFORE prompt delivery (A2) — while
+  // the failure's report semantics stay exactly as before (INJECTION_UNDELIVERED, exit 42).
+  const r = runProgram("valid-single-relay-run.json", ["--operator-handle", "h1"], { terminalSendOkFalse: true });
+  try {
+    assert.equal(r.status, REASONS.INJECTION_UNDELIVERED);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "INJECTION_UNDELIVERED");
+    const task = taskByOutcome(r.body, "outcome-a");
+    assert.equal(task.status, "escalated");
+
+    const receiptPath = receiptPathForWorld(r.world, "epic-demo-single");
+    assert.ok(fs.existsSync(receiptPath), "receipt persisted before the prompt hand-off failed");
+    const parsed = parseReceipt(fs.readFileSync(receiptPath, "utf-8"));
+    assert.equal(parsed.ok, true, `receipt must parse+validate: ${parsed.reason || ""}`);
+    const entry = taskByOutcome(parsed.receipt, "outcome-a");
+    // The full verified provenance trio is durable despite the prompt failure.
+    assert.ok(entry.orca_task_id, "orca_task_id persisted");
+    assert.ok(entry.dispatch_id, "dispatch_id persisted before prompt delivery");
+    assert.ok(entry.assignee, "assignee persisted before prompt delivery");
+    assert.equal(entry.assignee, "h1");
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
 test("D10.12: writeReceiptAtomic is temp+rename — a crash during rename leaves no partial receipt", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-atomic-"));
   const finalPath = path.join(dir, "nested", "receipt.json");
@@ -603,14 +632,24 @@ test("D10.12: writeReceiptAtomic is temp+rename — a crash during rename leaves
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test("D1: programSegment neutralizes path-traversal program ids so a receipt cannot escape its dir", () => {
-  assert.equal(programSegment(".."), "program");
-  assert.equal(programSegment("."), "program");
-  // separators collapse to a dash → a single safe segment that cannot traverse.
-  assert.equal(programSegment("../../etc/passwd"), "..-..-etc-passwd");
+test("D1/A6: programSegment is traversal-safe AND collision-resistant (sanitized base + stable hash)", () => {
+  // Traversal neutralized: no separators, and `.` / `..` collapse to the `program` base.
   assert.ok(!programSegment("../../etc/passwd").includes("/"));
-  assert.equal(programSegment("epic-941"), "epic-941");
-  assert.equal(programSegment("epic.941_v2"), "epic.941_v2");
+  assert.match(programSegment("../../etc/passwd"), /^\.\.-\.\.-etc-passwd-[0-9a-f]{8}$/);
+  assert.match(programSegment(".."), /^program-[0-9a-f]{8}$/);
+  assert.match(programSegment("."), /^program-[0-9a-f]{8}$/);
+  // `.` and `..` sanitize identically but MUST NOT collide (distinct paths).
+  assert.notEqual(programSegment("."), programSegment(".."));
+
+  // Collision resistance: two ids that sanitize to the SAME base get DISTINCT segments.
+  assert.match(programSegment("a b"), /^a-b-[0-9a-f]{8}$/);
+  assert.match(programSegment("a+b"), /^a-b-[0-9a-f]{8}$/);
+  assert.notEqual(programSegment("a b"), programSegment("a+b"));
+
+  // Stable + deterministic: the same id always yields the same segment.
+  assert.equal(programSegment("epic-941"), programSegment("epic-941"));
+  assert.match(programSegment("epic-941"), /^epic-941-[0-9a-f]{8}$/);
+  assert.match(programSegment("epic.941_v2"), /^epic\.941_v2-[0-9a-f]{8}$/);
 });
 
 // Keep the imported parse helper referenced.

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -338,6 +338,37 @@ test("D11.7: task-create failure → TASK_MATERIALIZE_FAILED exit 41, earlier ta
 });
 
 // ---------------------------------------------------------------------------
+// A12 — partial materialization persists earlier mappings before failing (exit 41)
+// ---------------------------------------------------------------------------
+
+test("A12: a mid-wave task-create failure persists the earlier task's orca_task_id to disk, then exits 41", () => {
+  const r = runProgram(
+    "run-two-wave1.json",
+    ["--operator-handle", "h1", "--operator-handle", "h2"],
+    { taskCreateFailFor: "bravo" },
+  );
+  try {
+    // The run still fails closed with TASK_MATERIALIZE_FAILED (exit 41)...
+    assert.equal(r.status, REASONS.TASK_MATERIALIZE_FAILED);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "TASK_MATERIALIZE_FAILED");
+
+    // ...but because the receipt is persisted after EACH successful task-create (A12),
+    // the receipt ON DISK already carries alpha's orca_task_id even though bravo's
+    // create failed and no post-materialization write ever ran.
+    const receiptPath = receiptPathForWorld(r.world, "epic-run-two");
+    assert.ok(fs.existsSync(receiptPath), "the partial mapping is durable on disk");
+    assert.equal(r.body.receipt_path, receiptPath, "the report echoes the partially-written receipt path");
+    const parsed = parseReceipt(fs.readFileSync(receiptPath, "utf-8"));
+    assert.equal(parsed.ok, true, `partial receipt must parse+validate: ${parsed.reason || ""}`);
+    assert.equal(taskByOutcome(parsed.receipt, "alpha").orca_task_id, "orca-live-alpha", "alpha's mapping survived the later failure");
+    assert.equal(taskByOutcome(parsed.receipt, "bravo").orca_task_id, null, "the failed create leaves bravo unmapped");
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // D11.8 / D11.9 / D11.12 — plan-library codes re-raised verbatim
 // ---------------------------------------------------------------------------
 
@@ -650,6 +681,38 @@ test("D1/A6: programSegment is traversal-safe AND collision-resistant (sanitized
   assert.equal(programSegment("epic-941"), programSegment("epic-941"));
   assert.match(programSegment("epic-941"), /^epic-941-[0-9a-f]{8}$/);
   assert.match(programSegment("epic.941_v2"), /^epic\.941_v2-[0-9a-f]{8}$/);
+});
+
+test("A15: a very long program id yields a bounded segment that writes+loads a receipt; shared 64-char prefixes stay distinct", () => {
+  const longId = "z".repeat(300);
+  const seg = programSegment(longId);
+  // The readable prefix is capped at 64 chars; the whole segment (≤ 64 + "-" + 8 hex)
+  // stays well under the filesystem per-segment name limit (NAME_MAX ~255).
+  assert.ok(seg.length <= 64 + 1 + 8, `segment must be bounded, got ${seg.length}`);
+  assert.match(seg, /^z{64}-[0-9a-f]{8}$/);
+
+  // The derived path must WRITE and LOAD a receipt without an ENAMETOOLONG error — the
+  // whole point of the bound (the un-truncated ~308-char segment would overflow NAME_MAX).
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-longseg-"));
+  try {
+    const finalPath = path.join(dir, programSegment(longId), "receipt.json");
+    const text = `${JSON.stringify({ schema: 1, program_id: longId }, null, 2)}\n`;
+    const written = writeReceiptAtomic(finalPath, text);
+    assert.equal(written, finalPath);
+    assert.equal(fs.readFileSync(finalPath, "utf-8"), text, "the long-id receipt round-trips on disk");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+
+  // Two distinct 300-char ids sharing the SAME 64-char readable prefix must NOT collide:
+  // the hash (over the full raw id, not the truncated prefix) keeps them on distinct paths.
+  const sharedPrefix = "p".repeat(64);
+  const idA = `${sharedPrefix}${"a".repeat(236)}`;
+  const idB = `${sharedPrefix}${"b".repeat(236)}`;
+  assert.equal(programSegment(idA).length, programSegment(idB).length);
+  assert.match(programSegment(idA), /^p{64}-[0-9a-f]{8}$/);
+  assert.match(programSegment(idB), /^p{64}-[0-9a-f]{8}$/);
+  assert.notEqual(programSegment(idA), programSegment(idB), "shared 64-char prefixes must resolve to distinct segments");
 });
 
 // Keep the imported parse helper referenced.

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -69,15 +69,28 @@ function runRun(args, env = {}) {
   return result;
 }
 
+// Initialize a REAL (tiny) git repo so `resolveCanonicalRepoRoot` succeeds. Since A24
+// removed the non-git realpath fallback (git-failure now fails closed with exit 52), the
+// hermetic --repo-root MUST be a git checkout. A freshly-init'd repo's git-common-dir is
+// `<root>/.git`, whose parent realpath's back to `<root>` — the same slug the fallback
+// used to yield — so every downstream receipt-path assertion stays byte-stable.
+function initGitRepo(root) {
+  const git = (args) => execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t.com"]);
+  git(["config", "user.name", "t"]);
+}
+
 // Isolate receipt persistence (#945 D2) into temp roots so run tests never touch the
-// real ~/.relay: a temp programs root + a temp --repo-root (realpath'd for a stable
-// slug). fake.cleanup() is extended to remove them.
+// real ~/.relay: a temp programs root + a temp --repo-root (a real git checkout, for a
+// stable git-canonical slug). fake.cleanup() is extended to remove them.
 function makeReceiptWorld() {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-run-receipt-"));
   const programsRoot = path.join(base, "programs");
   const repoRoot = path.join(base, "repo");
   fs.mkdirSync(programsRoot, { recursive: true });
   fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
   return { base, programsRoot, repoRoot, slug: computeRepoSlug(fs.realpathSync(repoRoot)) };
 }
 
@@ -524,9 +537,10 @@ test("D4/D7: deps carry real Orca ids in dependency order; later-wave task stays
     assert.equal(taskByOutcome(r.body, "fanout").status, "pending");
     assert.equal(taskByOutcome(r.body, "fanout").orca_task_id, "orca-live-fanout");
     // The fanout task-create passes the real Orca id of its dependency via --deps.
+    // A26: the task title embeds the collision-resistant program SEGMENT, not the raw id.
     const fanoutCreate = r.fake
       .readLog()
-      .find((l) => l.includes("task-create") && l.includes("epic-demo-mixed/fanout"));
+      .find((l) => l.includes("task-create") && l.includes(`${programSegment("epic-demo-mixed")}/fanout`));
     assert.ok(fanoutCreate.includes('--deps ["orca-live-foundation"]'), `deps missing: ${fanoutCreate}`);
     assertNoPoison(r.fake);
   } finally {
@@ -668,6 +682,44 @@ test("A22: run --repo-root pointed at a LINKED WORKTREE writes the receipt under
   } finally {
     fake.cleanup();
     fs.rmSync(world.base, { recursive: true, force: true });
+  }
+});
+
+test("A24: run --repo-root pointed at a NON-git dir fails closed with RECEIPT_REPO_MISMATCH exit 52 (no realpath fallback)", () => {
+  // A24 removed the non-git realpath fallback: a repo root that cannot be git-canonicalized
+  // must NEVER be silently downgraded to an arbitrary-directory slug (which could read/write
+  // another repo's receipts). run fails closed with the same code status uses.
+  const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-run-nongit-"));
+  const programsRoot = path.join(nonGit, "programs");
+  fs.mkdirSync(programsRoot, { recursive: true });
+  const fake = installFakeOrcaRun({});
+  try {
+    const r = runRun(
+      [
+        "--json",
+        "--orca-bin",
+        fake.orcaPath,
+        "--repo-root",
+        nonGit,
+        "--program-file",
+        fixture("run-two-wave1.json"),
+        "--operator-handle",
+        "h1",
+        "--operator-handle",
+        "h2",
+      ],
+      { RELAY_ORCA_PROGRAMS_ROOT: programsRoot },
+    );
+    assert.equal(r.status, 52, "git-canonicalization failure exits 52");
+    const body = JSON.parse(r.stdout);
+    assert.equal(body.ok, false);
+    assert.equal(body.reason_code, "RECEIPT_REPO_MISMATCH");
+    assert.match(body.message, /could not be canonicalized/i);
+    // No receipt is written anywhere under the programs root when canonicalization fails.
+    assert.deepEqual(fs.readdirSync(programsRoot), [], "no receipt directory is created on a fail-closed canonicalization");
+  } finally {
+    fake.cleanup();
+    fs.rmSync(nonGit, { recursive: true, force: true });
   }
 });
 

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -16,6 +16,7 @@ const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPT
 const { classifyOutcome } = require(path.join(SCRIPTS, "lib", "status-classify.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
+const { programSegment, runsRoot: resolveRunsRoot } = require(path.join(SCRIPTS, "receipt-io.js"));
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
@@ -39,7 +40,7 @@ function makeReceipt({ programId, slug, root, runtimeId, tasks }) {
       orca_task_id: task.orca_task_id === undefined ? `orca-live-${task.outcome_id}` : task.orca_task_id,
       dispatch_id: task.dispatch_id === undefined ? `disp-${task.outcome_id}` : task.dispatch_id,
       assignee: task.assignee === undefined ? `term-${task.outcome_id}` : task.assignee,
-      relay_ids: { request: null, run: task.run || null, fleet: null },
+      relay_ids: { request: null, run: task.run || null, fleet: task.fleet || null },
     })),
     terminals_created: [],
     created_at: "2026-07-12T00:00:00.000Z",
@@ -72,6 +73,29 @@ function orcaTask(programId, outcome, extra = {}) {
   };
 }
 
+// A relay-fleet manifest fixture matching the real shape (#945 A3): `fleet_id`,
+// `fleet_state`, and a single-line JSON `children` array of { leaf_ref, run_id, ... }.
+// Detected by buildWorld via the presence of `fleet_state`.
+function fleetManifestText(fields) {
+  const children = JSON.stringify(fields.children || []);
+  const lines = [
+    "---",
+    `fleet_id: '${fields.fleet_id || fields.run_id}'`,
+    `fleet_state: '${fields.fleet_state}'`,
+    `children: ${children}`,
+    "timestamps:",
+    "  created_at: '2026-07-12T00:00:00.000Z'",
+    "  updated_at: '2026-07-12T00:00:00.000Z'",
+    "---",
+    "",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function gate(orcaTaskId, extra = {}) {
+  return { id: extra.id || `gate-${orcaTaskId}`, task_id: orcaTaskId, status: extra.status || "pending", kind: extra.kind };
+}
+
 // --- world harness -------------------------------------------------------------
 
 function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, runtimeId }) {
@@ -84,14 +108,19 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
 
   const receiptObject = receipt || makeReceipt({ programId, slug, root: fs.realpathSync(repoRoot), runtimeId, tasks: [] });
   if (receiptObject.repo && receiptObject.repo.slug === "__SELF__") receiptObject.repo.slug = slug;
-  const receiptDir = path.join(programsRoot, slug, programId);
+  // The receipt lives at the SAME collision-resistant segment path status.js derives
+  // (#945 A6) so `run`-written receipts resolve back for `status`.
+  const receiptDir = path.join(programsRoot, slug, programSegment(programId));
   fs.mkdirSync(receiptDir, { recursive: true });
   const receiptPath = path.join(receiptDir, "receipt.json");
   fs.writeFileSync(receiptPath, `${JSON.stringify(receiptObject, null, 2)}\n`, "utf-8");
 
   const runsDir = path.join(runsRoot, slug);
   fs.mkdirSync(runsDir, { recursive: true });
-  manifests.forEach((fields) => fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8"));
+  manifests.forEach((fields) => {
+    const text = fields.fleet_state !== undefined ? fleetManifestText(fields) : manifestText(fields);
+    fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), text, "utf-8");
+  });
 
   const orca = installFakeOrcaStatus({ runtimeId: runtimeId || DEFAULT_RUNTIME_ID, ...orcaScenario });
   const gh = installFakeGh(ghScenario);
@@ -779,6 +808,354 @@ test("D9: a degraded (runtime unreachable) view still emits the exact nine keys 
     assert.deepEqual(Object.keys(r.body).sort(), [...REPORT_KEYS].sort());
     assert.equal(r.body.evidence_checked, true);
     assert.equal(outcomeById(r.body, "u").state, "stale_missing");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A3 — per-task-kind evidence contracts (each kind names its own live checks)
+// ---------------------------------------------------------------------------
+
+test("A3 relay_fleet complete: every child terminal + fleet manifest closed → complete_with_evidence", () => {
+  const programId = "epic-status-fleet-ok";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "fleet-a", fleet_state: "closed", children: [{ leaf_ref: "l1", run_id: "child-1" }, { leaf_ref: "l2", run_id: "child-2" }] },
+      { run_id: "child-1", state: "merged", pr_number: 201, issue_number: 2001 },
+      { run_id: "child-2", state: "merged", pr_number: 202, issue_number: 2002 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "fc", { status: "completed", worker_done: true })] },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "fc", kind: "relay_fleet", fleet: "fleet-a" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "fc");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { fleet_children_terminal: true, fleet_manifest_closed: true });
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 relay_fleet not complete: a non-terminal child holds the outcome back", () => {
+  const programId = "epic-status-fleet-partial";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "fleet-b", fleet_state: "closed", children: [{ leaf_ref: "l1", run_id: "child-x" }, { leaf_ref: "l2", run_id: "child-y" }] },
+      { run_id: "child-x", state: "merged", pr_number: 210, issue_number: 2100 },
+      { run_id: "child-y", state: "review_pending", pr_number: 211, issue_number: 2101 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "fp")] },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "fp", kind: "relay_fleet", fleet: "fleet-b" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "fp");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.fleet_children_terminal, false);
+    assert.equal(outcome.evidence.fleet_manifest_closed, true);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 integration_gate complete: a passing live gate → complete_with_evidence", () => {
+  const programId = "epic-status-igate-ok";
+  const world = buildWorld({
+    programId,
+    manifests: [],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "ig")],
+      gates: [gate("orca-live-ig", { status: "passed", kind: "integration" })],
+    },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ig", kind: "integration_gate" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "ig");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { gate_report_present: true, gate_check_passes: true });
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 integration_gate not complete: a pending gate → awaiting_decision, gate check not passed", () => {
+  const programId = "epic-status-igate-pending";
+  const world = buildWorld({
+    programId,
+    manifests: [],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "ig")],
+      gates: [gate("orca-live-ig", { status: "pending", kind: "integration" })],
+    },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ig", kind: "integration_gate" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "ig");
+    assert.equal(outcome.state, "awaiting_decision");
+    assert.deepEqual(outcome.evidence, { gate_report_present: true, gate_check_passes: false });
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 advisory_review complete: advisory gate resolved → complete_with_evidence", () => {
+  const programId = "epic-status-adv-ok";
+  const world = buildWorld({
+    programId,
+    manifests: [],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "ar")],
+      gates: [gate("orca-live-ar", { status: "resolved", kind: "advisory" })],
+    },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ar", kind: "advisory_review" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "ar");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { advisory_evidence_posted: true, blocking_findings_triaged: true });
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 advisory_review not complete: an unresolved advisory gate is not triaged", () => {
+  const programId = "epic-status-adv-open";
+  const world = buildWorld({
+    programId,
+    manifests: [],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "ar")],
+      gates: [gate("orca-live-ar", { status: "pending", kind: "advisory" })],
+    },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ar", kind: "advisory_review" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "ar");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.advisory_evidence_posted, true);
+    assert.equal(outcome.evidence.blocking_findings_triaged, false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 tracker_reconciliation complete: terminal manifest + closed issue → tracker_reconciled", () => {
+  const programId = "epic-status-tracker-ok";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-tr", state: "merged", pr_number: 220, issue_number: 2200 }],
+    orcaScenario: { tasks: [orcaTask(programId, "tr", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 220: { state: "MERGED", mergedAt: "2026-07-12T08:00:00Z" } }, issues: { 2200: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "tr", kind: "tracker_reconciliation", run: "run-tr" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "tr");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { tracker_reconciled: true });
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A3 tracker_reconciliation not complete: a still-open issue is not reconciled", () => {
+  const programId = "epic-status-tracker-open";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-tro", state: "merged", pr_number: 221, issue_number: 2210 }],
+    orcaScenario: { tasks: [orcaTask(programId, "tro")] },
+    ghScenario: { prs: { 221: { state: "MERGED", mergedAt: "2026-07-12T08:10:00Z" } }, issues: { 2210: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "tro", kind: "tracker_reconciliation", run: "run-tro" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "tro");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.tracker_reconciled, false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A4 — failed required Orca reads degrade to unreachable (never fabricate empty)
+// ---------------------------------------------------------------------------
+
+test("A4: a failed required task-list read → runtime unreachable, no fabricated MISSING_TASK", () => {
+  const programId = "epic-status-tl-fail";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-tl", state: "dispatched", pr_number: 300, issue_number: 3000 }],
+    orcaScenario: { taskListOk: false, tasks: [] },
+    ghScenario: { prs: { 300: { state: "OPEN" } }, issues: { 3000: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "t", run: "run-tl" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "unreachable");
+    assert.equal(diagCodes(r.body).includes("MISSING_TASK"), false, "a failed task-list must not forge MISSING_TASK");
+    // Orca facts withheld → the mapped outcome degrades to stale_missing (durable facts still render).
+    assert.equal(outcomeById(r.body, "t").state, "stale_missing");
+    assert.deepEqual(Object.keys(r.body).sort(), [...REPORT_KEYS].sort());
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A4: a failed required gate-list read → runtime unreachable, no false awaiting_decision suppression", () => {
+  const programId = "epic-status-gl-fail";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-gl", state: "dispatched", pr_number: 310, issue_number: 3100 }],
+    orcaScenario: {
+      gateListOk: false,
+      tasks: [orcaTask(programId, "g")],
+      gates: [{ id: "sec-gate", task_id: "orca-live-g", status: "pending" }],
+    },
+    ghScenario: { prs: { 310: { state: "OPEN" } }, issues: { 3100: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "g", run: "run-gl" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "unreachable");
+    // A gate-list that could not be read is WITHHELD, never fabricated as "no pending gate":
+    // the outcome degrades to stale_missing, not a false-clean running.
+    assert.equal(outcomeById(r.body, "g").state, "stale_missing");
+    assert.notEqual(outcomeById(r.body, "g").state, "running");
+    assert.equal(diagCodes(r.body).includes("MISSING_TASK"), false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A5 — relay runs-root resolution precedence (levels 1, 2, 4)
+// ---------------------------------------------------------------------------
+
+function withRunsRootEnv(overrides, fn) {
+  const keys = ["RELAY_ORCA_RUNS_ROOT", "RELAY_RUNS_BASE", "RELAY_HOME"];
+  const saved = {};
+  keys.forEach((key) => {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  });
+  Object.entries(overrides).forEach(([key, value]) => {
+    if (value !== undefined) process.env[key] = value;
+  });
+  try {
+    return fn();
+  } finally {
+    keys.forEach((key) => {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    });
+  }
+}
+
+test("A5: level 1 RELAY_ORCA_RUNS_ROOT wins over every lower precedence source", () => {
+  withRunsRootEnv({ RELAY_ORCA_RUNS_ROOT: "/abs/orca-runs", RELAY_RUNS_BASE: "/abs/runs-base", RELAY_HOME: "/abs/relay-home" }, () => {
+    assert.equal(resolveRunsRoot(), "/abs/orca-runs");
+  });
+});
+
+test("A5: level 2 RELAY_RUNS_BASE wins when level 1 is absent OR invalid (non-absolute → next)", () => {
+  withRunsRootEnv({ RELAY_RUNS_BASE: "/abs/runs-base", RELAY_HOME: "/abs/relay-home" }, () => {
+    assert.equal(resolveRunsRoot(), "/abs/runs-base");
+  });
+  // An invalid (non-absolute) level-1 value falls THROUGH to level 2, not to the default.
+  withRunsRootEnv({ RELAY_ORCA_RUNS_ROOT: "relative/not/absolute", RELAY_RUNS_BASE: "/abs/runs-base" }, () => {
+    assert.equal(resolveRunsRoot(), "/abs/runs-base");
+  });
+});
+
+test("A5: level 4 default ~/.relay/runs when no override is set", () => {
+  withRunsRootEnv({}, () => {
+    assert.equal(resolveRunsRoot(), path.join(os.homedir(), ".relay", "runs"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A6 — receipt program-id identity check on load
+// ---------------------------------------------------------------------------
+
+test("A6: a receipt whose program_id != requested --program-id → RECEIPT_CORRUPT exit 51 naming both", () => {
+  const programId = "epic-status-identity";
+  const world = buildWorld({ programId, orcaScenario: {}, ghScenario: {} });
+  const receipt = makeReceipt({ programId: "epic-OTHER-program", slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "x", run: "run-x" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, REASONS.RECEIPT_CORRUPT);
+    assert.equal(r.body.reason_code, "RECEIPT_CORRUPT");
+    assert.match(r.body.message, /epic-status-identity/, "message names the requested program-id");
+    assert.match(r.body.message, /epic-OTHER-program/, "message names the receipt's program-id");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A7 — every subprocess-derived diagnostic field (incl. ids) is bounded
+// ---------------------------------------------------------------------------
+
+test("A7: an adversarial 10,000-char PR head is bounded in the PR_CHANGED diagnostic ids", () => {
+  const programId = "epic-status-adversarial";
+  const huge = "f".repeat(10000);
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-adv", state: "merged", pr_number: 400, issue_number: 4000, head_sha: "expected-sha" }],
+    orcaScenario: { tasks: [orcaTask(programId, "adv", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 400: { state: "MERGED", mergedAt: "2026-07-12T09:00:00Z", headRefOid: huge } }, issues: { 4000: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "adv", run: "run-adv" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const prChanged = r.body.diagnostics.filter((d) => d.code === "PR_CHANGED");
+    assert.ok(prChanged.length > 0, "PR_CHANGED fires on the adversarial live head");
+    for (const d of prChanged) {
+      assert.ok(d.message.length <= 256, `message bounded: ${d.message.length}`);
+      for (const [key, value] of Object.entries(d.ids)) {
+        if (typeof value === "string") assert.ok(value.length <= 256, `ids.${key} bounded: ${value.length}`);
+      }
+    }
+    // The raw 10k subprocess string never leaks anywhere into the serialized report.
+    assert.equal(JSON.stringify(r.body).includes(huge), false, "no unbounded subprocess value leaks into the report");
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -1501,6 +1501,206 @@ test("A11: a failed required `issue view` read → stale_missing, exit 0", () =>
   }
 });
 
+// ---------------------------------------------------------------------------
+// A17 — every adopted read's runtime id is validated (task-list/gate-list + per-task)
+// ---------------------------------------------------------------------------
+
+test("A17: a task-list read carrying a DIFFERENT runtime id → runtime unreachable, Orca facts withheld, exit 0", () => {
+  const programId = "epic-status-tasklist-runtime-drift";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-tld", state: "dispatched", pr_number: 700, issue_number: 7000 }],
+    // status carries the receipt's runtime, but task-list's _meta.runtimeId is a DIFFERENT
+    // runtime — the read cannot be attributed to the receipt's runtime, so it is WITHHELD
+    // (unreachable) exactly like a failed required read (A4), never adopted.
+    orcaScenario: {
+      tasks: [orcaTask(programId, "tld")],
+      taskListRuntimeId: "77777777-7777-4777-8777-777777777777",
+    },
+    ghScenario: { prs: { 700: { state: "OPEN" } }, issues: { 7000: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "tld", run: "run-tld" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "unreachable");
+    // Withheld like A4 — never a forged RUNTIME_MISMATCH or MISSING_TASK.
+    assert.equal(diagCodes(r.body).includes("RUNTIME_MISMATCH"), false);
+    assert.equal(diagCodes(r.body).includes("MISSING_TASK"), false);
+    assert.equal(outcomeById(r.body, "tld").state, "stale_missing");
+    assert.deepEqual(Object.keys(r.body).sort(), [...REPORT_KEYS].sort());
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A17: a per-task dispatch-show from a MISMATCHED runtime id → that task unknown (stale_missing); other tasks unaffected", () => {
+  const programId = "epic-status-dispatch-runtime-drift";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-good", state: "dispatched", pr_number: 710, issue_number: 7100 },
+      { run_id: "run-bad", state: "dispatched", pr_number: 711, issue_number: 7101 },
+    ],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "good"), orcaTask(programId, "bad")],
+      // "bad"'s dispatch-show carries a DIFFERENT _meta.runtimeId → that task's runtime
+      // facts are unknown; "good"'s dispatch-show matches and classifies normally.
+      dispatch: { "orca-live-bad": { runtimeId: "66666666-6666-4666-8666-666666666666" } },
+    },
+    ghScenario: { prs: { 710: { state: "OPEN" }, 711: { state: "OPEN" } }, issues: { 7100: { state: "OPEN" }, 7101: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "good", run: "run-good" },
+      { outcome_id: "bad", run: "run-bad" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    // The whole runtime stays trusted (status + task-list + gate-list all matched)...
+    assert.equal(r.body.runtime, "ok");
+    // ...but the mismatched per-task dispatch-show marks ONLY "bad" unknown.
+    assert.equal(outcomeById(r.body, "bad").state, "stale_missing");
+    assert.equal(outcomeById(r.body, "good").state, "running");
+    // No false MISSING_DISPATCH / MISSING_TERMINAL forged for the withheld task.
+    assert.equal(diagCodes(r.body, "bad").includes("MISSING_DISPATCH"), false);
+    assert.equal(diagCodes(r.body, "bad").includes("MISSING_TERMINAL"), false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A18 — an escalated fleet child is TERMINAL but not complete → fleet escalated
+// ---------------------------------------------------------------------------
+
+test("A18: a closed fleet with one ESCALATED child → outcome escalated (terminal ≠ complete); the all-merged variant stays complete", () => {
+  // Escalated variant: the fleet manifest is closed and every child is TERMINAL, but one
+  // child ESCALATED. An escalated child is terminal (it will not progress) yet NOT complete,
+  // so the fleet cannot complete from that configuration and surfaces as escalated.
+  const escProgram = "epic-status-fleet-escalated";
+  const escWorld = buildWorld({
+    programId: escProgram,
+    manifests: [
+      { run_id: "fleet-esc", fleet_state: "closed", children: [{ leaf_ref: "l1", run_id: "child-e1" }, { leaf_ref: "l2", run_id: "child-e2" }] },
+      { run_id: "child-e1", state: "merged", pr_number: 261, issue_number: 2601 },
+      { run_id: "child-e2", state: "escalated", pr_number: 262, issue_number: 2602 },
+    ],
+    orcaScenario: { tasks: [orcaTask(escProgram, "fe")] },
+    ghScenario: {},
+  });
+  const escReceipt = makeReceipt({ programId: escProgram, slug: escWorld.slug, root: fs.realpathSync(escWorld.repoRoot), tasks: [{ outcome_id: "fe", kind: "relay_fleet", fleet: "fleet-esc" }] });
+  fs.writeFileSync(escWorld.receiptPath, `${JSON.stringify(escReceipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = escWorld.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "fe");
+    assert.equal(outcome.state, "escalated", "an escalated terminal child surfaces the fleet as escalated");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    // The escalated child IS terminal ({merged,closed,escalated}), so the fleet reached a
+    // terminal configuration — fleet_children_terminal is true — but it is not complete.
+    assert.equal(outcome.evidence.fleet_children_terminal, true);
+    assert.equal(outcome.evidence.fleet_manifest_closed, true);
+    assert.equal(r.body.program_state, "escalated");
+  } finally {
+    escWorld.cleanup();
+  }
+
+  // All-merged variant: every child complete (merged/closed) → still complete_with_evidence.
+  const okProgram = "epic-status-fleet-allmerged";
+  const okWorld = buildWorld({
+    programId: okProgram,
+    manifests: [
+      { run_id: "fleet-ok2", fleet_state: "closed", children: [{ leaf_ref: "l1", run_id: "child-m1" }, { leaf_ref: "l2", run_id: "child-m2" }] },
+      { run_id: "child-m1", state: "merged", pr_number: 271, issue_number: 2701 },
+      { run_id: "child-m2", state: "merged", pr_number: 272, issue_number: 2702 },
+    ],
+    orcaScenario: { tasks: [orcaTask(okProgram, "fm", { status: "completed", worker_done: true })] },
+    ghScenario: {},
+  });
+  const okReceipt = makeReceipt({ programId: okProgram, slug: okWorld.slug, root: fs.realpathSync(okWorld.repoRoot), tasks: [{ outcome_id: "fm", kind: "relay_fleet", fleet: "fleet-ok2" }] });
+  fs.writeFileSync(okWorld.receiptPath, `${JSON.stringify(okReceipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = okWorld.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "fm");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { fleet_children_terminal: true, fleet_manifest_closed: true });
+  } finally {
+    okWorld.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A19 — advisory evidence requires an EXPLICITLY advisory gate (no gates[0] fallback)
+// ---------------------------------------------------------------------------
+
+test("A19: a passed NON-advisory gate mapped to an advisory_review task is not advisory evidence → NOT complete_with_evidence", () => {
+  const programId = "epic-status-adv-nonadvisory";
+  const world = buildWorld({
+    programId,
+    manifests: [],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "ar")],
+      // A PASSED gate mapped to the task, but typed "integration" (NOT advisory). With the
+      // gates[0] fallback removed, an unmarked/non-advisory gate can never satisfy advisory
+      // evidence, so a passed integration gate must not forge advisory completion.
+      gates: [gate("orca-live-ar", { status: "passed", kind: "integration" })],
+    },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ar", kind: "advisory_review" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "ar");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.advisory_evidence_posted, false, "a non-advisory gate is never advisory evidence");
+    assert.equal(outcome.evidence.blocking_findings_triaged, false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A20 — a failed required PR sub-read = unreachable (no false complete via a null head)
+// ---------------------------------------------------------------------------
+
+test("A20: a merged outcome whose PR HEAD sub-read fails → stale_missing, never a false complete off a null head", () => {
+  // The merge read (mergedAt,state) SUCCEEDS (MERGED) but the head read (headRefOid) FAILS.
+  // Before A20 the head failure substituted {} and kept ok:true, so headRefOid=null silently
+  // disabled the PR_CHANGED head-moved detector and the merged manifest + closed issue would
+  // FALSE-complete. A20 makes any failed required PR sub-read unreachable → stale_missing.
+  const programId = "epic-status-pr-head-fail";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-ph", state: "merged", pr_number: 800, issue_number: 8000, head_sha: "expected-sha" }],
+    orcaScenario: { tasks: [orcaTask(programId, "ph", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 800: { state: "MERGED", mergedAt: "2026-07-12T12:00:00Z", headReadFails: true } }, issues: { 8000: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ph", run: "run-ph" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0, "an unreachable PR read never fails the command");
+    const outcome = outcomeById(r.body, "ph");
+    assert.equal(outcome.state, "stale_missing", "a partial PR read degrades the outcome, never false-completes");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.pr_merged, null, "the PR fact is withheld, not fabricated");
+    assert.equal(world.gh.readPoison(), null, "a failed read is not a write poison");
+  } finally {
+    world.cleanup();
+  }
+});
+
 test("usage: missing --program-id exits 64", () => {
   const result = { status: 0 };
   try {

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -1,0 +1,737 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
+const STATUS_JS = path.join(SCRIPTS, "status.js");
+
+const { REASONS } = require(path.join(SCRIPTS, "lib", "status-reasons.js"));
+const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPTS, "lib", "status-report.js"));
+const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
+const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
+const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
+const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+const FORBIDDEN_ENGINE_TOKENS = ["codex", "claude", "cursor", "cline", "opencode"];
+
+// --- receipt / manifest / scenario builders ------------------------------------
+
+function makeReceipt({ programId, slug, root, runtimeId, tasks }) {
+  return {
+    schema: 1,
+    program_id: programId,
+    source: "/tmp/accepted-program.json",
+    repo: { slug, root },
+    runtime_id: runtimeId || DEFAULT_RUNTIME_ID,
+    tasks: tasks.map((task) => ({
+      outcome_id: task.outcome_id,
+      task_id: task.task_id || `orca-task-${task.outcome_id}`,
+      kind: task.kind || "relay_run",
+      wave: task.wave || 1,
+      orca_task_id: task.orca_task_id === undefined ? `orca-live-${task.outcome_id}` : task.orca_task_id,
+      dispatch_id: task.dispatch_id === undefined ? `disp-${task.outcome_id}` : task.dispatch_id,
+      assignee: task.assignee === undefined ? `term-${task.outcome_id}` : task.assignee,
+      relay_ids: { request: null, run: task.run || null, fleet: null },
+    })),
+    terminals_created: [],
+    created_at: "2026-07-12T00:00:00.000Z",
+    updated_at: "2026-07-12T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+}
+
+function manifestText(fields) {
+  const lines = ["---", "relay_version: 2", `run_id: '${fields.run_id}'`, `state: '${fields.state}'`, "git:"];
+  lines.push(fields.pr_number != null ? `  pr_number: ${fields.pr_number}` : "  pr_number: null");
+  lines.push(`  working_branch: '${fields.working_branch || `${fields.run_id}-branch`}'`);
+  lines.push(`  base_branch: '${fields.base_branch || "main"}'`);
+  if (fields.head_sha) lines.push(`  head_sha: '${fields.head_sha}'`);
+  lines.push("issue:");
+  lines.push(fields.issue_number != null ? `  number: ${fields.issue_number}` : "  number: null");
+  lines.push("  source: 'github'");
+  lines.push("---");
+  lines.push("# Notes");
+  if (fields.body) lines.push(fields.body);
+  return `${lines.join("\n")}\n`;
+}
+
+function orcaTask(programId, outcome, extra = {}) {
+  return {
+    id: `orca-live-${outcome}`,
+    title: `relay-orca: ${programId}/${outcome}`,
+    status: extra.status || "dispatched",
+    worker_done: extra.worker_done === true,
+  };
+}
+
+// --- world harness -------------------------------------------------------------
+
+function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, runtimeId }) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-status-"));
+  const repoRoot = path.join(base, "repo");
+  const programsRoot = path.join(base, "programs");
+  const runsRoot = path.join(base, "runs");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  const slug = computeRepoSlug(fs.realpathSync(repoRoot));
+
+  const receiptObject = receipt || makeReceipt({ programId, slug, root: fs.realpathSync(repoRoot), runtimeId, tasks: [] });
+  if (receiptObject.repo && receiptObject.repo.slug === "__SELF__") receiptObject.repo.slug = slug;
+  const receiptDir = path.join(programsRoot, slug, programId);
+  fs.mkdirSync(receiptDir, { recursive: true });
+  const receiptPath = path.join(receiptDir, "receipt.json");
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receiptObject, null, 2)}\n`, "utf-8");
+
+  const runsDir = path.join(runsRoot, slug);
+  fs.mkdirSync(runsDir, { recursive: true });
+  manifests.forEach((fields) => fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8"));
+
+  const orca = installFakeOrcaStatus({ runtimeId: runtimeId || DEFAULT_RUNTIME_ID, ...orcaScenario });
+  const gh = installFakeGh(ghScenario);
+
+  return {
+    base,
+    repoRoot,
+    programsRoot,
+    runsRoot,
+    slug,
+    receiptPath,
+    orca,
+    gh,
+    run(extraArgs = []) {
+      const args = [
+        STATUS_JS,
+        "--program-id",
+        programId,
+        "--json",
+        "--orca-bin",
+        orca.orcaPath,
+        "--gh-bin",
+        gh.ghPath,
+        "--repo-root",
+        repoRoot,
+        ...extraArgs,
+      ];
+      const result = { status: 0, stdout: "", stderr: "" };
+      try {
+        result.stdout = execFileSync(process.execPath, args, {
+          encoding: "utf-8",
+          env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot, RELAY_ORCA_RUNS_ROOT: runsRoot },
+          stdio: "pipe",
+        });
+      } catch (error) {
+        result.status = error.status;
+        result.stdout = error.stdout ? String(error.stdout) : "";
+        result.stderr = error.stderr ? String(error.stderr) : "";
+      }
+      result.body = result.stdout ? JSON.parse(result.stdout) : null;
+      return result;
+    },
+    cleanup() {
+      orca.cleanup();
+      gh.cleanup();
+      fs.rmSync(base, { recursive: true, force: true });
+    },
+  };
+}
+
+function outcomeById(body, id) {
+  return body.outcomes.find((outcome) => outcome.outcome_id === id);
+}
+
+function diagCodes(body, outcomeId) {
+  return body.diagnostics.filter((d) => outcomeId === undefined || d.outcome_id === outcomeId).map((d) => d.code);
+}
+
+// ---------------------------------------------------------------------------
+// D9 report shape + verbatim taxonomy sanity
+// ---------------------------------------------------------------------------
+
+test("D7: the nine detector codes exist verbatim in DIAGNOSTIC_CODES", () => {
+  assert.deepEqual(
+    [...DIAGNOSTIC_CODES].sort(),
+    [
+      "DUPLICATE_MAPPING",
+      "ISSUE_REOPENED",
+      "MISSING_DISPATCH",
+      "MISSING_RELAY_RUN",
+      "MISSING_TASK",
+      "MISSING_TERMINAL",
+      "PR_CHANGED",
+      "RUNTIME_MISMATCH",
+      "STALE_WORKER_DONE",
+    ],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — clean running program
+// ---------------------------------------------------------------------------
+
+test("D10.1: clean running program → outcomes running, program running, exit 0", () => {
+  const programId = "epic-status-running";
+  const world = buildWorld({
+    programId,
+    receipt: null,
+    manifests: [
+      { run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 },
+      { run_id: "run-b", state: "review_pending", pr_number: 11, issue_number: 101 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "a"), orcaTask(programId, "b")] },
+    ghScenario: { prs: { 10: { state: "OPEN" }, 11: { state: "OPEN" } }, issues: { 100: { state: "OPEN" }, 101: { state: "OPEN" } } },
+  });
+  // author the receipt with mapped runs
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "a", run: "run-a" },
+      { outcome_id: "b", run: "run-b" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.deepEqual(Object.keys(r.body).sort(), [...REPORT_KEYS].sort());
+    assert.equal(r.body.evidence_checked, true);
+    assert.equal(r.body.runtime, "ok");
+    assert.equal(outcomeById(r.body, "a").state, "running");
+    assert.equal(outcomeById(r.body, "b").state, "running");
+    assert.equal(r.body.program_state, "running");
+    assert.deepEqual(Object.keys(outcomeById(r.body, "a")).sort(), [...OUTCOME_KEYS].sort());
+    assert.equal(world.orca.readPoison(), null);
+    assert.equal(world.gh.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — fully complete program
+// ---------------------------------------------------------------------------
+
+function completeWorld(programId) {
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-done", state: "merged", pr_number: 20, issue_number: 200, head_sha: "abc123" }],
+    orcaScenario: { tasks: [orcaTask(programId, "done", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 20: { state: "MERGED", mergedAt: "2026-07-12T01:00:00Z", headRefOid: "abc123" } }, issues: { 200: { state: "CLOSED", stateReason: "COMPLETED" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "done", run: "run-done" }],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  return world;
+}
+
+test("D10.2: fully complete program → complete_with_evidence everywhere, exit 0", () => {
+  const world = completeWorld("epic-status-complete");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "done");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { manifest_terminal: true, pr_merged: true, issue_closed: true });
+    assert.equal(r.body.program_state, "complete_with_evidence");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — stale worker_done (never complete)
+// ---------------------------------------------------------------------------
+
+test("D10.3: Orca task done + PR open → inconsistent + STALE_WORKER_DONE, never complete", () => {
+  const programId = "epic-status-stale";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-s", state: "review_pending", pr_number: 30, issue_number: 300 }],
+    orcaScenario: { tasks: [orcaTask(programId, "s", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 30: { state: "OPEN" } }, issues: { 300: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "s", run: "run-s" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "s").state, "inconsistent");
+    assert.ok(diagCodes(r.body, "s").includes("STALE_WORKER_DONE"));
+    assert.notEqual(outcomeById(r.body, "s").state, "complete_with_evidence");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — missing terminal but durable evidence complete (durable wins)
+// ---------------------------------------------------------------------------
+
+test("D10.4: durable-complete with vanished terminal → complete_with_evidence + MISSING_TERMINAL", () => {
+  const programId = "epic-status-missterm";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-m", state: "merged", pr_number: 40, issue_number: 400 }],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "m", { status: "completed", worker_done: true })],
+      dispatch: { "orca-live-m": { assignee: null, terminal_present: false } },
+    },
+    ghScenario: { prs: { 40: { state: "MERGED", mergedAt: "2026-07-12T02:00:00Z" } }, issues: { 400: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "m", run: "run-m" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "m").state, "complete_with_evidence");
+    assert.ok(diagCodes(r.body, "m").includes("MISSING_TERMINAL"));
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — missing relay manifest for a dispatched mapping
+// ---------------------------------------------------------------------------
+
+test("D10.5: dispatched mapping with no relay manifest → stale_missing + MISSING_RELAY_RUN", () => {
+  const programId = "epic-status-norun";
+  const world = buildWorld({
+    programId,
+    manifests: [],
+    orcaScenario: { tasks: [orcaTask(programId, "n")] },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "n", run: "run-vanished" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "n").state, "stale_missing");
+    assert.ok(diagCodes(r.body, "n").includes("MISSING_RELAY_RUN"));
+    assert.ok(r.body.repair_candidates.some((c) => c.kind === "reconcile_relay_run"));
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 6 — reopened issue after merge
+// ---------------------------------------------------------------------------
+
+test("D10.6: reopened issue after merge → inconsistent + ISSUE_REOPENED", () => {
+  const programId = "epic-status-reopened";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-r", state: "merged", pr_number: 60, issue_number: 600 }],
+    orcaScenario: { tasks: [orcaTask(programId, "r", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 60: { state: "MERGED", mergedAt: "2026-07-12T03:00:00Z" } }, issues: { 600: { state: "OPEN", stateReason: "REOPENED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "r", run: "run-r" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "r").state, "inconsistent");
+    assert.ok(diagCodes(r.body, "r").includes("ISSUE_REOPENED"));
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 7 — PR merged while Orca task still says dispatched
+// ---------------------------------------------------------------------------
+
+test("D10.7: PR merged while Orca task dispatched → evidence recognized, durable complete wins", () => {
+  const programId = "epic-status-prmerged";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-p", state: "merged", pr_number: 70, issue_number: 700 }],
+    orcaScenario: { tasks: [orcaTask(programId, "p", { status: "dispatched", worker_done: false })] },
+    ghScenario: { prs: { 70: { state: "MERGED", mergedAt: "2026-07-12T04:00:00Z" } }, issues: { 700: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "p", run: "run-p" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "p");
+    assert.equal(outcome.evidence.pr_merged, true, "PR merged feeds evidence");
+    assert.equal(outcome.state, "complete_with_evidence", "durable evidence outranks the lagging Orca task state");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 8 — runtime restart (live runtimeId ≠ receipt)
+// ---------------------------------------------------------------------------
+
+test("D10.8: runtime restart → runtime mismatch, Orca facts degrade, durable-complete still complete, exit 0", () => {
+  const programId = "epic-status-restart";
+  const otherRuntime = "99999999-9999-4999-8999-999999999999";
+  const world = buildWorld({
+    programId,
+    runtimeId: DEFAULT_RUNTIME_ID, // the receipt's runtime
+    manifests: [
+      { run_id: "run-done", state: "merged", pr_number: 80, issue_number: 800 },
+      { run_id: "run-live", state: "dispatched", pr_number: 81, issue_number: 801 },
+    ],
+    orcaScenario: {
+      runtimeId: otherRuntime, // live runtime restarted
+      tasks: [{ id: "foreign-1", title: "someone-else: other/thing", status: "dispatched", worker_done: false }],
+    },
+    ghScenario: {
+      prs: { 80: { state: "MERGED", mergedAt: "2026-07-12T05:00:00Z" }, 81: { state: "OPEN" } },
+      issues: { 800: { state: "CLOSED" }, 801: { state: "OPEN" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    runtimeId: DEFAULT_RUNTIME_ID,
+    tasks: [
+      { outcome_id: "done", run: "run-done" },
+      { outcome_id: "live", run: "run-live" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "mismatch");
+    assert.ok(diagCodes(r.body).includes("RUNTIME_MISMATCH"));
+    assert.equal(outcomeById(r.body, "done").state, "complete_with_evidence", "durable truth still renders");
+    assert.equal(outcomeById(r.body, "live").state, "stale_missing", "Orca facts degrade to stale_missing");
+    // foreign tasks are never attributed to this program's outcomes.
+    assert.deepEqual(r.body.outcomes.map((o) => o.outcome_id).sort(), ["done", "live"]);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 9 — fail-closed receipt errors (exit 50/51/52)
+// ---------------------------------------------------------------------------
+
+test("D10.9: missing receipt → RECEIPT_NOT_FOUND exit 50", () => {
+  const programId = "epic-status-missing";
+  const world = buildWorld({ programId, orcaScenario: {}, ghScenario: {} });
+  fs.rmSync(world.receiptPath, { force: true });
+  try {
+    const r = world.run();
+    assert.equal(r.status, REASONS.RECEIPT_NOT_FOUND);
+    assert.equal(r.body.reason_code, "RECEIPT_NOT_FOUND");
+    assert.equal(r.body.ok, false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D10.9: truncated receipt JSON → RECEIPT_CORRUPT exit 51", () => {
+  const programId = "epic-status-corrupt";
+  const world = buildWorld({ programId, orcaScenario: {}, ghScenario: {} });
+  fs.writeFileSync(world.receiptPath, '{ "schema": 1, "program_id": "epic-status-corrupt", "tas', "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, REASONS.RECEIPT_CORRUPT);
+    assert.equal(r.body.reason_code, "RECEIPT_CORRUPT");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D10.9: wrong repo slug → RECEIPT_REPO_MISMATCH exit 52", () => {
+  const programId = "epic-status-wrongrepo";
+  const world = buildWorld({ programId, orcaScenario: {}, ghScenario: {} });
+  const receipt = makeReceipt({ programId, slug: "some-other-repo-deadbeef", root: "/tmp/other", tasks: [{ outcome_id: "x", run: "run-x" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, REASONS.RECEIPT_REPO_MISMATCH);
+    assert.equal(r.body.reason_code, "RECEIPT_REPO_MISMATCH");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 10 — read-only proof
+// ---------------------------------------------------------------------------
+
+test("D10.10: status is read-only — receipt bytes identical, no gh/orca write poison fires", () => {
+  const world = completeWorld("epic-status-readonly");
+  try {
+    const before = fs.readFileSync(world.receiptPath);
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const after = fs.readFileSync(world.receiptPath);
+    assert.ok(before.equals(after), "receipt bytes must be identical before and after status");
+    assert.equal(world.gh.readPoison(), null, "gh non-read poison must never fire");
+    assert.equal(world.orca.readPoison(), null, "orca mutating/reset/worktree poison must never fire");
+    // The gh + orca logs prove only read subcommands ran.
+    world.gh.readLog().forEach((line) => assert.match(line, /^(issue view|pr view|api)/));
+    world.orca.readLog().forEach((line) => assert.match(line, /^(status|orchestration (task-list|gate-list|dispatch-show))/));
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D3: the fake gh poisons a non-read subcommand and the fake orca poisons a mutating subcommand", () => {
+  const world = completeWorld("epic-status-poisoncheck");
+  try {
+    let ghStatus = 0;
+    try {
+      execFileSync(world.gh.ghPath, ["pr", "merge", "1"], { stdio: "pipe" });
+    } catch (error) {
+      ghStatus = error.status;
+    }
+    assert.notEqual(ghStatus, 0);
+    assert.match(world.gh.readPoison(), /GH_WRITE_INVOKED/);
+
+    for (const mutating of [["orchestration", "reset"], ["worktree", "create"], ["orchestration", "task-create"], ["orchestration", "dispatch", "--task", "t"]]) {
+      fs.rmSync(world.orca.poisonPath, { force: true });
+      let orcaStatus = 0;
+      try {
+        execFileSync(world.orca.orcaPath, mutating, { stdio: "pipe" });
+      } catch (error) {
+        orcaStatus = error.status;
+      }
+      assert.notEqual(orcaStatus, 0, `mutating ${mutating.join(" ")} must poison`);
+      assert.ok(world.orca.readPoison(), `mutating ${mutating.join(" ")} must write a poison marker`);
+    }
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 11 — duplicate mapping + back-pointer discovery
+// ---------------------------------------------------------------------------
+
+test("D10.11: duplicate mapping → DUPLICATE_MAPPING; unmapped manifest referencing the program → repair_candidate", () => {
+  const programId = "epic-status-dup";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-1", state: "dispatched", pr_number: 90, issue_number: 900 },
+      // an orphan manifest referencing this program but absent from the receipt
+      { run_id: "run-orphan", state: "dispatched", pr_number: 91, issue_number: 901, body: `# relay-orca: ${programId}/orphan` },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "a"), orcaTask(programId, "b")] },
+    ghScenario: { prs: { 90: { state: "OPEN" }, 91: { state: "OPEN" } }, issues: { 900: { state: "OPEN" }, 901: { state: "OPEN" } } },
+  });
+  // two outcomes share the SAME orca_task_id
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "a", orca_task_id: "orca-live-shared", run: "run-1" },
+      { outcome_id: "b", orca_task_id: "orca-live-shared", run: "run-2" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.ok(diagCodes(r.body).includes("DUPLICATE_MAPPING"));
+    assert.ok(
+      r.body.repair_candidates.some((c) => c.kind === "adopt_relay_run" && /run-orphan/.test(c.proposal)),
+      "back-pointer discovery emits an adopt repair candidate (no mutation)",
+    );
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Additional detector coverage — MISSING_TASK / MISSING_DISPATCH / PR_CHANGED
+// ---------------------------------------------------------------------------
+
+test("D7: absent Orca task → MISSING_TASK; absent dispatch → MISSING_DISPATCH", () => {
+  const programId = "epic-status-misstask";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-mt", state: "dispatched", pr_number: 110, issue_number: 1100 },
+      { run_id: "run-md", state: "dispatched", pr_number: 111, issue_number: 1101 },
+    ],
+    orcaScenario: {
+      // outcome "mt" has NO live task; outcome "md" has a task but dispatch-show returns no dispatch id
+      tasks: [orcaTask(programId, "md")],
+      dispatch: { "orca-live-md": { dispatch_id: null, assignee: "term-md", terminal_present: true } },
+    },
+    ghScenario: { prs: { 110: { state: "OPEN" }, 111: { state: "OPEN" } }, issues: { 1100: { state: "OPEN" }, 1101: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "mt", orca_task_id: "orca-live-mt", run: "run-mt" },
+      { outcome_id: "md", orca_task_id: "orca-live-md", run: "run-md" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.ok(diagCodes(r.body, "mt").includes("MISSING_TASK"));
+    assert.ok(diagCodes(r.body, "md").includes("MISSING_DISPATCH"));
+    assert.equal(outcomeById(r.body, "mt").state, "stale_missing");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D7: merged manifest with a moved live PR head → PR_CHANGED + inconsistent", () => {
+  const programId = "epic-status-prchanged";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-pc", state: "merged", pr_number: 120, issue_number: 1200, head_sha: "expected-sha" }],
+    orcaScenario: { tasks: [orcaTask(programId, "pc", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 120: { state: "MERGED", mergedAt: "2026-07-12T06:00:00Z", headRefOid: "moved-sha" } }, issues: { 1200: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "pc", run: "run-pc" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.ok(diagCodes(r.body, "pc").includes("PR_CHANGED"));
+    assert.equal(outcomeById(r.body, "pc").state, "inconsistent");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 13 — awaiting decision (pending gate)
+// ---------------------------------------------------------------------------
+
+test("D10.13: a pending gate blocking a task → outcome awaiting_decision", () => {
+  const programId = "epic-status-gate";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-g", state: "dispatched", pr_number: 130, issue_number: 1300 }],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "g")],
+      gates: [{ id: "sec-gate", task_id: "orca-live-g", status: "pending" }],
+    },
+    ghScenario: { prs: { 130: { state: "OPEN" } }, issues: { 1300: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "g", run: "run-g" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "g").state, "awaiting_decision");
+    assert.equal(r.body.program_state, "awaiting_decision");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 14 — ready for next wave
+// ---------------------------------------------------------------------------
+
+test("D10.14: wave-1 complete, wave-2 pending → program ready_for_next_wave", () => {
+  const programId = "epic-status-nextwave";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-w1", state: "merged", pr_number: 140, issue_number: 1400 }],
+    orcaScenario: {
+      tasks: [
+        orcaTask(programId, "w1", { status: "completed", worker_done: true }),
+        orcaTask(programId, "w2", { status: "pending", worker_done: false }),
+      ],
+    },
+    ghScenario: { prs: { 140: { state: "MERGED", mergedAt: "2026-07-12T07:00:00Z" } }, issues: { 1400: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "w1", wave: 1, run: "run-w1" },
+      { outcome_id: "w2", wave: 2, dispatch_id: null, assignee: null, run: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "w1").state, "complete_with_evidence");
+    assert.equal(r.body.program_state, "ready_for_next_wave");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D11 engine-agnostic — receipt fixture + rendered report carry no engine tokens
+// ---------------------------------------------------------------------------
+
+test("D11: neither the receipt fixture nor a rendered status report names an engine/model", () => {
+  const world = completeWorld("epic-status-agnostic");
+  try {
+    const receiptBytes = fs.readFileSync(world.receiptPath, "utf-8").toLowerCase();
+    FORBIDDEN_ENGINE_TOKENS.forEach((token) => assert.equal(receiptBytes.includes(token), false, `receipt leaked ${token}`));
+    const r = world.run();
+    const reportBytes = JSON.stringify(r.body).toLowerCase();
+    FORBIDDEN_ENGINE_TOKENS.forEach((token) => assert.equal(reportBytes.includes(token), false, `report leaked ${token}`));
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9 degraded-path key set + usage
+// ---------------------------------------------------------------------------
+
+test("D9: a degraded (runtime unreachable) view still emits the exact nine keys and exits 0", () => {
+  const programId = "epic-status-unreachable";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-u", state: "dispatched", pr_number: 150, issue_number: 1500 }],
+    orcaScenario: { statusOk: false },
+    ghScenario: { prs: { 150: { state: "OPEN" } }, issues: { 1500: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "u", run: "run-u" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "unreachable");
+    assert.deepEqual(Object.keys(r.body).sort(), [...REPORT_KEYS].sort());
+    assert.equal(r.body.evidence_checked, true);
+    assert.equal(outcomeById(r.body, "u").state, "stale_missing");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("usage: missing --program-id exits 64", () => {
+  const result = { status: 0 };
+  try {
+    execFileSync(process.execPath, [STATUS_JS, "--json"], { stdio: "pipe" });
+  } catch (error) {
+    result.status = error.status;
+  }
+  assert.equal(result.status, 64);
+});

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -16,7 +16,7 @@ const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPT
 const { classifyOutcome } = require(path.join(SCRIPTS, "lib", "status-classify.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
-const { programSegment, runsRoot: resolveRunsRoot } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { programSegment, runsRoot: resolveRunsRoot, fleetsRoot: resolveFleetsRoot } = require(path.join(SCRIPTS, "receipt-io.js"));
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
@@ -32,16 +32,24 @@ function makeReceipt({ programId, slug, root, runtimeId, tasks }) {
     source: "/tmp/accepted-program.json",
     repo: { slug, root },
     runtime_id: runtimeId || DEFAULT_RUNTIME_ID,
-    tasks: tasks.map((task) => ({
-      outcome_id: task.outcome_id,
-      task_id: task.task_id || `orca-task-${task.outcome_id}`,
-      kind: task.kind || "relay_run",
-      wave: task.wave || 1,
-      orca_task_id: task.orca_task_id === undefined ? `orca-live-${task.outcome_id}` : task.orca_task_id,
-      dispatch_id: task.dispatch_id === undefined ? `disp-${task.outcome_id}` : task.dispatch_id,
-      assignee: task.assignee === undefined ? `term-${task.outcome_id}` : task.assignee,
-      relay_ids: { request: null, run: task.run || null, fleet: task.fleet || null },
-    })),
+    tasks: tasks.map((task) => {
+      const orcaTaskId = task.orca_task_id === undefined ? `orca-live-${task.outcome_id}` : task.orca_task_id;
+      // Default the recorded dispatch id to what the fake orca's dispatch-show returns
+      // for this task ("disp-" + orca_task_id), so a healthy (non-drifted) scenario has
+      // the live dispatch id EQUAL the receipt's — drift (#945 A10) is then modeled by
+      // an explicit dispatch_id override in the scenario.
+      const defaultDispatchId = orcaTaskId ? `disp-${orcaTaskId}` : `disp-${task.outcome_id}`;
+      return {
+        outcome_id: task.outcome_id,
+        task_id: task.task_id || `orca-task-${task.outcome_id}`,
+        kind: task.kind || "relay_run",
+        wave: task.wave || 1,
+        orca_task_id: orcaTaskId,
+        dispatch_id: task.dispatch_id === undefined ? defaultDispatchId : task.dispatch_id,
+        assignee: task.assignee === undefined ? `term-${task.outcome_id}` : task.assignee,
+        relay_ids: { request: null, run: task.run || null, fleet: task.fleet || null },
+      };
+    }),
     terminals_created: [],
     created_at: "2026-07-12T00:00:00.000Z",
     updated_at: "2026-07-12T00:00:00.000Z",
@@ -103,6 +111,9 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
   const repoRoot = path.join(base, "repo");
   const programsRoot = path.join(base, "programs");
   const runsRoot = path.join(base, "runs");
+  // Fleet manifests live under a SEPARATE fleets root (#945 A8), modeling relay's real
+  // split: child run manifests under runs root, fleet manifests under fleets root.
+  const fleetsRoot = path.join(base, "fleets");
   fs.mkdirSync(repoRoot, { recursive: true });
   const slug = computeRepoSlug(fs.realpathSync(repoRoot));
 
@@ -116,10 +127,17 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
   fs.writeFileSync(receiptPath, `${JSON.stringify(receiptObject, null, 2)}\n`, "utf-8");
 
   const runsDir = path.join(runsRoot, slug);
+  const fleetsDir = path.join(fleetsRoot, slug);
   fs.mkdirSync(runsDir, { recursive: true });
+  fs.mkdirSync(fleetsDir, { recursive: true });
+  // A fleet manifest (detected by `fleet_state`) lands under the fleets root; every
+  // ordinary run manifest (including fleet CHILDREN) lands under the runs root.
   manifests.forEach((fields) => {
-    const text = fields.fleet_state !== undefined ? fleetManifestText(fields) : manifestText(fields);
-    fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), text, "utf-8");
+    if (fields.fleet_state !== undefined) {
+      fs.writeFileSync(path.join(fleetsDir, `${fields.run_id}.md`), fleetManifestText(fields), "utf-8");
+    } else {
+      fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8");
+    }
   });
 
   const orca = installFakeOrcaStatus({ runtimeId: runtimeId || DEFAULT_RUNTIME_ID, ...orcaScenario });
@@ -130,11 +148,12 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
     repoRoot,
     programsRoot,
     runsRoot,
+    fleetsRoot,
     slug,
     receiptPath,
     orca,
     gh,
-    run(extraArgs = []) {
+    run(extraArgs = [], runOptions = {}) {
       const args = [
         STATUS_JS,
         "--program-id",
@@ -152,7 +171,13 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
       try {
         result.stdout = execFileSync(process.execPath, args, {
           encoding: "utf-8",
-          env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot, RELAY_ORCA_RUNS_ROOT: runsRoot },
+          env: {
+            ...process.env,
+            RELAY_ORCA_PROGRAMS_ROOT: programsRoot,
+            RELAY_ORCA_RUNS_ROOT: runsRoot,
+            RELAY_ORCA_FLEETS_ROOT: fleetsRoot,
+          },
+          cwd: runOptions.cwd || undefined,
           stdio: "pipe",
         });
       } catch (error) {
@@ -1109,6 +1134,115 @@ test("A5: level 4 default ~/.relay/runs when no override is set", () => {
 });
 
 // ---------------------------------------------------------------------------
+// A8 — fleet manifests resolve from the SEPARATE fleets root (not the runs root)
+// ---------------------------------------------------------------------------
+
+function withFleetsRootEnv(overrides, fn) {
+  const keys = ["RELAY_ORCA_FLEETS_ROOT", "RELAY_FLEETS_BASE", "RELAY_HOME"];
+  const saved = {};
+  keys.forEach((key) => {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  });
+  Object.entries(overrides).forEach(([key, value]) => {
+    if (value !== undefined) process.env[key] = value;
+  });
+  try {
+    return fn();
+  } finally {
+    keys.forEach((key) => {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    });
+  }
+}
+
+test("A8: fleetsRoot precedence — RELAY_ORCA_FLEETS_ROOT > RELAY_FLEETS_BASE > RELAY_HOME/fleets > default", () => {
+  withFleetsRootEnv({ RELAY_ORCA_FLEETS_ROOT: "/abs/orca-fleets", RELAY_FLEETS_BASE: "/abs/fleets-base", RELAY_HOME: "/abs/relay-home" }, () => {
+    assert.equal(resolveFleetsRoot(), "/abs/orca-fleets");
+  });
+  withFleetsRootEnv({ RELAY_FLEETS_BASE: "/abs/fleets-base", RELAY_HOME: "/abs/relay-home" }, () => {
+    assert.equal(resolveFleetsRoot(), "/abs/fleets-base");
+  });
+  // relay-fleet's actual convention: RELAY_HOME + "/fleets" when no base override is set.
+  withFleetsRootEnv({ RELAY_HOME: "/abs/relay-home" }, () => {
+    assert.equal(resolveFleetsRoot(), path.join("/abs/relay-home", "fleets"));
+  });
+  // A non-absolute higher-precedence value falls THROUGH (not straight to the default).
+  withFleetsRootEnv({ RELAY_ORCA_FLEETS_ROOT: "relative/not/absolute", RELAY_HOME: "/abs/relay-home" }, () => {
+    assert.equal(resolveFleetsRoot(), path.join("/abs/relay-home", "fleets"));
+  });
+  withFleetsRootEnv({}, () => {
+    assert.equal(resolveFleetsRoot(), path.join(os.homedir(), ".relay", "fleets"));
+  });
+});
+
+test("A8: a relay_fleet outcome resolves the fleet manifest from the FLEETS root, children from the RUNS root", () => {
+  // buildWorld routes the `fleet_state` manifest to the fleets root and the children to
+  // the runs root, so a green result proves the split lookup (fleet ← fleets root,
+  // children ← runs root) end to end.
+  const programId = "epic-status-fleet-split";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "fleet-split", fleet_state: "closed", children: [{ leaf_ref: "l1", run_id: "child-s1" }, { leaf_ref: "l2", run_id: "child-s2" }] },
+      { run_id: "child-s1", state: "merged", pr_number: 241, issue_number: 2401 },
+      { run_id: "child-s2", state: "merged", pr_number: 242, issue_number: 2402 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "fs", { status: "completed", worker_done: true })] },
+    ghScenario: {},
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "fs", kind: "relay_fleet", fleet: "fleet-split" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  // Prove the fleet manifest lives ONLY under the fleets root, never the runs root.
+  assert.ok(fs.existsSync(path.join(world.fleetsRoot, world.slug, "fleet-split.md")));
+  assert.equal(fs.existsSync(path.join(world.runsRoot, world.slug, "fleet-split.md")), false);
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "fs");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { fleet_children_terminal: true, fleet_manifest_closed: true });
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A8: a fleet manifest mistakenly left under the runs root is NOT adopted (split is enforced)", () => {
+  const programId = "epic-status-fleet-wrongroot";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "child-w1", state: "merged", pr_number: 251, issue_number: 2501 },
+      { run_id: "child-w2", state: "merged", pr_number: 252, issue_number: 2502 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "fw", { status: "completed", worker_done: true })] },
+    ghScenario: {},
+  });
+  // Write the fleet manifest into the WRONG (runs) root; status must not find it there.
+  const runsDir = path.join(world.runsRoot, world.slug);
+  fs.writeFileSync(
+    path.join(runsDir, "fleet-wrong.md"),
+    fleetManifestText({ run_id: "fleet-wrong", fleet_state: "closed", children: [{ leaf_ref: "l1", run_id: "child-w1" }, { leaf_ref: "l2", run_id: "child-w2" }] }),
+    "utf-8",
+  );
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "fw", kind: "relay_fleet", fleet: "fleet-wrong" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "fw");
+    // The fleet manifest is not on the fleets root → its evidence stays unknown (null)
+    // and the outcome never completes.
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.fleet_manifest_closed, null);
+    assert.equal(outcome.evidence.fleet_children_terminal, null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // A6 — receipt program-id identity check on load
 // ---------------------------------------------------------------------------
 
@@ -1156,6 +1290,130 @@ test("A7: an adversarial 10,000-char PR head is bounded in the PR_CHANGED diagno
     }
     // The raw 10k subprocess string never leaks anywhere into the serialized report.
     assert.equal(JSON.stringify(r.body).includes(huge), false, "no unbounded subprocess value leaks into the report");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A9 — every gh read is scoped to the selected repository (cwd = repo.root)
+// ---------------------------------------------------------------------------
+
+test("A9: every gh read runs in repo.root even when status is invoked from an unrelated cwd", () => {
+  const world = completeWorld("epic-status-ghcwd");
+  const otherCwd = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-other-cwd-"));
+  try {
+    const r = world.run([], { cwd: otherCwd });
+    assert.equal(r.status, 0);
+    const cwds = world.gh.readCwdLog();
+    assert.ok(cwds.length > 0, "the fake gh recorded at least one invocation cwd");
+    const expected = fs.realpathSync(world.repoRoot);
+    // Sanity: the caller cwd is genuinely different from the repo root.
+    assert.notEqual(fs.realpathSync(otherCwd), expected);
+    cwds.forEach((cwd) => assert.equal(fs.realpathSync(cwd), expected, "each gh read ran in repo.root, not the caller cwd"));
+  } finally {
+    fs.rmSync(otherCwd, { recursive: true, force: true });
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A10 — a changed live dispatch id is a stale mapping (MISSING_DISPATCH)
+// ---------------------------------------------------------------------------
+
+test("A10: a changed live dispatch id → MISSING_DISPATCH + stale_missing when durable evidence is non-terminal", () => {
+  const programId = "epic-status-dispatch-drift";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-d", state: "dispatched", pr_number: 500, issue_number: 5000 }],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "d")],
+      // dispatch-show reports a DIFFERENT dispatch id than the receipt recorded (the
+      // task was re-dispatched) → the recorded mapping drifted.
+      dispatch: { "orca-live-d": { dispatch_id: "disp-REDISPATCHED", assignee: "term-d", terminal_present: true } },
+    },
+    ghScenario: { prs: { 500: { state: "OPEN" } }, issues: { 5000: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "d", run: "run-d" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "d").state, "stale_missing");
+    const missing = r.body.diagnostics.filter((x) => x.code === "MISSING_DISPATCH" && x.outcome_id === "d");
+    assert.equal(missing.length, 1, "the drifted mapping emits exactly one MISSING_DISPATCH");
+    // The diagnostic carries BOTH the receipt id and the changed live id.
+    assert.equal(missing[0].ids.dispatch_id, "disp-orca-live-d");
+    assert.equal(missing[0].ids.live_dispatch_id, "disp-REDISPATCHED");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A10: the durable-complete variant stays complete_with_evidence despite a drifted dispatch id", () => {
+  const programId = "epic-status-dispatch-drift-complete";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-dc", state: "merged", pr_number: 501, issue_number: 5001 }],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "dc", { status: "completed", worker_done: true })],
+      dispatch: { "orca-live-dc": { dispatch_id: "disp-REDISPATCHED", assignee: "term-dc", terminal_present: true } },
+    },
+    ghScenario: { prs: { 501: { state: "MERGED", mergedAt: "2026-07-12T10:00:00Z" } }, issues: { 5001: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "dc", run: "run-dc" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    // Durable evidence still wins over the drifted runtime mapping.
+    assert.equal(outcomeById(r.body, "dc").state, "complete_with_evidence");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A11 — a failed REQUIRED live GitHub read degrades the outcome (never "running")
+// ---------------------------------------------------------------------------
+
+test("A11: a failed required `pr view` read → stale_missing, exit 0", () => {
+  const programId = "epic-status-pr-unreachable";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-pu", state: "dispatched", pr_number: 600, issue_number: 6000 }],
+    orcaScenario: { tasks: [orcaTask(programId, "pu")] },
+    // PR 600 is intentionally ABSENT from the scenario → `gh pr view 600` exits non-zero.
+    ghScenario: { issues: { 6000: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "pu", run: "run-pu" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0, "an unreachable GitHub read never fails the command");
+    assert.equal(outcomeById(r.body, "pu").state, "stale_missing");
+    assert.equal(world.gh.readPoison(), null, "a failed read is not a write poison");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A11: a failed required `issue view` read → stale_missing, exit 0", () => {
+  const programId = "epic-status-issue-unreachable";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-iu", state: "dispatched", pr_number: 610, issue_number: 6100 }],
+    orcaScenario: { tasks: [orcaTask(programId, "iu")] },
+    // Issue 6100 is ABSENT → `gh issue view 6100` exits non-zero; the PR read succeeds.
+    ghScenario: { prs: { 610: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "iu", run: "run-iu" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0, "an unreachable GitHub read never fails the command");
+    assert.equal(outcomeById(r.body, "iu").state, "stale_missing");
+    assert.equal(world.gh.readPoison(), null);
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -23,6 +23,9 @@ const {
   resolveCanonicalRepoRoot,
   resolveRepoContext,
 } = require(path.join(SCRIPTS, "receipt-io.js"));
+// status.js guards main() behind `require.main === module`, so importing it here exercises
+// the A28 read-only boundary directly without triggering a real status run.
+const { assertGhReadOnly } = require(STATUS_JS);
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
@@ -646,6 +649,77 @@ test("D3: the fake gh poisons a non-read subcommand and the fake orca poisons a 
     }
   } finally {
     world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A28 — the read-only gh boundary rejects mutation-shaped `gh api`
+// ---------------------------------------------------------------------------
+
+// Layer 1: the status.js structural guard (`assertGhReadOnly`).
+test("A28: assertGhReadOnly refuses mutation-shaped `gh api`, allows bare GET reads", () => {
+  // Body/field options make `gh api` default to a POST — every form is a write.
+  for (const argv of [
+    ["api", "repos/x", "-f", "a=b"],
+    ["api", "repos/x", "--field", "a=b"],
+    ["api", "repos/x", "-F", "a=b"],
+    ["api", "repos/x", "--raw-field", "a=b"],
+    ["api", "repos/x", "--input", "body.json"],
+  ]) {
+    assert.throws(() => assertGhReadOnly(argv), /non-read gh subcommand/, `must reject: gh ${argv.join(" ")}`);
+  }
+  // Explicit non-GET method (separated or attached) is a write.
+  for (const argv of [
+    ["api", "-X", "POST", "repos/x"],
+    ["api", "--method", "PATCH", "repos/x"],
+    ["api", "-XDELETE", "repos/x"],
+    ["api", "--method=PUT", "repos/x"],
+    ["api", "repos/x", "POST"],
+  ]) {
+    assert.throws(() => assertGhReadOnly(argv), /non-read gh subcommand/, `must reject: gh ${argv.join(" ")}`);
+  }
+  // Read-shaped invocations are allowed: bare/`-X GET` api reads and the two view reads.
+  for (const argv of [
+    ["api", "repos/x"],
+    ["api", "repos/x", "--jq", ".state"],
+    ["api", "-X", "GET", "repos/x"],
+    ["issue", "view", "1", "--json", "state,stateReason"],
+    ["pr", "view", "2", "--json", "mergedAt,state"],
+  ]) {
+    assert.doesNotThrow(() => assertGhReadOnly(argv), `must allow: gh ${argv.join(" ")}`);
+  }
+  // A non-view, non-api write subcommand is still refused (existing contract).
+  assert.throws(() => assertGhReadOnly(["pr", "merge", "1"]), /non-read gh subcommand/);
+});
+
+// Layer 2: the fake-gh poison used by the read-only tests.
+test("A28: the fake gh poison rejects mutation-shaped `gh api` and serves a bare GET", () => {
+  const gh = installFakeGh({});
+  try {
+    for (const argv of [
+      ["api", "repos/x", "-f", "a=b"],
+      ["api", "repos/x", "--field", "a=b"],
+      ["api", "-X", "POST", "repos/x"],
+      ["api", "--method=PATCH", "repos/x"],
+      ["api", "repos/x", "--input", "body.json"],
+    ]) {
+      fs.rmSync(gh.poisonPath, { force: true });
+      let code = 0;
+      try {
+        execFileSync(gh.ghPath, argv, { stdio: "pipe" });
+      } catch (error) {
+        code = error.status;
+      }
+      assert.notEqual(code, 0, `gh ${argv.join(" ")} must poison`);
+      assert.match(gh.readPoison(), /GH_WRITE_INVOKED/, `gh ${argv.join(" ")} must write a poison marker`);
+    }
+    // A bare GET `gh api` is served (exit 0), no poison.
+    fs.rmSync(gh.poisonPath, { force: true });
+    const out = execFileSync(gh.ghPath, ["api", "repos/x"], { stdio: "pipe", encoding: "utf-8" });
+    assert.equal(gh.readPoison(), null, "a bare GET api read must never poison");
+    assert.equal(out, "{}", "the fake serves a read-shaped api GET");
+  } finally {
+    gh.cleanup();
   }
 });
 

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -13,6 +13,7 @@ const STATUS_JS = path.join(SCRIPTS, "status.js");
 
 const { REASONS } = require(path.join(SCRIPTS, "lib", "status-reasons.js"));
 const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPTS, "lib", "status-report.js"));
+const { classifyOutcome } = require(path.join(SCRIPTS, "lib", "status-classify.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
@@ -614,6 +615,63 @@ test("D7: merged manifest with a moved live PR head → PR_CHANGED + inconsisten
     assert.equal(r.status, 0);
     assert.ok(diagCodes(r.body, "pc").includes("PR_CHANGED"));
     assert.equal(outcomeById(r.body, "pc").state, "inconsistent");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Regression — a transient dispatch-show failure must NOT forge MISSING_DISPATCH
+// ---------------------------------------------------------------------------
+
+test("D7: a failed (unreachable) dispatch-show read does not forge MISSING_DISPATCH / stale_missing", () => {
+  const facts = {
+    receiptTask: {
+      outcome_id: "x",
+      task_id: "orca-task-x",
+      kind: "relay_run",
+      wave: 1,
+      orca_task_id: "orca-live-x",
+      dispatch_id: "disp-x",
+      assignee: "term-x",
+      relay_ids: { request: null, run: "run-x", fleet: null },
+    },
+    manifest: { state: "dispatched", pr_number: 1, issue_number: 2 },
+    mappedRunId: "run-x",
+    mappedRunMissing: false,
+    orcaTask: { status: "dispatched", worker_done: false },
+    orcaTaskMissing: false,
+    dispatch: { ok: false, reachable: false }, // dispatch-show itself failed transiently
+    gateBlocking: false,
+    pr: { state: "OPEN" },
+    issue: { state: "OPEN" },
+    prUrl: null,
+    issueUrl: null,
+  };
+  const { outcome, diagnostics } = classifyOutcome(facts, { orcaTrusted: true, isDuplicate: false });
+  assert.equal(diagnostics.some((d) => d.code === "MISSING_DISPATCH"), false, "a flaky dispatch-show read must not forge MISSING_DISPATCH");
+  assert.equal(outcome.state, "running", "the outcome stays running, not stale_missing, on a transient read failure");
+});
+
+// ---------------------------------------------------------------------------
+// Regression — a force-closed (abandoned) relay manifest is escalated, not running
+// ---------------------------------------------------------------------------
+
+test("D5: a closed (abandoned, unmerged) relay manifest → escalated, never a silent running", () => {
+  const programId = "epic-status-closed";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-c", state: "closed", pr_number: 160, issue_number: 1600 }],
+    orcaScenario: { tasks: [orcaTask(programId, "c", { status: "dispatched", worker_done: false })] },
+    ghScenario: { prs: { 160: { state: "OPEN" } }, issues: { 1600: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "c", run: "run-c" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "c").state, "escalated");
+    assert.equal(r.body.program_state, "escalated");
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -81,7 +81,10 @@ function manifestText(fields) {
 function orcaTask(programId, outcome, extra = {}) {
   return {
     id: `orca-live-${outcome}`,
-    title: `relay-orca: ${programId}/${outcome}`,
+    // A26: run.js titles tasks with the collision-resistant program SEGMENT, not the raw
+    // id, so a healthy fixture task must carry the SAME segment for the foreign-task check
+    // (`title.includes("relay-orca: <segment>/")`) to attribute it to this program.
+    title: `relay-orca: ${programSegment(programId)}/${outcome}`,
     status: extra.status || "dispatched",
     worker_done: extra.worker_done === true,
   };
@@ -112,6 +115,18 @@ function gate(orcaTaskId, extra = {}) {
 
 // --- world harness -------------------------------------------------------------
 
+// Initialize a REAL (tiny) git repo so `resolveCanonicalRepoRoot` succeeds. A24 removed
+// the non-git realpath fallback (git-failure now fails closed with exit 52), so the
+// hermetic --repo-root MUST be a git checkout. A freshly-init'd repo's git-common-dir is
+// `<root>/.git`, whose parent realpath's back to `<root>` — the same slug the fallback
+// used to yield — so every downstream slug/receipt-path assertion stays byte-stable.
+function initGitRepo(root) {
+  const git = (args) => execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t.com"]);
+  git(["config", "user.name", "t"]);
+}
+
 function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, runtimeId }) {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-status-"));
   const repoRoot = path.join(base, "repo");
@@ -121,6 +136,7 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
   // split: child run manifests under runs root, fleet manifests under fleets root.
   const fleetsRoot = path.join(base, "fleets");
   fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
   const slug = computeRepoSlug(fs.realpathSync(repoRoot));
 
   const receiptObject = receipt || makeReceipt({ programId, slug, root: fs.realpathSync(repoRoot), runtimeId, tasks: [] });
@@ -481,6 +497,60 @@ test("D10.8: runtime restart → runtime mismatch, Orca facts degrade, durable-c
     assert.deepEqual(r.body.outcomes.map((o) => o.outcome_id).sort(), ["done", "live"]);
   } finally {
     world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A26 — the foreign-task marker embeds the collision-resistant program segment
+// ---------------------------------------------------------------------------
+
+test("A26: program `alpha` does NOT adopt a task titled for `alpha/child` (distinct segments); a same-segment task IS adopted", () => {
+  const programId = "alpha";
+  const siblingId = "alpha/child";
+  assert.notEqual(programSegment(programId), programSegment(siblingId), "the two program ids must resolve to DISTINCT segments");
+
+  // (a) collision avoided: the ONLY live task is titled for the SIBLING program
+  //     `alpha/child`. With the raw-id marker `relay-orca: alpha/` this task WOULD have
+  //     been adopted as alpha's (`alpha/child/...`.includes(`alpha/`)); the segment-based
+  //     marker is not a prefix of the sibling's segment, so it is FOREIGN and never adopted.
+  const foreign = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-al", state: "dispatched", pr_number: 12, issue_number: 120 }],
+    orcaScenario: {
+      tasks: [{ id: "orca-live-sib", title: `relay-orca: ${programSegment(siblingId)}/child-oc`, status: "dispatched", worker_done: false }],
+    },
+    ghScenario: { prs: { 12: { state: "OPEN" } }, issues: { 120: { state: "OPEN" } } },
+  });
+  const foreignReceipt = makeReceipt({ programId, slug: foreign.slug, root: fs.realpathSync(foreign.repoRoot), tasks: [{ outcome_id: "al", run: "run-al" }] });
+  fs.writeFileSync(foreign.receiptPath, `${JSON.stringify(foreignReceipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = foreign.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "foreign_state", "a task titled for alpha/child is foreign to alpha");
+    assert.ok(diagCodes(r.body).includes("RUNTIME_MISMATCH"));
+    // durable truth still renders; Orca facts degrade because the runtime is foreign.
+    assert.equal(outcomeById(r.body, "al").state, "stale_missing");
+  } finally {
+    foreign.cleanup();
+  }
+
+  // (b) healthy adoption still works: a task titled with alpha's OWN segment is adopted →
+  //     runtime ok, the mapped outcome renders normally.
+  const healthy = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-al2", state: "dispatched", pr_number: 13, issue_number: 130 }],
+    orcaScenario: { tasks: [orcaTask(programId, "al2")] },
+    ghScenario: { prs: { 13: { state: "OPEN" } }, issues: { 130: { state: "OPEN" } } },
+  });
+  const healthyReceipt = makeReceipt({ programId, slug: healthy.slug, root: fs.realpathSync(healthy.repoRoot), tasks: [{ outcome_id: "al2", run: "run-al2" }] });
+  fs.writeFileSync(healthy.receiptPath, `${JSON.stringify(healthyReceipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = healthy.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "ok", "alpha's own segment-marked task is adopted");
+    assert.equal(outcomeById(r.body, "al2").state, "running");
+  } finally {
+    healthy.cleanup();
   }
 });
 
@@ -1707,6 +1777,35 @@ test("A20: a merged outcome whose PR HEAD sub-read fails → stale_missing, neve
   }
 });
 
+test("A25: a merged PR whose head read SUCCEEDS but omits headRefOid → stale_missing, never complete off a null head", () => {
+  // The merge read (mergedAt,state) SUCCEEDS (MERGED) AND the head read SUCCEEDS (status 0,
+  // valid JSON) but carries NO headRefOid. Before A25 that parsed-but-missing head counted
+  // as reachable with headRefOid=null, silently skipping the live-head comparison while the
+  // merged manifest + closed issue false-completed. A25 makes a missing/empty head OID from a
+  // successful read UNREACHABLE too → the outcome degrades to stale_missing and pr_merged is
+  // never counted as completion evidence when the head comparison was skipped.
+  const programId = "epic-status-head-absent";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-ha", state: "merged", pr_number: 810, issue_number: 8100 }],
+    orcaScenario: { tasks: [orcaTask(programId, "ha", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 810: { state: "MERGED", mergedAt: "2026-07-12T12:30:00Z", headOmitted: true } }, issues: { 8100: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "ha", run: "run-ha" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0, "a head-missing PR read never fails the command");
+    const outcome = outcomeById(r.body, "ha");
+    assert.equal(outcome.state, "stale_missing", "a head-missing PR read degrades the outcome, never false-completes");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.pr_merged, null, "pr_merged is withheld, not fabricated, when the head comparison was skipped");
+    assert.equal(world.gh.readPoison(), null, "a read never writes a poison");
+  } finally {
+    world.cleanup();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // A22 — --repo-root is canonicalized through Git (a linked worktree → PRIMARY slug)
 // ---------------------------------------------------------------------------
@@ -1729,7 +1828,7 @@ function makeGitWorktree() {
   return { base, primary, worktree, primaryRoot, primarySlug: computeRepoSlug(primaryRoot), worktreeSlug: computeRepoSlug(fs.realpathSync(worktree)) };
 }
 
-test("A22: resolveRepoContext canonicalizes a linked worktree to the PRIMARY root/slug; a non-git dir falls back to realpath", () => {
+test("A22/A24: resolveRepoContext canonicalizes a linked worktree to the PRIMARY root/slug; a non-git dir FAILS CLOSED (no realpath fallback)", () => {
   const wt = makeGitWorktree();
   const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-nongit-"));
   try {
@@ -1740,9 +1839,18 @@ test("A22: resolveRepoContext canonicalizes a linked worktree to the PRIMARY roo
     assert.equal(fromWorktree.root, wt.primaryRoot, "the linked worktree collapses to the primary checkout root");
     assert.equal(fromWorktree.slug, wt.primarySlug, "the slug derives from the PRIMARY root, not the worktree dir");
     assert.equal(resolveCanonicalRepoRoot({ repoRootOverride: wt.primary }), wt.primaryRoot, "the primary checkout resolves to itself");
-    // On git failure (a plain non-repo dir) the resolver falls back to a realpath of the
-    // provided root — the hermetic behavior every other path test relies on.
-    assert.equal(resolveCanonicalRepoRoot({ repoRootOverride: nonGit }), fs.realpathSync(nonGit));
+    // A24: on git failure (a plain non-repo dir) the resolver FAILS CLOSED — it throws a
+    // RECEIPT_REPO_MISMATCH (exit 52) CanonicalizationError rather than silently falling
+    // back to a realpath of an arbitrary directory (which could point at another repo).
+    assert.throws(
+      () => resolveCanonicalRepoRoot({ repoRootOverride: nonGit }),
+      (error) => {
+        assert.equal(error.reasonCode, "RECEIPT_REPO_MISMATCH");
+        assert.equal(error.exitCode, 52);
+        assert.match(error.message, /could not be canonicalized/i);
+        return true;
+      },
+    );
   } finally {
     fs.rmSync(wt.base, { recursive: true, force: true });
     fs.rmSync(nonGit, { recursive: true, force: true });

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -16,7 +16,13 @@ const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPT
 const { classifyOutcome } = require(path.join(SCRIPTS, "lib", "status-classify.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
-const { programSegment, runsRoot: resolveRunsRoot, fleetsRoot: resolveFleetsRoot } = require(path.join(SCRIPTS, "receipt-io.js"));
+const {
+  programSegment,
+  runsRoot: resolveRunsRoot,
+  fleetsRoot: resolveFleetsRoot,
+  resolveCanonicalRepoRoot,
+  resolveRepoContext,
+} = require(path.join(SCRIPTS, "receipt-io.js"));
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
@@ -1696,6 +1702,162 @@ test("A20: a merged outcome whose PR HEAD sub-read fails → stale_missing, neve
     assert.notEqual(outcome.state, "complete_with_evidence");
     assert.equal(outcome.evidence.pr_merged, null, "the PR fact is withheld, not fabricated");
     assert.equal(world.gh.readPoison(), null, "a failed read is not a write poison");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A22 — --repo-root is canonicalized through Git (a linked worktree → PRIMARY slug)
+// ---------------------------------------------------------------------------
+
+// Build a REAL primary git checkout + a LINKED WORKTREE whose `.git` FILE points at the
+// primary's git-common-dir. Pointing --repo-root at the worktree must derive the PRIMARY
+// slug, not the worktree-directory slug.
+function makeGitWorktree() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-status-worktree-"));
+  const primary = path.join(base, "primary");
+  const worktree = path.join(base, "wt");
+  fs.mkdirSync(primary, { recursive: true });
+  const git = (args, cwd) => execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"], primary);
+  git(["config", "user.email", "t@t.com"], primary);
+  git(["config", "user.name", "t"], primary);
+  git(["commit", "-q", "--allow-empty", "-m", "init"], primary);
+  git(["worktree", "add", "-q", "--detach", worktree, "HEAD"], primary);
+  const primaryRoot = fs.realpathSync(primary);
+  return { base, primary, worktree, primaryRoot, primarySlug: computeRepoSlug(primaryRoot), worktreeSlug: computeRepoSlug(fs.realpathSync(worktree)) };
+}
+
+test("A22: resolveRepoContext canonicalizes a linked worktree to the PRIMARY root/slug; a non-git dir falls back to realpath", () => {
+  const wt = makeGitWorktree();
+  const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-nongit-"));
+  try {
+    assert.notEqual(wt.primarySlug, wt.worktreeSlug, "the worktree dir slug genuinely differs from the primary slug");
+    // run.js and status.js BOTH resolve --repo-root through resolveRepoContext, so this
+    // equality is exactly what makes them agree on where the receipt lives.
+    const fromWorktree = resolveRepoContext({ repoRootOverride: wt.worktree });
+    assert.equal(fromWorktree.root, wt.primaryRoot, "the linked worktree collapses to the primary checkout root");
+    assert.equal(fromWorktree.slug, wt.primarySlug, "the slug derives from the PRIMARY root, not the worktree dir");
+    assert.equal(resolveCanonicalRepoRoot({ repoRootOverride: wt.primary }), wt.primaryRoot, "the primary checkout resolves to itself");
+    // On git failure (a plain non-repo dir) the resolver falls back to a realpath of the
+    // provided root — the hermetic behavior every other path test relies on.
+    assert.equal(resolveCanonicalRepoRoot({ repoRootOverride: nonGit }), fs.realpathSync(nonGit));
+  } finally {
+    fs.rmSync(wt.base, { recursive: true, force: true });
+    fs.rmSync(nonGit, { recursive: true, force: true });
+  }
+});
+
+test("A22: status --repo-root pointed at a LINKED WORKTREE loads the receipt stored under the PRIMARY slug", () => {
+  const wt = makeGitWorktree();
+  const programId = "epic-status-worktree";
+  const orca = installFakeOrcaStatus({ runtimeId: DEFAULT_RUNTIME_ID, tasks: [] });
+  const gh = installFakeGh({});
+  const programsRoot = path.join(wt.base, "programs");
+  const runsRoot = path.join(wt.base, "runs");
+  const fleetsRoot = path.join(wt.base, "fleets");
+  // The receipt is stored under the PRIMARY slug (where `run` from the same worktree would
+  // have written it). A worktree-slug resolver would look under `worktreeSlug` and 404.
+  const receiptDir = path.join(programsRoot, wt.primarySlug, programSegment(programId));
+  fs.mkdirSync(receiptDir, { recursive: true });
+  const receiptPath = path.join(receiptDir, "receipt.json");
+  const receipt = makeReceipt({ programId, slug: wt.primarySlug, root: wt.primaryRoot, tasks: [{ outcome_id: "x", orca_task_id: null, dispatch_id: null, assignee: null, run: "run-x" }] });
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  fs.mkdirSync(path.join(runsRoot, wt.primarySlug), { recursive: true });
+  fs.writeFileSync(path.join(runsRoot, wt.primarySlug, "run-x.md"), manifestText({ run_id: "run-x", state: "dispatched", pr_number: null, issue_number: null }), "utf-8");
+  const args = [STATUS_JS, "--program-id", programId, "--json", "--orca-bin", orca.orcaPath, "--gh-bin", gh.ghPath, "--repo-root", wt.worktree];
+  const result = { status: 0, stdout: "" };
+  try {
+    result.stdout = execFileSync(process.execPath, args, {
+      encoding: "utf-8",
+      env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot, RELAY_ORCA_RUNS_ROOT: runsRoot, RELAY_ORCA_FLEETS_ROOT: fleetsRoot },
+      stdio: "pipe",
+    });
+  } catch (error) {
+    result.status = error.status;
+    result.stdout = error.stdout ? String(error.stdout) : "";
+  }
+  const body = result.stdout ? JSON.parse(result.stdout) : null;
+  try {
+    assert.equal(result.status, 0, "status finds the primary-slug receipt from the linked worktree (no RECEIPT_NOT_FOUND / REPO_MISMATCH)");
+    assert.equal(body.program_id, programId);
+    assert.equal(body.receipt_path, receiptPath, "the loaded receipt is the one under the primary slug");
+    assert.equal(outcomeById(body, "x").state, "running");
+  } finally {
+    orca.cleanup();
+    gh.cleanup();
+    fs.rmSync(wt.base, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A23 — a durable fleet mapping (relay_ids.fleet / live fleet manifest) counts as started
+// ---------------------------------------------------------------------------
+
+test("A23: a relay_fleet outcome with only relay_ids.fleet + a live non-complete fleet manifest is started → running", () => {
+  const facts = {
+    receiptTask: {
+      outcome_id: "f",
+      task_id: "orca-task-f",
+      kind: "relay_fleet",
+      wave: 2,
+      orca_task_id: null,
+      dispatch_id: null,
+      assignee: null,
+      relay_ids: { request: null, run: null, fleet: "fleet-live" },
+    },
+    manifest: null,
+    mappedRunId: null,
+    mappedRunMissing: false,
+    // A live fleet manifest is mapped for this outcome, but it is NOT terminal yet.
+    fleetManifest: { fleet_id: "fleet-live", fleet_state: "dispatched", fleet_children: [] },
+    mappedFleetId: "fleet-live",
+    fleetChildren: [],
+    fleetChildEscalated: false,
+    pr: null,
+    issue: null,
+    prUrl: null,
+    issueUrl: null,
+  };
+  const { outcome, started } = classifyOutcome(facts, { orcaTrusted: true, isDuplicate: false });
+  assert.equal(started, true, "a durable fleet mapping counts as started even with no dispatch_id / relay_ids.run / PR");
+  assert.equal(outcome.state, "running", "an in-progress fleet is running, never treated as unstarted");
+});
+
+test("A23: a wave whose only in-progress outcome is a live relay_fleet is NOT ready_for_next_wave — the program is running", () => {
+  const programId = "epic-status-fleet-started";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      // wave 1: a fully complete relay_run
+      { run_id: "run-w1", state: "merged", pr_number: 900, issue_number: 9000 },
+      // wave 2: a LIVE, non-complete fleet manifest (fleets root) + a non-terminal child
+      { run_id: "fleet-w2", fleet_state: "dispatched", children: [{ leaf_ref: "l1", run_id: "child-w2" }] },
+      { run_id: "child-w2", state: "dispatched", pr_number: 901, issue_number: 9001 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "w1", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 900: { state: "MERGED", mergedAt: "2026-07-12T13:00:00Z" } }, issues: { 9000: { state: "CLOSED" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "w1", wave: 1, run: "run-w1" },
+      // The wave-2 fleet outcome has NO dispatch_id / run / orca task yet — only relay_ids.fleet.
+      { outcome_id: "w2", wave: 2, kind: "relay_fleet", orca_task_id: null, dispatch_id: null, assignee: null, fleet: "fleet-w2" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(outcomeById(r.body, "w1").state, "complete_with_evidence");
+    assert.equal(outcomeById(r.body, "w2").state, "running", "the mapped, live fleet outcome is running");
+    // Because the wave-2 fleet is already started, the program is NOT falsely ready_for_next_wave.
+    assert.equal(r.body.program_state, "running");
+    assert.notEqual(r.body.program_state, "ready_for_next_wave");
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -732,6 +732,57 @@ test("D5: a closed (abandoned, unmerged) relay manifest → escalated, never a s
 });
 
 // ---------------------------------------------------------------------------
+// A14 — relay_run completion is merged-only (a closed manifest never completes)
+// ---------------------------------------------------------------------------
+
+test("A14: a closed manifest with a merged PR + closed issue → escalated, never complete; the merged variant stays complete", () => {
+  // Closed variant: the run manifest is force-closed (terminal, but NOT merged) yet the
+  // PR shows MERGED and the issue shows CLOSED. A14 requires state === "merged" for
+  // relay_run completion, so `manifest_terminal` stays false and the outcome escalates —
+  // it must never complete off the stray merged PR / closed issue.
+  const closedProgram = "epic-status-closed-merged-pr";
+  const closedWorld = buildWorld({
+    programId: closedProgram,
+    manifests: [{ run_id: "run-cm", state: "closed", pr_number: 170, issue_number: 1700 }],
+    orcaScenario: { tasks: [orcaTask(closedProgram, "cm", { status: "dispatched", worker_done: false })] },
+    ghScenario: { prs: { 170: { state: "MERGED", mergedAt: "2026-07-12T11:00:00Z" } }, issues: { 1700: { state: "CLOSED" } } },
+  });
+  const closedReceipt = makeReceipt({ programId: closedProgram, slug: closedWorld.slug, root: fs.realpathSync(closedWorld.repoRoot), tasks: [{ outcome_id: "cm", run: "run-cm" }] });
+  fs.writeFileSync(closedWorld.receiptPath, `${JSON.stringify(closedReceipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = closedWorld.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "cm");
+    assert.equal(outcome.state, "escalated", "a closed (not merged) manifest can never yield completion evidence");
+    assert.notEqual(outcome.state, "complete_with_evidence");
+    assert.equal(outcome.evidence.manifest_terminal, false, "manifest_terminal is merged-only, not any-terminal");
+    assert.equal(r.body.program_state, "escalated");
+  } finally {
+    closedWorld.cleanup();
+  }
+
+  // Merged variant: the SAME PR/issue evidence with a `merged` manifest stays complete.
+  const mergedProgram = "epic-status-merged-variant";
+  const mergedWorld = buildWorld({
+    programId: mergedProgram,
+    manifests: [{ run_id: "run-mm", state: "merged", pr_number: 171, issue_number: 1710 }],
+    orcaScenario: { tasks: [orcaTask(mergedProgram, "mm", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 171: { state: "MERGED", mergedAt: "2026-07-12T11:05:00Z" } }, issues: { 1710: { state: "CLOSED" } } },
+  });
+  const mergedReceipt = makeReceipt({ programId: mergedProgram, slug: mergedWorld.slug, root: fs.realpathSync(mergedWorld.repoRoot), tasks: [{ outcome_id: "mm", run: "run-mm" }] });
+  fs.writeFileSync(mergedWorld.receiptPath, `${JSON.stringify(mergedReceipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = mergedWorld.run();
+    assert.equal(r.status, 0);
+    const outcome = outcomeById(r.body, "mm");
+    assert.equal(outcome.state, "complete_with_evidence", "the merged variant still completes on the same evidence");
+    assert.deepEqual(outcome.evidence, { manifest_terminal: true, pr_merged: true, issue_closed: true });
+  } finally {
+    mergedWorld.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Scenario 13 — awaiting decision (pending gate)
 // ---------------------------------------------------------------------------
 
@@ -1082,6 +1133,37 @@ test("A4: a failed required gate-list read → runtime unreachable, no false awa
     assert.equal(outcomeById(r.body, "g").state, "stale_missing");
     assert.notEqual(outcomeById(r.body, "g").state, "running");
     assert.equal(diagCodes(r.body).includes("MISSING_TASK"), false);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A13 — a status read with a missing live runtime id degrades to unreachable
+// ---------------------------------------------------------------------------
+
+test("A13: status succeeds but carries no live runtime id → runtime unreachable, no Orca-fact adoption, exit 0", () => {
+  const programId = "epic-status-no-runtimeid";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-nr", state: "dispatched", pr_number: 320, issue_number: 3200 }],
+    // status SUCCEEDS (ok:true) but carries NO runtimeId. A foreign task is present so a
+    // TRUSTED runtime would have adopted Orca facts here — the A13 guard withholds them
+    // instead of silently passing the mismatch check and trusting an unidentified runtime.
+    orcaScenario: { omitRuntimeId: true, tasks: [{ id: "foreign-x", title: "someone-else: other/thing", status: "dispatched" }] },
+    ghScenario: { prs: { 320: { state: "OPEN" } }, issues: { 3200: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "nr", run: "run-nr" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0, "a missing live runtime id never fails the command");
+    assert.equal(r.body.runtime, "unreachable");
+    // Facts are WITHHELD (same degradation as A4), never fabricated as a RUNTIME_MISMATCH.
+    assert.equal(diagCodes(r.body).includes("RUNTIME_MISMATCH"), false, "no mismatch diagnostic is forged");
+    // Orca facts withheld → the mapped outcome degrades to stale_missing; durable renders.
+    assert.equal(outcomeById(r.body, "nr").state, "stale_missing");
+    assert.deepEqual(Object.keys(r.body).sort(), [...REPORT_KEYS].sort());
   } finally {
     world.cleanup();
   }


### PR DESCRIPTION
## Dispatch Summary

```text
Done. Issue #945 is implemented, self-reviewed, hardened, and committed to `issue-945`.

## Summary

**Two deliverables shipped** (commits `9116fe4` + `54d7dc5`):

1. **Receipt persistence** wired into the `run` intent (bounded edit): `run.js` atomically writes a minimal, versioned `receipt.json` (schema `1`, identity/mapping only, verbatim authority-disclaimer `note`) under `~/.relay/programs/<repo-slug>/<program-id>/` after materialization and each verified dispatch. The slug replicates relay'
```

## Score Log

- Run: issue-945-20260712210646556-5a866c22
- Executor: claude
- Branch: issue-945


Fixes #945


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `relay-orca status` 읽기 전용 명령을 추가했습니다.
  * 실행 결과에 재현 가능한 영수증 경로를 표시하고, 실행 중 영수증을 안전하게 저장합니다.
  * 릴레이, GitHub, Orca의 실시간 신호를 종합해 프로그램 및 작업 상태를 제공합니다.
  * JSON 상태 리포트, 진단 코드, 증거 정보와 수정 후보를 지원합니다.
* **문서**
  * `run` 및 `status` 명령, 영수증 형식, 상태 분류와 오류 처리 규칙을 문서화했습니다.
* **버그 수정**
  * 상태 조회가 읽기 전용으로 동작하도록 보장하고, 잘못된 영수증에 대해 명확한 오류를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->