### PR TITLE
fix: address reviewer capability preflight feedback

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1010,7 +1010,7 @@ function captureProcessGroupSurvivorInventory(pgid) {
   try {
     // Prefer pgrep -g: group-scoped, avoids full-process-table scans that time out under load.
     try {
-      const pgrepOut = execFileSync("pgrep", ["-g", String(pgid), "."], {
+      const pgrepOut = execFileSync("pgrep", ["-g", String(pgid)], {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "ignore"],
         timeout: 2000,
@@ -1040,25 +1040,6 @@ function captureProcessGroupSurvivorInventory(pgid) {
       if (error && (error.status === 1 || error.code === "ETIMEDOUT" || error.killed)) {
         return [];
       }
-    }
-
-    // Sandboxed macOS hosts can deny pgrep/ps process-list access while still
-    // allowing lsof's group-scoped selector. Keep this fallback best-effort.
-    try {
-      const lsofOut = execFileSync("lsof", ["-nP", "-a", "-g", String(pgid), "-Fpgc"], {
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 2000,
-        maxBuffer: 1024 * 1024,
-      });
-      const entries = [];
-      for (const line of lsofOut.split(/\r?\n/)) {
-        if (line.startsWith("p")) entries.push({ pid: Number(line.slice(1)), command: "" });
-        if (line.startsWith("c") && entries.length) entries.at(-1).command = line.slice(1);
-      }
-      if (entries.length) return entries.filter((entry) => Number.isFinite(entry.pid) && entry.pid > 0);
-    } catch {
-      // Missing/denied lsof falls through to the existing group-scoped ps query.
     }
 
     // Fallback only when pgrep is unavailable (ENOENT): group-scoped ps, never full-table.

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1010,7 +1010,7 @@ function captureProcessGroupSurvivorInventory(pgid) {
   try {
     // Prefer pgrep -g: group-scoped, avoids full-process-table scans that time out under load.
     try {
-      const pgrepOut = execFileSync("pgrep", ["-g", String(pgid)], {
+      const pgrepOut = execFileSync("pgrep", ["-g", String(pgid), "."], {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "ignore"],
         timeout: 2000,
@@ -1040,6 +1040,25 @@ function captureProcessGroupSurvivorInventory(pgid) {
       if (error && (error.status === 1 || error.code === "ETIMEDOUT" || error.killed)) {
         return [];
       }
+    }
+
+    // Sandboxed macOS hosts can deny pgrep/ps process-list access while still
+    // allowing lsof's group-scoped selector. Keep this fallback best-effort.
+    try {
+      const lsofOut = execFileSync("lsof", ["-nP", "-a", "-g", String(pgid), "-Fpgc"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 2000,
+        maxBuffer: 1024 * 1024,
+      });
+      const entries = [];
+      for (const line of lsofOut.split(/\r?\n/)) {
+        if (line.startsWith("p")) entries.push({ pid: Number(line.slice(1)), command: "" });
+        if (line.startsWith("c") && entries.length) entries.at(-1).command = line.slice(1);
+      }
+      if (entries.length) return entries.filter((entry) => Number.isFinite(entry.pid) && entry.pid > 0);
+    } catch {
+      // Missing/denied lsof falls through to the existing group-scoped ps query.
     }
 
     // Fallback only when pgrep is unavailable (ENOENT): group-scoped ps, never full-table.

--- a/skills/relay-dispatch/scripts/relay-config.js
+++ b/skills/relay-dispatch/scripts/relay-config.js
@@ -32,6 +32,7 @@ const {
   resolutionMetadata,
 } = require("./model-resolver");
 const { catalogFreshnessReport } = require("./model-catalog");
+const { ADAPTER_PHASES, listAgentAdapterNames, supportsAgentAdapterPhase } = require("./agent-adapters");
 
 const args = process.argv.slice(2);
 const COMMAND_NAME = "relay-config";
@@ -383,6 +384,31 @@ function listDoctorRunAdvisories(repoRoot, options) {
   }
 }
 
+function isAdvisoryOnlyAdapter(name) {
+  if (!listAgentAdapterNames().includes(name)) return false;
+  return !supportsAgentAdapterPhase(name, ADAPTER_PHASES.PRIMARY_REVIEW)
+    && supportsAgentAdapterPhase(name, ADAPTER_PHASES.ADVISORY_REVIEW);
+}
+
+function primaryReviewerRouteEntries(policy) {
+  const entries = [];
+  if (policy.defaults.review?.reviewer) entries.push({ adapter: policy.defaults.review.reviewer, source: "defaults.review" });
+  for (const [index, route] of policy.allowed_model_routes.entries()) {
+    if (route.phases !== undefined && !route.phases.includes("review")) continue;
+    for (const adapter of route.reviewers || []) entries.push({ adapter, route: route.route, source: `routes[${index}]` });
+  }
+  for (const [name, preset] of Object.entries(policy.presets || {})) {
+    if (preset.review?.reviewer) entries.push({ adapter: preset.review.reviewer, source: `presets.${name}.review` });
+  }
+  return entries;
+}
+
+function listPrimaryReviewerRouteAdvisories(policy) {
+  return primaryReviewerRouteEntries(policy)
+    .filter(({ adapter }) => isAdvisoryOnlyAdapter(adapter))
+    .map((entry) => ({ kind: "advisory_only_primary_reviewer", ...entry }));
+}
+
 function commandDoctor(positionals, jsonOut) {
   if (positionals.length !== 1) {
     throw new Error("doctor does not accept positional arguments");
@@ -407,9 +433,10 @@ function commandDoctor(positionals, jsonOut) {
   const tools = toolNames.map((name) => doctorTool(result.policy, name));
   const projectConfig = loadProjectConfig({ repoRoot: process.cwd() });
   const projectRoutes = loadProjectRoutes({ repoRoot: process.cwd() });
-  const advisories = listDoctorRunAdvisories(process.cwd(), {
-    mutate: hasCliFlag("--reconcile"),
-  });
+  const advisories = [
+    ...listDoctorRunAdvisories(process.cwd(), { mutate: hasCliFlag("--reconcile") }),
+    ...listPrimaryReviewerRouteAdvisories(result.policy),
+  ];
   const output = {
     ok: true,
     status: result.status,
@@ -429,11 +456,15 @@ function commandDoctor(positionals, jsonOut) {
       console.log(`${tool.name}: ${installed}; ${displayToolRouteStatus(tool)} (${tool.reason})`);
     }
     for (const advisory of advisories) {
-      if (advisory.kind !== "dead_dispatched_run") continue;
-      console.log(
-        `advisory: run ${advisory.runId} is dispatched with ${advisory.leaseStatus} lease; ` +
-        `reconcile row ${advisory.reconcile?.row || "unknown"} (${advisory.reconcile?.rowName || "unknown"})`
-      );
+      if (advisory.kind === "dead_dispatched_run") {
+        console.log(
+          `advisory: run ${advisory.runId} is dispatched with ${advisory.leaseStatus} lease; ` +
+          `reconcile row ${advisory.reconcile?.row || "unknown"} (${advisory.reconcile?.rowName || "unknown"})`
+        );
+      }
+      if (advisory.kind === "advisory_only_primary_reviewer") {
+        console.log(`advisory: ${advisory.source} configures advisory-only adapter '${advisory.adapter}' for primary review`);
+      }
     }
   }
 }

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -22,6 +22,7 @@ const { applyVerdictToManifest } = require("./review-runner/manifest-apply");
 const { enforceRoundCap } = require("./review-runner/round-cap");
 const { passNextActionsFor, writeRoundArtifacts } = require("./review-runner/round-artifacts");
 const { maybeBlockForBehindBasePreflight, maybeBlockForExecutionEvidencePreflight } = require("./review-runner/preflight");
+const { preflightResolvedPrimaryReviewer } = require("./review-runner/entry-preflight");
 const { buildPrimaryReviewerPreflight, loadReviewText, loadRunRoutePlan, resolveReviewerName, resolveReviewerScript } = require("./review-runner/reviewer-invoke");
 const { maybeSwapReviewer } = require("./review-runner/reviewer-swap");
 const { appendAdvisoryRunsForTrigger, resolveAdvisoryConfig } = require("./review-runner/advisory-orchestration");
@@ -393,6 +394,6 @@ async function run() {
 }
 
 if (require.main === module) {
-  dispatchReviewEntry({ options, args, entryPath: __filename, jsonOut: cliArgs.hasFlag("--json"), run, printFailureAndExit });
+  dispatchReviewEntry({ options, args, entryPath: __filename, jsonOut: cliArgs.hasFlag("--json"), preflight: () => { assertKnownReviewRunnerFlags(args); preflightResolvedPrimaryReviewer(options); }, run, printFailureAndExit });
 }
 module.exports = { applyVerdictToManifest, buildCommentBody, buildPrompt, buildRedispatchPrompt, buildReviewRunnerRubricGateFailure, detectChurnGrowth, formatIssueList, formatPriorVerdictSummary, formatScopeDrift, getGhLogin, loadRubricFromRunDir, parseRemoteHost, parseReviewVerdict, parseScoreLog, resolveIssueNumber, resolveRemoteHost, validateReviewVerdict, validateScopeDrift };

--- a/skills/relay-review/scripts/review-runner/detach.js
+++ b/skills/relay-review/scripts/review-runner/detach.js
@@ -237,7 +237,13 @@ async function launchDetachedReviewAndExit({ entryPath, args, options, jsonOut }
 // Module entry dispatcher. Parent side of --detach (no receipt env yet) launches a
 // detached supervisor and exits; otherwise (foreground or the detached child) run()
 // executes and, when a supervisor is active, writes the completion sentinel on settle.
-function dispatchReviewEntry({ options, args, entryPath, jsonOut, run, printFailureAndExit }) {
+function dispatchReviewEntry({ options, args, entryPath, jsonOut, preflight, run, printFailureAndExit }) {
+  try {
+    if (!process.env[DETACH_RECEIPT_ENV]) preflight?.();
+  } catch (error) {
+    printFailureAndExit(error, { jsonOut });
+    return;
+  }
   if (options.detach && !process.env[DETACH_RECEIPT_ENV]) {
     launchDetachedReviewAndExit({ entryPath, args, options, jsonOut }).catch((error) => {
       printFailureAndExit(error, { jsonOut });

--- a/skills/relay-review/scripts/review-runner/entry-preflight.js
+++ b/skills/relay-review/scripts/review-runner/entry-preflight.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const { resolveContext } = require("./context");
+const {
+  loadRunRoutePlan, preflightPrimaryReviewerCapability, resolveReviewerName,
+} = require("./reviewer-invoke");
+
+function preflightResolvedPrimaryReviewer(options) {
+  if (options.reviewFile || options.reviewerScriptArg) return;
+  const {
+    branchArg, doneCriteriaFile, manifestPathArg, prArg, repoArg, repoPath, reviewerArg, runIdArg,
+  } = options;
+  const context = resolveContext(repoPath, repoArg, manifestPathArg, runIdArg, branchArg, prArg, doneCriteriaFile);
+  const { data } = context.manifest;
+  const routePlan = loadRunRoutePlan(context.runRepoPath, data.run_id).plan;
+  preflightPrimaryReviewerCapability(resolveReviewerName(data, reviewerArg, { routePlan }));
+}
+
+module.exports = { preflightResolvedPrimaryReviewer };

--- a/skills/relay-review/scripts/review-runner/reviewer-invoke.js
+++ b/skills/relay-review/scripts/review-runner/reviewer-invoke.js
@@ -62,6 +62,11 @@ function supportedAdapterPhases(reviewerName) {
     .filter((phase) => supportsAgentAdapterPhase(reviewerName, phase));
 }
 
+function adaptersSupportingPhase(phase) {
+  return listAgentAdapterNames()
+    .filter((name) => supportsAgentAdapterPhase(name, phase));
+}
+
 function formatUnsupportedReviewerPhaseError(reviewerName, phase) {
   const supported = supportedAdapterPhases(reviewerName);
   if (
@@ -71,7 +76,7 @@ function formatUnsupportedReviewerPhaseError(reviewerName, phase) {
     return (
       `Reviewer adapter '${reviewerName}' supports advisory_review but not primary_review; ` +
       `use --advisory-reviewer ${reviewerName} instead of --reviewer ${reviewerName} until primary review support is implemented. ` +
-      "Use --reviewer-script for an operator override."
+      `Use --reviewer-script for an operator override. Primary-review-capable adapters: ${adaptersSupportingPhase(phase).join(", ")}.`
     );
   }
   if (
@@ -87,6 +92,21 @@ function formatUnsupportedReviewerPhaseError(reviewerName, phase) {
     `Reviewer adapter '${reviewerName}' does not support ${phase}. ` +
     `Supported phases: ${supported.join(", ") || "(none)"}. Use --reviewer-script for an operator override.`
   );
+}
+
+function preflightPrimaryReviewerCapability(reviewerName) {
+  if (!listAgentAdapterNames().includes(reviewerName)) return;
+  if (supportsAgentAdapterPhase(reviewerName, ADAPTER_PHASES.PRIMARY_REVIEW)) return;
+  const message = formatUnsupportedReviewerPhaseError(reviewerName, ADAPTER_PHASES.PRIMARY_REVIEW);
+  throw new AdapterCapabilityError({
+    adapter: reviewerName,
+    phase: ADAPTER_PHASES.PRIMARY_REVIEW,
+    requested: { phase: ADAPTER_PHASES.PRIMARY_REVIEW },
+    safe: false,
+    supported_phases: supportedAdapterPhases(reviewerName),
+    fail_closed_reasons: [message],
+    warnings: [],
+  }, message);
 }
 
 function resolveReviewerScript(reviewerName, reviewerScriptArg, { phase = ADAPTER_PHASES.PRIMARY_REVIEW } = {}) {
@@ -414,6 +434,7 @@ module.exports = {
   buildPrimaryReviewerPolicy,
   buildPrimaryReviewerPreflight,
   buildReviewerPolicy,
+  preflightPrimaryReviewerCapability,
   resolveReviewerName,
   resolveReviewerModel,
   resolveReviewerScript,

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -51,6 +51,10 @@ function readRoutes(relayHome) {
   return JSON.parse(fs.readFileSync(path.join(relayHome, "routes.json"), "utf-8"));
 }
 
+function writeRoutes(relayHome, routes) {
+  fs.writeFileSync(path.join(relayHome, "routes.json"), `${JSON.stringify(routes, null, 2)}\n`, "utf-8");
+}
+
 function writeFakeOpencode(binDir, models = []) {
   const opencodePath = path.join(binDir, "opencode");
   fs.writeFileSync(opencodePath, `#!/bin/sh
@@ -170,6 +174,43 @@ test("catalog-report passes through wrapper", () => {
   assert.equal(output.ok, true);
   assert.ok(output.catalog.summary.total > 0);
   assert.equal(output.catalog.summary.total, output.catalog.entries.length);
+});
+
+test("doctor warns when a review route names an advisory-only adapter", () => {
+  const relayHome = tempDir();
+  writeRoutes(relayHome, {
+    version: 2,
+    routes: [{ route: "cline-pass/*", phases: ["review"], reviewers: ["cline"] }],
+  });
+
+  const jsonResult = runConfig(["doctor", "--json"], { relayHome });
+  assert.equal(jsonResult.status, 0, jsonResult.combined);
+  const advisory = parseJson(jsonResult).advisories.find((entry) => entry.kind === "advisory_only_primary_reviewer");
+  assert.deepEqual(advisory, {
+    kind: "advisory_only_primary_reviewer",
+    adapter: "cline",
+    route: "cline-pass/*",
+    source: "routes[0]",
+  });
+
+  const humanResult = runConfig(["doctor"], { relayHome });
+  assert.equal(humanResult.status, 0, humanResult.combined);
+  assert.match(humanResult.stdout, /advisory: routes\[0\] configures advisory-only adapter 'cline' for primary review/);
+});
+
+test("doctor stays quiet when primary-review routes use capable adapters", () => {
+  const relayHome = tempDir();
+  writeRoutes(relayHome, {
+    version: 2,
+    routes: [{ route: "openai/*", phases: ["review"], reviewers: ["codex"] }],
+  });
+
+  const result = runConfig(["doctor", "--json"], { relayHome });
+  assert.equal(result.status, 0, result.combined);
+  assert.equal(
+    parseJson(result).advisories.some((entry) => entry.kind === "advisory_only_primary_reviewer"),
+    false
+  );
 });
 
 test("preset add resolves compact actor short-model and stores explicit route provenance", () => {

--- a/tests/relay-review/scripts/review-runner-capability-preflight.test.js
+++ b/tests/relay-review/scripts/review-runner-capability-preflight.test.js
@@ -6,7 +6,7 @@ const os = require("os");
 const path = require("path");
 
 const {
-  STATES, createManifestSkeleton, ensureRunLayout, updateManifestState, writeManifest,
+  STATES, createManifestSkeleton, ensureRunLayout, readManifest, updateManifestState, writeManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
 const { createEnforcementFixture, DEFAULT_ENFORCEMENT_RUBRIC } = require("../../relay-dispatch/scripts/test-support");
 
@@ -35,6 +35,8 @@ function setupRun() {
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
   manifest.anchor = createEnforcementFixture({ repoRoot, runId, state: "loaded", rubricContent: DEFAULT_ENFORCEMENT_RUBRIC }).anchor;
   manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  manifest.review.last_reviewer = "codex";
+  manifest = updateManifestState(manifest, STATES.ESCALATED, "inspect_review_failure");
   writeManifest(manifestPath, manifest);
   if (priorHome === undefined) delete process.env.RELAY_HOME; else process.env.RELAY_HOME = priorHome;
   const doneCriteriaPath = path.join(repoRoot, "done.md");
@@ -63,9 +65,18 @@ function roundArtifacts(runDir) {
   return fs.readdirSync(runDir).filter((name) => name.startsWith("review-round-"));
 }
 
+function readEvents(eventsPath) {
+  if (!fs.existsSync(eventsPath)) return [];
+  return fs.readFileSync(eventsPath, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
 test("entry preflight rejects before swap, events, artifacts, or checks wait", () => {
   const fixture = setupRun();
   const before = fs.readFileSync(fixture.manifestPath);
+  const beforeData = readManifest(fixture.manifestPath).data;
+  assert.equal(beforeData.state, STATES.ESCALATED);
+  assert.equal(beforeData.review.last_reviewer, "codex");
+  assert.equal(beforeData.review.reviewer_swap_count, 0);
   const eventsPath = path.join(fixture.runDir, "events.jsonl");
   const eventsBefore = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath) : null;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-capability-gh-"));
@@ -83,6 +94,7 @@ test("entry preflight rejects before swap, events, artifacts, or checks wait", (
   assert.equal(fs.existsSync(ghMarker), false, "CI checks were never queried");
   assert.deepEqual(roundArtifacts(fixture.runDir), []);
   assert.deepEqual(fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath) : null, eventsBefore);
+  assert.equal(readEvents(eventsPath).some((event) => event.event === "reviewer_swap"), false);
 });
 
 test("detach parent rejects without receipt, lease, supervisor, or round artifacts", () => {

--- a/tests/relay-review/scripts/review-runner-capability-preflight.test.js
+++ b/tests/relay-review/scripts/review-runner-capability-preflight.test.js
@@ -88,12 +88,15 @@ test("entry preflight rejects before swap, events, artifacts, or checks wait", (
 test("detach parent rejects without receipt, lease, supervisor, or round artifacts", () => {
   const fixture = setupRun();
   const before = fs.readFileSync(fixture.manifestPath);
-  const result = run(fixture, ["--detach"]);
+  const detachTmp = fs.mkdtempSync(path.join(os.tmpdir(), "relay-capability-detach-tmp-"));
+  const result = run(fixture, ["--detach"], { TMPDIR: detachTmp });
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /supports advisory_review but not primary_review/);
   assert.doesNotMatch(result.stdout, /detached|receipt|sentinel|lease/i);
   assert.equal(fs.existsSync(path.join(fixture.runDir, "lease.json")), false);
+  const detachDirs = fs.readdirSync(detachTmp).filter((name) => name.startsWith("relay-review-detach-"));
+  assert.deepEqual(detachDirs, [], "no supervisor receipt directory or receipt.json artifact is created");
   assert.deepEqual(roundArtifacts(fixture.runDir), []);
   assert.deepEqual(fs.readFileSync(fixture.manifestPath), before);
 });

--- a/tests/relay-review/scripts/review-runner-capability-preflight.test.js
+++ b/tests/relay-review/scripts/review-runner-capability-preflight.test.js
@@ -1,0 +1,114 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES, createManifestSkeleton, ensureRunLayout, updateManifestState, writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { createEnforcementFixture, DEFAULT_ENFORCEMENT_RUBRIC } = require("../../relay-dispatch/scripts/test-support");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "review-runner.js");
+
+function setupRun() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-capability-preflight-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Test"], { cwd: repoRoot });
+  execFileSync("git", ["config", "user.email", "relay@example.com"], { cwd: repoRoot });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+  const runId = "issue-910-20260713010515947";
+  const worktreePath = path.join(repoRoot, "wt", "issue-910");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", `issue-910-${Date.now()}`], { cwd: repoRoot, stdio: "pipe" });
+  const priorHome = process.env.RELAY_HOME;
+  process.env.RELAY_HOME = relayHome;
+  const { manifestPath, runDir } = ensureRunLayout(repoRoot, runId);
+  let manifest = createManifestSkeleton({
+    repoRoot, runId, branch: "issue-910", baseBranch: "main", issueNumber: 910,
+    worktreePath, orchestrator: "codex", executor: "codex", reviewer: "codex",
+  });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+  manifest.anchor = createEnforcementFixture({ repoRoot, runId, state: "loaded", rubricContent: DEFAULT_ENFORCEMENT_RUBRIC }).anchor;
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+  writeManifest(manifestPath, manifest);
+  if (priorHome === undefined) delete process.env.RELAY_HOME; else process.env.RELAY_HOME = priorHome;
+  const doneCriteriaPath = path.join(repoRoot, "done.md");
+  const diffPath = path.join(repoRoot, "change.diff");
+  fs.writeFileSync(doneCriteriaPath, "# Done\n");
+  fs.writeFileSync(diffPath, "diff --git a/a b/a\n");
+  return { repoRoot, relayHome, runId, runDir, manifestPath, doneCriteriaPath, diffPath };
+}
+
+function baseArgs(fixture) {
+  return [
+    SCRIPT, "--repo", fixture.repoRoot, "--run-id", fixture.runId,
+    "--pr", "123",
+    "--done-criteria-file", fixture.doneCriteriaPath, "--diff-file", fixture.diffPath,
+    "--reviewer", "cline", "--no-comment", "--json",
+  ];
+}
+
+function run(fixture, extra = [], env = {}) {
+  return spawnSync(process.execPath, [...baseArgs(fixture), ...extra], {
+    encoding: "utf-8", env: { ...process.env, RELAY_HOME: fixture.relayHome, ...env },
+  });
+}
+
+function roundArtifacts(runDir) {
+  return fs.readdirSync(runDir).filter((name) => name.startsWith("review-round-"));
+}
+
+test("entry preflight rejects before swap, events, artifacts, or checks wait", () => {
+  const fixture = setupRun();
+  const before = fs.readFileSync(fixture.manifestPath);
+  const eventsPath = path.join(fixture.runDir, "events.jsonl");
+  const eventsBefore = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath) : null;
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-capability-gh-"));
+  const ghMarker = path.join(binDir, "gh-called");
+  const gh = path.join(binDir, "gh");
+  fs.writeFileSync(gh, `#!/bin/sh\ntouch ${JSON.stringify(ghMarker)}\nexit 1\n`);
+  fs.chmodSync(gh, 0o755);
+
+  const result = run(fixture, ["--wait-for-checks", "30"], { PATH: `${binDir}${path.delimiter}${process.env.PATH}` });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /supports advisory_review but not primary_review/);
+  assert.match(result.stderr, /Primary-review-capable adapters:/);
+  assert.deepEqual(fs.readFileSync(fixture.manifestPath), before, "manifest remains byte-identical");
+  assert.equal(fs.existsSync(ghMarker), false, "CI checks were never queried");
+  assert.deepEqual(roundArtifacts(fixture.runDir), []);
+  assert.deepEqual(fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath) : null, eventsBefore);
+});
+
+test("detach parent rejects without receipt, lease, supervisor, or round artifacts", () => {
+  const fixture = setupRun();
+  const before = fs.readFileSync(fixture.manifestPath);
+  const result = run(fixture, ["--detach"]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /supports advisory_review but not primary_review/);
+  assert.doesNotMatch(result.stdout, /detached|receipt|sentinel|lease/i);
+  assert.equal(fs.existsSync(path.join(fixture.runDir, "lease.json")), false);
+  assert.deepEqual(roundArtifacts(fixture.runDir), []);
+  assert.deepEqual(fs.readFileSync(fixture.manifestPath), before);
+});
+
+test("review-file and reviewer-script overrides bypass capability preflight", () => {
+  const reviewFileFixture = setupRun();
+  const reviewFile = path.join(reviewFileFixture.repoRoot, "verdict.json");
+  fs.writeFileSync(reviewFile, "{}\n");
+  const fromFile = run(reviewFileFixture, ["--review-file", reviewFile, "--prepare-only"]);
+  assert.equal(fromFile.status, 0, `${fromFile.stderr}\n${fromFile.stdout}`);
+
+  const scriptFixture = setupRun();
+  const reviewerScript = path.join(scriptFixture.repoRoot, "reviewer.js");
+  fs.writeFileSync(reviewerScript, "#!/usr/bin/env node\n", "utf-8");
+  fs.chmodSync(reviewerScript, 0o755);
+  const fromScript = run(scriptFixture, ["--reviewer-script", reviewerScript, "--prepare-only"]);
+  assert.equal(fromScript.status, 0, `${fromScript.stderr}\n${fromScript.stdout}`);
+});

--- a/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
+++ b/tests/relay-review/scripts/review-runner-reviewer-invoke.test.js
@@ -9,12 +9,13 @@ const { STATES, updateManifestState } = require("../../../skills/relay-dispatch/
 const { ensureRunLayout, getEventsPath } = require("../../../skills/relay-dispatch/scripts/manifest/paths");
 const { createManifestSkeleton, readManifest, writeManifest } = require("../../../skills/relay-dispatch/scripts/manifest/store");
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
-const { ADAPTER_PHASES } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
+const { ADAPTER_PHASES, listAgentAdapterNames, supportsAgentAdapterPhase } = require("../../../skills/relay-dispatch/scripts/agent-adapters");
 const {
   buildPrimaryReviewerPolicy,
   captureGitStatus,
   loadRunRoutePlan,
   loadReviewText,
+  preflightPrimaryReviewerCapability,
   resolveReviewerName,
   resolveReviewerScript,
 } = require("../../../skills/relay-review/scripts/review-runner/reviewer-invoke");
@@ -171,6 +172,18 @@ test("reviewer-invoke/resolveReviewerScript resolves built-in adapters and rejec
     /supports advisory_review but not primary_review/
   );
   assert.throws(() => resolveReviewerScript("../bad"), /Invalid reviewer name/);
+});
+
+test("reviewer-invoke primary capability error lists every capable registered adapter", () => {
+  const capable = listAgentAdapterNames()
+    .filter((name) => supportsAgentAdapterPhase(name, ADAPTER_PHASES.PRIMARY_REVIEW));
+  assert.throws(() => preflightPrimaryReviewerCapability("cline"), (error) => {
+    assert.match(error.message, /supports advisory_review but not primary_review/);
+    assert.match(error.message, /--advisory-reviewer cline/);
+    assert.match(error.message, /--reviewer-script for an operator override/);
+    assert.match(error.message, new RegExp(`Primary-review-capable adapters: ${capable.join(", ")}\\.`));
+    return true;
+  });
 });
 
 test("reviewer-invoke/resolveReviewerScript allows parity adapters for advisory review", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed both requested fixes:

- Reverted unrelated `pgrep`/`lsof` process-inventory changes.
- Added explicit filesystem verification that no detach receipt directory or `receipt.json` is created.

Commit: `0beb307`

Tests:

- Focused preflight tests: 3/3 passed.
- Full serialized suites: 1,674 passed; 4 unrelated process-group tests failed due the explicitly requested inventory revert.

Push could not complete because the environment cannot resolve `github.com`, and the GitHu
```

## Score Log

- Run: issue-910-20260713010515947-341269ae
- Executor: codex
- Branch: issue-910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 설정 진단에서 기본 리뷰어가 주 리뷰를 지원하지 않고 자문 리뷰만 지원하는 경우, advisory-only 경고를 표시합니다.
  - 리뷰 실행 전에 선택된 기본 리뷰어의 주 리뷰 지원 여부를 확인합니다.

- **버그 수정**
  - 지원되지 않는 리뷰어 설정을 실행 전에 명확한 오류로 안내하며, 실행 결과나 매니페스트가 변경되지 않도록 개선했습니다.
  - 사전 검사 실패 시 분리 실행에서도 불필요한 산출물이 생성되지 않습니다.

- **개선**
  - 별도 리뷰 파일이나 리뷰어 스크립트를 사용하는 준비 작업은 기존처럼 진행할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->