### PR TITLE
relay-orca #947: integration gates, follow-up waves, evidence-backed completion

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -43,7 +43,7 @@ relay-orca exposes exactly five intents. All five — `plan` (read-only), `run` 
 | --- | --- | --- |
 | `plan` | implemented (read-only) | Compile an accepted program into an immutable wave plan. |
 | `run` | implemented (#944) | Dispatch provenance-injected relay/fleet operators for a plan. |
-| `status` | implemented (#945) | Derive a read-only live program view from receipt + relay + GitHub + Orca. |
+| `status` | implemented (#945; #947 modes) | Derive a read-only live program view from receipt + relay + GitHub + Orca. Read-only `--gates` / `--final-summary` modes evaluate exit gates and declare evidence-backed completion (#947). |
 | `resume` | implemented (#946) | Reconcile-first, idempotent resumption from the receipt; fail closed on unsafe state, never reset Orca. |
 | `stop` | implemented (#946) | Stop the coordinator only; never kill relay runs or discard durable state. |
 
@@ -104,6 +104,17 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
 ```
 
 `status` reconciles durable truth (relay manifests, PRs/issues) against Orca runtime signals — `worker_done` is never completion evidence. Report shape, the state taxonomy, the nine detector codes, and reason codes 50–52: [references/commands.md](references/commands.md) and [references/receipt-and-status.md](references/receipt-and-status.md).
+
+Evaluate the program's exit gates and declare evidence-backed completion — both READ-ONLY `status` modes (still exactly five intents; no new intent):
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
+  --program-id epic-941 --gates --program-file /tmp/accepted-program.json --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
+  --program-id epic-941 --final-summary --program-file /tmp/accepted-program.json --json
+```
+
+Exit gates come ONLY from the program's `exit_gates`; a failing integration gate is never masked by task completion; follow-up proposals are advisory (accepted by the operator as a new later wave). Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization records, the completion rule, stop conditions, and fail-closed codes 70–72: [references/gates-and-completion.md](references/gates-and-completion.md).
 
 Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fail closed on ambiguity):
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -108,7 +108,15 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
 | `--concurrency N` | Override the concurrency ceiling. Default 2, hard maximum 4 (rejected via the plan library). |
 | `--operator-handle <handle>` | Repeatable. An explicit operator terminal handle to dispatch to. With none, `run` creates its own terminals via `orca terminal create` and records them. |
 | `--orca-bin <path>` | Explicit Orca CLI override — passed to the capability probe and used for all orchestration calls. |
+| `--resolve-decision <id>` | (#947) Write a resolved `decision:` record for `<id>` into the receipt's `decisions[]`. Requires `--resolution` and `--resolver`; provenance (question/options/downstream_wave) is sourced from the program's declared `decision_gates[<id>]`. Never automatic. |
+| `--resolution <text>` | The decision resolution (with `--resolve-decision`). |
+| `--resolver <handle>` | Who resolved the decision (with `--resolve-decision`). |
+| `--record-authorization <id>` | (#947) Write an `authorization:` record for `<id>` into the receipt's `authorizations[]`. Requires `--authorizer`. Never automatic. |
+| `--authorizer <handle>` | Who authorized (with `--record-authorization`). |
 | `--help`, `-h` | Print usage. |
+
+The #947 record flags are additive: without them the receipt is byte-identical to a
+pre-#947 run. See [gates-and-completion.md](gates-and-completion.md).
 
 `run` compiles the program through the FROZEN plan library, then requires capability
 admission from the FROZEN #942 probe **before any mutation**. Only after admission does it
@@ -198,6 +206,43 @@ Usage errors exit `64`. A successfully derived view exits `0` even when it is fu
 `inconsistent`/`stale_missing` outcomes; runtime mismatch and unreachable Orca/GitHub degrade
 to diagnostics rather than failing.
 
+### Gate + completion modes (`--gates` / `--final-summary`, #947)
+
+Two additional READ-ONLY `status` modes (no new intent) evaluate the program's exit gates
+and declare evidence-backed completion:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
+  --program-id <program-id> --gates --program-file <accepted-program.json> \
+  [--gate-evidence-dir <dir>] [--record-proposals] [--strict] --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
+  --program-id <program-id> --final-summary --program-file <accepted-program.json> \
+  [--gate-evidence-dir <dir>] [--strict] --json
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--gates` | Evaluate the program's exit gates (read-only). Mutually exclusive with `--final-summary`. |
+| `--final-summary` | Declare evidence-backed program completion (read-only). |
+| `--program-file <path>` | The accepted program — the ONLY source of `exit_gates` (required by both modes; its `id` must match the receipt). |
+| `--gate-evidence-dir <dir>` | Directory of live `integration:` evidence artifacts (`<check>.json` → `{ "passed": bool }`); also env `RELAY_ORCA_GATE_EVIDENCE_ROOT`. |
+| `--record-proposals` | (`--gates` only) Append discovered follow-up proposals to the receipt's `follow_ups`. WITHOUT it, both modes are strictly read-only. |
+| `--strict` | Turn the fail-closed conditions below into non-zero exits. Without it, both modes exit `0` with the truthful report. |
+
+`--gates --json` keys (verbatim): `ok`, `program_id`, `receipt_path`, `prerequisites_met`,
+`gates`, `follow_ups`, `blocking_reasons`. `--final-summary --json` keys (verbatim): `ok`,
+`program_id`, `receipt_path`, `program_complete`, `stopped_on`, `outcomes`, `gates`,
+`follow_ups`, `deferred`, `decisions`, `blocking_reasons`.
+
+| reason_code | exit | Trigger (only under `--strict`) |
+| --- | --- | --- |
+| `GATES_NOT_EVALUABLE` | 70 | `--gates`/`--final-summary` before prerequisites reconcile. |
+| `GATE_FAILED` | 71 | Any exit gate failed. |
+| `COMPLETION_BLOCKED` | 72 | `--final-summary` and `program_complete` is false. |
+
+Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization records,
+the completion rule, and the stop-condition table: [gates-and-completion.md](gates-and-completion.md).
+
 ## `resume` — crash-safe, reconcile-first, idempotent resumption
 
 ```bash
@@ -214,6 +259,9 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
 | `--orca-bin <path>` | Explicit Orca CLI override for the reconciliation reads and the restoration mutations. |
 | `--gh-bin <path>` | Explicit `gh` CLI override (or env `RELAY_ORCA_GH_BIN`). |
 | `--repo-root <path>` | Explicit repo root for slug derivation (defaults to the git repo of the cwd). |
+| `--resolve-decision <id>` / `--resolution` / `--resolver` | (#947) Write a resolved `decision:` record up front (before reconciliation), so it persists regardless of the resume verdict. Same semantics as on `run`. |
+| `--record-authorization <id>` / `--authorizer` | (#947) Write an `authorization:` record up front. |
+| `--program-file <path>` | (#947) OPTIONAL — sources the decision-gate provenance (question/options/downstream_wave) when resolving a decision from resume. |
 | `--help`, `-h` | Print usage. |
 
 `resume` loads the reconstructible receipt (fail-closed codes 50–52 verbatim), then runs the

--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -1,0 +1,151 @@
+# Exit gates, follow-up waves, and evidence-backed completion (#947)
+
+Two READ-ONLY `status` modes layer program-level assurance on the #945 reconciliation.
+`status --gates` evaluates the accepted program's exit gates; `status --final-summary`
+declares evidence-backed program completion. Both land INSIDE the existing five intents —
+there is no new intent and no new top-level entry point. Follow-up acceptance flows through
+the existing `plan`/`run` on an operator-extended program JSON; decision/authorization
+records are additive receipt fields written only via explicit operator flags on
+`run`/`resume`.
+
+## Exit gates are input artifacts
+
+Exit gates come ONLY from the accepted program's `exit_gates` array (already required by
+the frozen plan compiler). `status --gates` evaluates each gate **verbatim** — no code path
+invents, renames, drops, or weakens a gate, and the gates listed in every report are
+byte-equal to the program file's entries. Because the gates are input, `status --gates`
+requires `--program-file <accepted-program.json>`; its program id must match the receipt's
+program id.
+
+## Gate kinds (pinned `kind:` prefix convention)
+
+Each gate is keyed by a pinned, verbatim prefix on the gate string:
+
+| Prefix | Meaning | Evidence source |
+| --- | --- | --- |
+| `integration:<check>` | a named check / evidence artifact must pass **live** | a live evidence artifact under `--gate-evidence-dir` (`<check>.json` → `{ "passed": true/false }`); never task/worker status |
+| `advisory:<ref>` | advisory evidence posted + blocking findings triaged (reuses the #945 advisory contract) | the reconciled `advisory_review` outcomes |
+| `tracker:<ref>` | tracker reconciliation clean for the program's issues | no reopened issue / duplicate-or-lost mapping / unreconciled back-pointer in the reconciliation |
+| `decision:<id>` | an explicit, resolved user decision record exists | the receipt's `decisions[]` (six provenance keys) |
+| `budget:<counter> <= <int>` | a numeric ceiling on a receipt-recorded counter | derived counters (`tasks_created`, `dispatches_performed`, `waves_dispatched`) |
+| `authorization:<id>` | an explicit authorization record exists | the receipt's `authorizations[]` |
+
+A gate string **without a recognized prefix evaluates as `unevaluable`** — NEVER as passed
+(fail closed) — with a diagnostic naming it. A `budget:` ref that does not parse, or names
+an unknown counter, is likewise `unevaluable`.
+
+Gate states (verbatim enum): `passed`, `failed`, `not_yet_evaluable`, `awaiting_decision`,
+`unevaluable`.
+
+## Evaluation ordering and the masking rule
+
+- **Prerequisite (ordering).** Exit gates evaluate ONLY after **every** accepted outcome
+  reconciles `complete_with_evidence` via the #945 classifier. Before that, every gate
+  reports `not_yet_evaluable` with the blocking outcomes listed in `blocking_reasons`.
+- **Masking rule.** A failing integration gate can NEVER be masked by Orca task completion.
+  Gate results derive **exclusively** from live evidence (checks, artifacts, tracker,
+  decision/authorization records, receipt counters) — never from task or `worker_done`
+  status. Even with every Orca task completed and every outcome durably complete, a failing
+  integration gate keeps the program NOT complete and the gate `failed`.
+
+## Decision records preserve full provenance
+
+A `decision:` gate resolves ONLY against a decision record carrying ALL of (verbatim keys):
+`question`, `options` (array), `resolution`, `resolver`, `resolved_at`, `downstream_wave`
+(int|null). Records live in the receipt under `decisions`. `run`/`resume` write a decision
+record ONLY from an explicit operator flag — never automatically:
+
+```bash
+run.js --program-file <program.json> --resolve-decision <id> --resolution "<text>" --resolver "<handle>"
+resume.js --program-id <id> --program-file <program.json> --resolve-decision <id> --resolution "<text>" --resolver "<handle>"
+```
+
+The `question`/`options`/`downstream_wave` provenance is sourced from the program's declared
+`decision_gates[<id>]`; `resolution`/`resolver` come from the flags; `resolved_at` is
+stamped at write time. An unresolved decision gate reports `awaiting_decision` and blocks
+completion. Missing any provenance key → the record is invalid → gate `unevaluable` (fail
+closed), diagnostic naming the missing key.
+
+## Budget and authorization records
+
+- **Budget.** `budget:` gates compare a receipt-recorded counter against the gate's ceiling.
+  Counters are DERIVED from the receipt mapping (a recorded `orca_task_id` = created, a
+  recorded `dispatch_id` = dispatched, distinct dispatched waves = waves dispatched); an
+  explicit `counters` object overrides per counter. Under ceiling → `passed`; at/over →
+  `failed` with BOTH numbers in the message.
+- **Authorization.** `authorization:` gates require an explicit authorization record
+  (`authorizations[]`), written only via `--record-authorization <id> --authorizer <handle>`
+  on `run`/`resume`. Absent → `awaiting_decision`-equivalent state, never passed.
+
+## Follow-up proposals are advisory until accepted
+
+When gate evaluation or reconciliation discovers implementation work, `status` records a
+PROPOSED follow-up: `{ "id", "source_gate" | "source_outcome", "description",
+"proposed_wave": <next wave int>, "status": "proposed" }` in the report.
+
+- Proposals are **ADVISORY**: no code path creates issues, dispatches work, merges, deploys,
+  or closes tracker items from a proposal.
+- **Acceptance is an OPERATOR act outside the skill**: file the tracker issue, append the
+  outcome to the program JSON as a **NEW LATER wave** with a stable new outcome id, and
+  re-run `plan`/`run`. The frozen compiler already rejects same-wave dependencies and cycles
+  and requires prepared fleet leaves, so follow-up waves inherit those protections
+  (`SAME_WAVE_DEPENDENCY`, `UNPREPARED_FLEET_LEAF` re-raise verbatim).
+- A PROPOSED follow-up that targets accepted scope blocks completion; a follow-up recorded
+  with `"status": "deferred"` is listed separately (a `deferred` section) and does not block.
+
+### The `--record-proposals` boundary
+
+Proposals are written to the receipt (under `follow_ups`) ONLY by
+`status --gates --record-proposals` (an explicit flag). Without it, `status --gates` /
+`status --final-summary` stay strictly READ-ONLY — proposals appear in the report only, and
+the receipt is byte-identical. `--record-proposals` is valid only with `--gates`.
+
+## Completion declaration
+
+`status --final-summary` declares `program_complete: true` ONLY when: every accepted outcome
+is `complete_with_evidence` AND every exit gate evaluates `passed` AND no outcome is
+`escalated`/`inconsistent`/`stale_missing`/`awaiting_decision` AND no PROPOSED follow-up
+targets accepted scope. The summary is REPRODUCIBLE from live state — no generated
+timestamps or randomness — and links, per outcome: outcome id, relay run/fleet ids, issue
+URL, PR URL, verification evidence names, decision records touching it, and its final state.
+
+### Stop conditions → `stopped_on`
+
+When completion cannot be declared, the most-severe blocking condition becomes `stopped_on`
+(a single token); `blocking_reasons` lists them all.
+
+| Stop condition | `stopped_on` |
+| --- | --- |
+| tracker/receipt graph ambiguous | `graph_ambiguous` |
+| relay run/fleet escalated / inconsistent | `relay_escalated` |
+| Orca injection/lifecycle failure | `orca_lifecycle_failure` |
+| integration gate failed | `integration_gate_failed` |
+| budget ceiling reached | `budget_ceiling_reached` |
+| advisory/tracker gate failed | `gate_failed` |
+| a gate is unevaluable | `gate_unevaluable` |
+| human decision required (decision/authorization awaiting) | `awaiting_decision` |
+| unaccepted follow-up discovered | `unaccepted_follow_up` |
+| accepted outcomes still incomplete | `outcomes_incomplete` |
+
+## Fail-closed exit codes (70-range)
+
+| reason_code | exit | trigger |
+| --- | --- | --- |
+| `GATES_NOT_EVALUABLE` | 70 | `--gates`/`--final-summary` before prerequisites reconcile, under `--strict` |
+| `GATE_FAILED` | 71 | any exit gate failed, under `--strict` |
+| `COMPLETION_BLOCKED` | 72 | `--final-summary --strict` and `program_complete` is false |
+
+Without `--strict`, these situations exit 0 with the truthful report (information is the
+product, matching `status`'s house rule). Receipt-layer failures reuse 50–52; usage is 64.
+
+## Report surfaces
+
+- `status --gates --json` top-level keys (verbatim): `ok`, `program_id`, `receipt_path`,
+  `prerequisites_met`, `gates`, `follow_ups`, `blocking_reasons`. Each gate:
+  `{ gate, kind, state, evidence, message }`.
+- `status --final-summary --json` top-level keys (verbatim): `ok`, `program_id`,
+  `receipt_path`, `program_complete`, `stopped_on`, `outcomes`, `gates`, `follow_ups`,
+  `deferred`, `decisions`, `blocking_reasons`.
+
+Every excerpt is bounded; neither report generates timestamps or randomness; plain `status`
+(no mode flag) output stays byte-identical to the shipped #945/#946 shape.

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -86,6 +86,29 @@ stop record is coordination metadata — it is **not** a completion or cancellat
 never claims the program or its outcomes are cancelled/complete. `resume` preserves it verbatim
 when it rewrites the receipt.
 
+### Optional additive record fields (#947)
+
+Four more top-level keys MAY be appended — each written ONLY at a pinned write point, each
+**not** part of the canonical `RECEIPT_KEYS`, so a receipt that never carried them serializes
+**byte-identically** to a pre-#947 receipt and still loads for `status`/`resume` (validation
+ignores extra keys):
+
+- `follow_ups` — proposed follow-ups `{ id, source_gate | source_outcome, description,
+  proposed_wave, status }`. Written ONLY by `status --gates --record-proposals` (an explicit
+  flag). Advisory only — never triggers work.
+- `decisions` — decision records carrying the six verbatim provenance keys (`question`,
+  `options`, `resolution`, `resolver`, `resolved_at`, `downstream_wave`). Written ONLY via the
+  `run`/`resume` `--resolve-decision` operator flag — never automatically.
+- `authorizations` — authorization records `{ id, authorizer }`. Written ONLY via the
+  `run`/`resume` `--record-authorization` operator flag.
+- `counters` — OPTIONAL explicit budget counters. When absent, `budget:` gates DERIVE
+  `tasks_created` / `dispatches_performed` / `waves_dispatched` from the receipt mapping
+  itself (a recorded `orca_task_id` = created, a recorded `dispatch_id` = dispatched), so no
+  new write point is required. These are the counters the #944/#946 write points already imply.
+
+`run` carries these forward across its receipt rewrite; the additive fields are coordination
+metadata, not a second lifecycle state machine. See [gates-and-completion.md](gates-and-completion.md).
+
 - **Atomic write:** a temp file in the same directory + `rename`. Partial/torn receipts are
   impossible by construction.
 - **Write points (bounded edit to `run`):** after **each** successful task-create (A12),

--- a/skills/relay-orca/scripts/lib/budget-counters.js
+++ b/skills/relay-orca/scripts/lib/budget-counters.js
@@ -1,0 +1,54 @@
+"use strict";
+
+// Budget counters + `budget:` gate expression parsing (#947 D5). Pure: no I/O.
+//
+// The three counters — tasks_created, dispatches_performed, waves_dispatched — are the
+// ones the #944/#946 write points already imply, so they are DERIVED from the receipt's
+// own identity/mapping (never a second state machine): a recorded orca_task_id means the
+// task was created, a recorded dispatch_id means it was dispatched, and the distinct
+// dispatched waves are the waves dispatched. An explicit receipt `counters` object (if a
+// future write point adds one) takes precedence; otherwise the derived values are used.
+
+const COUNTER_NAMES = Object.freeze(["tasks_created", "dispatches_performed", "waves_dispatched"]);
+
+function deriveCounters(receipt) {
+  const tasks = Array.isArray(receipt && receipt.tasks) ? receipt.tasks : [];
+  const dispatchedWaves = new Set();
+  let created = 0;
+  let dispatched = 0;
+  tasks.forEach((task) => {
+    if (task && task.orca_task_id) created += 1;
+    if (task && task.dispatch_id) {
+      dispatched += 1;
+      dispatchedWaves.add(task.wave);
+    }
+  });
+  return { tasks_created: created, dispatches_performed: dispatched, waves_dispatched: dispatchedWaves.size };
+}
+
+// Effective counters: an explicit receipt.counters value overrides the derived one per
+// counter (integer only), so an operator/future write point can pin a counter without
+// losing the receipt-derived default for the others.
+function effectiveCounters(receipt) {
+  const derived = deriveCounters(receipt);
+  const explicit = receipt && receipt.counters && typeof receipt.counters === "object" ? receipt.counters : {};
+  const out = {};
+  COUNTER_NAMES.forEach((name) => {
+    out[name] = Number.isInteger(explicit[name]) ? explicit[name] : derived[name];
+  });
+  return out;
+}
+
+// Parse a `budget:` gate reference into { counter, ceiling }. Accepted forms (spaces
+// tolerated): `<counter>:<int>`, `<counter><=<int>`, `<counter> <= <int>`,
+// `<counter>=<int>`. The counter name is the leading identifier; the ceiling is the
+// trailing non-negative integer. Returns null when either part is missing/invalid so the
+// evaluator can fail closed (unevaluable) rather than guess a ceiling.
+function parseBudgetRef(ref) {
+  if (typeof ref !== "string") return null;
+  const match = ref.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*(?:<=|:|=)\s*(\d+)$/);
+  if (!match) return null;
+  return { counter: match[1], ceiling: Number(match[2]) };
+}
+
+module.exports = { COUNTER_NAMES, deriveCounters, effectiveCounters, parseBudgetRef };

--- a/skills/relay-orca/scripts/lib/decision-records.js
+++ b/skills/relay-orca/scripts/lib/decision-records.js
@@ -1,0 +1,81 @@
+"use strict";
+
+// Decision + authorization record shaping and validation (#947 D4/D5). Pure: no I/O.
+// The records live in the receipt (additive `decisions` / `authorizations` fields) and
+// are WRITTEN only from an explicit run/resume operator flag — this module only shapes
+// and validates them; the atomic receipt write lives in the top-level scripts.
+
+// The SIX verbatim provenance keys a `decision:` gate resolves against (D4). A record
+// missing ANY of these keys is invalid → the gate is `unevaluable` (fail closed), never
+// passed. `options` must be an array; `downstream_wave` must be an integer OR null.
+const DECISION_KEYS = Object.freeze(["question", "options", "resolution", "resolver", "resolved_at", "downstream_wave"]);
+
+// Validate a decision record's provenance. Returns { valid, missingKey }. The first
+// missing/ill-typed key is named so the diagnostic can point at it (D4). A structurally
+// valid record may still be UNRESOLVED (empty resolution) — that is a separate state the
+// evaluator maps to awaiting_decision, not an invalidity.
+function validateDecisionRecord(record) {
+  if (!record || typeof record !== "object" || Array.isArray(record)) return { valid: false, missingKey: "question" };
+  for (const key of DECISION_KEYS) {
+    if (!(key in record)) return { valid: false, missingKey: key };
+  }
+  if (!Array.isArray(record.options)) return { valid: false, missingKey: "options" };
+  if (!(record.downstream_wave === null || Number.isInteger(record.downstream_wave))) {
+    return { valid: false, missingKey: "downstream_wave" };
+  }
+  if (typeof record.question !== "string" || typeof record.resolution !== "string" || typeof record.resolver !== "string") {
+    return { valid: false, missingKey: typeof record.question !== "string" ? "question" : (typeof record.resolution !== "string" ? "resolution" : "resolver") };
+  }
+  if (typeof record.resolved_at !== "string") return { valid: false, missingKey: "resolved_at" };
+  return { valid: true, missingKey: null };
+}
+
+// A structurally valid record is RESOLVED only when its resolution is a non-empty string.
+function isResolved(record) {
+  const check = validateDecisionRecord(record);
+  return check.valid && record.resolution.trim() !== "";
+}
+
+// Build a full 6-key decision record from an operator flag trio + the program's declared
+// decision-gate definition (which supplies the question/options/downstream_wave
+// provenance) + a caller-supplied resolved_at timestamp. When the program does not
+// declare the gate, the provenance defaults are conservative (empty question/options),
+// which keeps the record structurally valid but auditable. NOT a write — the caller
+// persists it.
+function buildDecisionRecord({ id, resolution, resolver, resolvedAt, gateDef }) {
+  const def = gateDef && typeof gateDef === "object" ? gateDef : {};
+  const question = typeof def.question === "string" ? def.question : (typeof def.description === "string" ? def.description : "");
+  const options = Array.isArray(def.options) ? def.options.slice() : [];
+  const downstreamWave = Number.isInteger(def.downstream_wave) ? def.downstream_wave : null;
+  return {
+    id,
+    question,
+    options,
+    resolution: typeof resolution === "string" ? resolution : "",
+    resolver: typeof resolver === "string" ? resolver : "",
+    resolved_at: typeof resolvedAt === "string" ? resolvedAt : "",
+    downstream_wave: downstreamWave,
+  };
+}
+
+// Build an authorization record (D5). Simpler than a decision: an explicit id plus the
+// authorizing handle. Presence of a matching record is what an `authorization:` gate
+// requires; absence is never a pass.
+function buildAuthorizationRecord({ id, authorizer }) {
+  return { id, authorizer: typeof authorizer === "string" ? authorizer : "" };
+}
+
+// Find a record by id in an additive receipt array (decisions/authorizations).
+function findById(records, id) {
+  if (!Array.isArray(records)) return null;
+  return records.find((record) => record && record.id === id) || null;
+}
+
+module.exports = {
+  DECISION_KEYS,
+  validateDecisionRecord,
+  isResolved,
+  buildDecisionRecord,
+  buildAuthorizationRecord,
+  findById,
+};

--- a/skills/relay-orca/scripts/lib/final-summary.js
+++ b/skills/relay-orca/scripts/lib/final-summary.js
@@ -4,8 +4,9 @@
 // timestamps/randomness — the summary is REPRODUCIBLE from live state (re-running against
 // unchanged live systems yields identical bytes). Given the #945 reconciliation report,
 // the receipt, the evaluated gates, and the merged follow-ups, it declares
-// `program_complete` under the FULL D6 conjunction and maps the reason completion cannot
-// be declared to a single `stopped_on` token.
+// `program_complete` under the FULL D6 conjunction AND an empty detected-stop set — any
+// present stop condition VETOES completion (owner amendment A2) — and maps the reason
+// completion cannot be declared to a single `stopped_on` token.
 const { boundedExcerpt } = require("./bounded-excerpt");
 const { allGatesPassed } = require("./gate-evaluate");
 
@@ -129,10 +130,17 @@ function buildFinalSummary({ programId, receiptPath, report, gateEval, followUps
   const outcomesComplete = outcomes.length > 0 && outcomes.every((outcome) => outcome.state === "complete_with_evidence");
   const gatesPassed = allGatesPassed(gateEval.gates);
   const noBlockingFollowUp = (followUps.blocking || []).length === 0;
-  const programComplete = outcomesComplete && gateEval.prerequisites_met && gatesPassed && noBlockingFollowUp;
 
+  // Owner amendment A2: compute the detected stop set FIRST, then let ANY present stop
+  // condition veto completion. `program_complete` is true ONLY when the full D6 conjunction
+  // holds AND no stop token is present — otherwise a stop like `graph_ambiguous` (an unmapped
+  // back-pointer repair candidate) or `orca_lifecycle_failure` (a runtime mismatch/lifecycle
+  // diagnostic) could be silently masked as complete with a null `stopped_on`. `stopped_on`
+  // is never null while any stop token is present (first per STOP_PRIORITY).
   const present = detectStops({ report, gates: gateEval.gates, followUps, outcomesComplete });
-  const stoppedOn = programComplete ? null : pickStoppedOn(present);
+  const d6Conjunction = outcomesComplete && gateEval.prerequisites_met && gatesPassed && noBlockingFollowUp;
+  const programComplete = d6Conjunction && present.size === 0;
+  const stoppedOn = pickStoppedOn(present);
   const decisionRecords = (Array.isArray(decisions) ? decisions : []).map(boundedDecision);
 
   return {

--- a/skills/relay-orca/scripts/lib/final-summary.js
+++ b/skills/relay-orca/scripts/lib/final-summary.js
@@ -1,0 +1,153 @@
+"use strict";
+
+// Program-level completion declaration (#947 D6). Pure: no I/O, no generated
+// timestamps/randomness — the summary is REPRODUCIBLE from live state (re-running against
+// unchanged live systems yields identical bytes). Given the #945 reconciliation report,
+// the receipt, the evaluated gates, and the merged follow-ups, it declares
+// `program_complete` under the FULL D6 conjunction and maps the reason completion cannot
+// be declared to a single `stopped_on` token.
+const { boundedExcerpt } = require("./bounded-excerpt");
+const { allGatesPassed } = require("./gate-evaluate");
+
+// Priority-ordered stop conditions (D6). The FIRST present condition becomes `stopped_on`
+// (most-severe-first); `blocking_reasons` lists them all. When completion is declared,
+// `stopped_on` is null.
+const STOP_PRIORITY = Object.freeze([
+  "graph_ambiguous",
+  "relay_escalated",
+  "orca_lifecycle_failure",
+  "integration_gate_failed",
+  "budget_ceiling_reached",
+  "gate_failed",
+  "gate_unevaluable",
+  "awaiting_decision",
+  "unaccepted_follow_up",
+  "outcomes_incomplete",
+]);
+
+const LIFECYCLE_DIAGNOSTICS = new Set(["MISSING_TASK", "MISSING_DISPATCH", "MISSING_TERMINAL", "RUNTIME_MISMATCH"]);
+
+function diagnosticCodes(report) {
+  return new Set((report.diagnostics || []).map((diagnostic) => diagnostic.code));
+}
+
+function gatesOfKindFailed(gates, kind) {
+  return gates.some((gate) => gate.kind === kind && gate.state === "failed");
+}
+
+// Detect which stop conditions are present. Each maps to a distinct token (D6).
+function detectStops({ report, gates, followUps, outcomesComplete }) {
+  const outcomes = report.outcomes || [];
+  const codes = diagnosticCodes(report);
+  const present = new Set();
+  if (codes.has("DUPLICATE_MAPPING") || (report.repair_candidates || []).length > 0) present.add("graph_ambiguous");
+  if (outcomes.some((outcome) => outcome.state === "escalated" || outcome.state === "inconsistent")) present.add("relay_escalated");
+  if (report.runtime === "mismatch" || report.runtime === "foreign_state" || [...codes].some((code) => LIFECYCLE_DIAGNOSTICS.has(code))) {
+    present.add("orca_lifecycle_failure");
+  }
+  if (gatesOfKindFailed(gates, "integration")) present.add("integration_gate_failed");
+  if (gatesOfKindFailed(gates, "budget")) present.add("budget_ceiling_reached");
+  if (gates.some((gate) => gate.state === "failed" && gate.kind !== "integration" && gate.kind !== "budget")) present.add("gate_failed");
+  if (gates.some((gate) => gate.state === "unevaluable")) present.add("gate_unevaluable");
+  if (outcomes.some((outcome) => outcome.state === "awaiting_decision") || gates.some((gate) => gate.state === "awaiting_decision")) {
+    present.add("awaiting_decision");
+  }
+  if ((followUps.blocking || []).length > 0) present.add("unaccepted_follow_up");
+  if (!outcomesComplete && present.size === 0) present.add("outcomes_incomplete");
+  return present;
+}
+
+function pickStoppedOn(present) {
+  for (const token of STOP_PRIORITY) {
+    if (present.has(token)) return token;
+  }
+  return null;
+}
+
+function evidenceNames(evidence) {
+  if (!evidence || typeof evidence !== "object") return [];
+  return Object.keys(evidence).filter((key) => evidence[key] === true);
+}
+
+// A decision record "touches" an outcome when its downstream_wave targets that outcome's
+// wave (the wave the decision gates). Deterministic linkage (D6).
+function decisionsTouching(outcome, decisions) {
+  return (Array.isArray(decisions) ? decisions : [])
+    .filter((record) => record && Number.isInteger(record.downstream_wave) && record.downstream_wave === outcome.wave)
+    .map((record) => record.id);
+}
+
+function linkedOutcome(outcome, decisions) {
+  return {
+    outcome_id: outcome.outcome_id,
+    state: outcome.state,
+    wave: outcome.wave,
+    relay_ids: outcome.relay_ids,
+    issue_url: outcome.issue_url ?? null,
+    pr_url: outcome.pr_url ?? null,
+    evidence_names: evidenceNames(outcome.evidence),
+    decisions: decisionsTouching(outcome, decisions),
+  };
+}
+
+// Bound the string fields of a decision record for the report (D8 bounded-excerpt rule).
+// resolved_at is echoed verbatim from the receipt (a stored, stable value — NOT generated
+// here), so reproducibility holds.
+function boundedDecision(record) {
+  return {
+    id: boundedExcerpt(record.id != null ? record.id : ""),
+    question: boundedExcerpt(record.question != null ? record.question : ""),
+    options: (Array.isArray(record.options) ? record.options : []).map((option) => boundedExcerpt(option)),
+    resolution: boundedExcerpt(record.resolution != null ? record.resolution : ""),
+    resolver: boundedExcerpt(record.resolver != null ? record.resolver : ""),
+    resolved_at: boundedExcerpt(record.resolved_at != null ? record.resolved_at : ""),
+    downstream_wave: Number.isInteger(record.downstream_wave) ? record.downstream_wave : null,
+  };
+}
+
+function buildBlockingReasons({ report, gateBlocking, followUps, outcomesComplete }) {
+  const reasons = [];
+  (gateBlocking || []).forEach((reason) => reasons.push({ reason_code: reason.reason_code, message: boundedExcerpt(reason.message) }));
+  (report.outcomes || []).forEach((outcome) => {
+    if (outcome.state !== "complete_with_evidence" && !["running", "stale_missing"].includes(outcome.state)) {
+      reasons.push({ reason_code: `OUTCOME_${outcome.state.toUpperCase()}`, message: boundedExcerpt(`outcome ${outcome.outcome_id} reconciled ${outcome.state}`) });
+    }
+  });
+  (followUps.blocking || []).forEach((followUp) => {
+    reasons.push({ reason_code: "UNACCEPTED_FOLLOW_UP", message: boundedExcerpt(`unaccepted follow-up ${followUp.id} targets accepted scope`) });
+  });
+  if (!outcomesComplete && reasons.length === 0) {
+    reasons.push({ reason_code: "OUTCOMES_INCOMPLETE", message: boundedExcerpt("not every accepted outcome is complete_with_evidence") });
+  }
+  return reasons;
+}
+
+// Assemble the D6/D8 final-summary body (11 keys). `gateEval` is evaluateGates' output;
+// `followUps` is mergeFollowUps' { blocking, deferred }; `decisions` is receipt.decisions.
+function buildFinalSummary({ programId, receiptPath, report, gateEval, followUps, decisions }) {
+  const outcomes = report.outcomes || [];
+  const outcomesComplete = outcomes.length > 0 && outcomes.every((outcome) => outcome.state === "complete_with_evidence");
+  const gatesPassed = allGatesPassed(gateEval.gates);
+  const noBlockingFollowUp = (followUps.blocking || []).length === 0;
+  const programComplete = outcomesComplete && gateEval.prerequisites_met && gatesPassed && noBlockingFollowUp;
+
+  const present = detectStops({ report, gates: gateEval.gates, followUps, outcomesComplete });
+  const stoppedOn = programComplete ? null : pickStoppedOn(present);
+  const decisionRecords = (Array.isArray(decisions) ? decisions : []).map(boundedDecision);
+
+  return {
+    ok: true,
+    program_id: programId,
+    receipt_path: receiptPath,
+    program_complete: programComplete,
+    stopped_on: stoppedOn,
+    outcomes: outcomes.map((outcome) => linkedOutcome(outcome, decisions)),
+    gates: gateEval.gates,
+    follow_ups: followUps.blocking || [],
+    deferred: followUps.deferred || [],
+    decisions: decisionRecords,
+    blocking_reasons: buildBlockingReasons({ report, gateBlocking: gateEval.blocking_reasons, followUps, outcomesComplete }),
+  };
+}
+
+module.exports = { STOP_PRIORITY, detectStops, pickStoppedOn, linkedOutcome, buildFinalSummary };

--- a/skills/relay-orca/scripts/lib/follow-ups.js
+++ b/skills/relay-orca/scripts/lib/follow-ups.js
@@ -101,4 +101,21 @@ function proposalFrom(entry, status) {
   return out;
 }
 
-module.exports = { proposal, deriveProposals, mergeFollowUps, nextWave, sanitizeId };
+// Additive id-keyed upsert for the `--record-proposals` receipt append (#947 owner
+// amendment A1). The recorded follow_ups already on the receipt are preserved BYTE-FOR-BYTE
+// (same object references, untouched) and WIN on id conflict — so an operator-set `deferred`
+// row is never overwritten by a freshly-derived `proposed` one. Only derived proposals whose
+// id is not already recorded are appended, in derivation order, after the recorded block.
+// Pure: no I/O, no mutation of either input array or its entries.
+function upsertRecordedFollowUps({ recorded, derived }) {
+  const existing = Array.isArray(recorded) ? recorded : [];
+  const recordedIds = new Set(
+    existing.filter((entry) => entry && typeof entry.id === "string").map((entry) => entry.id),
+  );
+  const appended = (Array.isArray(derived) ? derived : []).filter(
+    (entry) => entry && typeof entry.id === "string" && !recordedIds.has(entry.id),
+  );
+  return [...existing, ...appended];
+}
+
+module.exports = { proposal, deriveProposals, mergeFollowUps, upsertRecordedFollowUps, nextWave, sanitizeId };

--- a/skills/relay-orca/scripts/lib/follow-ups.js
+++ b/skills/relay-orca/scripts/lib/follow-ups.js
@@ -1,0 +1,104 @@
+"use strict";
+
+// Follow-up PROPOSAL derivation (#947 D3). Pure: no I/O. A follow-up is ADVISORY: this
+// module only shapes proposals for the report (and, ONLY under an explicit
+// `--record-proposals` flag, for the receipt append performed by the top-level script).
+// No code path here creates issues, dispatches work, merges, deploys, or mutates a
+// tracker — acceptance is an OPERATOR act (file the issue, append a NEW LATER-wave
+// outcome to the program JSON, re-run plan/run).
+const { boundedExcerpt } = require("./bounded-excerpt");
+
+// The verbatim proposed-follow-up entry shape (D3). Exactly one source key.
+function proposal({ id, sourceGate, sourceOutcome, description, proposedWave }) {
+  const entry = { id };
+  if (sourceGate != null) entry.source_gate = sourceGate;
+  else entry.source_outcome = sourceOutcome != null ? sourceOutcome : null;
+  entry.description = boundedExcerpt(description);
+  entry.proposed_wave = proposedWave;
+  entry.status = "proposed";
+  return entry;
+}
+
+function sanitizeId(source) {
+  return String(source)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "source";
+}
+
+// The next wave int = one past the highest wave recorded in the receipt mapping (D3).
+function nextWave(receipt) {
+  const tasks = Array.isArray(receipt && receipt.tasks) ? receipt.tasks : [];
+  const maxWave = tasks.reduce((max, task) => (Number.isInteger(task.wave) && task.wave > max ? task.wave : max), 0);
+  return maxWave + 1;
+}
+
+// Derive proposals from evaluated gates + reconciliation. A failing/unevaluable EXIT gate
+// implies remediation work; an escalated/inconsistent/stale outcome discovered before the
+// prerequisites reconcile is discovered implementation work. Each becomes one proposal.
+function deriveProposals({ report, gates, receipt }) {
+  const wave = nextWave(receipt);
+  const proposals = [];
+  (gates || []).forEach((gate) => {
+    if (gate.state === "failed" || gate.state === "unevaluable") {
+      proposals.push(
+        proposal({
+          id: `followup-${sanitizeId(gate.gate)}`,
+          sourceGate: gate.gate,
+          description: `Exit gate "${gate.gate}" is ${gate.state}; file remediation work as a new later-wave outcome`,
+          proposedWave: wave,
+        }),
+      );
+    }
+  });
+  (report.outcomes || []).forEach((outcome) => {
+    if (outcome.state === "escalated" || outcome.state === "inconsistent" || outcome.state === "stale_missing") {
+      proposals.push(
+        proposal({
+          id: `followup-${sanitizeId(outcome.outcome_id)}`,
+          sourceOutcome: outcome.outcome_id,
+          description: `Outcome "${outcome.outcome_id}" reconciled ${outcome.state}; file follow-up work as a new later-wave outcome`,
+          proposedWave: wave,
+        }),
+      );
+    }
+  });
+  return proposals;
+}
+
+// Merge freshly-derived proposals with any receipt-recorded follow_ups, de-duplicating by
+// id (a recorded entry wins so an operator-set `deferred` status is preserved). Returns
+// { blocking, deferred }: blocking = status "proposed" (targets accepted scope → blocks
+// completion); deferred = status "deferred" (non-blocking, listed separately, D6).
+function mergeFollowUps({ derived, recorded }) {
+  const byId = new Map();
+  (derived || []).forEach((entry) => byId.set(entry.id, entry));
+  (Array.isArray(recorded) ? recorded : []).forEach((entry) => {
+    if (entry && typeof entry.id === "string") byId.set(entry.id, normalizeRecorded(entry));
+  });
+  const all = [...byId.values()];
+  return {
+    blocking: all.filter((entry) => entry.status !== "deferred"),
+    deferred: all.filter((entry) => entry.status === "deferred"),
+  };
+}
+
+// Normalize a receipt-recorded follow_up back into the verbatim entry shape so a
+// hand-appended or prior-write entry renders deterministically. Unknown status defaults
+// to "proposed" (fail closed: an unrecognized status still blocks completion).
+function normalizeRecorded(entry) {
+  const status = entry.status === "deferred" ? "deferred" : "proposed";
+  return proposalFrom(entry, status);
+}
+
+function proposalFrom(entry, status) {
+  const out = { id: entry.id };
+  if (entry.source_gate != null) out.source_gate = entry.source_gate;
+  else out.source_outcome = entry.source_outcome != null ? entry.source_outcome : null;
+  out.description = boundedExcerpt(entry.description != null ? entry.description : "");
+  out.proposed_wave = Number.isInteger(entry.proposed_wave) ? entry.proposed_wave : null;
+  out.status = status;
+  return out;
+}
+
+module.exports = { proposal, deriveProposals, mergeFollowUps, nextWave, sanitizeId };

--- a/skills/relay-orca/scripts/lib/gate-evaluate.js
+++ b/skills/relay-orca/scripts/lib/gate-evaluate.js
@@ -1,0 +1,188 @@
+"use strict";
+
+// Pure exit-gate evaluation (#947 D1/D2/D4/D5). Given the #945 reconciliation report, the
+// parsed receipt, the program's VERBATIM exit_gates, and an injected integration-evidence
+// reader, this module evaluates each gate per kind and returns the per-gate results plus
+// the prerequisite verdict and blocking reasons. It performs NO I/O — the top-level
+// script injects the live-evidence reader — so plan.js's frozen lib source-scan keeps
+// passing.
+//
+// Two invariants are load-bearing (severity-calibrated safety properties):
+//   - Gates are INPUT artifacts: every result is keyed to a program exit-gate string
+//     verbatim; nothing is invented, renamed, dropped, or weakened. Unrecognized prefix →
+//     `unevaluable`, NEVER passed (fail closed).
+//   - Gate results derive EXCLUSIVELY from live evidence (integration artifact, decision /
+//     authorization records, receipt counters, reconciliation) — NEVER from Orca task or
+//     worker status. A failing integration gate can never be masked by task completion.
+const { boundedExcerpt } = require("./bounded-excerpt");
+const { parseGate } = require("./gate-kinds");
+const { effectiveCounters, parseBudgetRef, COUNTER_NAMES } = require("./budget-counters");
+const { validateDecisionRecord, isResolved, findById } = require("./decision-records");
+
+function result(state, evidence, message) {
+  return { state, evidence: boundedExcerpt(evidence), message: boundedExcerpt(message) };
+}
+
+// integration: a named live check / evidence artifact must PASS live. The artifact is read
+// through the injected reader (top-level fs), NEVER from task status. Absent artifact →
+// failed (no live pass evidence), never passed.
+function evalIntegration(ref, readIntegrationEvidence) {
+  const evidence = typeof readIntegrationEvidence === "function" ? readIntegrationEvidence(ref) : null;
+  if (!evidence || evidence.present !== true) {
+    return result("failed", `no live evidence artifact for ${ref}`, `integration check "${ref}" has no live evidence artifact; gate cannot pass`);
+  }
+  if (evidence.passed === true) {
+    return result("passed", evidence.evidence || `check ${ref} passed`, `integration check "${ref}" passed live`);
+  }
+  return result("failed", evidence.evidence || `check ${ref} failed`, `integration check "${ref}" failed live`);
+}
+
+// advisory: reuse the #945 advisory contract — advisory evidence posted AND every blocking
+// finding triaged, derived from the reconciled advisory_review outcomes.
+function evalAdvisory(ref, advisory) {
+  if (advisory.posted && advisory.triaged) {
+    return result("passed", `advisory ${ref} posted+triaged`, `advisory "${ref}": evidence posted and blocking findings triaged`);
+  }
+  return result("failed", `advisory ${ref} incomplete`, `advisory "${ref}": evidence not posted or blocking findings not triaged`);
+}
+
+// tracker: tracker reconciliation clean for the program's issues — no reopened issue, no
+// duplicate/lost receipt↔live mapping, no unreconciled back-pointer.
+function evalTracker(ref, trackerClean) {
+  if (trackerClean) return result("passed", `tracker ${ref} reconciled`, `tracker "${ref}": reconciliation clean for the program's issues`);
+  return result("failed", `tracker ${ref} ambiguous`, `tracker "${ref}": reconciliation not clean (reopened issue or ambiguous receipt/tracker graph)`);
+}
+
+// decision: resolves ONLY against a decision record carrying all six provenance keys.
+// Missing key → unevaluable (fail closed). Present-but-unresolved → awaiting_decision.
+function evalDecision(ref, receipt) {
+  const record = findById(receipt.decisions, ref);
+  if (!record) return result("awaiting_decision", "no decision record", `decision "${ref}" has no record; awaiting explicit operator resolution`);
+  const check = validateDecisionRecord(record);
+  if (!check.valid) {
+    return result("unevaluable", "invalid decision record", `decision record "${ref}" is invalid: missing/ill-typed provenance key "${check.missingKey}"`);
+  }
+  if (!isResolved(record)) return result("awaiting_decision", "recorded but unresolved", `decision "${ref}" is recorded but unresolved; awaiting a resolution`);
+  return result("passed", `resolved: ${record.resolution}`, `decision "${ref}" resolved by ${record.resolver}`);
+}
+
+// budget: compare a receipt-recorded counter against the gate's numeric ceiling. Under
+// ceiling → passed; at/over → failed with BOTH numbers in the message.
+function evalBudget(ref, receipt) {
+  const parsed = parseBudgetRef(ref);
+  if (!parsed) return result("unevaluable", "unparseable budget ref", `budget gate ref "${ref}" is not a <counter> <= <int> expression; fail closed`);
+  if (!COUNTER_NAMES.includes(parsed.counter)) {
+    return result("unevaluable", "unknown counter", `budget gate references unknown counter "${parsed.counter}" (known: ${COUNTER_NAMES.join(", ")})`);
+  }
+  const value = effectiveCounters(receipt)[parsed.counter];
+  if (value < parsed.ceiling) {
+    return result("passed", `${parsed.counter}=${value} < ${parsed.ceiling}`, `budget "${parsed.counter}": ${value} under ceiling ${parsed.ceiling}`);
+  }
+  return result("failed", `${parsed.counter}=${value} >= ${parsed.ceiling}`, `budget ceiling reached: ${parsed.counter}=${value} at/over ceiling ${parsed.ceiling}`);
+}
+
+// authorization: requires an explicit authorization record. Absent → awaiting_decision-
+// equivalent gate state, never passed (D5).
+function evalAuthorization(ref, receipt) {
+  const record = findById(receipt.authorizations, ref);
+  if (!record) return result("awaiting_decision", "absent", `authorization "${ref}" has no record; awaiting explicit operator authorization`);
+  return result("passed", `authorizer ${record.authorizer}`, `authorization "${ref}" recorded by ${record.authorizer}`);
+}
+
+// Derive the advisory/tracker reconciliation facts once from the report.
+function reconciliationFacts(report) {
+  const outcomes = report.outcomes || [];
+  const advisoryOutcomes = outcomes.filter((outcome) => outcome.kind === "advisory_review");
+  const advisory = {
+    posted: advisoryOutcomes.length > 0 && advisoryOutcomes.every((outcome) => outcome.evidence && outcome.evidence.advisory_evidence_posted === true),
+    triaged: advisoryOutcomes.length > 0 && advisoryOutcomes.every((outcome) => outcome.evidence && outcome.evidence.blocking_findings_triaged === true),
+  };
+  const codes = new Set((report.diagnostics || []).map((diagnostic) => diagnostic.code));
+  const trackerClean =
+    !codes.has("ISSUE_REOPENED") &&
+    !codes.has("DUPLICATE_MAPPING") &&
+    !codes.has("MISSING_RELAY_RUN") &&
+    (report.repair_candidates || []).length === 0;
+  return { advisory, trackerClean };
+}
+
+function evaluateOneGate(gateString, ctx) {
+  const parsed = parseGate(gateString);
+  const { kind, ref } = parsed;
+  let evaluated;
+  switch (kind) {
+    case "integration":
+      evaluated = evalIntegration(ref, ctx.readIntegrationEvidence);
+      break;
+    case "advisory":
+      evaluated = evalAdvisory(ref, ctx.facts.advisory);
+      break;
+    case "tracker":
+      evaluated = evalTracker(ref, ctx.facts.trackerClean);
+      break;
+    case "decision":
+      evaluated = evalDecision(ref, ctx.receipt);
+      break;
+    case "budget":
+      evaluated = evalBudget(ref, ctx.receipt);
+      break;
+    case "authorization":
+      evaluated = evalAuthorization(ref, ctx.receipt);
+      break;
+    default:
+      evaluated = result(
+        "unevaluable",
+        "",
+        `exit gate "${gateString}" has no recognized kind prefix (integration:/advisory:/tracker:/decision:/budget:/authorization:); fail closed`,
+      );
+  }
+  return { gate: gateString, kind, state: evaluated.state, evidence: evaluated.evidence, message: evaluated.message };
+}
+
+const BLOCKING_REASON_BY_STATE = Object.freeze({
+  failed: "GATE_FAILED",
+  unevaluable: "GATE_UNEVALUABLE",
+  awaiting_decision: "GATE_AWAITING_DECISION",
+});
+
+// Evaluate every program exit gate verbatim (D1). Prerequisite (D2): gates evaluate ONLY
+// after every accepted outcome reconciles complete_with_evidence; before that they are
+// `not_yet_evaluable` with the blocking outcomes listed. Returns { prerequisites_met,
+// gates, blocking_reasons, blocking_outcomes }.
+function evaluateGates({ report, receipt, exitGates, readIntegrationEvidence }) {
+  const gateStrings = Array.isArray(exitGates) ? exitGates : [];
+  const outcomes = report.outcomes || [];
+  const blockingOutcomes = outcomes.filter((outcome) => outcome.state !== "complete_with_evidence");
+  const prerequisitesMet = outcomes.length > 0 && blockingOutcomes.length === 0;
+
+  if (!prerequisitesMet) {
+    const gates = gateStrings.map((gateString) => {
+      const parsed = parseGate(gateString);
+      return {
+        gate: gateString,
+        kind: parsed.kind,
+        state: "not_yet_evaluable",
+        evidence: "",
+        message: boundedExcerpt(`prerequisite: ${blockingOutcomes.length} accepted outcome(s) not yet complete_with_evidence`),
+      };
+    });
+    const blocking = blockingOutcomes.map((outcome) => ({
+      reason_code: "PREREQUISITES_NOT_MET",
+      message: boundedExcerpt(`outcome ${outcome.outcome_id} is ${outcome.state}, not complete_with_evidence`),
+    }));
+    return { prerequisites_met: false, gates, blocking_reasons: blocking, blocking_outcomes: blockingOutcomes.map((outcome) => outcome.outcome_id) };
+  }
+
+  const ctx = { receipt, readIntegrationEvidence, facts: reconciliationFacts(report) };
+  const gates = gateStrings.map((gateString) => evaluateOneGate(gateString, ctx));
+  const blocking = gates
+    .filter((gate) => gate.state !== "passed")
+    .map((gate) => ({ reason_code: BLOCKING_REASON_BY_STATE[gate.state] || "GATE_BLOCKED", message: boundedExcerpt(gate.message) }));
+  return { prerequisites_met: true, gates, blocking_reasons: blocking, blocking_outcomes: [] };
+}
+
+function allGatesPassed(gates) {
+  return Array.isArray(gates) && gates.length > 0 && gates.every((gate) => gate.state === "passed");
+}
+
+module.exports = { evaluateGates, evaluateOneGate, reconciliationFacts, allGatesPassed };

--- a/skills/relay-orca/scripts/lib/gate-kinds.js
+++ b/skills/relay-orca/scripts/lib/gate-kinds.js
@@ -1,0 +1,26 @@
+"use strict";
+
+// Exit-gate KIND parsing (#947 D1). Gate kinds are keyed by a PINNED `kind:` prefix
+// convention on the exit-gate string; the prefix is matched verbatim and never
+// invented, renamed, or dropped. A gate string without a recognized prefix parses as
+// the `unevaluable` kind (fail closed) — NEVER as a passed gate. Pure: no I/O.
+
+// The six pinned, verbatim gate-kind prefixes (D1). Order is stable for reporting.
+const GATE_KINDS = Object.freeze(["integration", "advisory", "tracker", "decision", "budget", "authorization"]);
+const GATE_KIND_SET = new Set(GATE_KINDS);
+
+// Parse one exit-gate string into { gate, kind, ref }. `gate` is the ORIGINAL string
+// (byte-preserved for the report); `kind` is one of GATE_KINDS or "unevaluable"; `ref`
+// is the substring after the first `:` (the check name / record id / budget expression),
+// or null when there is no recognized prefix. A non-string or empty gate has no
+// recognized prefix → unevaluable (fail closed).
+function parseGate(gate) {
+  if (typeof gate !== "string") return { gate: String(gate), kind: "unevaluable", ref: null };
+  const colon = gate.indexOf(":");
+  if (colon <= 0) return { gate, kind: "unevaluable", ref: null };
+  const prefix = gate.slice(0, colon);
+  if (!GATE_KIND_SET.has(prefix)) return { gate, kind: "unevaluable", ref: null };
+  return { gate, kind: prefix, ref: gate.slice(colon + 1) };
+}
+
+module.exports = { GATE_KINDS, GATE_KIND_SET, parseGate };

--- a/skills/relay-orca/scripts/lib/gate-reasons.js
+++ b/skills/relay-orca/scripts/lib/gate-reasons.js
@@ -1,0 +1,48 @@
+"use strict";
+
+// relay-orca `status --gates` / `status --final-summary` fail-closed reason matrix
+// (#947 D7). A NEW module in the 70-range so it never collides with plan.js's 2–21
+// codes, the probe's 30–37, run's 40–44, status/resume/receipt's 50–63, or Node's own
+// fatal/exec codes (<=125). Existing reason modules (lib/reasons.js,
+// lib/probe-reasons.js, lib/run-reasons.js, lib/status-reasons.js, lib/resume-reasons.js,
+// lib/stop-reasons.js) stay untouched.
+//
+// These three are the ONLY conditions that fail a gate/completion command, and ONLY
+// under `--strict`. Without `--strict` the mode exits 0 with the truthful report
+// (information is the product, matching status's house rule). Receipt-layer failures
+// reuse the shipped 50–52 (StatusError); usage stays 64. Pure: no I/O.
+const REASONS = Object.freeze({
+  GATES_NOT_EVALUABLE: 70, // --gates/--final-summary before prerequisites reconcile, under --strict
+  GATE_FAILED: 71, // any exit gate failed, under --strict
+  COMPLETION_BLOCKED: 72, // --final-summary and program_complete is false, under --strict
+});
+
+const REMEDIATION = Object.freeze({
+  GATES_NOT_EVALUABLE:
+    "Exit gates evaluate only after every accepted outcome reconciles complete_with_evidence; drive the blocking outcomes to completion (relay/relay-fleet) before evaluating gates, or drop --strict to see the truthful report.",
+  GATE_FAILED:
+    "At least one exit gate failed against live evidence; address the failing gate (fix the integration check, resolve the decision, stay under budget, record authorization) and re-evaluate, or drop --strict.",
+  COMPLETION_BLOCKED:
+    "program_complete is false; consult stopped_on / blocking_reasons for the specific stop condition, resolve it, and re-run --final-summary, or drop --strict to see the truthful report.",
+});
+
+const USAGE_EXIT = 64;
+
+class GateError extends Error {
+  constructor(reasonCode, message, remediation) {
+    super(message);
+    this.name = "GateError";
+    this.reasonCode = reasonCode;
+    this.exitCode = REASONS[reasonCode];
+    this.remediation = remediation || REMEDIATION[reasonCode] || "";
+    if (this.exitCode === undefined) {
+      throw new Error(`unknown gate reason code: ${reasonCode}`);
+    }
+  }
+}
+
+function reject(reasonCode, message, remediation) {
+  throw new GateError(reasonCode, message, remediation);
+}
+
+module.exports = { REASONS, REMEDIATION, USAGE_EXIT, GateError, reject };

--- a/skills/relay-orca/scripts/lib/gate-report.js
+++ b/skills/relay-orca/scripts/lib/gate-report.js
@@ -1,0 +1,112 @@
+"use strict";
+
+// Stable machine-readable report shapes for `status --gates` and `status --final-summary`
+// (#947 D8). EXACTLY these verbatim, ordered top-level keys on EVERY path — success,
+// failed, not-yet-evaluable, or degraded. No timestamps or randomness are generated in
+// either report body (D6/D8 reproducibility); any receipt-stored timestamp passes through
+// verbatim. Pure: no I/O.
+
+// `status --gates --json` — the seven verbatim top-level keys (D8).
+const GATES_REPORT_KEYS = Object.freeze([
+  "ok",
+  "program_id",
+  "receipt_path",
+  "prerequisites_met",
+  "gates",
+  "follow_ups",
+  "blocking_reasons",
+]);
+
+// `status --final-summary --json` — the eleven verbatim top-level keys (D8).
+const FINAL_SUMMARY_KEYS = Object.freeze([
+  "ok",
+  "program_id",
+  "receipt_path",
+  "program_complete",
+  "stopped_on",
+  "outcomes",
+  "gates",
+  "follow_ups",
+  "deferred",
+  "decisions",
+  "blocking_reasons",
+]);
+
+// Per-gate entry shape (D8). Deterministic key set on every path.
+const GATE_ENTRY_KEYS = Object.freeze(["gate", "kind", "state", "evidence", "message"]);
+
+// The verbatim gate-state enum (D8).
+const GATE_STATES = Object.freeze([
+  "passed",
+  "failed",
+  "not_yet_evaluable",
+  "awaiting_decision",
+  "unevaluable",
+]);
+
+// The distinct `stopped_on` values (D6). Each stop condition maps to exactly one token.
+const STOPPED_ON_VALUES = Object.freeze([
+  "graph_ambiguous",
+  "relay_escalated",
+  "orca_lifecycle_failure",
+  "integration_gate_failed",
+  "budget_ceiling_reached",
+  "gate_failed",
+  "gate_unevaluable",
+  "awaiting_decision",
+  "unaccepted_follow_up",
+  "outcomes_incomplete",
+]);
+
+function orderGate(gate) {
+  const ordered = {};
+  GATE_ENTRY_KEYS.forEach((key) => {
+    ordered[key] = gate[key];
+  });
+  return ordered;
+}
+
+// A follow-up carries EXACTLY one source key (`source_gate` OR `source_outcome`, D3), so
+// the ordered entry emits whichever is present — never both, never neither.
+function orderFollowUp(followUp) {
+  const ordered = { id: followUp.id };
+  if (followUp.source_gate != null) ordered.source_gate = followUp.source_gate;
+  else ordered.source_outcome = followUp.source_outcome != null ? followUp.source_outcome : null;
+  ordered.description = followUp.description;
+  ordered.proposed_wave = followUp.proposed_wave;
+  ordered.status = followUp.status;
+  return ordered;
+}
+
+function orderGatesReport(report) {
+  const ordered = {};
+  GATES_REPORT_KEYS.forEach((key) => {
+    ordered[key] = report[key];
+  });
+  ordered.gates = (report.gates || []).map(orderGate);
+  ordered.follow_ups = (report.follow_ups || []).map(orderFollowUp);
+  return ordered;
+}
+
+function orderFinalSummary(report) {
+  const ordered = {};
+  FINAL_SUMMARY_KEYS.forEach((key) => {
+    ordered[key] = report[key];
+  });
+  ordered.gates = (report.gates || []).map(orderGate);
+  ordered.follow_ups = (report.follow_ups || []).map(orderFollowUp);
+  ordered.deferred = (report.deferred || []).map(orderFollowUp);
+  return ordered;
+}
+
+module.exports = {
+  GATES_REPORT_KEYS,
+  FINAL_SUMMARY_KEYS,
+  GATE_ENTRY_KEYS,
+  GATE_STATES,
+  STOPPED_ON_VALUES,
+  orderGate,
+  orderFollowUp,
+  orderGatesReport,
+  orderFinalSummary,
+};

--- a/skills/relay-orca/scripts/lib/operator-records.js
+++ b/skills/relay-orca/scripts/lib/operator-records.js
@@ -1,0 +1,48 @@
+"use strict";
+
+// Apply the #947 additive OPERATOR records to a receipt mapping (D4/D5). Pure: no I/O —
+// the atomic receipt persistence lives in the top-level run/resume scripts, which also
+// supply the `resolved_at` timestamp. This module only carries forward existing additive
+// records across a run's receipt rewrite and upserts the operator-flag record. A decision
+// or authorization record is written ONLY when the caller passes an explicit operator flag
+// (run/resume never fabricate one automatically).
+const { buildDecisionRecord, buildAuthorizationRecord } = require("./decision-records");
+
+const CARRY_FORWARD_KEYS = Object.freeze(["follow_ups", "decisions", "authorizations", "counters"]);
+
+// Upsert a record into an array field by `id` (replace same-id, else append). Preserves
+// order for a stable, reproducible serialization.
+function upsertById(list, record) {
+  const arr = Array.isArray(list) ? list.slice() : [];
+  const index = arr.findIndex((entry) => entry && entry.id === record.id);
+  if (index >= 0) arr[index] = record;
+  else arr.push(record);
+  return arr;
+}
+
+// Carry forward the additive record fields from a prior receipt into a freshly-built
+// mapping (run rewrites the receipt from a fresh orchestration each invocation, so without
+// this a previously-recorded decision/authorization/follow-up would be lost). resume
+// operates on the live receipt object in place, so it passes no priorReceipt.
+function carryForward(mapping, priorReceipt) {
+  if (!priorReceipt || typeof priorReceipt !== "object") return;
+  CARRY_FORWARD_KEYS.forEach((key) => {
+    if (mapping[key] === undefined && priorReceipt[key] !== undefined) mapping[key] = priorReceipt[key];
+  });
+}
+
+// Apply operator records to `mapping`. `decision` (when present) is
+// { id, resolution, resolver, resolvedAt, gateDef }; `authorization` is { id, authorizer }.
+// Returns the mutated mapping.
+function applyOperatorRecords(mapping, { priorReceipt = null, decision = null, authorization = null } = {}) {
+  carryForward(mapping, priorReceipt);
+  if (decision && decision.id) {
+    mapping.decisions = upsertById(mapping.decisions, buildDecisionRecord(decision));
+  }
+  if (authorization && authorization.id) {
+    mapping.authorizations = upsertById(mapping.authorizations, buildAuthorizationRecord(authorization));
+  }
+  return mapping;
+}
+
+module.exports = { CARRY_FORWARD_KEYS, upsertById, carryForward, applyOperatorRecords };

--- a/skills/relay-orca/scripts/lib/receipt.js
+++ b/skills/relay-orca/scripts/lib/receipt.js
@@ -51,6 +51,26 @@ const RELAY_ID_KEYS = Object.freeze(["request", "run", "fleet"]);
 const STOP_KEYS = Object.freeze(["stopped_at", "stop_reason"]);
 const STOP_REASON_MAX = 256;
 
+// #947 additive record fields — appended ONLY when present, AFTER the canonical
+// RECEIPT_KEYS block and the optional stop record. They are NOT part of RECEIPT_KEYS, so a
+// receipt that never carried them serializes byte-identically to before (existing
+// #944/#945/#946 receipts and their assertions are unchanged). validateReceipt ignores
+// extra keys, so a receipt carrying them still loads for status/resume. Each is written
+// only at a pinned run/resume/flag point:
+//   - follow_ups     : proposed follow-ups, written ONLY by `status --gates --record-proposals`
+//   - decisions      : decision records, written ONLY via the run/resume --resolve-decision flag
+//   - authorizations : authorization records, written ONLY via the run/resume --record-authorization flag
+//   - counters       : optional explicit budget counters (otherwise derived from the mapping)
+const ADDITIVE_RECORD_KEYS = Object.freeze(["follow_ups", "decisions", "authorizations", "counters"]);
+
+// An additive record field is "present" (worth serializing) when it is a non-empty array
+// or a non-empty object. Absent/empty → skipped, preserving byte-identity with a receipt
+// that never carried it.
+function additivePresent(value) {
+  if (Array.isArray(value)) return value.length > 0;
+  return Boolean(value && typeof value === "object" && Object.keys(value).length > 0);
+}
+
 function boundStopReason(value) {
   if (typeof value !== "string" || value === "") return "";
   return value.length <= STOP_REASON_MAX ? value : value.slice(0, STOP_REASON_MAX);
@@ -135,6 +155,23 @@ function serializeReceiptWithStop(receipt) {
   return `${JSON.stringify(ordered, null, 2)}\n`;
 }
 
+// #947: serialize a receipt that MAY carry a bounded stop record AND/OR the additive
+// #947 record fields. Both blocks are appended AFTER the canonical RECEIPT_KEYS block and
+// ONLY when present, so a receipt carrying neither serializes byte-identically to
+// serializeReceipt (and one carrying only a stop record serializes byte-identically to
+// serializeReceiptWithStop). This keeps every existing receipt assertion intact while
+// letting the pinned run/resume/status write points persist their additive records.
+function serializeReceiptWithRecords(receipt) {
+  const ordered = orderReceipt(receipt);
+  STOP_KEYS.forEach((key) => {
+    if (receipt[key] !== undefined) ordered[key] = receipt[key];
+  });
+  ADDITIVE_RECORD_KEYS.forEach((key) => {
+    if (additivePresent(receipt[key])) ordered[key] = receipt[key];
+  });
+  return `${JSON.stringify(ordered, null, 2)}\n`;
+}
+
 function validateTask(task) {
   if (!task || typeof task !== "object") return "a task entry is not an object";
   for (const key of TASK_KEYS) {
@@ -189,12 +226,15 @@ module.exports = {
   RELAY_ID_KEYS,
   STOP_KEYS,
   STOP_REASON_MAX,
+  ADDITIVE_RECORD_KEYS,
   boundStopReason,
+  additivePresent,
   buildReceiptMapping,
   receiptTaskEntry,
   orderReceipt,
   serializeReceipt,
   serializeReceiptWithStop,
+  serializeReceiptWithRecords,
   validateReceipt,
   parseReceipt,
 };

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -26,7 +26,8 @@ const {
   writeReceiptAtomic,
   programSegment,
 } = require("./receipt-io");
-const { parseReceipt, serializeReceiptWithStop } = require("./lib/receipt");
+const { parseReceipt, serializeReceiptWithRecords } = require("./lib/receipt");
+const { applyOperatorRecords } = require("./lib/operator-records");
 const { boundedExcerpt } = require("./lib/bounded-excerpt");
 const { parseManifest } = require("./lib/manifest-parse");
 const { deriveStatusReport } = require("./lib/status-derive");
@@ -60,18 +61,46 @@ function requireValue(value, flag) {
 }
 
 function parseArgs(argv) {
-  const opts = { programId: null, json: false, operatorHandles: [], orcaBin: null, ghBin: null, repoRoot: null, help: false };
+  const opts = {
+    programId: null,
+    json: false,
+    operatorHandles: [],
+    orcaBin: null,
+    ghBin: null,
+    repoRoot: null,
+    help: false,
+    // #947 additive operator-record flags (D4/D5) — a decision/authorization record is
+    // written into the receipt ONLY when its explicit flag is present, never automatically.
+    // `--program-file` is OPTIONAL and sources the decision-gate provenance
+    // (question/options/downstream_wave) when resolving a decision from resume.
+    resolveDecision: null,
+    resolution: null,
+    resolver: null,
+    recordAuthorization: null,
+    authorizer: null,
+    programFile: null,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--program-id" || arg === "-p") opts.programId = requireValue(argv[(i += 1)], "--program-id");
     else if (arg === "--json") opts.json = true;
     else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
+    else if (arg === "--resolve-decision") opts.resolveDecision = requireValue(argv[(i += 1)], "--resolve-decision");
+    else if (arg === "--resolution") opts.resolution = requireValue(argv[(i += 1)], "--resolution");
+    else if (arg === "--resolver") opts.resolver = requireValue(argv[(i += 1)], "--resolver");
+    else if (arg === "--record-authorization") opts.recordAuthorization = requireValue(argv[(i += 1)], "--record-authorization");
+    else if (arg === "--authorizer") opts.authorizer = requireValue(argv[(i += 1)], "--authorizer");
+    else if (arg === "--program-file") opts.programFile = requireValue(argv[(i += 1)], "--program-file");
     else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
     else if (arg === "--gh-bin") opts.ghBin = requireValue(argv[(i += 1)], "--gh-bin");
     else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
     else if (arg === "--help" || arg === "-h") opts.help = true;
     else usageError(`unrecognized argument: ${arg}`);
   }
+  if (opts.resolveDecision && (!opts.resolution || !opts.resolver)) {
+    usageError("--resolve-decision requires --resolution and --resolver");
+  }
+  if (opts.recordAuthorization && !opts.authorizer) usageError("--record-authorization requires --authorizer");
   return opts;
 }
 
@@ -190,9 +219,44 @@ function reconcile({ receipt, opts, repo, receiptPath }) {
 function makeReceiptPersistor(receipt, receiptPath) {
   return function persist() {
     receipt.updated_at = new Date().toISOString();
-    writeReceiptAtomic(receiptPath, serializeReceiptWithStop(receipt));
+    // serializeReceiptWithRecords preserves the optional stop record AND the #947 additive
+    // records (follow_ups/decisions/authorizations); with none present it is byte-identical
+    // to serializeReceiptWithStop, so existing resume receipt assertions are unchanged.
+    writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
     return receiptPath;
   };
+}
+
+// Source a decision-gate definition (question/options/downstream_wave provenance) from an
+// OPTIONAL --program-file so a resume-written decision record carries full provenance.
+function decisionGateDefFromFile(programFile, decisionId) {
+  if (!programFile) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(programFile, "utf-8"));
+    const prog = parsed && parsed.program && typeof parsed.program === "object" ? parsed.program : parsed;
+    const gates = prog && Array.isArray(prog.decision_gates) ? prog.decision_gates : [];
+    return gates.find((gate) => gate && gate.id === decisionId) || null;
+  } catch {
+    return null;
+  }
+}
+
+// #947 D4/D5: write an operator decision/authorization record into the live receipt when
+// the explicit flag is present, BEFORE reconciliation, so the record persists even if
+// resume later fails closed on unsafe runtime state. Flagless resume writes NOTHING here,
+// preserving the existing byte-identity-on-abort invariant.
+function recordOperatorDecisions(receipt, receiptPath, opts) {
+  if (!opts.resolveDecision && !opts.recordAuthorization) return false;
+  const nowIso = new Date().toISOString();
+  applyOperatorRecords(receipt, {
+    decision: opts.resolveDecision
+      ? { id: opts.resolveDecision, resolution: opts.resolution, resolver: opts.resolver, resolvedAt: nowIso, gateDef: decisionGateDefFromFile(opts.programFile, opts.resolveDecision) }
+      : null,
+    authorization: opts.recordAuthorization ? { id: opts.recordAuthorization, authorizer: opts.authorizer } : null,
+  });
+  receipt.updated_at = nowIso;
+  writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
+  return true;
 }
 
 // Synthesize the operator prompt inputs from the receipt alone (resume starts from the
@@ -324,6 +388,9 @@ function main() {
     if (receipt.repo && receipt.repo.slug !== repo.slug) {
       rejectReceipt("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
     }
+    // #947: an explicit --resolve-decision / --record-authorization writes its record to the
+    // receipt up front, so the decision persists regardless of the reconciliation verdict.
+    recordOperatorDecisions(receipt, receiptPath, opts);
     ({ report, liveDispatch } = reconcile({ receipt, opts, repo, receiptPath }));
   } catch (error) {
     if (error instanceof StatusError || error instanceof CanonicalizationError) failReceipt(error, opts.json);

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -14,7 +14,8 @@ const { execFileSync } = require("node:child_process");
 const { PlanError } = require("./lib/reasons");
 const { orchestrate } = require("./lib/run-orchestrator");
 const { orderedReport } = require("./lib/run-report");
-const { buildReceiptMapping, serializeReceipt } = require("./lib/receipt");
+const { buildReceiptMapping, serializeReceiptWithRecords } = require("./lib/receipt");
+const { applyOperatorRecords } = require("./lib/operator-records");
 const {
   CanonicalizationError,
   resolveRepoContext,
@@ -74,19 +75,42 @@ function usageError(message) {
 }
 
 function parseArgs(argv) {
-  const opts = { programFile: null, json: false, concurrency: undefined, operatorHandles: [], orcaBin: null, repoRoot: null };
+  const opts = {
+    programFile: null,
+    json: false,
+    concurrency: undefined,
+    operatorHandles: [],
+    orcaBin: null,
+    repoRoot: null,
+    // #947 additive operator-record flags. A decision/authorization record is written
+    // into the receipt ONLY when its explicit flag is present (never automatically, D4/D5).
+    resolveDecision: null,
+    resolution: null,
+    resolver: null,
+    recordAuthorization: null,
+    authorizer: null,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--program-file" || arg === "-f") opts.programFile = argv[(i += 1)];
     else if (arg === "--json") opts.json = true;
     else if (arg === "--concurrency") opts.concurrency = Number(argv[(i += 1)]);
     else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
+    else if (arg === "--resolve-decision") opts.resolveDecision = requireValue(argv[(i += 1)], "--resolve-decision");
+    else if (arg === "--resolution") opts.resolution = requireValue(argv[(i += 1)], "--resolution");
+    else if (arg === "--resolver") opts.resolver = requireValue(argv[(i += 1)], "--resolver");
+    else if (arg === "--record-authorization") opts.recordAuthorization = requireValue(argv[(i += 1)], "--record-authorization");
+    else if (arg === "--authorizer") opts.authorizer = requireValue(argv[(i += 1)], "--authorizer");
     else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
     else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
     else if (arg === "--help" || arg === "-h") opts.help = true;
     else if (!arg.startsWith("-") && !opts.programFile) opts.programFile = arg;
     else usageError(`unrecognized argument: ${arg}`);
   }
+  if (opts.resolveDecision && (!opts.resolution || !opts.resolver)) {
+    usageError("--resolve-decision requires --resolution and --resolver");
+  }
+  if (opts.recordAuthorization && !opts.authorizer) usageError("--record-authorization requires --authorizer");
   return opts;
 }
 
@@ -98,18 +122,39 @@ function parseArgs(argv) {
 // receipt-loss condition A12 forbids: the created task's mapping would never be persisted).
 // created_at is preserved across the materialize/dispatch rewrites; only the atomic write +
 // timestamps live here (top-level), while the pure mapping is built by lib/receipt.js.
-function makeReceiptPersistor(opts) {
+function decisionGateDef(program, decisionId) {
+  const prog = program && program.program && typeof program.program === "object" ? program.program : program;
+  const gates = prog && Array.isArray(prog.decision_gates) ? prog.decision_gates : [];
+  return gates.find((gate) => gate && gate.id === decisionId) || null;
+}
+
+// Build the operator-record inputs (#947 D4/D5) from the explicit flags. A decision/
+// authorization record is produced ONLY when its flag is present; the decision's
+// question/options/downstream_wave provenance is sourced from the program's declared
+// decision_gates entry, and resolved_at is stamped at write time (top-level).
+function operatorRecordInputs(opts, program, nowIso) {
+  return {
+    decision: opts.resolveDecision
+      ? { id: opts.resolveDecision, resolution: opts.resolution, resolver: opts.resolver, resolvedAt: nowIso, gateDef: decisionGateDef(program, opts.resolveDecision) }
+      : null,
+    authorization: opts.recordAuthorization ? { id: opts.recordAuthorization, authorizer: opts.authorizer } : null,
+  };
+}
+
+function makeReceiptPersistor(opts, program) {
   const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
   return function persistReceipt(core) {
     const finalPath = receiptPathFor(repo.slug, core.program_id);
     const nowIso = new Date().toISOString();
     let createdAt = nowIso;
+    let prior = null;
     if (receiptExists(finalPath)) {
       try {
-        const prior = JSON.parse(readReceiptFile(finalPath));
+        prior = JSON.parse(readReceiptFile(finalPath));
         if (typeof prior.created_at === "string" && prior.created_at) createdAt = prior.created_at;
       } catch {
         createdAt = nowIso;
+        prior = null;
       }
     }
     const mapping = buildReceiptMapping({
@@ -122,7 +167,11 @@ function makeReceiptPersistor(opts) {
     });
     mapping.created_at = createdAt;
     mapping.updated_at = nowIso;
-    writeReceiptAtomic(finalPath, serializeReceipt(mapping));
+    // Carry forward any prior additive records across the rewrite and apply the operator
+    // flags' decision/authorization records. With no prior records and no flags, this is a
+    // no-op and the serialized bytes are IDENTICAL to the pre-#947 receipt.
+    applyOperatorRecords(mapping, { priorReceipt: prior, ...operatorRecordInputs(opts, program, nowIso) });
+    writeReceiptAtomic(finalPath, serializeReceiptWithRecords(mapping));
     return finalPath;
   };
 }
@@ -183,7 +232,7 @@ function main() {
     // receipt path before orchestrate runs ANY admission/materialization mutation — a
     // git-canonicalization failure exits 52 here (CanonicalizationError, caught below) with
     // zero mutating Orca invocations.
-    const persistReceipt = makeReceiptPersistor(opts);
+    const persistReceipt = makeReceiptPersistor(opts, program);
     result = orchestrate(program, {
       concurrency: opts.concurrency,
       operatorHandles: opts.operatorHandles,

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -31,7 +31,7 @@ const { deriveStatusReport } = require("./lib/status-derive");
 const { StatusError, USAGE_EXIT, reject } = require("./lib/status-reasons");
 const { evaluateGates } = require("./lib/gate-evaluate");
 const { orderGatesReport, orderFinalSummary } = require("./lib/gate-report");
-const { deriveProposals, mergeFollowUps } = require("./lib/follow-ups");
+const { deriveProposals, mergeFollowUps, upsertRecordedFollowUps } = require("./lib/follow-ups");
 const { buildFinalSummary } = require("./lib/final-summary");
 const { REASONS: GATE_REASONS } = require("./lib/gate-reasons");
 
@@ -319,10 +319,13 @@ function makeIntegrationEvidenceReader(dir) {
 
 // D9.12 PINNED: proposals reach the receipt ONLY via `status --gates --record-proposals`.
 // Without the flag, status writes NOTHING (byte-identity preserved). With it, the proposed
-// follow-ups are appended to the receipt under `follow_ups` (additive; A-series atomic
-// write) and the receipt's updated_at is bumped.
+// follow-ups are UPSERTED into the receipt under `follow_ups` (additive; A-series atomic
+// write) and the receipt's updated_at is bumped. Owner amendment A1: recording MUST NOT
+// replace the existing `follow_ups` — an operator-set `deferred` row must survive. The
+// upsert preserves recorded entries byte-for-byte (they win on id conflict) and appends
+// only NEW derived ids, so re-recording never clobbers an operator's deferral.
 function recordProposals(receipt, receiptPath, proposals) {
-  receipt.follow_ups = proposals;
+  receipt.follow_ups = upsertRecordedFollowUps({ recorded: receipt.follow_ups, derived: proposals });
   receipt.updated_at = new Date().toISOString();
   writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
 }

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -20,22 +20,31 @@ const {
   listManifestFiles,
   listFleetManifestFiles,
   makeUrlResolver,
+  writeReceiptAtomic,
   programSegment,
 } = require("./receipt-io");
 const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
-const { parseReceipt } = require("./lib/receipt");
+const { parseReceipt, serializeReceiptWithRecords } = require("./lib/receipt");
 const { boundedExcerpt } = require("./lib/bounded-excerpt");
 const { parseManifest } = require("./lib/manifest-parse");
 const { deriveStatusReport } = require("./lib/status-derive");
 const { StatusError, USAGE_EXIT, reject } = require("./lib/status-reasons");
+const { evaluateGates } = require("./lib/gate-evaluate");
+const { orderGatesReport, orderFinalSummary } = require("./lib/gate-report");
+const { deriveProposals, mergeFollowUps } = require("./lib/follow-ups");
+const { buildFinalSummary } = require("./lib/final-summary");
+const { REASONS: GATE_REASONS } = require("./lib/gate-reasons");
 
+const fs = require("node:fs");
+const path = require("node:path");
 const READ_TIMEOUT_MS = 15000;
 const READ_MAX_BUFFER = 4 * 1024 * 1024;
 
 function usageError(message) {
   process.stderr.write(`relay-orca status: ${message}\n`);
   process.stderr.write(
-    "usage: status.js --program-id <id> [--json] [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
+    "usage: status.js --program-id <id> [--json] [--gates | --final-summary] [--program-file <accepted-program.json>] " +
+      "[--gate-evidence-dir <dir>] [--record-proposals] [--strict] [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
   );
   process.exit(USAGE_EXIT);
 }
@@ -46,17 +55,40 @@ function requireValue(value, flag) {
 }
 
 function parseArgs(argv) {
-  const opts = { programId: null, json: false, orcaBin: null, ghBin: null, repoRoot: null, help: false };
+  const opts = {
+    programId: null,
+    json: false,
+    orcaBin: null,
+    ghBin: null,
+    repoRoot: null,
+    help: false,
+    // #947 read-only status modes. `--gates`/`--final-summary` are mutually exclusive
+    // status modes; both stay READ-ONLY unless `--record-proposals` is passed (D9.12).
+    gates: false,
+    finalSummary: false,
+    recordProposals: false,
+    strict: false,
+    programFile: null,
+    gateEvidenceDir: null,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--program-id" || arg === "-p") opts.programId = requireValue(argv[(i += 1)], "--program-id");
     else if (arg === "--json") opts.json = true;
+    else if (arg === "--gates") opts.gates = true;
+    else if (arg === "--final-summary") opts.finalSummary = true;
+    else if (arg === "--record-proposals") opts.recordProposals = true;
+    else if (arg === "--strict") opts.strict = true;
+    else if (arg === "--program-file") opts.programFile = requireValue(argv[(i += 1)], "--program-file");
+    else if (arg === "--gate-evidence-dir") opts.gateEvidenceDir = requireValue(argv[(i += 1)], "--gate-evidence-dir");
     else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
     else if (arg === "--gh-bin") opts.ghBin = requireValue(argv[(i += 1)], "--gh-bin");
     else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
     else if (arg === "--help" || arg === "-h") opts.help = true;
     else usageError(`unrecognized argument: ${arg}`);
   }
+  if (opts.gates && opts.finalSummary) usageError("--gates and --final-summary are mutually exclusive");
+  if (opts.recordProposals && !opts.gates) usageError("--record-proposals is only valid with --gates");
   return opts;
 }
 
@@ -196,45 +228,159 @@ function failStatus(error, json) {
   process.exit(error.exitCode);
 }
 
+// The SAME read-only reconciliation the plain `status` path builds (#945), factored out
+// so the #947 read-only modes (`--gates`, `--final-summary`) reconcile identically before
+// evaluating gates. Returns { report, receipt, receiptPath, repo }. Throws
+// StatusError/CanonicalizationError, which main() maps to the fail-closed exit codes.
+function gatherReconciliation(opts) {
+  const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+  const receiptPath = receiptPathFor(repo.slug, opts.programId);
+  const receipt = loadReceipt(receiptPath, opts.programId);
+  if (receipt.repo && receipt.repo.slug !== repo.slug) {
+    reject("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
+  }
+  // Child run manifests come from the runs root; fleet manifests come from the
+  // SEPARATE fleets root (#945 A8). A fleet outcome's `relay_ids.fleet` resolves to a
+  // fleet manifest here, while its children still resolve against the runs-root map.
+  const manifests = listManifestFiles(repo.slug).map((entry) => ({
+    run_id: entry.run_id,
+    text: entry.text,
+    parsed: parseManifest(entry.text),
+  }));
+  const fleetManifests = listFleetManifestFiles(repo.slug).map((entry) => ({
+    run_id: entry.run_id,
+    text: entry.text,
+    parsed: parseManifest(entry.text),
+  }));
+  const report = deriveStatusReport({
+    receipt,
+    programId: opts.programId,
+    receiptPath,
+    manifests,
+    fleetManifests,
+    orca: makeRunner(resolveOrca(opts), assertOrcaReadOnly, repo.root),
+    gh: makeRunner(resolveGhBin(opts), assertGhReadOnly, repo.root),
+    urlFor: makeUrlResolver(repo.root),
+    // A26: the foreign-task marker embeds the SAME collision-resistant segment used for
+    // the receipt path, injected as a pure function (lib/ stays subprocess-free).
+    programSegment,
+  });
+  return { report, receipt, receiptPath, repo };
+}
+
+// Read the accepted program's exit_gates VERBATIM (#947 D1). Exit gates are INPUT
+// artifacts — they come ONLY from the program file, never from the receipt or an invented
+// default. The program id must match the receipt's program id (a mismatch is an operator
+// input error → usage 64). The root may be the program object directly or wrapped under a
+// `program` key (same as the frozen compiler's unwrap).
+function readProgramExitGates(programFile, receiptProgramId) {
+  if (!programFile) usageError("--gates/--final-summary require --program-file (exit gates come only from the accepted program)");
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(programFile, "utf-8"));
+  } catch (error) {
+    usageError(`cannot read program file ${programFile}: ${error.message}`);
+  }
+  const program = parsed && parsed.program && typeof parsed.program === "object" ? parsed.program : parsed;
+  if (!program || typeof program !== "object") usageError(`program file ${programFile} is not a program object`);
+  if (program.id !== receiptProgramId) {
+    usageError(`program file id ${boundedExcerpt(program.id)} does not match the receipt program id ${boundedExcerpt(receiptProgramId)}`);
+  }
+  if (!Array.isArray(program.exit_gates) || program.exit_gates.length === 0) {
+    usageError(`program file ${programFile} has no exit_gates array`);
+  }
+  return { exitGates: program.exit_gates, decisionGates: Array.isArray(program.decision_gates) ? program.decision_gates : [] };
+}
+
+function sanitizeArtifactName(ref) {
+  return String(ref == null ? "" : ref).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "gate";
+}
+
+// Build the injected integration-evidence reader (#947 D1/D2). An `integration:` gate's
+// live evidence is an artifact FILE under the gate-evidence directory; the gate result
+// derives from that artifact, NEVER from Orca task/worker status. A missing dir/file →
+// { present: false } so the gate fails closed (never passed). This is the ONLY new
+// filesystem read the gate modes perform, and it is strictly read-only.
+function makeIntegrationEvidenceReader(dir) {
+  const root = dir || (process.env.RELAY_ORCA_GATE_EVIDENCE_ROOT || "").trim() || null;
+  return (ref) => {
+    if (!root) return { present: false };
+    const artifact = path.join(root, `${sanitizeArtifactName(ref)}.json`);
+    if (!fs.existsSync(artifact)) return { present: false };
+    try {
+      const json = JSON.parse(fs.readFileSync(artifact, "utf-8"));
+      return { present: true, passed: json.passed === true, evidence: typeof json.evidence === "string" ? json.evidence : `check ${ref}` };
+    } catch (error) {
+      // A corrupt artifact is unusable live evidence → not present → fail closed.
+      return { present: false };
+    }
+  };
+}
+
+// D9.12 PINNED: proposals reach the receipt ONLY via `status --gates --record-proposals`.
+// Without the flag, status writes NOTHING (byte-identity preserved). With it, the proposed
+// follow-ups are appended to the receipt under `follow_ups` (additive; A-series atomic
+// write) and the receipt's updated_at is bumped.
+function recordProposals(receipt, receiptPath, proposals) {
+  receipt.follow_ups = proposals;
+  receipt.updated_at = new Date().toISOString();
+  writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
+}
+
+// Apply the D7 fail-closed exit codes under --strict (precedence 70 > 71 > 72). Without
+// --strict every situation exits 0 with the truthful report (information is the product).
+function strictExitCode(opts, gateEval, programComplete) {
+  if (!opts.strict) return 0;
+  if (!gateEval.prerequisites_met) return GATE_REASONS.GATES_NOT_EVALUABLE;
+  if (gateEval.gates.some((gate) => gate.state === "failed")) return GATE_REASONS.GATE_FAILED;
+  if (opts.finalSummary && programComplete === false) return GATE_REASONS.COMPLETION_BLOCKED;
+  return 0;
+}
+
+function runGatesMode(opts, { report, receipt, receiptPath }) {
+  const { exitGates } = readProgramExitGates(opts.programFile, opts.programId);
+  const gateEval = evaluateGates({ report, receipt, exitGates, readIntegrationEvidence: makeIntegrationEvidenceReader(opts.gateEvidenceDir) });
+  const proposals = deriveProposals({ report, gates: gateEval.gates, receipt });
+  if (opts.recordProposals && proposals.length > 0) recordProposals(receipt, receiptPath, proposals);
+  const body = orderGatesReport({
+    ok: true,
+    program_id: opts.programId,
+    receipt_path: receiptPath,
+    prerequisites_met: gateEval.prerequisites_met,
+    gates: gateEval.gates,
+    follow_ups: proposals,
+    blocking_reasons: gateEval.blocking_reasons,
+  });
+  process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  process.exitCode = strictExitCode(opts, gateEval, null);
+}
+
+function runFinalSummaryMode(opts, { report, receipt, receiptPath }) {
+  const { exitGates } = readProgramExitGates(opts.programFile, opts.programId);
+  const gateEval = evaluateGates({ report, receipt, exitGates, readIntegrationEvidence: makeIntegrationEvidenceReader(opts.gateEvidenceDir) });
+  const derived = deriveProposals({ report, gates: gateEval.gates, receipt });
+  const followUps = mergeFollowUps({ derived, recorded: receipt.follow_ups });
+  const summary = buildFinalSummary({
+    programId: opts.programId,
+    receiptPath,
+    report,
+    gateEval,
+    followUps,
+    decisions: receipt.decisions,
+  });
+  const body = orderFinalSummary(summary);
+  process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  process.exitCode = strictExitCode(opts, gateEval, summary.program_complete);
+}
+
 function main() {
   const opts = parseArgs(process.argv.slice(2));
   if (opts.help) usageError("read-only live reconciler for an accepted program");
   if (!opts.programId) usageError("--program-id is required");
 
-  let report;
+  let reconciliation;
   try {
-    const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
-    const receiptPath = receiptPathFor(repo.slug, opts.programId);
-    const receipt = loadReceipt(receiptPath, opts.programId);
-    if (receipt.repo && receipt.repo.slug !== repo.slug) {
-      reject("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
-    }
-    // Child run manifests come from the runs root; fleet manifests come from the
-    // SEPARATE fleets root (#945 A8). A fleet outcome's `relay_ids.fleet` resolves to a
-    // fleet manifest here, while its children still resolve against the runs-root map.
-    const manifests = listManifestFiles(repo.slug).map((entry) => ({
-      run_id: entry.run_id,
-      text: entry.text,
-      parsed: parseManifest(entry.text),
-    }));
-    const fleetManifests = listFleetManifestFiles(repo.slug).map((entry) => ({
-      run_id: entry.run_id,
-      text: entry.text,
-      parsed: parseManifest(entry.text),
-    }));
-    report = deriveStatusReport({
-      receipt,
-      programId: opts.programId,
-      receiptPath,
-      manifests,
-      fleetManifests,
-      orca: makeRunner(resolveOrca(opts), assertOrcaReadOnly, repo.root),
-      gh: makeRunner(resolveGhBin(opts), assertGhReadOnly, repo.root),
-      urlFor: makeUrlResolver(repo.root),
-      // A26: the foreign-task marker embeds the SAME collision-resistant segment used for
-      // the receipt path, injected as a pure function (lib/ stays subprocess-free).
-      programSegment,
-    });
+    reconciliation = gatherReconciliation(opts);
   } catch (error) {
     // A24: a repo root that cannot be git-canonicalized fails closed with the same
     // RECEIPT_REPO_MISMATCH (exit 52) contract as a cross-repo receipt.
@@ -242,7 +388,12 @@ function main() {
     throw error;
   }
 
-  printReport(report, opts.json);
+  // #947 read-only status modes. Plain `status` (no mode flag) output stays BYTE-IDENTICAL
+  // to the shipped #945/#946 shape.
+  if (opts.gates) return void runGatesMode(opts, reconciliation);
+  if (opts.finalSummary) return void runFinalSummaryMode(opts, reconciliation);
+
+  printReport(reconciliation.report, opts.json);
   process.exitCode = 0;
 }
 

--- a/tests/relay-orca/fixtures/followup-later-wave.json
+++ b/tests/relay-orca/fixtures/followup-later-wave.json
@@ -1,0 +1,28 @@
+{
+  "program": {
+    "id": "epic-followup-later-wave",
+    "source": "file:///tmp/epic-followup.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 2,
+    "exit_gates": ["integration:e2e-suite", "tracker:milestone-clean"],
+    "outcomes": [
+      {
+        "id": "base-widget",
+        "issue": 7001,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["base widget merged"],
+        "depends_on": [],
+        "wave": 1
+      },
+      {
+        "id": "followup-hardening",
+        "issue": 7002,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["hardening merged"],
+        "depends_on": ["base-widget"],
+        "wave": 2
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/scripts/gates.test.js
+++ b/tests/relay-orca/scripts/gates.test.js
@@ -1,0 +1,709 @@
+"use strict";
+
+// #947 — integration gates, follow-up waves, and evidence-backed completion. Scenarios
+// D9.1–D9.12. Fakes only (fake --orca-bin and fake --gh-bin for every invocation, never
+// the real app); poisons active everywhere so any mutation/reset/worktree call hard-fails.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
+const STATUS_JS = path.join(SCRIPTS, "status.js");
+const RUN_JS = path.join(SCRIPTS, "run.js");
+
+const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
+const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { GATES_REPORT_KEYS, FINAL_SUMMARY_KEYS, GATE_ENTRY_KEYS, GATE_STATES, STOPPED_ON_VALUES } = require(path.join(SCRIPTS, "lib", "gate-report.js"));
+const { DECISION_KEYS } = require(path.join(SCRIPTS, "lib", "decision-records.js"));
+const { REASONS: GATE_REASONS } = require(path.join(SCRIPTS, "lib", "gate-reasons.js"));
+const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
+const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
+const { installFakeOrcaRun } = require(path.join(__dirname, "..", "fixtures", "fake-orca-run.js"));
+const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+// --- builders (mirroring the status.test.js house harness) ----------------------
+
+function makeReceipt({ programId, slug, root, runtimeId, tasks, decisions, authorizations, followUps, counters }) {
+  const receipt = {
+    schema: 1,
+    program_id: programId,
+    source: "/tmp/accepted-program.json",
+    repo: { slug, root },
+    runtime_id: runtimeId || DEFAULT_RUNTIME_ID,
+    tasks: tasks.map((task) => {
+      const orcaTaskId = task.orca_task_id === undefined ? `orca-live-${task.outcome_id}` : task.orca_task_id;
+      const defaultDispatchId = orcaTaskId ? `disp-${orcaTaskId}` : `disp-${task.outcome_id}`;
+      return {
+        outcome_id: task.outcome_id,
+        task_id: task.task_id || `orca-task-${task.outcome_id}`,
+        kind: task.kind || "relay_run",
+        wave: task.wave || 1,
+        orca_task_id: orcaTaskId,
+        dispatch_id: task.dispatch_id === undefined ? defaultDispatchId : task.dispatch_id,
+        assignee: task.assignee === undefined ? `term-${task.outcome_id}` : task.assignee,
+        relay_ids: { request: null, run: task.run || null, fleet: task.fleet || null },
+      };
+    }),
+    terminals_created: [],
+    created_at: "2026-07-13T00:00:00.000Z",
+    updated_at: "2026-07-13T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+  // Additive #947 record fields appended ONLY when the scenario supplies them.
+  if (decisions) receipt.decisions = decisions;
+  if (authorizations) receipt.authorizations = authorizations;
+  if (followUps) receipt.follow_ups = followUps;
+  if (counters) receipt.counters = counters;
+  return receipt;
+}
+
+function manifestText(fields) {
+  const lines = ["---", "relay_version: 2", `run_id: '${fields.run_id}'`, `state: '${fields.state}'`, "git:"];
+  lines.push(fields.pr_number != null ? `  pr_number: ${fields.pr_number}` : "  pr_number: null");
+  lines.push(`  working_branch: '${fields.run_id}-branch'`);
+  lines.push("  base_branch: 'main'");
+  if (fields.head_sha) lines.push(`  head_sha: '${fields.head_sha}'`);
+  lines.push("issue:");
+  lines.push(fields.issue_number != null ? `  number: ${fields.issue_number}` : "  number: null");
+  lines.push("  source: 'github'");
+  lines.push("---");
+  lines.push("# Notes");
+  return `${lines.join("\n")}\n`;
+}
+
+function orcaTask(programId, outcome, extra = {}) {
+  return {
+    id: `orca-live-${outcome}`,
+    title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    status: extra.status || "dispatched",
+    worker_done: extra.worker_done === true,
+  };
+}
+
+function initGitRepo(root) {
+  const git = (args) => execFileSync("git", ["-C", root, ...args], { stdio: ["ignore", "pipe", "pipe"] });
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t.com"]);
+  git(["config", "user.name", "t"]);
+}
+
+function sanitizeArtifact(ref) {
+  return String(ref == null ? "" : ref).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "gate";
+}
+
+// Build a hermetic gate world: real tiny git repo, receipt at the collision-resistant
+// segment path, run/fleet manifests, fake read-only orca + gh, an accepted program file
+// carrying the exit_gates verbatim, and a gate-evidence directory of live artifacts.
+function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, exitGates = [], decisionGates = [], gateEvidence = {} }) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-gates-"));
+  const repoRoot = path.join(base, "repo");
+  const programsRoot = path.join(base, "programs");
+  const runsRoot = path.join(base, "runs");
+  const fleetsRoot = path.join(base, "fleets");
+  const evidenceDir = path.join(base, "gate-evidence");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  fs.mkdirSync(evidenceDir, { recursive: true });
+  initGitRepo(repoRoot);
+  const slug = computeRepoSlug(fs.realpathSync(repoRoot));
+
+  const receiptObject = receipt;
+  if (receiptObject.repo && receiptObject.repo.slug === "__SELF__") receiptObject.repo.slug = slug;
+  if (receiptObject.repo) receiptObject.repo.root = fs.realpathSync(repoRoot);
+  const receiptDir = path.join(programsRoot, slug, programSegment(programId));
+  fs.mkdirSync(receiptDir, { recursive: true });
+  const receiptPath = path.join(receiptDir, "receipt.json");
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receiptObject, null, 2)}\n`, "utf-8");
+
+  const runsDir = path.join(runsRoot, slug);
+  fs.mkdirSync(runsDir, { recursive: true });
+  fs.mkdirSync(path.join(fleetsRoot, slug), { recursive: true });
+  manifests.forEach((fields) => fs.writeFileSync(path.join(runsDir, `${fields.run_id}.md`), manifestText(fields), "utf-8"));
+
+  // The accepted program file — the ONLY source of exit_gates (input artifacts).
+  const programFile = path.join(base, "accepted-program.json");
+  fs.writeFileSync(
+    programFile,
+    `${JSON.stringify({ program: { id: programId, exit_gates: exitGates, decision_gates: decisionGates, outcomes: receiptObject.tasks.map((task) => ({ id: task.outcome_id, task_kind: task.kind, accepted_outcomes: ["x"] })) } }, null, 2)}\n`,
+    "utf-8",
+  );
+
+  Object.entries(gateEvidence).forEach(([name, value]) => {
+    fs.writeFileSync(path.join(evidenceDir, `${sanitizeArtifact(name)}.json`), `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+  });
+
+  const orca = installFakeOrcaStatus({ runtimeId: DEFAULT_RUNTIME_ID, ...orcaScenario });
+  const gh = installFakeGh(ghScenario);
+
+  return {
+    base,
+    repoRoot,
+    programFile,
+    evidenceDir,
+    receiptPath,
+    slug,
+    orca,
+    gh,
+    receiptOnDisk() {
+      return fs.readFileSync(receiptPath, "utf-8");
+    },
+    run(mode, extraArgs = []) {
+      const args = [
+        STATUS_JS,
+        "--program-id",
+        programId,
+        "--json",
+        mode,
+        "--program-file",
+        programFile,
+        "--gate-evidence-dir",
+        evidenceDir,
+        "--orca-bin",
+        orca.orcaPath,
+        "--gh-bin",
+        gh.ghPath,
+        "--repo-root",
+        repoRoot,
+        ...extraArgs,
+      ];
+      const result = { status: 0, stdout: "", stderr: "" };
+      try {
+        result.stdout = execFileSync(process.execPath, args, {
+          encoding: "utf-8",
+          env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot, RELAY_ORCA_RUNS_ROOT: runsRoot, RELAY_ORCA_FLEETS_ROOT: fleetsRoot },
+          stdio: "pipe",
+        });
+      } catch (error) {
+        result.status = error.status;
+        result.stdout = error.stdout ? String(error.stdout) : "";
+        result.stderr = error.stderr ? String(error.stderr) : "";
+      }
+      result.body = result.stdout ? JSON.parse(result.stdout) : null;
+      return result;
+    },
+    cleanup() {
+      orca.cleanup();
+      gh.cleanup();
+      fs.rmSync(base, { recursive: true, force: true });
+    },
+  };
+}
+
+// A single durable-complete relay_run outcome "a" (merged run + merged PR + closed issue +
+// completed Orca task). This satisfies the D2 prerequisite so exit gates can evaluate.
+function greenWorld(programId, opts = {}) {
+  const receipt = makeReceipt({
+    programId,
+    slug: "__SELF__",
+    root: "__SELF__",
+    tasks: [{ outcome_id: "a", run: "run-a" }, ...(opts.extraTasks || [])],
+    decisions: opts.decisions,
+    authorizations: opts.authorizations,
+    followUps: opts.followUps,
+    counters: opts.counters,
+  });
+  return buildGateWorld({
+    programId,
+    receipt,
+    manifests: [{ run_id: "run-a", state: "merged", pr_number: 10, issue_number: 100, head_sha: "abc" }, ...(opts.manifests || [])],
+    orcaScenario: { tasks: [orcaTask(programId, "a", { status: "completed", worker_done: true }), ...(opts.orcaTasks || [])] },
+    ghScenario: {
+      prs: { 10: { state: "MERGED", mergedAt: "2026-07-13T01:00:00Z", headRefOid: "abc" }, ...(opts.prs || {}) },
+      issues: { 100: { state: "CLOSED", stateReason: "COMPLETED" }, ...(opts.issues || {}) },
+    },
+    exitGates: opts.exitGates || [],
+    decisionGates: opts.decisionGates || [],
+    gateEvidence: opts.gateEvidence || {},
+  });
+}
+
+function gateByString(body, gateString) {
+  return body.gates.find((gate) => gate.gate === gateString);
+}
+
+// ---------------------------------------------------------------------------
+// Report-shape sanity (D8)
+// ---------------------------------------------------------------------------
+
+test("D8: verbatim gate-state enum and stopped_on tokens are exactly the pinned sets", () => {
+  assert.deepEqual([...GATE_STATES].sort(), ["awaiting_decision", "failed", "not_yet_evaluable", "passed", "unevaluable"]);
+  assert.deepEqual([...GATE_ENTRY_KEYS], ["gate", "kind", "state", "evidence", "message"]);
+  assert.ok(STOPPED_ON_VALUES.includes("integration_gate_failed") && STOPPED_ON_VALUES.includes("unaccepted_follow_up"));
+});
+
+// ---------------------------------------------------------------------------
+// D9.1 — passing integration gate; masking (all tasks completed + failing gate)
+// ---------------------------------------------------------------------------
+
+test("D9.1: passing integration gate after all outcomes complete → passed; report has the seven verbatim keys", () => {
+  const world = greenWorld("epic-gate-pass", { exitGates: ["integration:e2e"], gateEvidence: { e2e: { passed: true, evidence: "suite green" } } });
+  try {
+    const r = world.run("--gates");
+    assert.equal(r.status, 0);
+    assert.deepEqual(Object.keys(r.body).sort(), [...GATES_REPORT_KEYS].sort());
+    assert.equal(r.body.prerequisites_met, true);
+    const gate = gateByString(r.body, "integration:e2e");
+    assert.equal(gate.state, "passed");
+    assert.equal(gate.kind, "integration");
+    assert.deepEqual(Object.keys(gate).sort(), [...GATE_ENTRY_KEYS].sort());
+    assert.equal(world.orca.readPoison(), null);
+    assert.equal(world.gh.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D9.1/D2 MASKING: every Orca task completed but the integration check FAILS → gate failed, program NOT complete", () => {
+  const world = greenWorld("epic-gate-mask", { exitGates: ["integration:e2e"], gateEvidence: { e2e: { passed: false, evidence: "suite RED" } } });
+  try {
+    // Gate view: the outcome durably reconciles complete (prereq met) yet the gate fails
+    // from LIVE evidence — task completion cannot mask it.
+    const g = world.run("--gates");
+    assert.equal(g.body.prerequisites_met, true);
+    assert.equal(gateByString(g.body, "integration:e2e").state, "failed");
+    // Program-level: not complete, stop reason is the integration failure (never masked).
+    const f = world.run("--final-summary");
+    assert.equal(f.body.program_complete, false);
+    assert.equal(f.body.stopped_on, "integration_gate_failed");
+    // D7: a failed exit gate under --strict exits 71 (GATE_FAILED) in BOTH modes.
+    assert.equal(world.run("--gates", ["--strict"]).status, GATE_REASONS.GATE_FAILED);
+    assert.equal(world.run("--gates", ["--strict"]).status, 71);
+    assert.equal(world.run("--final-summary", ["--strict"]).status, 71);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.2 — gates before prerequisites → not_yet_evaluable; --strict exit 70
+// ---------------------------------------------------------------------------
+
+function runningWorld(programId, exitGates) {
+  const receipt = makeReceipt({ programId, slug: "__SELF__", root: "__SELF__", tasks: [{ outcome_id: "a", run: "run-a" }] });
+  return buildGateWorld({
+    programId,
+    receipt,
+    manifests: [{ run_id: "run-a", state: "review_pending", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask(programId, "a")] },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+    exitGates,
+  });
+}
+
+test("D9.2: gates before prerequisites reconcile → not_yet_evaluable + blocking outcomes; --strict exits 70", () => {
+  const world = runningWorld("epic-gate-early", ["integration:e2e"]);
+  try {
+    const r = world.run("--gates");
+    assert.equal(r.status, 0);
+    assert.equal(r.body.prerequisites_met, false);
+    assert.equal(gateByString(r.body, "integration:e2e").state, "not_yet_evaluable");
+    assert.ok(r.body.blocking_reasons.some((reason) => reason.reason_code === "PREREQUISITES_NOT_MET" && reason.message.includes("a")));
+    const strict = world.run("--gates", ["--strict"]);
+    assert.equal(strict.status, GATE_REASONS.GATES_NOT_EVALUABLE);
+    assert.equal(strict.status, 70);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.3 — unrecognized prefix → unevaluable, never passed
+// ---------------------------------------------------------------------------
+
+test("D9.3: an unrecognized gate prefix evaluates as unevaluable (never passed) with a naming diagnostic", () => {
+  const world = greenWorld("epic-gate-unknown", { exitGates: ["frobnicate:the-widget"] });
+  try {
+    const r = world.run("--gates");
+    const gate = gateByString(r.body, "frobnicate:the-widget");
+    assert.equal(gate.state, "unevaluable");
+    assert.notEqual(gate.state, "passed");
+    assert.match(gate.message, /no recognized kind prefix/);
+    assert.match(gate.message, /frobnicate:the-widget/);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.4 — follow-up proposal recorded; NOTHING dispatched/created
+// ---------------------------------------------------------------------------
+
+test("D9.4: a failing gate proposes a follow-up in the report + receipt (--record-proposals); nothing is dispatched/created", () => {
+  const world = greenWorld("epic-gate-followup", { exitGates: ["integration:e2e"], gateEvidence: { e2e: { passed: false } } });
+  try {
+    const before = world.receiptOnDisk();
+    // Report always carries the proposal; the pinned entry shape (D3).
+    const r = world.run("--gates");
+    assert.equal(r.body.follow_ups.length, 1);
+    const proposal = r.body.follow_ups[0];
+    assert.equal(proposal.source_gate, "integration:e2e");
+    assert.equal(proposal.status, "proposed");
+    assert.equal(typeof proposal.proposed_wave, "number");
+    assert.deepEqual(Object.keys(proposal).sort(), ["description", "id", "proposed_wave", "source_gate", "status"].sort());
+    // WITHOUT --record-proposals the receipt is byte-identical (strictly read-only).
+    assert.equal(world.receiptOnDisk(), before, "flagless --gates never writes the receipt");
+    // WITH --record-proposals the proposal is appended to the receipt under follow_ups.
+    const recorded = world.run("--gates", ["--record-proposals"]);
+    assert.equal(recorded.status, 0);
+    const persisted = JSON.parse(world.receiptOnDisk());
+    assert.equal(persisted.follow_ups[0].source_gate, "integration:e2e");
+    assert.equal(persisted.follow_ups[0].status, "proposed");
+    // No mutation reached Orca or gh on any path (invocation log + poison proof). Note
+    // `dispatch-show` is a READ and is expected in the log; only a bare `dispatch`,
+    // task-create/task-update, terminal, reset, or worktree would be a mutation.
+    assert.equal(world.orca.readPoison(), null);
+    assert.equal(world.gh.readPoison(), null);
+    const mutating = world.orca.readLog().some((line) => /task-create|task-update|reset|worktree|(^|\s)terminal(\s|$)|orchestration dispatch(\s|$)/.test(line));
+    assert.equal(mutating, false, "no mutating Orca subcommand was invoked");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.5 — follow-up ACCEPTANCE path; frozen compiler protections re-raise
+// ---------------------------------------------------------------------------
+
+function runRun(fixtureName, extraArgs = []) {
+  const fake = installFakeOrcaRun({});
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-gates-run-"));
+  const programsRoot = path.join(base, "programs");
+  const repoRoot = path.join(base, "repo");
+  fs.mkdirSync(programsRoot, { recursive: true });
+  fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
+  const args = ["--json", "--orca-bin", fake.orcaPath, "--repo-root", repoRoot, "--program-file", path.join(REPO_ROOT, "tests", "relay-orca", "fixtures", fixtureName), ...extraArgs];
+  const result = { status: 0, stdout: "", stderr: "" };
+  try {
+    result.stdout = execFileSync(process.execPath, [RUN_JS, ...args], { encoding: "utf-8", env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot }, stdio: "pipe" });
+  } catch (error) {
+    result.status = error.status;
+    result.stdout = error.stdout ? String(error.stdout) : "";
+    result.stderr = error.stderr ? String(error.stderr) : "";
+  }
+  result.body = result.stdout ? JSON.parse(result.stdout) : null;
+  result.cleanup = () => {
+    fake.cleanup();
+    fs.rmSync(base, { recursive: true, force: true });
+  };
+  return result;
+}
+
+test("D9.5: an accepted follow-up (appended later-wave outcome) compiles and runs through the existing run intent", () => {
+  const r = runRun("followup-later-wave.json", ["--operator-handle", "h1", "--operator-handle", "h2"]);
+  try {
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.body.ok, true);
+    // The base outcome (wave 1) is materialized/dispatched; the follow-up sits in a strictly
+    // later wave, honoring the immutable-wave contract.
+    const base = r.body.tasks.find((task) => task.outcome_id === "base-widget");
+    assert.ok(base && base.orca_task_id, "base outcome dispatched");
+  } finally {
+    r.cleanup();
+  }
+});
+
+test("D9.5: a follow-up with a SAME-WAVE dependency is re-raised verbatim by the frozen compiler (exit 14)", () => {
+  const r = runRun("reject-same-wave.json");
+  try {
+    assert.equal(r.status, 14);
+    assert.equal(r.body.reason_code, "SAME_WAVE_DEPENDENCY");
+  } finally {
+    r.cleanup();
+  }
+});
+
+test("D9.6: an UNPREPARED fleet follow-up is re-raised verbatim (UNPREPARED_FLEET_LEAF, exit 12)", () => {
+  const r = runRun("reject-unprepared-fleet.json");
+  try {
+    assert.equal(r.status, 12);
+    assert.equal(r.body.reason_code, "UNPREPARED_FLEET_LEAF");
+  } finally {
+    r.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.7 — decision gate provenance + explicit-flag write boundary
+// ---------------------------------------------------------------------------
+
+const DECISION_GATE_DEF = { id: "signoff", question: "proceed to completion?", options: ["yes", "no"], downstream_wave: 2 };
+
+test("D9.7: an unresolved decision gate reports awaiting_decision and blocks completion", () => {
+  const world = greenWorld("epic-decision-open", { exitGates: ["decision:signoff"], decisionGates: [DECISION_GATE_DEF] });
+  try {
+    const g = world.run("--gates");
+    assert.equal(gateByString(g.body, "decision:signoff").state, "awaiting_decision");
+    const f = world.run("--final-summary");
+    assert.equal(f.body.program_complete, false);
+    assert.equal(f.body.stopped_on, "awaiting_decision");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D9.7: a decision resolved via the explicit run flag carries all six provenance keys and passes the gate", () => {
+  // Resolve the decision by riding the flag on a `run` (the receipt gains a decisions[]).
+  const r = runRun("valid-single-relay-run.json", ["--operator-handle", "h1", "--resolve-decision", "signoff", "--resolution", "approved by owner", "--resolver", "alice"]);
+  try {
+    assert.equal(r.status, 0, r.stderr);
+    const receiptPath = r.body.receipt_path;
+    const receipt = JSON.parse(fs.readFileSync(receiptPath, "utf-8"));
+    assert.equal(receipt.decisions.length, 1);
+    const record = receipt.decisions[0];
+    assert.equal(record.id, "signoff");
+    // ALL six verbatim provenance keys present (question/options from the program's
+    // decision_gates def; resolution/resolver from the flag; resolved_at stamped).
+    DECISION_KEYS.forEach((key) => assert.ok(key in record, `decision record missing provenance key ${key}`));
+    assert.equal(record.resolution, "approved by owner");
+    assert.equal(record.resolver, "alice");
+    // question/options/downstream_wave are sourced from the program's decision_gates def.
+    assert.equal(record.question, "operator approves program completion");
+    assert.ok(Array.isArray(record.options));
+    assert.ok(record.downstream_wave === null || Number.isInteger(record.downstream_wave));
+  } finally {
+    r.cleanup();
+  }
+});
+
+test("D9.7: a decision record missing a provenance key → unevaluable (fail closed), diagnostic naming the key", () => {
+  const world = greenWorld("epic-decision-bad", {
+    exitGates: ["decision:signoff"],
+    decisionGates: [DECISION_GATE_DEF],
+    // resolved_at and downstream_wave omitted → invalid record.
+    decisions: [{ id: "signoff", question: "q", options: ["y"], resolution: "ok", resolver: "a" }],
+  });
+  try {
+    const g = world.run("--gates");
+    const gate = gateByString(g.body, "decision:signoff");
+    assert.equal(gate.state, "unevaluable");
+    assert.match(gate.message, /provenance key/);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.8 — budget gate: under ceiling passes; at/over fails with both numbers
+// ---------------------------------------------------------------------------
+
+test("D9.8: budget counter under ceiling → passed; at/over → failed with BOTH numbers", () => {
+  // One dispatched task in the receipt → dispatches_performed = 1.
+  const under = greenWorld("epic-budget-under", { exitGates: ["budget:dispatches_performed:5"] });
+  try {
+    const r = under.run("--gates");
+    const gate = gateByString(r.body, "budget:dispatches_performed:5");
+    assert.equal(gate.state, "passed");
+    assert.match(gate.evidence, /dispatches_performed=1/);
+  } finally {
+    under.cleanup();
+  }
+  const over = greenWorld("epic-budget-over", { exitGates: ["budget:dispatches_performed:1"] });
+  try {
+    const r = over.run("--gates");
+    const gate = gateByString(r.body, "budget:dispatches_performed:1");
+    assert.equal(gate.state, "failed");
+    assert.match(gate.message, /dispatches_performed=1/);
+    assert.match(gate.message, /ceiling 1/);
+    const f = over.run("--final-summary");
+    assert.equal(f.body.stopped_on, "budget_ceiling_reached");
+  } finally {
+    over.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.9 — authorization gate: absent never passes; present passes
+// ---------------------------------------------------------------------------
+
+test("D9.9: an absent authorization record never passes; a present record (explicit flag) passes", () => {
+  const absent = greenWorld("epic-auth-absent", { exitGates: ["authorization:deploy"] });
+  try {
+    const r = absent.run("--gates");
+    const gate = gateByString(r.body, "authorization:deploy");
+    assert.notEqual(gate.state, "passed");
+    assert.equal(gate.state, "awaiting_decision");
+  } finally {
+    absent.cleanup();
+  }
+  const present = greenWorld("epic-auth-present", { exitGates: ["authorization:deploy"], authorizations: [{ id: "deploy", authorizer: "release-captain" }] });
+  try {
+    const r = present.run("--gates");
+    assert.equal(gateByString(r.body, "authorization:deploy").state, "passed");
+  } finally {
+    present.cleanup();
+  }
+});
+
+test("D9.9: an authorization record is written ONLY via the explicit run flag", () => {
+  const r = runRun("valid-single-relay-run.json", ["--operator-handle", "h1", "--record-authorization", "deploy", "--authorizer", "release-captain"]);
+  try {
+    assert.equal(r.status, 0, r.stderr);
+    const receipt = JSON.parse(fs.readFileSync(r.body.receipt_path, "utf-8"));
+    assert.deepEqual(receipt.authorizations, [{ id: "deploy", authorizer: "release-captain" }]);
+  } finally {
+    r.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.10 — final summary: fully green completes + reproducible; stop-condition map
+// ---------------------------------------------------------------------------
+
+test("D9.10: a fully green program declares program_complete:true with the eleven verbatim keys, and is REPRODUCIBLE", () => {
+  const world = greenWorld("epic-complete", {
+    exitGates: ["integration:e2e", "budget:waves_dispatched:9", "decision:signoff", "authorization:deploy"],
+    decisionGates: [DECISION_GATE_DEF],
+    gateEvidence: { e2e: { passed: true, evidence: "green" } },
+    decisions: [{ id: "signoff", question: "proceed?", options: ["y", "n"], resolution: "approved", resolver: "alice", resolved_at: "2026-07-13T02:00:00Z", downstream_wave: 2 }],
+    authorizations: [{ id: "deploy", authorizer: "release-captain" }],
+  });
+  try {
+    const first = world.run("--final-summary");
+    assert.equal(first.status, 0);
+    assert.deepEqual(Object.keys(first.body).sort(), [...FINAL_SUMMARY_KEYS].sort());
+    assert.equal(first.body.program_complete, true);
+    assert.equal(first.body.stopped_on, null);
+    assert.equal(first.body.gates.every((gate) => gate.state === "passed"), true);
+    // Reproducible: re-running against unchanged live state yields byte-identical bytes.
+    const second = world.run("--final-summary");
+    assert.equal(first.stdout, second.stdout, "final summary must be reproducible (no timestamps/randomness)");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D9.10: each pinned stop condition maps to its distinct stopped_on value", () => {
+  // (a) integration gate failure
+  const gateFail = greenWorld("epic-stop-gate", { exitGates: ["integration:e2e"], gateEvidence: { e2e: { passed: false } } });
+  try {
+    assert.equal(gateFail.run("--final-summary").body.stopped_on, "integration_gate_failed");
+  } finally {
+    gateFail.cleanup();
+  }
+  // (b) awaiting decision
+  const awaiting = greenWorld("epic-stop-dec", { exitGates: ["decision:signoff"], decisionGates: [DECISION_GATE_DEF] });
+  try {
+    assert.equal(awaiting.run("--final-summary").body.stopped_on, "awaiting_decision");
+  } finally {
+    awaiting.cleanup();
+  }
+  // (c) escalated outcome (force-closed relay manifest) — prereq not met
+  const escalated = buildGateWorld({
+    programId: "epic-stop-esc",
+    receipt: makeReceipt({ programId: "epic-stop-esc", slug: "__SELF__", root: "__SELF__", tasks: [{ outcome_id: "a", run: "run-a" }] }),
+    manifests: [{ run_id: "run-a", state: "closed", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask("epic-stop-esc", "a")] },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+    exitGates: ["integration:e2e"],
+  });
+  try {
+    assert.equal(escalated.run("--final-summary").body.stopped_on, "relay_escalated");
+  } finally {
+    escalated.cleanup();
+  }
+  // (d) unaccepted follow-up (recorded proposed follow_up, everything else green)
+  const unaccepted = greenWorld("epic-stop-fu", {
+    exitGates: ["budget:waves_dispatched:9"],
+    followUps: [{ id: "followup-old", source_gate: "integration:old", description: "prior discovery", proposed_wave: 2, status: "proposed" }],
+  });
+  try {
+    const f = unaccepted.run("--final-summary");
+    assert.equal(f.body.program_complete, false);
+    assert.equal(f.body.stopped_on, "unaccepted_follow_up");
+  } finally {
+    unaccepted.cleanup();
+  }
+  // (e) budget ceiling
+  const budget = greenWorld("epic-stop-budget", { exitGates: ["budget:dispatches_performed:1"] });
+  try {
+    assert.equal(budget.run("--final-summary").body.stopped_on, "budget_ceiling_reached");
+  } finally {
+    budget.cleanup();
+  }
+});
+
+test("D9.10: a deferred follow-up is listed separately and does NOT block completion; --strict exits 72 when blocked", () => {
+  const deferred = greenWorld("epic-deferred", {
+    exitGates: ["budget:waves_dispatched:9"],
+    followUps: [{ id: "followup-later", source_outcome: "a", description: "nice to have", proposed_wave: 3, status: "deferred" }],
+  });
+  try {
+    const f = deferred.run("--final-summary");
+    assert.equal(f.body.program_complete, true, "a deferred follow-up does not block");
+    assert.equal(f.body.deferred.length, 1);
+    assert.equal(f.body.deferred[0].status, "deferred");
+  } finally {
+    deferred.cleanup();
+  }
+  // --strict completion-blocked exit 72 when a decision gate blocks completion.
+  const blocked = greenWorld("epic-blocked", { exitGates: ["decision:signoff"], decisionGates: [DECISION_GATE_DEF] });
+  try {
+    const strict = blocked.run("--final-summary", ["--strict"]);
+    assert.equal(strict.status, GATE_REASONS.COMPLETION_BLOCKED);
+    assert.equal(strict.status, 72);
+  } finally {
+    blocked.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.11 — stale worker_done + escalated relay run block completion (#945 classifier)
+// ---------------------------------------------------------------------------
+
+test("D9.11: a stale worker_done (task done + PR open) reconciles inconsistent → gates not_yet_evaluable, completion blocked", () => {
+  const world = buildGateWorld({
+    programId: "epic-stale",
+    receipt: makeReceipt({ programId: "epic-stale", slug: "__SELF__", root: "__SELF__", tasks: [{ outcome_id: "a", run: "run-a" }] }),
+    manifests: [{ run_id: "run-a", state: "review_pending", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask("epic-stale", "a", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+    exitGates: ["integration:e2e"],
+  });
+  try {
+    const g = world.run("--gates");
+    assert.equal(g.body.prerequisites_met, false);
+    assert.equal(gateByString(g.body, "integration:e2e").state, "not_yet_evaluable");
+    const f = world.run("--final-summary");
+    assert.equal(f.body.program_complete, false);
+    assert.equal(f.body.stopped_on, "relay_escalated");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D9.12 — read-only boundary: flagless modes write NOTHING; poisons active
+// ---------------------------------------------------------------------------
+
+test("D9.12: --gates and --final-summary WITHOUT --record-proposals leave the receipt byte-identical (read-only)", () => {
+  const world = greenWorld("epic-readonly", { exitGates: ["integration:e2e", "decision:signoff"], decisionGates: [DECISION_GATE_DEF], gateEvidence: { e2e: { passed: true } } });
+  try {
+    const before = world.receiptOnDisk();
+    world.run("--gates");
+    assert.equal(world.receiptOnDisk(), before, "--gates is read-only without --record-proposals");
+    world.run("--final-summary");
+    assert.equal(world.receiptOnDisk(), before, "--final-summary is strictly read-only");
+    // No mutating/reset/worktree Orca or write-gh call ever ran.
+    assert.equal(world.orca.readPoison(), null);
+    assert.equal(world.gh.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D9.12: gate/final-summary modes never leak engine/model tokens into the report", () => {
+  const world = greenWorld("epic-engine-agnostic", { exitGates: ["integration:e2e"], gateEvidence: { e2e: { passed: true } } });
+  try {
+    const lowered = JSON.stringify(world.run("--final-summary").body).toLowerCase();
+    ["codex", "claude", "cursor", "cline", "opencode", "gpt", "opus", "sonnet"].forEach((token) => {
+      assert.equal(lowered.includes(token), false, `report leaked engine token ${token}`);
+    });
+  } finally {
+    world.cleanup();
+  }
+});

--- a/tests/relay-orca/scripts/gates.test.js
+++ b/tests/relay-orca/scripts/gates.test.js
@@ -365,6 +365,65 @@ test("D9.4: a failing gate proposes a follow-up in the report + receipt (--recor
 });
 
 // ---------------------------------------------------------------------------
+// A1 (owner amendment) — --record-proposals UPSERTS follow_ups; never replaces.
+// A prior operator-set `deferred` row must survive; only NEW derived ids append.
+// ---------------------------------------------------------------------------
+
+test("A1: --record-proposals upserts follow_ups — a pre-seeded deferred entry survives byte-for-byte and new proposals are appended", () => {
+  const deferredEntry = { id: "followup-later", source_outcome: "a", description: "operator deferred this", proposed_wave: 3, status: "deferred" };
+  const world = greenWorld("epic-a1-append", {
+    exitGates: ["integration:e2e"],
+    gateEvidence: { e2e: { passed: false } },
+    followUps: [deferredEntry],
+  });
+  try {
+    const before = JSON.parse(world.receiptOnDisk());
+    const recorded = world.run("--gates", ["--record-proposals"]);
+    assert.equal(recorded.status, 0);
+    const persisted = JSON.parse(world.receiptOnDisk());
+    // The operator-set deferred row survives byte-for-byte (still first, still deferred).
+    assert.deepEqual(persisted.follow_ups[0], deferredEntry);
+    // The freshly-derived proposal for the failing gate is APPENDED, not a replacement.
+    assert.equal(persisted.follow_ups.length, 2);
+    const appended = persisted.follow_ups[1];
+    assert.equal(appended.id, "followup-integration-e2e");
+    assert.equal(appended.source_gate, "integration:e2e");
+    assert.equal(appended.status, "proposed");
+    // Nothing else in the receipt changed (everything except follow_ups + the updated_at bump).
+    const strip = (r) => { const c = { ...r }; delete c.follow_ups; delete c.updated_at; return c; };
+    assert.deepEqual(strip(persisted), strip(before));
+    // Strictly read-only toward Orca/gh on the record path (poisons + the same log guard as D9.4).
+    assert.equal(world.orca.readPoison(), null);
+    assert.equal(world.gh.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A1: a derived proposal whose id collides with a recorded deferred entry does NOT overwrite it (recorded wins)", () => {
+  // The recorded entry shares the exact id the failing gate would derive, but the operator
+  // deferred it — recording must keep the deferral, never flip it back to a blocking proposal.
+  const deferredEntry = { id: "followup-integration-e2e", source_gate: "integration:e2e", description: "known-flaky, deferred by operator", proposed_wave: 4, status: "deferred" };
+  const world = greenWorld("epic-a1-conflict", {
+    exitGates: ["integration:e2e"],
+    gateEvidence: { e2e: { passed: false } },
+    followUps: [deferredEntry],
+  });
+  try {
+    const recorded = world.run("--gates", ["--record-proposals"]);
+    assert.equal(recorded.status, 0);
+    const persisted = JSON.parse(world.receiptOnDisk());
+    // Exactly one entry — the recorded deferred one, unchanged. The derived proposed twin was
+    // dropped on conflict rather than clobbering the operator's deferral.
+    assert.equal(persisted.follow_ups.length, 1);
+    assert.deepEqual(persisted.follow_ups[0], deferredEntry);
+    assert.equal(persisted.follow_ups[0].status, "deferred");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // D9.5 — follow-up ACCEPTANCE path; frozen compiler protections re-raise
 // ---------------------------------------------------------------------------
 

--- a/tests/relay-orca/scripts/gates.test.js
+++ b/tests/relay-orca/scripts/gates.test.js
@@ -73,6 +73,9 @@ function manifestText(fields) {
   lines.push("  source: 'github'");
   lines.push("---");
   lines.push("# Notes");
+  // Optional free-text notes (additive) so a scenario can plant a manifest whose body
+  // references the program — the signal live→receipt back-pointer discovery scans for.
+  if (fields.notes) lines.push(fields.notes);
   return `${lines.join("\n")}\n`;
 }
 
@@ -707,6 +710,58 @@ test("D9.10: a deferred follow-up is listed separately and does NOT block comple
     assert.equal(strict.status, 72);
   } finally {
     blocked.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A2 (owner amendment) — ANY present stop condition VETOES program_complete, even when
+// the D6 conjunction (outcomes complete + prerequisites met + gates passed + no blocking
+// follow-up) is otherwise fully green. stopped_on is never null while a stop is present.
+// ---------------------------------------------------------------------------
+
+test("A2: an unmapped back-pointer repair candidate vetoes program_complete though D6 is otherwise green → stopped_on graph_ambiguous", () => {
+  // Every D6 term is green: outcome "a" is durably complete and the budget gate passes. The
+  // ONLY blemish is a live relay manifest that references this program but is ABSENT from the
+  // receipt mapping — an unmapped back-pointer surfaced as a repair_candidate (graph ambiguous).
+  const world = greenWorld("epic-a2-backptr", {
+    exitGates: ["budget:waves_dispatched:9"],
+    manifests: [{ run_id: "run-orphan", state: "review_pending", pr_number: 20, issue_number: 200, notes: "relay-orca run for program epic-a2-backptr (unmapped back-pointer)" }],
+  });
+  try {
+    const f = world.run("--final-summary");
+    // The exit gate itself passed and there is NO gate/outcome/follow-up blocking reason —
+    // completion is denied solely because a stop condition is present.
+    assert.equal(f.body.gates.every((gate) => gate.state === "passed"), true, "the exit gate passed");
+    assert.equal(f.body.blocking_reasons.length, 0, "no gate/outcome/follow-up blocking reason — only the stop condition vetoes");
+    assert.equal(f.body.program_complete, false, "a present stop condition vetoes completion");
+    assert.equal(f.body.stopped_on, "graph_ambiguous");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("A2: a runtime mismatch vetoes program_complete though the outcome is durably complete → stopped_on orca_lifecycle_failure", () => {
+  // The outcome reconciles complete_with_evidence off DURABLE evidence (merged manifest +
+  // merged PR + closed issue) regardless of runtime trust, and the budget gate passes — so
+  // the D6 conjunction holds. But the live runtime id does not match the receipt's, so the
+  // report attributes runtime "mismatch" (a lifecycle failure). It must veto completion.
+  const world = buildGateWorld({
+    programId: "epic-a2-runtime",
+    receipt: makeReceipt({ programId: "epic-a2-runtime", slug: "__SELF__", root: "__SELF__", runtimeId: "runtime-receipt-abc", tasks: [{ outcome_id: "a", run: "run-a" }] }),
+    manifests: [{ run_id: "run-a", state: "merged", pr_number: 10, issue_number: 100, head_sha: "abc" }],
+    orcaScenario: { runtimeId: "runtime-live-xyz", tasks: [orcaTask("epic-a2-runtime", "a", { status: "completed", worker_done: true })] },
+    ghScenario: { prs: { 10: { state: "MERGED", mergedAt: "2026-07-13T01:00:00Z", headRefOid: "abc" } }, issues: { 100: { state: "CLOSED", stateReason: "COMPLETED" } } },
+    exitGates: ["budget:waves_dispatched:9"],
+  });
+  try {
+    const g = world.run("--gates");
+    assert.equal(g.body.prerequisites_met, true, "the outcome is durably complete even under a runtime mismatch");
+    assert.equal(g.body.gates.every((gate) => gate.state === "passed"), true, "the exit gate passed");
+    const f = world.run("--final-summary");
+    assert.equal(f.body.program_complete, false, "a runtime mismatch vetoes completion");
+    assert.equal(f.body.stopped_on, "orca_lifecycle_failure");
+  } finally {
+    world.cleanup();
   }
 });
 


### PR DESCRIPTION
## Dispatch Summary

```text
Implementation of **#947 — relay-orca: integration gates, follow-up waves, evidence-backed completion** is complete and committed (`744bd41` on `issue-947`).

## What shipped

Everything landed **inside the existing five intents** — no new intent, no new top-level script.

**New READ-ONLY `status` modes**
- `status --gates` evaluates the accepted program's `exit_gates` **verbatim** (six pinned prefixes: `integration:`/`advisory:`/`tracker:`/`decision:`/`budget:`/`authorization:`; unknown prefix 
```

## Score Log

- Run: issue-947-20260713114644983-35fab2ca
- Executor: claude
- Branch: issue-947


Fixes #947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * `status --gates` 및 `status --final-summary` 읽기 전용 모드를 추가했습니다.
  * 게이트 평가, 증거 기반 완료 여부, 차단 사유 및 후속 조치 제안을 확인할 수 있습니다.
  * `run`과 `resume`에서 결정 및 권한 기록을 선택적으로 저장할 수 있습니다.
  * 엄격 모드에서 실패 원인에 따라 명확한 종료 상태를 제공합니다.

* **문서**
  * 새 명령 옵션, 게이트 규칙, 완료 판정 및 영수증 기록 동작을 문서화했습니다.

* **버그 수정**
  * 기존 영수증 형식과 직렬화 결과의 호환성을 유지하면서 추가 기록을 안전하게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->