### PR TITLE
relay-orca #1001: align run/status/resume to real Orca CLI shapes

### DIFF
--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -255,7 +255,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
 | --- | --- |
 | `--program-id`, `-p` | The accepted program's stable id (required). Resolves the receipt under the programs root. |
 | `--json` | Emit the machine-readable resume report as JSON on stdout. |
-| `--operator-handle <handle>` | Repeatable. An explicit operator terminal to re-dispatch/reacquire to. `resume` never creates its own terminal and never adopts one it did not receive here: if an outcome needs (re)dispatch and no handle is provided, `resume` fails closed with a `decision_required` report (`RESUME_NO_OPERATOR_HANDLE`, exit 65) and performs zero mutation. Each handle must already run an agent CLI. |
+| `--operator-handle <handle>` | Repeatable. An explicit operator terminal to re-dispatch/reacquire to. `resume` never creates its own terminal and never adopts one it did not receive here: if an outcome needs (re)dispatch and no handle is provided, `resume` fails closed with a `decision_required` report (`RESUME_NO_OPERATOR_HANDLE`, exit 66) and performs zero mutation. Each handle must already run an agent CLI. |
 | `--orca-bin <path>` | Explicit Orca CLI override for the reconciliation reads and the restoration mutations. |
 | `--gh-bin <path>` | Explicit `gh` CLI override (or env `RELAY_ORCA_GH_BIN`). |
 | `--repo-root <path>` | Explicit repo root for slug derivation (defaults to the git repo of the cwd). |

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -106,7 +106,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
 | `--program-file`, `-f` | Accepted-program JSON contract (required) — the SAME input as `plan`. A precompiled plan JSON is NOT accepted (prevents tampered-plan injection). May be passed positionally. |
 | `--json` | Emit the machine-readable run report as JSON on stdout. |
 | `--concurrency N` | Override the concurrency ceiling. Default 2, hard maximum 4 (rejected via the plan library). |
