### PR TITLE
fix(review): advisory-lane lifecycle — timeout-kill, per-attempt leases, cleanup sweep (#988)

### DIFF
--- a/skills/relay-dispatch/scripts/cleanup-worktrees.js
+++ b/skills/relay-dispatch/scripts/cleanup-worktrees.js
@@ -41,7 +41,7 @@ const {
 const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { appendRunEvent, EVENTS } = require("./relay-events");
 const { safeFormatRunId } = require("./relay-resolver");
-const { assertNoLiveRunLease, corruptRunLeaseReportFields } = require("./run-runtime-state");
+const { assertNoLiveRunLease, corruptRunLeaseReportFields, reapAdvisoryLaneLeases } = require("./run-runtime-state");
 const {
   DEFAULT_STALE_DAYS,
   assessRunWorktreeHealth,
@@ -345,6 +345,8 @@ function run() {
     advisoryRefused: [],
   };
 
+  const advisoryLaneReaps = [];
+
   const manifestPaths = listManifestPaths(repoRoot);
   for (const manifestPath of manifestPaths) {
     const { data, body } = readManifest(manifestPath);
@@ -568,6 +570,17 @@ function run() {
       }
     }
 
+    // Terminal + age-eligible: reap any surviving advisory-lane process groups
+    // recorded in per-attempt lane leases (#988). Non-terminal runs never reach here.
+    const runDir = getRunDir(repoRoot, normalizedData.run_id);
+    const laneReaps = reapAdvisoryLaneLeases({ runDir, dryRun });
+    for (const reap of laneReaps) {
+      advisoryLaneReaps.push({
+        ...reap,
+        runId: normalizedData.run_id,
+      });
+    }
+
     if (cleanupStatus === CLEANUP_STATUSES.SUCCEEDED) {
       result.skipped.push({ ...enrichedBaseInfo, reason: "already_cleaned" });
       continue;
@@ -656,6 +669,10 @@ function run() {
     result.skippedShells = shellSweep.skipped;
   }
 
+  if (advisoryLaneReaps.length > 0) {
+    result.advisoryLaneReaps = advisoryLaneReaps;
+  }
+
   if (jsonOut) {
     console.log(JSON.stringify(result, null, 2));
   } else {
@@ -696,6 +713,12 @@ function run() {
       console.log("  advisory refused:");
       result.advisoryRefused.forEach((entry) => {
         console.log(`    ${entry.runId}: ${entry.classification} ${entry.path} (${entry.reason})`);
+      });
+    }
+    if (advisoryLaneReaps.length) {
+      console.log(`  advisory lane reaps: ${advisoryLaneReaps.length}`);
+      advisoryLaneReaps.forEach((entry) => {
+        console.log(`    ${entry.runId}: ${entry.outcome} pgid=${entry.pgid} reviewer=${entry.reviewer} round=${entry.round}`);
       });
     }
     if (dryRun) {

--- a/skills/relay-dispatch/scripts/run-runtime-state.js
+++ b/skills/relay-dispatch/scripts/run-runtime-state.js
@@ -13,7 +13,10 @@ const DISPATCH_STDOUT_LOG = "dispatch-stdout.log";
 const DISPATCH_STDERR_LOG = "dispatch-stderr.log";
 const DISPATCH_RESULT_FILE = "dispatch-result.txt";
 const LEASE_DEATH_CONFIRM_DELAY_MS = 50;
-const ADVISORY_LANE_LEASE_RE = /^review-round-(\d+)-advisory-(.+)-lane-lease\.json$/;
+// Matches legacy `...-advisory-<reviewer>-lane-lease.json` and per-attempt
+// `...-advisory-<reviewer>-attempt-<K>-lane-lease.json`. Non-greedy reviewer
+// capture keeps `-attempt-N` out of the reviewer group when present.
+const ADVISORY_LANE_LEASE_RE = /^review-round-(\d+)-advisory-(.+?)(?:-attempt-(\d+))?-lane-lease\.json$/;
 const DEFAULT_ADVISORY_LANE_REAP_GRACE_MS = 3000;
 
 let posixProcessStateInspectionUnavailable = false;
@@ -363,21 +366,33 @@ function assertNoLiveRunLease({ repoRoot, runId, force = false, caller = "relay-
   return status;
 }
 
-function advisoryLaneLeaseFilename(round, reviewer) {
+function advisoryLaneLeaseFilename(round, reviewer, attempt = 1) {
+  const normalizedAttempt = Number(attempt);
+  if (Number.isInteger(normalizedAttempt) && normalizedAttempt > 1) {
+    return `review-round-${round}-advisory-${reviewer}-attempt-${normalizedAttempt}-lane-lease.json`;
+  }
+  // Attempt 1 keeps the legacy single-attempt filename so older installs and
+  // existing tests that pin getAdvisoryLaneLeasePath remain discoverable.
   return `review-round-${round}-advisory-${reviewer}-lane-lease.json`;
 }
 
-function getAdvisoryLaneLeasePath(runDir, round, reviewer) {
-  return path.join(runDir, advisoryLaneLeaseFilename(round, reviewer));
+function getAdvisoryLaneLeasePath(runDir, round, reviewer, attempt = 1) {
+  return path.join(runDir, advisoryLaneLeaseFilename(round, reviewer, attempt));
 }
 
-function normalizeAdvisoryLaneLease(raw) {
+function normalizeAdvisoryLaneLease(raw, { attempt = null } = {}) {
   const pid = Number(raw?.pid);
   const pgid = Number(raw?.pgid);
   const host = typeof raw?.host === "string" ? raw.host.trim() : "";
   const startedAt = typeof raw?.started_at === "string" ? raw.started_at.trim() : "";
   const round = Number(raw?.round);
   const reviewer = typeof raw?.reviewer === "string" ? raw.reviewer.trim() : "";
+  const rawAttempt = raw?.attempt !== undefined && raw?.attempt !== null
+    ? Number(raw.attempt)
+    : attempt;
+  const normalizedAttempt = Number.isInteger(Number(rawAttempt)) && Number(rawAttempt) > 0
+    ? Number(rawAttempt)
+    : 1;
   if (!Number.isInteger(pid) || pid <= 0) {
     throw new Error("advisory lane lease pid must be a positive integer");
   }
@@ -396,7 +411,28 @@ function normalizeAdvisoryLaneLease(raw) {
   if (!reviewer) {
     throw new Error("advisory lane lease reviewer must be set");
   }
-  return { pid, pgid, host, started_at: startedAt, round, reviewer };
+  return {
+    pid,
+    pgid,
+    host,
+    started_at: startedAt,
+    round,
+    reviewer,
+    attempt: normalizedAttempt,
+  };
+}
+
+function nextAdvisoryLaneAttempt(runDir, round, reviewer) {
+  let maxAttempt = 0;
+  for (const entry of readAdvisoryLaneLeases(runDir)) {
+    const entryRound = entry.lease?.round ?? entry.round;
+    const entryReviewer = entry.lease?.reviewer ?? entry.reviewer;
+    if (Number(entryRound) !== Number(round)) continue;
+    if (String(entryReviewer) !== String(reviewer)) continue;
+    const attempt = entry.lease?.attempt ?? entry.attempt ?? 1;
+    if (Number(attempt) > maxAttempt) maxAttempt = Number(attempt);
+  }
+  return maxAttempt + 1;
 }
 
 function writeAdvisoryLaneLease(runDir, {
@@ -406,11 +442,15 @@ function writeAdvisoryLaneLease(runDir, {
   startedAt = new Date().toISOString(),
   round,
   reviewer,
+  attempt = null,
 }) {
   if (typeof runDir !== "string" || !runDir.trim()) {
     throw new Error("writeAdvisoryLaneLease requires runDir");
   }
   fs.mkdirSync(runDir, { recursive: true });
+  const resolvedAttempt = Number.isInteger(Number(attempt)) && Number(attempt) > 0
+    ? Number(attempt)
+    : nextAdvisoryLaneAttempt(runDir, round, reviewer);
   const lease = normalizeAdvisoryLaneLease({
     pid,
     pgid,
@@ -418,16 +458,23 @@ function writeAdvisoryLaneLease(runDir, {
     started_at: startedAt,
     round,
     reviewer,
+    attempt: resolvedAttempt,
   });
-  const leasePath = getAdvisoryLaneLeasePath(runDir, lease.round, lease.reviewer);
+  const leasePath = getAdvisoryLaneLeasePath(runDir, lease.round, lease.reviewer, lease.attempt);
+  // Never truncate-overwrite a possibly-live prior attempt's lease.
+  if (fs.existsSync(leasePath)) {
+    throw new Error(
+      `advisory lane lease already exists for round=${lease.round} reviewer=${lease.reviewer} attempt=${lease.attempt}: ${leasePath}`
+    );
+  }
   fs.writeFileSync(leasePath, `${JSON.stringify(lease, null, 2)}\n`, "utf-8");
   return { lease, leasePath };
 }
 
-function removeAdvisoryLaneLease(runDir, round, reviewer) {
-  const leasePath = getAdvisoryLaneLeasePath(runDir, round, reviewer);
-  fs.rmSync(leasePath, { force: true });
-  return leasePath;
+function removeAdvisoryLaneLease(runDir, round, reviewer, { attempt = 1, leasePath = null } = {}) {
+  const target = leasePath || getAdvisoryLaneLeasePath(runDir, round, reviewer, attempt);
+  fs.rmSync(target, { force: true });
+  return target;
 }
 
 function readAdvisoryLaneLeases(runDir) {
@@ -444,8 +491,12 @@ function readAdvisoryLaneLeases(runDir) {
     const match = name.match(ADVISORY_LANE_LEASE_RE);
     if (!match) continue;
     const leasePath = path.join(runDir, name);
+    const filenameAttempt = match[3] ? Number(match[3]) : 1;
     try {
-      const lease = normalizeAdvisoryLaneLease(JSON.parse(fs.readFileSync(leasePath, "utf-8")));
+      const lease = normalizeAdvisoryLaneLease(
+        JSON.parse(fs.readFileSync(leasePath, "utf-8")),
+        { attempt: filenameAttempt }
+      );
       leases.push({ lease, leasePath });
     } catch (error) {
       leases.push({
@@ -455,6 +506,7 @@ function readAdvisoryLaneLeases(runDir) {
         error: error.message,
         round: Number(match[1]) || null,
         reviewer: match[2] || null,
+        attempt: filenameAttempt,
       });
     }
   }
@@ -464,7 +516,10 @@ function readAdvisoryLaneLeases(runDir) {
     if (roundA !== roundB) return roundA - roundB;
     const reviewerA = a.lease?.reviewer ?? a.reviewer ?? "";
     const reviewerB = b.lease?.reviewer ?? b.reviewer ?? "";
-    return reviewerA.localeCompare(reviewerB);
+    if (reviewerA !== reviewerB) return reviewerA.localeCompare(reviewerB);
+    const attemptA = a.lease?.attempt ?? a.attempt ?? 1;
+    const attemptB = b.lease?.attempt ?? b.attempt ?? 1;
+    return attemptA - attemptB;
   });
 }
 
@@ -498,6 +553,16 @@ function waitForProcessGroupExitSync(pgid, { timeoutMs = 1500, intervalMs = 50 }
   return !isProcessGroupAlive(pgid);
 }
 
+function waitForProcessExitSync(pid, { timeoutMs = 1500, intervalMs = 50 } = {}) {
+  if (!pid || !Number.isFinite(Number(pid))) return false;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    sleepSync(Math.min(intervalMs, Math.max(1, deadline - Date.now())));
+  }
+  return !isProcessAlive(pid);
+}
+
 function resolveAdvisoryLaneReapGraceMs(explicitMs) {
   if (Number.isFinite(Number(explicitMs)) && Number(explicitMs) >= 0) {
     return Number(explicitMs);
@@ -507,17 +572,34 @@ function resolveAdvisoryLaneReapGraceMs(explicitMs) {
   return DEFAULT_ADVISORY_LANE_REAP_GRACE_MS;
 }
 
+function resolveAdvisoryLaneWorkerExitWaitMs(explicitMs) {
+  if (Number.isFinite(Number(explicitMs)) && Number(explicitMs) >= 0) {
+    return Number(explicitMs);
+  }
+  const fromEnv = Number(process.env.RELAY_ADVISORY_LANE_WORKER_EXIT_WAIT_MS);
+  if (Number.isFinite(fromEnv) && fromEnv >= 0) return fromEnv;
+  return resolveAdvisoryLaneReapGraceMs();
+}
+
 function reapAdvisoryLaneLeases({
   runDir,
   dryRun = false,
   graceMs,
   host = os.hostname(),
+  match = null,
+  waitForWorkerPid = false,
+  workerExitWaitMs,
 } = {}) {
   const grace = resolveAdvisoryLaneReapGraceMs(graceMs);
+  const workerWait = waitForWorkerPid
+    ? resolveAdvisoryLaneWorkerExitWaitMs(workerExitWaitMs)
+    : 0;
   const entries = readAdvisoryLaneLeases(runDir);
   const outcomes = [];
 
   for (const entry of entries) {
+    if (typeof match === "function" && !match(entry)) continue;
+
     if (entry.corrupt || !entry.lease) {
       outcomes.push({
         pgid: null,
@@ -557,7 +639,7 @@ function reapAdvisoryLaneLeases({
         outcome: dryRun ? "would_remove_stale" : "stale",
       });
       if (!dryRun) {
-        removeAdvisoryLaneLease(runDir, lease.round, lease.reviewer);
+        fs.rmSync(leasePath, { force: true });
       }
       continue;
     }
@@ -568,6 +650,12 @@ function reapAdvisoryLaneLeases({
         outcome: "would_reap",
       });
       continue;
+    }
+
+    // Timeout-observed reap: let the worker finish writing its result + ADVISORY_REVIEW
+    // event before signalling the group. If the worker pid hangs, reap anyway.
+    if (waitForWorkerPid && lease.pid) {
+      waitForProcessExitSync(lease.pid, { timeoutMs: workerWait });
     }
 
     signalProcessGroup(lease.pgid, "SIGTERM");
@@ -581,7 +669,7 @@ function reapAdvisoryLaneLeases({
 
     const gone = !isProcessGroupAlive(lease.pgid);
     if (gone) {
-      removeAdvisoryLaneLease(runDir, lease.round, lease.reviewer);
+      fs.rmSync(leasePath, { force: true });
       outcomes.push({
         ...base,
         outcome: "reaped",
@@ -619,8 +707,10 @@ module.exports = {
   getRunArtifactPaths,
   getRunLeaseStatus,
   isDestructiveCleanupBlockedByLease,
+  isProcessAlive,
   isProcessGroupAlive,
   latestRunEvent,
+  nextAdvisoryLaneAttempt,
   readAdvisoryLaneLeases,
   readRunLease,
   reapAdvisoryLaneLeases,
@@ -628,6 +718,7 @@ module.exports = {
   removeRunLease,
   signalProcessGroup,
   terminateProcessGroup,
+  waitForProcessExitSync,
   waitForProcessGroupExit,
   waitForProcessGroupExitSync,
   writeAdvisoryLaneLease,

--- a/skills/relay-review/scripts/advisory-worker.js
+++ b/skills/relay-review/scripts/advisory-worker.js
@@ -2,7 +2,9 @@
 
 const fs = require("fs");
 const { executeAdvisoryRequest } = require("./review-runner/advisory");
-const { removeAdvisoryLaneLease } = require("../../relay-dispatch/scripts/run-runtime-state");
+const {
+  readAdvisoryLaneLeases,
+} = require("../../relay-dispatch/scripts/run-runtime-state");
 
 function clearOwnLaneLease(request) {
   if (!request || typeof request !== "object") return;
@@ -11,7 +13,17 @@ function clearOwnLaneLease(request) {
   const reviewer = request.artifactReviewerName || request.reviewerName;
   if (!runDir || !Number.isInteger(round) || round <= 0 || !reviewer) return;
   try {
-    removeAdvisoryLaneLease(runDir, round, reviewer);
+    if (typeof request.laneLeasePath === "string" && request.laneLeasePath.trim()) {
+      fs.rmSync(request.laneLeasePath, { force: true });
+      return;
+    }
+    for (const entry of readAdvisoryLaneLeases(runDir)) {
+      if (!entry.lease) continue;
+      if (entry.lease.round !== round) continue;
+      if (entry.lease.reviewer !== reviewer) continue;
+      if (entry.lease.pid !== process.pid) continue;
+      fs.rmSync(entry.leasePath, { force: true });
+    }
   } catch {
     // Best-effort: missing or unreadable lease must not fail the worker exit.
   }
@@ -23,10 +35,15 @@ function main() {
     throw new Error("advisory-worker requires a request JSON path");
   }
   const request = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
+  let result = null;
   try {
-    executeAdvisoryRequest(request);
+    result = executeAdvisoryRequest(request);
   } finally {
-    clearOwnLaneLease(request);
+    // Timeout leaves the lease in place so the runner / janitor can still
+    // discover and reap the (often TERM-ignoring) lane process group.
+    if (result?.status !== "timeout") {
+      clearOwnLaneLease(request);
+    }
   }
 }
 

--- a/skills/relay-review/scripts/review-runner/advisory-lane-reap.js
+++ b/skills/relay-review/scripts/review-runner/advisory-lane-reap.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const fs = require("fs");
+const {
+  reapAdvisoryLaneLeases,
+} = require("../../../relay-dispatch/scripts/run-runtime-state");
+
+function matchRoundReviewer(round, reviewer) {
+  return (entry) => {
+    const entryRound = entry.lease?.round ?? entry.round;
+    const entryReviewer = entry.lease?.reviewer ?? entry.reviewer;
+    return Number(entryRound) === Number(round) && String(entryReviewer) === String(reviewer);
+  };
+}
+
+/**
+ * Reap every live (or stale) lane lease for a (round, reviewer) before spawning
+ * a new attempt. Host-mismatch leases are skipped+reported without blocking.
+ */
+function reapPriorAdvisoryLaneAttempts({
+  runDir,
+  round,
+  reviewer,
+  dryRun = false,
+  graceMs,
+  host,
+} = {}) {
+  if (!runDir || !Number.isInteger(Number(round)) || !reviewer) return [];
+  return reapAdvisoryLaneLeases({
+    runDir,
+    dryRun,
+    graceMs,
+    host,
+    match: matchRoundReviewer(round, reviewer),
+  });
+}
+
+function buildLaneReapField(outcomes) {
+  if (!Array.isArray(outcomes) || outcomes.length === 0) {
+    return { outcome: "stale", pgid: null };
+  }
+  const primary = outcomes[0];
+  const field = {
+    outcome: primary.outcome,
+    pgid: primary.pgid ?? null,
+  };
+  if (primary.signaled_kill === true) field.signaled_kill = true;
+  if (primary.signaled_kill === false) field.signaled_kill = false;
+  if (outcomes.length > 1) field.all = outcomes;
+  return field;
+}
+
+/**
+ * After the runner consumes a settled `status: "timeout"` lane result, reap that
+ * lane's lease-recorded pgid (wait for worker pid first), then record the outcome
+ * onto the lane result artifact as `lane_reap`.
+ */
+function reapTimeoutAdvisoryLane({
+  runDir,
+  round,
+  reviewer,
+  resultPath = null,
+  result = null,
+  dryRun = false,
+  graceMs,
+  host,
+  workerExitWaitMs,
+} = {}) {
+  const outcomes = reapAdvisoryLaneLeases({
+    runDir,
+    dryRun,
+    graceMs,
+    host,
+    match: matchRoundReviewer(round, reviewer),
+    waitForWorkerPid: true,
+    workerExitWaitMs,
+  });
+  const laneReap = buildLaneReapField(outcomes);
+  let nextResult = result;
+  if (resultPath && typeof resultPath === "string") {
+    try {
+      const existing = nextResult && typeof nextResult === "object"
+        ? nextResult
+        : JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+      nextResult = { ...existing, lane_reap: laneReap };
+      if (!dryRun) {
+        fs.writeFileSync(resultPath, `${JSON.stringify(nextResult, null, 2)}\n`, "utf-8");
+      }
+    } catch {
+      // Best-effort: reap still happened even if the artifact cannot be patched.
+      if (nextResult && typeof nextResult === "object") {
+        nextResult = { ...nextResult, lane_reap: laneReap };
+      }
+    }
+  } else if (nextResult && typeof nextResult === "object") {
+    nextResult = { ...nextResult, lane_reap: laneReap };
+  }
+  return { outcomes, laneReap, result: nextResult };
+}
+
+module.exports = {
+  buildLaneReapField,
+  matchRoundReviewer,
+  reapPriorAdvisoryLaneAttempts,
+  reapTimeoutAdvisoryLane,
+};

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -13,6 +13,7 @@ const {
   validateAdvisoryProfile,
   writeAdvisoryDecision,
 } = require("./advisory");
+const { reapTimeoutAdvisoryLane } = require("./advisory-lane-reap");
 const { resolveReviewerScript } = require("./reviewer-invoke");
 
 // finishAdvisoryReview polls with early return (see advisory.js), so this
@@ -443,6 +444,17 @@ async function settleOneAdvisoryForVerdict({ advisoryRun, config, currentState, 
       criticalPathWaitMs,
       phaseDecisionWaited: criticalPathWaitMs > 0,
     };
+  }
+  if (advisoryResult?.status === "timeout") {
+    const artifactReviewer = advisoryRun.artifactReviewerName || advisoryRun.reviewerName;
+    const { result: reapedResult } = reapTimeoutAdvisoryLane({
+      runDir: advisoryRun.runDir,
+      round: advisoryRun.round,
+      reviewer: artifactReviewer,
+      resultPath: advisoryRun.resultPath,
+      result: advisoryResult,
+    });
+    if (reapedResult) advisoryResult = reapedResult;
   }
   return {
     advisoryResult,

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -213,6 +213,47 @@ function startAdvisoryReview({
     reviewer: artifactName,
   });
 
+  // Fail-closed: a same-host prior group that survives TERM→KILL must not share
+  // request/result artifact paths with a new worker. Host-mismatch stays
+  // skip+report and does not block spawn.
+  const unreaped = priorLaneReaps.filter((entry) => entry?.outcome === "reap_failed");
+  if (unreaped.length > 0) {
+    const unreapedPgids = unreaped
+      .map((entry) => entry.pgid)
+      .filter((pgid) => Number.isFinite(Number(pgid)));
+    const failureReason = (
+      `prior advisory lane pgid ${unreapedPgids.join(", ") || "unknown"} ` +
+      "could not be reaped before re-spawn"
+    );
+    writeJson(paths.resultPath, {
+      artifactHash: null,
+      artifactPath: null,
+      attemptCount: 0,
+      completed_at: new Date().toISOString(),
+      failureReason,
+      gating: request.gating === true,
+      lane_index: request.laneIndex || 1,
+      model: request.reviewerModel || null,
+      profile: request.profile,
+      rawResponsePath: null,
+      rawResponsePaths: [],
+      reviewer: request.reviewerName,
+      source: request.source || null,
+      status: "failed",
+      trigger: request.trigger || "every_round",
+      advisory_count: 0,
+      duplicate_low_confidence_count: 0,
+      required_count: 0,
+    });
+    return {
+      ...request,
+      child: null,
+      laneLeasePath: null,
+      laneAttempt: null,
+      priorLaneReaps,
+    };
+  }
+
   writeJson(paths.requestPath, request);
 
   const workerPath = path.join(__dirname, "..", "advisory-worker.js");

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -14,6 +14,7 @@ const { resolveExecutorDefaultModel } = require("../../../relay-dispatch/scripts
 const { hashFileSha256 } = require("../../../relay-dispatch/scripts/execution-evidence");
 const { appendRunEvent, appendUnregisteredRouteUsedEvent, EVENTS, readRunEvents } = require("../../../relay-dispatch/scripts/relay-events");
 const { writeAdvisoryLaneLease } = require("../../../relay-dispatch/scripts/run-runtime-state");
+const { reapPriorAdvisoryLaneAttempts } = require("./advisory-lane-reap");
 const { parseAdvisoryReview, validateAdvisoryProfile } = require("../advisory-review-schema");
 const { captureGitStatus, resolveReviewerScript } = require("./reviewer-invoke");
 const { writeText } = require("./common");
@@ -204,6 +205,14 @@ function startAdvisoryReview({
     timeoutSeconds: parsePositiveSeconds(timeoutSeconds),
     trigger,
   };
+  // Relaunched rounds may still have live prior-attempt groups. Reap them
+  // (TERM→grace→KILL→verify) before allocating a new per-attempt lease.
+  const priorLaneReaps = reapPriorAdvisoryLaneAttempts({
+    runDir,
+    round,
+    reviewer: artifactName,
+  });
+
   writeJson(paths.requestPath, request);
 
   const workerPath = path.join(__dirname, "..", "advisory-worker.js");
@@ -215,19 +224,29 @@ function startAdvisoryReview({
   });
   child.unref();
   // detached: true → child is its own process-group leader (pgid == pid).
-  // Persist a lane lease distinct from the round lease (lease.json / #951).
+  // Persist a per-attempt lane lease distinct from the round lease (lease.json / #951).
+  let laneLeasePath = null;
+  let laneAttempt = null;
   if (Number.isInteger(child.pid) && child.pid > 0) {
-    writeAdvisoryLaneLease(runDir, {
+    const written = writeAdvisoryLaneLease(runDir, {
       pid: child.pid,
       pgid: child.pid,
       round,
       reviewer: artifactName,
     });
+    laneLeasePath = written.leasePath;
+    laneAttempt = written.lease.attempt;
+    request.laneLeasePath = laneLeasePath;
+    request.laneAttempt = laneAttempt;
+    writeJson(paths.requestPath, request);
   }
 
   return {
     ...request,
     child,
+    laneLeasePath,
+    laneAttempt,
+    priorLaneReaps,
   };
 }
 

--- a/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
+++ b/tests/relay-dispatch/scripts/cleanup-worktrees.test.js
@@ -1206,3 +1206,125 @@ test("cleanup-worktrees #969 prunes advisory worktrees of merged runs and leaves
     new RegExp(openAdvisory.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
   );
 });
+
+test("cleanup-worktrees #988 reaps terminal lane leases, leaves non-terminal untouched, dry-run inert", () => {
+  const { isProcessGroupAlive, writeAdvisoryLaneLease } = require("../../../skills/relay-dispatch/scripts/run-runtime-state");
+  const TERM_IGNORING_LANE = path.join(__dirname, "..", "..", "relay-merge", "fixtures", "term-ignoring-lane.js");
+
+  function spawnTermIgnoringLane() {
+    const child = spawn(process.execPath, [TERM_IGNORING_LANE], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    assert.ok(Number.isInteger(child.pid) && child.pid > 0);
+    assert.equal(isProcessGroupAlive(child.pid), true);
+    return child.pid;
+  }
+
+  function forceKillPgid(pgid) {
+    try {
+      process.kill(-pgid, "SIGKILL");
+    } catch {}
+  }
+
+  const { repoRoot } = setupNamedMainRepo("dev-relay");
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  const priorGrace = process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS;
+  process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = "200";
+
+  const merged = writeRun(repoRoot, {
+    branch: "issue-988-lane-merged",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const mergedRunId = readManifest(merged.manifestPath).data.run_id;
+  const mergedRunDir = ensureRunLayout(repoRoot, mergedRunId).runDir;
+
+  const open = writeRun(repoRoot, {
+    branch: "issue-988-lane-open",
+    state: STATES.REVIEW_PENDING,
+    updatedAt,
+  });
+  const openRunId = readManifest(open.manifestPath).data.run_id;
+  const openRunDir = ensureRunLayout(repoRoot, openRunId).runDir;
+
+  const mergedPgid = spawnTermIgnoringLane();
+  const openPgid = spawnTermIgnoringLane();
+  let mergedLeasePath = null;
+  let openLeasePath = null;
+  try {
+    mergedLeasePath = writeAdvisoryLaneLease(mergedRunDir, {
+      pid: mergedPgid,
+      pgid: mergedPgid,
+      round: 1,
+      reviewer: "codex",
+    }).leasePath;
+    openLeasePath = writeAdvisoryLaneLease(openRunDir, {
+      pid: openPgid,
+      pgid: openPgid,
+      round: 1,
+      reviewer: "opencode",
+    }).leasePath;
+
+    const dryRun = JSON.parse(execFileSync("node", [
+      SCRIPT, "--repo", repoRoot, "--all", "--dry-run", "--json",
+    ], {
+      encoding: "utf-8",
+      env: { ...process.env, RELAY_ADVISORY_LANE_REAP_GRACE_MS: "200" },
+    }));
+    assert.ok(Array.isArray(dryRun.advisoryLaneReaps));
+    const dryMerged = dryRun.advisoryLaneReaps.find((entry) => entry.pgid === mergedPgid);
+    assert.ok(dryMerged, `dry-run must list terminal lane: ${JSON.stringify(dryRun.advisoryLaneReaps)}`);
+    assert.equal(dryMerged.outcome, "would_reap");
+    assert.equal(
+      dryRun.advisoryLaneReaps.some((entry) => entry.pgid === openPgid),
+      false,
+      "non-terminal lane must not appear in dry-run reaps"
+    );
+    assert.equal(isProcessGroupAlive(mergedPgid), true);
+    assert.equal(fs.existsSync(mergedLeasePath), true);
+    assert.equal(isProcessGroupAlive(openPgid), true);
+    assert.equal(fs.existsSync(openLeasePath), true);
+
+    const result = JSON.parse(execFileSync("node", [
+      SCRIPT, "--repo", repoRoot, "--all", "--json",
+    ], {
+      encoding: "utf-8",
+      env: { ...process.env, RELAY_ADVISORY_LANE_REAP_GRACE_MS: "200" },
+    }));
+    assert.ok(Array.isArray(result.advisoryLaneReaps));
+    const reaped = result.advisoryLaneReaps.find((entry) => entry.pgid === mergedPgid);
+    assert.ok(reaped, `must reap terminal lane: ${JSON.stringify(result.advisoryLaneReaps)}`);
+    assert.equal(reaped.outcome, "reaped");
+    assert.equal(reaped.signaled_kill, true);
+    assert.equal(isProcessGroupAlive(mergedPgid), false);
+    assert.equal(fs.existsSync(mergedLeasePath), false);
+    assert.equal(
+      result.advisoryLaneReaps.some((entry) => entry.pgid === openPgid),
+      false,
+      "non-terminal lane must remain untouched"
+    );
+    assert.equal(isProcessGroupAlive(openPgid), true);
+    assert.equal(fs.existsSync(openLeasePath), true);
+  } finally {
+    forceKillPgid(mergedPgid);
+    forceKillPgid(openPgid);
+    if (priorGrace === undefined) delete process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS;
+    else process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = priorGrace;
+  }
+});
+
+test("cleanup-worktrees #988 omits advisoryLaneReaps when idle (byte-identical shape)", () => {
+  const { repoRoot } = setupNamedMainRepo("dev-relay");
+  const updatedAt = "2026-04-01T00:00:00.000Z";
+  writeRun(repoRoot, {
+    branch: "issue-988-idle",
+    state: STATES.MERGED,
+    updatedAt,
+  });
+  const result = JSON.parse(execFileSync("node", [
+    SCRIPT, "--repo", repoRoot, "--all", "--json",
+  ], { encoding: "utf-8" }));
+  assert.equal("advisoryLaneReaps" in result, false);
+});

--- a/tests/relay-merge/scripts/finalize-run-advisory-lane-reap.test.js
+++ b/tests/relay-merge/scripts/finalize-run-advisory-lane-reap.test.js
@@ -342,3 +342,42 @@ test("finalize-run with no advisory lane leases omits advisoryLaneReaps (byte-id
   assert.equal("advisoryLaneReaps" in result, false);
   assert.equal(result.cleanup.worktreeRemoved, true);
 });
+
+test("finalize-run reaps two coexisting per-attempt lane leases for the same reviewer", () => {
+  const fixture = setupRepo();
+  const pgid1 = spawnTermIgnoringLane();
+  const pgid2 = spawnTermIgnoringLane();
+  try {
+    const first = writeAdvisoryLaneLease(fixture.runDir, {
+      pid: pgid1,
+      pgid: pgid1,
+      round: 1,
+      reviewer: "codex",
+    });
+    const second = writeAdvisoryLaneLease(fixture.runDir, {
+      pid: pgid2,
+      pgid: pgid2,
+      round: 1,
+      reviewer: "codex",
+    });
+    assert.equal(first.lease.attempt, 1);
+    assert.equal(second.lease.attempt, 2);
+    assert.notEqual(first.leasePath, second.leasePath);
+
+    const { result } = execFinalize(fixture);
+
+    assert.equal(isProcessGroupAlive(pgid1), false);
+    assert.equal(isProcessGroupAlive(pgid2), false);
+    assert.equal(fs.existsSync(first.leasePath), false);
+    assert.equal(fs.existsSync(second.leasePath), false);
+    assert.equal(result.advisoryLaneReaps.length, 2);
+    const byPgid = new Map(result.advisoryLaneReaps.map((entry) => [entry.pgid, entry]));
+    assert.equal(byPgid.get(pgid1).outcome, "reaped");
+    assert.equal(byPgid.get(pgid2).outcome, "reaped");
+    assert.equal(byPgid.get(pgid1).signaled_kill, true);
+    assert.equal(byPgid.get(pgid2).signaled_kill, true);
+  } finally {
+    forceKillPgid(pgid1);
+    forceKillPgid(pgid2);
+  }
+});

--- a/tests/relay-review/scripts/advisory-lane-lease.test.js
+++ b/tests/relay-review/scripts/advisory-lane-lease.test.js
@@ -112,28 +112,36 @@ function waitUntil(predicate, { timeoutMs = 20000, intervalMs = 100 } = {}) {
   return predicate();
 }
 
-test("writeAdvisoryLaneLease retry overwrites the same reviewer+round lease", () => {
+test("writeAdvisoryLaneLease allocates a new attempt without overwriting a prior lease", () => {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-lane-lease-unit-"));
-  writeAdvisoryLaneLease(runDir, {
+  const first = writeAdvisoryLaneLease(runDir, {
     pid: 111,
     pgid: 111,
     round: 1,
     reviewer: "opencode",
   });
-  writeAdvisoryLaneLease(runDir, {
+  const second = writeAdvisoryLaneLease(runDir, {
     pid: 222,
     pgid: 222,
     round: 1,
     reviewer: "opencode",
   });
+  assert.equal(first.lease.attempt, 1);
+  assert.equal(second.lease.attempt, 2);
+  assert.notEqual(first.leasePath, second.leasePath);
+  assert.equal(fs.existsSync(first.leasePath), true);
+  assert.equal(fs.existsSync(second.leasePath), true);
+  const firstOnDisk = JSON.parse(fs.readFileSync(first.leasePath, "utf-8"));
+  assert.equal(firstOnDisk.pid, 111);
+  assert.equal(firstOnDisk.pgid, 111);
   const leases = readAdvisoryLaneLeases(runDir);
-  assert.equal(leases.length, 1);
-  assert.equal(leases[0].lease.pid, 222);
-  assert.equal(leases[0].lease.pgid, 222);
-  assert.equal(leases[0].lease.round, 1);
+  assert.equal(leases.length, 2);
+  assert.equal(leases[0].lease.pid, 111);
+  assert.equal(leases[1].lease.pid, 222);
+  assert.equal(leases[0].lease.attempt, 1);
+  assert.equal(leases[1].lease.attempt, 2);
   assert.equal(leases[0].lease.reviewer, "opencode");
-  assert.ok(leases[0].lease.host);
-  assert.ok(leases[0].lease.started_at);
+  assert.equal(leases[1].lease.reviewer, "opencode");
 });
 
 test("startAdvisoryReview writes a lane lease and the worker removes it on completion", () => {

--- a/tests/relay-review/scripts/advisory-lane-lifecycle-988.test.js
+++ b/tests/relay-review/scripts/advisory-lane-lifecycle-988.test.js
@@ -272,6 +272,77 @@ test("pre-spawn reap verifies prior attempt is gone before the new spawn", () =>
   }
 });
 
+test("pre-spawn reap fails closed when a prior local group cannot be reaped", () => {
+  const { repoRoot, runDir, runId, headSha } = setupRepo();
+  const unreapablePgid = 988001;
+  const priorEnv = {
+    grace: process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS,
+    eperm: process.env.RELAY_TEST_PROCESS_GROUP_ALIVE_EPERM,
+    states: process.env.RELAY_TEST_PROCESS_GROUP_STATES,
+  };
+  process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = "50";
+  // Fake unkillable group: probe reports EPERM + non-zombie state through TERM/KILL.
+  process.env.RELAY_TEST_PROCESS_GROUP_ALIVE_EPERM = String(unreapablePgid);
+  process.env.RELAY_TEST_PROCESS_GROUP_STATES = JSON.stringify([
+    { pgid: unreapablePgid, stat: "R" },
+  ]);
+  try {
+    const priorLease = writeAdvisoryLaneLease(runDir, {
+      pid: unreapablePgid,
+      pgid: unreapablePgid,
+      round: 1,
+      reviewer: "opencode",
+    });
+    assert.equal(isProcessGroupAlive(unreapablePgid), true);
+
+    const reviewerScript = writeFastAdvisoryReviewer(repoRoot);
+    const started = startAdvisoryReview({
+      gating: false,
+      headSha,
+      laneIndex: 1,
+      profile: "blindspot",
+      promptText: "Fail-closed pre-spawn prompt",
+      reviewerModel: "example/opencode-model-fast",
+      reviewerName: "opencode",
+      reviewerScript,
+      reviewRepoPath: repoRoot,
+      round: 1,
+      runDir,
+      runId,
+      runRepoPath: repoRoot,
+      state: STATES.REVIEW_PENDING,
+      timeoutSeconds: 30,
+      trigger: "every_round",
+    });
+
+    assert.equal(started.child, null, "must not spawn a new worker when prior reap fails");
+    assert.equal(fs.existsSync(started.requestPath), false, "must not write request JSON");
+    assert.equal(fs.existsSync(started.resultPath), true);
+    const result = JSON.parse(fs.readFileSync(started.resultPath, "utf-8"));
+    assert.equal(result.status, "failed");
+    assert.match(String(result.failureReason || ""), new RegExp(String(unreapablePgid)));
+    assert.ok(Array.isArray(started.priorLaneReaps));
+    assert.equal(
+      started.priorLaneReaps.some((entry) => (
+        entry.pgid === unreapablePgid && entry.outcome === "reap_failed"
+      )),
+      true
+    );
+    // Prior lease stays discoverable for finalize/cleanup.
+    const leases = readAdvisoryLaneLeases(runDir);
+    assert.equal(leases.length, 1);
+    assert.equal(leases[0].leasePath, priorLease.leasePath);
+    assert.equal(leases[0].lease.pgid, unreapablePgid);
+  } finally {
+    if (priorEnv.grace === undefined) delete process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS;
+    else process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = priorEnv.grace;
+    if (priorEnv.eperm === undefined) delete process.env.RELAY_TEST_PROCESS_GROUP_ALIVE_EPERM;
+    else process.env.RELAY_TEST_PROCESS_GROUP_ALIVE_EPERM = priorEnv.eperm;
+    if (priorEnv.states === undefined) delete process.env.RELAY_TEST_PROCESS_GROUP_STATES;
+    else process.env.RELAY_TEST_PROCESS_GROUP_STATES = priorEnv.states;
+  }
+});
+
 test("legacy single-attempt lease filenames remain discoverable beside attempt-suffixed leases", () => {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-legacy-lease-"));
   const legacyPath = getAdvisoryLaneLeasePath(runDir, 1, "codex", 1);

--- a/tests/relay-review/scripts/advisory-lane-lifecycle-988.test.js
+++ b/tests/relay-review/scripts/advisory-lane-lifecycle-988.test.js
@@ -1,0 +1,298 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { spawn } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  getAdvisoryLaneLeasePath,
+  isProcessGroupAlive,
+  readAdvisoryLaneLeases,
+  writeAdvisoryLaneLease,
+} = require("../../../skills/relay-dispatch/scripts/run-runtime-state");
+const {
+  reapPriorAdvisoryLaneAttempts,
+  reapTimeoutAdvisoryLane,
+} = require("../../../skills/relay-review/scripts/review-runner/advisory-lane-reap");
+const { startAdvisoryReview } = require("../../../skills/relay-review/scripts/review-runner/advisory");
+const {
+  STATES,
+  createManifestSkeleton,
+  ensureRunLayout,
+  updateManifestState,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { createEnforcementFixture, DEFAULT_ENFORCEMENT_RUBRIC } = require("../../relay-dispatch/scripts/test-support");
+const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+
+const TERM_IGNORING_LANE = path.join(
+  __dirname,
+  "..",
+  "..",
+  "relay-merge",
+  "fixtures",
+  "term-ignoring-lane.js"
+);
+
+function spawnTermIgnoringLane() {
+  const child = spawn(process.execPath, [TERM_IGNORING_LANE], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  assert.ok(Number.isInteger(child.pid) && child.pid > 0);
+  assert.equal(isProcessGroupAlive(child.pid), true);
+  return child.pid;
+}
+
+function forceKillPgid(pgid) {
+  try {
+    process.kill(-pgid, "SIGKILL");
+  } catch {}
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitUntil(predicate, { timeoutMs = 20000, intervalMs = 50 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    sleepSync(intervalMs);
+  }
+  return predicate();
+}
+
+function setupRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-lane-reap-"));
+  const remoteRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-lane-reap-origin-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-lane-reap-"));
+  const { execFileSync } = require("child_process");
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["init", "--bare", remoteRoot], { encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Lane Reap Test"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-lane-reap@example.com"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["remote", "add", "origin", remoteRoot], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+
+  const runId = "issue-988-20260713010000000";
+  const worktreePath = path.join(repoRoot, "wt", "issue-988");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", "issue-988"], { cwd: repoRoot, encoding: "utf-8", stdio: "pipe" });
+  const headSha = execFileSync("git", ["-C", worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8", stdio: "pipe" }).trim();
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-988",
+    baseBranch: "main",
+    issueNumber: 988,
+    worktreePath,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor = createEnforcementFixture({
+    repoRoot,
+    runId,
+    state: "loaded",
+    rubricContent: DEFAULT_ENFORCEMENT_RUBRIC,
+  }).anchor;
+  manifest = { ...manifest, git: { ...(manifest.git || {}), pr_number: 988, head_sha: headSha } };
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(manifestPath, manifest);
+  fs.writeFileSync(path.join(runDir, EXECUTION_EVIDENCE_FILENAME), `${JSON.stringify({
+    schema_version: 1,
+    head_sha: headSha,
+    test_command: "node --test",
+    test_result_hash: "unspecified",
+    test_result_summary: "pass",
+    recorded_at: "2026-07-13T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  }, null, 2)}\n`, "utf-8");
+  return { repoRoot, runDir, runId, headSha, worktreePath };
+}
+
+function writeFastAdvisoryReviewer(repoRoot) {
+  const filePath = path.join(repoRoot, "fake-fast-reviewer.js");
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  profile: "blindspot",
+  summary: "Fast fixture advisory.",
+  required_findings: [],
+  advisory_findings: [],
+  duplicate_or_low_confidence: []
+}));
+`, "utf-8");
+  fs.chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+test("timeout-observed reap escalates to SIGKILL and records lane_reap on the result artifact", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-timeout-reap-"));
+  const pgid = spawnTermIgnoringLane();
+  const resultPath = path.join(runDir, "review-round-1-advisory-codex-result.json");
+  const priorEnv = {
+    grace: process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS,
+    worker: process.env.RELAY_ADVISORY_LANE_WORKER_EXIT_WAIT_MS,
+  };
+  process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = "200";
+  process.env.RELAY_ADVISORY_LANE_WORKER_EXIT_WAIT_MS = "50";
+  try {
+    writeAdvisoryLaneLease(runDir, {
+      pid: pgid,
+      pgid,
+      round: 1,
+      reviewer: "codex",
+    });
+    const result = {
+      status: "timeout",
+      failureReason: "fixture timeout",
+      reviewer: "codex",
+      profile: "blindspot",
+    };
+    fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf-8");
+
+    const { laneReap, result: nextResult } = reapTimeoutAdvisoryLane({
+      runDir,
+      round: 1,
+      reviewer: "codex",
+      resultPath,
+      result,
+    });
+
+    assert.equal(isProcessGroupAlive(pgid), false);
+    assert.equal(fs.existsSync(getAdvisoryLaneLeasePath(runDir, 1, "codex")), false);
+    assert.equal(laneReap.outcome, "reaped");
+    assert.equal(laneReap.pgid, pgid);
+    assert.equal(laneReap.signaled_kill, true);
+    assert.equal(nextResult.lane_reap.outcome, "reaped");
+    assert.equal(nextResult.lane_reap.pgid, pgid);
+    const onDisk = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    assert.equal(onDisk.lane_reap.outcome, "reaped");
+    assert.equal(onDisk.lane_reap.pgid, pgid);
+    assert.equal(onDisk.lane_reap.signaled_kill, true);
+    assert.equal(onDisk.status, "timeout");
+  } finally {
+    forceKillPgid(pgid);
+    if (priorEnv.grace === undefined) delete process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS;
+    else process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = priorEnv.grace;
+    if (priorEnv.worker === undefined) delete process.env.RELAY_ADVISORY_LANE_WORKER_EXIT_WAIT_MS;
+    else process.env.RELAY_ADVISORY_LANE_WORKER_EXIT_WAIT_MS = priorEnv.worker;
+  }
+});
+
+test("pre-spawn reap verifies prior attempt is gone before the new spawn", () => {
+  const { repoRoot, runDir, runId, headSha } = setupRepo();
+  const priorPgid = spawnTermIgnoringLane();
+  const priorEnv = process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS;
+  process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = "200";
+  let started = null;
+  try {
+    writeAdvisoryLaneLease(runDir, {
+      pid: priorPgid,
+      pgid: priorPgid,
+      round: 1,
+      reviewer: "opencode",
+    });
+    assert.equal(isProcessGroupAlive(priorPgid), true);
+
+    const observerPath = path.join(runDir, "pre-spawn-liveness.jsonl");
+    // Probe liveness transition via the shared reap helper first, then spawn —
+    // startAdvisoryReview does the same ordering internally; assert the helper
+    // transition, then that startAdvisoryReview leaves the prior group gone.
+    const reaps = reapPriorAdvisoryLaneAttempts({
+      runDir,
+      round: 1,
+      reviewer: "opencode",
+    });
+    assert.equal(reaps.length, 1);
+    assert.equal(reaps[0].outcome, "reaped");
+    assert.equal(isProcessGroupAlive(priorPgid), false);
+    fs.appendFileSync(observerPath, `${JSON.stringify({ priorAlive: false, at: "after_reap" })}\n`);
+
+    // Re-seed a second live prior group to exercise startAdvisoryReview's
+    // built-in pre-spawn reap ordering end-to-end.
+    const priorPgid2 = spawnTermIgnoringLane();
+    writeAdvisoryLaneLease(runDir, {
+      pid: priorPgid2,
+      pgid: priorPgid2,
+      round: 1,
+      reviewer: "opencode",
+    });
+    assert.equal(isProcessGroupAlive(priorPgid2), true);
+
+    const reviewerScript = writeFastAdvisoryReviewer(repoRoot);
+    started = startAdvisoryReview({
+      gating: false,
+      headSha,
+      laneIndex: 1,
+      profile: "blindspot",
+      promptText: "Pre-spawn reap prompt",
+      reviewerModel: "example/opencode-model-fast",
+      reviewerName: "opencode",
+      reviewerScript,
+      reviewRepoPath: repoRoot,
+      round: 1,
+      runDir,
+      runId,
+      runRepoPath: repoRoot,
+      state: STATES.REVIEW_PENDING,
+      timeoutSeconds: 30,
+      trigger: "every_round",
+    });
+
+    assert.equal(isProcessGroupAlive(priorPgid2), false, "prior attempt must be gone after startAdvisoryReview");
+    assert.ok(Array.isArray(started.priorLaneReaps));
+    assert.equal(started.priorLaneReaps.some((entry) => entry.pgid === priorPgid2 && entry.outcome === "reaped"), true);
+    assert.ok(Number.isInteger(started.child.pid) && started.child.pid > 0);
+    assert.notEqual(started.child.pid, priorPgid2);
+    assert.ok(started.laneAttempt >= 1);
+
+    waitUntil(() => {
+      try {
+        process.kill(started.child.pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    }, { timeoutMs: 15000 });
+    forceKillPgid(priorPgid2);
+  } finally {
+    forceKillPgid(priorPgid);
+    if (started?.child?.pid) forceKillPgid(started.child.pid);
+    if (priorEnv === undefined) delete process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS;
+    else process.env.RELAY_ADVISORY_LANE_REAP_GRACE_MS = priorEnv;
+  }
+});
+
+test("legacy single-attempt lease filenames remain discoverable beside attempt-suffixed leases", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-legacy-lease-"));
+  const legacyPath = getAdvisoryLaneLeasePath(runDir, 1, "codex", 1);
+  fs.writeFileSync(legacyPath, `${JSON.stringify({
+    pid: 101,
+    pgid: 101,
+    host: os.hostname(),
+    started_at: new Date().toISOString(),
+    round: 1,
+    reviewer: "codex",
+  }, null, 2)}\n`, "utf-8");
+  const second = writeAdvisoryLaneLease(runDir, {
+    pid: 202,
+    pgid: 202,
+    round: 1,
+    reviewer: "codex",
+  });
+  assert.equal(second.lease.attempt, 2);
+  const leases = readAdvisoryLaneLeases(runDir);
+  assert.equal(leases.length, 2);
+  assert.equal(leases[0].leasePath, legacyPath);
+  assert.equal(leases[0].lease.attempt, 1);
+  assert.equal(leases[1].leasePath, second.leasePath);
+});


### PR DESCRIPTION
## Summary
- On lane `timeout`, the worker leaves its lease in place and the runner reaps the recorded pgid (worker-exit wait → TERM → grace → KILL → verify), recording `lane_reap` on the result artifact.
- Per-attempt lease filenames prevent re-spawn truncate-overwrite; pre-spawn reaps prior live attempts; legacy single-attempt leases remain discoverable.
- `cleanup-worktrees` reaps terminal age-eligible lane leases (with a dedicated report bucket); non-terminal and idle paths stay untouched.

Closes #988

## Test plan
- [x] `node --test tests/relay-review/scripts/advisory-lane-lease.test.js tests/relay-review/scripts/advisory-lane-lifecycle-988.test.js`
- [x] `node --test tests/relay-merge/scripts/finalize-run-advisory-lane-reap.test.js`
- [x] `node --test tests/relay-dispatch/scripts/cleanup-worktrees.test.js` (#988 cases)
- [x] Serialized gate: `node --test --test-concurrency=1 tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js` (1877 pass, 2 skipped)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Advisory 작업 재시도마다 독립적인 실행 상태를 추적해 이전 시도와 안전하게 공존하도록 개선했습니다.
  * 시간 초과 또는 종료된 작업의 남은 프로세스를 자동으로 정리하고, 정리 결과를 실행 결과에 표시합니다.
  * 정리 작업의 미리보기 모드에서 실제 정리 예정 항목을 확인할 수 있습니다.
  * 기존 형식의 실행 상태 파일도 계속 인식합니다.

* **버그 수정**
  * 시간 초과된 작업이 남긴 프로세스와 상태 파일이 정리되지 않던 문제를 해결했습니다.
  * 재시작 시 이전 작업이 새 작업과 충돌할 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->