### PR TITLE
fix(dispatch): combined rebase+rebrand recovery for behind-base double-preflight (#964)

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -88,6 +88,7 @@ const FLAGS = [
   { flag: "--reasoning", kind: VALUE, mode: MODE_PARSED, valueName: "<level>",
     allowedValues: ["none", "minimal", "low", "medium", "high", "xhigh"],
     rationale: "Codex reasoning_effort override; closed selector over codex CLI levels." },
+  { flag: "--rebase-onto-base", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Opt-in combined recovery: rebase the retained worktree onto origin/<base>, force-with-lease push, then rebrand evidence." },
   { flag: "--reconcile", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicit opt-in to mutate dead dispatched runs during doctor/preflight reconciliation." },
   { flag: "--reconcile-merged", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Reconcile merged drift for ready_to_merge runs with merge evidence." },
   { flag: "--replace-placeholder-evidence", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Explicitly replace timeout placeholder evidence with operator-verified evidence; no value is consumed." },
@@ -215,7 +216,7 @@ const COMMAND_FLAGS = {
     "--reconcile", "--review-assurance", "--advisory-profile", "--json", "--help",
   ],
   "rebrand-evidence": [
-    "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",
+    "--repo", "--run-id", "--manifest", "--reason", "--rebase-onto-base", "--dry-run", "--json", "--help",
   ],
   "relay-reconcile-artifact": [
     "--repo", "--run-id", "--manifest", "--branch", "--pr",

--- a/skills/relay-dispatch/scripts/rebrand-evidence.js
+++ b/skills/relay-dispatch/scripts/rebrand-evidence.js
@@ -4,6 +4,9 @@
 /**
  * relay-rebrand-evidence: update execution evidence after orchestrator-side
  * correction commits without committing, pushing, opening PRs, or changing state.
+ *
+ * Opt-in `--rebase-onto-base` extends this into a combined behind-base recovery:
+ * fetch + rebase onto origin/<base>, force-with-lease push, then rebrand.
  */
 
 const fs = require("fs");
@@ -37,19 +40,30 @@ class UsageError extends Error {
   }
 }
 
+class RebaseConflictError extends Error {
+  constructor(result) {
+    super(result.reason);
+    this.name = "RebaseConflictError";
+    this.result = result;
+  }
+}
+
 function printHelp(exitCode) {
-  console.log("Usage: rebrand-evidence.js (--repo <path> --run-id <id> | --manifest <path>) --reason <text> [--dry-run] [--json]");
+  console.log("Usage: rebrand-evidence.js (--repo <path> --run-id <id> | --manifest <path>) --reason <text> [--rebase-onto-base] [--dry-run] [--json]");
   console.log("\nRebind an existing execution-evidence.json artifact to the current correction commit without publishing git changes.");
+  console.log("With --rebase-onto-base, first rebase the retained worktree onto origin/<base_branch>, force-with-lease push, then rebrand.");
   console.log("\nOptions:");
-  console.log(`  --repo <path>       ${modeLabel("--repo")} Repository root used with --run-id (default: .)`);
-  console.log(`  --run-id <id>       ${modeLabel("--run-id")} Relay run identifier`);
-  console.log(`  --manifest <path>   ${modeLabel("--manifest")} Explicit manifest path`);
-  console.log(`  --reason <text>     ${modeLabel("--reason")} Required audit reason; preserved verbatim`);
-  console.log(`  --dry-run           ${modeLabel("--dry-run")} Print the planned evidence mutation only`);
-  console.log(`  --json              ${modeLabel("--json")} Output JSON`);
-  console.log(`  --help              ${modeLabel("--help")} Show this help`);
+  console.log(`  --repo <path>         ${modeLabel("--repo")} Repository root used with --run-id (default: .)`);
+  console.log(`  --run-id <id>         ${modeLabel("--run-id")} Relay run identifier`);
+  console.log(`  --manifest <path>     ${modeLabel("--manifest")} Explicit manifest path`);
+  console.log(`  --reason <text>       ${modeLabel("--reason")} Required audit reason; preserved verbatim`);
+  console.log(`  --rebase-onto-base    ${modeLabel("--rebase-onto-base")} Rebase onto origin/<base>, force-with-lease push, then rebrand`);
+  console.log(`  --dry-run             ${modeLabel("--dry-run")} Print the planned evidence mutation only`);
+  console.log(`  --json                ${modeLabel("--json")} Output JSON`);
+  console.log(`  --help                ${modeLabel("--help")} Show this help`);
   console.log("\nDecision tree:");
   console.log("  Use rebrand-evidence after the orchestrator already made a correction commit and only execution-evidence.json is stale.");
+  console.log("  Use --rebase-onto-base when a base-advancing merge left the review branch behind and a conflict-free rebase can clear both behind-base and stale-evidence preflights.");
   console.log("  Use recover-commit when the executor left recoverable work that still needs commit, push, or PR publication.");
   console.log("  Use finalize-run --force-finalize-nonready only when an operator intentionally finalizes a non-ready run despite the review gate.");
   process.exit(exitCode);
@@ -109,6 +123,70 @@ function readCurrentHeadSha(data, validatedPaths) {
   };
 }
 
+function requireRetainedWorktree(data, validatedPaths) {
+  if (data.cleanup?.worktree_removed !== false) {
+    throw new Error("--rebase-onto-base requires a retained worktree (cleanup.worktree_removed must be false)");
+  }
+  if (!validatedPaths.worktree) {
+    throw new Error("manifest paths.worktree is required for --rebase-onto-base");
+  }
+  return validatedPaths.worktree;
+}
+
+function summarizeGitFailure(error) {
+  return [error.stderr, error.stdout, error.message]
+    .map((part) => String(part || "").trim())
+    .filter(Boolean)
+    .join(" ")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .slice(0, 8)
+    .join(" ");
+}
+
+function rebaseOntoBaseAndPush({ worktreePath, baseBranch, branch }) {
+  const oldHeadSha = execGit(worktreePath, ["rev-parse", "HEAD"]);
+  // Untracked runtime/test files must not block conflict-free rebase recovery.
+  const dirty = execGit(worktreePath, ["status", "--porcelain", "-uno"]);
+  if (dirty) {
+    throw new Error("worktree has uncommitted changes; clean or commit before --rebase-onto-base");
+  }
+
+  const originBase = `origin/${baseBranch}`;
+  execGit(worktreePath, ["fetch", "origin", baseBranch]);
+
+  try {
+    execGit(worktreePath, ["rebase", originBase]);
+  } catch (error) {
+    try {
+      execGit(worktreePath, ["rebase", "--abort"]);
+    } catch {
+      // Abort best-effort; structured failure still reports restored state below.
+    }
+    const restoredHead = execGit(worktreePath, ["rev-parse", "HEAD"]);
+    const statusAfter = execGit(worktreePath, ["status", "--porcelain"]);
+    throw new RebaseConflictError({
+      status: "failed",
+      failure_class: "rebase_conflict",
+      next_action: "resolve_rebase_manually",
+      reason: `rebase onto ${originBase} conflicted; aborted with no push and no rebrand`,
+      detail: summarizeGitFailure(error),
+      branch,
+      base: originBase,
+      oldHeadSha,
+      newHeadSha: restoredHead,
+      headRestored: restoredHead === oldHeadSha,
+      worktreeClean: !statusAfter,
+      pushed: false,
+      rebranded: false,
+    });
+  }
+
+  const newHeadSha = execGit(worktreePath, ["rev-parse", "HEAD"]);
+  execGit(worktreePath, ["push", "--force-with-lease", "origin", branch]);
+  return { oldHeadSha, newHeadSha, base: originBase };
+}
+
 function previewRebrand(runDir, { newHeadSha, reason }) {
   const evidencePath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
   if (!fs.existsSync(evidencePath)) {
@@ -136,7 +214,7 @@ function previewRebrand(runDir, { newHeadSha, reason }) {
   };
 }
 
-function buildResult({ status, manifestPath, data, branch, headSource, newHeadSha, dryRun, rebrandResult }) {
+function buildResult({ status, manifestPath, data, branch, headSource, newHeadSha, dryRun, rebrandResult, rebase = null }) {
   return {
     status,
     manifestPath,
@@ -145,6 +223,11 @@ function buildResult({ status, manifestPath, data, branch, headSource, newHeadSh
     headSource,
     newHeadSha,
     dryRun,
+    ...(rebase ? {
+      rebaseOntoBase: true,
+      oldHeadSha: rebase.oldHeadSha,
+      base: rebase.base,
+    } : {}),
     ...rebrandResult,
   };
 }
@@ -167,6 +250,18 @@ function printResult(result, jsonOut) {
     return;
   }
 
+  if (result.rebaseOntoBase) {
+    console.log(`Rebased onto ${result.base} and rebranded execution evidence for ${result.runId}`);
+    console.log(`  Previous HEAD: ${result.oldHeadSha}`);
+    console.log(`  New HEAD:      ${result.newHeadSha}`);
+    if (result.skipped) {
+      console.log(`  Rebrand:       skipped (${result.skipped})`);
+    } else {
+      console.log(`  Evidence:      ${result.previousSha} -> ${result.newHeadSha}`);
+    }
+    return;
+  }
+
   if (result.skipped) {
     console.log(`Skipped rebrand: ${result.skipped}`);
     return;
@@ -174,6 +269,18 @@ function printResult(result, jsonOut) {
   console.log(`Rebranded execution evidence for ${result.runId}`);
   console.log(`  Previous HEAD: ${result.previousSha}`);
   console.log(`  New HEAD:      ${result.newHeadSha}`);
+}
+
+function printConflictFailure(result, jsonOut) {
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.error(`Error: ${result.reason}`);
+  console.error(`  Failure class: ${result.failure_class}`);
+  console.error(`  Next action:   ${result.next_action}`);
+  console.error(`  Old HEAD:      ${result.oldHeadSha}`);
+  console.error(`  Restored HEAD: ${result.newHeadSha}`);
 }
 
 function main() {
@@ -186,6 +293,7 @@ function main() {
   const runId = getCliArg("--run-id");
   const manifestArg = getCliArg("--manifest");
   const reason = String(getCliArg("--reason") || "").trim();
+  const rebaseOntoBase = hasCliFlag("--rebase-onto-base");
   const dryRun = hasCliFlag("--dry-run");
   const jsonOut = hasCliFlag("--json");
 
@@ -197,6 +305,9 @@ function main() {
   }
   if (!reason) {
     usageError("--reason <text> is required");
+  }
+  if (rebaseOntoBase && dryRun) {
+    usageError("--dry-run is not supported with --rebase-onto-base");
   }
 
   const manifestRecord = resolveRun({ repoArg, runId, manifestArg });
@@ -215,6 +326,22 @@ function main() {
       worktree: validatedPaths.worktree,
     },
   };
+
+  let rebaseMeta = null;
+  if (rebaseOntoBase) {
+    const worktreePath = requireRetainedWorktree(data, validatedPaths);
+    const branch = data.git?.working_branch;
+    if (!branch) {
+      throw new Error("manifest is missing git.working_branch");
+    }
+    const currentBranch = execGit(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (currentBranch !== branch) {
+      throw new Error(`manifest worktree is on branch ${currentBranch}, expected ${branch}`);
+    }
+    const baseBranch = data.git?.base_branch || "main";
+    rebaseMeta = rebaseOntoBaseAndPush({ worktreePath, baseBranch, branch });
+  }
+
   const { branch, newHeadSha, headSource } = readCurrentHeadSha(data, validatedPaths);
   const runDir = getRunDir(validatedPaths.repoRoot, data.run_id);
 
@@ -263,12 +390,17 @@ function main() {
     newHeadSha,
     dryRun: false,
     rebrandResult,
+    rebase: rebaseMeta,
   }), jsonOut);
 }
 
 try {
   main();
 } catch (error) {
+  if (error instanceof RebaseConflictError) {
+    printConflictFailure(error.result, hasCliFlag("--json"));
+    process.exit(2);
+  }
   console.error(error instanceof UsageError ? error.message : `Error: ${error.message}`);
   process.exit(1);
 }

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -2,6 +2,10 @@ const { buildExecutionEvidencePreflight } = require("./execution-evidence");
 const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { git } = require("./common");
 
+function buildBehindBaseRecoveryCommand(runId, baseBranch) {
+  return `node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id ${runId} --rebase-onto-base --reason "rebase onto origin/${baseBranch} after base advance"`;
+}
+
 function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha }) {
   const baseBranch = data?.git?.base_branch || "main";
   const candidates = [`origin/${baseBranch}`, baseBranch];
@@ -18,14 +22,18 @@ function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha }) {
   }
 
   const behindCount = Number(git(reviewRepoPath, "rev-list", "--count", `${reviewedHeadSha}..${base}`).trim());
+  const blocked = behindCount > 0;
   return {
-    status: behindCount > 0 ? "blocked" : "pass",
+    status: blocked ? "blocked" : "pass",
     base,
     behindCount,
-    reason: behindCount > 0
+    reason: blocked
       ? `branch is ${behindCount} ${behindCount === 1 ? "commit" : "commits"} behind ${base}; rebase and re-run`
       : null,
-    nextAction: behindCount > 0 ? "rebase_and_rerun" : null,
+    nextAction: blocked ? "rebase_and_rerun" : null,
+    recoveryCommand: blocked && data?.run_id
+      ? buildBehindBaseRecoveryCommand(data.run_id, baseBranch)
+      : null,
   };
 }
 
@@ -67,6 +75,9 @@ function maybeBlockForBehindBasePreflight({
   } else {
     console.log(`Review preflight blocked round ${round}: ${preflight.reason}`);
     console.log(`  Next action: ${preflight.nextAction}`);
+    if (preflight.recoveryCommand) {
+      console.log(`  Recovery command: ${preflight.recoveryCommand}`);
+    }
   }
   process.exitCode = 2;
   return true;
@@ -120,6 +131,7 @@ function maybeBlockForExecutionEvidencePreflight({
 
 module.exports = {
   buildBehindBasePreflight,
+  buildBehindBaseRecoveryCommand,
   maybeBlockForBehindBasePreflight,
   maybeBlockForExecutionEvidencePreflight,
 };

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -2,11 +2,18 @@ const { buildExecutionEvidencePreflight } = require("./execution-evidence");
 const { appendRunEvent, EVENTS } = require("../../../relay-dispatch/scripts/relay-events");
 const { git } = require("./common");
 
-function buildBehindBaseRecoveryCommand(runId, baseBranch) {
-  return `node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id ${runId} --rebase-onto-base --reason "rebase onto origin/${baseBranch} after base advance"`;
+function shellQuote(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
 }
 
-function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha }) {
+function buildBehindBaseRecoveryCommand(runId, baseBranch, repoRoot) {
+  return (
+    `node skills/relay-dispatch/scripts/rebrand-evidence.js --repo ${shellQuote(repoRoot)} ` +
+    `--run-id ${runId} --rebase-onto-base --reason "rebase onto origin/${baseBranch} after base advance"`
+  );
+}
+
+function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha, runRepoPath }) {
   const baseBranch = data?.git?.base_branch || "main";
   const candidates = [`origin/${baseBranch}`, baseBranch];
   let base = null;
@@ -23,6 +30,7 @@ function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha }) {
 
   const behindCount = Number(git(reviewRepoPath, "rev-list", "--count", `${reviewedHeadSha}..${base}`).trim());
   const blocked = behindCount > 0;
+  const repoRoot = runRepoPath || data?.paths?.repo_root || null;
   return {
     status: blocked ? "blocked" : "pass",
     base,
@@ -31,8 +39,8 @@ function buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha }) {
       ? `branch is ${behindCount} ${behindCount === 1 ? "commit" : "commits"} behind ${base}; rebase and re-run`
       : null,
     nextAction: blocked ? "rebase_and_rerun" : null,
-    recoveryCommand: blocked && data?.run_id
-      ? buildBehindBaseRecoveryCommand(data.run_id, baseBranch)
+    recoveryCommand: blocked && data?.run_id && repoRoot
+      ? buildBehindBaseRecoveryCommand(data.run_id, baseBranch, repoRoot)
       : null,
   };
 }
@@ -47,7 +55,7 @@ function maybeBlockForBehindBasePreflight({
   round,
   runRepoPath,
 }) {
-  result.behindBasePreflight = buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha });
+  result.behindBasePreflight = buildBehindBasePreflight({ data, reviewRepoPath, reviewedHeadSha, runRepoPath });
   const preflight = result.behindBasePreflight;
   if (preflight.status !== "blocked") return false;
 

--- a/tests/relay-dispatch/scripts/rebrand-evidence.test.js
+++ b/tests/relay-dispatch/scripts/rebrand-evidence.test.js
@@ -47,6 +47,18 @@ function setupRepo({ evidence = true, advanceHead = false, withOrigin = false, b
   execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   if (withOrigin) {
     execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+    // Pin bare-origin HEAD so clones check out `main` even when the runner's
+    // git init default branch is not main (CI runners often leave HEAD on master).
+    execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/main"], {
+      cwd: originRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+    execFileSync("git", ["remote", "set-head", "origin", "main"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
   }
 
   const branch = "issue-332";
@@ -113,6 +125,7 @@ function setupRepo({ evidence = true, advanceHead = false, withOrigin = false, b
 function advanceBaseOnOrigin(fixture, { conflicting = false } = {}) {
   const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "relay-rebrand-base-"));
   execFileSync("git", ["clone", fixture.originRoot, scratch], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["config", "user.name", "Relay Rebrand Base"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "relay-rebrand-base@example.com"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
   const fileName = conflicting ? "feature.txt" : "base-advance.txt";

--- a/tests/relay-dispatch/scripts/rebrand-evidence.test.js
+++ b/tests/relay-dispatch/scripts/rebrand-evidence.test.js
@@ -25,17 +25,29 @@ const {
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "rebrand-evidence.js");
 
-function setupRepo({ evidence = true, advanceHead = false } = {}) {
+function setupRepo({ evidence = true, advanceHead = false, withOrigin = false, branchWork = false } = {}) {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-rebrand-evidence-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")));
   process.env.RELAY_HOME = relayHome;
 
+  let originRoot = null;
+  if (withOrigin) {
+    originRoot = path.join(repoRoot, "origin.git");
+    execFileSync("git", ["init", "--bare", originRoot], { encoding: "utf-8", stdio: "pipe" });
+  }
+
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["config", "user.name", "Relay Rebrand Evidence Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "relay-rebrand@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  if (withOrigin) {
+    execFileSync("git", ["remote", "add", "origin", originRoot], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  }
   fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
   execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  if (withOrigin) {
+    execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  }
 
   const branch = "issue-332";
   const worktreePath = path.join(repoRoot, "wt", branch);
@@ -43,10 +55,16 @@ function setupRepo({ evidence = true, advanceHead = false } = {}) {
   execFileSync("git", ["worktree", "add", worktreePath, "-b", branch], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
   const originalSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
 
-  if (advanceHead) {
-    fs.writeFileSync(path.join(worktreePath, "correction.txt"), "orchestrator correction\n", "utf-8");
-    execFileSync("git", ["-C", worktreePath, "add", "correction.txt"], { encoding: "utf-8", stdio: "pipe" });
-    execFileSync("git", ["-C", worktreePath, "commit", "-m", "Orchestrator correction"], { encoding: "utf-8", stdio: "pipe" });
+  if (branchWork || advanceHead) {
+    const fileName = advanceHead ? "correction.txt" : "feature.txt";
+    const contents = advanceHead ? "orchestrator correction\n" : "branch work\n";
+    const message = advanceHead ? "Orchestrator correction" : "Branch work";
+    fs.writeFileSync(path.join(worktreePath, fileName), contents, "utf-8");
+    execFileSync("git", ["-C", worktreePath, "add", fileName], { encoding: "utf-8", stdio: "pipe" });
+    execFileSync("git", ["-C", worktreePath, "commit", "-m", message], { encoding: "utf-8", stdio: "pipe" });
+  }
+  if (withOrigin) {
+    execFileSync("git", ["-C", worktreePath, "push", "-u", "origin", branch], { encoding: "utf-8", stdio: "pipe" });
   }
   const currentSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
 
@@ -89,7 +107,28 @@ function setupRepo({ evidence = true, advanceHead = false } = {}) {
     ...process.env,
     RELAY_HOME: relayHome,
   };
-  return { repoRoot, relayHome, runId, manifestPath: layout.manifestPath, runDir: layout.runDir, worktreePath, branch, originalSha, currentSha, env };
+  return { repoRoot, originRoot, relayHome, runId, manifestPath: layout.manifestPath, runDir: layout.runDir, worktreePath, branch, originalSha, currentSha, env };
+}
+
+function advanceBaseOnOrigin(fixture, { conflicting = false } = {}) {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "relay-rebrand-base-"));
+  execFileSync("git", ["clone", fixture.originRoot, scratch], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Rebrand Base"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-rebrand-base@example.com"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
+  const fileName = conflicting ? "feature.txt" : "base-advance.txt";
+  const contents = conflicting ? "base side conflict\n" : "base advanced\n";
+  fs.writeFileSync(path.join(scratch, fileName), contents, "utf-8");
+  execFileSync("git", ["add", fileName], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "advance base"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["push", "origin", "main"], { cwd: scratch, encoding: "utf-8", stdio: "pipe" });
+  const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: scratch, encoding: "utf-8" }).trim();
+  return { scratch, baseSha };
+}
+
+function originBranchSha(fixture, branch) {
+  return execFileSync("git", ["--git-dir", fixture.originRoot, "rev-parse", `refs/heads/${branch}`], {
+    encoding: "utf-8",
+  }).trim();
 }
 
 function runRebrand(fixture, extraArgs = []) {
@@ -106,7 +145,7 @@ function readEvidence(fixture) {
 
 test("rebrand-evidence flags are registered with the CLI schema", () => {
   assert.deepEqual(COMMAND_FLAGS["rebrand-evidence"], [
-    "--repo", "--run-id", "--manifest", "--reason", "--dry-run", "--json", "--help",
+    "--repo", "--run-id", "--manifest", "--reason", "--rebase-onto-base", "--dry-run", "--json", "--help",
   ]);
 });
 
@@ -207,6 +246,96 @@ test("dry-run previews the rebrand without writing evidence or appending an even
   assert.equal(parsed.plannedMutation.previousHeadSha, fixture.originalSha);
   assert.equal(parsed.plannedMutation.newHeadSha, fixture.currentSha);
   assert.equal(parsed.plannedMutation.recordedBy, "orchestrator-correction-rebrand");
+  assert.equal(fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"), beforeEvidence);
+  assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
+});
+
+test("flagless rebrand remains byte-identical to the pre-rebase-onto-base contract", () => {
+  const fixture = setupRepo({ evidence: true, advanceHead: true });
+  const result = runRebrand(fixture, ["--reason", "orchestrator fixed typo", "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, "rebranded");
+  assert.equal(parsed.rewritten, true);
+  assert.equal(parsed.previousSha, fixture.originalSha);
+  assert.equal(parsed.newHeadSha, fixture.currentSha);
+  assert.equal(parsed.rebaseOntoBase, undefined);
+  assert.equal(parsed.oldHeadSha, undefined);
+  assert.equal(parsed.base, undefined);
+
+  const evidence = readEvidence(fixture);
+  assert.equal(evidence.head_sha, fixture.currentSha);
+  assert.equal(evidence.recorded_by, "orchestrator-correction-rebrand");
+  assert.equal(evidence.rebrand.reason, "orchestrator fixed typo");
+});
+
+test("--rebase-onto-base rebases, force-with-lease pushes, and rebrands in one shot", () => {
+  const fixture = setupRepo({ evidence: true, withOrigin: true, branchWork: true });
+  const beforeEvidence = readEvidence(fixture);
+  assert.equal(beforeEvidence.head_sha, fixture.originalSha);
+  const remoteBefore = originBranchSha(fixture, fixture.branch);
+  assert.equal(remoteBefore, fixture.currentSha);
+
+  advanceBaseOnOrigin(fixture);
+  const reason = `rebase onto origin/main after base advance`;
+  const result = runRebrand(fixture, ["--rebase-onto-base", "--reason", reason, "--json"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, "rebranded");
+  assert.equal(parsed.rebaseOntoBase, true);
+  assert.equal(parsed.oldHeadSha, fixture.currentSha);
+  assert.equal(parsed.base, "origin/main");
+  assert.notEqual(parsed.newHeadSha, fixture.currentSha);
+  assert.equal(parsed.rewritten, true);
+  assert.equal(parsed.previousSha, fixture.originalSha);
+  assert.equal(parsed.newHeadSha, parsed.newHeadSha);
+
+  const worktreeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  assert.equal(worktreeHead, parsed.newHeadSha);
+  assert.equal(originBranchSha(fixture, fixture.branch), parsed.newHeadSha);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "");
+
+  const evidence = readEvidence(fixture);
+  assert.equal(evidence.head_sha, parsed.newHeadSha);
+  assert.equal(evidence.rebrand.reason, reason);
+
+  const rebrandEvents = readRunEvents(fixture.repoRoot, fixture.runId)
+    .filter((entry) => entry.event === "execution_evidence_rebranded");
+  assert.equal(rebrandEvents.length, 1);
+  assert.equal(rebrandEvents[0].reason, reason);
+  assert.equal(rebrandEvents[0].new_head_sha, parsed.newHeadSha);
+});
+
+test("--rebase-onto-base aborts on conflict without push or rebrand", () => {
+  const fixture = setupRepo({ evidence: true, withOrigin: true, branchWork: true });
+  const beforeEvidence = fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8");
+  const remoteBefore = originBranchSha(fixture, fixture.branch);
+
+  advanceBaseOnOrigin(fixture, { conflicting: true });
+  const result = runRebrand(fixture, [
+    "--rebase-onto-base",
+    "--reason", "rebase onto origin/main after base advance",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.status, "failed");
+  assert.equal(parsed.failure_class, "rebase_conflict");
+  assert.equal(parsed.next_action, "resolve_rebase_manually");
+  assert.equal(parsed.oldHeadSha, fixture.currentSha);
+  assert.equal(parsed.newHeadSha, fixture.currentSha);
+  assert.equal(parsed.headRestored, true);
+  assert.equal(parsed.worktreeClean, true);
+  assert.equal(parsed.pushed, false);
+  assert.equal(parsed.rebranded, false);
+
+  const worktreeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  assert.equal(worktreeHead, fixture.currentSha);
+  assert.equal(execFileSync("git", ["-C", fixture.worktreePath, "status", "--porcelain"], { encoding: "utf-8" }).trim(), "");
+  assert.equal(originBranchSha(fixture, fixture.branch), remoteBefore);
   assert.equal(fs.readFileSync(path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME), "utf-8"), beforeEvidence);
   assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
 });

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -2447,7 +2447,9 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
   advanceBaseAfterFork(repoRoot);
   const markerPath = path.join(repoRoot, "behind-base-reviewer-invoked.txt");
   const reviewerScript = writeMarkerReviewerScript(repoRoot, "behind-base-reviewer.js", markerPath);
-  const expectedRecoveryCommand = `node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id ${runId} --rebase-onto-base --reason "rebase onto origin/main after base advance"`;
+  const expectedRecoveryCommand =
+    `node skills/relay-dispatch/scripts/rebrand-evidence.js --repo '${repoRoot}' ` +
+    `--run-id ${runId} --rebase-onto-base --reason "rebase onto origin/main after base advance"`;
 
   const result = spawnSync("node", [
     SCRIPT,
@@ -2471,6 +2473,9 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
   assert.equal(output.behindBasePreflight.recoveryCommand, expectedRecoveryCommand);
   assert.equal(output.behindBasePreflight.recoveryCommand.includes("<"), false);
   assert.equal(output.behindBasePreflight.recoveryCommand.includes(runId), true);
+  assert.match(output.behindBasePreflight.recoveryCommand, /--repo '/);
+  assert.equal(output.behindBasePreflight.recoveryCommand.includes(repoRoot), true);
+  assert.equal(path.isAbsolute(repoRoot), true);
   assert.equal(output.nextState, STATES.REVIEW_PENDING);
   assert.equal(output.rawResponsePath, null);
 
@@ -2500,7 +2505,9 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
     "--no-comment",
   ], { encoding: "utf-8" });
   assert.equal(textResult.status, 2, textResult.stderr || textResult.stdout);
-  const textRecovery = `node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id ${textFixture.runId} --rebase-onto-base --reason "rebase onto origin/main after base advance"`;
+  const textRecovery =
+    `node skills/relay-dispatch/scripts/rebrand-evidence.js --repo '${textFixture.repoRoot}' ` +
+    `--run-id ${textFixture.runId} --rebase-onto-base --reason "rebase onto origin/main after base advance"`;
   assert.match(textResult.stdout, new RegExp(`Recovery command: ${textRecovery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.equal(textResult.stdout.includes("<"), false);
 });
@@ -2529,9 +2536,13 @@ test("review-runner behind-base recovery command clears both preflights on re-en
   assert.ok(recoveryCommand);
   assert.equal(recoveryCommand.includes("<"), false);
   assert.match(recoveryCommand, new RegExp(`--run-id ${runId}`));
+  assert.match(recoveryCommand, /--repo '/);
+  assert.equal(recoveryCommand.includes(repoRoot), true);
+  assert.equal(path.isAbsolute(repoRoot), true);
 
   const repoScriptsRoot = path.resolve(__dirname, "..", "..", "..");
-  const recoveryResult = spawnSync("sh", ["-c", `${recoveryCommand} --repo ${JSON.stringify(repoRoot)} --json`], {
+  // Surfaced command must be copy-pasteable as-is (includes --repo); run it alone.
+  const recoveryResult = spawnSync("sh", ["-c", `${recoveryCommand} --json`], {
     encoding: "utf-8",
     cwd: repoScriptsRoot,
     env,

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -2447,6 +2447,7 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
   advanceBaseAfterFork(repoRoot);
   const markerPath = path.join(repoRoot, "behind-base-reviewer-invoked.txt");
   const reviewerScript = writeMarkerReviewerScript(repoRoot, "behind-base-reviewer.js", markerPath);
+  const expectedRecoveryCommand = `node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id ${runId} --rebase-onto-base --reason "rebase onto origin/main after base advance"`;
 
   const result = spawnSync("node", [
     SCRIPT,
@@ -2467,6 +2468,9 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
   assert.equal(output.behindBasePreflight.behindCount, 1);
   assert.equal(output.behindBasePreflight.base, "origin/main");
   assert.match(output.behindBasePreflight.reason, /branch is 1 commit behind origin\/main; rebase and re-run/);
+  assert.equal(output.behindBasePreflight.recoveryCommand, expectedRecoveryCommand);
+  assert.equal(output.behindBasePreflight.recoveryCommand.includes("<"), false);
+  assert.equal(output.behindBasePreflight.recoveryCommand.includes(runId), true);
   assert.equal(output.nextState, STATES.REVIEW_PENDING);
   assert.equal(output.rawResponsePath, null);
 
@@ -2482,6 +2486,80 @@ test("review-runner behind-base preflight fails fast before reviewer invocation"
   assert.equal(preflightEvent.state_from, STATES.REVIEW_PENDING);
   assert.equal(preflightEvent.state_to, STATES.REVIEW_PENDING);
   assert.equal(preflightEvent.reviewer_rounds_avoided, 1);
+
+  const textFixture = setupRepo();
+  advanceBaseAfterFork(textFixture.repoRoot);
+  const textResult = spawnSync("node", [
+    SCRIPT,
+    "--repo", textFixture.repoRoot,
+    "--run-id", textFixture.runId,
+    "--pr", "123",
+    "--done-criteria-file", textFixture.doneCriteriaPath,
+    "--diff-file", textFixture.diffPath,
+    "--reviewer-script", writeMarkerReviewerScript(textFixture.repoRoot, "behind-base-text-reviewer.js", path.join(textFixture.repoRoot, "behind-base-text.txt")),
+    "--no-comment",
+  ], { encoding: "utf-8" });
+  assert.equal(textResult.status, 2, textResult.stderr || textResult.stdout);
+  const textRecovery = `node skills/relay-dispatch/scripts/rebrand-evidence.js --run-id ${textFixture.runId} --rebase-onto-base --reason "rebase onto origin/main after base advance"`;
+  assert.match(textResult.stdout, new RegExp(`Recovery command: ${textRecovery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.equal(textResult.stdout.includes("<"), false);
+});
+
+test("review-runner behind-base recovery command clears both preflights on re-entry", () => {
+  const { repoRoot, worktreePath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  execFileSync("git", ["push", "-u", "origin", "issue-42"], { cwd: worktreePath, stdio: "pipe" });
+  advanceBaseAfterFork(repoRoot);
+  const env = { ...process.env, RELAY_HOME: process.env.RELAY_HOME };
+
+  const blocked = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer-script", writeMarkerReviewerScript(repoRoot, "behind-base-oneshot-blocked.js", path.join(repoRoot, "oneshot-blocked.txt")),
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8", env });
+  assert.equal(blocked.status, 2, blocked.stderr || blocked.stdout);
+  const blockedOutput = JSON.parse(blocked.stdout);
+  assert.equal(blockedOutput.behindBasePreflight.status, "blocked");
+  const recoveryCommand = blockedOutput.behindBasePreflight.recoveryCommand;
+  assert.ok(recoveryCommand);
+  assert.equal(recoveryCommand.includes("<"), false);
+  assert.match(recoveryCommand, new RegExp(`--run-id ${runId}`));
+
+  const repoScriptsRoot = path.resolve(__dirname, "..", "..", "..");
+  const recoveryResult = spawnSync("sh", ["-c", `${recoveryCommand} --repo ${JSON.stringify(repoRoot)} --json`], {
+    encoding: "utf-8",
+    cwd: repoScriptsRoot,
+    env,
+  });
+  assert.equal(recoveryResult.status, 0, recoveryResult.stderr || recoveryResult.stdout);
+  const recoveryOutput = JSON.parse(recoveryResult.stdout);
+  assert.equal(recoveryOutput.rebaseOntoBase, true);
+  assert.equal(recoveryOutput.status, "rebranded");
+
+  const markerPath = path.join(repoRoot, "oneshot-reentry-reviewer.txt");
+  const reentry = spawnSync("node", [
+    SCRIPT,
+    "--repo", repoRoot,
+    "--run-id", runId,
+    "--pr", "123",
+    "--done-criteria-file", doneCriteriaPath,
+    "--diff-file", diffPath,
+    "--reviewer-script", writeMarkerReviewerScript(repoRoot, "behind-base-oneshot-reentry.js", markerPath),
+    "--no-comment",
+    "--json",
+  ], { encoding: "utf-8", env });
+  assert.equal(reentry.status, 0, reentry.stderr || reentry.stdout);
+  const reentryOutput = JSON.parse(reentry.stdout);
+  assert.equal(reentryOutput.behindBasePreflight.status, "pass");
+  assert.equal(reentryOutput.behindBasePreflight.behindCount, 0);
+  assert.equal(reentryOutput.executionEvidencePreflight.status, "pass");
+  assert.equal(fs.existsSync(markerPath), true);
+  assert.equal(reentryOutput.state, STATES.READY_TO_MERGE);
 });
 
 test("review-runner proceeds after the reviewed branch is rebased onto its base", () => {


### PR DESCRIPTION
## Summary
- Adds opt-in `--rebase-onto-base` to `rebrand-evidence.js`: fetch base, conflict-free rebase, `--force-with-lease` push, then rebrand evidence under one audit reason; conflicts abort with no push/rebrand and a classified failure.
- Behind-base review preflight now surfaces a copy-pasteable recovery command with the real `--run-id` (no angle-bracket placeholders) in both human text and `--json`.
- Tests cover happy path (surfaced command clears both preflights on re-entry), conflict abort, flagless byte-identical behavior, and command-string realness.

Closes #964

## Test plan
- [x] `node --test tests/relay-dispatch/scripts/rebrand-evidence.test.js`
- [x] `node --test --test-name-pattern "behind-base" tests/relay-review/scripts/review-runner.test.js`
- [x] `node --test --test-concurrency=1 tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js` (1650 pass, 0 fail)


Made with [Cursor](https://cursor.com)