-| `--operator-handle <handle>` | Repeatable. An explicit operator terminal handle to dispatch to. With none, `run` creates its own terminals via `orca terminal create` and records them. |
+| `--operator-handle <handle>` | Repeatable. An explicit operator terminal handle to dispatch to — REQUIRED. `run` dispatches ONLY to handles provided here and never creates its own terminal (a self-created terminal has no recognized agent and cannot accept `--inject`). With zero handles, `run` fails closed with `OPERATOR_DISPATCH_FAILED` (44) before any mutation. Each handle must be a terminal already running an agent CLI (`orca terminal create --command "<agent-cli>" --json`). |
 | `--orca-bin <path>` | Explicit Orca CLI override — passed to the capability probe and used for all orchestration calls. |
 | `--resolve-decision <id>` | (#947) Write a resolved `decision:` record for `<id>` into the receipt's `decisions[]`. Requires `--resolution` and `--resolver`; provenance (question/options/downstream_wave) is sourced from the program's declared `decision_gates[<id>]`. Never automatic. |
 | `--resolution <text>` | The decision resolution (with `--resolve-decision`). |
@@ -155,7 +155,7 @@ Completion-driven wave advancement is #945/#947 scope.
 | `TASK_MATERIALIZE_FAILED` | 41 | An `orca orchestration task-create` failed; earlier tasks are left in place and listed. |
 | `INJECTION_UNDELIVERED` | 42 | An `orca orchestration dispatch --inject` failed (or the post-verification prompt hand-off failed). |
 | `PROVENANCE_MISMATCH` | 43 | `dispatch-show` returned a null/empty/mismatched task id, dispatch id, or assignee. |
-| `OPERATOR_DISPATCH_FAILED` | 44 | No valid operator target remained for an eligible task (terminal create yielded no usable handle). |
+| `OPERATOR_DISPATCH_FAILED` | 44 | No operator terminal was provided: `run` was invoked with zero `--operator-handle` (it never self-creates a terminal). Rejected upfront, before any mutation. |
 
 A `42`/`43` failure records the failing task `escalated`, dispatches no further pending task,
 and does not touch already-verified running operators (stop semantics are #946). Plan-library
@@ -255,7 +255,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
 | --- | --- |
 | `--program-id`, `-p` | The accepted program's stable id (required). Resolves the receipt under the programs root. |
 | `--json` | Emit the machine-readable resume report as JSON on stdout. |
-| `--operator-handle <handle>` | Repeatable. An explicit operator terminal to re-dispatch/reacquire to. With none, `resume` creates its own terminals and records them; it never adopts a terminal it did not create or receive here. |
+| `--operator-handle <handle>` | Repeatable. An explicit operator terminal to re-dispatch/reacquire to. `resume` never creates its own terminal and never adopts one it did not receive here: if an outcome needs (re)dispatch and no handle is provided, `resume` fails closed with a `decision_required` report (`RESUME_NO_OPERATOR_HANDLE`, exit 65) and performs zero mutation. Each handle must already run an agent CLI. |
 | `--orca-bin <path>` | Explicit Orca CLI override for the reconciliation reads and the restoration mutations. |
 | `--gh-bin <path>` | Explicit `gh` CLI override (or env `RELAY_ORCA_GH_BIN`). |
 | `--repo-root <path>` | Explicit repo root for slug derivation (defaults to the git repo of the cwd). |

--- a/skills/relay-orca/references/operator-dispatch.md
+++ b/skills/relay-orca/references/operator-dispatch.md
@@ -57,19 +57,26 @@ For each dispatched task, in order:
 2. `orca orchestration dispatch-show --task <orca_task_id> --json` MUST carry a task id equal to
    the dispatched id, a non-null non-empty dispatch id, and a non-null non-empty assignee
    handle. Any null/empty/mismatched value → `PROVENANCE_MISMATCH` (exit 43).
-3. **Only after** verification succeeds is the operator prompt delivered (via `orca terminal
-   send`, prompt on stdin). It is never delivered before verification.
+3. **Only after** verification succeeds is the operator prompt delivered via one
+   `orca terminal send --terminal <handle> --text <full prompt> --enter --json` (the real
+   mid-2026 CLI — no `--to`, no `--task`, no stdin). The full prompt rides in a single
+   `--text` value and is never split. It is never delivered before verification.
 
 An unverified task is never reported `dispatched`. A step 1–2 failure records the task
 `escalated`, dispatches no further pending task, and leaves already-verified running operators
 untouched (stop semantics are #946).
 
-## Terminal acquisition
+## Terminal acquisition — explicit handles only
 
-`run` dispatches only to handles it (a) received via a repeatable `--operator-handle`, or (b)
-created itself via `orca terminal create` this invocation (each created handle recorded in the
-report's `terminals_created`). A handle carries at most one active dispatched task; when ready
-tasks exceed available handles, remaining tasks stay `pending` (partial wave dispatch).
+`run` dispatches ONLY to operator terminals passed via a repeatable `--operator-handle`. It
+NEVER creates its own terminal: a bare `orca terminal create` yields an agent-less terminal,
+and `orca orchestration dispatch --inject` to such a terminal hard-fails with *"no recognized
+agent detected"*. Each handle must therefore already be running an agent CLI — create one with
+`orca terminal create --command "<agent-cli>" --json` and pass its handle. Invoked with zero
+handles, `run` fails closed with `OPERATOR_DISPATCH_FAILED` (44) BEFORE any mutation (no
+task-create, no dispatch, no terminal create); `terminals_created` is always `[]`. A handle
+carries at most one active dispatched task; when ready tasks exceed available handles, the
+remaining tasks stay `pending` (partial wave dispatch).
 
 ## Reason codes
 
@@ -79,6 +86,6 @@ tasks exceed available handles, remaining tasks stay `pending` (partial wave dis
 | `TASK_MATERIALIZE_FAILED` | 41 | An `orca orchestration task-create` failed; earlier tasks left in place and listed. |
 | `INJECTION_UNDELIVERED` | 42 | A `dispatch --inject` step failed (or the post-verification prompt hand-off failed). |
 | `PROVENANCE_MISMATCH` | 43 | `dispatch-show` returned null/empty/mismatched provenance. |
-| `OPERATOR_DISPATCH_FAILED` | 44 | No valid operator target remained for an eligible task. |
+| `OPERATOR_DISPATCH_FAILED` | 44 | `run` was invoked with zero `--operator-handle` (it never self-creates a terminal). Rejected upfront, before any mutation. |
 
 Plan-library rejections (`2`–`21`) re-raise verbatim; usage errors exit `64`.

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -20,7 +20,7 @@ creates its own operator terminal — on any path, including every failure path.
 mutations `resume` performs are, on a safe outcome, `orca orchestration dispatch --inject` and
 `orca terminal send`, both against a terminal the operator provided via `--operator-handle`; if
 an outcome needs (re)dispatch and no handle was provided, `resume` fails closed with
-`RESUME_NO_OPERATOR_HANDLE` (exit 65) and mutates nothing. `stop`'s only mutation is
+`RESUME_NO_OPERATOR_HANDLE` (exit 66) and mutates nothing. `stop`'s only mutation is
 `orca orchestration run-stop`.
 
 ## Reading a `decision_required` report
@@ -76,7 +76,7 @@ that would duplicate operator work. Bounded steps:
 2. Restore the missing `dispatch_id`/`assignee` in the receipt to match the live dispatch.
 3. Re-run `resume` — the outcome now reads back as a valid live mapping and is reused.
 
-### `RESUME_NO_OPERATOR_HANDLE` (exit 65) — an outcome needs (re)dispatch but no handle was given
+### `RESUME_NO_OPERATOR_HANDLE` (exit 66) — an outcome needs (re)dispatch but no handle was given
 
 Reconciliation found at least one outcome that is safe to re-dispatch or whose operator terminal
 must be reacquired, but the invocation provided no `--operator-handle`. `resume` never creates its

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -3,7 +3,8 @@
 `resume` is **reconcile-first and fail-closed**: it loads the reconstructible receipt, runs the
 SAME live reconciliation as `status` **before any mutation**, and only then restores what is
 safe (reuse valid mappings, reacquire a lost operator terminal, re-dispatch a verifiably-absent,
-relay-clean, wave-1 outcome through the verified path). **"Verifiably absent" means a live
+relay-clean, wave-1 outcome through the verified path — always to an explicitly provided
+`--operator-handle`, never a self-created terminal). **"Verifiably absent" means a live
 `dispatch-show` read for that task, taken during the reconciliation pass, reported NO dispatch —
 a null `dispatch_id` in the receipt alone NEVER qualifies.** In the crash window (a
 `dispatch --inject` landed a live dispatch but the receipt write recording it never happened),
@@ -14,10 +15,13 @@ and emits a `decision_required` report with a bounded exit code. This reference 
 anchor for those decisions.
 
 None of the steps below are performed automatically by the skill. The skill **never** resets
-Orca, deletes a task, removes a worktree, deletes a branch/PR, or force-closes a relay run — on
-any path, including every failure path. The **only** mutations `resume` performs are, on a safe
-outcome, `orca orchestration dispatch --inject`, `orca terminal create`, and `orca terminal
-send`; `stop`'s only mutation is `orca orchestration run-stop`.
+Orca, deletes a task, removes a worktree, deletes a branch/PR, force-closes a relay run, or
+creates its own operator terminal — on any path, including every failure path. The **only**
+mutations `resume` performs are, on a safe outcome, `orca orchestration dispatch --inject` and
+`orca terminal send`, both against a terminal the operator provided via `--operator-handle`; if
+an outcome needs (re)dispatch and no handle was provided, `resume` fails closed with
+`RESUME_NO_OPERATOR_HANDLE` (exit 65) and mutates nothing. `stop`'s only mutation is
+`orca orchestration run-stop`.
 
 ## Reading a `decision_required` report
 
@@ -71,6 +75,19 @@ that would duplicate operator work. Bounded steps:
 1. Read the live dispatch: `orca orchestration dispatch-show --task <orca_task_id> --json`.
 2. Restore the missing `dispatch_id`/`assignee` in the receipt to match the live dispatch.
 3. Re-run `resume` — the outcome now reads back as a valid live mapping and is reused.
+
+### `RESUME_NO_OPERATOR_HANDLE` (exit 65) — an outcome needs (re)dispatch but no handle was given
+
+Reconciliation found at least one outcome that is safe to re-dispatch or whose operator terminal
+must be reacquired, but the invocation provided no `--operator-handle`. `resume` never creates its
+own terminal (a self-created terminal has no recognized agent and cannot accept `--inject`), so it
+performs **zero** mutation and asks for a terminal. Bounded steps:
+
+1. Create an operator terminal running an agent CLI: `orca terminal create --command "<agent-cli>" --json`.
+2. Re-run `resume` with that terminal handle:
+   `node scripts/resume.js --program-id <id> --operator-handle <handle> --json`.
+3. Provide one handle per outcome that needs a fresh operator surface; a shortfall leaves the
+   excess outcomes untouched for a follow-up resume.
 
 ## Corrupt or global task-graph recovery
 

--- a/skills/relay-orca/scripts/lib/orca-reads.js
+++ b/skills/relay-orca/scripts/lib/orca-reads.js
@@ -52,8 +52,9 @@ function orcaGateList(run, orcaBin, options = {}) {
   return { ok: true, reachable: true, gates, runtimeId: metaRuntimeId(value), proc };
 }
 
-// First non-empty string among the candidates, else null. Used so a reader can prefer the
-// real nested provenance and still fall back to a legacy flat field.
+// First non-empty string among the candidates, else null. Candidates are drawn from a
+// SINGLE provenance domain (all nested, or all flat) — never mixed — so the authoritative
+// rule below is honored; it exists only to pick among tolerated aliases within that domain.
 function firstNonEmpty(...candidates) {
   for (const candidate of candidates) {
     if (isNonEmptyString(candidate)) return candidate;
@@ -68,20 +69,33 @@ function orcaDispatchShow(run, orcaBin, taskId, options = {}) {
   const result = value.result || {};
   // Real mid-2026 shape (D4.3): provenance is nested under result.dispatch — task id at
   // task_id, dispatch id at id (tolerating dispatch_id), assignee at assignee_handle
-  // (tolerating assignee/to). Legacy flat fields stay as a fallback.
-  const dispatch = result.dispatch && typeof result.dispatch === "object" ? result.dispatch : {};
-  const assignee = firstNonEmpty(dispatch.assignee_handle, dispatch.assignee, dispatch.to, result.assignee);
-  // Terminal presence: an explicit `terminal_present:false` anywhere in result OR
-  // result.dispatch (or a null assignee) means the dispatched operator terminal is gone
-  // (feeds MISSING_TERMINAL, D7).
-  const terminalGone = result.terminal_present === false || dispatch.terminal_present === false;
-  const terminalPresent = terminalGone ? false : Boolean(assignee);
+  // (tolerating assignee/to). When result.dispatch is a present object it is AUTHORITATIVE:
+  // facts resolve ONLY inside it, so an empty/missing nested field stays null (upstream →
+  // PROVENANCE_MISMATCH / MISSING_*) rather than being rescued by a legacy flat field. The
+  // flat fields apply ONLY when result.dispatch is absent or is not an object.
+  const nested = result.dispatch && typeof result.dispatch === "object" ? result.dispatch : null;
+  const facts = nested
+    ? {
+        taskId: firstNonEmpty(nested.task_id),
+        dispatchId: firstNonEmpty(nested.id, nested.dispatch_id),
+        assignee: firstNonEmpty(nested.assignee_handle, nested.assignee, nested.to),
+      }
+    : {
+        taskId: firstNonEmpty(result.task_id),
+        dispatchId: firstNonEmpty(result.dispatch_id),
+        assignee: firstNonEmpty(result.assignee),
+      };
+  // Terminal presence: an explicit `terminal_present:false` in result OR result.dispatch (or
+  // a null resolved assignee) means the dispatched operator terminal is gone (feeds
+  // MISSING_TERMINAL, D7).
+  const terminalGone = result.terminal_present === false || (nested && nested.terminal_present === false);
+  const terminalPresent = terminalGone ? false : Boolean(facts.assignee);
   return {
     ok: true,
     reachable: true,
-    taskId: firstNonEmpty(dispatch.task_id, result.task_id),
-    dispatchId: firstNonEmpty(dispatch.id, dispatch.dispatch_id, result.dispatch_id),
-    assignee,
+    taskId: facts.taskId,
+    dispatchId: facts.dispatchId,
+    assignee: facts.assignee,
     terminalPresent,
     // A17: expose the per-task read's `_meta.runtimeId` so the caller can prove THIS
     // task's dispatch-show came from the receipt's runtime before adopting its facts.

--- a/skills/relay-orca/scripts/lib/orca-reads.js
+++ b/skills/relay-orca/scripts/lib/orca-reads.js
@@ -52,20 +52,35 @@ function orcaGateList(run, orcaBin, options = {}) {
   return { ok: true, reachable: true, gates, runtimeId: metaRuntimeId(value), proc };
 }
 
+// First non-empty string among the candidates, else null. Used so a reader can prefer the
+// real nested provenance and still fall back to a legacy flat field.
+function firstNonEmpty(...candidates) {
+  for (const candidate of candidates) {
+    if (isNonEmptyString(candidate)) return candidate;
+  }
+  return null;
+}
+
 function orcaDispatchShow(run, orcaBin, taskId, options = {}) {
   const proc = run(orcaBin, ["orchestration", "dispatch-show", "--task", String(taskId), "--json"], options);
   const { ok, value } = envelope(proc);
   if (!ok) return { ok: false, reachable: false, proc };
   const result = value.result || {};
-  const assignee = isNonEmptyString(result.assignee) ? result.assignee : null;
-  // Terminal presence: an explicit `terminal_present:false` (or a null assignee)
-  // means the dispatched operator terminal is gone (feeds MISSING_TERMINAL, D7).
-  const terminalPresent = result.terminal_present === false ? false : Boolean(assignee);
+  // Real mid-2026 shape (D4.3): provenance is nested under result.dispatch — task id at
+  // task_id, dispatch id at id (tolerating dispatch_id), assignee at assignee_handle
+  // (tolerating assignee/to). Legacy flat fields stay as a fallback.
+  const dispatch = result.dispatch && typeof result.dispatch === "object" ? result.dispatch : {};
+  const assignee = firstNonEmpty(dispatch.assignee_handle, dispatch.assignee, dispatch.to, result.assignee);
+  // Terminal presence: an explicit `terminal_present:false` anywhere in result OR
+  // result.dispatch (or a null assignee) means the dispatched operator terminal is gone
+  // (feeds MISSING_TERMINAL, D7).
+  const terminalGone = result.terminal_present === false || dispatch.terminal_present === false;
+  const terminalPresent = terminalGone ? false : Boolean(assignee);
   return {
     ok: true,
     reachable: true,
-    taskId: isNonEmptyString(result.task_id) ? result.task_id : null,
-    dispatchId: isNonEmptyString(result.dispatch_id) ? result.dispatch_id : null,
+    taskId: firstNonEmpty(dispatch.task_id, result.task_id),
+    dispatchId: firstNonEmpty(dispatch.id, dispatch.dispatch_id, result.dispatch_id),
     assignee,
     terminalPresent,
     // A17: expose the per-task read's `_meta.runtimeId` so the caller can prove THIS

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -203,9 +203,30 @@ function classifyAction(task, report, unmappedRelayWork, liveDispatch) {
   return makeAction(task, "skipped", `outcome ${task.outcome_id} has in-flight/durable relay work or is a later wave; left untouched`);
 }
 
+// D3.3: an outcome that needs a fresh operator surface (a redispatch or a terminal
+// reacquisition carries an `exec` plan) can only be executed against an explicitly provided
+// --operator-handle — resume NEVER creates its own operator terminal. With no usable handle,
+// resume fails closed as a `decision_required` report with ZERO mutation, offering the
+// operator-handle path. Reused/skipped outcomes carry no `exec`, so a handle-free resume
+// with nothing to (re)dispatch proceeds normally.
+function blockedByNoOperatorHandle(receipt, actions, hasOperatorHandle) {
+  if (hasOperatorHandle || !actions.some((action) => action.exec)) return null;
+  const decision = decisionEntry(
+    "RESUME_NO_OPERATOR_HANDLE",
+    "one or more outcomes need (re)dispatch but no --operator-handle was provided; resume never creates its own operator terminal, so it performs no mutation",
+  );
+  const blocked = receipt.tasks.map((task) => makeAction(task, "decision_required", boundedExcerpt(`blocked: ${decision.reason_code}`), null));
+  return {
+    decisions: [decision],
+    actions: blocked,
+    blockingReasons: [{ reason_code: decision.reason_code, message: decision.message }],
+    exitCode: exitCodeFor(decision.reason_code),
+  };
+}
+
 // The whole plan: program-level decisions plus per-outcome actions. When any decision
 // fires, EVERY outcome is `decision_required` (resume performs zero mutation, D2).
-function planResume({ receipt, report, liveDispatch }) {
+function planResume({ receipt, report, liveDispatch, hasOperatorHandle = false }) {
   const decisions = planDecisions(receipt, report, liveDispatch);
   if (decisions.length) {
     const reason = boundedExcerpt(`blocked: ${decisions[0].reason_code}`);
@@ -215,7 +236,7 @@ function planResume({ receipt, report, liveDispatch }) {
   }
   const unmappedRelayWork = hasUnmappedRelayWork(report);
   const actions = receipt.tasks.map((task) => classifyAction(task, report, unmappedRelayWork, liveDispatch));
-  return { decisions: [], actions, blockingReasons: [], exitCode: 0 };
+  return blockedByNoOperatorHandle(receipt, actions, hasOperatorHandle) || { decisions: [], actions, blockingReasons: [], exitCode: 0 };
 }
 
 module.exports = {

--- a/skills/relay-orca/scripts/lib/resume-reasons.js
+++ b/skills/relay-orca/scripts/lib/resume-reasons.js
@@ -3,7 +3,8 @@
 // relay-orca `resume` fail-closed DECISION matrix (#946 D2). A NEW module in the
 // 60-range so it never collides with plan.js's 2-21 codes, the probe's 30-37, run's
 // 40-44, status/receipt's 50-52, or Node's own fatal/exec codes (<=125). Existing
-// reason modules stay untouched. 64 is deliberately avoided (usage errors own it).
+// reason modules stay untouched. 64 (usage errors) and 65 (stop's
+// COORDINATOR_STOP_FAILED) are deliberately avoided.
 //
 // These are the ONLY conditions that make resumption unsafe. In any of them
 // resume performs NO automatic mutation: it emits a `decision_required` report and
@@ -17,7 +18,7 @@ const REASONS = Object.freeze({
   RESUME_AMBIGUOUS_STATE: 61, // foreign/unreachable runtime, or an unclassifiable outcome
   RESUME_CONFLICTING_MAPPING: 62, // duplicate or contradictory (changed) mappings
   RESUME_MISSING_PROVENANCE: 63, // a mapping's dispatch context/assignee is missing where a live dispatch exists
-  RESUME_NO_OPERATOR_HANDLE: 65, // an outcome needs (re)dispatch but no --operator-handle was provided (64 = usage)
+  RESUME_NO_OPERATOR_HANDLE: 66, // an outcome needs (re)dispatch but no --operator-handle was provided (64 = usage, 65 = stop's COORDINATOR_STOP_FAILED)
 });
 
 // Bounded recovery options per decision code (D2). Each option names a concrete

--- a/skills/relay-orca/scripts/lib/resume-reasons.js
+++ b/skills/relay-orca/scripts/lib/resume-reasons.js
@@ -5,7 +5,7 @@
 // 40-44, status/receipt's 50-52, or Node's own fatal/exec codes (<=125). Existing
 // reason modules stay untouched. 64 is deliberately avoided (usage errors own it).
 //
-// These four are the ONLY conditions that make resumption unsafe. In any of them
+// These are the ONLY conditions that make resumption unsafe. In any of them
 // resume performs NO automatic mutation: it emits a `decision_required` report and
 // exits with the matching code. Receipt-layer failures re-use status's 50-52
 // verbatim (imported by resume.js); these decision codes are surfaced through the
@@ -17,6 +17,7 @@ const REASONS = Object.freeze({
   RESUME_AMBIGUOUS_STATE: 61, // foreign/unreachable runtime, or an unclassifiable outcome
   RESUME_CONFLICTING_MAPPING: 62, // duplicate or contradictory (changed) mappings
   RESUME_MISSING_PROVENANCE: 63, // a mapping's dispatch context/assignee is missing where a live dispatch exists
+  RESUME_NO_OPERATOR_HANDLE: 65, // an outcome needs (re)dispatch but no --operator-handle was provided (64 = usage)
 });
 
 // Bounded recovery options per decision code (D2). Each option names a concrete
@@ -43,6 +44,11 @@ const OPTIONS = Object.freeze({
     "Verify the live dispatch: `orca orchestration dispatch-show --task <orca_task_id> --json`.",
     "Restore the missing dispatch context/assignee in the receipt by hand before resuming.",
     "See references/recovery.md § RESUME_MISSING_PROVENANCE for the bounded manual steps.",
+  ],
+  RESUME_NO_OPERATOR_HANDLE: [
+    "Create an operator terminal running an agent CLI: `orca terminal create --command \"<agent-cli>\" --json`.",
+    "Re-run resume with the terminal handle: `node scripts/resume.js --program-id <id> --operator-handle <handle> --json`.",
+    "See references/recovery.md § RESUME_NO_OPERATOR_HANDLE for the bounded manual steps.",
   ],
 });
 

--- a/skills/relay-orca/scripts/lib/run-orca.js
+++ b/skills/relay-orca/scripts/lib/run-orca.js
@@ -40,8 +40,18 @@ function pickString(result, keys) {
   return null;
 }
 
+function dispatchObject(result) {
+  return result && typeof result.dispatch === "object" && result.dispatch ? result.dispatch : null;
+}
+
+// Real mid-2026 shape (D2): provenance is nested under result.dispatch — the task id at
+// result.dispatch.task_id, the dispatch id at result.dispatch.id (tolerating dispatch_id),
+// and the assignee at result.dispatch.assignee_handle (tolerating assignee/to). The flat
+// reads are retained as a fallback for legacy payloads.
 function extractTaskId(payload) {
   const result = payload && payload.result;
+  const nested = pickString(dispatchObject(result), ["task_id"]);
+  if (nested) return nested;
   const direct = pickString(result, ["task_id", "taskId", "id"]);
   if (direct) return direct;
   if (result && result.task) return pickString(result.task, ["id", "task_id"]);
@@ -50,25 +60,19 @@ function extractTaskId(payload) {
 
 function extractDispatchId(payload) {
   const result = payload && payload.result;
+  const nested = pickString(dispatchObject(result), ["id", "dispatch_id"]);
+  if (nested) return nested;
   const direct = pickString(result, ["dispatch_id", "dispatchId", "id"]);
   if (direct) return direct;
-  if (result && result.dispatch) return pickString(result.dispatch, ["id", "dispatch_id"]);
   return null;
 }
 
 function extractAssignee(payload) {
   const result = payload && payload.result;
+  const nested = pickString(dispatchObject(result), ["assignee_handle", "assignee", "to"]);
+  if (nested) return nested;
   const direct = pickString(result, ["assignee", "to", "handle"]);
   if (direct) return direct;
-  if (result && result.dispatch) return pickString(result.dispatch, ["assignee", "to"]);
-  return null;
-}
-
-function extractHandle(payload) {
-  const result = payload && payload.result;
-  const direct = pickString(result, ["handle", "terminal_id", "terminalId", "id"]);
-  if (direct) return direct;
-  if (result && result.terminal) return pickString(result.terminal, ["handle", "id"]);
   return null;
 }
 
@@ -110,19 +114,14 @@ function showDispatch(run, orcaBin, { orcaTaskId }, options = {}) {
   };
 }
 
-function createTerminal(run, orcaBin, options = {}) {
-  const proc = run(orcaBin, ["terminal", "create", "--json"], options);
-  const parsed = parseJson(proc.stdout);
-  const handle = envelopeOk(proc, parsed) ? extractHandle(parsed.value) : null;
-  return { ok: envelopeOk(proc, parsed) && isNonEmptyString(handle), handle, proc, parsed };
-}
-
-// Prompt delivery (D6 step 3). Called ONLY after provenance verification. The
-// prompt is passed on stdin (via options.input) so a multi-line operator prompt
-// never lands in argv (and never corrupts the invocation log used by tests).
-function sendPrompt(run, orcaBin, { orcaTaskId, handle, prompt }, options = {}) {
-  const args = ["terminal", "send", "--to", handle, "--task", orcaTaskId, "--json"];
-  const proc = run(orcaBin, args, { ...options, input: prompt });
+// Prompt delivery (D6 step 3). Called ONLY after provenance verification. The real
+// mid-2026 CLI is `orca terminal send --terminal <handle> --text <text> [--enter] [--json]`
+// — there is NO --to flag, NO --task flag, and NO stdin payload path (D1). The full
+// operator prompt is delivered as ONE --text value in a SINGLE send (never split), and the
+// success gate stays fail-closed and unchanged (exit 0 + JSON + ok===true).
+function sendPrompt(run, orcaBin, { handle, prompt }, options = {}) {
+  const args = ["terminal", "send", "--terminal", handle, "--text", String(prompt), "--enter", "--json"];
+  const proc = run(orcaBin, args, options);
   const parsed = parseJson(proc.stdout);
   return { ok: envelopeOk(proc, parsed), proc, parsed };
 }
@@ -135,6 +134,5 @@ module.exports = {
   createTask,
   dispatchTask,
   showDispatch,
-  createTerminal,
   sendPrompt,
 };

--- a/skills/relay-orca/scripts/lib/run-orca.js
+++ b/skills/relay-orca/scripts/lib/run-orca.js
@@ -46,12 +46,15 @@ function dispatchObject(result) {
 
 // Real mid-2026 shape (D2): provenance is nested under result.dispatch — the task id at
 // result.dispatch.task_id, the dispatch id at result.dispatch.id (tolerating dispatch_id),
-// and the assignee at result.dispatch.assignee_handle (tolerating assignee/to). The flat
-// reads are retained as a fallback for legacy payloads.
+// and the assignee at result.dispatch.assignee_handle (tolerating assignee/to). When
+// result.dispatch is a present object it is AUTHORITATIVE: provenance resolves ONLY inside
+// it, so an empty/missing nested value stays null (upstream → PROVENANCE_MISMATCH) rather
+// than being rescued by a legacy flat field. The flat reads apply ONLY when result.dispatch
+// is absent or is not an object.
 function extractTaskId(payload) {
   const result = payload && payload.result;
-  const nested = pickString(dispatchObject(result), ["task_id"]);
-  if (nested) return nested;
+  const dispatch = dispatchObject(result);
+  if (dispatch) return pickString(dispatch, ["task_id"]);
   const direct = pickString(result, ["task_id", "taskId", "id"]);
   if (direct) return direct;
   if (result && result.task) return pickString(result.task, ["id", "task_id"]);
@@ -60,20 +63,16 @@ function extractTaskId(payload) {
 
 function extractDispatchId(payload) {
   const result = payload && payload.result;
-  const nested = pickString(dispatchObject(result), ["id", "dispatch_id"]);
-  if (nested) return nested;
-  const direct = pickString(result, ["dispatch_id", "dispatchId", "id"]);
-  if (direct) return direct;
-  return null;
+  const dispatch = dispatchObject(result);
+  if (dispatch) return pickString(dispatch, ["id", "dispatch_id"]);
+  return pickString(result, ["dispatch_id", "dispatchId", "id"]);
 }
 
 function extractAssignee(payload) {
   const result = payload && payload.result;
-  const nested = pickString(dispatchObject(result), ["assignee_handle", "assignee", "to"]);
-  if (nested) return nested;
-  const direct = pickString(result, ["assignee", "to", "handle"]);
-  if (direct) return direct;
-  return null;
+  const dispatch = dispatchObject(result);
+  if (dispatch) return pickString(dispatch, ["assignee_handle", "assignee", "to"]);
+  return pickString(result, ["assignee", "to", "handle"]);
 }
 
 // A subprocess is "ok" only when it exited 0, produced parseable JSON, and that

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -16,7 +16,6 @@ const {
   createTask,
   dispatchTask,
   showDispatch,
-  createTerminal,
   sendPrompt,
 } = require("./run-orca");
 const { buildOperatorPrompt } = require("./operator-prompt");
@@ -123,36 +122,36 @@ function materialize(plan, program, report, orcaBin, options) {
   return { taskByPlanId, entryByPlanId, orcaIdByPlanId };
 }
 
-// D5 terminal acquisition. A handle is either (a) an explicit --operator-handle
-// or (b) one created via `orca terminal create` this invocation. When explicit
-// handles are provided, run uses only those: exhausting them leaves the remaining
-// eligible tasks pending (handle-shortfall, no error). With no explicit handles,
-// run creates a fresh terminal per dispatch; a create that yields no usable
-// handle is OPERATOR_DISPATCH_FAILED. Every created handle is recorded (D10).
-function makeHandlePool(orcaBin, report, options) {
+// D3 terminal acquisition: EXPLICIT handles only. `run` dispatches solely to the
+// terminals the operator passed via --operator-handle and NEVER creates one itself —
+// a bare `terminal create` yields an agent-less terminal that can never accept
+// `--inject` ("no recognized agent detected"). Exhausting the provided handles leaves
+// the remaining eligible tasks pending (handle-shortfall, no error). The zero-handle
+// case is rejected UPFRONT (requireOperatorHandles) before any materialization, so the
+// pool here is only ever consulted when at least one handle exists.
+function makeHandlePool(options) {
   const explicit = Array.isArray(options.operatorHandles) ? options.operatorHandles.slice() : [];
-  const hasExplicit = explicit.length > 0;
   let index = 0;
   return {
     acquire() {
-      if (hasExplicit) return index < explicit.length ? explicit[index++] : null;
-      const term = createTerminal(options.runOrca, orcaBin);
-      if (!term.ok) {
-        reject(
-          "OPERATOR_DISPATCH_FAILED",
-          "no valid operator target: orca terminal create yielded no usable handle" +
-            procDetail(term.proc, "response reported ok:false or returned no handle"),
-        );
-      }
-      report.terminals_created.push(term.handle);
-      // A16: persist the receipt IMMEDIATELY after recording the created terminal handle —
-      // before the dispatch that may fail. A dispatch (or provenance) failure right after
-      // auto terminal creation must leave the on-disk receipt already carrying the handle,
-      // so a reconcile can adopt (not re-create) the terminal instead of leaking it.
-      persistReceipt(report, options);
-      return term.handle;
+      return index < explicit.length ? explicit[index++] : null;
     },
   };
+}
+
+// D3.1: `run` invoked with ZERO --operator-handle fails closed with
+// OPERATOR_DISPATCH_FAILED (exit 44) BEFORE any mutating Orca subcommand runs (no
+// task-create, no dispatch, no terminal create). The remediation instructs creating a
+// terminal with an agent CLI and re-running with an explicit handle.
+function requireOperatorHandles(options) {
+  const explicit = Array.isArray(options.operatorHandles) ? options.operatorHandles : [];
+  if (explicit.length === 0) {
+    reject(
+      "OPERATOR_DISPATCH_FAILED",
+      "no operator terminal provided: relay-orca run dispatches only to explicitly provided --operator-handle terminals and never creates its own (a self-created terminal has no recognized agent and cannot accept --inject)",
+      'Create an operator terminal running an agent CLI via `orca terminal create --command "<agent-cli>" --json`, then re-run with `--operator-handle <handle>`.',
+    );
+  }
 }
 
 // D6.2 provenance trio verification. Returns a bounded description of the first
@@ -229,7 +228,7 @@ function dispatchOne(ctx) {
 function dispatchWave(plan, program, report, orcaBin, maps, options) {
   const wave1 = plan.waves.length ? plan.waves[0].task_ids : [];
   const target = Math.min(wave1.length, plan.concurrency);
-  const handles = makeHandlePool(orcaBin, report, options);
+  const handles = makeHandlePool(options);
   const outcomeById = new Map(program.outcomes.map((outcome) => [outcome.id, outcome]));
   for (let i = 0; i < target; i += 1) {
     const planId = wave1[i];
@@ -259,6 +258,9 @@ function orchestrate(rawProgram, options = {}) {
   const report = initReport(plan);
   try {
     const orcaBin = admit(report, options);
+    // D3.1: reject a zero-handle run AFTER admission (probe result) and BEFORE any
+    // materialization mutation, so no task-create/dispatch/terminal-create ever runs.
+    requireOperatorHandles(options);
     // materialize persists the receipt after EACH successful task-create (A12), so the
     // full outcome→orca_task_id mapping is already durable here; dispatchWave then
     // re-persists after each provenance verification (A2). No separate post-materialize

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -46,6 +46,20 @@ function referencesProgram(text, programId) {
   return body.includes("relay-orca") && body.includes(programId);
 }
 
+// D4.1: a live task row's display string is the FIRST non-empty of `task_title`,
+// `display_name`, `title`. The real mid-2026 task-list row carries `task_title`
+// (and `display_name`) and NO `title`; older rows may still carry only `title`.
+// Reading `task_title` first means a real row is never dropped, while the `title`
+// fallback keeps legacy rows resolvable.
+function taskDisplayString(task) {
+  if (!task || typeof task !== "object") return "";
+  const candidates = [task.task_title, task.display_name, task.title];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) return candidate;
+  }
+  return "";
+}
+
 // Attribute the live runtime (D6). Orca facts are trusted ONLY when the live runtime
 // id matches the receipt AND every live orchestration task is marked for this program.
 function attributeRuntime({ receipt, programId, orca, programSegment }) {
@@ -72,7 +86,7 @@ function attributeRuntime({ receipt, programId, orca, programSegment }) {
   const tasks = taskList.tasks;
   const gates = gateList.gates;
   const marker = programMarker(programId, programSegment);
-  const foreignTasks = tasks.filter((task) => !(typeof task.title === "string" && task.title.includes(marker)));
+  const foreignTasks = tasks.filter((task) => !taskDisplayString(task).includes(marker));
   // The live runtime id is subprocess-derived, so it is bounded (≤256 chars, marker
   // included) before it enters a diagnostic — the same rule the probe uses (D7).
   const liveRuntime = boundedExcerpt(status.runtimeId);

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -34,7 +34,7 @@ const { deriveStatusReport } = require("./lib/status-derive");
 const { StatusError, USAGE_EXIT, reject: rejectReceipt } = require("./lib/status-reasons");
 const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
 const { assertOrcaReadOnly, assertGhReadOnly } = require("./status.js");
-const { dispatchTask, showDispatch, createTerminal, sendPrompt } = require("./lib/run-orca");
+const { dispatchTask, showDispatch, sendPrompt } = require("./lib/run-orca");
 const { provenanceMismatch } = require("./lib/run-orchestrator");
 const { buildOperatorPrompt } = require("./lib/operator-prompt");
 const { routeFor, defaultEvidenceFor } = require("./lib/task-kinds");
@@ -274,17 +274,13 @@ function syntheticTask(receiptTask) {
   };
 }
 
-// Acquire an operator handle: an explicit --operator-handle first (never adopting a
-// terminal it did not receive — D4), else a freshly created terminal recorded in the
-// receipt IMMEDIATELY (A16) before the dispatch that may fail.
+// Acquire an operator handle: EXPLICIT --operator-handle only (never adopting a terminal it
+// did not receive, and never self-creating one — a bare `terminal create` yields an
+// agent-less terminal that cannot accept --inject, D3). Exhausting the provided handles
+// returns null; the zero-handle case is caught upfront by planResume (RESUME_NO_OPERATOR_HANDLE)
+// so a partial-handle shortfall is the only null path reachable here.
 function acquireHandle(ctx) {
-  if (ctx.explicit.length) return ctx.index < ctx.explicit.length ? ctx.explicit[ctx.index++] : null;
-  const term = createTerminal(ctx.runOrca, ctx.orcaBin);
-  if (!term.ok) return null;
-  ctx.receipt.terminals_created.push(term.handle);
-  ctx.reportTerminals.push(term.handle);
-  ctx.persist();
-  return term.handle;
+  return ctx.index < ctx.explicit.length ? ctx.explicit[ctx.index++] : null;
 }
 
 function blockingReason(reasonCode, message) {
@@ -399,7 +395,7 @@ function main() {
 
   // Reconciliation is complete; the plan is pure. A program-level decision performs ZERO
   // mutation and exits 60-63; otherwise the safe actions execute through the verified path.
-  const plan = planResume({ receipt, report, liveDispatch });
+  const plan = planResume({ receipt, report, liveDispatch, hasOperatorHandle: opts.operatorHandles.length > 0 });
   let terminalsCreated = [];
   let blockingReasons = plan.blockingReasons.slice();
   if (plan.exitCode === 0) {

--- a/tests/relay-orca/fixtures/fake-orca-resume.js
+++ b/tests/relay-orca/fixtures/fake-orca-resume.js
@@ -140,11 +140,25 @@ if (args[0] === "terminal" && args[1] === "create") {
   emit({ ok: true, result: { handle: "orca-term-" + n, id: "orca-term-" + n }, _meta: meta }, 0);
 }
 if (args[0] === "terminal" && args[1] === "send") {
-  // D1/D5.3 poison-pin: the real 'terminal send' has NO --to and NO --task flag.
-  if (args.indexOf("--to") >= 0 || args.indexOf("--task") >= 0) {
-    const badFlag = args.indexOf("--to") >= 0 ? "--to" : "--task";
-    process.stderr.write("terminal send: unrecognized flag " + badFlag + "\\n");
-    emit({ ok: false, error: "terminal send does not accept " + badFlag }, 2);
+  // D1/D5.3: validate the COMPLETE argv against the real 'terminal send' allowlist. Value
+  // flags take exactly one argument; boolean flags take none. ANY unknown flag (e.g. --to,
+  // --task, --bogus) or wrong arity hard-fails (non-zero exit, ok:false, error naming the
+  // offending flag) — the fake never silently accepts a flag the real CLI would reject.
+  const VALUE_FLAGS = ["--terminal", "--text"];
+  const BOOL_FLAGS = ["--enter", "--interrupt", "--json"];
+  const sendArgs = args.slice(2);
+  for (let i = 0; i < sendArgs.length; i++) {
+    const flag = sendArgs[i];
+    if (VALUE_FLAGS.indexOf(flag) >= 0) {
+      if (i + 1 >= sendArgs.length) {
+        process.stderr.write("terminal send: flag " + flag + " requires a value\\n");
+        emit({ ok: false, error: "terminal send: flag " + flag + " requires a value" }, 2);
+      }
+      i++; // consume the flag's value (taken literally, even if it looks like a flag)
+    } else if (BOOL_FLAGS.indexOf(flag) < 0) {
+      process.stderr.write("terminal send: unrecognized flag " + flag + "\\n");
+      emit({ ok: false, error: "terminal send does not accept " + flag }, 2);
+    }
   }
   if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
   emit({ ok: true, result: { delivered: true } }, 0);

--- a/tests/relay-orca/fixtures/fake-orca-resume.js
+++ b/tests/relay-orca/fixtures/fake-orca-resume.js
@@ -43,6 +43,9 @@ function defaultResumeScenario(overrides = {}) {
     // Execution knobs (fail-closed / optional): an orca task id whose `dispatch --inject`
     // returns ok:false, and terminal-create failure modes.
     dispatchFailFor: overrides.dispatchFailFor || null,
+    // D5.4: handles with no recognized agent — `dispatch --inject` to one hard-fails with
+    // the real "no recognized agent detected" error. Empty by default.
+    injectNonAgentHandles: Array.isArray(overrides.injectNonAgentHandles) ? overrides.injectNonAgentHandles : [],
     terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
     terminalCreateEmptyHandle: overrides.terminalCreateEmptyHandle || false,
     terminalSendOkFalse: overrides.terminalSendOkFalse || false,
@@ -62,10 +65,16 @@ const stateDir = ${JSON.stringify(stateDir)};
 
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
 appendLog(args.join(" "));
+// The real dispatch-show payload nests provenance under result.dispatch (D4.3/D5.2).
+function nestDispatch(flat) {
+  const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
+  const result = { dispatch: dispatch };
+  if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
+  return result;
+}
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
 function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
 function argValue(flag) { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : undefined; }
-function drainStdin() { try { fs.readFileSync(0); } catch (e) { /* no stdin */ } }
 function stateFile(taskId) { return path.join(stateDir, "disp-" + String(taskId).replace(/[^a-zA-Z0-9._-]/g, "_") + ".json"); }
 function poison(marker, code) { if (poisonPath) fs.writeFileSync(poisonPath, marker + ":" + args.join(" "), "utf-8"); process.stderr.write("POISON: " + marker + "\\n"); process.exit(code); }
 
@@ -105,12 +114,17 @@ if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   Object.keys(seed).forEach((k) => { if (k === "runtimeId") seedRuntime = seed[k]; else result[k] = seed[k]; });
   try { Object.assign(result, JSON.parse(fs.readFileSync(stateFile(task), "utf-8"))); } catch (e) { /* no real dispatch yet */ }
   const dispatchMeta = seedRuntime !== undefined ? { runtimeId: seedRuntime } : meta;
-  emit({ id: "ds-" + task, ok: true, result, _meta: dispatchMeta }, 0);
+  emit({ id: "ds-" + task, ok: true, result: nestDispatch(result), _meta: dispatchMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "dispatch") {
   const task = argValue("--task");
   const handle = argValue("--to");
   if (scenario.dispatchFailFor && scenario.dispatchFailFor === task) emit({ ok: false, error: "dispatch inject undelivered" }, 0);
+  // D5.4: a handle with no recognized agent CLI cannot accept --inject (verbatim error).
+  if (scenario.injectNonAgentHandles && scenario.injectNonAgentHandles.indexOf(handle) >= 0) {
+    process.stderr.write("Cannot dispatch --inject to terminal " + handle + ": no recognized agent detected. Start an agent CLI (e.g. claude, codex, gemini, droid) in the terminal first, or dispatch without --inject and send the prompt manually.\\n");
+    emit({ ok: false, error: "no recognized agent detected for terminal " + handle }, 0);
+  }
   const record = { task_id: task, dispatch_id: "disp-" + task, assignee: handle, terminal_present: true };
   try { fs.writeFileSync(stateFile(task), JSON.stringify(record), "utf-8"); } catch (e) { /* ignore */ }
   emit({ id: "d-" + task, ok: true, result: { id: record.dispatch_id, dispatch_id: record.dispatch_id, assignee: handle }, _meta: meta }, 0);
@@ -126,7 +140,12 @@ if (args[0] === "terminal" && args[1] === "create") {
   emit({ ok: true, result: { handle: "orca-term-" + n, id: "orca-term-" + n }, _meta: meta }, 0);
 }
 if (args[0] === "terminal" && args[1] === "send") {
-  drainStdin();
+  // D1/D5.3 poison-pin: the real 'terminal send' has NO --to and NO --task flag.
+  if (args.indexOf("--to") >= 0 || args.indexOf("--task") >= 0) {
+    const badFlag = args.indexOf("--to") >= 0 ? "--to" : "--task";
+    process.stderr.write("terminal send: unrecognized flag " + badFlag + "\\n");
+    emit({ ok: false, error: "terminal send does not accept " + badFlag }, 2);
+  }
   if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
   emit({ ok: true, result: { delivered: true } }, 0);
 }

--- a/tests/relay-orca/fixtures/fake-orca-run.js
+++ b/tests/relay-orca/fixtures/fake-orca-run.js
@@ -160,12 +160,25 @@ if (args[0] === "terminal" && args[1] === "send") {
   // Record every send's exact argv so a test can assert the D1 contract
   // ["terminal","send","--terminal",<handle>,"--text",<prompt>,"--enter","--json"].
   if (sendsPath) fs.appendFileSync(sendsPath, JSON.stringify(args) + "\\n", "utf-8");
-  // D1/D5.3 poison-pin: the real 'terminal send' has NO --to and NO --task flag. Either
-  // one hard-fails (non-zero exit, ok:false, error naming the flag).
-  if (args.indexOf("--to") >= 0 || args.indexOf("--task") >= 0) {
-    const badFlag = args.indexOf("--to") >= 0 ? "--to" : "--task";
-    process.stderr.write("terminal send: unrecognized flag " + badFlag + "\\n");
-    emit({ ok: false, error: "terminal send does not accept " + badFlag }, 2);
+  // D1/D5.3: validate the COMPLETE argv against the real 'terminal send' allowlist. Value
+  // flags take exactly one argument; boolean flags take none. ANY unknown flag (e.g. --to,
+  // --task, --bogus) or wrong arity hard-fails (non-zero exit, ok:false, error naming the
+  // offending flag) — the fake never silently accepts a flag the real CLI would reject.
+  const VALUE_FLAGS = ["--terminal", "--text"];
+  const BOOL_FLAGS = ["--enter", "--interrupt", "--json"];
+  const sendArgs = args.slice(2);
+  for (let i = 0; i < sendArgs.length; i++) {
+    const flag = sendArgs[i];
+    if (VALUE_FLAGS.indexOf(flag) >= 0) {
+      if (i + 1 >= sendArgs.length) {
+        process.stderr.write("terminal send: flag " + flag + " requires a value\\n");
+        emit({ ok: false, error: "terminal send: flag " + flag + " requires a value" }, 2);
+      }
+      i++; // consume the flag's value (taken literally, even if it looks like a flag)
+    } else if (BOOL_FLAGS.indexOf(flag) < 0) {
+      process.stderr.write("terminal send: unrecognized flag " + flag + "\\n");
+      emit({ ok: false, error: "terminal send does not accept " + flag }, 2);
+    }
   }
   if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
   emit({ ok: true, result: { delivered: true } }, 0);

--- a/tests/relay-orca/fixtures/fake-orca-run.js
+++ b/tests/relay-orca/fixtures/fake-orca-run.js
@@ -42,6 +42,10 @@ function defaultRunScenario(overrides = {}) {
     taskCreateFailFor: overrides.taskCreateFailFor || null, // outcome id whose task-create fails
     taskCreateFailMode: overrides.taskCreateFailMode || "ok_false", // ok_false | nonzero | empty_id
     dispatchFailFor: overrides.dispatchFailFor || null, // orca task id whose dispatch returns ok:false
+    // D5.4: handles NOT backed by a recognized agent — `dispatch --inject` to one hard-fails
+    // with the real "no recognized agent detected" error (a self-created terminal can never
+    // accept --inject). Empty by default so every provided operator handle is agent-backed.
+    injectNonAgentHandles: Array.isArray(overrides.injectNonAgentHandles) ? overrides.injectNonAgentHandles : [],
     provenanceOverride: overrides.provenanceOverride || null, // merged over dispatch-show result
     provenanceOverrideFor: overrides.provenanceOverrideFor || null, // limit override to one orca task id
     terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
@@ -50,7 +54,7 @@ function defaultRunScenario(overrides = {}) {
   };
 }
 
-function fakeOrcaRunScript({ scenarioPath, logPath, poisonPath, stateDir }) {
+function fakeOrcaRunScript({ scenarioPath, logPath, poisonPath, stateDir, sendsPath }) {
   return `#!/usr/bin/env node
 "use strict";
 const fs = require("fs");
@@ -60,9 +64,17 @@ const scenarioPath = ${JSON.stringify(scenarioPath)};
 const logPath = ${JSON.stringify(logPath)};
 const poisonPath = ${JSON.stringify(poisonPath)};
 const stateDir = ${JSON.stringify(stateDir)};
+const sendsPath = ${JSON.stringify(sendsPath)};
 
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
 appendLog(args.join(" "));
+// The real dispatch-show payload nests provenance under result.dispatch (D2/D5.2).
+function nestDispatch(flat) {
+  const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
+  const result = { dispatch: dispatch };
+  if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
+  return result;
+}
 
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
 function writeJson(value) { process.stdout.write(JSON.stringify(value)); }
@@ -72,7 +84,6 @@ function emit(payload, exitCode, stdoutOverride) {
   process.exit(typeof exitCode === "number" ? exitCode : 0);
 }
 function argValue(flag) { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : undefined; }
-function drainStdin() { try { fs.readFileSync(0); } catch (e) { /* no stdin */ } }
 function stateFile(taskId) { return path.join(stateDir, "disp-" + String(taskId).replace(/[^a-zA-Z0-9._-]/g, "_") + ".json"); }
 
 // D2 poison: reset must never be invoked.
@@ -112,19 +123,26 @@ if (args[0] === "orchestration" && args[1] === "dispatch") {
   if (scenario.dispatchFailFor && scenario.dispatchFailFor === task) {
     emit({ ok: false, error: "dispatch inject undelivered" }, 0);
   }
-  const record = { task_id: task, dispatch_id: "disp-" + task, assignee: handle };
+  // D5.4: a handle with no recognized agent CLI cannot accept --inject. The real error
+  // is verbatim below; the task never gets a dispatch state, so run escalates via the
+  // existing INJECTION_UNDELIVERED (exit 42) path.
+  if (scenario.injectNonAgentHandles && scenario.injectNonAgentHandles.indexOf(handle) >= 0) {
+    process.stderr.write("Cannot dispatch --inject to terminal " + handle + ": no recognized agent detected. Start an agent CLI (e.g. claude, codex, gemini, droid) in the terminal first, or dispatch without --inject and send the prompt manually.\\n");
+    emit({ ok: false, error: "no recognized agent detected for terminal " + handle }, 0);
+  }
+  const record = { task_id: task, dispatch_id: "disp-" + task, assignee: handle, terminal_present: true };
   try { fs.writeFileSync(stateFile(task), JSON.stringify(record), "utf-8"); } catch (e) { /* ignore */ }
   emit({ id: "d-" + task, ok: true, result: { id: record.dispatch_id, dispatch_id: record.dispatch_id, assignee: handle }, _meta: { runtimeId: scenario.runtimeId } }, 0);
 }
 
 if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   const task = argValue("--task");
-  let base = { task_id: task, dispatch_id: "disp-" + task, assignee: "assignee-" + task };
-  try { base = JSON.parse(fs.readFileSync(stateFile(task), "utf-8")); } catch (e) { /* no prior dispatch */ }
+  let base = { task_id: task, dispatch_id: "disp-" + task, assignee: "assignee-" + task, terminal_present: true };
+  try { base = Object.assign(base, JSON.parse(fs.readFileSync(stateFile(task), "utf-8"))); } catch (e) { /* no prior dispatch */ }
   if (scenario.provenanceOverride && (!scenario.provenanceOverrideFor || scenario.provenanceOverrideFor === task)) {
     Object.assign(base, scenario.provenanceOverride);
   }
-  emit({ id: "ds-" + task, ok: true, result: base, _meta: { runtimeId: scenario.runtimeId } }, 0);
+  emit({ id: "ds-" + task, ok: true, result: nestDispatch(base), _meta: { runtimeId: scenario.runtimeId } }, 0);
 }
 
 if (args[0] === "terminal" && args[1] === "create") {
@@ -139,7 +157,16 @@ if (args[0] === "terminal" && args[1] === "create") {
 }
 
 if (args[0] === "terminal" && args[1] === "send") {
-  drainStdin();
+  // Record every send's exact argv so a test can assert the D1 contract
+  // ["terminal","send","--terminal",<handle>,"--text",<prompt>,"--enter","--json"].
+  if (sendsPath) fs.appendFileSync(sendsPath, JSON.stringify(args) + "\\n", "utf-8");
+  // D1/D5.3 poison-pin: the real 'terminal send' has NO --to and NO --task flag. Either
+  // one hard-fails (non-zero exit, ok:false, error naming the flag).
+  if (args.indexOf("--to") >= 0 || args.indexOf("--task") >= 0) {
+    const badFlag = args.indexOf("--to") >= 0 ? "--to" : "--task";
+    process.stderr.write("terminal send: unrecognized flag " + badFlag + "\\n");
+    emit({ ok: false, error: "terminal send does not accept " + badFlag }, 2);
+  }
   if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
   emit({ ok: true, result: { delivered: true } }, 0);
 }
@@ -156,10 +183,11 @@ function installFakeOrcaRun(scenarioOverrides = {}, options = {}) {
   const logPath = path.join(dir, "invocations.log");
   const poisonPath = path.join(dir, "poison.txt");
   const stateDir = path.join(dir, "state");
+  const sendsPath = path.join(dir, "sends.jsonl");
   fs.mkdirSync(stateDir, { recursive: true });
   const scenario = defaultRunScenario(scenarioOverrides);
   fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2), "utf-8");
-  fs.writeFileSync(orcaPath, fakeOrcaRunScript({ scenarioPath, logPath, poisonPath, stateDir }), "utf-8");
+  fs.writeFileSync(orcaPath, fakeOrcaRunScript({ scenarioPath, logPath, poisonPath, stateDir, sendsPath }), "utf-8");
   fs.chmodSync(orcaPath, 0o755);
 
   return {
@@ -169,6 +197,7 @@ function installFakeOrcaRun(scenarioOverrides = {}, options = {}) {
     logPath,
     poisonPath,
     stateDir,
+    sendsPath,
     scenario,
     restore() {
       /* PATH is never mutated: tests pass --orca-bin explicitly. */
@@ -176,6 +205,11 @@ function installFakeOrcaRun(scenarioOverrides = {}, options = {}) {
     readLog() {
       if (!fs.existsSync(logPath)) return [];
       return fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean);
+    },
+    // Each recorded `terminal send` invocation's exact argv array (D1 contract proof).
+    readSends() {
+      if (!fs.existsSync(sendsPath)) return [];
+      return fs.readFileSync(sendsPath, "utf-8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
     },
     readPoison() {
       if (!fs.existsSync(poisonPath)) return null;

--- a/tests/relay-orca/fixtures/fake-orca-status.js
+++ b/tests/relay-orca/fixtures/fake-orca-status.js
@@ -58,6 +58,13 @@ const poisonPath = ${JSON.stringify(poisonPath)};
 
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
 appendLog(args.join(" "));
+// The real dispatch-show payload nests provenance under result.dispatch (D4.3/D5.2).
+function nestDispatch(flat) {
+  const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
+  const result = { dispatch: dispatch };
+  if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
+  return result;
+}
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
 function emit(payload, exitCode) { if (payload !== undefined && payload !== null) process.stdout.write(JSON.stringify(payload)); process.exit(typeof exitCode === "number" ? exitCode : 0); }
 function argValue(flag) { const i = args.indexOf(flag); return i >= 0 ? args[i + 1] : undefined; }
@@ -100,8 +107,8 @@ if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   const dispatchMeta = override.runtimeId !== undefined ? { runtimeId: override.runtimeId } : meta;
   const resultOverride = Object.assign({}, override);
   delete resultOverride.runtimeId;
-  const result = Object.assign({ task_id: task, dispatch_id: "disp-" + task, assignee: "term-" + task, terminal_present: true }, resultOverride);
-  emit({ id: "ds-" + task, ok: true, result, _meta: dispatchMeta }, 0);
+  const flat = Object.assign({ task_id: task, dispatch_id: "disp-" + task, assignee: "term-" + task, terminal_present: true }, resultOverride);
+  emit({ id: "ds-" + task, ok: true, result: nestDispatch(flat), _meta: dispatchMeta }, 0);
 }
 
 process.stderr.write("Unsupported fake orca (status) invocation: " + args.join(" ") + "\\n");

--- a/tests/relay-orca/scripts/gates.test.js
+++ b/tests/relay-orca/scripts/gates.test.js
@@ -82,7 +82,10 @@ function manifestText(fields) {
 function orcaTask(programId, outcome, extra = {}) {
   return {
     id: `orca-live-${outcome}`,
-    title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    // D4: the real mid-2026 task-list row carries `task_title` (and `display_name`), never
+    // `title` — matching the status.test.js/resume.test.js helpers.
+    task_title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    display_name: `relay-orca: ${programSegment(programId)}/${outcome}`,
     status: extra.status || "dispatched",
     worker_done: extra.worker_done === true,
   };

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -76,7 +76,9 @@ function manifestText(fields) {
 function orcaTask(programId, outcome, extra = {}) {
   return {
     id: `orca-live-${outcome}`,
-    title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    // D4: the real task-list row carries `task_title` (and `display_name`), never `title`.
+    task_title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    display_name: `relay-orca: ${programSegment(programId)}/${outcome}`,
     status: extra.status || "dispatched",
     worker_done: extra.worker_done === true,
   };
@@ -84,7 +86,7 @@ function orcaTask(programId, outcome, extra = {}) {
 
 // A task-list entry NOT marked for this program — makes the runtime foreign_state.
 function foreignTask(id) {
-  return { id, title: `relay-orca: other-program/${id}`, status: "dispatched", worker_done: false };
+  return { id, task_title: `relay-orca: other-program/${id}`, status: "dispatched", worker_done: false };
 }
 
 // A dispatch-show seed modeling GENUINE absence (owner amendment A1, #946 R1): the Orca
@@ -289,19 +291,21 @@ test("D9.3: terminal loss on a resumable outcome → terminal reacquired via inj
   const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a", run: "run-a" }] });
   fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
   try {
-    const r = world.run();
+    const r = world.run(["--operator-handle", "h-reacq"]);
     assert.equal(r.status, 0);
     assertReportShape(r.body);
     assert.equal(actionFor(r.body, "a").action, "redispatched");
-    assert.equal(r.body.terminals_created.length, 1);
+    // Explicit-handles-only (D3): resume reacquires through the PROVIDED handle and never
+    // self-creates a terminal, so terminals_created stays [] on every path.
+    assert.deepEqual(r.body.terminals_created, []);
     const log = world.orca.readLog();
-    assert.ok(log.some((l) => l.startsWith("terminal create")), "a replacement terminal is created");
+    assert.ok(!log.some((l) => l.startsWith("terminal create")), "resume never creates its own terminal");
     assert.ok(log.some((l) => l.startsWith("orchestration dispatch --task orca-live-a")), "re-injected through dispatch");
     assert.ok(log.some((l) => l.startsWith("orchestration dispatch-show --task orca-live-a")), "provenance re-verified through dispatch-show");
-    // Receipt persisted immediately (A16): the created handle is durable on disk.
+    // The provided handle is recorded as the reacquired outcome's assignee, persisted at A2.
     const persisted = parseReceipt(world.receiptOnDisk()).receipt;
-    assert.deepEqual(persisted.terminals_created, r.body.terminals_created);
-    assert.equal(persisted.tasks[0].assignee, r.body.terminals_created[0], "reacquired terminal recorded as the outcome assignee");
+    assert.deepEqual(persisted.terminals_created, []);
+    assert.equal(persisted.tasks[0].assignee, "h-reacq", "reacquired terminal recorded as the outcome assignee");
     assertNoPoison(world);
   } finally {
     world.cleanup();
@@ -365,7 +369,7 @@ test("D9.6: partial dispatch → only the absent+clean outcome dispatches, throu
   const programId = "epic-resume-partial";
   const world = partialWorld(programId);
   try {
-    const r = world.run();
+    const r = world.run(["--operator-handle", "h1"]);
     assert.equal(r.status, 0);
     assert.equal(actionFor(r.body, "a").action, "reused");
     assert.equal(actionFor(r.body, "b").action, "redispatched");
@@ -373,6 +377,41 @@ test("D9.6: partial dispatch → only the absent+clean outcome dispatches, throu
     assert.equal(injects.length, 1, "exactly one re-dispatch");
     assert.ok(injects[0].includes("orca-live-b"), "only the absent outcome b is dispatched");
     assert.ok(!injects.some((l) => l.includes("orca-live-a")), "the reused outcome a is never re-dispatched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D3 — resume with an outcome to (re)dispatch but NO --operator-handle → decision_required
+// ---------------------------------------------------------------------------
+
+test("D3: resume needing re-dispatch with zero --operator-handle → RESUME_NO_OPERATOR_HANDLE exit 65, zero mutation", () => {
+  const programId = "epic-resume-no-handle";
+  const world = buildWorld({
+    programId,
+    // Outcome b is verifiably absent (genuine absence), so it would otherwise re-dispatch —
+    // but resume never self-creates a terminal, so with no handle it must fail closed.
+    orcaScenario: { tasks: [orcaTask(programId, "b")], dispatch: absentDispatch("b") },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "b", dispatch_id: null, assignee: null }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(); // NO --operator-handle
+    assert.equal(r.status, RESUME_REASONS.RESUME_NO_OPERATOR_HANDLE);
+    assert.equal(r.status, 65);
+    assertReportShape(r.body);
+    assert.equal(r.body.ok, false);
+    const decision = r.body.decision_required.find((d) => d.reason_code === "RESUME_NO_OPERATOR_HANDLE");
+    assert.ok(decision, "RESUME_NO_OPERATOR_HANDLE decision present");
+    assert.ok(decision.options.some((o) => o.includes("--operator-handle")), "options offer providing --operator-handle");
+    assert.equal(actionFor(r.body, "b").action, "decision_required");
+    assert.deepEqual(r.body.terminals_created, []);
+    // ZERO mutation: no dispatch/terminal/task-create, and the receipt is byte-identical.
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before, "receipt byte-identical on the no-handle abort");
     assertNoPoison(world);
   } finally {
     world.cleanup();
@@ -426,7 +465,7 @@ test("A1(b) genuine absence: live dispatch-show empty + receipt dispatch_id null
   const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "b", dispatch_id: null, assignee: null }] });
   fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
   try {
-    const r = world.run();
+    const r = world.run(["--operator-handle", "h1"]);
     assert.equal(r.status, 0);
     assert.deepEqual(r.body.decision_required, [], "no fail-closed decision on genuine absence");
     assert.equal(actionFor(r.body, "b").action, "redispatched");
@@ -502,7 +541,7 @@ test("D1: reconciliation (status/task-list/gate-list) runs before any mutating s
   const programId = "epic-resume-order";
   const world = partialWorld(programId);
   try {
-    const r = world.run();
+    const r = world.run(["--operator-handle", "h1"]);
     assert.equal(r.status, 0);
     const log = world.orca.readLog();
     const firstMutation = log.findIndex((l) => mutationLines([l]).length > 0);
@@ -524,7 +563,7 @@ test("D9.5: double resume is idempotent — second run does zero task-create/ter
   const programId = "epic-resume-idempotent";
   const world = partialWorld(programId);
   try {
-    const first = world.run();
+    const first = world.run(["--operator-handle", "h1"]);
     assert.equal(first.status, 0);
     assert.equal(actionFor(first.body, "b").action, "redispatched");
     const firstMutations = mutationLines(world.orca.readLog()).length;
@@ -533,7 +572,7 @@ test("D9.5: double resume is idempotent — second run does zero task-create/ter
     // Second resume reads the receipt the first resume persisted → everything now live.
     const beforeSecond = world.receiptOnDisk();
     const secondLogStart = world.orca.readLog().length;
-    const second = world.run();
+    const second = world.run(["--operator-handle", "h1"]);
     assert.equal(second.status, 0);
     const secondLog = world.orca.readLog().slice(secondLogStart);
     assert.deepEqual(mutationLines(secondLog), [], "the second resume performs ZERO task-create/terminal/dispatch");
@@ -682,7 +721,7 @@ test("D9.8: resume preserves a prior stop record when it rewrites the receipt", 
   });
   fs.writeFileSync(world.receiptPath, serializeReceiptWithStop(receipt), "utf-8");
   try {
-    const r = world.run();
+    const r = world.run(["--operator-handle", "h1"]);
     assert.equal(r.status, 0);
     assert.equal(actionFor(r.body, "b").action, "redispatched", "resume still re-dispatches the absent outcome");
     const persisted = parseReceipt(world.receiptOnDisk()).receipt;

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -387,7 +387,7 @@ test("D9.6: partial dispatch → only the absent+clean outcome dispatches, throu
 // D3 — resume with an outcome to (re)dispatch but NO --operator-handle → decision_required
 // ---------------------------------------------------------------------------
 
-test("D3: resume needing re-dispatch with zero --operator-handle → RESUME_NO_OPERATOR_HANDLE exit 65, zero mutation", () => {
+test("D3: resume needing re-dispatch with zero --operator-handle → RESUME_NO_OPERATOR_HANDLE exit 66, zero mutation", () => {
   const programId = "epic-resume-no-handle";
   const world = buildWorld({
     programId,
@@ -401,7 +401,7 @@ test("D3: resume needing re-dispatch with zero --operator-handle → RESUME_NO_O
   try {
     const r = world.run(); // NO --operator-handle
     assert.equal(r.status, RESUME_REASONS.RESUME_NO_OPERATOR_HANDLE);
-    assert.equal(r.status, 65);
+    assert.equal(r.status, 66);
     assertReportShape(r.body);
     assert.equal(r.body.ok, false);
     const decision = r.body.decision_required.find((d) => d.reason_code === "RESUME_NO_OPERATOR_HANDLE");

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -25,6 +25,8 @@ const {
   READ_ONLY_MARKER,
   NO_EDIT_CLAUSE,
 } = require(path.join(SCRIPTS, "lib", "operator-prompt.js"));
+const { showDispatch } = require(path.join(SCRIPTS, "lib", "run-orca.js"));
+const { provenanceMismatch } = require(path.join(SCRIPTS, "lib", "run-orchestrator.js"));
 const { installFakeOrcaRun } = require(path.join(__dirname, "..", "fixtures", "fake-orca-run.js"));
 const { readyStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
 
@@ -205,8 +207,23 @@ test("D11.1: 2-task wave dispatches, provenance verified, exact D10 report", () 
     // Prompt (terminal send) is delivered ONLY after dispatch-show verification.
     const log = r.fake.readLog();
     const showIdx = log.findIndex((l) => l.includes("dispatch-show --task orca-live-alpha"));
-    const sendIdx = log.findIndex((l) => l.includes("terminal send --to h1"));
+    const sendIdx = log.findIndex((l) => l.includes("terminal send --terminal h1"));
     assert.ok(showIdx >= 0 && sendIdx > showIdx, "prompt must be sent after verification");
+    // D1: the prompt is delivered by ONE `terminal send` per dispatched task, with the
+    // exact real-CLI argv — no --to, no --task, no stdin.
+    const sends = r.fake.readSends();
+    assert.equal(sends.length, 2, "exactly one send per dispatched task (never split)");
+    const alphaSend = sends.find((argv) => argv[3] === "h1");
+    assert.equal(alphaSend[0], "terminal");
+    assert.equal(alphaSend[1], "send");
+    assert.equal(alphaSend[2], "--terminal");
+    assert.equal(alphaSend[3], "h1");
+    assert.equal(alphaSend[4], "--text");
+    assert.ok(typeof alphaSend[5] === "string" && alphaSend[5].length > 0, "the full operator prompt rides in one --text value");
+    assert.equal(alphaSend[6], "--enter");
+    assert.equal(alphaSend[7], "--json");
+    assert.equal(alphaSend.length, 8, "no extra flags");
+    assert.ok(!alphaSend.includes("--to") && !alphaSend.includes("--task"), "no --to/--task on terminal send");
     assertNoPoison(r.fake);
   } finally {
     r.fake.cleanup();
@@ -256,7 +273,7 @@ test("D11.3: dispatch ok:false → INJECTION_UNDELIVERED exit 42, escalated, pri
     // bravo never advances: no dispatch-show, no prompt hand-off after the failure.
     const log = r.fake.readLog().join(" ");
     assert.equal(log.includes("dispatch-show --task orca-live-bravo"), false);
-    assert.equal(log.includes("terminal send --to h2"), false);
+    assert.equal(log.includes("terminal send --terminal h2"), false);
     assertNoPoison(r.fake);
   } finally {
     r.fake.cleanup();
@@ -524,6 +541,31 @@ test("D11.11: reset AND worktree subcommands poison the fixture", () => {
   }
 });
 
+test("D5.3: fake `terminal send` hard-fails on --to or --task and accepts only the real flags", () => {
+  const fake = installFakeOrcaRun();
+  try {
+    for (const badFlag of ["--to", "--task"]) {
+      let status = 0;
+      let stdout = "";
+      try {
+        stdout = execFileSync(fake.orcaPath, ["terminal", "send", badFlag, "h1", "--text", "hi", "--json"], { stdio: "pipe", encoding: "utf-8" });
+      } catch (error) {
+        status = error.status;
+        stdout = error.stdout ? String(error.stdout) : "";
+      }
+      assert.notEqual(status, 0, `terminal send ${badFlag} must exit non-zero`);
+      const body = JSON.parse(stdout);
+      assert.equal(body.ok, false);
+      assert.ok(body.error.includes(badFlag), `the error names the rejected flag ${badFlag}`);
+    }
+    // The real-CLI argv succeeds.
+    const okOut = execFileSync(fake.orcaPath, ["terminal", "send", "--terminal", "h1", "--text", "hi", "--enter", "--json"], { stdio: "pipe", encoding: "utf-8" });
+    assert.equal(JSON.parse(okOut).ok, true);
+  } finally {
+    fake.cleanup();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // D4/D7 — dependency-ordered materialization + later-wave pending
 // ---------------------------------------------------------------------------
@@ -549,35 +591,83 @@ test("D4/D7: deps carry real Orca ids in dependency order; later-wave task stays
 });
 
 // ---------------------------------------------------------------------------
-// D5 — self-created terminals recorded; D7 — OPERATOR_DISPATCH_FAILED
+// D3 — explicit-handles-only: zero --operator-handle is rejected UPFRONT
 // ---------------------------------------------------------------------------
 
-test("D5: no explicit handle → run creates terminals and records them", () => {
+test("D3: run with zero --operator-handle → OPERATOR_DISPATCH_FAILED exit 44 before any mutation", () => {
   const r = runProgram("run-two-wave1.json", []);
   try {
-    assert.equal(r.status, 0);
-    assert.equal(r.body.terminals_created.length, 2);
-    r.body.tasks.forEach((task) => {
-      assert.equal(task.status, "dispatched");
-      assert.ok(r.body.terminals_created.includes(task.assignee));
-    });
+    assert.equal(r.status, REASONS.OPERATOR_DISPATCH_FAILED);
+    assertReportKeys(r.body);
+    assert.equal(r.body.ok, false);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "OPERATOR_DISPATCH_FAILED");
+    // No task ever materialized or dispatched; terminals_created stays [].
+    r.body.tasks.forEach((task) => assert.equal(task.status, "pending"));
+    assert.deepEqual(r.body.terminals_created, []);
+    assert.equal(r.body.receipt_path, null, "nothing is materialized, so no receipt is written");
+    // The rejection is UPFRONT (after admission, before materialization): the fixture log
+    // carries NO task-create, NO dispatch, and NO terminal create.
+    assertNoMutations(r.fake);
+    // Remediation names creating an agent-backed terminal and re-running with a handle.
+    const remediation = r.body.blocking_reasons[0].remediation;
+    assert.match(remediation, /orca terminal create --command/);
+    assert.match(remediation, /--operator-handle/);
     assertNoPoison(r.fake);
   } finally {
     r.fake.cleanup();
   }
 });
 
-test("D7: terminal create yields no usable handle → OPERATOR_DISPATCH_FAILED exit 44", () => {
-  const r = runProgram("run-two-wave1.json", [], { terminalCreateEmptyHandle: true });
+test("D5.4: --inject to a handle with no recognized agent → escalated via INJECTION_UNDELIVERED (42), no prompt sent", () => {
+  const r = runProgram("valid-single-relay-run.json", ["--operator-handle", "h-noagent"], { injectNonAgentHandles: ["h-noagent"] });
   try {
-    assert.equal(r.status, REASONS.OPERATOR_DISPATCH_FAILED);
-    assert.equal(r.body.blocking_reasons[0].reason_code, "OPERATOR_DISPATCH_FAILED");
-    // No task ever became dispatched.
-    assert.equal(r.body.tasks.every((t) => t.status !== "dispatched"), true);
+    assert.equal(r.status, REASONS.INJECTION_UNDELIVERED);
+    assert.equal(r.body.blocking_reasons[0].reason_code, "INJECTION_UNDELIVERED");
+    assert.equal(taskByOutcome(r.body, "outcome-a").status, "escalated");
+    // Provenance was never verified, so no operator prompt is ever sent.
+    assert.equal(r.fake.readLog().join(" ").includes("terminal send"), false);
     assertNoPoison(r.fake);
   } finally {
     r.fake.cleanup();
   }
+});
+
+// ---------------------------------------------------------------------------
+// D2 — dispatch-show nested-provenance parsing (verbatim live payload)
+// ---------------------------------------------------------------------------
+
+test("D2: showDispatch parses the verbatim live nested payload and provenance verifies", () => {
+  const payload = {
+    ok: true,
+    result: {
+      dispatch: {
+        id: "ctx_4654f2173b94",
+        task_id: "task_5a43aa730015",
+        assignee_handle: "term_2bc82c69-815b-4c8d-b8a4-10193ac4e0f0",
+        status: "dispatched",
+        failure_count: 0,
+        dispatched_at: "2026-07-13 12:23:40",
+      },
+    },
+  };
+  const run = () => ({ status: 0, stdout: JSON.stringify(payload), stderr: "" });
+  const show = showDispatch(run, "orca", { orcaTaskId: "task_5a43aa730015" });
+  assert.equal(show.ok, true);
+  assert.equal(show.taskId, "task_5a43aa730015");
+  assert.equal(show.dispatchId, "ctx_4654f2173b94");
+  assert.equal(show.assignee, "term_2bc82c69-815b-4c8d-b8a4-10193ac4e0f0");
+  // The full provenance trio verifies against the dispatched task id.
+  assert.equal(provenanceMismatch(show, "task_5a43aa730015"), null);
+});
+
+test("D2: null/empty/mismatched values inside result.dispatch still fail closed (PROVENANCE_MISMATCH)", () => {
+  const shape = (dispatch) => showDispatch(() => ({ status: 0, stdout: JSON.stringify({ ok: true, result: { dispatch } }), stderr: "" }), "orca", { orcaTaskId: "task_x" });
+  // wrong nested task id
+  assert.ok(provenanceMismatch(shape({ id: "ctx_x", task_id: "task_WRONG", assignee_handle: "term_x" }), "task_x"));
+  // null nested assignee
+  assert.ok(provenanceMismatch(shape({ id: "ctx_x", task_id: "task_x", assignee_handle: null }), "task_x"));
+  // empty nested dispatch id
+  assert.ok(provenanceMismatch(shape({ id: "", task_id: "task_x", assignee_handle: "term_x" }), "task_x"));
 });
 
 // ---------------------------------------------------------------------------
@@ -772,28 +862,23 @@ test("A2: a prompt-delivery failure still leaves the receipt carrying the verifi
   }
 });
 
-test("A16: a dispatch failure right after an AUTO-created terminal leaves the on-disk receipt already carrying the handle", () => {
-  // No explicit --operator-handle → run auto-creates a terminal ("orca-term-1"), records
-  // it, and (A16) persists the receipt IMMEDIATELY — BEFORE the dispatch. The dispatch then
-  // fails (INJECTION_UNDELIVERED, exit 42) before any provenance-verification write could run.
-  // Without the immediate persist the mapping-changing writes only happen after dispatch-show,
-  // so the handle would be lost from disk; A16 makes the created terminal durable so a
-  // reconcile can adopt (not re-create) it.
-  const r = runProgram("valid-single-relay-run.json", [], { dispatchFailFor: "orca-live-outcome-a" });
+test("D3: a dispatch failure with an EXPLICIT handle escalates via the 42-path and never records a terminal", () => {
+  // Explicit --operator-handle h1; the dispatch --inject fails (INJECTION_UNDELIVERED, exit
+  // 42). run never self-creates a terminal, so terminals_created stays []. The verified
+  // provenance write only happens after dispatch-show, which is never reached here — but the
+  // receipt was already persisted after the successful task-create (A12).
+  const r = runProgram("valid-single-relay-run.json", ["--operator-handle", "h1"], { dispatchFailFor: "orca-live-outcome-a" });
   try {
     assert.equal(r.status, REASONS.INJECTION_UNDELIVERED);
     assert.equal(r.body.blocking_reasons[0].reason_code, "INJECTION_UNDELIVERED");
     assert.equal(taskByOutcome(r.body, "outcome-a").status, "escalated");
-    // The in-memory report is truthful about the auto-created terminal...
-    assert.deepEqual(r.body.terminals_created, ["orca-term-1"]);
-
-    // ...and so is the receipt ON DISK, written before the failing dispatch.
+    assert.deepEqual(r.body.terminals_created, [], "run never records a self-created terminal");
+    // The receipt exists (persisted after the successful task-create) but no terminal create ran.
     const receiptPath = receiptPathForWorld(r.world, "epic-demo-single");
-    assert.ok(fs.existsSync(receiptPath), "receipt persisted right after the terminal was created");
-    assert.equal(r.body.receipt_path, receiptPath, "the report echoes the persisted receipt path");
+    assert.ok(fs.existsSync(receiptPath), "receipt persisted after the materialize");
     const parsed = parseReceipt(fs.readFileSync(receiptPath, "utf-8"));
-    assert.equal(parsed.ok, true, `receipt must parse+validate: ${parsed.reason || ""}`);
-    assert.deepEqual(parsed.receipt.terminals_created, ["orca-term-1"], "the created terminal handle is durable despite the dispatch failure");
+    assert.deepEqual(parsed.receipt.terminals_created, [], "no terminal handle is ever recorded");
+    assert.equal(r.fake.readLog().join(" ").includes("terminal create"), false, "no terminal create is reachable from run");
     assertNoPoison(r.fake);
   } finally {
     r.fake.cleanup();

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -566,6 +566,29 @@ test("D5.3: fake `terminal send` hard-fails on --to or --task and accepts only t
   }
 });
 
+test("D5.3: fake `terminal send` hard-fails on ANY unknown flag (not only --to/--task), naming the offending flag", () => {
+  const fake = installFakeOrcaRun();
+  try {
+    let status = 0;
+    let stdout = "";
+    try {
+      stdout = execFileSync(fake.orcaPath, ["terminal", "send", "--terminal", "h1", "--text", "hi", "--bogus", "x", "--json"], { stdio: "pipe", encoding: "utf-8" });
+    } catch (error) {
+      status = error.status;
+      stdout = error.stdout ? String(error.stdout) : "";
+    }
+    assert.notEqual(status, 0, "an unknown flag must exit non-zero");
+    const body = JSON.parse(stdout);
+    assert.equal(body.ok, false);
+    assert.ok(body.error.includes("--bogus"), "the error names the offending flag");
+    // --interrupt is a real boolean flag; the complete real argv still succeeds.
+    const okOut = execFileSync(fake.orcaPath, ["terminal", "send", "--terminal", "h1", "--text", "hi", "--interrupt", "--json"], { stdio: "pipe", encoding: "utf-8" });
+    assert.equal(JSON.parse(okOut).ok, true);
+  } finally {
+    fake.cleanup();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // D4/D7 — dependency-ordered materialization + later-wave pending
 // ---------------------------------------------------------------------------
@@ -668,6 +691,16 @@ test("D2: null/empty/mismatched values inside result.dispatch still fail closed 
   assert.ok(provenanceMismatch(shape({ id: "ctx_x", task_id: "task_x", assignee_handle: null }), "task_x"));
   // empty nested dispatch id
   assert.ok(provenanceMismatch(shape({ id: "", task_id: "task_x", assignee_handle: "term_x" }), "task_x"));
+});
+
+test("D2: a present result.dispatch is authoritative — an empty nested task_id is NOT rescued by a conflicting flat task_id (PROVENANCE_MISMATCH)", () => {
+  // Real payload where result.dispatch is present but its task_id is empty while a legacy
+  // flat result.task_id carries "expected". The nested object is authoritative, so the flat
+  // field must NOT rescue provenance: taskId resolves null and verification fails closed.
+  const payload = { ok: true, result: { dispatch: { task_id: "", id: "ctx", assignee_handle: "term" }, task_id: "expected" } };
+  const show = showDispatch(() => ({ status: 0, stdout: JSON.stringify(payload), stderr: "" }), "orca", { orcaTaskId: "expected" });
+  assert.equal(show.taskId, null, "the empty nested task_id resolves null, never the flat 'expected'");
+  assert.ok(provenanceMismatch(show, "expected"), "provenance fails closed on the empty nested task id");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -84,10 +84,12 @@ function manifestText(fields) {
 function orcaTask(programId, outcome, extra = {}) {
   return {
     id: `orca-live-${outcome}`,
-    // A26: run.js titles tasks with the collision-resistant program SEGMENT, not the raw
-    // id, so a healthy fixture task must carry the SAME segment for the foreign-task check
-    // (`title.includes("relay-orca: <segment>/")`) to attribute it to this program.
-    title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    // A26/D4: the real mid-2026 task-list row carries `task_title` (and `display_name`),
+    // NOT `title`. run.js titles tasks with the collision-resistant program SEGMENT, not
+    // the raw id, so a healthy fixture row must carry the SAME segment for the foreign-task
+    // check (resolved display string `.includes("relay-orca: <segment>/")`) to attribute it.
+    task_title: `relay-orca: ${programSegment(programId)}/${outcome}`,
+    display_name: `relay-orca: ${programSegment(programId)}/${outcome}`,
     status: extra.status || "dispatched",
     worker_done: extra.worker_done === true,
   };
@@ -472,7 +474,7 @@ test("D10.8: runtime restart → runtime mismatch, Orca facts degrade, durable-c
     ],
     orcaScenario: {
       runtimeId: otherRuntime, // live runtime restarted
-      tasks: [{ id: "foreign-1", title: "someone-else: other/thing", status: "dispatched", worker_done: false }],
+      tasks: [{ id: "foreign-1", task_title: "someone-else: other/thing", status: "dispatched", worker_done: false }],
     },
     ghScenario: {
       prs: { 80: { state: "MERGED", mergedAt: "2026-07-12T05:00:00Z" }, 81: { state: "OPEN" } },
@@ -505,6 +507,113 @@ test("D10.8: runtime restart → runtime mismatch, Orca facts degrade, durable-c
 });
 
 // ---------------------------------------------------------------------------
+// D4 — real task-list row shape (task_title, no title) + nested dispatch facts
+// ---------------------------------------------------------------------------
+
+test("D4.1: the verbatim live task_title row (no title key) attributes the runtime as OWNED, not foreign_state", () => {
+  const programId = "pilot-948";
+  // The exact live row captured on 2026-07-13 (Done Criteria D4): task_title carries the
+  // program marker; there is NO `title` key. Program `pilot-948` resolves to the same segment.
+  assert.equal(programSegment(programId), "pilot-948-92ff09e7");
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-g", state: "dispatched", pr_number: 990, issue_number: 9900 }],
+    orcaScenario: {
+      tasks: [
+        {
+          id: "task_5a43aa730015",
+          parent_id: null,
+          created_by_terminal_handle: "term_a18f2822-64ad-4825-9e43-a2135ca3a0ea",
+          task_title: "relay-orca: pilot-948-92ff09e7/gh-guard-990",
+          display_name: "relay-orca: pilot-948-92ff09e7/gh-guard-990",
+          status: "dispatched",
+          deps: "[]",
+          result: null,
+        },
+      ],
+    },
+    ghScenario: { prs: { 990: { state: "OPEN" } }, issues: { 9900: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "gh-guard-990", orca_task_id: "task_5a43aa730015", run: "run-g" }],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "ok", "the markered real row attributes the runtime as owned");
+    assert.equal(diagCodes(r.body).includes("RUNTIME_MISMATCH"), false, "an owned runtime never fires RUNTIME_MISMATCH");
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D4.2: a real task_title row LACKING the program marker still forces foreign_state", () => {
+  const programId = "pilot-948";
+  const world = buildWorld({
+    programId,
+    orcaScenario: {
+      tasks: [{ id: "task_intruder", task_title: "relay-orca: someone-else-deadbeef/other", display_name: "relay-orca: someone-else-deadbeef/other", status: "dispatched" }],
+    },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "x" }] });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "foreign_state", "an unmarkered real row makes the runtime foreign");
+    assert.ok(diagCodes(r.body).includes("RUNTIME_MISMATCH"));
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("D4.3: status derives provenance from the nested result.dispatch shape (present → no MISSING_*, terminal_present:false → MISSING_TERMINAL)", () => {
+  const programId = "epic-status-nested-dispatch";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-ok", state: "dispatched", pr_number: 70, issue_number: 700 },
+      { run_id: "run-lost", state: "dispatched", pr_number: 71, issue_number: 701 },
+    ],
+    orcaScenario: {
+      tasks: [orcaTask(programId, "ok"), orcaTask(programId, "lost")],
+      // 'lost' outcome: dispatch present but the operator terminal is gone
+      // (nested terminal_present:false in the real result.dispatch shape).
+      dispatch: { "orca-live-lost": { terminal_present: false } },
+    },
+    ghScenario: { prs: { 70: { state: "OPEN" }, 71: { state: "OPEN" } }, issues: { 700: { state: "OPEN" }, 701: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "ok", orca_task_id: "orca-live-ok", run: "run-ok" },
+      { outcome_id: "lost", orca_task_id: "orca-live-lost", run: "run-lost" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.equal(r.body.runtime, "ok");
+    // 'ok' outcome: full nested provenance present → no MISSING_* diagnostics forged.
+    assert.equal(diagCodes(r.body, "ok").some((c) => c.startsWith("MISSING_")), false, "nested provenance present yields no MISSING_* for ok");
+    // 'lost' outcome: nested terminal_present:false feeds MISSING_TERMINAL.
+    assert.ok(diagCodes(r.body, "lost").includes("MISSING_TERMINAL"), "nested terminal_present:false feeds MISSING_TERMINAL");
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // A26 — the foreign-task marker embeds the collision-resistant program segment
 // ---------------------------------------------------------------------------
 
@@ -521,7 +630,7 @@ test("A26: program `alpha` does NOT adopt a task titled for `alpha/child` (disti
     programId,
     manifests: [{ run_id: "run-al", state: "dispatched", pr_number: 12, issue_number: 120 }],
     orcaScenario: {
-      tasks: [{ id: "orca-live-sib", title: `relay-orca: ${programSegment(siblingId)}/child-oc`, status: "dispatched", worker_done: false }],
+      tasks: [{ id: "orca-live-sib", task_title: `relay-orca: ${programSegment(siblingId)}/child-oc`, status: "dispatched", worker_done: false }],
     },
     ghScenario: { prs: { 12: { state: "OPEN" } }, issues: { 120: { state: "OPEN" } } },
   });
@@ -1368,7 +1477,7 @@ test("A13: status succeeds but carries no live runtime id → runtime unreachabl
     // status SUCCEEDS (ok:true) but carries NO runtimeId. A foreign task is present so a
     // TRUSTED runtime would have adopted Orca facts here — the A13 guard withholds them
     // instead of silently passing the mismatch check and trusting an unidentified runtime.
-    orcaScenario: { omitRuntimeId: true, tasks: [{ id: "foreign-x", title: "someone-else: other/thing", status: "dispatched" }] },
+    orcaScenario: { omitRuntimeId: true, tasks: [{ id: "foreign-x", task_title: "someone-else: other/thing", status: "dispatched" }] },
     ghScenario: { prs: { 320: { state: "OPEN" } }, issues: { 3200: { state: "OPEN" } } },
   });
   const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "nr", run: "run-nr" }] });

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -14,6 +14,7 @@ const STATUS_JS = path.join(SCRIPTS, "status.js");
 const { REASONS } = require(path.join(SCRIPTS, "lib", "status-reasons.js"));
 const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPTS, "lib", "status-report.js"));
 const { classifyOutcome } = require(path.join(SCRIPTS, "lib", "status-classify.js"));
+const { orcaDispatchShow } = require(path.join(SCRIPTS, "lib", "orca-reads.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
 const {
@@ -611,6 +612,28 @@ test("D4.3: status derives provenance from the nested result.dispatch shape (pre
   } finally {
     world.cleanup();
   }
+});
+
+test("D4.3: a present result.dispatch is authoritative — empty nested facts resolve null, never rescued by flat fields", () => {
+  // The dispatch-show payload nests provenance under an authoritative result.dispatch whose
+  // fields are empty, while legacy flat result.* fields carry conflicting values. Every fact
+  // must resolve from the nested object ONLY: empty nested → null, and the empty nested
+  // assignee (with no explicit terminal_present) yields terminalPresent:false.
+  const payload = {
+    ok: true,
+    result: {
+      dispatch: { task_id: "", id: "", assignee_handle: "" },
+      task_id: "flat-task",
+      dispatch_id: "flat-disp",
+      assignee: "flat-term",
+    },
+  };
+  const show = orcaDispatchShow(() => ({ status: 0, stdout: JSON.stringify(payload), stderr: "" }), "orca", "flat-task");
+  assert.equal(show.ok, true);
+  assert.equal(show.taskId, null, "empty nested task_id resolves null, never the flat value");
+  assert.equal(show.dispatchId, null, "empty nested dispatch id resolves null, never the flat value");
+  assert.equal(show.assignee, null, "empty nested assignee resolves null, never the flat value");
+  assert.equal(show.terminalPresent, false, "a null resolved assignee means the terminal is gone");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Dispatch Summary

```text
All work is complete, committed, and verified. Here's the final summary.

## Summary

Fixed issue #1001 — aligned relay-orca's `run`/`status`/`resume` surfaces and their fakes to the real mid-2026 Orca CLI shapes, keeping every fail-closed guarantee intact. Committed as `d72a234` on branch `issue-1001` (working tree clean).

### What changed (16 files, all in the D0 allowed surface)

- **D1** `run-orca.js` `sendPrompt`: argv is now exactly `["terminal","send","--terminal",<handle>,"--text",<prom
```

## Score Log

- Run: issue-1001-20260713123353429-9b46b162
- Executor: claude
- Branch: issue-1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 오퍼레이터 터미널은 명시적으로 제공된 핸들로만 사용되며, 자동 생성되지 않습니다.
  * 핸들이 없을 경우 변경 작업 없이 안전하게 중단하고, 재개 작업에는 복구 안내가 제공됩니다.
  * 디스패치 검증이 완료된 후에만 프롬프트가 전송되며, 검증 실패 작업은 보류 또는 에스컬레이션됩니다.
  * 최신 중첩 디스패치 정보와 다양한 작업명 형식을 안정적으로 처리합니다.
  * 부분 디스패치와 터미널 유실 복구 동작이 개선되었습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1001