### PR TITLE
fix(review): empty-checks grace window for fresh-push race (#979)

### DIFF
--- a/skills/relay-review/scripts/review-runner/check-wait.js
+++ b/skills/relay-review/scripts/review-runner/check-wait.js
@@ -22,6 +22,10 @@ const { writeText } = require("./common");
 const DEFAULT_POLL_INTERVAL_MS = 12000;
 const MAX_GH_RETRIES = 3;
 const PENDING_CHECKS_MARKER_KEY = "pending_checks_marker";
+// Fresh-push registration race (#979): GitHub returns [] for seconds after a new
+// head is pushed before check runs register. An empty set must not settle during
+// this window. Overridable via deps.emptyChecksGraceMs for tests only — no CLI/env.
+const EMPTY_CHECKS_GRACE_MS = 90_000;
 
 function resolvePollIntervalMs() {
   const raw = Number(process.env.RELAY_REVIEW_CHECK_POLL_INTERVAL_MS);
@@ -48,12 +52,22 @@ function blockingSleep(ms) {
 // Poll a PR's checks until none are pending, or the budget is exhausted. Transient
 // gh failures are tolerated (never abort the round); a persistent gh failure past
 // the retry budget just proceeds with the checks state unknown.
+//
+// Empty-checks grace (#979): a successful fetch of [] does not settle while still
+// inside both the wait deadline and `start + EMPTY_CHECKS_GRACE_MS`. Once any check
+// has been observed, existing settle/pending/deadline/marker semantics apply.
+// Grace expiry (or deadline, whichever first) with zero checks ever observed →
+// settled-empty plus emptyGraceExpired.
 function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs }, deps = {}) {
   const now = deps.now || Date.now;
   const wait = deps.sleep || blockingSleep;
   const getChecks = deps.fetchChecks || fetchChecks;
   const start = now();
   const deadline = start + Math.max(0, budgetSeconds) * 1000;
+  const emptyChecksGraceMs = Number.isFinite(deps.emptyChecksGraceMs) && deps.emptyChecksGraceMs >= 0
+    ? deps.emptyChecksGraceMs
+    : EMPTY_CHECKS_GRACE_MS;
+  const graceDeadline = start + emptyChecksGraceMs;
   let checks = [];
   let ghErrors = 0;
   let polls = 0;
@@ -62,6 +76,8 @@ function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs 
   // distinct from budgetExhausted (deadline reached). Lets callers tell "nothing was
   // pending" (pending_checks: []) apart from "check state unknown due to gh failures".
   let checksUnknown = false;
+  let sawAnyCheck = false;
+  let emptyGraceExpired = false;
   while (true) {
     polls += 1;
     let fetchError = null;
@@ -71,9 +87,23 @@ function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs 
       fetchError = error;
       ghErrors += 1;
     }
-    if (!fetchError && classifyChecks(checks).pendingChecks.length === 0) {
-      settled = true;
-      break;
+    if (!fetchError) {
+      if (Array.isArray(checks) && checks.length > 0) {
+        sawAnyCheck = true;
+      }
+      if (classifyChecks(checks).pendingChecks.length === 0) {
+        if (sawAnyCheck) {
+          settled = true;
+          break;
+        }
+        // Empty set: do not settle while before both the wait deadline and grace.
+        // Grace is effectively capped by the budget (budgetSeconds: 0 → immediate).
+        if (now() >= deadline || now() >= graceDeadline) {
+          settled = true;
+          emptyGraceExpired = true;
+          break;
+        }
+      }
     }
     if (fetchError && ghErrors > MAX_GH_RETRIES) {
       checksUnknown = true;
@@ -93,6 +123,7 @@ function pollChecksUntilSettled({ repoPath, prNumber, budgetSeconds, intervalMs 
     polls,
     ghErrors,
     checksUnknown,
+    emptyGraceExpired,
   };
 }
 
@@ -108,6 +139,7 @@ function toResultSummary(outcome) {
     checks: outcome.checks,
     pending_checks: outcome.pendingCheckNames,
     ...(outcome.checksUnknown ? { checks_unknown: true } : {}),
+    ...(outcome.emptyGraceExpired ? { empty_grace_expired: true } : {}),
   };
 }
 
@@ -173,6 +205,7 @@ function applyPendingChecksMarker(reviewSection, { appliedVerdict, checkWait, re
 
 module.exports = {
   DEFAULT_POLL_INTERVAL_MS,
+  EMPTY_CHECKS_GRACE_MS,
   MAX_GH_RETRIES,
   PENDING_CHECKS_MARKER_KEY,
   applyPendingChecksMarker,

--- a/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
+++ b/tests/relay-review/scripts/review-runner-wait-for-checks.test.js
@@ -261,6 +261,7 @@ test("a normal settle summary does not carry checks_unknown (#970)", () => {
   assert.equal(outcome.pending, false);
   const summary = toResultSummary(outcome);
   assert.equal("checks_unknown" in summary, false, "settled rounds never carry the field");
+  assert.equal("empty_grace_expired" in summary, false, "observed-check settle never carries empty_grace_expired");
 });
 
 test("a normal budget-exhausted summary (no gh errors) does not carry checks_unknown (#970)", () => {
@@ -277,6 +278,7 @@ test("a normal budget-exhausted summary (no gh errors) does not carry checks_unk
   assert.equal(outcome.budgetExhausted, true);
   const summary = toResultSummary(outcome);
   assert.equal("checks_unknown" in summary, false, "a clean budget-exhaustion is not a gh-error exhaustion");
+  assert.equal("empty_grace_expired" in summary, false);
 });
 
 test("parseWaitForChecksSeconds: absent flag -> null, valid -> number, invalid -> throw", () => {
@@ -286,6 +288,125 @@ test("parseWaitForChecksSeconds: absent flag -> null, valid -> number, invalid -
   assert.equal(parseWaitForChecksSeconds("0"), 0);
   assert.throws(() => parseWaitForChecksSeconds("soon"), /non-negative number of seconds/);
   assert.throws(() => parseWaitForChecksSeconds("-5"), /non-negative number of seconds/);
+});
+
+// ---- #979: empty-checks grace window (fresh-push registration race) -------------
+
+test("pollChecksUntilSettled: fresh-push empty → checks appear → green settles without empty_grace_expired (#979 a)", () => {
+  const clock = { t: 0 };
+  // Two empty polls (registration lag), then pending, then green.
+  const timeline = [
+    [],
+    [],
+    [{ name: "unit", bucket: "pending" }],
+    [{ name: "unit", bucket: "pass" }],
+  ];
+  let call = 0;
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 60, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      emptyChecksGraceMs: 30_000,
+      fetchChecks: () => timeline[Math.min(call++, timeline.length - 1)],
+    }
+  );
+  assert.equal(outcome.pending, false, "settled once the registered check went green");
+  assert.equal(outcome.polls, 4, "kept polling through the empty registration window");
+  assert.equal(outcome.waitedMs, 3000, "three 1s sleeps across four polls");
+  assert.deepEqual(outcome.checks, [{ name: "unit", bucket: "pass" }]);
+  assert.equal(outcome.emptyGraceExpired, false);
+  assert.equal(outcome.budgetExhausted, false);
+  const summary = toResultSummary(outcome);
+  assert.equal("empty_grace_expired" in summary, false, "field absent when checks were observed");
+});
+
+test("pollChecksUntilSettled: zero-checks-forever settles at grace expiry with empty_grace_expired (#979 b)", () => {
+  const clock = { t: 0 };
+  const graceMs = 5000;
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 60, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      emptyChecksGraceMs: graceMs,
+      fetchChecks: () => [],
+    }
+  );
+  assert.equal(outcome.pending, false, "settled-empty at grace expiry (CI-less repo path)");
+  assert.equal(outcome.budgetExhausted, false, "grace ended before the wait budget");
+  assert.equal(outcome.emptyGraceExpired, true);
+  assert.equal(outcome.waitedMs, graceMs);
+  assert.ok(outcome.polls >= 2, `polled across the grace window (got ${outcome.polls})`);
+  assert.deepEqual(outcome.pendingCheckNames, []);
+  const summary = toResultSummary(outcome);
+  assert.equal(summary.empty_grace_expired, true);
+  assert.equal(summary.proceeded_with_pending, false);
+  assert.equal("checks_unknown" in summary, false);
+});
+
+test("pollChecksUntilSettled: budget shorter than grace settles at budget with empty_grace_expired (#979 c)", () => {
+  const clock = { t: 0 };
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 2, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      emptyChecksGraceMs: 90_000,
+      fetchChecks: () => [],
+    }
+  );
+  assert.equal(outcome.pending, false, "settled-empty when budget caps the grace");
+  assert.equal(outcome.emptyGraceExpired, true);
+  assert.equal(outcome.waitedMs, 2000, "never exceeds the budget");
+  assert.ok(outcome.waitedMs <= 2000);
+  assert.equal(outcome.budgetExhausted, false, "settled-empty is not proceeded-with-pending");
+  const summary = toResultSummary(outcome);
+  assert.equal(summary.empty_grace_expired, true);
+  assert.equal(summary.proceeded_with_pending, false);
+});
+
+test("pollChecksUntilSettled: budgetSeconds 0 + empty set is poll-once non-blocking with flag (#979 d)", () => {
+  const clock = { t: 0 };
+  let sleeps = 0;
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 0, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { sleeps += 1; clock.t += ms; },
+      emptyChecksGraceMs: 90_000,
+      fetchChecks: () => [],
+    }
+  );
+  assert.equal(outcome.polls, 1, "single poll");
+  assert.equal(sleeps, 0, "never blocks on a zero budget");
+  assert.equal(outcome.waitedMs, 0);
+  assert.equal(outcome.pending, false);
+  assert.equal(outcome.emptyGraceExpired, true, "grace capped by the zero deadline");
+  assert.equal(outcome.budgetExhausted, false);
+  const summary = toResultSummary(outcome);
+  assert.equal(summary.empty_grace_expired, true);
+  assert.equal(summary.proceeded_with_pending, false);
+});
+
+test("pollChecksUntilSettled: gh-error exhaustion still fires with empty checks (#979 / #970)", () => {
+  const clock = { t: 0 };
+  let calls = 0;
+  const outcome = pollChecksUntilSettled(
+    { repoPath: ".", prNumber: 1, budgetSeconds: 600, intervalMs: 1000 },
+    {
+      now: () => clock.t,
+      sleep: (ms) => { clock.t += ms; },
+      emptyChecksGraceMs: 90_000,
+      fetchChecks: () => { calls += 1; throw new Error("gh pr checks failed: API unavailable"); },
+    }
+  );
+  assert.equal(calls, MAX_GH_RETRIES + 1);
+  assert.equal(outcome.checksUnknown, true);
+  assert.equal(outcome.emptyGraceExpired, false, "gh-error path does not claim grace expiry");
+  const summary = toResultSummary(outcome);
+  assert.equal(summary.checks_unknown, true);
+  assert.equal("empty_grace_expired" in summary, false);
 });
 
 // ---- End-to-end review-runner rounds through the fake gh ----


### PR DESCRIPTION
## Summary
- `pollChecksUntilSettled` no longer settles on a successful empty check set while still inside both the wait deadline and a 90s empty-checks grace window (`EMPTY_CHECKS_GRACE_MS`, overridable via `deps.emptyChecksGraceMs` for tests only).
- Once any check has been observed, existing settle / pending / deadline / `checks_unknown` semantics are unchanged. Grace (or budget) expiry with zero checks ever seen returns settled-empty plus `empty_grace_expired: true` (spread-only-when-set, like `checks_unknown`).
- `budgetSeconds: 0` stays poll-once non-blocking; CI-less repos still complete at most `min(grace, budget)` later than before.

Closes #979

## Test plan
- [x] `node --test tests/relay-review/scripts/review-runner-wait-for-checks.test.js`
- [x] `node --test --test-concurrency=1 tests/relay-review/scripts/*.test.js` (589 pass)
- [ ] Fresh-push: empty → checks register → green settles without `empty_grace_expired`
- [ ] Zero-checks-forever settles at grace with `empty_grace_expired: true`
- [ ] Budget shorter than grace / `budgetSeconds: 0` still respect the deadline cap


Made with [Cursor](https://cursor.com)