### PR TITLE
fix(merge): reap own-pgid advisory lanes before worktree removal (#963)

### DIFF
--- a/skills/relay-dispatch/scripts/run-runtime-state.js
+++ b/skills/relay-dispatch/scripts/run-runtime-state.js
@@ -13,6 +13,8 @@ const DISPATCH_STDOUT_LOG = "dispatch-stdout.log";
 const DISPATCH_STDERR_LOG = "dispatch-stderr.log";
 const DISPATCH_RESULT_FILE = "dispatch-result.txt";
 const LEASE_DEATH_CONFIRM_DELAY_MS = 50;
+const ADVISORY_LANE_LEASE_RE = /^review-round-(\d+)-advisory-(.+)-lane-lease\.json$/;
+const DEFAULT_ADVISORY_LANE_REAP_GRACE_MS = 3000;
 
 let posixProcessStateInspectionUnavailable = false;
 
@@ -361,17 +363,257 @@ function assertNoLiveRunLease({ repoRoot, runId, force = false, caller = "relay-
   return status;
 }
 
+function advisoryLaneLeaseFilename(round, reviewer) {
+  return `review-round-${round}-advisory-${reviewer}-lane-lease.json`;
+}
+
+function getAdvisoryLaneLeasePath(runDir, round, reviewer) {
+  return path.join(runDir, advisoryLaneLeaseFilename(round, reviewer));
+}
+
+function normalizeAdvisoryLaneLease(raw) {
+  const pid = Number(raw?.pid);
+  const pgid = Number(raw?.pgid);
+  const host = typeof raw?.host === "string" ? raw.host.trim() : "";
+  const startedAt = typeof raw?.started_at === "string" ? raw.started_at.trim() : "";
+  const round = Number(raw?.round);
+  const reviewer = typeof raw?.reviewer === "string" ? raw.reviewer.trim() : "";
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error("advisory lane lease pid must be a positive integer");
+  }
+  if (!Number.isInteger(pgid) || pgid <= 0) {
+    throw new Error("advisory lane lease pgid must be a positive integer");
+  }
+  if (!host) {
+    throw new Error("advisory lane lease host must be set");
+  }
+  if (!startedAt || Number.isNaN(Date.parse(startedAt))) {
+    throw new Error("advisory lane lease started_at must be an ISO timestamp");
+  }
+  if (!Number.isInteger(round) || round <= 0) {
+    throw new Error("advisory lane lease round must be a positive integer");
+  }
+  if (!reviewer) {
+    throw new Error("advisory lane lease reviewer must be set");
+  }
+  return { pid, pgid, host, started_at: startedAt, round, reviewer };
+}
+
+function writeAdvisoryLaneLease(runDir, {
+  pid,
+  pgid,
+  host = os.hostname(),
+  startedAt = new Date().toISOString(),
+  round,
+  reviewer,
+}) {
+  if (typeof runDir !== "string" || !runDir.trim()) {
+    throw new Error("writeAdvisoryLaneLease requires runDir");
+  }
+  fs.mkdirSync(runDir, { recursive: true });
+  const lease = normalizeAdvisoryLaneLease({
+    pid,
+    pgid,
+    host,
+    started_at: startedAt,
+    round,
+    reviewer,
+  });
+  const leasePath = getAdvisoryLaneLeasePath(runDir, lease.round, lease.reviewer);
+  fs.writeFileSync(leasePath, `${JSON.stringify(lease, null, 2)}\n`, "utf-8");
+  return { lease, leasePath };
+}
+
+function removeAdvisoryLaneLease(runDir, round, reviewer) {
+  const leasePath = getAdvisoryLaneLeasePath(runDir, round, reviewer);
+  fs.rmSync(leasePath, { force: true });
+  return leasePath;
+}
+
+function readAdvisoryLaneLeases(runDir) {
+  if (typeof runDir !== "string" || !runDir.trim()) return [];
+  let entries = [];
+  try {
+    entries = fs.readdirSync(runDir);
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+  const leases = [];
+  for (const name of entries) {
+    const match = name.match(ADVISORY_LANE_LEASE_RE);
+    if (!match) continue;
+    const leasePath = path.join(runDir, name);
+    try {
+      const lease = normalizeAdvisoryLaneLease(JSON.parse(fs.readFileSync(leasePath, "utf-8")));
+      leases.push({ lease, leasePath });
+    } catch (error) {
+      leases.push({
+        lease: null,
+        leasePath,
+        corrupt: true,
+        error: error.message,
+        round: Number(match[1]) || null,
+        reviewer: match[2] || null,
+      });
+    }
+  }
+  return leases.sort((a, b) => {
+    const roundA = a.lease?.round ?? a.round ?? 0;
+    const roundB = b.lease?.round ?? b.round ?? 0;
+    if (roundA !== roundB) return roundA - roundB;
+    const reviewerA = a.lease?.reviewer ?? a.reviewer ?? "";
+    const reviewerB = b.lease?.reviewer ?? b.reviewer ?? "";
+    return reviewerA.localeCompare(reviewerB);
+  });
+}
+
+function signalProcessGroup(pgid, signal) {
+  if (!pgid || !Number.isFinite(Number(pgid))) return;
+  try {
+    if (process.platform === "win32") {
+      require("child_process").execFileSync("taskkill", ["/PID", String(pgid), "/T", "/F"], { stdio: "pipe" });
+    } else {
+      process.kill(-Number(pgid), signal);
+    }
+  } catch (error) {
+    if (error.code === "ESRCH") return;
+    // Best-effort: finalize continues even if an unexpected signal error occurs.
+  }
+}
+
+function sleepSync(ms) {
+  const waitMs = Math.max(0, Number(ms) || 0);
+  if (waitMs <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, waitMs);
+}
+
+function waitForProcessGroupExitSync(pgid, { timeoutMs = 1500, intervalMs = 50 } = {}) {
+  if (!pgid || !Number.isFinite(Number(pgid))) return false;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessGroupAlive(pgid)) return true;
+    sleepSync(Math.min(intervalMs, Math.max(1, deadline - Date.now())));
+  }
+  return !isProcessGroupAlive(pgid);
+}
+
+function resolveAdvisoryLaneReapGraceMs(explicitMs) {
+  if (Number.isFinite(Number(explicitMs)) && Number(explicitMs) >= 0) {
+    return Number(explicitMs);
+  }
+  const fromEnv = Number(process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS);
+  if (Number.isFinite(fromEnv) && fromEnv >= 0) return fromEnv;
+  return DEFAULT_ADVISORY_LANE_REAP_GRACE_MS;
+}
+
+function reapAdvisoryLaneLeases({
+  runDir,
+  dryRun = false,
+  graceMs,
+  host = os.hostname(),
+} = {}) {
+  const grace = resolveAdvisoryLaneReapGraceMs(graceMs);
+  const entries = readAdvisoryLaneLeases(runDir);
+  const outcomes = [];
+
+  for (const entry of entries) {
+    if (entry.corrupt || !entry.lease) {
+      outcomes.push({
+        pgid: null,
+        reviewer: entry.reviewer || null,
+        round: entry.round || null,
+        outcome: dryRun ? "would_remove_corrupt" : "corrupt",
+        leasePath: entry.leasePath,
+        error: entry.error || "invalid advisory lane lease",
+      });
+      if (!dryRun) {
+        fs.rmSync(entry.leasePath, { force: true });
+      }
+      continue;
+    }
+
+    const { lease, leasePath } = entry;
+    const base = {
+      pgid: lease.pgid,
+      pid: lease.pid,
+      reviewer: lease.reviewer,
+      round: lease.round,
+      host: lease.host,
+      leasePath,
+    };
+
+    if (lease.host !== host) {
+      outcomes.push({
+        ...base,
+        outcome: "skipped_host_mismatch",
+      });
+      continue;
+    }
+
+    if (!isProcessGroupAlive(lease.pgid)) {
+      outcomes.push({
+        ...base,
+        outcome: dryRun ? "would_remove_stale" : "stale",
+      });
+      if (!dryRun) {
+        removeAdvisoryLaneLease(runDir, lease.round, lease.reviewer);
+      }
+      continue;
+    }
+
+    if (dryRun) {
+      outcomes.push({
+        ...base,
+        outcome: "would_reap",
+      });
+      continue;
+    }
+
+    signalProcessGroup(lease.pgid, "SIGTERM");
+    waitForProcessGroupExitSync(lease.pgid, { timeoutMs: grace });
+    let signaledKill = false;
+    if (isProcessGroupAlive(lease.pgid)) {
+      signaledKill = true;
+      signalProcessGroup(lease.pgid, "SIGKILL");
+      waitForProcessGroupExitSync(lease.pgid, { timeoutMs: grace });
+    }
+
+    const gone = !isProcessGroupAlive(lease.pgid);
+    if (gone) {
+      removeAdvisoryLaneLease(runDir, lease.round, lease.reviewer);
+      outcomes.push({
+        ...base,
+        outcome: "reaped",
+        signaled_kill: signaledKill,
+      });
+    } else {
+      outcomes.push({
+        ...base,
+        outcome: "reap_failed",
+        signaled_kill: signaledKill,
+      });
+    }
+  }
+
+  return outcomes;
+}
+
 module.exports = {
+  ADVISORY_LANE_LEASE_RE,
+  DEFAULT_ADVISORY_LANE_REAP_GRACE_MS,
   DISPATCH_RESULT_FILE,
   DISPATCH_STDERR_LOG,
   DISPATCH_STDOUT_LOG,
   LEASE_FILENAME,
+  advisoryLaneLeaseFilename,
   assertNoLiveRunLease,
   corruptRunLeaseEventFields,
   corruptRunLeaseReportFields,
   confirmRunLeaseSupervisorDeath,
   dispatchManifestPathFields,
   formatLeaseForMessage,
+  getAdvisoryLaneLeasePath,
   getDispatchResultCandidates,
   getLeasePath,
   getRunArtifactPaths,
@@ -379,9 +621,15 @@ module.exports = {
   isDestructiveCleanupBlockedByLease,
   isProcessGroupAlive,
   latestRunEvent,
+  readAdvisoryLaneLeases,
   readRunLease,
+  reapAdvisoryLaneLeases,
+  removeAdvisoryLaneLease,
   removeRunLease,
+  signalProcessGroup,
   terminateProcessGroup,
   waitForProcessGroupExit,
+  waitForProcessGroupExitSync,
+  writeAdvisoryLaneLease,
   writeRunLease,
 };

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -67,6 +67,7 @@ const {
   summarizeRubricAuditForSkip,
 } = require("./review-gate");
 const { STATUS: LEARNING_STATUS, appendLearnings } = require("./append-learnings");
+const { reapAdvisoryLaneLeases } = require("../../relay-dispatch/scripts/run-runtime-state");
 
 const ALLOWED_CHECK_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
 
@@ -1412,6 +1413,11 @@ function main() {
     }
   }
 
