### PR TITLE
harden cline-jsonl fallback tests: schema-valid fixtures + gate-acceptance assertions (follow-up to #989) (#995)

### DIFF
--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -217,7 +217,7 @@ function main() {
     });
   } catch (error) {
     throw withRawAdapterOutput(new Error(
-      `${error.message}. Cline advisory review must return JSON in run_result.text or the final text content_end; relay cannot treat this as healthy advisory evidence.`
+      `${error.message}. Cline advisory review must return JSON in run_result.text, then the last text content_end, then single-line plain-JSON stdout; relay cannot treat this as healthy advisory evidence.`
     ), rawOutput, rawStderr);
   }
 

--- a/tests/relay-dispatch/scripts/cline-jsonl.test.js
+++ b/tests/relay-dispatch/scripts/cline-jsonl.test.js
@@ -5,6 +5,7 @@ const {
   extractClineAdvisoryCandidates,
   extractClineRunResultText,
 } = require("../../../skills/relay-dispatch/scripts/agent-adapters/cline-jsonl");
+const { parseAdvisoryReview } = require("../../../skills/relay-review/scripts/advisory-review-schema");
 
 test("cline advisory extraction reports empty stdout with stderr tail", () => {
   assert.throws(
@@ -35,18 +36,33 @@ test("cline advisory extraction names invalid JSONL line number", () => {
 });
 
 test("cline advisory extraction falls back to text content_end when run_result is missing", () => {
+  const payload = JSON.stringify({
+    profile: "blindspot",
+    summary: "Schema-valid content_end fallback with empty finding arrays.",
+    required_findings: [],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  });
   const stdout = [
-    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: "{\"ok\":true}" } }),
+    JSON.stringify({ type: "agent_event", event: { type: "content_end", contentType: "text", text: payload } }),
   ].join("\n");
 
-  assert.deepEqual(
-    extractClineAdvisoryCandidates(stdout, {
-      adapter: "cline",
-      phase: "advisory_review",
-      stderr: "session not found",
-    }),
-    ["{\"ok\":true}"]
-  );
+  const candidates = extractClineAdvisoryCandidates(stdout, {
+    adapter: "cline",
+    phase: "advisory_review",
+    stderr: "session not found",
+  });
+  assert.deepEqual(candidates, [payload]);
+
+  const parsed = parseAdvisoryReview(candidates[0], {
+    adapter: "cline",
+    phase: "advisory_review",
+    profile: "blindspot",
+  });
+  assert.equal(parsed.summary, "Schema-valid content_end fallback with empty finding arrays.");
+  assert.equal(parsed.required_findings.length, 0);
+  assert.equal(parsed.advisory_findings.length, 0);
+  assert.equal(parsed.duplicate_or_low_confidence.length, 0);
 });
 
 test("cline advisory extraction falls back to plain advisory JSON stdout when run_result is missing", () => {
@@ -56,23 +72,39 @@ test("cline advisory extraction falls back to plain advisory JSON stdout when ru
     summary: "Survival issue-172 R5 shape: whole stdout is plain advisory JSON.",
     required_findings: [
       {
-        id: "finding-1",
-        severity: "high",
         title: "Real finding",
-        detail: "Present in plain JSON stdout without a run_result envelope.",
+        body: "Present in plain JSON stdout without a run_result envelope.",
+        file: "skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js",
+        severity: "P2",
+        category: "edge-case",
+        confidence: 0.9,
       },
     ],
     advisory_findings: [],
     duplicate_or_low_confidence: [],
   });
 
-  assert.deepEqual(
-    extractClineAdvisoryCandidates(advisoryJson, {
-      adapter: "cline",
-      phase: "advisory_review",
-    }),
-    [advisoryJson]
-  );
+  const candidates = extractClineAdvisoryCandidates(advisoryJson, {
+    adapter: "cline",
+    phase: "advisory_review",
+  });
+  assert.deepEqual(candidates, [advisoryJson]);
+
+  const parsed = parseAdvisoryReview(candidates[0], {
+    adapter: "cline",
+    phase: "advisory_review",
+    profile: "blindspot",
+  });
+  assert.equal(parsed.required_findings.length, 1);
+  assert.deepEqual(parsed.required_findings[0], {
+    title: "Real finding",
+    body: "Present in plain JSON stdout without a run_result envelope.",
+    file: "skills/relay-dispatch/scripts/agent-adapters/cline-jsonl.js",
+    line: null,
+    severity: "P2",
+    category: "edge-case",
+    confidence: 0.9,
+  });
 });
 
 test("cline advisory extraction reports missing run_result with stderr tail when no fallback exists", () => {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-995-20260713120903012-6c395bf4
- Branch: issue-995
- Reason: executor completed all DC work; total_timeout (load-87 spike + cursor connection flap) killed it pre-commit; diff verified against frozen DC, targeted 9/9, full serialized gate 1663/0 green
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-995-20260713120903012-6c395bf4.md; orchestrator=unknown; executor=cursor
- Recovered at (UTC): 2026-07-13T14:12:53.905Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Cline 검토 결과에서 JSON 응답을 찾지 못했을 때 표시되는 안내 메시지를 더 구체적으로 개선했습니다.

* **테스트**
  * 다양한 JSON 응답 대체 경로를 검증하도록 테스트를 강화했습니다.
  * 검토 요약, 발견 사항, 파일·줄 번호·심각도 등 결과 필드가 올바르게 처리되는지 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->