### PR TITLE
fix(relay-orca): guard attached gh api body options (#990)

### DIFF
--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -110,20 +110,22 @@ function assertOrcaReadOnly(argv) {
 // Present in ANY of these forms, an `api` call is a write even without a literal `-X`.
 const GH_API_BODY_OPTS = new Set(["-f", "--field", "-F", "--raw-field", "--input"]);
 
-function isGhApiBodyOption(token) {
+function isMutatingGhApiOption(token) {
   if (GH_API_BODY_OPTS.has(token)
     || token.startsWith("--field=")
     || token.startsWith("--raw-field=")
     || token.startsWith("--input=")) return true;
 
   // Cobra permits boolean shorthands to be clustered before a value-taking flag.
-  // For `gh api`, `-i` is boolean, so `-ifa=b` and `-iFa=b` carry body fields.
-  // Stop at any other shorthand because a value-taking flag (notably `-XGET`)
-  // consumes the remainder of its token as its value.
+  // For `gh api`, `-i` is boolean, so value-taking `f`, `F`, or `X` may follow
+  // one or more leading `i` shorthands. Body fields always mutate; an attached
+  // explicit method mutates unless it is GET. Other shorthands remain read-shaped.
   if (!token.startsWith("-") || token.startsWith("--")) return false;
   let index = 1;
   while (token[index] === "i") index += 1;
-  return token[index] === "f" || token[index] === "F";
+  if (token[index] === "f" || token[index] === "F") return true;
+  if (index > 1 && token[index] === "X") return token.slice(index + 1).trim().toUpperCase() !== "GET";
+  return false;
 }
 
 // Extract an explicit `gh api` method, handling both separated (`-X POST`, `--method POST`)
@@ -144,7 +146,7 @@ function ghApiMethod(argv) {
 // method, no body/field) is a read-only GET.
 function isMutatingGhApi(argv) {
   if (argv[0] !== "api") return false;
-  if (argv.some((token) => isGhApiBodyOption(token))) return true;
+  if (argv.some((token) => isMutatingGhApiOption(token))) return true;
   const method = ghApiMethod(argv);
   if (method !== null && method.trim().toUpperCase() !== "GET") return true;
   return argv.some((token) => /^(POST|PATCH|PUT|DELETE)$/i.test(token));

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -110,6 +110,14 @@ function assertOrcaReadOnly(argv) {
 // Present in ANY of these forms, an `api` call is a write even without a literal `-X`.
 const GH_API_BODY_OPTS = new Set(["-f", "--field", "-F", "--raw-field", "--input"]);
 
+function isGhApiBodyOption(token) {
+  return GH_API_BODY_OPTS.has(token)
+    || token.startsWith("--field=")
+    || token.startsWith("--raw-field=")
+    || token.startsWith("--input=")
+    || ((token.startsWith("-f") || token.startsWith("-F")) && token.length > 2);
+}
+
 // Extract an explicit `gh api` method, handling both separated (`-X POST`, `--method POST`)
 // and attached (`-XPOST`, `--method=POST`) forms. Returns null when no method is specified
 // (a bare `gh api` defaults to GET).
@@ -128,7 +136,7 @@ function ghApiMethod(argv) {
 // method, no body/field) is a read-only GET.
 function isMutatingGhApi(argv) {
   if (argv[0] !== "api") return false;
-  if (argv.some((token) => GH_API_BODY_OPTS.has(token))) return true;
+  if (argv.some((token) => isGhApiBodyOption(token))) return true;
   const method = ghApiMethod(argv);
   if (method !== null && method.trim().toUpperCase() !== "GET") return true;
   return argv.some((token) => /^(POST|PATCH|PUT|DELETE)$/i.test(token));

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -111,11 +111,19 @@ function assertOrcaReadOnly(argv) {
 const GH_API_BODY_OPTS = new Set(["-f", "--field", "-F", "--raw-field", "--input"]);
 
 function isGhApiBodyOption(token) {
-  return GH_API_BODY_OPTS.has(token)
+  if (GH_API_BODY_OPTS.has(token)
     || token.startsWith("--field=")
     || token.startsWith("--raw-field=")
-    || token.startsWith("--input=")
-    || ((token.startsWith("-f") || token.startsWith("-F")) && token.length > 2);
+    || token.startsWith("--input=")) return true;
+
+  // Cobra permits boolean shorthands to be clustered before a value-taking flag.
+  // For `gh api`, `-i` is boolean, so `-ifa=b` and `-iFa=b` carry body fields.
+  // Stop at any other shorthand because a value-taking flag (notably `-XGET`)
+  // consumes the remainder of its token as its value.
+  if (!token.startsWith("-") || token.startsWith("--")) return false;
+  let index = 1;
+  while (token[index] === "i") index += 1;
+  return token[index] === "f" || token[index] === "F";
 }
 
 // Extract an explicit `gh api` method, handling both separated (`-X POST`, `--method POST`)

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -49,6 +49,13 @@ const isPrView = args[0] === "pr" && args[1] === "view";
 // an explicit non-GET method (separated or attached) is likewise a write. Mirror the
 // status.js assertGhReadOnly boundary so this poison layer rejects the same shapes.
 const GH_API_BODY_OPTS = ["-f", "--field", "-F", "--raw-field", "--input"];
+function isGhApiBodyOption(t) {
+  return GH_API_BODY_OPTS.indexOf(t) >= 0
+    || t.indexOf("--field=") === 0
+    || t.indexOf("--raw-field=") === 0
+    || t.indexOf("--input=") === 0
+    || ((t.indexOf("-f") === 0 || t.indexOf("-F") === 0) && t.length > 2);
+}
 function ghApiMethod(a) {
   for (var i = 0; i < a.length; i++) {
     var t = a[i];
@@ -60,7 +67,7 @@ function ghApiMethod(a) {
 }
 var apiMethod = args[0] === "api" ? ghApiMethod(args) : null;
 const isApiWrite = args[0] === "api" && (
-  args.some(function (t) { return GH_API_BODY_OPTS.indexOf(t) >= 0; })
+  args.some(function (t) { return isGhApiBodyOption(t); })
   || (apiMethod !== null && apiMethod.trim().toUpperCase() !== "GET")
   || args.some(function (t) { return /^(POST|PATCH|PUT|DELETE)$/i.test(t); })
 );

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -49,20 +49,22 @@ const isPrView = args[0] === "pr" && args[1] === "view";
 // an explicit non-GET method (separated or attached) is likewise a write. Mirror the
 // status.js assertGhReadOnly boundary so this poison layer rejects the same shapes.
 const GH_API_BODY_OPTS = ["-f", "--field", "-F", "--raw-field", "--input"];
-function isGhApiBodyOption(t) {
+function isMutatingGhApiOption(t) {
   if (GH_API_BODY_OPTS.indexOf(t) >= 0
     || t.indexOf("--field=") === 0
     || t.indexOf("--raw-field=") === 0
     || t.indexOf("--input=") === 0) return true;
 
   // Cobra permits boolean shorthands to be clustered before a value-taking flag.
-  // For gh api, -i is boolean, so -ifa=b and -iFa=b carry body fields.
-  // Stop at any other shorthand because a value-taking flag (notably -XGET)
-  // consumes the remainder of its token as its value.
+  // For gh api, -i is boolean, so value-taking f, F, or X may follow one or
+  // more leading i shorthands. Body fields always mutate; an attached explicit
+  // method mutates unless it is GET. Other shorthands remain read-shaped.
   if (t.indexOf("-") !== 0 || t.indexOf("--") === 0) return false;
   var index = 1;
   while (t[index] === "i") index += 1;
-  return t[index] === "f" || t[index] === "F";
+  if (t[index] === "f" || t[index] === "F") return true;
+  if (index > 1 && t[index] === "X") return t.slice(index + 1).trim().toUpperCase() !== "GET";
+  return false;
 }
 function ghApiMethod(a) {
   for (var i = 0; i < a.length; i++) {
@@ -75,7 +77,7 @@ function ghApiMethod(a) {
 }
 var apiMethod = args[0] === "api" ? ghApiMethod(args) : null;
 const isApiWrite = args[0] === "api" && (
-  args.some(function (t) { return isGhApiBodyOption(t); })
+  args.some(function (t) { return isMutatingGhApiOption(t); })
   || (apiMethod !== null && apiMethod.trim().toUpperCase() !== "GET")
   || args.some(function (t) { return /^(POST|PATCH|PUT|DELETE)$/i.test(t); })
 );

--- a/tests/relay-orca/fixtures/fake-gh.js
+++ b/tests/relay-orca/fixtures/fake-gh.js
@@ -50,11 +50,19 @@ const isPrView = args[0] === "pr" && args[1] === "view";
 // status.js assertGhReadOnly boundary so this poison layer rejects the same shapes.
 const GH_API_BODY_OPTS = ["-f", "--field", "-F", "--raw-field", "--input"];
 function isGhApiBodyOption(t) {
-  return GH_API_BODY_OPTS.indexOf(t) >= 0
+  if (GH_API_BODY_OPTS.indexOf(t) >= 0
     || t.indexOf("--field=") === 0
     || t.indexOf("--raw-field=") === 0
-    || t.indexOf("--input=") === 0
-    || ((t.indexOf("-f") === 0 || t.indexOf("-F") === 0) && t.length > 2);
+    || t.indexOf("--input=") === 0) return true;
+
+  // Cobra permits boolean shorthands to be clustered before a value-taking flag.
+  // For gh api, -i is boolean, so -ifa=b and -iFa=b carry body fields.
+  // Stop at any other shorthand because a value-taking flag (notably -XGET)
+  // consumes the remainder of its token as its value.
+  if (t.indexOf("-") !== 0 || t.indexOf("--") === 0) return false;
+  var index = 1;
+  while (t[index] === "i") index += 1;
+  return t[index] === "f" || t[index] === "F";
 }
 function ghApiMethod(a) {
   for (var i = 0; i < a.length; i++) {

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -803,6 +803,8 @@ test("A28: assertGhReadOnly refuses mutation-shaped `gh api`, allows bare GET re
     ["api", "repos/x", "--input=body.json"],
     ["api", "repos/x", "-fa=b"],
     ["api", "repos/x", "-Fa=b"],
+    ["api", "repos/x", "-ifa=b"],
+    ["api", "repos/x", "-iFa=b"],
   ]) {
     assert.throws(() => assertGhReadOnly(argv), /non-read gh subcommand/, `must reject: gh ${argv.join(" ")}`);
   }
@@ -843,6 +845,8 @@ test("A28: the fake gh poison rejects mutation-shaped `gh api` and serves a bare
       ["api", "repos/x", "--input=body.json"],
       ["api", "repos/x", "-fa=b"],
       ["api", "repos/x", "-Fa=b"],
+      ["api", "repos/x", "-ifa=b"],
+      ["api", "repos/x", "-iFa=b"],
       ["api", "-X", "POST", "repos/x"],
       ["api", "--method=PATCH", "repos/x"],
       ["api", "repos/x", "--input", "body.json"],
@@ -857,11 +861,13 @@ test("A28: the fake gh poison rejects mutation-shaped `gh api` and serves a bare
       assert.notEqual(code, 0, `gh ${argv.join(" ")} must poison`);
       assert.match(gh.readPoison(), /GH_WRITE_INVOKED/, `gh ${argv.join(" ")} must write a poison marker`);
     }
-    // A bare GET `gh api` is served (exit 0), no poison.
-    fs.rmSync(gh.poisonPath, { force: true });
-    const out = execFileSync(gh.ghPath, ["api", "repos/x"], { stdio: "pipe", encoding: "utf-8" });
-    assert.equal(gh.readPoison(), null, "a bare GET api read must never poison");
-    assert.equal(out, "{}", "the fake serves a read-shaped api GET");
+    // Bare and explicitly attached GET `gh api` reads are served (exit 0), no poison.
+    for (const argv of [["api", "repos/x"], ["api", "-XGET", "repos/x"]]) {
+      fs.rmSync(gh.poisonPath, { force: true });
+      const out = execFileSync(gh.ghPath, argv, { stdio: "pipe", encoding: "utf-8" });
+      assert.equal(gh.readPoison(), null, `gh ${argv.join(" ")} must never poison`);
+      assert.equal(out, "{}", `the fake serves read-shaped gh ${argv.join(" ")}`);
+    }
   } finally {
     gh.cleanup();
   }

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -813,6 +813,7 @@ test("A28: assertGhReadOnly refuses mutation-shaped `gh api`, allows bare GET re
     ["api", "-X", "POST", "repos/x"],
     ["api", "--method", "PATCH", "repos/x"],
     ["api", "-XDELETE", "repos/x"],
+    ["api", "-iXPOST", "repos/x"],
     ["api", "--method=PUT", "repos/x"],
     ["api", "repos/x", "POST"],
   ]) {
@@ -824,6 +825,7 @@ test("A28: assertGhReadOnly refuses mutation-shaped `gh api`, allows bare GET re
     ["api", "repos/x", "--jq", ".state"],
     ["api", "-X", "GET", "repos/x"],
     ["api", "-XGET", "repos/x"],
+    ["api", "-iXGET", "repos/x"],
     ["issue", "view", "1", "--json", "state,stateReason"],
     ["pr", "view", "2", "--json", "mergedAt,state"],
   ]) {
@@ -849,6 +851,7 @@ test("A28: the fake gh poison rejects mutation-shaped `gh api` and serves a bare
       ["api", "repos/x", "-iFa=b"],
       ["api", "-X", "POST", "repos/x"],
       ["api", "--method=PATCH", "repos/x"],
+      ["api", "-iXPOST", "repos/x"],
       ["api", "repos/x", "--input", "body.json"],
     ]) {
       fs.rmSync(gh.poisonPath, { force: true });
@@ -862,7 +865,7 @@ test("A28: the fake gh poison rejects mutation-shaped `gh api` and serves a bare
       assert.match(gh.readPoison(), /GH_WRITE_INVOKED/, `gh ${argv.join(" ")} must write a poison marker`);
     }
     // Bare and explicitly attached GET `gh api` reads are served (exit 0), no poison.
-    for (const argv of [["api", "repos/x"], ["api", "-XGET", "repos/x"]]) {
+    for (const argv of [["api", "repos/x"], ["api", "-XGET", "repos/x"], ["api", "-iXGET", "repos/x"]]) {
       fs.rmSync(gh.poisonPath, { force: true });
       const out = execFileSync(gh.ghPath, argv, { stdio: "pipe", encoding: "utf-8" });
       assert.equal(gh.readPoison(), null, `gh ${argv.join(" ")} must never poison`);

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -798,6 +798,11 @@ test("A28: assertGhReadOnly refuses mutation-shaped `gh api`, allows bare GET re
     ["api", "repos/x", "-F", "a=b"],
     ["api", "repos/x", "--raw-field", "a=b"],
     ["api", "repos/x", "--input", "body.json"],
+    ["api", "repos/x", "--field=a=b"],
+    ["api", "repos/x", "--raw-field=a=b"],
+    ["api", "repos/x", "--input=body.json"],
+    ["api", "repos/x", "-fa=b"],
+    ["api", "repos/x", "-Fa=b"],
   ]) {
     assert.throws(() => assertGhReadOnly(argv), /non-read gh subcommand/, `must reject: gh ${argv.join(" ")}`);
   }
@@ -816,6 +821,7 @@ test("A28: assertGhReadOnly refuses mutation-shaped `gh api`, allows bare GET re
     ["api", "repos/x"],
     ["api", "repos/x", "--jq", ".state"],
     ["api", "-X", "GET", "repos/x"],
+    ["api", "-XGET", "repos/x"],
     ["issue", "view", "1", "--json", "state,stateReason"],
     ["pr", "view", "2", "--json", "mergedAt,state"],
   ]) {
@@ -832,6 +838,11 @@ test("A28: the fake gh poison rejects mutation-shaped `gh api` and serves a bare
     for (const argv of [
       ["api", "repos/x", "-f", "a=b"],
       ["api", "repos/x", "--field", "a=b"],
+      ["api", "repos/x", "--field=a=b"],
+      ["api", "repos/x", "--raw-field=a=b"],
+      ["api", "repos/x", "--input=body.json"],
+      ["api", "repos/x", "-fa=b"],
+      ["api", "repos/x", "-Fa=b"],
       ["api", "-X", "POST", "repos/x"],
       ["api", "--method=PATCH", "repos/x"],
       ["api", "repos/x", "--input", "body.json"],


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #990.

- Guard and fake-gh poison now reject all five attached body-option forms.
- Added coverage for each form in both layers.
- Preserved `-XGET` as read-only.
- TDD confirmed red → green.
- `status.test.js`: 68/68 passed.
- Full relay-orca suite: 220/220 passed.
- Commit: `47cd01c fix(relay-orca): guard attached gh api body options (#990)`
- Working tree clean; no push or PR created.
```

## Score Log

- Run: issue-990-20260713150122262-a8e4cd20
- Executor: codex
- Branch: issue-990