+  // Reap own-pgid advisory lanes before retained-worktree removal so finalize
+  // does not orphan TERM-ignoring lane process groups (ppid 1).
+  const runDir = getRunDir(repoPath, updated.run_id);
+  const advisoryLaneReaps = reapAdvisoryLaneLeases({ runDir, dryRun });
+
   const cleanupResult = runFinalizeCleanup({
     repoRoot: repoPath,
     data: updated,
@@ -1462,6 +1468,8 @@ function main() {
     forceFinalized: forceFinalizeNonready,
     forceFinalizeReason: forceFinalizeNonready ? forceFinalizeReason : null,
     ...(freshness ? { freshness } : {}),
+    // Omit when idle so no-lease finalize stays byte-identical to prior output.
+    ...(advisoryLaneReaps.length > 0 ? { advisoryLaneReaps } : {}),
   };
 
   if (jsonOut) {
@@ -1476,6 +1484,11 @@ function main() {
       if (remoteBranchDeleteWarning) console.log(`  Remote note:  ${remoteBranchDeleteWarning}`);
     }
     console.log(`  Issue close:  ${issueNumber ? (issueClosed ? "closed" : (issueCloseWarning ? `warning: ${issueCloseWarning}` : "skipped")) : "none"}`);
+    if (advisoryLaneReaps.length > 0) {
+      for (const reap of advisoryLaneReaps) {
+        console.log(`  Advisory lane: pgid=${reap.pgid ?? "unknown"} reviewer=${reap.reviewer ?? "unknown"} outcome=${reap.outcome}`);
+      }
+    }
     console.log(`  Cleanup:      ${cleanupResult.summary.cleanupStatus}`);
     if (cleanupResult.summary.error) console.log(`  Cleanup note: ${cleanupResult.summary.error}`);
     if (dryRun) console.log("  dry-run:      no changes written");

--- a/skills/relay-review/scripts/advisory-worker.js
+++ b/skills/relay-review/scripts/advisory-worker.js
@@ -2,6 +2,20 @@
 
 const fs = require("fs");
 const { executeAdvisoryRequest } = require("./review-runner/advisory");
+const { removeAdvisoryLaneLease } = require("../../relay-dispatch/scripts/run-runtime-state");
+
+function clearOwnLaneLease(request) {
+  if (!request || typeof request !== "object") return;
+  const runDir = typeof request.runDir === "string" ? request.runDir : null;
+  const round = Number(request.round);
+  const reviewer = request.artifactReviewerName || request.reviewerName;
+  if (!runDir || !Number.isInteger(round) || round <= 0 || !reviewer) return;
+  try {
+    removeAdvisoryLaneLease(runDir, round, reviewer);
+  } catch {
+    // Best-effort: missing or unreadable lease must not fail the worker exit.
+  }
+}
 
 function main() {
   const requestPath = process.argv[2];
@@ -9,7 +23,11 @@ function main() {
     throw new Error("advisory-worker requires a request JSON path");
   }
   const request = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
-  executeAdvisoryRequest(request);
+  try {
+    executeAdvisoryRequest(request);
+  } finally {
+    clearOwnLaneLease(request);
+  }
 }
 
 try {

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -13,6 +13,7 @@ const {
 const { resolveExecutorDefaultModel } = require("../../../relay-dispatch/scripts/executor-model-config");
 const { hashFileSha256 } = require("../../../relay-dispatch/scripts/execution-evidence");
 const { appendRunEvent, appendUnregisteredRouteUsedEvent, EVENTS, readRunEvents } = require("../../../relay-dispatch/scripts/relay-events");
+const { writeAdvisoryLaneLease } = require("../../../relay-dispatch/scripts/run-runtime-state");
 const { parseAdvisoryReview, validateAdvisoryProfile } = require("../advisory-review-schema");
 const { captureGitStatus, resolveReviewerScript } = require("./reviewer-invoke");
 const { writeText } = require("./common");
@@ -213,6 +214,16 @@ function startAdvisoryReview({
     stdio: "ignore",
   });
   child.unref();
+  // detached: true → child is its own process-group leader (pgid == pid).
+  // Persist a lane lease distinct from the round lease (lease.json / #951).
+  if (Number.isInteger(child.pid) && child.pid > 0) {
+    writeAdvisoryLaneLease(runDir, {
+      pid: child.pid,
+      pgid: child.pid,
+      round,
+      reviewer: artifactName,
+    });
+  }
 
   return {
     ...request,

--- a/tests/relay-merge/fixtures/term-ignoring-lane.js
+++ b/tests/relay-merge/fixtures/term-ignoring-lane.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// TERM-ignoring fixture for advisory-lane reap tests (#963).
+// Ignores SIGTERM so finalize-run must escalate to SIGKILL.
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 60_000);

--- a/tests/relay-merge/scripts/finalize-run-advisory-lane-reap.test.js
+++ b/tests/relay-merge/scripts/finalize-run-advisory-lane-reap.test.js
@@ -1,0 +1,344 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawn } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  createRunId,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
+const { createEnforcementFixture } = require("../../relay-dispatch/scripts/test-support");
+const {
+  getAdvisoryLaneLeasePath,
+  isProcessGroupAlive,
+  writeAdvisoryLaneLease,
+} = require("../../../skills/relay-dispatch/scripts/run-runtime-state");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-merge", "scripts", "finalize-run.js");
+const TERM_IGNORING_LANE = path.join(__dirname, "..", "fixtures", "term-ignoring-lane.js");
+const DEFAULT_COMMIT_DATE = "2026-04-03T08:00:00Z";
+const DEFAULT_REVIEW_COMMENT = {
+  body: "<!-- relay-review -->\n## Relay Review\nVerdict: LGTM\nRounds: 1",
+  createdAt: DEFAULT_COMMIT_DATE,
+};
+
+function buildReadyManifest(manifest) {
+  let next = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  next = updateManifestState(next, STATES.REVIEW_PENDING, "run_review");
+  next = updateManifestState(next, STATES.READY_TO_MERGE, "await_explicit_merge");
+  return {
+    ...next,
+    review: {
+      ...(next.review || {}),
+      last_reviewed_sha: next.git?.head_sha || null,
+      latest_verdict: "lgtm",
+      rounds: 1,
+    },
+  };
+}
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-finalize-lane-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-lane-"));
+  const originRoot = path.join(repoRoot, "origin.git");
+  execFileSync("git", ["init", "--bare", originRoot], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Merge Lane Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-merge-lane@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", originRoot], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const branch = "issue-963";
+  const worktreePath = path.join(repoRoot, "wt", branch);
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(worktreePath, "smoke.txt"), "ok\n", "utf-8");
+  execFileSync("git", ["-C", worktreePath, "add", "smoke.txt"], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "commit", "-m", "Add smoke"], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["-C", worktreePath, "push", "-u", "origin", branch], { encoding: "utf-8", stdio: "pipe" });
+  const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim();
+
+  const runId = createRunId({
+    branch,
+    timestamp: new Date("2026-07-12T07:00:00.000Z"),
+  });
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch,
+    baseBranch: "main",
+    issueNumber: 963,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+  }).anchor;
+  manifest.git.pr_number = 123;
+  manifest.git.head_sha = headSha;
+  manifest = buildReadyManifest(manifest);
+  writeManifest(manifestPath, manifest);
+
+  return { repoRoot, manifestPath, branch, worktreePath, headSha, runId, runDir };
+}
+
+function writeFakeGh(logPath, {
+  comments = [DEFAULT_REVIEW_COMMENT],
+  commits = [],
+  headRefName = "issue-963",
+} = {}) {
+  const ghPath = path.join(path.dirname(logPath), "fake-gh-lane.js");
+  const statePath = path.join(path.dirname(logPath), "fake-gh-lane-state.json");
+  fs.writeFileSync(statePath, JSON.stringify({
+    headRefName,
+    baseRefName: "main",
+    defaultBranchName: "main",
+    comments,
+    commits,
+    state: "OPEN",
+    mergeCommit: null,
+    mergeable: "MERGEABLE",
+    statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
+    stateAfterMerge: "MERGED",
+    mergeCommitAfterMerge: { oid: "merged-sha" },
+    prMergeExitCode: 0,
+    prMergeStderr: "",
+    title: "fix(relay): advisory lane reap",
+  }), "utf-8");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+const statePath = ${JSON.stringify(statePath)};
+function loadState() {
+  return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+}
+function saveState(next) {
+  fs.writeFileSync(statePath, JSON.stringify(next), "utf-8");
+}
+fs.appendFileSync(${JSON.stringify(logPath)}, args.join(" ") + "\\n", "utf-8");
+if (args[0] === "pr" && args[1] === "merge") {
+  const state = loadState();
+  state.state = state.stateAfterMerge;
+  state.mergeCommit = state.mergeCommitAfterMerge;
+  saveState(state);
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "view") {
+  const state = loadState();
+  process.stdout.write(JSON.stringify({
+    headRefName: state.headRefName,
+    baseRefName: state.baseRefName,
+    state: state.state,
+    mergeCommit: state.mergeCommit,
+    comments: state.comments,
+    commits: state.commits,
+    mergeable: state.mergeable,
+    statusCheckRollup: state.statusCheckRollup,
+    title: state.title,
+    headRefOid: state.commits[0]?.oid || null,
+  }));
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "list") {
+  process.stdout.write("[]");
+  process.exit(0);
+}
+if (args[0] === "repo" && args[1] === "view") {
+  const state = loadState();
+  process.stdout.write(JSON.stringify({
+    defaultBranchRef: { name: state.defaultBranchName },
+  }));
+  process.exit(0);
+}
+if (args[0] === "issue" && args[1] === "close") {
+  process.exit(0);
+}
+process.exit(0);
+`, "utf-8");
+  fs.chmodSync(ghPath, 0o755);
+  return ghPath;
+}
+
+function execFinalize(fixture, { extraArgs = [], env = {} } = {}) {
+  const logPath = path.join(fixture.repoRoot, "gh.log");
+  const fakeGh = writeFakeGh(logPath, {
+    comments: [DEFAULT_REVIEW_COMMENT],
+    commits: [{ oid: fixture.headSha, committedDate: DEFAULT_COMMIT_DATE }],
+  });
+  const stdout = execFileSync("node", [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--branch", fixture.branch,
+    "--pr", "123",
+    "--no-issue-close",
+    ...extraArgs,
+    "--json",
+  ], {
+    cwd: fixture.repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      RELAY_GH_BIN: fakeGh,
+      RELAY_ADVISORY_LANE_REAP_GRACE_MS: "400",
+      ...env,
+    },
+  });
+  return {
+    ...fixture,
+    logPath,
+    result: JSON.parse(stdout),
+    events: readRunEvents(fixture.repoRoot, fixture.runId),
+  };
+}
+
+function spawnTermIgnoringLane() {
+  const child = spawn(process.execPath, [TERM_IGNORING_LANE], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  assert.ok(Number.isInteger(child.pid) && child.pid > 0);
+  // Detached spawn → pgid == pid.
+  assert.equal(isProcessGroupAlive(child.pid), true);
+  return child.pid;
+}
+
+function forceKillPgid(pgid) {
+  try {
+    process.kill(-pgid, "SIGKILL");
+  } catch {}
+}
+
+test("finalize-run reaps a live TERM-ignoring advisory lane before worktree removal", () => {
+  const fixture = setupRepo();
+  const pgid = spawnTermIgnoringLane();
+  const leasePath = getAdvisoryLaneLeasePath(fixture.runDir, 1, "codex");
+  try {
+    writeAdvisoryLaneLease(fixture.runDir, {
+      pid: pgid,
+      pgid,
+      round: 1,
+      reviewer: "codex",
+    });
+    assert.equal(fs.existsSync(leasePath), true);
+    assert.equal(fs.existsSync(fixture.worktreePath), true);
+
+    const { result } = execFinalize(fixture);
+
+    assert.equal(isProcessGroupAlive(pgid), false);
+    assert.equal(fs.existsSync(leasePath), false);
+    assert.equal(fs.existsSync(fixture.worktreePath), false);
+    assert.ok(Array.isArray(result.advisoryLaneReaps));
+    assert.equal(result.advisoryLaneReaps.length, 1);
+    assert.deepEqual(result.advisoryLaneReaps[0], {
+      pgid,
+      pid: pgid,
+      reviewer: "codex",
+      round: 1,
+      host: os.hostname(),
+      leasePath,
+      outcome: "reaped",
+      signaled_kill: true,
+    });
+    assert.equal(result.cleanup.worktreeRemoved, true);
+  } finally {
+    forceKillPgid(pgid);
+  }
+});
+
+test("finalize-run removes a stale dead-pid advisory lane lease without signaling", () => {
+  const fixture = setupRepo();
+  const deadPgid = 2147483646;
+  assert.equal(isProcessGroupAlive(deadPgid), false);
+  const leasePath = getAdvisoryLaneLeasePath(fixture.runDir, 1, "opencode");
+  writeAdvisoryLaneLease(fixture.runDir, {
+    pid: deadPgid,
+    pgid: deadPgid,
+    round: 1,
+    reviewer: "opencode",
+  });
+
+  const { result } = execFinalize(fixture);
+
+  assert.equal(fs.existsSync(leasePath), false);
+  assert.equal(result.advisoryLaneReaps.length, 1);
+  assert.equal(result.advisoryLaneReaps[0].outcome, "stale");
+  assert.equal(result.advisoryLaneReaps[0].pgid, deadPgid);
+  assert.equal(result.advisoryLaneReaps[0].reviewer, "opencode");
+  assert.equal(result.cleanup.worktreeRemoved, true);
+});
+
+test("finalize-run skips host-mismatch advisory lane leases and leaves the process alive", () => {
+  const fixture = setupRepo();
+  const pgid = spawnTermIgnoringLane();
+  const leasePath = getAdvisoryLaneLeasePath(fixture.runDir, 2, "pi");
+  try {
+    writeAdvisoryLaneLease(fixture.runDir, {
+      pid: pgid,
+      pgid,
+      host: "foreign.example.invalid",
+      round: 2,
+      reviewer: "pi",
+    });
+
+    const { result } = execFinalize(fixture);
+
+    assert.equal(isProcessGroupAlive(pgid), true);
+    assert.equal(fs.existsSync(leasePath), true);
+    assert.equal(result.advisoryLaneReaps.length, 1);
+    assert.equal(result.advisoryLaneReaps[0].outcome, "skipped_host_mismatch");
+    assert.equal(result.advisoryLaneReaps[0].pgid, pgid);
+    assert.equal(result.advisoryLaneReaps[0].reviewer, "pi");
+  } finally {
+    forceKillPgid(pgid);
+  }
+});
+
+test("finalize-run --dry-run reports would_reap and leaves the lane process alive", () => {
+  const fixture = setupRepo();
+  const pgid = spawnTermIgnoringLane();
+  const leasePath = getAdvisoryLaneLeasePath(fixture.runDir, 1, "codex");
+  try {
+    writeAdvisoryLaneLease(fixture.runDir, {
+      pid: pgid,
+      pgid,
+      round: 1,
+      reviewer: "codex",
+    });
+
+    const { result } = execFinalize(fixture, { extraArgs: ["--dry-run"] });
+
+    assert.equal(result.dryRun, true);
+    assert.equal(isProcessGroupAlive(pgid), true);
+    assert.equal(fs.existsSync(leasePath), true);
+    assert.equal(fs.existsSync(fixture.worktreePath), true);
+    assert.equal(result.advisoryLaneReaps.length, 1);
+    assert.equal(result.advisoryLaneReaps[0].outcome, "would_reap");
+    assert.equal(result.advisoryLaneReaps[0].pgid, pgid);
+  } finally {
+    forceKillPgid(pgid);
+  }
+});
+
+test("finalize-run with no advisory lane leases omits advisoryLaneReaps (byte-identical idle shape)", () => {
+  const fixture = setupRepo();
+  const { result } = execFinalize(fixture);
+  assert.equal("advisoryLaneReaps" in result, false);
+  assert.equal(result.cleanup.worktreeRemoved, true);
+});

--- a/tests/relay-review/scripts/advisory-lane-lease.test.js
+++ b/tests/relay-review/scripts/advisory-lane-lease.test.js
@@ -1,0 +1,235 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES,
+  createManifestSkeleton,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { createEnforcementFixture, DEFAULT_ENFORCEMENT_RUBRIC } = require("../../relay-dispatch/scripts/test-support");
+const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+const { startAdvisoryReview } = require("../../../skills/relay-review/scripts/review-runner/advisory");
+const {
+  getAdvisoryLaneLeasePath,
+  readAdvisoryLaneLeases,
+  writeAdvisoryLaneLease,
+} = require("../../../skills/relay-dispatch/scripts/run-runtime-state");
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-lane-lease-"));
+  const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-lane-lease-origin-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-lane-lease-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["init", "--bare", remoteRoot], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Lane Lease Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-lane-lease@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", remoteRoot], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const runId = "issue-963-20260712010000000";
+  const worktreePath = path.join(repoRoot, "wt", "issue-963");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", "issue-963"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-963",
+    baseBranch: "main",
+    issueNumber: 963,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+    rubricContent: DEFAULT_ENFORCEMENT_RUBRIC,
+  }).anchor;
+  manifest = { ...manifest, git: { ...(manifest.git || {}), pr_number: 963, head_sha: headSha } };
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(manifestPath, manifest);
+  fs.writeFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), `${JSON.stringify({
+    schema_version: 1,
+    head_sha: headSha,
+    test_command: "node --test",
+    test_result_hash: "unspecified",
+    test_result_summary: "pass",
+    recorded_at: "2026-07-12T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  }, null, 2)}\n`, "utf-8");
+  return { repoRoot, runDir, runId, headSha, worktreePath };
+}
+
+function writeDelayedAdvisoryReviewer(repoRoot, { delayMs = 1500 } = {}) {
+  const filePath = path.join(repoRoot, "fake-lane-reviewer.js");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    profile: "blindspot",
+    summary: "Lane lease fixture advisory.",
+    required_findings: [],
+    advisory_findings: [{
+      title: "Advisory-only test gap",
+      body: "Recorded for lease bookkeeping coverage.",
+      file: "README.md",
+      line: 1,
+      severity: "P3",
+      category: "test-gap",
+      confidence: 0.8
+    }],
+    duplicate_or_low_confidence: []
+  }));
+}, ${Number(delayMs)});
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitUntil(predicate, { timeoutMs = 20000, intervalMs = 100 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    sleepSync(intervalMs);
+  }
+  return predicate();
+}
+
+test("writeAdvisoryLaneLease retry overwrites the same reviewer+round lease", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-lane-lease-unit-"));
+  writeAdvisoryLaneLease(runDir, {
+    pid: 111,
+    pgid: 111,
+    round: 1,
+    reviewer: "opencode",
+  });
+  writeAdvisoryLaneLease(runDir, {
+    pid: 222,
+    pgid: 222,
+    round: 1,
+    reviewer: "opencode",
+  });
+  const leases = readAdvisoryLaneLeases(runDir);
+  assert.equal(leases.length, 1);
+  assert.equal(leases[0].lease.pid, 222);
+  assert.equal(leases[0].lease.pgid, 222);
+  assert.equal(leases[0].lease.round, 1);
+  assert.equal(leases[0].lease.reviewer, "opencode");
+  assert.ok(leases[0].lease.host);
+  assert.ok(leases[0].lease.started_at);
+});
+
+test("startAdvisoryReview writes a lane lease and the worker removes it on completion", () => {
+  const { repoRoot, runDir, runId, headSha } = setupRepo();
+  const reviewerScript = writeDelayedAdvisoryReviewer(repoRoot, { delayMs: 1200 });
+  const started = startAdvisoryReview({
+    gating: false,
+    headSha,
+    laneIndex: 1,
+    profile: "blindspot",
+    promptText: "Advisory lease prompt",
+    reviewerModel: "example/opencode-model-fast",
+    reviewerName: "opencode",
+    reviewerScript,
+    reviewRepoPath: repoRoot,
+    round: 1,
+    runDir,
+    runId,
+    runRepoPath: repoRoot,
+    state: STATES.REVIEW_PENDING,
+    timeoutSeconds: 30,
+    trigger: "every_round",
+  });
+
+  const leasePath = getAdvisoryLaneLeasePath(runDir, 1, "opencode");
+  assert.equal(fs.existsSync(leasePath), true);
+  const lease = JSON.parse(fs.readFileSync(leasePath, "utf-8"));
+  assert.equal(lease.pid, started.child.pid);
+  assert.equal(lease.pgid, started.child.pid);
+  assert.equal(lease.round, 1);
+  assert.equal(lease.reviewer, "opencode");
+  assert.equal(lease.host, os.hostname());
+  assert.ok(lease.started_at);
+  assert.ok(!Number.isNaN(Date.parse(lease.started_at)));
+
+  assert.equal(
+    waitUntil(() => !fs.existsSync(leasePath), { timeoutMs: 25000 }),
+    true,
+    "worker should remove its lane lease on normal completion"
+  );
+  assert.equal(readAdvisoryLaneLeases(runDir).length, 0);
+
+  // Ensure the detached worker has fully exited so temp dirs can be cleaned later.
+  waitUntil(() => {
+    try {
+      process.kill(started.child.pid, 0);
+      return false;
+    } catch {
+      return true;
+    }
+  }, { timeoutMs: 5000 });
+});
+
+test("advisory-worker best-effort lease removal tolerates a missing lease file", () => {
+  const { repoRoot, runDir, runId, headSha } = setupRepo();
+  const reviewerScript = writeDelayedAdvisoryReviewer(repoRoot, { delayMs: 0 });
+  const requestPath = path.join(runDir, "review-round-1-advisory-opencode-request.json");
+  const resultPath = path.join(runDir, "review-round-1-advisory-opencode-result.json");
+  const promptPath = path.join(runDir, "review-round-1-advisory-opencode-prompt.md");
+  const decisionPath = path.join(runDir, "review-round-1-advisory-opencode-decision.json");
+  fs.writeFileSync(promptPath, "prompt\n", "utf-8");
+  fs.writeFileSync(requestPath, `${JSON.stringify({
+    artifactReviewerName: "opencode",
+    decisionPath,
+    gating: false,
+    headSha,
+    laneIndex: 1,
+    profile: "blindspot",
+    promptPath,
+    requestPath,
+    resultPath,
+    reviewerModel: null,
+    reviewerName: "opencode",
+    reviewerPolicy: null,
+    policyDecision: null,
+    modelResolution: null,
+    reviewerScript,
+    reviewRepoPath: repoRoot,
+    round: 1,
+    runDir,
+    runId,
+    runRepoPath: repoRoot,
+    source: null,
+    startedAt: Date.now(),
+    state: STATES.REVIEW_PENDING,
+    timeoutSeconds: 30,
+    trigger: "every_round",
+  }, null, 2)}\n`, "utf-8");
+
+  const workerPath = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "advisory-worker.js");
+  const result = spawnSync(process.execPath, [workerPath, requestPath], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(getAdvisoryLaneLeasePath(runDir, 1, "opencode")), false);
+  assert.ok(fs.existsSync(resultPath));
+});


### PR DESCRIPTION
## Summary
- Persist advisory-lane leases (`review-round-<N>-advisory-<reviewer>-lane-lease.json`) at spawn with pid/pgid/host/started_at/round/reviewer, and have the worker best-effort self-clean on completion.
- Have `finalize-run` reap recorded own-pgid lanes (TERM → bounded grace → KILL) before retained-worktree removal, reporting reaped/stale/host-mismatch outcomes (dry-run signals nothing).
- Add TERM-ignoring fixture coverage so the KILL escalation path is deterministic; idle no-lease finalize stays byte-identical.

Closes #963

## Test plan
- [x] `node --test tests/relay-review/scripts/advisory-lane-lease.test.js tests/relay-merge/scripts/finalize-run-advisory-lane-reap.test.js`
- [x] `node --test --test-concurrency=1 tests/relay-merge/scripts/*.test.js tests/relay-review/scripts/*.test.js` (808 pass)
- [ ] Confirm dry-run leaves a live fake lane alive and reports `would_reap`
- [ ] Confirm host-mismatch leases are skipped without signaling


Made with [Cursor](https://cursor.com)