### PR TITLE
docs(relay-merge): freshness gate domain — remote-tip by design, fork/non-origin out of scope (#966)

### DIFF
--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -74,6 +74,7 @@ This script:
 - `--allow-behind-main --reason "..."` is the audited operator escape hatch.
 - If the remote PR head cannot be resolved (`ls-remote` fails), the gate is skipped fail-open and finalize records `freshness: { skipped: true, reason: "unresolvable_remote_head" }`.
 - Finalize never auto-rebases: a rebase changes the reviewed head and re-enters the existing stale-review path (#884).
+- The gate sources the PR head from the tracked remote's branch tip (`ls-remote`), not GitHub's `headRefOid`. Relay pushes every PR branch to that remote, so the tip is the exact commit GitHub merges. Fork and non-origin-head PRs are outside the gate's domain by design (#966): on such PRs the gate degrades to the fail-open skip above rather than validating a head relay never pushed.
 - Accepted residual risk: cross-file semantic coupling is not detected.
 
 If the retained worktree is dirty, merge still succeeds but cleanup is recorded as `failed` and the manifest moves to `next_action=manual_cleanup_required`.

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -545,6 +545,9 @@ function remoteBranchExists(repoPath, remoteName, branch) {
 
 // Resolve the remote branch tip that `gh pr merge` will merge — not the
 // retained worktree HEAD, which can lag on normal ready_to_merge runs.
+// Deliberately the branch tip rather than GitHub's headRefOid: relay pushes every
+// PR branch to its tracked remote, so the tip IS the merge commit; fork and
+// non-origin-head PRs are outside this gate's domain (#966).
 function resolveRemoteBranchHead(repoPath, remoteName, branch) {
   if (!remoteName || !branch) {
     throw new Error("Cannot resolve remote PR head without remote and branch");


### PR DESCRIPTION
Closes #966 with **option (b)** — keep remote-tip sourcing; document fork/non-origin-head PRs as outside the freshness gate's domain.

## Decision rationale (re-reviewed 2026-07-12)

- The gate already resolves the branch's **tracked remote** (`resolveRemoteName(...) || "origin"`, finalize-run.js:1056), which covers the non-origin-tracking half of the original objection.
- Within relay's workflow, remote tip == GitHub `headRefOid`: publish-run creates every PR from a branch relay pushed to that remote. The false-PASS path (fork PR + same-named diverged origin branch + matching manifest head) requires hand-wiring a foreign PR number into a manifest — unreachable through relay itself.
- On genuinely foreign PRs the gate degrades to the #965 fail-open skip (`freshness: { skipped: true }`), visible in the finalize JSON — it never silently validates a head relay didn't push.
- Options (a)/(c) were prototyped in the #929 arc: the mandatory `git fetch <headRefOid>` broke placeholder-head fixtures across suites (4 rounds of whack-a-mole), and (c) adds a second resolution path whose behavior is identical in-domain and still falls back out-of-domain. No in-workflow consumer exists (consumer-first gate).

## Changes
- `skills/relay-merge/SKILL.md`: one bullet in the Merge-time freshness gate section stating the domain boundary.
- `skills/relay-merge/scripts/finalize-run.js`: 3-line comment at `resolveRemoteBranchHead` pinning that remote-tip is deliberate, not an approximation.

## Verification
- Full serialized gate on this worktree: 2183 tests, 1 fail = known full-suite flake (advisory suite passes 78/78 in isolation; prose-pinning suites skills-lint + relay-merge pass 249/0 targeted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)