### PR TITLE
relay-orca #946: crash-safe resume + coordinator-only stop

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js` (fail-closed Orca capability probe).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js` (admission-gated provenance-injected operator dispatch).
 - Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js` (read-only live reconciler over receipt + relay + GitHub + Orca).
+- Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js` (crash-safe, reconcile-first, idempotent resumption from the receipt).
+- Script: `${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/stop.js` (coordinator-only stop; never touches relay runs or durable state).
 
 # relay-orca
 
@@ -35,15 +37,15 @@ relay-orca is **explicit-only**. It must never be auto-selected from ordinary re
 
 ## Intents
 
-relay-orca exposes exactly five intents. `plan` (read-only), `run` (admission-gated operator dispatch), and `status` (read-only live reconciler) are implemented; the remaining runtime intents are contract-only here and delivered in a later leaf, gated on the Orca capability probe.
+relay-orca exposes exactly five intents. All five — `plan` (read-only), `run` (admission-gated operator dispatch), `status` (read-only live reconciler), `resume` (crash-safe resumption), and `stop` (coordinator-only stop) — are implemented; the runtime intents are gated on the Orca capability probe.
 
 | Intent | Status | Purpose |
 | --- | --- | --- |
 | `plan` | implemented (read-only) | Compile an accepted program into an immutable wave plan. |
 | `run` | implemented (#944) | Dispatch provenance-injected relay/fleet operators for a plan. |
 | `status` | implemented (#945) | Derive a read-only live program view from receipt + relay + GitHub + Orca. |
-| `resume` | contract-only (#946) | Resume a coordinator from a reconstructible receipt without resetting Orca. |
-| `stop` | contract-only (#946) | Stop the coordinator only; never kill relay runs or discard durable state. |
+| `resume` | implemented (#946) | Reconcile-first, idempotent resumption from the receipt; fail closed on unsafe state, never reset Orca. |
+| `stop` | implemented (#946) | Stop the coordinator only; never kill relay runs or discard durable state. |
 
 Command tables and flag semantics: [references/commands.md](references/commands.md).
 
@@ -102,6 +104,27 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
 ```
 
 `status` reconciles durable truth (relay manifests, PRs/issues) against Orca runtime signals — `worker_done` is never completion evidence. Report shape, the state taxonomy, the nine detector codes, and reason codes 50–52: [references/commands.md](references/commands.md) and [references/receipt-and-status.md](references/receipt-and-status.md).
+
+Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fail closed on ambiguity):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
+  --program-id epic-941 \
+  --json
+```
+
+`resume` loads the receipt, runs the SAME reconciliation as `status` **before any mutation**, reuses valid mappings, reacquires lost operator terminals, and re-dispatches ONLY outcomes whose Orca dispatch is verifiably absent AND whose relay side is clean — through the verified path. It never resets Orca, deletes a task/worktree/branch/PR, or force-closes a relay run. Running it twice is idempotent. Fail-closed decision codes 60–63 and recovery steps: [references/commands.md](references/commands.md) and [references/recovery.md](references/recovery.md).
+
+Coordinator-only stop (records a bounded stop record; never cancels outcomes):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/stop.js" \
+  --program-id epic-941 \
+  --reason "operator pause" \
+  --json
+```
+
+`stop` invokes ONLY `orca orchestration run-stop` and records `stopped_at`/`stop_reason` in the receipt. It never terminates relay executors, deletes worktrees, closes PRs/issues, or claims the program is cancelled/complete. Flags and the 7-key report: [references/commands.md](references/commands.md).
 
 ## Ownership invariants
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -198,9 +198,90 @@ Usage errors exit `64`. A successfully derived view exits `0` even when it is fu
 `inconsistent`/`stale_missing` outcomes; runtime mismatch and unreachable Orca/GitHub degrade
 to diagnostics rather than failing.
 
-## Runtime intents (contract-only in this leaf)
+## `resume` — crash-safe, reconcile-first, idempotent resumption
 
-`run` (#944) and `status` (#945) are implemented. `resume` and `stop` remain defined by the
-skill contract but **not implemented here** — they are delivered in #946 and gated on the same
-Orca capability probe (`probe-orca.js`). See [experimental-status.md](experimental-status.md)
-for the pilot boundary and [capability-probe.md](capability-probe.md) for admission details.
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
+  --program-id <program-id> [--json] [--operator-handle <handle> ...] \
+  [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--program-id`, `-p` | The accepted program's stable id (required). Resolves the receipt under the programs root. |
+| `--json` | Emit the machine-readable resume report as JSON on stdout. |
+| `--operator-handle <handle>` | Repeatable. An explicit operator terminal to re-dispatch/reacquire to. With none, `resume` creates its own terminals and records them; it never adopts a terminal it did not create or receive here. |
+| `--orca-bin <path>` | Explicit Orca CLI override for the reconciliation reads and the restoration mutations. |
+| `--gh-bin <path>` | Explicit `gh` CLI override (or env `RELAY_ORCA_GH_BIN`). |
+| `--repo-root <path>` | Explicit repo root for slug derivation (defaults to the git repo of the cwd). |
+| `--help`, `-h` | Print usage. |
+
+`resume` loads the reconstructible receipt (fail-closed codes 50–52 verbatim), then runs the
+**same** live reconciliation as `status` (the imported #945 pipeline) **before any mutation**.
+It then reuses valid live mappings, reacquires a lost operator terminal, and re-dispatches an
+outcome **only** when ALL of: its Orca dispatch is verifiably absent, its relay side shows no
+in-flight/durable work, and the wave rules allow it — through the SAME verified path as `run`
+(inject → dispatch-show → prompt), persisting the receipt at the same A-series write points.
+Running it twice is **idempotent**: no duplicate Orca tasks, dispatches, relay runs, fleets,
+branches, or PRs can result. It **never** invokes `orca orchestration reset`, any `orca
+worktree` subcommand, task deletion, or relay force-close, and it never creates Orca worktrees.
+
+### Resume report (`--json`)
+
+Exactly these top-level keys: `ok`, `program_id`, `receipt_path`, `runtime`, `reconciliation`
+(the status-report outcome entries), `actions` (`{ outcome_id, action, reason }` where `action`
+is `reused | redispatched | skipped | decision_required`), `terminals_created`,
+`decision_required` (`{ reason_code, message, options }`, empty when none), `blocking_reasons`,
+and `reconciliation_required` (literally `true`).
+
+### Resume decision matrix (fail closed, no mutation)
+
+A reconciliation result that makes resumption unsafe fails closed with a `decision_required`
+report and **zero** mutation — resume creates no Orca gate, resets nothing, and deletes nothing.
+The recovery options never advise `reset`, task deletion, worktree deletion, or relay
+force-close (see [recovery.md](recovery.md)).
+
+| reason_code | exit | Trigger |
+| --- | --- | --- |
+| `RESUME_RUNTIME_CHANGED` | 60 | Live runtime id differs from the receipt `runtime_id`. |
+| `RESUME_AMBIGUOUS_STATE` | 61 | Runtime foreign/unreachable, or an outcome cannot be classified for resumption (e.g. a stale-`worker_done` inconsistency). |
+| `RESUME_CONFLICTING_MAPPING` | 62 | Duplicate or contradictory (changed) mappings. |
+| `RESUME_MISSING_PROVENANCE` | 63 | A live dispatch exists but the recorded dispatch context/assignee is missing. |
+
+Receipt-layer failures re-use `50`–`52` verbatim; usage errors exit `64`.
+
+## `stop` — coordinator-only stop
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/stop.js" \
+  --program-id <program-id> [--reason <text>] [--json] [--orca-bin <path>] [--repo-root <path>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--program-id`, `-p` | The accepted program's stable id (required). Resolves the receipt under the programs root. |
+| `--reason <text>` | Operator reason recorded verbatim (bounded to ≤256 chars) in the receipt's `stop_reason`. |
+| `--json` | Emit the machine-readable stop report as JSON on stdout. |
+| `--orca-bin <path>` | Explicit Orca CLI override for `run-stop`. |
+| `--repo-root <path>` | Explicit repo root for slug derivation. |
+| `--help`, `-h` | Print usage. |
+
+`stop` loads the receipt (fail-closed codes 50–52 verbatim) and invokes the **only** mutating
+Orca subcommand it may ever use — `orca orchestration run-stop` — then records a bounded stop
+record (`stopped_at`, `stop_reason`) in the receipt. Only those two fields change; every other
+field is byte-identical. A second stop is idempotent: it leaves the original stop record intact
+and rewrites nothing. `stop` **never** terminates relay executors, deletes worktrees, closes
+PRs/issues, invokes `reset`, invokes any `task-create`/`task-update`/`dispatch`/`terminal`
+subcommand, or emits language claiming the program or its outcomes are cancelled/complete —
+relay/fleet artifacts stay discoverable through normal relay tooling.
+
+### Stop report (`--json`)
+
+Exactly these top-level keys: `ok`, `program_id`, `receipt_path`, `coordinator_stopped`
+(boolean from the live `run-stop` result), `stopped_at`, `stop_reason`, `blocking_reasons`. A
+`run-stop` that does not succeed reports `coordinator_stopped: false` with a
+`COORDINATOR_STOP_FAILED` (exit `65`) blocking reason and writes no stop record.
+
+See [experimental-status.md](experimental-status.md) for the pilot boundary,
+[capability-probe.md](capability-probe.md) for admission details, and
+[recovery.md](recovery.md) for the manual decision-recovery steps.

--- a/skills/relay-orca/references/experimental-status.md
+++ b/skills/relay-orca/references/experimental-status.md
@@ -13,10 +13,11 @@ relay use never routes through relay-orca.
 - The OpenAI agent interface pins `allow_implicit_invocation: false` (see
   [../agents/openai.yaml](../agents/openai.yaml)), so no agent may auto-select relay-orca from
   ordinary relay, relay-fleet, delegation, implementation, or planning requests (D5).
-- `plan` requires only Node.js 18+ and is read-only. `run` (#944) additionally requires the
-  experimental Orca orchestration surface and is gated on the Orca capability probe; `status`
-  (#945) is read-only but reads the same live runtime signals; the remaining runtime intents
-  (`resume`/`stop`) stay contract-only until #946 delivers them.
+- `plan` requires only Node.js 18+ and is read-only. All five intents are now implemented:
+  `run` (#944), `status` (#945, read-only), and `resume`/`stop` (#946). `run`, `status`,
+  `resume`, and `stop` require the experimental Orca orchestration surface and are gated on the
+  Orca capability probe; `resume` fails closed on unsafe runtime state, and `stop` stops only
+  the coordinator.
 
 ## Pilot boundary
 

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -74,6 +74,18 @@ entry: `outcome_id`, `task_id`, `kind`, `wave`, `orca_task_id`, `dispatch_id`, `
 The receipt records **only identity and mapping**. It MUST NOT contain child lifecycle
 states, PR/issue status, Done Criteria text, completion flags, prompts, or terminal output.
 
+### Optional stop record (#946)
+
+`stop` (coordinator-only) is the ONLY writer that may append two extra top-level keys —
+`stopped_at` (ISO-8601, the one generated timestamp) and `stop_reason` (the operator's
+`--reason`, bounded to ≤256 chars). They are **not** part of the canonical `RECEIPT_KEYS`, so a
+receipt that never stopped serializes **byte-identically** to a `run`/`status` receipt, and a
+stopped receipt still loads for `status`/`resume` (validation ignores extra keys). A stop
+records these fields **once**: a second stop leaves the record byte-identical (idempotent). The
+stop record is coordination metadata — it is **not** a completion or cancellation flag, and it
+never claims the program or its outcomes are cancelled/complete. `resume` preserves it verbatim
+when it rewrites the receipt.
+
 - **Atomic write:** a temp file in the same directory + `rename`. Partial/torn receipts are
   impossible by construction.
 - **Write points (bounded edit to `run`):** after **each** successful task-create (A12),

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -1,0 +1,91 @@
+# relay-orca recovery — `resume`/`stop` decision handling
+
+`resume` is **reconcile-first and fail-closed**: it loads the reconstructible receipt, runs the
+SAME live reconciliation as `status` **before any mutation**, and only then restores what is
+safe (reuse valid mappings, reacquire a lost operator terminal, re-dispatch a verifiably-absent,
+relay-clean, wave-1 outcome through the verified path). When the reconciliation shows a state
+that makes resumption unsafe, `resume` performs **zero** mutation and emits a `decision_required`
+report with a bounded exit code. This reference is the operator anchor for those decisions.
+
+None of the steps below are performed automatically by the skill. The skill **never** resets
+Orca, deletes a task, removes a worktree, deletes a branch/PR, or force-closes a relay run — on
+any path, including every failure path. The **only** mutations `resume` performs are, on a safe
+outcome, `orca orchestration dispatch --inject`, `orca terminal create`, and `orca terminal
+send`; `stop`'s only mutation is `orca orchestration run-stop`.
+
+## Reading a `decision_required` report
+
+`resume --json` emits `decision_required: [{ reason_code, message, options }]` and exits with the
+matching code. `options` are bounded strings, each naming a concrete operator command or this
+reference — never a destructive action. Resolve the decision by hand, then re-run `resume`.
+
+### `RESUME_RUNTIME_CHANGED` (exit 60) — live runtime id ≠ receipt
+
+The Orca runtime was restarted (or replaced): the live `runtime_id` no longer matches the
+receipt, so every recorded `orca_task_id`/`dispatch_id`/terminal belongs to a runtime that is
+gone. Bounded steps:
+
+1. Inspect the live view: `node scripts/status.js --program-id <id> --json`.
+2. Confirm — from live relay manifests, PRs, and issues — which outcomes already have durable
+   work, so a fresh run cannot duplicate it.
+3. Only then, against the new runtime, re-run `node scripts/run.js --program-file <program>` for
+   the outcomes that are genuinely unstarted. Leave in-flight relay runs alone.
+
+### `RESUME_AMBIGUOUS_STATE` (exit 61) — foreign/unreachable runtime or an unclassifiable outcome
+
+Either the runtime carries orchestration tasks not marked for this program (`foreign_state`), the
+runtime is unreachable, or an outcome is `inconsistent` (e.g. a stale `worker_done` with an open
+PR / non-terminal manifest — see [receipt-and-status.md](receipt-and-status.md)). Bounded steps:
+
+1. Inspect: `node scripts/status.js --program-id <id> --json` and read the diagnostics.
+2. For a foreign runtime, verify no unrelated orchestration program is running before acting.
+3. For an `inconsistent` outcome, drive the outcome to a decided durable state through the
+   **normal relay path** (review → merge, or escalate), then re-run `resume`. Do not force it.
+
+### `RESUME_CONFLICTING_MAPPING` (exit 62) — duplicate or changed mapping
+
+Two receipt entries share an `orca_task_id`/relay run id, or a recorded dispatch id drifted away
+from the live one. Bounded steps:
+
+1. Inspect: `node scripts/status.js --program-id <id> --json` (`DUPLICATE_MAPPING` /
+   `MISSING_DISPATCH` diagnostics name the conflicting ids).
+2. Determine which mapping reflects the live dispatch (`orca orchestration dispatch-show --task
+   <orca_task_id> --json`) and correct the receipt mapping by hand.
+3. Re-run `resume`.
+
+### `RESUME_MISSING_PROVENANCE` (exit 63) — live dispatch without recorded provenance
+
+A live dispatch exists for a mapped task, but the receipt's dispatch context/assignee is
+incomplete, so `resume` cannot verify which terminal owns it. Bounded steps:
+
+1. Read the live dispatch: `orca orchestration dispatch-show --task <orca_task_id> --json`.
+2. Restore the missing dispatch id/assignee in the receipt to match the live dispatch.
+3. Re-run `resume`.
+
+## Corrupt or global task-graph recovery
+
+- **Corrupt / missing receipt** (`RECEIPT_NOT_FOUND` 50, `RECEIPT_CORRUPT` 51,
+  `RECEIPT_REPO_MISMATCH` 52): the receipt is reconstructible coordination metadata, not a source
+  of truth. Never hand-edit it into validity blindly — re-derive it. Confirm the program's real
+  state from live relay manifests, PRs, and issues via `status`, then re-run `run` from the
+  accepted-program contract to rewrite a fresh atomic receipt. Invoke from the same repo (or pass
+  `--repo-root`) that produced the receipt.
+- **Foreign / ambiguous global task graph**: relay-orca is single-program-per-runtime in v0. If
+  the runtime carries another program's orchestration tasks, resolve that program first; do not
+  adopt or reset the shared runtime from `resume`.
+
+## Destructive manual actions — OUTSIDE automatic skill behavior
+
+> The following are **destructive** and are **never** performed by `resume` or `stop` on any
+> path. They are listed here only so an operator who chooses to perform them does so knowingly
+> and by hand. The skill will not do them for you and does not recommend them as automatic
+> recovery.
+
+- `orca orchestration reset` — wipes runtime orchestration state. Never run by the skill.
+- Orca task deletion / `orca orchestration task-*` deletes — never run by the skill.
+- Any `orca worktree` subcommand / worktree removal — relay owns implementation worktrees.
+- relay run force-close, branch deletion, or PR/issue closure — durable relay state; use the
+  normal relay tooling (`relay-merge`, `dev-backlog`) deliberately, never as a resume side effect.
+
+If a recovery seems to require one of these, stop and treat it as a manual, audited operator
+decision — not a step `resume`/`stop` will take for you.

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -3,9 +3,15 @@
 `resume` is **reconcile-first and fail-closed**: it loads the reconstructible receipt, runs the
 SAME live reconciliation as `status` **before any mutation**, and only then restores what is
 safe (reuse valid mappings, reacquire a lost operator terminal, re-dispatch a verifiably-absent,
-relay-clean, wave-1 outcome through the verified path). When the reconciliation shows a state
-that makes resumption unsafe, `resume` performs **zero** mutation and emits a `decision_required`
-report with a bounded exit code. This reference is the operator anchor for those decisions.
+relay-clean, wave-1 outcome through the verified path). **"Verifiably absent" means a live
+`dispatch-show` read for that task, taken during the reconciliation pass, reported NO dispatch —
+a null `dispatch_id` in the receipt alone NEVER qualifies.** In the crash window (a
+`dispatch --inject` landed a live dispatch but the receipt write recording it never happened),
+the receipt id is null yet a live dispatch is present; re-injecting would duplicate operator work,
+so that case fails closed as `RESUME_MISSING_PROVENANCE` (exit 63) instead of re-dispatching. When
+the reconciliation shows a state that makes resumption unsafe, `resume` performs **zero** mutation
+and emits a `decision_required` report with a bounded exit code. This reference is the operator
+anchor for those decisions.
 
 None of the steps below are performed automatically by the skill. The skill **never** resets
 Orca, deletes a task, removes a worktree, deletes a branch/PR, or force-closes a relay run — on
@@ -55,12 +61,16 @@ from the live one. Bounded steps:
 
 ### `RESUME_MISSING_PROVENANCE` (exit 63) — live dispatch without recorded provenance
 
-A live dispatch exists for a mapped task, but the receipt's dispatch context/assignee is
-incomplete, so `resume` cannot verify which terminal owns it. Bounded steps:
+A live `dispatch-show` read reports a dispatch **present** for a mapped task, but the receipt's
+recorded provenance is incomplete — either the `assignee` is missing (so `resume` cannot verify
+which terminal owns the live dispatch), or **both the `dispatch_id` and `assignee` are absent**
+(the crash window: `dispatch --inject` landed a live dispatch but the receipt write that records it
+never happened). In every case a live dispatch already exists, so `resume` will **not** re-inject —
+that would duplicate operator work. Bounded steps:
 
 1. Read the live dispatch: `orca orchestration dispatch-show --task <orca_task_id> --json`.
-2. Restore the missing dispatch id/assignee in the receipt to match the live dispatch.
-3. Re-run `resume`.
+2. Restore the missing `dispatch_id`/`assignee` in the receipt to match the live dispatch.
+3. Re-run `resume` — the outcome now reads back as a valid live mapping and is reused.
 
 ## Corrupt or global task-graph recovery
 

--- a/skills/relay-orca/scripts/lib/receipt.js
+++ b/skills/relay-orca/scripts/lib/receipt.js
@@ -42,6 +42,20 @@ const TASK_KEYS = Object.freeze([
 
 const RELAY_ID_KEYS = Object.freeze(["request", "run", "fleet"]);
 
+// #946 D5 stop record — appended ONLY by `stop`, and ONLY these two bounded fields:
+// `stopped_at` (ISO-8601) and `stop_reason` (operator-provided, ≤256 chars). They are
+// NOT part of RECEIPT_KEYS, so a receipt that never stopped serializes byte-identically
+// to before (run/status receipts are unchanged). validateReceipt ignores extra keys, so
+// a stopped receipt still loads for `status`/`resume`. The cap keeps a pathological
+// operator reason from inflating the receipt.
+const STOP_KEYS = Object.freeze(["stopped_at", "stop_reason"]);
+const STOP_REASON_MAX = 256;
+
+function boundStopReason(value) {
+  if (typeof value !== "string" || value === "") return "";
+  return value.length <= STOP_REASON_MAX ? value : value.slice(0, STOP_REASON_MAX);
+}
+
 function relayIds(source) {
   const raw = source && typeof source === "object" ? source : {};
   const normalizeId = (value) => (typeof value === "string" && value.length > 0 ? value : null);
@@ -109,6 +123,18 @@ function serializeReceipt(receipt) {
   return `${JSON.stringify(orderReceipt(receipt), null, 2)}\n`;
 }
 
+// #946 D5: serialize a receipt that MAY carry a bounded stop record. The stop keys are
+// appended AFTER the canonical RECEIPT_KEYS block ONLY when present, so a receipt with no
+// stop record serializes byte-identically to serializeReceipt (existing #944/#945
+// receipts are unchanged). This is the only writer that emits `stopped_at`/`stop_reason`.
+function serializeReceiptWithStop(receipt) {
+  const ordered = orderReceipt(receipt);
+  STOP_KEYS.forEach((key) => {
+    if (receipt[key] !== undefined) ordered[key] = receipt[key];
+  });
+  return `${JSON.stringify(ordered, null, 2)}\n`;
+}
+
 function validateTask(task) {
   if (!task || typeof task !== "object") return "a task entry is not an object";
   for (const key of TASK_KEYS) {
@@ -161,10 +187,14 @@ module.exports = {
   RECEIPT_KEYS,
   TASK_KEYS,
   RELAY_ID_KEYS,
+  STOP_KEYS,
+  STOP_REASON_MAX,
+  boundStopReason,
   buildReceiptMapping,
   receiptTaskEntry,
   orderReceipt,
   serializeReceipt,
+  serializeReceiptWithStop,
   validateReceipt,
   parseReceipt,
 };

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -41,6 +41,29 @@ function missingProvenance(task) {
   return Boolean(task.orca_task_id) && Boolean(task.dispatch_id) && !isNonEmpty(task.assignee);
 }
 
+// D2 code 63, crash window (owner amendment A1, #946 R1): a live dispatch-show read
+// reports a dispatch PRESENT for this task, but the receipt records NO provenance
+// (dispatch_id and/or assignee absent) — the signature of `dispatch --inject` landing a
+// live dispatch and the receipt write that records it never happening. The live dispatch
+// is real, so re-injecting would DUPLICATE operator work: a null receipt dispatch_id here
+// is NOT verifiable absence, and resume fails closed (RESUME_MISSING_PROVENANCE) with
+// zero mutation rather than re-dispatching.
+function liveDispatchWithoutProvenance(task, livePresent) {
+  return livePresent === true && isNonEmpty(task.orca_task_id) && (!isNonEmpty(task.dispatch_id) || !isNonEmpty(task.assignee));
+}
+
+// Per-outcome live dispatch fact threaded from resume's reconciliation pass (the pipeline
+// already performs the per-task dispatch-show reads): `{ present, absent }` where
+// `present` = a reachable, runtime-attributed dispatch-show reported a dispatch id, and
+// `absent` = it reported none. Both false = UNKNOWN (untrusted runtime, an unattributable
+// per-task read, or a task missing from the runtime) — which NEVER qualifies as verifiable
+// absence. Accepts a Map or a plain object; a missing entry degrades to unknown.
+function liveDispatchFact(liveDispatch, outcomeId) {
+  if (liveDispatch && typeof liveDispatch.get === "function") return liveDispatch.get(outcomeId) || {};
+  if (liveDispatch && typeof liveDispatch === "object") return liveDispatch[outcomeId] || {};
+  return {};
+}
+
 function isNonEmpty(value) {
   return typeof value === "string" && value.length > 0;
 }
@@ -80,11 +103,18 @@ function needsTerminalReacquire(task, diags) {
   );
 }
 
-// D3 re-dispatch: the Orca dispatch is verifiably absent (never dispatched: no recorded
-// dispatch id), the materialized task still exists, the relay side is clean, and the
-// wave rule allows it (v0 dispatches only wave 1, matching the #944 run anchor).
-function isRedispatchCandidate(task, diags, outcome) {
+// D3 re-dispatch: the Orca dispatch is VERIFIABLY absent, the materialized task still
+// exists, the relay side is clean, and the wave rule allows it (v0 dispatches only wave
+// 1, matching the #944 run anchor). "Verifiably absent" (owner amendment A1, #946 R1) is
+// satisfied ONLY by `liveAbsent` — a live dispatch-show read for THIS task, threaded from
+// the reconciliation pass, that reports NO dispatch. A null receipt `dispatch_id` alone
+// NEVER qualifies: in the crash window (dispatch --inject landed a live dispatch but the
+// receipt write that records it never happened) the receipt id is null yet a live dispatch
+// is present, and re-injecting there would duplicate operator work — that case fails closed
+// as RESUME_MISSING_PROVENANCE in planDecisions instead of re-dispatching here.
+function isRedispatchCandidate(task, diags, outcome, liveAbsent) {
   return (
+    liveAbsent === true &&
     !isNonEmpty(task.dispatch_id) &&
     isNonEmpty(task.orca_task_id) &&
     !hasDiag(diags, "MISSING_TASK") &&
@@ -95,7 +125,7 @@ function isRedispatchCandidate(task, diags, outcome) {
 
 // Program-level fail-closed decisions (D2). Deduped by reason_code and ordered by exit
 // code so the process exit is deterministic (60 < 61 < 62 < 63).
-function planDecisions(receipt, report) {
+function planDecisions(receipt, report, liveDispatch) {
   const decisions = [];
   const add = (code, message) => {
     if (!decisions.some((entry) => entry.reason_code === code)) decisions.push(decisionEntry(code, message));
@@ -111,9 +141,16 @@ function planDecisions(receipt, report) {
   }
   receipt.tasks.forEach((task) => {
     const diags = diagsFor(report, task.outcome_id);
+    const live = liveDispatchFact(liveDispatch, task.outcome_id);
     if (driftedDispatch(diags)) add("RESUME_CONFLICTING_MAPPING", `outcome ${task.outcome_id} dispatch id changed under the mapping; resume performs no mutation`);
     if (missingProvenance(task) && !hasDiag(diags, "MISSING_DISPATCH")) {
       add("RESUME_MISSING_PROVENANCE", `outcome ${task.outcome_id} has a live dispatch but its recorded provenance is incomplete; resume performs no mutation`);
+    }
+    // Crash window (A1): a live dispatch-show read reports a dispatch present but the
+    // receipt recorded no provenance for it. A null receipt dispatch_id is NOT absence
+    // here — re-injecting would duplicate operator work — so fail closed with zero mutation.
+    if (liveDispatchWithoutProvenance(task, live.present)) {
+      add("RESUME_MISSING_PROVENANCE", `outcome ${task.outcome_id} has a live dispatch but the receipt records no dispatch provenance; resume performs no mutation`);
     }
   });
   const inconsistent = (report.outcomes || []).filter((outcome) => outcome.state === "inconsistent");
@@ -148,14 +185,15 @@ function hasUnmappedRelayWork(report) {
 // terminal is reacquired; a verifiably-absent, relay-clean, wave-1 outcome is
 // re-dispatched; everything else (in-flight/durable child, later wave, or unattributable
 // unmapped relay work) is left untouched.
-function classifyAction(task, report, unmappedRelayWork) {
+function classifyAction(task, report, unmappedRelayWork, liveDispatch) {
   const outcome = reportOutcomeById(report, task.outcome_id) || {};
   const diags = diagsFor(report, task.outcome_id);
+  const live = liveDispatchFact(liveDispatch, task.outcome_id);
   if (outcome.state === "complete_with_evidence") return makeAction(task, "skipped", "already complete with live evidence; nothing to resume");
   if (outcome.state === "escalated") return makeAction(task, "skipped", "escalated; requires operator action, not automatic resume");
   if (needsTerminalReacquire(task, diags)) return makeAction(task, "redispatched", `outcome ${task.outcome_id} operator terminal is gone; reacquiring through the verified inject->dispatch-show->prompt path`, execPlan(task, "reacquire_terminal"));
   if (mappingLive(task, diags)) return makeAction(task, "reused", `outcome ${task.outcome_id} has a valid live mapping (task+dispatch+terminal); reused, not re-dispatched`);
-  if (isRedispatchCandidate(task, diags, outcome)) {
+  if (isRedispatchCandidate(task, diags, outcome, live.absent)) {
     if (unmappedRelayWork) return makeAction(task, "skipped", `outcome ${task.outcome_id} is absent, but unmapped relay work references this program; not re-dispatched to avoid duplicating it`);
     return makeAction(task, "redispatched", `outcome ${task.outcome_id} Orca dispatch verifiably absent and relay side clean; re-dispatching through the verified path`, execPlan(task, "redispatch"));
   }
@@ -164,8 +202,8 @@ function classifyAction(task, report, unmappedRelayWork) {
 
 // The whole plan: program-level decisions plus per-outcome actions. When any decision
 // fires, EVERY outcome is `decision_required` (resume performs zero mutation, D2).
-function planResume({ receipt, report }) {
-  const decisions = planDecisions(receipt, report);
+function planResume({ receipt, report, liveDispatch }) {
+  const decisions = planDecisions(receipt, report, liveDispatch);
   if (decisions.length) {
     const reason = boundedExcerpt(`blocked: ${decisions[0].reason_code}`);
     const actions = receipt.tasks.map((task) => makeAction(task, "decision_required", reason, null));
@@ -173,7 +211,7 @@ function planResume({ receipt, report }) {
     return { decisions, actions, blockingReasons, exitCode: exitCodeFor(decisions[0].reason_code) };
   }
   const unmappedRelayWork = hasUnmappedRelayWork(report);
-  const actions = receipt.tasks.map((task) => classifyAction(task, report, unmappedRelayWork));
+  const actions = receipt.tasks.map((task) => classifyAction(task, report, unmappedRelayWork, liveDispatch));
   return { decisions: [], actions, blockingReasons: [], exitCode: 0 };
 }
 
@@ -188,5 +226,6 @@ module.exports = {
   needsTerminalReacquire,
   isRedispatchCandidate,
   missingProvenance,
+  liveDispatchWithoutProvenance,
   driftedDispatch,
 };

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -171,13 +171,16 @@ function execPlan(task, type) {
 }
 
 // Program-level "unmapped relay work" signal (D3 no-duplicate-work): reconciliation
-// discovered a relay run manifest that references this program but is ABSENT from the
-// receipt mapping. It cannot be attributed to a specific outcome, so re-dispatching ANY
-// verifiably-absent outcome could duplicate that unmapped work — such outcomes are skipped
-// (left for a supervised reconcile) rather than re-dispatched. Reuse/reacquisition of
-// already-mapped outcomes is unaffected.
+// discovered a relay run manifest (runs root, `adopt_relay_run`) OR a relay fleet manifest
+// (fleets root #945 A8, `adopt_relay_fleet`, owner amendment A2) that references this program
+// but is ABSENT from the receipt mapping. Neither can be attributed to a specific outcome, so
+// re-dispatching ANY verifiably-absent outcome could duplicate that unmapped work — and
+// re-dispatching a relay_fleet outcome would duplicate the whole fleet (forbidden by the drain
+// invariant). Such outcomes are skipped (left for a supervised reconcile) rather than
+// re-dispatched. Reuse/reacquisition of already-mapped outcomes is unaffected.
+const UNMAPPED_WORK_KINDS = new Set(["adopt_relay_run", "adopt_relay_fleet"]);
 function hasUnmappedRelayWork(report) {
-  return (report.repair_candidates || []).some((candidate) => candidate.kind === "adopt_relay_run");
+  return (report.repair_candidates || []).some((candidate) => UNMAPPED_WORK_KINDS.has(candidate.kind));
 }
 
 // Classify ONE outcome into a safe action (only reached when NO program-level decision

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -1,0 +1,192 @@
+"use strict";
+
+// Pure `resume` action planner (#946 D2/D3/D4/D6). Given the parsed receipt and the
+// live reconciliation report produced by the imported #945 status pipeline, it decides
+// — with NO I/O — whether resumption is safe and, if so, exactly which outcomes are
+// reused, re-dispatched, reacquire a terminal, or are left untouched. All subprocess
+// and fs work happens in the top-level resume.js via injected adapters; this module is
+// pure so plan.js's frozen lib source-scan keeps passing.
+//
+// Completion authority stays with the imported classifier (D6): a worker_done outcome
+// with an open PR / non-terminal manifest is `inconsistent` here too, and resume never
+// re-dispatches it — it surfaces as a decision. The re-dispatch predicate is the D3
+// conjunction: an outcome is re-dispatched ONLY when its Orca dispatch is verifiably
+// absent AND its relay side shows no in-flight/durable work AND the wave rules allow it.
+const { boundedExcerpt } = require("./bounded-excerpt");
+const { REASONS, exitCodeFor, decisionEntry } = require("./resume-reasons");
+const { actionEntry } = require("./resume-report");
+
+function reportOutcomeById(report, outcomeId) {
+  return (report.outcomes || []).find((outcome) => outcome.outcome_id === outcomeId) || null;
+}
+
+function diagsFor(report, outcomeId) {
+  return (report.diagnostics || []).filter((diagnostic) => diagnostic.outcome_id === outcomeId);
+}
+
+function hasDiag(diags, code) {
+  return diags.some((diagnostic) => diagnostic.code === code);
+}
+
+// A DUPLICATE_MAPPING diagnostic OR a dispatch id that drifted under the mapping (a
+// MISSING_DISPATCH carrying a live_dispatch_id, #945 A10) is a contradictory mapping.
+function driftedDispatch(diags) {
+  return diags.some((diagnostic) => diagnostic.code === "MISSING_DISPATCH" && diagnostic.ids && "live_dispatch_id" in diagnostic.ids);
+}
+
+// D2 code 63: the receipt records a dispatch (a live dispatch therefore exists — no
+// MISSING_DISPATCH fired) but its provenance is incomplete (no assignee), so resume
+// cannot verify which terminal owns the live dispatch.
+function missingProvenance(task) {
+  return Boolean(task.orca_task_id) && Boolean(task.dispatch_id) && !isNonEmpty(task.assignee);
+}
+
+function isNonEmpty(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function relayIds(task) {
+  return task.relay_ids && typeof task.relay_ids === "object" ? task.relay_ids : {};
+}
+
+// D3 relay-side cleanliness: no mapped relay run, no mapped fleet, and no PR — the only
+// state in which re-dispatch cannot duplicate in-flight/durable relay work.
+function relayClean(task, outcome) {
+  const ids = relayIds(task);
+  return !isNonEmpty(ids.run) && !isNonEmpty(ids.fleet) && !(outcome && outcome.pr_url);
+}
+
+// A fully valid live mapping: task + dispatch + terminal all present and unbroken.
+function mappingLive(task, diags) {
+  return (
+    isNonEmpty(task.orca_task_id) &&
+    isNonEmpty(task.dispatch_id) &&
+    isNonEmpty(task.assignee) &&
+    !hasDiag(diags, "MISSING_TASK") &&
+    !hasDiag(diags, "MISSING_DISPATCH") &&
+    !hasDiag(diags, "MISSING_TERMINAL")
+  );
+}
+
+// D4 terminal reacquisition: the Orca task + dispatch survive but the operator terminal
+// is gone. The surface is re-established through the SAME verified path as a dispatch.
+function needsTerminalReacquire(task, diags) {
+  return (
+    isNonEmpty(task.orca_task_id) &&
+    isNonEmpty(task.dispatch_id) &&
+    hasDiag(diags, "MISSING_TERMINAL") &&
+    !hasDiag(diags, "MISSING_TASK") &&
+    !hasDiag(diags, "MISSING_DISPATCH")
+  );
+}
+
+// D3 re-dispatch: the Orca dispatch is verifiably absent (never dispatched: no recorded
+// dispatch id), the materialized task still exists, the relay side is clean, and the
+// wave rule allows it (v0 dispatches only wave 1, matching the #944 run anchor).
+function isRedispatchCandidate(task, diags, outcome) {
+  return (
+    !isNonEmpty(task.dispatch_id) &&
+    isNonEmpty(task.orca_task_id) &&
+    !hasDiag(diags, "MISSING_TASK") &&
+    task.wave === 1 &&
+    relayClean(task, outcome)
+  );
+}
+
+// Program-level fail-closed decisions (D2). Deduped by reason_code and ordered by exit
+// code so the process exit is deterministic (60 < 61 < 62 < 63).
+function planDecisions(receipt, report) {
+  const decisions = [];
+  const add = (code, message) => {
+    if (!decisions.some((entry) => entry.reason_code === code)) decisions.push(decisionEntry(code, message));
+  };
+  if (report.runtime === "mismatch") {
+    add("RESUME_RUNTIME_CHANGED", "live Orca runtime id does not match the receipt runtime_id; resume performs no mutation until it is reconciled");
+  }
+  if (report.runtime === "foreign_state" || report.runtime === "unreachable") {
+    add("RESUME_AMBIGUOUS_STATE", `live runtime is ${report.runtime}; resume cannot attribute Orca facts, so it performs no mutation`);
+  }
+  if ((report.diagnostics || []).some((diagnostic) => diagnostic.code === "DUPLICATE_MAPPING")) {
+    add("RESUME_CONFLICTING_MAPPING", "receipt carries duplicate/contradictory mappings (DUPLICATE_MAPPING); resume performs no mutation");
+  }
+  receipt.tasks.forEach((task) => {
+    const diags = diagsFor(report, task.outcome_id);
+    if (driftedDispatch(diags)) add("RESUME_CONFLICTING_MAPPING", `outcome ${task.outcome_id} dispatch id changed under the mapping; resume performs no mutation`);
+    if (missingProvenance(task) && !hasDiag(diags, "MISSING_DISPATCH")) {
+      add("RESUME_MISSING_PROVENANCE", `outcome ${task.outcome_id} has a live dispatch but its recorded provenance is incomplete; resume performs no mutation`);
+    }
+  });
+  const inconsistent = (report.outcomes || []).filter((outcome) => outcome.state === "inconsistent");
+  if (inconsistent.length) {
+    add("RESUME_AMBIGUOUS_STATE", `outcome ${inconsistent[0].outcome_id} is inconsistent (durable evidence conflicts with a lifecycle signal); resume performs no mutation`);
+  }
+  return decisions.sort((a, b) => exitCodeFor(a.reason_code) - exitCodeFor(b.reason_code));
+}
+
+// Internal action carrier: the report entry plus an `exec` plan the top-level executor
+// consumes. `exec` is null for reused/skipped/decision_required (no mutation).
+function makeAction(task, action, reason, exec) {
+  return { outcome_id: task.outcome_id, action, reason: boundedExcerpt(reason), exec: exec || null };
+}
+
+function execPlan(task, type) {
+  return { type, outcome_id: task.outcome_id, orca_task_id: task.orca_task_id, kind: task.kind, wave: task.wave };
+}
+
+// Program-level "unmapped relay work" signal (D3 no-duplicate-work): reconciliation
+// discovered a relay run manifest that references this program but is ABSENT from the
+// receipt mapping. It cannot be attributed to a specific outcome, so re-dispatching ANY
+// verifiably-absent outcome could duplicate that unmapped work — such outcomes are skipped
+// (left for a supervised reconcile) rather than re-dispatched. Reuse/reacquisition of
+// already-mapped outcomes is unaffected.
+function hasUnmappedRelayWork(report) {
+  return (report.repair_candidates || []).some((candidate) => candidate.kind === "adopt_relay_run");
+}
+
+// Classify ONE outcome into a safe action (only reached when NO program-level decision
+// fired). Completion/escalation are terminal (skipped); a live mapping is reused; a lost
+// terminal is reacquired; a verifiably-absent, relay-clean, wave-1 outcome is
+// re-dispatched; everything else (in-flight/durable child, later wave, or unattributable
+// unmapped relay work) is left untouched.
+function classifyAction(task, report, unmappedRelayWork) {
+  const outcome = reportOutcomeById(report, task.outcome_id) || {};
+  const diags = diagsFor(report, task.outcome_id);
+  if (outcome.state === "complete_with_evidence") return makeAction(task, "skipped", "already complete with live evidence; nothing to resume");
+  if (outcome.state === "escalated") return makeAction(task, "skipped", "escalated; requires operator action, not automatic resume");
+  if (needsTerminalReacquire(task, diags)) return makeAction(task, "redispatched", `outcome ${task.outcome_id} operator terminal is gone; reacquiring through the verified inject->dispatch-show->prompt path`, execPlan(task, "reacquire_terminal"));
+  if (mappingLive(task, diags)) return makeAction(task, "reused", `outcome ${task.outcome_id} has a valid live mapping (task+dispatch+terminal); reused, not re-dispatched`);
+  if (isRedispatchCandidate(task, diags, outcome)) {
+    if (unmappedRelayWork) return makeAction(task, "skipped", `outcome ${task.outcome_id} is absent, but unmapped relay work references this program; not re-dispatched to avoid duplicating it`);
+    return makeAction(task, "redispatched", `outcome ${task.outcome_id} Orca dispatch verifiably absent and relay side clean; re-dispatching through the verified path`, execPlan(task, "redispatch"));
+  }
+  return makeAction(task, "skipped", `outcome ${task.outcome_id} has in-flight/durable relay work or is a later wave; left untouched`);
+}
+
+// The whole plan: program-level decisions plus per-outcome actions. When any decision
+// fires, EVERY outcome is `decision_required` (resume performs zero mutation, D2).
+function planResume({ receipt, report }) {
+  const decisions = planDecisions(receipt, report);
+  if (decisions.length) {
+    const reason = boundedExcerpt(`blocked: ${decisions[0].reason_code}`);
+    const actions = receipt.tasks.map((task) => makeAction(task, "decision_required", reason, null));
+    const blockingReasons = decisions.map((decision) => ({ reason_code: decision.reason_code, message: decision.message }));
+    return { decisions, actions, blockingReasons, exitCode: exitCodeFor(decisions[0].reason_code) };
+  }
+  const unmappedRelayWork = hasUnmappedRelayWork(report);
+  const actions = receipt.tasks.map((task) => classifyAction(task, report, unmappedRelayWork));
+  return { decisions: [], actions, blockingReasons: [], exitCode: 0 };
+}
+
+module.exports = {
+  REASONS,
+  planResume,
+  planDecisions,
+  classifyAction,
+  hasUnmappedRelayWork,
+  relayClean,
+  mappingLive,
+  needsTerminalReacquire,
+  isRedispatchCandidate,
+  missingProvenance,
+  driftedDispatch,
+};

--- a/skills/relay-orca/scripts/lib/resume-reasons.js
+++ b/skills/relay-orca/scripts/lib/resume-reasons.js
@@ -1,0 +1,66 @@
+"use strict";
+
+// relay-orca `resume` fail-closed DECISION matrix (#946 D2). A NEW module in the
+// 60-range so it never collides with plan.js's 2-21 codes, the probe's 30-37, run's
+// 40-44, status/receipt's 50-52, or Node's own fatal/exec codes (<=125). Existing
+// reason modules stay untouched. 64 is deliberately avoided (usage errors own it).
+//
+// These four are the ONLY conditions that make resumption unsafe. In any of them
+// resume performs NO automatic mutation: it emits a `decision_required` report and
+// exits with the matching code. Receipt-layer failures re-use status's 50-52
+// verbatim (imported by resume.js); these decision codes are surfaced through the
+// report's `decision_required` array, never a task/terminal/dispatch mutation.
+const { boundedExcerpt } = require("./bounded-excerpt");
+
+const REASONS = Object.freeze({
+  RESUME_RUNTIME_CHANGED: 60, // live runtime id != receipt runtime_id
+  RESUME_AMBIGUOUS_STATE: 61, // foreign/unreachable runtime, or an unclassifiable outcome
+  RESUME_CONFLICTING_MAPPING: 62, // duplicate or contradictory (changed) mappings
+  RESUME_MISSING_PROVENANCE: 63, // a mapping's dispatch context/assignee is missing where a live dispatch exists
+});
+
+// Bounded recovery options per decision code (D2). Each option names a concrete
+// operator command to run and stays under the shared excerpt limit. Options NEVER
+// name `orca orchestration reset`, task deletion, worktree deletion, or relay
+// force-close — resume never performs a destructive action and never advises one.
+const OPTIONS = Object.freeze({
+  RESUME_RUNTIME_CHANGED: [
+    "Inspect the live runtime: `node scripts/status.js --program-id <id> --json`.",
+    "Only after confirming no duplicate work: re-run `node scripts/run.js --program-file <program>` against the new runtime.",
+    "See references/recovery.md § RESUME_RUNTIME_CHANGED for the bounded manual steps.",
+  ],
+  RESUME_AMBIGUOUS_STATE: [
+    "Inspect the foreign/ambiguous runtime: `node scripts/status.js --program-id <id> --json`.",
+    "Resolve the ambiguous outcome by hand, then re-run resume.",
+    "See references/recovery.md § RESUME_AMBIGUOUS_STATE for the bounded manual steps.",
+  ],
+  RESUME_CONFLICTING_MAPPING: [
+    "Inspect the duplicate/changed mapping: `node scripts/status.js --program-id <id> --json`.",
+    "Reconcile the conflicting mapping by hand before resuming.",
+    "See references/recovery.md § RESUME_CONFLICTING_MAPPING for the bounded manual steps.",
+  ],
+  RESUME_MISSING_PROVENANCE: [
+    "Verify the live dispatch: `orca orchestration dispatch-show --task <orca_task_id> --json`.",
+    "Restore the missing dispatch context/assignee in the receipt by hand before resuming.",
+    "See references/recovery.md § RESUME_MISSING_PROVENANCE for the bounded manual steps.",
+  ],
+});
+
+function exitCodeFor(reasonCode) {
+  const code = REASONS[reasonCode];
+  if (code === undefined) throw new Error(`unknown resume reason code: ${reasonCode}`);
+  return code;
+}
+
+// Build a decision_required report entry (D8). `message` is a bounded excerpt so a
+// subprocess-derived detail can never inflate or line-inject the report; `options`
+// come from the pinned bounded set above (each already ≤ the excerpt limit).
+function decisionEntry(reasonCode, message) {
+  return {
+    reason_code: reasonCode,
+    message: boundedExcerpt(message),
+    options: (OPTIONS[reasonCode] || []).map((option) => boundedExcerpt(option)),
+  };
+}
+
+module.exports = { REASONS, OPTIONS, exitCodeFor, decisionEntry };

--- a/skills/relay-orca/scripts/lib/resume-report.js
+++ b/skills/relay-orca/scripts/lib/resume-report.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// Stable machine-readable `resume` report shape (#946 D8). EXACTLY these ten
+// top-level keys, verbatim and in order, on EVERY resume-report path — a successful
+// resume, a decision-required abort (exit 60-63), and an idempotent re-run.
+// `reconciliation_required` is literally `true` in every report (live reconciliation
+// is #945, and resume never claims completion). Pure: no subprocess, no fs mutation,
+// so plan.js's frozen lib source-scan keeps passing.
+
+const REPORT_KEYS = Object.freeze([
+  "ok",
+  "program_id",
+  "receipt_path",
+  "runtime",
+  "reconciliation",
+  "actions",
+  "terminals_created",
+  "decision_required",
+  "blocking_reasons",
+  "reconciliation_required",
+]);
+
+// D8 per-outcome action taxonomy — exactly these four tokens. `reused` = valid live
+// mapping left untouched; `redispatched` = the operator surface was re-established
+// through the verified inject->dispatch-show->prompt path (a re-dispatch or a
+// terminal reacquisition); `skipped` = left alone (in-flight/durable child or a
+// later wave); `decision_required` = blocked pending an operator decision.
+const ACTIONS = Object.freeze(["reused", "redispatched", "skipped", "decision_required"]);
+
+// One report action entry per receipt outcome (D8). `reason` is a bounded excerpt.
+function actionEntry(outcomeId, action, reason) {
+  return { outcome_id: outcomeId, action, reason };
+}
+
+// Emit exactly REPORT_KEYS, in order, regardless of insertion order above.
+function orderReport(report) {
+  const ordered = {};
+  REPORT_KEYS.forEach((key) => {
+    ordered[key] = report[key];
+  });
+  return ordered;
+}
+
+module.exports = {
+  REPORT_KEYS,
+  ACTIONS,
+  actionEntry,
+  orderReport,
+};

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -275,4 +275,8 @@ function orchestrate(rawProgram, options = {}) {
   }
 }
 
-module.exports = { orchestrate };
+// provenanceMismatch is additively exported (#946) so `resume` reuses the EXACT dispatch
+// verification `run` applies — the same trio check on the same dispatch-show shape — when
+// it re-dispatches or reacquires a terminal through the verified path. orchestrate and
+// the run flow are unchanged (byte-equivalent).
+module.exports = { orchestrate, provenanceMismatch };

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -305,10 +305,27 @@ function repairForOutcome(entry) {
   return repairs;
 }
 
+// Reconciliation-derived live dispatch fact for one outcome (#946 R1, owner amendment A1).
+// `resume` threads this into its planner (via the optional `liveDispatchSink`) so
+// "verifiably absent" is decided by a live dispatch-show read, NEVER by a null receipt id.
+// Trustworthy ONLY when the runtime is attributed AND this task's dispatch-show was
+// reachable and runtime-attributed: `present` = it reported a dispatch id; `absent` = it
+// reported none. Both false = unknown (untrusted runtime, an unattributable per-task read,
+// or a task missing from the runtime), which never counts as verifiable absence.
+function summarizeLiveDispatch(runtime, facts) {
+  if (!runtime.orcaTrusted || facts.dispatchRuntimeUnknown) return { present: false, absent: false };
+  const dispatch = facts.dispatch;
+  if (!dispatch || dispatch.reachable !== true) return { present: false, absent: false };
+  const liveId = typeof dispatch.dispatchId === "string" && dispatch.dispatchId ? dispatch.dispatchId : null;
+  return { present: Boolean(liveId), absent: !liveId };
+}
+
 // Assemble the full D9 report from the receipt + injected read adapters. `manifests`
 // are the child run manifests (runs root); `fleetManifests` are the fleet manifests
-// from the SEPARATE fleets root (#945 A8), keyed by fleet id.
-function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment }) {
+// from the SEPARATE fleets root (#945 A8), keyed by fleet id. `liveDispatchSink` is an
+// OPTIONAL Map that, when provided (only `resume` passes it), is populated per outcome
+// with the reconciliation's live dispatch fact — it never changes the returned report.
+function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment, liveDispatchSink }) {
   const resolvedUrlFor = typeof urlFor === "function" ? urlFor : () => null;
   const manifestByRunId = new Map(manifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
   const fleetManifestById = new Map(fleetManifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
@@ -317,6 +334,9 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
 
   const entries = receipt.tasks.map((task) => {
     const facts = gatherOutcomeFacts(task, { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor: resolvedUrlFor });
+    if (liveDispatchSink && typeof liveDispatchSink.set === "function") {
+      liveDispatchSink.set(task.outcome_id, summarizeLiveDispatch(runtime, facts));
+    }
     return classifyOutcome(facts, { orcaTrusted: runtime.orcaTrusted, isDuplicate: duplicateOutcomeIds.has(task.outcome_id) });
   });
 
@@ -343,4 +363,4 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
   return orderReport(report);
 }
 
-module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers };
+module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers, summarizeLiveDispatch };

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -292,6 +292,28 @@ function discoverBackPointers({ manifests, tasks, programId }) {
   return candidates;
 }
 
+// live→receipt FLEET back-pointer discovery (D7/A2): a fleet manifest under the SEPARATE
+// fleets root (#945 A8) that references this program but is absent from the receipt's
+// `relay_ids.fleet` mappings. Mirrors discoverBackPointers for the runs root, keyed off
+// `relay_ids.fleet` instead of `relay_ids.run` and scanning the fleets-root manifests. An
+// unmapped fleet cannot be attributed to a specific outcome, so resume must not re-dispatch
+// a relay_fleet outcome while it is present — that would duplicate the whole fleet (forbidden
+// by the drain invariant). Text only; NO mutation is performed.
+function discoverFleetBackPointers({ fleetManifests, tasks, programId }) {
+  const knownFleetIds = new Set(tasks.map((task) => task.relay_ids && task.relay_ids.fleet).filter(Boolean));
+  const candidates = [];
+  fleetManifests.forEach((entry) => {
+    if (!entry.run_id || knownFleetIds.has(entry.run_id)) return;
+    if (!referencesProgram(entry.text, programId)) return;
+    candidates.push({
+      kind: "adopt_relay_fleet",
+      outcome_id: null,
+      proposal: boundedExcerpt(`relay fleet ${entry.run_id} references program ${programId} but is absent from the receipt; reconcile it into the receipt mapping (no mutation performed)`),
+    });
+  });
+  return candidates;
+}
+
 function repairForOutcome(entry) {
   const repairs = [];
   entry.diagnostics.forEach((diagnostic) => {
@@ -348,6 +370,7 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
   const repairCandidates = [];
   entries.forEach((entry) => repairForOutcome(entry).forEach((repair) => repairCandidates.push(repair)));
   discoverBackPointers({ manifests, tasks: receipt.tasks, programId }).forEach((candidate) => repairCandidates.push(candidate));
+  discoverFleetBackPointers({ fleetManifests, tasks: receipt.tasks, programId }).forEach((candidate) => repairCandidates.push(candidate));
 
   const report = {
     ok: true,
@@ -363,4 +386,4 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
   return orderReport(report);
 }
 
-module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers, summarizeLiveDispatch };
+module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers, discoverFleetBackPointers, summarizeLiveDispatch };

--- a/skills/relay-orca/scripts/lib/stop-reasons.js
+++ b/skills/relay-orca/scripts/lib/stop-reasons.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// relay-orca `stop` reason matrix (#946 D5). Receipt-layer failures re-use status's
+// 50-52 verbatim (imported by stop.js), so this module only owns the ONE stop-specific
+// failure: the coordinator run-stop itself did not succeed. Code 65 stays clear of
+// plan's 2-21, the probe's 30-37, run's 40-44, status/receipt's 50-52, resume's 60-63,
+// and the 64 usage slot. Existing reason modules stay untouched.
+const REASONS = Object.freeze({
+  COORDINATOR_STOP_FAILED: 65, // `orca orchestration run-stop` returned non-ok / non-zero
+});
+
+const REMEDIATION = Object.freeze({
+  COORDINATOR_STOP_FAILED:
+    "The coordinator run-stop did not succeed; inspect the Orca runtime and retry `stop`. No relay run, worktree, PR, or issue is ever touched by stop.",
+});
+
+const USAGE_EXIT = 64;
+
+class StopError extends Error {
+  constructor(reasonCode, message, remediation) {
+    super(message);
+    this.name = "StopError";
+    this.reasonCode = reasonCode;
+    this.exitCode = REASONS[reasonCode];
+    this.remediation = remediation || REMEDIATION[reasonCode] || "";
+    if (this.exitCode === undefined) {
+      throw new Error(`unknown stop reason code: ${reasonCode}`);
+    }
+  }
+}
+
+module.exports = { REASONS, REMEDIATION, USAGE_EXIT, StopError };

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+"use strict";
+
+// relay-orca `resume` — crash-safe, receipt-driven, reconcile-first, idempotent
+// resumption (issue #946). It loads the reconstructible bridge receipt through the
+// shipped receipt-io (fail-closed codes 50-52 verbatim), runs the SAME live
+// reconciliation as `status` (the imported #945 pipeline) BEFORE any mutation, and only
+// then plans and executes bounded restoration: valid live mappings are REUSED, a lost
+// operator terminal is REACQUIRED, and an outcome whose Orca dispatch is verifiably
+// absent AND whose relay side is clean is RE-DISPATCHED through the SAME verified path as
+// `run` (inject -> dispatch-show -> prompt). Reconciliation results that make resumption
+// unsafe fail closed with a `decision_required` report and ZERO mutation (codes 60-63).
+// It NEVER invokes `orca orchestration reset` (D7) or any `orca worktree` subcommand
+// (D7), never deletes a task/worktree/branch/PR, and never force-closes a relay run.
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+const {
+  CanonicalizationError,
+  resolveRepoContext,
+  receiptPathFor,
+  readReceiptFile,
+  receiptExists,
+  listManifestFiles,
+  listFleetManifestFiles,
+  makeUrlResolver,
+  writeReceiptAtomic,
+  programSegment,
+} = require("./receipt-io");
+const { parseReceipt, serializeReceiptWithStop } = require("./lib/receipt");
+const { boundedExcerpt } = require("./lib/bounded-excerpt");
+const { parseManifest } = require("./lib/manifest-parse");
+const { deriveStatusReport } = require("./lib/status-derive");
+const { StatusError, USAGE_EXIT, reject: rejectReceipt } = require("./lib/status-reasons");
+const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
+const { assertOrcaReadOnly, assertGhReadOnly } = require("./status.js");
+const { dispatchTask, showDispatch, createTerminal, sendPrompt } = require("./lib/run-orca");
+const { provenanceMismatch } = require("./lib/run-orchestrator");
+const { buildOperatorPrompt } = require("./lib/operator-prompt");
+const { routeFor, defaultEvidenceFor } = require("./lib/task-kinds");
+const { planResume } = require("./lib/resume-plan");
+const { orderReport } = require("./lib/resume-report");
+
+const READ_TIMEOUT_MS = 15000;
+const READ_MAX_BUFFER = 4 * 1024 * 1024;
+const DEFAULT_RUN_TIMEOUT_MS = 30000;
+const RUN_MAX_BUFFER = 4 * 1024 * 1024;
+
+function usageError(message) {
+  process.stderr.write(`relay-orca resume: ${message}\n`);
+  process.stderr.write(
+    "usage: resume.js --program-id <id> [--json] [--operator-handle <handle> ...] " +
+      "[--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
+  );
+  process.exit(USAGE_EXIT);
+}
+
+function requireValue(value, flag) {
+  if (!value || value.startsWith("-")) usageError(`${flag} requires a value`);
+  return value;
+}
+
+function parseArgs(argv) {
+  const opts = { programId: null, json: false, operatorHandles: [], orcaBin: null, ghBin: null, repoRoot: null, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--program-id" || arg === "-p") opts.programId = requireValue(argv[(i += 1)], "--program-id");
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
+    else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
+    else if (arg === "--gh-bin") opts.ghBin = requireValue(argv[(i += 1)], "--gh-bin");
+    else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+function resolveRunTimeoutMs() {
+  const raw = process.env.RELAY_ORCA_RUN_TIMEOUT_MS;
+  if (raw === undefined || raw === null || raw === "") return DEFAULT_RUN_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_RUN_TIMEOUT_MS;
+}
+
+// The MUTATING Orca boundary (execution phase only). Two surfaces are structurally
+// refused here, independent of any fixture poison: `orca orchestration reset` (D7) and
+// any `orca worktree` subcommand (D7) — no resume code path builds either. Task deletion
+// is never built at all.
+function runOrcaMutating(orcaBin, args, options = {}) {
+  const argv = Array.isArray(args) ? args.map(String) : [];
+  if (argv.includes("reset")) throw new Error("relay-orca resume must never invoke orca orchestration reset (D7)");
+  if (argv.includes("worktree")) throw new Error("relay-orca resume must never invoke any orca worktree subcommand (D7)");
+  const hasInput = options.input !== undefined && options.input !== null;
+  try {
+    const stdout = execFileSync(orcaBin, argv, {
+      encoding: "utf-8",
+      stdio: hasInput ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+      timeout: resolveRunTimeoutMs(),
+      maxBuffer: RUN_MAX_BUFFER,
+      ...(hasInput ? { input: String(options.input) } : {}),
+    });
+    return { status: 0, stdout: String(stdout || ""), stderr: "" };
+  } catch (error) {
+    return {
+      status: typeof error.status === "number" ? error.status : 1,
+      stdout: error.stdout ? String(error.stdout) : "",
+      stderr: error.stderr ? String(error.stderr) : "",
+    };
+  }
+}
+
+// Read-only runner for the reconciliation phase (D1). Reuses status.js's exported
+// read-only guards, so a mutating Orca/gh subcommand can never run during reconciliation.
+function makeReadRunner(bin, assertReadOnly, cwd) {
+  if (!bin) return null;
+  return (_bin, args) => {
+    const argv = (Array.isArray(args) ? args : []).map(String);
+    assertReadOnly(argv);
+    try {
+      const stdout = execFileSync(bin, argv, {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+        cwd: cwd || undefined,
+        timeout: READ_TIMEOUT_MS,
+        maxBuffer: READ_MAX_BUFFER,
+      });
+      return { status: 0, stdout: String(stdout || ""), stderr: "" };
+    } catch (error) {
+      return {
+        status: typeof error.status === "number" ? error.status : 1,
+        stdout: error.stdout ? String(error.stdout) : "",
+        stderr: error.stderr ? String(error.stderr) : "",
+      };
+    }
+  };
+}
+
+function resolveGhBin(opts) {
+  if (opts.ghBin) return opts.ghBin;
+  const env = process.env.RELAY_ORCA_GH_BIN;
+  return env && env.trim() !== "" ? env.trim() : "gh";
+}
+
+function resolveOrca(opts) {
+  const resolved = resolveOrcaBin({ orcaBinOverride: opts.orcaBin || null });
+  return resolved.path || null;
+}
+
+// Load + validate the receipt (fail-closed codes 50-52 verbatim, D2). Identical contract
+// to `status`: not-found -> 50, corrupt/schema/identity mismatch -> 51, repo mismatch -> 52.
+function loadReceipt(receiptPath, requestedProgramId) {
+  if (!receiptExists(receiptPath)) rejectReceipt("RECEIPT_NOT_FOUND", `no receipt found at ${receiptPath}`);
+  const parsed = parseReceipt(readReceiptFile(receiptPath));
+  if (!parsed.ok) rejectReceipt("RECEIPT_CORRUPT", parsed.reason);
+  if (parsed.receipt.program_id !== requestedProgramId) {
+    rejectReceipt(
+      "RECEIPT_CORRUPT",
+      `receipt program_id ${boundedExcerpt(parsed.receipt.program_id)} does not match the requested --program-id ${boundedExcerpt(requestedProgramId)}`,
+    );
+  }
+  return parsed.receipt;
+}
+
+// The imported #945 reconciliation, run BEFORE any mutation (D1). Reads only.
+function reconcile({ receipt, opts, repo, receiptPath }) {
+  const manifests = listManifestFiles(repo.slug).map((entry) => ({ run_id: entry.run_id, text: entry.text, parsed: parseManifest(entry.text) }));
+  const fleetManifests = listFleetManifestFiles(repo.slug).map((entry) => ({ run_id: entry.run_id, text: entry.text, parsed: parseManifest(entry.text) }));
+  return deriveStatusReport({
+    receipt,
+    programId: opts.programId,
+    receiptPath,
+    manifests,
+    fleetManifests,
+    orca: makeReadRunner(resolveOrca(opts), assertOrcaReadOnly, repo.root),
+    gh: makeReadRunner(resolveGhBin(opts), assertGhReadOnly, repo.root),
+    urlFor: makeUrlResolver(repo.root),
+    programSegment,
+  });
+}
+
+// Persist the live receipt object atomically, preserving created_at and any stop record
+// (D5/scenario 8) and bumping updated_at. Used at the A16 (terminal recorded) and A2
+// (provenance verified) write points during execution.
+function makeReceiptPersistor(receipt, receiptPath) {
+  return function persist() {
+    receipt.updated_at = new Date().toISOString();
+    writeReceiptAtomic(receiptPath, serializeReceiptWithStop(receipt));
+    return receiptPath;
+  };
+}
+
+// Synthesize the operator prompt inputs from the receipt alone (resume starts from the
+// receipt, not the program file — D1). Route + expected evidence come from the FROZEN
+// task-kinds defaults; the accepted-outcome/leaf detail is not in the receipt, so the
+// prompt is best-effort but structurally identical to run's.
+function syntheticTask(receiptTask) {
+  return {
+    outcome_id: receiptTask.outcome_id,
+    task_id: receiptTask.task_id,
+    kind: receiptTask.kind,
+    wave: receiptTask.wave,
+    recommended_route: routeFor(receiptTask.kind),
+    expected_evidence: defaultEvidenceFor(receiptTask.kind),
+  };
+}
+
+// Acquire an operator handle: an explicit --operator-handle first (never adopting a
+// terminal it did not receive — D4), else a freshly created terminal recorded in the
+// receipt IMMEDIATELY (A16) before the dispatch that may fail.
+function acquireHandle(ctx) {
+  if (ctx.explicit.length) return ctx.index < ctx.explicit.length ? ctx.explicit[ctx.index++] : null;
+  const term = createTerminal(ctx.runOrca, ctx.orcaBin);
+  if (!term.ok) return null;
+  ctx.receipt.terminals_created.push(term.handle);
+  ctx.reportTerminals.push(term.handle);
+  ctx.persist();
+  return term.handle;
+}
+
+function blockingReason(reasonCode, message) {
+  return { reason_code: reasonCode, message: boundedExcerpt(message) };
+}
+
+// Execute ONE re-dispatch / terminal-reacquisition action through the SAME verified path
+// as run: inject -> dispatch-show (provenance trio) -> prompt, persisting the receipt at
+// A16 (handle) and A2 (verified provenance) write points.
+function executeAction(action, ctx) {
+  const receiptTask = ctx.taskByOutcome.get(action.outcome_id);
+  const orcaTaskId = action.exec.orca_task_id;
+  const handle = acquireHandle(ctx);
+  if (!handle) return void ctx.blocking.push(blockingReason("RESUME_REDISPATCH_FAILED", `no operator handle available for outcome ${action.outcome_id}`));
+  const disp = dispatchTask(ctx.runOrca, ctx.orcaBin, { orcaTaskId, handle });
+  if (!disp.ok) return void ctx.blocking.push(blockingReason("RESUME_REDISPATCH_FAILED", `dispatch --inject failed for outcome ${action.outcome_id}`));
+  const show = showDispatch(ctx.runOrca, ctx.orcaBin, { orcaTaskId });
+  const mismatch = provenanceMismatch(show, orcaTaskId);
+  if (mismatch) return void ctx.blocking.push(blockingReason("RESUME_REDISPATCH_FAILED", `dispatch-show provenance verification failed for outcome ${action.outcome_id}: ${mismatch}`));
+  receiptTask.dispatch_id = show.dispatchId;
+  receiptTask.assignee = show.assignee;
+  ctx.persist();
+  const prompt = buildOperatorPrompt(syntheticTask(receiptTask), { id: ctx.receipt.program_id }, {});
+  const sent = sendPrompt(ctx.runOrca, ctx.orcaBin, { orcaTaskId, handle, prompt });
+  if (!sent.ok) ctx.blocking.push(blockingReason("RESUME_REDISPATCH_FAILED", `operator prompt hand-off failed for outcome ${action.outcome_id}`));
+}
+
+// Execute every action carrying an `exec` plan (redispatch / reacquire_terminal). Actions
+// without an `exec` (reused / skipped) are no-ops. Returns the terminals created THIS
+// invocation and any blocking reasons.
+function executeActions({ receipt, actions, opts, orcaBin, persist }) {
+  const ctx = {
+    receipt,
+    runOrca: runOrcaMutating,
+    orcaBin,
+    explicit: Array.isArray(opts.operatorHandles) ? opts.operatorHandles.slice() : [],
+    index: 0,
+    reportTerminals: [],
+    blocking: [],
+    persist,
+    taskByOutcome: new Map(receipt.tasks.map((task) => [task.outcome_id, task])),
+  };
+  actions.forEach((action) => {
+    if (action.exec) executeAction(action, ctx);
+  });
+  return { reportTerminals: ctx.reportTerminals, blocking: ctx.blocking };
+}
+
+function reportActions(actions) {
+  return actions.map((action) => ({ outcome_id: action.outcome_id, action: action.action, reason: action.reason }));
+}
+
+function buildReport({ opts, receiptPath, report, plan, terminalsCreated, blockingReasons, decisions }) {
+  const ok = plan.exitCode === 0 && blockingReasons.length === 0;
+  return orderReport({
+    ok,
+    program_id: opts.programId,
+    receipt_path: receiptPath,
+    runtime: report.runtime,
+    reconciliation: report.outcomes,
+    actions: reportActions(plan.actions),
+    terminals_created: terminalsCreated,
+    decision_required: decisions,
+    blocking_reasons: blockingReasons,
+    reconciliation_required: true,
+  });
+}
+
+function printReport(body, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+    return;
+  }
+  const stream = body.ok ? process.stdout : process.stderr;
+  stream.write(`relay-orca resume for ${body.program_id} (runtime=${body.runtime}, ok=${body.ok})\n`);
+  body.actions.forEach((entry) => stream.write(`  ${entry.outcome_id} [${entry.action}]: ${entry.reason}\n`));
+  body.decision_required.forEach((decision) => stream.write(`  decision_required [${decision.reason_code}]: ${decision.message}\n`));
+}
+
+function failReceipt(error, json) {
+  const body = { ok: false, reason_code: error.reasonCode, message: error.message, remediation: error.remediation || "" };
+  if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  else process.stderr.write(`relay-orca resume rejected [${error.reasonCode}]: ${error.message}\n`);
+  process.exit(error.exitCode);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) usageError("crash-safe receipt-driven resumption for an accepted program");
+  if (!opts.programId) usageError("--program-id is required");
+
+  let repo;
+  let receipt;
+  let receiptPath;
+  let report;
+  try {
+    repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+    receiptPath = receiptPathFor(repo.slug, opts.programId);
+    receipt = loadReceipt(receiptPath, opts.programId);
+    if (receipt.repo && receipt.repo.slug !== repo.slug) {
+      rejectReceipt("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
+    }
+    report = reconcile({ receipt, opts, repo, receiptPath });
+  } catch (error) {
+    if (error instanceof StatusError || error instanceof CanonicalizationError) failReceipt(error, opts.json);
+    throw error;
+  }
+
+  // Reconciliation is complete; the plan is pure. A program-level decision performs ZERO
+  // mutation and exits 60-63; otherwise the safe actions execute through the verified path.
+  const plan = planResume({ receipt, report });
+  let terminalsCreated = [];
+  let blockingReasons = plan.blockingReasons.slice();
+  if (plan.exitCode === 0) {
+    const persist = makeReceiptPersistor(receipt, receiptPath);
+    const executed = executeActions({ receipt, actions: plan.actions, opts, orcaBin: resolveOrca(opts), persist });
+    terminalsCreated = executed.reportTerminals;
+    blockingReasons = executed.blocking;
+  }
+
+  const body = buildReport({ opts, receiptPath, report, plan, terminalsCreated, blockingReasons, decisions: plan.decisions });
+  printReport(body, opts.json);
+  // Only the fail-closed decision codes (60-63) are non-zero exits. A best-effort
+  // execution shortfall (a dispatch surface that broke mid-resume) is surfaced through
+  // ok:false + blocking_reasons with the receipt left in its A16/A2 recorded state — it
+  // never invents a new exit code and never leaves torn Orca state.
+  process.exitCode = plan.exitCode;
+}
+
+// Run as a CLI only when invoked directly; importing this module exercises the helpers
+// without triggering a real resume run.
+if (require.main === module) main();
+
+module.exports = { syntheticTask, reportActions };

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -161,11 +161,15 @@ function loadReceipt(receiptPath, requestedProgramId) {
   return parsed.receipt;
 }
 
-// The imported #945 reconciliation, run BEFORE any mutation (D1). Reads only.
+// The imported #945 reconciliation, run BEFORE any mutation (D1). Reads only. The
+// reconciliation's per-task dispatch-show reads are captured into `liveDispatch` and
+// returned alongside the report so the planner can decide "verifiably absent" from a live
+// read (owner amendment A1, #946 R1), never from a null receipt dispatch_id.
 function reconcile({ receipt, opts, repo, receiptPath }) {
   const manifests = listManifestFiles(repo.slug).map((entry) => ({ run_id: entry.run_id, text: entry.text, parsed: parseManifest(entry.text) }));
   const fleetManifests = listFleetManifestFiles(repo.slug).map((entry) => ({ run_id: entry.run_id, text: entry.text, parsed: parseManifest(entry.text) }));
-  return deriveStatusReport({
+  const liveDispatch = new Map();
+  const report = deriveStatusReport({
     receipt,
     programId: opts.programId,
     receiptPath,
@@ -175,7 +179,9 @@ function reconcile({ receipt, opts, repo, receiptPath }) {
     gh: makeReadRunner(resolveGhBin(opts), assertGhReadOnly, repo.root),
     urlFor: makeUrlResolver(repo.root),
     programSegment,
+    liveDispatchSink: liveDispatch,
   });
+  return { report, liveDispatch };
 }
 
 // Persist the live receipt object atomically, preserving created_at and any stop record
@@ -310,6 +316,7 @@ function main() {
   let receipt;
   let receiptPath;
   let report;
+  let liveDispatch;
   try {
     repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
     receiptPath = receiptPathFor(repo.slug, opts.programId);
@@ -317,7 +324,7 @@ function main() {
     if (receipt.repo && receipt.repo.slug !== repo.slug) {
       rejectReceipt("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
     }
-    report = reconcile({ receipt, opts, repo, receiptPath });
+    ({ report, liveDispatch } = reconcile({ receipt, opts, repo, receiptPath }));
   } catch (error) {
     if (error instanceof StatusError || error instanceof CanonicalizationError) failReceipt(error, opts.json);
     throw error;
@@ -325,7 +332,7 @@ function main() {
 
   // Reconciliation is complete; the plan is pure. A program-level decision performs ZERO
   // mutation and exits 60-63; otherwise the safe actions execute through the verified path.
-  const plan = planResume({ receipt, report });
+  const plan = planResume({ receipt, report, liveDispatch });
   let terminalsCreated = [];
   let blockingReasons = plan.blockingReasons.slice();
   if (plan.exitCode === 0) {

--- a/skills/relay-orca/scripts/stop.js
+++ b/skills/relay-orca/scripts/stop.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+"use strict";
+
+// relay-orca `stop` — COORDINATOR-ONLY stop (issue #946 D5). It loads the reconstructible
+// receipt through the shipped receipt-io (fail-closed codes 50-52 verbatim), invokes the
+// ONLY mutating Orca subcommand it may ever use — `orca orchestration run-stop` — and
+// records a bounded stop record (`stopped_at` + `stop_reason`) into the receipt. It MUST
+// NOT terminate relay executors, delete worktrees, close PRs/issues, invoke `reset`, or
+// invoke any task-create / task-update / dispatch / terminal subcommand, and it emits NO
+// language claiming the program or its outcomes are cancelled or complete. Relay/fleet
+// artifacts stay discoverable through normal relay tooling — nothing is moved or renamed.
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+const {
+  CanonicalizationError,
+  resolveRepoContext,
+  receiptPathFor,
+  readReceiptFile,
+  receiptExists,
+  writeReceiptAtomic,
+} = require("./receipt-io");
+const { parseReceipt, serializeReceiptWithStop, boundStopReason } = require("./lib/receipt");
+const { boundedExcerpt } = require("./lib/bounded-excerpt");
+const { StatusError, USAGE_EXIT, reject: rejectReceipt } = require("./lib/status-reasons");
+const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
+const { StopError, REASONS: STOP_REASONS } = require("./lib/stop-reasons");
+
+const RUN_TIMEOUT_MS = 15000;
+const RUN_MAX_BUFFER = 4 * 1024 * 1024;
+
+function usageError(message) {
+  process.stderr.write(`relay-orca stop: ${message}\n`);
+  process.stderr.write("usage: stop.js --program-id <id> [--reason <text>] [--json] [--orca-bin <path>] [--repo-root <path>]\n");
+  process.exit(USAGE_EXIT);
+}
+
+function requireValue(value, flag) {
+  if (value === undefined || value === null || (typeof value === "string" && value.startsWith("-"))) usageError(`${flag} requires a value`);
+  return value;
+}
+
+function parseArgs(argv) {
+  const opts = { programId: null, reason: "", json: false, orcaBin: null, repoRoot: null, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--program-id" || arg === "-p") opts.programId = requireValue(argv[(i += 1)], "--program-id");
+    else if (arg === "--reason") opts.reason = requireValue(argv[(i += 1)], "--reason");
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
+    else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+function resolveOrca(opts) {
+  const resolved = resolveOrcaBin({ orcaBinOverride: opts.orcaBin || null });
+  return resolved.path || null;
+}
+
+// The ONE mutating Orca boundary for stop. Structurally refuses EVERY mutating surface
+// except `run-stop` (belt-and-suspenders alongside the fixture poison): no reset, no
+// worktree, no task-create/task-update/dispatch, no terminal subcommand is ever built.
+function assertRunStopOnly(argv) {
+  const forbidden = argv.includes("reset")
+    || argv.includes("worktree")
+    || argv.includes("task-create")
+    || argv.includes("task-update")
+    || (argv[0] === "orchestration" && argv[1] === "dispatch")
+    || argv[0] === "terminal";
+  if (forbidden) throw new Error(`relay-orca stop must never invoke a mutating Orca subcommand other than run-stop (got: ${argv.join(" ")})`);
+}
+
+// Invoke `orca orchestration run-stop --json` and normalize the result. `coordinator_stopped`
+// is true only on a well-formed ok envelope; an explicit `stopped:false` keeps it false.
+function runStop(orcaBin) {
+  const argv = ["orchestration", "run-stop", "--json"];
+  assertRunStopOnly(argv);
+  let proc;
+  try {
+    const stdout = execFileSync(orcaBin, argv, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], timeout: RUN_TIMEOUT_MS, maxBuffer: RUN_MAX_BUFFER });
+    proc = { status: 0, stdout: String(stdout || ""), stderr: "" };
+  } catch (error) {
+    proc = { status: typeof error.status === "number" ? error.status : 1, stdout: error.stdout ? String(error.stdout) : "", stderr: error.stderr ? String(error.stderr) : "" };
+  }
+  let value = null;
+  try {
+    value = JSON.parse(String(proc.stdout || "").trim());
+  } catch {
+    value = null;
+  }
+  const ok = proc.status === 0 && value && value.ok === true;
+  const result = ok && value.result && typeof value.result === "object" ? value.result : {};
+  return { ok: Boolean(ok), coordinatorStopped: Boolean(ok) && result.stopped !== false, proc };
+}
+
+function loadReceipt(receiptPath, requestedProgramId) {
+  if (!receiptExists(receiptPath)) rejectReceipt("RECEIPT_NOT_FOUND", `no receipt found at ${receiptPath}`);
+  const parsed = parseReceipt(readReceiptFile(receiptPath));
+  if (!parsed.ok) rejectReceipt("RECEIPT_CORRUPT", parsed.reason);
+  if (parsed.receipt.program_id !== requestedProgramId) {
+    rejectReceipt(
+      "RECEIPT_CORRUPT",
+      `receipt program_id ${boundedExcerpt(parsed.receipt.program_id)} does not match the requested --program-id ${boundedExcerpt(requestedProgramId)}`,
+    );
+  }
+  return parsed.receipt;
+}
+
+function existingStop(receipt) {
+  return typeof receipt.stopped_at === "string" && receipt.stopped_at !== "";
+}
+
+// Record the bounded stop record into the receipt ONCE (D5). `stopped_at` is the only
+// generated timestamp in stop; `stop_reason` is the bounded operator reason. Preserves
+// every other field verbatim (serializeReceiptWithStop appends ONLY the two stop keys,
+// so a byte comparison shows exactly the stop fields changed). Idempotent: a receipt that
+// already carries a stop record is left byte-identical (D9.13) — no rewrite.
+function recordStop(receipt, receiptPath, reason) {
+  receipt.stopped_at = new Date().toISOString();
+  receipt.stop_reason = boundStopReason(reason);
+  writeReceiptAtomic(receiptPath, serializeReceiptWithStop(receipt));
+}
+
+function buildReport({ opts, receiptPath, coordinatorStopped, stoppedAt, stopReason, blockingReasons }) {
+  return {
+    ok: blockingReasons.length === 0,
+    program_id: opts.programId,
+    receipt_path: receiptPath,
+    coordinator_stopped: coordinatorStopped,
+    stopped_at: stoppedAt,
+    stop_reason: stopReason,
+    blocking_reasons: blockingReasons,
+  };
+}
+
+function printReport(body, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+    return;
+  }
+  const stream = body.ok ? process.stdout : process.stderr;
+  stream.write(`relay-orca stop for ${body.program_id} (coordinator_stopped=${body.coordinator_stopped}, stopped_at=${body.stopped_at || "-"})\n`);
+  body.blocking_reasons.forEach((reason) => stream.write(`  blocked [${reason.reason_code}]: ${reason.message}\n`));
+}
+
+function failReceipt(error, json) {
+  const body = { ok: false, reason_code: error.reasonCode, message: error.message, remediation: error.remediation || "" };
+  if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  else process.stderr.write(`relay-orca stop rejected [${error.reasonCode}]: ${error.message}\n`);
+  process.exit(error.exitCode);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) usageError("coordinator-only stop for an accepted program");
+  if (!opts.programId) usageError("--program-id is required");
+
+  let receipt;
+  let receiptPath;
+  try {
+    const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+    receiptPath = receiptPathFor(repo.slug, opts.programId);
+    receipt = loadReceipt(receiptPath, opts.programId);
+    if (receipt.repo && receipt.repo.slug !== repo.slug) {
+      rejectReceipt("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
+    }
+  } catch (error) {
+    if (error instanceof StatusError || error instanceof CanonicalizationError) failReceipt(error, opts.json);
+    throw error;
+  }
+
+  const alreadyStopped = existingStop(receipt);
+  const stop = runStop(resolveOrca(opts));
+  const blockingReasons = [];
+  if (!stop.coordinatorStopped) {
+    blockingReasons.push({ reason_code: "COORDINATOR_STOP_FAILED", message: boundedExcerpt(`orca orchestration run-stop did not succeed${stop.proc.stderr ? `: ${stop.proc.stderr}` : ""}`) });
+  } else if (!alreadyStopped) {
+    // First successful stop: record the bounded stop record once. A prior record is left
+    // byte-identical (idempotent) — a second stop reports the live run-stop result and the
+    // ORIGINAL stopped_at/stop_reason without rewriting the receipt.
+    recordStop(receipt, receiptPath, opts.reason);
+  }
+
+  const body = buildReport({
+    opts,
+    receiptPath,
+    coordinatorStopped: stop.coordinatorStopped,
+    stoppedAt: existingStop(receipt) ? receipt.stopped_at : null,
+    stopReason: existingStop(receipt) ? receipt.stop_reason : "",
+    blockingReasons,
+  });
+  printReport(body, opts.json);
+  process.exitCode = stop.coordinatorStopped ? 0 : STOP_REASONS.COORDINATOR_STOP_FAILED;
+}
+
+if (require.main === module) main();
+
+module.exports = { assertRunStopOnly, existingStop, StopError };

--- a/tests/relay-orca/fixtures/fake-orca-resume.js
+++ b/tests/relay-orca/fixtures/fake-orca-resume.js
@@ -1,0 +1,174 @@
+"use strict";
+
+/**
+ * Resume-capable fake Orca CLI fixture for relay-orca `resume` tests (#946).
+ *
+ * A SUPERSET of the read-only status fake and the run fake's mutation surface: it serves
+ * the reconciliation reads `resume` runs FIRST (`status`, `orchestration task-list`,
+ * `orchestration gate-list`, `orchestration dispatch-show`) AND the restoration mutations
+ * `resume` may run AFTER reconciliation (`orchestration dispatch --inject`,
+ * `terminal create`, `terminal send`). Behavior is scenario-driven; every invocation is
+ * appended to a shared log.
+ *
+ * Poison set (D7): ONLY `orca orchestration reset` and any `orca worktree` subcommand are
+ * poisoned — resume MAY use dispatch/terminal, so those are NOT poisoned here. A poisoned
+ * surface writes a marker and exits non-zero so the test hard-fails on EVERY path.
+ *
+ * Dispatch provenance is stateful: a real `dispatch --inject` writes a per-task state
+ * file, and a following `dispatch-show` returns that FRESH dispatch (terminal present)
+ * — this is what makes a second resume idempotent (the re-established mapping now reads
+ * back as live). The scenario's initial per-task `dispatch` overrides seed the pre-resume
+ * state (e.g. a lost terminal) and are superseded by a real dispatch's state file.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { DEFAULT_RUNTIME_ID } = require("./fake-orca");
+
+function defaultResumeScenario(overrides = {}) {
+  const runtimeId = overrides.runtimeId || DEFAULT_RUNTIME_ID;
+  return {
+    runtimeId,
+    statusOk: overrides.statusOk !== undefined ? overrides.statusOk : true,
+    taskListOk: overrides.taskListOk !== undefined ? overrides.taskListOk : true,
+    gateListOk: overrides.gateListOk !== undefined ? overrides.gateListOk : true,
+    omitRuntimeId: overrides.omitRuntimeId === true,
+    taskListRuntimeId: overrides.taskListRuntimeId,
+    gateListRuntimeId: overrides.gateListRuntimeId,
+    tasks: overrides.tasks || [],
+    gates: overrides.gates || [],
+    // Per-task dispatch-show seed (pre-resume state): { terminal_present, assignee,
+    // dispatch_id, runtimeId }. A real dispatch supersedes it for that task.
+    dispatch: overrides.dispatch || {},
+    // Execution knobs (fail-closed / optional): an orca task id whose `dispatch --inject`
+    // returns ok:false, and terminal-create failure modes.
+    dispatchFailFor: overrides.dispatchFailFor || null,
+    terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
+    terminalCreateEmptyHandle: overrides.terminalCreateEmptyHandle || false,
+    terminalSendOkFalse: overrides.terminalSendOkFalse || false,
+  };
+}
+
+function fakeOrcaResumeScript({ scenarioPath, logPath, poisonPath, stateDir }) {
+  return `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+const stateDir = ${JSON.stringify(stateDir)};
+
+function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
+appendLog(args.join(" "));
+function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
+function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
+function argValue(flag) { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : undefined; }
+function drainStdin() { try { fs.readFileSync(0); } catch (e) { /* no stdin */ } }
+function stateFile(taskId) { return path.join(stateDir, "disp-" + String(taskId).replace(/[^a-zA-Z0-9._-]/g, "_") + ".json"); }
+function poison(marker, code) { if (poisonPath) fs.writeFileSync(poisonPath, marker + ":" + args.join(" "), "utf-8"); process.stderr.write("POISON: " + marker + "\\n"); process.exit(code); }
+
+// D7 poison: reset + worktree only (resume MAY dispatch/terminal). Active on every path.
+if (args.includes("reset")) poison("RESET_INVOKED", 99);
+if (args.includes("worktree")) poison("WORKTREE_INVOKED", 98);
+
+const scenario = loadScenario();
+const meta = { runtimeId: scenario.runtimeId };
+
+if (args[0] === "status") {
+  if (!scenario.statusOk) { process.stderr.write("orca status unreachable\\n"); process.exit(1); }
+  const runtime = { state: "ready", reachable: true };
+  if (!scenario.omitRuntimeId) runtime.runtimeId = scenario.runtimeId;
+  const statusMeta = scenario.omitRuntimeId ? {} : meta;
+  emit({ id: "status-1", ok: true, result: { app: { running: true, pid: 1 }, runtime, graph: { state: "ready" } }, _meta: statusMeta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "task-list") {
+  if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }
+  const tasks = Array.isArray(scenario.tasks) ? scenario.tasks : [];
+  const taskMeta = scenario.taskListRuntimeId !== undefined ? { runtimeId: scenario.taskListRuntimeId } : meta;
+  emit({ id: "task-list-1", ok: true, result: { tasks, count: tasks.length }, _meta: taskMeta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "gate-list") {
+  if (scenario.gateListOk === false) { process.stderr.write("orca gate-list unreachable\\n"); process.exit(1); }
+  const gates = Array.isArray(scenario.gates) ? scenario.gates : [];
+  const gateMeta = scenario.gateListRuntimeId !== undefined ? { runtimeId: scenario.gateListRuntimeId } : meta;
+  emit({ id: "gate-list-1", ok: true, result: { gates, count: gates.length }, _meta: gateMeta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "dispatch-show") {
+  const task = argValue("--task");
+  // base -> scenario seed -> real-dispatch state file (state file WINS so a re-established
+  // mapping reads back live and a second resume is idempotent).
+  let result = { task_id: task, dispatch_id: "disp-" + task, assignee: "term-" + task, terminal_present: true };
+  const seed = (scenario.dispatch && scenario.dispatch[task]) || {};
+  let seedRuntime;
+  Object.keys(seed).forEach((k) => { if (k === "runtimeId") seedRuntime = seed[k]; else result[k] = seed[k]; });
+  try { Object.assign(result, JSON.parse(fs.readFileSync(stateFile(task), "utf-8"))); } catch (e) { /* no real dispatch yet */ }
+  const dispatchMeta = seedRuntime !== undefined ? { runtimeId: seedRuntime } : meta;
+  emit({ id: "ds-" + task, ok: true, result, _meta: dispatchMeta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "dispatch") {
+  const task = argValue("--task");
+  const handle = argValue("--to");
+  if (scenario.dispatchFailFor && scenario.dispatchFailFor === task) emit({ ok: false, error: "dispatch inject undelivered" }, 0);
+  const record = { task_id: task, dispatch_id: "disp-" + task, assignee: handle, terminal_present: true };
+  try { fs.writeFileSync(stateFile(task), JSON.stringify(record), "utf-8"); } catch (e) { /* ignore */ }
+  emit({ id: "d-" + task, ok: true, result: { id: record.dispatch_id, dispatch_id: record.dispatch_id, assignee: handle }, _meta: meta }, 0);
+}
+if (args[0] === "terminal" && args[1] === "create") {
+  if (scenario.terminalCreateOkFalse) emit({ ok: false, error: "terminal create failed" }, 1);
+  if (scenario.terminalCreateEmptyHandle) emit({ ok: true, result: {} }, 0);
+  let n = 0;
+  const counter = path.join(stateDir, "term-counter");
+  try { n = Number(fs.readFileSync(counter, "utf-8")) || 0; } catch (e) { n = 0; }
+  n += 1;
+  try { fs.writeFileSync(counter, String(n), "utf-8"); } catch (e) { /* ignore */ }
+  emit({ ok: true, result: { handle: "orca-term-" + n, id: "orca-term-" + n }, _meta: meta }, 0);
+}
+if (args[0] === "terminal" && args[1] === "send") {
+  drainStdin();
+  if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
+  emit({ ok: true, result: { delivered: true } }, 0);
+}
+
+process.stderr.write("Unsupported fake orca (resume) invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+}
+
+function installFakeOrcaResume(scenarioOverrides = {}, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-orca-resume-"));
+  const orcaPath = path.join(dir, options.binName || "orca");
+  const scenarioPath = path.join(dir, "scenario.json");
+  const logPath = path.join(dir, "invocations.log");
+  const poisonPath = path.join(dir, "poison.txt");
+  const stateDir = path.join(dir, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const scenario = defaultResumeScenario(scenarioOverrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
+  fs.writeFileSync(orcaPath, fakeOrcaResumeScript({ scenarioPath, logPath, poisonPath, stateDir }), "utf-8");
+  fs.chmodSync(orcaPath, 0o755);
+
+  return {
+    dir,
+    orcaPath,
+    scenarioPath,
+    logPath,
+    poisonPath,
+    stateDir,
+    scenario,
+    readLog() {
+      if (!fs.existsSync(logPath)) return [];
+      return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readPoison() {
+      if (!fs.existsSync(poisonPath)) return null;
+      return fs.readFileSync(poisonPath, "utf-8");
+    },
+    cleanup() {
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+module.exports = { defaultResumeScenario, fakeOrcaResumeScript, installFakeOrcaResume };

--- a/tests/relay-orca/fixtures/fake-orca-stop.js
+++ b/tests/relay-orca/fixtures/fake-orca-stop.js
@@ -1,0 +1,94 @@
+"use strict";
+
+/**
+ * Coordinator-only-stop fake Orca CLI fixture for relay-orca `stop` tests (#946 D5/D7).
+ *
+ * Serves ONLY `orca orchestration run-stop`. EVERY other mutating surface is POISONED on
+ * every path (writes a marker, exits non-zero, hard-fails the test): `reset`, any
+ * `worktree` subcommand, `orchestration task-create`/`task-update`/`dispatch`, and any
+ * `terminal` subcommand. This is the restricted poison set D5 pins — "everything mutating
+ * EXCEPT run-stop" — proving stop is coordinator-only.
+ *
+ * Behavior is scenario-driven (run-stop may succeed or fail); every invocation is logged.
+ */
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function defaultStopScenario(overrides = {}) {
+  return {
+    // run-stop outcome: ok envelope + result.stopped. `runStopOk:false` models a failed
+    // run-stop (coordinator_stopped:false); `stopped:false` models an ok envelope that
+    // reports the coordinator was not running.
+    runStopOk: overrides.runStopOk !== undefined ? overrides.runStopOk : true,
+    stopped: overrides.stopped !== undefined ? overrides.stopped : true,
+    runId: overrides.runId || "coordinator-run-1",
+  };
+}
+
+function fakeOrcaStopScript({ scenarioPath, logPath, poisonPath }) {
+  return `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+
+function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
+appendLog(args.join(" "));
+function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
+function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
+function poison(marker, code) { if (poisonPath) fs.writeFileSync(poisonPath, marker + ":" + args.join(" "), "utf-8"); process.stderr.write("POISON: " + marker + "\\n"); process.exit(code); }
+
+// D5/D7 restricted poison set: everything mutating EXCEPT run-stop. Active on every path.
+if (args.includes("reset")) poison("RESET_INVOKED", 99);
+if (args.includes("worktree")) poison("WORKTREE_INVOKED", 98);
+if (args[0] === "orchestration" && (args[1] === "task-create" || args[1] === "task-update" || args[1] === "dispatch")) poison("MUTATION_INVOKED", 97);
+if (args[0] === "terminal") poison("TERMINAL_INVOKED", 96);
+
+const scenario = loadScenario();
+
+if (args[0] === "orchestration" && args[1] === "run-stop") {
+  if (!scenario.runStopOk) { process.stderr.write("run-stop failed\\n"); process.exit(1); }
+  emit({ id: "run-stop-1", ok: true, result: { stopped: scenario.stopped, run_id: scenario.runId } }, 0);
+}
+
+process.stderr.write("Unsupported fake orca (stop) invocation: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+}
+
+function installFakeOrcaStop(scenarioOverrides = {}, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "relay-fake-orca-stop-"));
+  const orcaPath = path.join(dir, options.binName || "orca");
+  const scenarioPath = path.join(dir, "scenario.json");
+  const logPath = path.join(dir, "invocations.log");
+  const poisonPath = path.join(dir, "poison.txt");
+  const scenario = defaultStopScenario(scenarioOverrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
+  fs.writeFileSync(orcaPath, fakeOrcaStopScript({ scenarioPath, logPath, poisonPath }), "utf-8");
+  fs.chmodSync(orcaPath, 0o755);
+
+  return {
+    dir,
+    orcaPath,
+    scenarioPath,
+    logPath,
+    poisonPath,
+    scenario,
+    readLog() {
+      if (!fs.existsSync(logPath)) return [];
+      return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    readPoison() {
+      if (!fs.existsSync(poisonPath)) return null;
+      return fs.readFileSync(poisonPath, "utf-8");
+    },
+    cleanup() {
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+module.exports = { defaultStopScenario, fakeOrcaStopScript, installFakeOrcaStop };

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -107,7 +107,7 @@ function initGitRepo(root) {
   git(["config", "user.name", "t"]);
 }
 
-function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, runtimeId, corruptReceipt }) {
+function buildWorld({ programId, receipt, manifests = [], fleetManifests = [], orcaScenario = {}, ghScenario = {}, runtimeId, corruptReceipt }) {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-resume-"));
   const repoRoot = path.join(base, "repo");
   const programsRoot = path.join(base, "programs");
@@ -130,8 +130,11 @@ function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghS
 
   const runsDir = path.join(runsRoot, slug);
   fs.mkdirSync(runsDir, { recursive: true });
-  fs.mkdirSync(path.join(fleetsRoot, slug), { recursive: true });
+  const fleetsDir = path.join(fleetsRoot, slug);
+  fs.mkdirSync(fleetsDir, { recursive: true });
   manifests.forEach((fields) => fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8"));
+  // Fleet manifests live under the SEPARATE fleets root (#945 A8), keyed by fleet id.
+  fleetManifests.forEach((fields) => fs.writeFileSync(path.join(fleetsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8"));
 
   const orca = installFakeOrcaResume({ runtimeId: runtimeId || DEFAULT_RUNTIME_ID, ...orcaScenario });
   const gh = installFakeGh(ghScenario);
@@ -456,6 +459,37 @@ test("D3: an absent outcome is NOT re-dispatched while unmapped relay work refer
     assert.equal(r.status, 0);
     assert.equal(actionFor(r.body, "b").action, "skipped", "absent outcome is skipped, not re-dispatched, to avoid duplicating unmapped relay work");
     assert.deepEqual(mutationLines(world.orca.readLog()), [], "no re-dispatch while unmapped relay work exists");
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// A2 (#946 R2, owner amendment A2): an unmapped FLEET manifest under the SEPARATE fleets
+// root blocks re-dispatch of an absent relay_fleet outcome — re-injecting would duplicate
+// the whole fleet (forbidden by the drain invariant), the same no-duplicate-work semantics
+// as the runs-root back-pointer above.
+test("A2: an absent relay_fleet outcome is NOT re-dispatched while an unmapped fleet manifest references the program", () => {
+  const programId = "epic-resume-fleet-backpointer";
+  const world = buildWorld({
+    programId,
+    // An unmapped fleet manifest under the fleets root that references this program.
+    fleetManifests: [{ run_id: "fleet-unmapped", state: "dispatched", pr_number: 50, issue_number: 500, body: `relay-orca program ${programId} operator fleet` }],
+    orcaScenario: { tasks: [orcaTask(programId, "b")], dispatch: absentDispatch("b") },
+  });
+  // Outcome b is a relay_fleet outcome, verifiably absent + relay clean (no fleet mapped in
+  // the receipt) + wave 1 — it would normally re-dispatch, but the unmapped fleet back-pointer
+  // means re-dispatch could duplicate the whole fleet.
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "b", kind: "relay_fleet", dispatch_id: null, assignee: null }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "b").action, "skipped", "absent relay_fleet outcome is skipped, not re-dispatched, to avoid duplicating the unmapped fleet");
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "no re-dispatch while an unmapped fleet references the program");
+    assert.ok(!world.orca.readLog().some((l) => l.startsWith("orchestration dispatch --task")), "ZERO dispatch invocations for the fleet outcome");
     assert.equal(world.receiptOnDisk(), before);
     assertNoPoison(world);
   } finally {

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -1,0 +1,662 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
+const RESUME_JS = path.join(SCRIPTS, "resume.js");
+
+const { REPORT_KEYS, ACTIONS } = require(path.join(SCRIPTS, "lib", "resume-report.js"));
+const { REASONS: RESUME_REASONS } = require(path.join(SCRIPTS, "lib", "resume-reasons.js"));
+const { RECEIPT_NOTE, parseReceipt, serializeReceipt, serializeReceiptWithStop } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
+const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { installFakeOrcaResume } = require(path.join(__dirname, "..", "fixtures", "fake-orca-resume.js"));
+const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
+const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+const FORBIDDEN_ENGINE_TOKENS = ["codex", "claude", "gpt", "opus", "sonnet", "haiku", "gemini", "cursor", "cline", "grok", "glm", "opencode"];
+const CANCELLATION_TOKENS = ["cancel", "cancelled", "canceled", "complete", "completed", "aborted", "discard"];
+
+// --- receipt / manifest / scenario builders ------------------------------------
+
+function makeReceipt({ programId, slug, root, runtimeId, tasks, stop }) {
+  const receipt = {
+    schema: 1,
+    program_id: programId,
+    source: "/tmp/accepted-program.json",
+    repo: { slug, root },
+    runtime_id: runtimeId || DEFAULT_RUNTIME_ID,
+    tasks: tasks.map((task) => {
+      const orcaTaskId = task.orca_task_id === undefined ? `orca-live-${task.outcome_id}` : task.orca_task_id;
+      const defaultDispatchId = orcaTaskId ? `disp-${orcaTaskId}` : null;
+      return {
+        outcome_id: task.outcome_id,
+        task_id: task.task_id || `orca-task-${task.outcome_id}`,
+        kind: task.kind || "relay_run",
+        wave: task.wave || 1,
+        orca_task_id: orcaTaskId,
+        dispatch_id: task.dispatch_id === undefined ? defaultDispatchId : task.dispatch_id,
+        assignee: task.assignee === undefined ? `term-${task.outcome_id}` : task.assignee,
+        relay_ids: { request: null, run: task.run || null, fleet: task.fleet || null },
+      };
+    }),
+    terminals_created: [],
+    created_at: "2026-07-12T00:00:00.000Z",
+    updated_at: "2026-07-12T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+  if (stop) {
+    receipt.stopped_at = stop.stopped_at;
+    receipt.stop_reason = stop.stop_reason;
+  }
+  return receipt;
+}
+
+function manifestText(fields) {
+  const lines = ["---", "relay_version: 2", `run_id: '${fields.run_id}'`, `state: '${fields.state}'`, "git:"];
+  lines.push(fields.pr_number != null ? `  pr_number: ${fields.pr_number}` : "  pr_number: null");
+  lines.push(`  working_branch: '${fields.working_branch || `${fields.run_id}-branch`}'`);
+  lines.push(`  base_branch: '${fields.base_branch || "main"}'`);
+  if (fields.head_sha) lines.push(`  head_sha: '${fields.head_sha}'`);
+  lines.push("issue:");
+  lines.push(fields.issue_number != null ? `  number: ${fields.issue_number}` : "  number: null");
+  lines.push("  source: 'github'");
+  lines.push("---");
+  lines.push("# Notes");
+  if (fields.body) lines.push(fields.body);
+  return `${lines.join("\n")}\n`;
+}
+
+function orcaTask(programId, outcome, extra = {}) {
+  return {
+    id: `orca-live-${outcome}`,
+    title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    status: extra.status || "dispatched",
+    worker_done: extra.worker_done === true,
+  };
+}
+
+// A task-list entry NOT marked for this program — makes the runtime foreign_state.
+function foreignTask(id) {
+  return { id, title: `relay-orca: other-program/${id}`, status: "dispatched", worker_done: false };
+}
+
+function initGitRepo(root) {
+  const git = (args) => execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t.com"]);
+  git(["config", "user.name", "t"]);
+}
+
+function buildWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, runtimeId, corruptReceipt }) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-resume-"));
+  const repoRoot = path.join(base, "repo");
+  const programsRoot = path.join(base, "programs");
+  const runsRoot = path.join(base, "runs");
+  const fleetsRoot = path.join(base, "fleets");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
+  const slug = computeRepoSlug(fs.realpathSync(repoRoot));
+
+  const receiptDir = path.join(programsRoot, slug, programSegment(programId));
+  fs.mkdirSync(receiptDir, { recursive: true });
+  const receiptPath = path.join(receiptDir, "receipt.json");
+  if (corruptReceipt !== undefined) {
+    fs.writeFileSync(receiptPath, corruptReceipt, "utf-8");
+  } else {
+    const receiptObject = receipt || makeReceipt({ programId, slug, root: fs.realpathSync(repoRoot), runtimeId, tasks: [] });
+    if (receiptObject.repo && receiptObject.repo.slug === "__SELF__") receiptObject.repo.slug = slug;
+    fs.writeFileSync(receiptPath, serializeReceipt(receiptObject), "utf-8");
+  }
+
+  const runsDir = path.join(runsRoot, slug);
+  fs.mkdirSync(runsDir, { recursive: true });
+  fs.mkdirSync(path.join(fleetsRoot, slug), { recursive: true });
+  manifests.forEach((fields) => fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8"));
+
+  const orca = installFakeOrcaResume({ runtimeId: runtimeId || DEFAULT_RUNTIME_ID, ...orcaScenario });
+  const gh = installFakeGh(ghScenario);
+
+  return {
+    base,
+    repoRoot,
+    programsRoot,
+    runsRoot,
+    slug,
+    receiptPath,
+    orca,
+    gh,
+    receiptOnDisk() {
+      return fs.readFileSync(receiptPath, "utf-8");
+    },
+    run(extraArgs = []) {
+      const args = [RESUME_JS, "--program-id", programId, "--json", "--orca-bin", orca.orcaPath, "--gh-bin", gh.ghPath, "--repo-root", repoRoot, ...extraArgs];
+      const result = { status: 0, stdout: "", stderr: "" };
+      try {
+        result.stdout = execFileSync(process.execPath, args, {
+          encoding: "utf-8",
+          env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot, RELAY_ORCA_RUNS_ROOT: runsRoot, RELAY_ORCA_FLEETS_ROOT: fleetsRoot },
+          stdio: "pipe",
+        });
+      } catch (error) {
+        result.status = error.status;
+        result.stdout = error.stdout ? String(error.stdout) : "";
+        result.stderr = error.stderr ? String(error.stderr) : "";
+      }
+      result.body = result.stdout ? JSON.parse(result.stdout) : null;
+      return result;
+    },
+    cleanup() {
+      orca.cleanup();
+      gh.cleanup();
+      fs.rmSync(base, { recursive: true, force: true });
+    },
+  };
+}
+
+function actionFor(body, outcomeId) {
+  return body.actions.find((entry) => entry.outcome_id === outcomeId);
+}
+
+// Mutating Orca subcommand lines (dispatch --inject / terminal create / terminal send /
+// task-create) — dispatch-show is a READ and is excluded.
+function mutationLines(log) {
+  return log.filter(
+    (line) =>
+      line.startsWith("orchestration dispatch --task") ||
+      line.startsWith("terminal create") ||
+      line.startsWith("terminal send") ||
+      line.startsWith("orchestration task-create"),
+  );
+}
+
+function assertNoPoison(world) {
+  assert.equal(world.orca.readPoison(), null, "reset/worktree poison must never fire");
+  assert.equal(world.gh.readPoison(), null, "gh write poison must never fire");
+}
+
+function assertReportShape(body) {
+  assert.deepEqual(Object.keys(body).sort(), [...REPORT_KEYS].sort());
+  assert.equal(body.reconciliation_required, true);
+  body.actions.forEach((entry) => {
+    assert.deepEqual(Object.keys(entry).sort(), ["action", "outcome_id", "reason"]);
+    assert.ok(ACTIONS.includes(entry.action), `action ${entry.action} in the pinned enum`);
+  });
+  body.decision_required.forEach((entry) => {
+    assert.deepEqual(Object.keys(entry).sort(), ["message", "options", "reason_code"]);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// D9.1 — coordinator death, children alive: reuse everything, zero mutation
+// ---------------------------------------------------------------------------
+
+test("D9.1: coordinator death, children alive → all mappings reused, zero mutations, children untouched", () => {
+  const programId = "epic-resume-coord-death";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 },
+      { run_id: "run-b", state: "review_pending", pr_number: 11, issue_number: 101 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "a"), orcaTask(programId, "b")] },
+    ghScenario: { prs: { 10: { state: "OPEN" }, 11: { state: "OPEN" } }, issues: { 100: { state: "OPEN" }, 101: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", run: "run-a" }, { outcome_id: "b", run: "run-b" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assertReportShape(r.body);
+    assert.equal(r.body.runtime, "ok");
+    assert.equal(actionFor(r.body, "a").action, "reused");
+    assert.equal(actionFor(r.body, "b").action, "reused");
+    assert.deepEqual(r.body.terminals_created, []);
+    assert.deepEqual(r.body.decision_required, []);
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "zero mutating subcommands");
+    assert.equal(world.receiptOnDisk(), before, "receipt untouched when nothing is re-dispatched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.2 — Orca runtime restart (live id != receipt) → exit 60, zero mutation
+// ---------------------------------------------------------------------------
+
+test("D9.2: runtime restart (live id != receipt) → RESUME_RUNTIME_CHANGED exit 60, zero mutation", () => {
+  const programId = "epic-resume-runtime-changed";
+  const world = buildWorld({
+    programId,
+    runtimeId: DEFAULT_RUNTIME_ID,
+    orcaScenario: { runtimeId: "99999999-9999-4999-8999-999999999999", tasks: [] },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), runtimeId: DEFAULT_RUNTIME_ID, tasks: [{ outcome_id: "a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, RESUME_REASONS.RESUME_RUNTIME_CHANGED);
+    assert.equal(r.status, 60);
+    assertReportShape(r.body);
+    assert.equal(r.body.runtime, "mismatch");
+    assert.equal(r.body.ok, false);
+    assert.ok(r.body.decision_required.some((d) => d.reason_code === "RESUME_RUNTIME_CHANGED"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "no mutation on a runtime-changed abort");
+    assert.equal(world.receiptOnDisk(), before, "receipt byte-identical on abort");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.3 — operator terminal loss → replacement terminal, receipt updated, verified
+// ---------------------------------------------------------------------------
+
+test("D9.3: terminal loss on a resumable outcome → terminal reacquired via inject->dispatch-show, receipt updated immediately", () => {
+  const programId = "epic-resume-term-loss";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask(programId, "a")], dispatch: { "orca-live-a": { terminal_present: false } } },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", run: "run-a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assertReportShape(r.body);
+    assert.equal(actionFor(r.body, "a").action, "redispatched");
+    assert.equal(r.body.terminals_created.length, 1);
+    const log = world.orca.readLog();
+    assert.ok(log.some((l) => l.startsWith("terminal create")), "a replacement terminal is created");
+    assert.ok(log.some((l) => l.startsWith("orchestration dispatch --task orca-live-a")), "re-injected through dispatch");
+    assert.ok(log.some((l) => l.startsWith("orchestration dispatch-show --task orca-live-a")), "provenance re-verified through dispatch-show");
+    // Receipt persisted immediately (A16): the created handle is durable on disk.
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    assert.deepEqual(persisted.terminals_created, r.body.terminals_created);
+    assert.equal(persisted.tasks[0].assignee, r.body.terminals_created[0], "reacquired terminal recorded as the outcome assignee");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.4 — live child continuation: in-flight relay run is NEVER re-dispatched
+// ---------------------------------------------------------------------------
+
+test("D9.4: in-flight relay run (absent Orca dispatch) is skipped, never re-dispatched", () => {
+  const programId = "epic-resume-live-child";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-live", state: "review_pending", pr_number: 20, issue_number: 200 }],
+    orcaScenario: { tasks: [orcaTask(programId, "a")] },
+    ghScenario: { prs: { 20: { state: "OPEN" } }, issues: { 200: { state: "OPEN" } } },
+  });
+  // Orca dispatch verifiably absent (dispatch_id null) but the relay side is in-flight.
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", dispatch_id: null, assignee: null, run: "run-live" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "a").action, "skipped");
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "an in-flight relay run is never re-dispatched");
+    assert.equal(world.receiptOnDisk(), before, "the in-flight child's mapping is untouched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.6 — partial dispatch: only the verifiably-absent, relay-clean outcome dispatches
+// ---------------------------------------------------------------------------
+
+function partialWorld(programId) {
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask(programId, "a"), orcaTask(programId, "b")] },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "a", run: "run-a" }, // dispatched + live → reused
+      { outcome_id: "b", dispatch_id: null, assignee: null }, // never dispatched, relay clean, wave 1 → redispatch
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  return world;
+}
+
+test("D9.6: partial dispatch → only the absent+clean outcome dispatches, through the verified path", () => {
+  const programId = "epic-resume-partial";
+  const world = partialWorld(programId);
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "a").action, "reused");
+    assert.equal(actionFor(r.body, "b").action, "redispatched");
+    const injects = world.orca.readLog().filter((l) => l.startsWith("orchestration dispatch --task"));
+    assert.equal(injects.length, 1, "exactly one re-dispatch");
+    assert.ok(injects[0].includes("orca-live-b"), "only the absent outcome b is dispatched");
+    assert.ok(!injects.some((l) => l.includes("orca-live-a")), "the reused outcome a is never re-dispatched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// D3: unmapped relay work (a back-pointer) blocks re-dispatch of an absent outcome.
+test("D3: an absent outcome is NOT re-dispatched while unmapped relay work references the program", () => {
+  const programId = "epic-resume-backpointer";
+  const world = buildWorld({
+    programId,
+    // An unmapped relay run manifest that references this program (a back-pointer).
+    manifests: [{ run_id: "run-unmapped", state: "dispatched", pr_number: 40, issue_number: 400, body: `relay-orca program ${programId} operator run` }],
+    orcaScenario: { tasks: [orcaTask(programId, "b")] },
+    ghScenario: { prs: { 40: { state: "OPEN" } }, issues: { 400: { state: "OPEN" } } },
+  });
+  // Outcome b is verifiably absent + relay clean + wave 1 (would normally re-dispatch),
+  // but the back-pointer means re-dispatch could duplicate the unmapped work.
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "b", dispatch_id: null, assignee: null }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "b").action, "skipped", "absent outcome is skipped, not re-dispatched, to avoid duplicating unmapped relay work");
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "no re-dispatch while unmapped relay work exists");
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// D1: reconciliation reads run BEFORE any mutation.
+test("D1: reconciliation (status/task-list/gate-list) runs before any mutating subcommand", () => {
+  const programId = "epic-resume-order";
+  const world = partialWorld(programId);
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    const log = world.orca.readLog();
+    const firstMutation = log.findIndex((l) => mutationLines([l]).length > 0);
+    assert.ok(firstMutation > 0, "a mutation occurred");
+    ["status", "orchestration task-list", "orchestration gate-list"].forEach((read) => {
+      const idx = log.findIndex((l) => l.startsWith(read));
+      assert.ok(idx >= 0 && idx < firstMutation, `${read} reconciliation read precedes the first mutation`);
+    });
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.5 / D3 — double resume is idempotent (the core invariant)
+// ---------------------------------------------------------------------------
+
+test("D9.5: double resume is idempotent — second run does zero task-create/terminal/dispatch, all reused/skipped", () => {
+  const programId = "epic-resume-idempotent";
+  const world = partialWorld(programId);
+  try {
+    const first = world.run();
+    assert.equal(first.status, 0);
+    assert.equal(actionFor(first.body, "b").action, "redispatched");
+    const firstMutations = mutationLines(world.orca.readLog()).length;
+    assert.ok(firstMutations > 0, "the first resume mutated (re-dispatched the absent outcome)");
+
+    // Second resume reads the receipt the first resume persisted → everything now live.
+    const beforeSecond = world.receiptOnDisk();
+    const secondLogStart = world.orca.readLog().length;
+    const second = world.run();
+    assert.equal(second.status, 0);
+    const secondLog = world.orca.readLog().slice(secondLogStart);
+    assert.deepEqual(mutationLines(secondLog), [], "the second resume performs ZERO task-create/terminal/dispatch");
+    second.body.actions.forEach((entry) => assert.ok(["reused", "skipped"].includes(entry.action), `${entry.outcome_id} is reused/skipped on the second run`));
+    assert.equal(actionFor(second.body, "b").action, "reused", "the re-established outcome reads back as reused");
+    assert.equal(world.receiptOnDisk(), beforeSecond, "the second resume rewrites nothing (idempotent)");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.9 — corrupted global state (foreign) → 61; corrupted receipt → 51
+// ---------------------------------------------------------------------------
+
+test("D9.9a: foreign runtime tasks → RESUME_AMBIGUOUS_STATE exit 61, options listed, zero mutation", () => {
+  const programId = "epic-resume-foreign";
+  const world = buildWorld({
+    programId,
+    orcaScenario: { tasks: [orcaTask(programId, "a"), foreignTask("intruder-1")] },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 61);
+    assertReportShape(r.body);
+    assert.equal(r.body.runtime, "foreign_state");
+    const decision = r.body.decision_required.find((d) => d.reason_code === "RESUME_AMBIGUOUS_STATE");
+    assert.ok(decision, "RESUME_AMBIGUOUS_STATE decision present");
+    assert.ok(decision.options.length > 0, "recovery options listed");
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D9.9b: corrupted receipt → RECEIPT_CORRUPT exit 51 verbatim", () => {
+  const programId = "epic-resume-corrupt";
+  const world = buildWorld({ programId, corruptReceipt: "{ not valid json" });
+  try {
+    const r = world.run();
+    assert.equal(r.status, 51);
+    assert.equal(r.body.reason_code, "RECEIPT_CORRUPT");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.10 / D6 — worker_done + open PR → not re-dispatched, decision_required
+// ---------------------------------------------------------------------------
+
+test("D9.10: worker_done + open PR outcome is inconsistent → decision_required, never re-dispatched (D6)", () => {
+  const programId = "epic-resume-stale-done";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-s", state: "review_pending", pr_number: 30, issue_number: 300 }],
+    orcaScenario: { tasks: [orcaTask(programId, "s", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 30: { state: "OPEN" } }, issues: { 300: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "s", run: "run-s" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 61);
+    assertReportShape(r.body);
+    assert.ok(r.body.reconciliation.find((o) => o.outcome_id === "s").state === "inconsistent");
+    assert.ok(r.body.decision_required.some((d) => d.reason_code === "RESUME_AMBIGUOUS_STATE"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "a worker_done+open-PR outcome is never re-dispatched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.11 — conflicting mapping (changed dispatch id) → 62; missing provenance → 63
+// ---------------------------------------------------------------------------
+
+test("D9.11a: changed dispatch id under the mapping → RESUME_CONFLICTING_MAPPING exit 62, zero mutation", () => {
+  const programId = "epic-resume-conflict";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 }],
+    // Live dispatch id drifted away from the receipt's recorded dispatch id.
+    orcaScenario: { tasks: [orcaTask(programId, "a")], dispatch: { "orca-live-a": { dispatch_id: "disp-CHANGED" } } },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", run: "run-a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 62);
+    assertReportShape(r.body);
+    assert.ok(r.body.decision_required.some((d) => d.reason_code === "RESUME_CONFLICTING_MAPPING"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D9.11b: live dispatch present but recorded provenance incomplete → RESUME_MISSING_PROVENANCE exit 63", () => {
+  const programId = "epic-resume-missing-prov";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask(programId, "a")] },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+  });
+  // dispatch_id present (a live dispatch exists) but assignee missing → provenance gap.
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", assignee: null, run: "run-a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 63);
+    assertReportShape(r.body);
+    assert.ok(r.body.decision_required.some((d) => d.reason_code === "RESUME_MISSING_PROVENANCE"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.8 — stop then resume: the stop record survives a resume that rewrites the receipt
+// ---------------------------------------------------------------------------
+
+test("D9.8: resume preserves a prior stop record when it rewrites the receipt", () => {
+  const programId = "epic-resume-after-stop";
+  const world = buildWorld({
+    programId,
+    orcaScenario: { tasks: [orcaTask(programId, "b")] },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "b", dispatch_id: null, assignee: null }],
+    stop: { stopped_at: "2026-07-12T05:00:00.000Z", stop_reason: "operator paused the coordinator" },
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceiptWithStop(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "b").action, "redispatched", "resume still re-dispatches the absent outcome");
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    assert.equal(persisted.stopped_at, "2026-07-12T05:00:00.000Z", "stop record survives the receipt rewrite");
+    assert.equal(persisted.stop_reason, "operator paused the coordinator");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D2 — decision options never advise a destructive action; no cancellation language
+// ---------------------------------------------------------------------------
+
+test("D2/D8: decision options name operator commands, are bounded, and never advise reset/deletion/force-close", () => {
+  const programId = "epic-resume-options";
+  const world = buildWorld({ programId, orcaScenario: { runtimeId: "88888888-8888-4888-8888-888888888888" } });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 60);
+    const serialized = JSON.stringify(r.body).toLowerCase();
+    ["reset", "task delete", "task-delete", "delete task", "worktree", "force-close", "force close", "rm -rf"].forEach((forbidden) => {
+      assert.ok(!serialized.includes(forbidden), `resume report must never advise ${forbidden}`);
+    });
+    CANCELLATION_TOKENS.forEach((token) => assert.ok(!serialized.includes(token), `resume report must not claim ${token}`));
+    r.body.decision_required.forEach((decision) => {
+      decision.options.forEach((option) => {
+        assert.ok(option.length <= 256, "options bounded to <=256 chars");
+        assert.ok(/status\.js|run\.js|dispatch-show|recovery\.md/.test(option), "each option names a concrete operator command/reference");
+      });
+    });
+    FORBIDDEN_ENGINE_TOKENS.forEach((token) => assert.ok(!serialized.includes(token), `resume report must not name engine ${token}`));
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Receipt-layer + usage fail-closed contracts
+// ---------------------------------------------------------------------------
+
+test("receipt: missing receipt → RECEIPT_NOT_FOUND exit 50", () => {
+  const programId = "epic-resume-absent";
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-resume-nf-"));
+  const repoRoot = path.join(base, "repo");
+  const programsRoot = path.join(base, "programs");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  fs.mkdirSync(programsRoot, { recursive: true });
+  initGitRepo(repoRoot);
+  const orca = installFakeOrcaResume({});
+  try {
+    let status = 0;
+    let body = null;
+    try {
+      execFileSync(process.execPath, [RESUME_JS, "--program-id", programId, "--json", "--orca-bin", orca.orcaPath, "--repo-root", repoRoot], {
+        encoding: "utf-8",
+        env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot },
+        stdio: "pipe",
+      });
+    } catch (error) {
+      status = error.status;
+      body = error.stdout ? JSON.parse(String(error.stdout)) : null;
+    }
+    assert.equal(status, 50);
+    assert.equal(body.reason_code, "RECEIPT_NOT_FOUND");
+    assert.equal(orca.readPoison(), null);
+  } finally {
+    orca.cleanup();
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("usage: unknown flag exits 64", () => {
+  const world = buildWorld({ programId: "epic-resume-usage" });
+  try {
+    const r = world.run(["--bogus"]);
+    assert.equal(r.status, 64);
+  } finally {
+    world.cleanup();
+  }
+});

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -87,6 +87,19 @@ function foreignTask(id) {
   return { id, title: `relay-orca: other-program/${id}`, status: "dispatched", worker_done: false };
 }
 
+// A dispatch-show seed modeling GENUINE absence (owner amendment A1, #946 R1): the Orca
+// task exists (materialized) but was never dispatched, so dispatch-show reports NO
+// dispatch and no terminal. This live-absent read is the ONLY thing that qualifies an
+// outcome as verifiably-absent for re-dispatch — a null receipt dispatch_id alone does
+// not. Without this seed the fake reports a PRESENT dispatch (the crash-window state).
+function absentDispatch(...outcomes) {
+  const seed = {};
+  outcomes.forEach((outcome) => {
+    seed[`orca-live-${outcome}`] = { dispatch_id: null, terminal_present: false, assignee: null };
+  });
+  return seed;
+}
+
 function initGitRepo(root) {
   const git = (args) => execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "pipe"] });
   git(["init", "-q"]);
@@ -301,10 +314,10 @@ test("D9.4: in-flight relay run (absent Orca dispatch) is skipped, never re-disp
   const world = buildWorld({
     programId,
     manifests: [{ run_id: "run-live", state: "review_pending", pr_number: 20, issue_number: 200 }],
-    orcaScenario: { tasks: [orcaTask(programId, "a")] },
+    orcaScenario: { tasks: [orcaTask(programId, "a")], dispatch: absentDispatch("a") },
     ghScenario: { prs: { 20: { state: "OPEN" } }, issues: { 200: { state: "OPEN" } } },
   });
-  // Orca dispatch verifiably absent (dispatch_id null) but the relay side is in-flight.
+  // Orca dispatch verifiably absent (live dispatch-show reports none) but the relay side is in-flight.
   const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", dispatch_id: null, assignee: null, run: "run-live" }] });
   fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
   const before = world.receiptOnDisk();
@@ -328,7 +341,8 @@ function partialWorld(programId) {
   const world = buildWorld({
     programId,
     manifests: [{ run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 }],
-    orcaScenario: { tasks: [orcaTask(programId, "a"), orcaTask(programId, "b")] },
+    // Outcome b's dispatch is verifiably absent via a live dispatch-show read (A1).
+    orcaScenario: { tasks: [orcaTask(programId, "a"), orcaTask(programId, "b")], dispatch: absentDispatch("b") },
     ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
   });
   const receipt = makeReceipt({
@@ -362,6 +376,66 @@ test("D9.6: partial dispatch → only the absent+clean outcome dispatches, throu
   }
 });
 
+// ---------------------------------------------------------------------------
+// A1 (#946 R1) — redispatch requires LIVE dispatch absence, not a null receipt id
+// ---------------------------------------------------------------------------
+
+// (a) Crash window: `dispatch --inject` landed a live dispatch, but the receipt write that
+// records its provenance never happened (crash between inject and the receipt write). The
+// receipt dispatch_id is null yet a live dispatch is PRESENT — re-injecting would duplicate
+// operator work, so resume fails closed as RESUME_MISSING_PROVENANCE (exit 63) with ZERO
+// dispatch invocations. A null receipt dispatch_id is NOT verifiable absence.
+test("A1(a) crash window: live dispatch present + receipt dispatch_id null → RESUME_MISSING_PROVENANCE exit 63, zero dispatch", () => {
+  const programId = "epic-resume-crash-window";
+  const world = buildWorld({
+    programId,
+    // NO dispatch seed → the fake dispatch-show reports a PRESENT live dispatch for the task.
+    orcaScenario: { tasks: [orcaTask(programId, "b")] },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "b", dispatch_id: null, assignee: null }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, 63);
+    assertReportShape(r.body);
+    assert.equal(r.body.ok, false);
+    assert.ok(r.body.decision_required.some((d) => d.reason_code === "RESUME_MISSING_PROVENANCE"), "crash window fails closed as RESUME_MISSING_PROVENANCE");
+    assert.equal(actionFor(r.body, "b").action, "decision_required");
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "no mutating subcommand on the crash-window abort");
+    assert.ok(!world.orca.readLog().some((l) => l.startsWith("orchestration dispatch --task")), "ZERO dispatch invocations in the crash window");
+    assert.equal(world.receiptOnDisk(), before, "receipt byte-identical on the fail-closed abort");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// (b) Genuine absence: the task exists but a live dispatch-show reports NO dispatch. THIS
+// is verifiable absence, so the absent + relay-clean + wave-1 outcome re-dispatches through
+// the verified inject->dispatch-show->prompt path, exactly as before.
+test("A1(b) genuine absence: live dispatch-show empty + receipt dispatch_id null → re-dispatch proceeds through the verified path", () => {
+  const programId = "epic-resume-genuine-absence";
+  const world = buildWorld({
+    programId,
+    orcaScenario: { tasks: [orcaTask(programId, "b")], dispatch: absentDispatch("b") },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "b", dispatch_id: null, assignee: null }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.deepEqual(r.body.decision_required, [], "no fail-closed decision on genuine absence");
+    assert.equal(actionFor(r.body, "b").action, "redispatched");
+    const log = world.orca.readLog();
+    assert.ok(log.some((l) => l.startsWith("orchestration dispatch-show --task orca-live-b")), "reconciliation reads the live dispatch before deciding");
+    assert.ok(log.some((l) => l.startsWith("orchestration dispatch --task orca-live-b")), "re-injected through the verified dispatch path");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
 // D3: unmapped relay work (a back-pointer) blocks re-dispatch of an absent outcome.
 test("D3: an absent outcome is NOT re-dispatched while unmapped relay work references the program", () => {
   const programId = "epic-resume-backpointer";
@@ -369,7 +443,7 @@ test("D3: an absent outcome is NOT re-dispatched while unmapped relay work refer
     programId,
     // An unmapped relay run manifest that references this program (a back-pointer).
     manifests: [{ run_id: "run-unmapped", state: "dispatched", pr_number: 40, issue_number: 400, body: `relay-orca program ${programId} operator run` }],
-    orcaScenario: { tasks: [orcaTask(programId, "b")] },
+    orcaScenario: { tasks: [orcaTask(programId, "b")], dispatch: absentDispatch("b") },
     ghScenario: { prs: { 40: { state: "OPEN" } }, issues: { 400: { state: "OPEN" } } },
   });
   // Outcome b is verifiably absent + relay clean + wave 1 (would normally re-dispatch),
@@ -563,7 +637,7 @@ test("D9.8: resume preserves a prior stop record when it rewrites the receipt", 
   const programId = "epic-resume-after-stop";
   const world = buildWorld({
     programId,
-    orcaScenario: { tasks: [orcaTask(programId, "b")] },
+    orcaScenario: { tasks: [orcaTask(programId, "b")], dispatch: absentDispatch("b") },
   });
   const receipt = makeReceipt({
     programId,

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -107,8 +107,9 @@ function fleetManifestText(fields) {
     "  created_at: '2026-07-12T00:00:00.000Z'",
     "  updated_at: '2026-07-12T00:00:00.000Z'",
     "---",
-    "",
+    "# Notes",
   ];
+  if (fields.body) lines.push(fields.body);
   return `${lines.join("\n")}\n`;
 }
 
@@ -757,6 +758,73 @@ test("D10.11: duplicate mapping → DUPLICATE_MAPPING; unmapped manifest referen
     assert.ok(
       r.body.repair_candidates.some((c) => c.kind === "adopt_relay_run" && /run-orphan/.test(c.proposal)),
       "back-pointer discovery emits an adopt repair candidate (no mutation)",
+    );
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// A2 (#946 R2, owner amendment A2) — an unmapped FLEET manifest under the SEPARATE fleets
+// root referencing the program → adopt_relay_fleet repair candidate (mirrors the runs-root
+// back-pointer discovery so resume can block a duplicate fleet redispatch).
+test("A2: unmapped fleet manifest (fleets root) referencing the program → adopt_relay_fleet repair_candidate", () => {
+  const programId = "epic-status-fleet-orphan";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-1", state: "dispatched", pr_number: 92, issue_number: 902 },
+      // an orphan FLEET manifest (lands under the fleets root via `fleet_state`) referencing
+      // this program but absent from the receipt's relay_ids.fleet mappings.
+      { run_id: "fleet-orphan", fleet_state: "dispatching", children: [], body: `relay-orca program ${programId} operator fleet` },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "a")] },
+    ghScenario: { prs: { 92: { state: "OPEN" } }, issues: { 902: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "a", orca_task_id: "orca-live-a", run: "run-1" }],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.ok(
+      r.body.repair_candidates.some((c) => c.kind === "adopt_relay_fleet" && /fleet-orphan/.test(c.proposal)),
+      "fleet back-pointer discovery emits an adopt_relay_fleet repair candidate (no mutation)",
+    );
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// A2 — a fleet manifest that IS mapped in relay_ids.fleet is NOT reported as unmapped
+// back-pointer work (the properly mapped variant is unaffected).
+test("A2: a fleet manifest mapped in relay_ids.fleet emits NO adopt_relay_fleet candidate", () => {
+  const programId = "epic-status-fleet-mapped";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "fleet-mapped", fleet_state: "dispatching", children: [], body: `relay-orca program ${programId} operator fleet` },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "fc")] },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "fc", kind: "relay_fleet", orca_task_id: "orca-live-fc", fleet: "fleet-mapped" }],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.ok(
+      !r.body.repair_candidates.some((c) => c.kind === "adopt_relay_fleet"),
+      "a mapped fleet is never reported as unmapped fleet back-pointer work",
     );
     assert.equal(world.orca.readPoison(), null);
   } finally {

--- a/tests/relay-orca/scripts/stop.test.js
+++ b/tests/relay-orca/scripts/stop.test.js
@@ -1,0 +1,289 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
+const STOP_JS = path.join(SCRIPTS, "stop.js");
+
+const { RECEIPT_NOTE, parseReceipt, serializeReceipt, STOP_REASON_MAX } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { REASONS: STOP_REASONS } = require(path.join(SCRIPTS, "lib", "stop-reasons.js"));
+const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
+const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { installFakeOrcaStop } = require(path.join(__dirname, "..", "fixtures", "fake-orca-stop.js"));
+const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+const STOP_REPORT_KEYS = ["ok", "program_id", "receipt_path", "coordinator_stopped", "stopped_at", "stop_reason", "blocking_reasons"];
+const CANCELLATION_TOKENS = ["cancel", "cancelled", "canceled", "complete", "completed", "aborted", "discard"];
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function makeReceipt({ programId, slug, root }) {
+  return {
+    schema: 1,
+    program_id: programId,
+    source: "/tmp/accepted-program.json",
+    repo: { slug, root },
+    runtime_id: DEFAULT_RUNTIME_ID,
+    tasks: [
+      { outcome_id: "a", task_id: "orca-task-a", kind: "relay_run", wave: 1, orca_task_id: "orca-live-a", dispatch_id: "disp-orca-live-a", assignee: "term-a", relay_ids: { request: null, run: "run-a", fleet: null } },
+    ],
+    terminals_created: [],
+    created_at: "2026-07-12T00:00:00.000Z",
+    updated_at: "2026-07-12T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+}
+
+function initGitRepo(root) {
+  const git = (args) => execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t.com"]);
+  git(["config", "user.name", "t"]);
+}
+
+function buildWorld({ programId, stopScenario = {}, corruptReceipt, receiptOverride }) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-stop-"));
+  const repoRoot = path.join(base, "repo");
+  const programsRoot = path.join(base, "programs");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
+  const slug = computeRepoSlug(fs.realpathSync(repoRoot));
+  const receiptDir = path.join(programsRoot, slug, programSegment(programId));
+  fs.mkdirSync(receiptDir, { recursive: true });
+  const receiptPath = path.join(receiptDir, "receipt.json");
+  if (corruptReceipt !== undefined) {
+    fs.writeFileSync(receiptPath, corruptReceipt, "utf-8");
+  } else {
+    const receipt = receiptOverride || makeReceipt({ programId, slug, root: fs.realpathSync(repoRoot) });
+    fs.writeFileSync(receiptPath, serializeReceipt(receipt), "utf-8");
+  }
+  const orca = installFakeOrcaStop(stopScenario);
+  return {
+    base,
+    repoRoot,
+    programsRoot,
+    slug,
+    receiptPath,
+    orca,
+    receiptOnDisk() {
+      return fs.readFileSync(receiptPath, "utf-8");
+    },
+    run(extraArgs = []) {
+      const args = [STOP_JS, "--program-id", programId, "--json", "--orca-bin", orca.orcaPath, "--repo-root", repoRoot, ...extraArgs];
+      const result = { status: 0, stdout: "", stderr: "" };
+      try {
+        result.stdout = execFileSync(process.execPath, args, { encoding: "utf-8", env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot }, stdio: "pipe" });
+      } catch (error) {
+        result.status = error.status;
+        result.stdout = error.stdout ? String(error.stdout) : "";
+        result.stderr = error.stderr ? String(error.stderr) : "";
+      }
+      result.body = result.stdout ? JSON.parse(result.stdout) : null;
+      return result;
+    },
+    cleanup() {
+      orca.cleanup();
+      fs.rmSync(base, { recursive: true, force: true });
+    },
+  };
+}
+
+// Strip the two stop fields and re-serialize to prove only the stop fields changed.
+function receiptMinusStop(text) {
+  const receipt = parseReceipt(text).receipt;
+  delete receipt.stopped_at;
+  delete receipt.stop_reason;
+  return serializeReceipt(receipt);
+}
+
+// ---------------------------------------------------------------------------
+// D9.7 — run-stop invoked, bounded stop record added, nothing else changes
+// ---------------------------------------------------------------------------
+
+test("D9.7: stop invokes run-stop, records bounded stopped_at/stop_reason, only stop fields change, no cancellation language", () => {
+  const programId = "epic-stop-basic";
+  const world = buildWorld({ programId });
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--reason", "operator maintenance window"]);
+    assert.equal(r.status, 0);
+    assert.deepEqual(Object.keys(r.body).sort(), [...STOP_REPORT_KEYS].sort());
+    assert.equal(r.body.coordinator_stopped, true);
+    assert.match(r.body.stopped_at, ISO_RE);
+    assert.equal(r.body.stop_reason, "operator maintenance window");
+    assert.deepEqual(r.body.blocking_reasons, []);
+
+    // Exactly ONE mutating Orca subcommand — run-stop — was invoked.
+    const log = world.orca.readLog();
+    assert.deepEqual(log, ["orchestration run-stop --json"], "the only mutating subcommand is run-stop");
+    assert.equal(world.orca.readPoison(), null, "restricted poison set never fires");
+
+    // Byte comparison: only the stop fields changed.
+    const after = world.receiptOnDisk();
+    assert.notEqual(after, before, "stop fields were added");
+    assert.equal(receiptMinusStop(after), before, "every non-stop field is byte-identical");
+    const persisted = parseReceipt(after).receipt;
+    assert.equal(persisted.stopped_at, r.body.stopped_at);
+    assert.equal(persisted.stop_reason, "operator maintenance window");
+    assert.equal(persisted.updated_at, "2026-07-12T00:00:00.000Z", "stop does not bump updated_at");
+
+    // No cancellation/completion language anywhere in the report.
+    const serialized = JSON.stringify(r.body).toLowerCase();
+    CANCELLATION_TOKENS.forEach((token) => assert.ok(!serialized.includes(token), `stop report must not claim ${token}`));
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D5 — coordinator-only: restricted poison set proves no task/terminal is touched
+// ---------------------------------------------------------------------------
+
+test("D5: stop touches ONLY run-stop — no task-create/task-update/dispatch/terminal/reset/worktree", () => {
+  const programId = "epic-stop-coordinator-only";
+  const world = buildWorld({ programId });
+  try {
+    const r = world.run(["--reason", "pause"]);
+    assert.equal(r.status, 0);
+    const log = world.orca.readLog().join(" ");
+    ["task-create", "task-update", "dispatch", "terminal", "reset", "worktree"].forEach((forbidden) => {
+      assert.ok(!log.includes(forbidden), `stop must never invoke ${forbidden}; log=${log}`);
+    });
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.13 — idempotency: second stop is a no-op, receipt byte-identical
+// ---------------------------------------------------------------------------
+
+test("D9.13: a second stop leaves the original stop record byte-identical and does not duplicate it", () => {
+  const programId = "epic-stop-idempotent";
+  const world = buildWorld({ programId });
+  try {
+    const first = world.run(["--reason", "first pause"]);
+    assert.equal(first.status, 0);
+    const afterFirst = world.receiptOnDisk();
+    const firstStoppedAt = first.body.stopped_at;
+
+    const second = world.run(["--reason", "second pause (should be ignored)"]);
+    assert.equal(second.status, 0);
+    assert.equal(second.body.coordinator_stopped, true, "second stop still reports the live run-stop result");
+    assert.equal(second.body.stopped_at, firstStoppedAt, "second stop reports the ORIGINAL stopped_at");
+    assert.equal(second.body.stop_reason, "first pause", "the original stop_reason is preserved, not overwritten");
+    assert.equal(world.receiptOnDisk(), afterFirst, "the receipt is byte-identical after the second stop");
+
+    // The stop record appears exactly once (never duplicated).
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    assert.equal(persisted.stop_reason, "first pause");
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// stop_reason is bounded (<=256)
+// ---------------------------------------------------------------------------
+
+test("D5: stop_reason is bounded to <=256 chars", () => {
+  const programId = "epic-stop-bounded";
+  const world = buildWorld({ programId });
+  try {
+    const r = world.run(["--reason", "x".repeat(1000)]);
+    assert.equal(r.status, 0);
+    assert.equal(r.body.stop_reason.length, STOP_REASON_MAX);
+    assert.ok(r.body.stop_reason.length <= 256);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// run-stop failure → coordinator_stopped false, blocking_reason, no receipt write
+// ---------------------------------------------------------------------------
+
+test("run-stop failure → coordinator_stopped false, blocking_reasons, exit 65, receipt untouched", () => {
+  const programId = "epic-stop-fail";
+  const world = buildWorld({ programId, stopScenario: { runStopOk: false } });
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--reason", "attempted"]);
+    assert.equal(r.status, STOP_REASONS.COORDINATOR_STOP_FAILED);
+    assert.equal(r.status, 65);
+    assert.equal(r.body.coordinator_stopped, false);
+    assert.equal(r.body.ok, false);
+    assert.ok(r.body.blocking_reasons.some((b) => b.reason_code === "COORDINATOR_STOP_FAILED"));
+    assert.equal(r.body.stopped_at, null, "no stop record is written when run-stop fails");
+    assert.equal(world.receiptOnDisk(), before, "the receipt is untouched on a failed stop");
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Receipt-layer fail-closed (50-52 verbatim) + usage
+// ---------------------------------------------------------------------------
+
+test("receipt: corrupted receipt → RECEIPT_CORRUPT exit 51, run-stop never invoked", () => {
+  const programId = "epic-stop-corrupt";
+  const world = buildWorld({ programId, corruptReceipt: "{ not json" });
+  try {
+    const r = world.run(["--reason", "x"]);
+    assert.equal(r.status, 51);
+    assert.equal(r.body.reason_code, "RECEIPT_CORRUPT");
+    assert.deepEqual(world.orca.readLog(), [], "a corrupt receipt fails closed before run-stop");
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("receipt: repo slug mismatch → RECEIPT_REPO_MISMATCH exit 52", () => {
+  const programId = "epic-stop-repo-mismatch";
+  const world = buildWorld({ programId, receiptOverride: null });
+  // Rewrite the receipt with a foreign slug so the identity check fails closed.
+  const receipt = makeReceipt({ programId, slug: "some-other-repo-deadbeef", root: "/tmp/other" });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run(["--reason", "x"]);
+    assert.equal(r.status, 52);
+    assert.equal(r.body.reason_code, "RECEIPT_REPO_MISMATCH");
+    assert.deepEqual(world.orca.readLog(), []);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("usage: unknown flag exits 64", () => {
+  const world = buildWorld({ programId: "epic-stop-usage" });
+  try {
+    const r = world.run(["--bogus"]);
+    assert.equal(r.status, 64);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("usage: missing --program-id exits 64", () => {
+  const world = buildWorld({ programId: "epic-stop-usage2" });
+  try {
+    const result = { status: 0 };
+    try {
+      execFileSync(process.execPath, [STOP_JS, "--json", "--orca-bin", world.orca.orcaPath, "--repo-root", world.repoRoot], { encoding: "utf-8", env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: world.programsRoot }, stdio: "pipe" });
+    } catch (error) {
+      result.status = error.status;
+    }
+    assert.equal(result.status, 64);
+  } finally {
+    world.cleanup();
+  }
+});


### PR DESCRIPTION
## Dispatch Summary

```text
Working tree is clean and the work is committed. Here's the completion summary.

## What shipped (#946 — relay-orca crash-safe `resume` + coordinator-only `stop`)

**Two new top-level scripts** (all I/O lives here; lib stays pure per the frozen `plan.test.js` source-scan):
- `scripts/resume.js` — loads the receipt via shipped receipt-io (codes 50–52 verbatim), runs the **imported #945 reconciliation before any mutation**, then reuses/reacquires/re-dispatches only what is safe through the verifie
```

## Score Log

- Run: issue-946-20260713090040270-04fef6f8
- Executor: claude
- Branch: issue-946


Fixes #946


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 크래시 이후 안전하게 작업을 재개하는 `resume` 명령을 추가했습니다.
  * 코디네이터만 중단하는 `stop` 명령을 추가했습니다.
  * 재개 시 상태를 먼저 확인하고, 검증된 작업만 재사용하거나 재실행합니다.
  * 중단 사유와 시각을 기록하고, 반복 실행에도 결과를 안정적으로 유지합니다.

* **문서**
  * `resume` 및 `stop`의 사용법, 결과 형식, 오류 상황과 복구 절차를 문서화했습니다.
  * 위험하거나 모호한 상태에서는 변경 없이 추가 확인을 요청하도록 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->