### PR TITLE
fix(dispatch): cline advisory fallback when no run_result (#989)

### DIFF
--- a/skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js
@@ -22,6 +22,26 @@ function previewText(value, maxLength) {
   return String(value || "").replace(/\s+/g, " ").trim().slice(0, maxLength);
 }
 
+/** Whole trimmed stdout that parses as one non-event JSON object (no JSONL `type` field). */
+function tryPlainJsonStdoutFallback(raw) {
+  const trimmed = String(raw || "").trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (
+      parsed
+      && typeof parsed === "object"
+      && !Array.isArray(parsed)
+      && !Object.prototype.hasOwnProperty.call(parsed, "type")
+    ) {
+      return trimmed;
+    }
+  } catch {
+    // Not a single JSON object — leave fallback empty.
+  }
+  return null;
+}
+
 function extractClineAdvisoryCandidates(stdout, {
   adapter = "cline",
   phase = "advisory_review",
@@ -54,7 +74,18 @@ function extractClineAdvisoryCandidates(stdout, {
   }
 
   if (!runResultCount) {
-    throw new Error(`${context} Cline JSONL output did not include a run_result event (no run_result events found)${stderrTail(stderr)}`);
+    const fallbackCandidates = [];
+    if (typeof lastTextContentEnd === "string" && lastTextContentEnd.trim()) {
+      fallbackCandidates.push(lastTextContentEnd.trim());
+    }
+    const plainJsonStdout = tryPlainJsonStdoutFallback(raw);
+    if (plainJsonStdout && !fallbackCandidates.includes(plainJsonStdout)) {
+      fallbackCandidates.push(plainJsonStdout);
+    }
+    if (!fallbackCandidates.length) {
+      throw new Error(`${context} Cline JSONL output did not include a run_result event (no run_result events found)${stderrTail(stderr)}`);
+    }
+    return fallbackCandidates;
   }
 
   if (runResult?.finishReason !== "completed") {

--- a/tests/relay-dispatch/scripts/cline-jsonl.test.js
+++ b/tests/relay-dispatch/scripts/cline-jsonl.test.js
@@ -34,9 +34,51 @@ test("cline advisory extraction names invalid JSONL line number", () => {
   );
 });
 
-test("cline advisory extraction reports missing run_result with stderr tail", () => {
+test("cline advisory extraction falls back to text content_end when run_result is missing", () => {
   const stdout = [
     JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: "{\"ok\":true}" } }),
+  ].join("\n");
+
+  assert.deepEqual(
+    extractClineAdvisoryCandidates(stdout, {
+      adapter: "cline",
+      phase: "advisory_review",
+      stderr: "session not found",
+    }),
+    ["{\"ok\":true}"]
+  );
+});
+
+test("cline advisory extraction falls back to plain advisory JSON stdout when run_result is missing", () => {
+  const advisoryJson = JSON.stringify({
+    schema_version: 1,
+    profile: "blindspot",
+    summary: "Survival issue-172 R5 shape: whole stdout is plain advisory JSON.",
+    required_findings: [
+      {
+        id: "finding-1",
+        severity: "high",
+        title: "Real finding",
+        detail: "Present in plain JSON stdout without a run_result envelope.",
+      },
+    ],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  });
+
+  assert.deepEqual(
+    extractClineAdvisoryCandidates(advisoryJson, {
+      adapter: "cline",
+      phase: "advisory_review",
+    }),
+    [advisoryJson]
+  );
+});
+
+test("cline advisory extraction reports missing run_result with stderr tail when no fallback exists", () => {
+  const stdout = [
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "reasoning", text: "thinking only" } }),
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "tool", text: "tool only" } }),
   ].join("\n");
 
   assert.throws(
@@ -69,6 +111,25 @@ test("cline advisory extraction fails on non-completed finishReason without pars
       assert.ok(error.message.length < 520, "run_result.text preview should be bounded");
       return true;
     }
+  );
+});
+
+test("cline advisory extraction does not fall back past explicit non-completed finishReason", () => {
+  const stdout = [
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: "{\"ok\":true}" } }),
+    JSON.stringify({
+      type: "run_result",
+      finishReason: "error",
+      text: "explicit failure",
+    }),
+  ].join("\n");
+
+  assert.throws(
+    () => extractClineAdvisoryCandidates(stdout, {
+      adapter: "cline",
+      phase: "advisory_review",
+    }),
+    /finishReason "error"/
   );
 });
 


### PR DESCRIPTION
## Summary
- When Cline advisory JSONL has no `run_result` event, `extractClineAdvisoryCandidates` now yields fallback candidates: last text `content_end`, then whole stdout when it is a single non-event JSON object (survival issue-172 R5 shape).
- Still throws the existing `no run_result events found` error (with stderr tail) only when no fallback exists; explicit `finishReason !== "completed"` remains fail-closed with no fallback bypass.
- Dispatch-phase `extractClineRunResultText` / `copyClineRunResultTextToResultFile` unchanged; acceptance gate stays `parseAdvisoryReview`.

Closes #989

## Test plan
- [x] `node --test tests/relay-dispatch/scripts/cline-jsonl.test.js`
- [x] `node --test --test-concurrency=1 tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js` (1653 pass, 0 fail)
- [ ] Post-merge: re-run sample with `--advisory-profile blindspot` cline lanes (orchestrator-owned AC-2)


Made with [Cursor](https://cursor.com)