### PR TITLE
fix(relay-orca): relay_ids mapping intake — operator marker + resume --map-relay-run (#1008)

### DIFF
--- a/skills/relay-orca/references/install-and-operate.md
+++ b/skills/relay-orca/references/install-and-operate.md
@@ -110,7 +110,7 @@ coordinator (a terminal session running relay-orca's CLI scripts)
 
 ## Recovery and manual-cleanup limitations (open follow-ups from the 2026-07-13 pilot)
 
-These are honest, open follow-ups surfaced by the pilot; they are not yet fixed:
+These are supervised limitations and open follow-ups surfaced by the pilot:
 
 - **`stop` cannot currently succeed in the v0 topology (#1005).** `stop`'s only mutation,
   `orca orchestration run-stop`, assumes an always-on Orca coordinator loop that the stateless-CLI
@@ -118,18 +118,19 @@ These are honest, open follow-ups surfaced by the pilot; they are not yet fixed:
   fail-closed behavior is honest, but the intent — durably recording an operator interruption — is
   unreachable today.
 - **Operator-driven outcomes need a supervised receipt-mapping reconcile before they classify
-  complete (#1008).** `run` writes the receipt before the operator's relay run exists, and no code
-  path consumes the operator's completion payload back into the receipt, so `relay_ids.run` stays
-  null and the outcome reads `running` forever. Verified-evidence-first recipe: **live-verify**
-  the relay manifest is terminal, the PR is MERGED, and the issue is CLOSED, **then** atomically
-  write the confirmed `relay_ids.run` into the receipt. Only after that mapping does the #945
-  evidence classifier report `complete_with_evidence`.
+  complete (#1008).** `run` writes the receipt before the operator's relay run exists. The shipped
+  supervised intake path is `resume --program-file <program> --map-relay-run
+  <outcome_id>=<run_id>`: **live-verify** the relay manifest is terminal, the PR is MERGED, and the
+  issue is CLOSED before invoking it. The flag validates the outcome, manifest, and tracker issue,
+  then atomically records `relay_ids.run`; only the following #945 live reconciliation can report
+  `complete_with_evidence`. See [recovery.md](recovery.md#supervised-relay-run-mapping-intake).
 - **Waves beyond wave 1 need a supervised manual dispatch (#1009).** No shipped code path advances
   a program past wave 1: `run` dispatches wave 1 only (and cannot re-run under empty-runtime
   admission), `resume` re-dispatches only crash-lost wave-1 outcomes, and the #947 gate/completion
   modes are read-only. The supervised workaround is to replay `run`'s exact verified sequence for
   the next-wave task — `dispatch --inject` → `dispatch-show` provenance verify → `terminal send`
-  prompt — then reconcile the receipt per #1008.
+  prompt — then reconcile the receipt with `resume --program-file <program> --map-relay-run
+  <outcome_id>=<run_id>` per #1008.
 
 `resume` and `stop` never reset Orca, delete a task/worktree/branch/PR, or force-close a relay
 run on any path. Manual decision recovery: [recovery.md](recovery.md).

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -1,10 +1,12 @@
 # relay-orca recovery — `resume`/`stop` decision handling
 
-`resume` is **reconcile-first and fail-closed**: it loads the reconstructible receipt, runs the
-SAME live reconciliation as `status` **before any mutation**, and only then restores what is
-safe (reuse valid mappings, reacquire a lost operator terminal, re-dispatch a verifiably-absent,
-relay-clean, wave-1 outcome through the verified path — always to an explicitly provided
-`--operator-handle`, never a self-created terminal). **"Verifiably absent" means a live
+`resume` is **reconcile-first and fail-closed for runtime restoration**: it loads the
+reconstructible receipt, runs the SAME live reconciliation as `status` before restoring an Orca
+dispatch, and only then restores what is safe (reuse valid mappings, reacquire a lost operator
+terminal, re-dispatch a verifiably-absent, relay-clean, wave-1 outcome through the verified path —
+always to an explicitly provided `--operator-handle`, never a self-created terminal). The explicit
+`--map-relay-run` intake described below is the narrow exception: it validates and atomically
+records supervised coordination metadata before live reconciliation. **"Verifiably absent" means a live
 `dispatch-show` read for that task, taken during the reconciliation pass, reported NO dispatch —
 a null `dispatch_id` in the receipt alone NEVER qualifies.** In the crash window (a
 `dispatch --inject` landed a live dispatch but the receipt write recording it never happened),
@@ -16,9 +18,10 @@ anchor for those decisions.
 
 None of the steps below are performed automatically by the skill. The skill **never** resets
 Orca, deletes a task, removes a worktree, deletes a branch/PR, force-closes a relay run, or
-creates its own operator terminal — on any path, including every failure path. The **only**
-mutations `resume` performs are, on a safe outcome, `orca orchestration dispatch --inject` and
-`orca terminal send`, both against a terminal the operator provided via `--operator-handle`; if
+creates its own operator terminal — on any path, including every failure path. Its runtime
+mutations on a safe outcome are limited to `orca orchestration dispatch --inject` and `orca
+terminal send`, both against a terminal the operator provided via `--operator-handle`; explicit
+operator-record and relay-run-mapping flags may atomically update receipt metadata. If
 an outcome needs (re)dispatch and no handle was provided, `resume` fails closed with
 `RESUME_NO_OPERATOR_HANDLE` (exit 66) and mutates nothing. `stop`'s only mutation is
 `orca orchestration run-stop`.
@@ -88,6 +91,30 @@ performs **zero** mutation and asks for a terminal. Bounded steps:
    `node scripts/resume.js --program-id <id> --operator-handle <handle> --json`.
 3. Provide one handle per outcome that needs a fresh operator surface; a shortfall leaves the
    excess outcomes untouched for a follow-up resume.
+
+## Supervised relay run mapping intake
+
+Operator-driven relay work is adopted into the receipt only through an explicit, supervised
+mapping. Before changing coordination metadata, live-verify all three durable facts: the intended
+relay run manifest is terminal, its PR is `MERGED`, and its tracker issue is `CLOSED`. Then run:
+
+```bash
+node scripts/resume.js --program-id <id> --program-file <program> --map-relay-run <outcome_id>=<run_id> --json
+```
+
+The accepted program supplies the outcome's declared issue, and the manifest filename supplies
+the exact run id. The batch is rejected without changing the receipt when any mapping fails:
+
+- `RESUME_MAP_TARGET_INVALID` (exit 67): the outcome is unknown, its task kind cannot consume a
+  relay run mapping, or the accepted outcome has no declared issue.
+- `RESUME_MAP_RUN_NOT_FOUND` (exit 68): no runs-root manifest filename exactly matches the run id.
+- `RESUME_MAP_ISSUE_MISMATCH` (exit 69): the manifest issue differs from the accepted outcome issue.
+- `RESUME_CONFLICTING_MAPPING` (exit 62): the run belongs to another receipt task or the target
+  already names a different run.
+
+This intake is explicit-only and never automatic. Back-pointer discovery can propose a candidate,
+but neither `status` nor flagless `resume` adopts it. The mapping records coordination metadata;
+the next live reconciliation remains the only authority for `complete_with_evidence`.
 
 ## Corrupt or global task-graph recovery
 

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -67,23 +67,32 @@ function fleetLeavesBlock(outcome) {
   return ["prepared fleet leaves:", ...lines].join("\n");
 }
 
-function bodyBlock(task, outcome) {
+function manifestMarkerBlock(task, program, segmentEncoder) {
+  if (task.kind !== "relay_run" && task.kind !== "relay_fleet") return null;
+  if (typeof segmentEncoder !== "function") throw new TypeError("operator prompt requires the shared program segment encoder");
+  const destination = task.kind === "relay_fleet" ? "relay fleet manifest" : "relay run manifest";
+  const marker = `relay-orca: ${segmentEncoder(program.id)}/${task.outcome_id}`;
+  return `Embed this exact program marker line in the ${destination}:\n${marker}`;
+}
+
+function bodyBlock(task, program, outcome, segmentEncoder) {
   const route = task.recommended_route || {};
   if (route.read_only) {
     return [NO_EDIT_CLAUSE, `Deliver the ${route.mode} evidence, then triage blocking findings into tracker follow-ups.`].join("\n");
   }
+  const marker = manifestMarkerBlock(task, program, segmentEncoder);
   if (task.kind === "relay_fleet") {
-    return [RELAY_PATH, fleetLeavesBlock(outcome), OWNERSHIP_NOTE].join("\n");
+    return [RELAY_PATH, fleetLeavesBlock(outcome), OWNERSHIP_NOTE, marker].join("\n");
   }
-  return [RELAY_PATH, OWNERSHIP_NOTE].join("\n");
+  return [RELAY_PATH, OWNERSHIP_NOTE, marker].filter(Boolean).join("\n");
 }
 
 // Build the full operator prompt for a single task. `outcome` is the original
 // program outcome (carries relay_fleet leaves); `task` is the compiled plan task.
-function buildOperatorPrompt(task, program, outcome = {}) {
+function buildOperatorPrompt(task, program, outcome = {}, segmentEncoder) {
   return [
     headerBlock(task, program, outcome),
-    bodyBlock(task, outcome),
+    bodyBlock(task, program, outcome, segmentEncoder),
     payloadContractBlock(),
   ].join("\n\n");
 }

--- a/skills/relay-orca/scripts/lib/resume-mapping.js
+++ b/skills/relay-orca/scripts/lib/resume-mapping.js
@@ -20,14 +20,31 @@ function programOutcomes(program) {
   return program && Array.isArray(program.outcomes) ? program.outcomes : [];
 }
 
-function declaredIssue(outcome) {
-  return outcome && outcome.issue !== undefined && outcome.issue !== null ? outcome.issue : null;
+// Normalize a tracker issue value to a finite integer or null, consistent with how
+// manifest-parse.js reads `issue.number` (a raw number, or a scalar string matching
+// /^-?\d+$/). Empty strings, non-numeric strings, null/undefined, and non-finite
+// numbers are all UNDECLARED (null) — they must never coerce to 0 via Number().
+function normalizeIssueNumber(value) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return /^-?\d+$/.test(trimmed) ? Number(trimmed) : null;
+  }
+  return null;
 }
 
+function declaredIssue(outcome) {
+  return outcome ? normalizeIssueNumber(outcome.issue) : null;
+}
+
+// Two issues are equal ONLY when BOTH sides normalize to a finite integer and match.
+// An absent/empty/non-numeric value on either side normalizes to null and can never
+// compare equal — this closes the Number("")===Number(null)===0 coercion hole so a
+// missing manifest issue_number always fails the RESUME_MAP_ISSUE_MISMATCH gate.
 function issuesEqual(left, right) {
-  const leftNumber = Number(left);
-  const rightNumber = Number(right);
-  return Number.isFinite(leftNumber) && Number.isFinite(rightNumber) && leftNumber === rightNumber;
+  const leftNumber = normalizeIssueNumber(left);
+  const rightNumber = normalizeIssueNumber(right);
+  return leftNumber !== null && rightNumber !== null && leftNumber === rightNumber;
 }
 
 // Validate category-by-category so the documented order is deterministic across a batch:

--- a/skills/relay-orca/scripts/lib/resume-mapping.js
+++ b/skills/relay-orca/scripts/lib/resume-mapping.js
@@ -1,0 +1,119 @@
+"use strict";
+
+// Pure validation and receipt-object update logic for explicit relay run mapping intake.
+// The entry script supplies the accepted program and already-read manifest records. This
+// module never performs live reconciliation and never persists anything itself.
+const { decisionEntry, exitCodeFor } = require("./resume-reasons");
+
+const MAPPABLE_KINDS = new Set(["relay_run", "tracker_reconciliation"]);
+
+function reject(reasonCode, message) {
+  return {
+    ok: false,
+    decision: decisionEntry(reasonCode, message),
+    exitCode: exitCodeFor(reasonCode),
+    mappings: [],
+  };
+}
+
+function programOutcomes(program) {
+  return program && Array.isArray(program.outcomes) ? program.outcomes : [];
+}
+
+function declaredIssue(outcome) {
+  return outcome && outcome.issue !== undefined && outcome.issue !== null ? outcome.issue : null;
+}
+
+function issuesEqual(left, right) {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+  return Number.isFinite(leftNumber) && Number.isFinite(rightNumber) && leftNumber === rightNumber;
+}
+
+// Validate category-by-category so the documented order is deterministic across a batch:
+// target, manifest existence, tracker issue, then duplicate/contradictory mappings.
+function validateRelayRunMappings({ receipt, program, requested, manifests }) {
+  const tasks = Array.isArray(receipt && receipt.tasks) ? receipt.tasks : [];
+  const outcomes = programOutcomes(program);
+  const manifestList = Array.isArray(manifests) ? manifests : [];
+  const prepared = [];
+
+  for (const mapping of requested || []) {
+    const task = tasks.find((entry) => entry.outcome_id === mapping.outcome_id) || null;
+    const outcome = outcomes.find((entry) => entry && entry.id === mapping.outcome_id) || null;
+    const issue = declaredIssue(outcome);
+    if (!task || !MAPPABLE_KINDS.has(task.kind) || issue === null) {
+      return reject(
+        "RESUME_MAP_TARGET_INVALID",
+        `outcome ${mapping.outcome_id} is not a receipt target that accepts relay run mapping with a declared issue`,
+      );
+    }
+    prepared.push({ ...mapping, task, issue, manifest: null });
+  }
+
+  for (const mapping of prepared) {
+    mapping.manifest = manifestList.find((entry) => entry.run_id === mapping.run_id) || null;
+    if (!mapping.manifest) {
+      return reject(
+        "RESUME_MAP_RUN_NOT_FOUND",
+        `relay run manifest ${mapping.run_id} was not found by exact filename stem under the repository runs root`,
+      );
+    }
+  }
+
+  for (const mapping of prepared) {
+    const manifestIssue = mapping.manifest.parsed && mapping.manifest.parsed.issue_number;
+    if (!issuesEqual(manifestIssue, mapping.issue)) {
+      return reject(
+        "RESUME_MAP_ISSUE_MISMATCH",
+        `relay run ${mapping.run_id} issue ${manifestIssue} does not match outcome ${mapping.outcome_id} issue ${mapping.issue}`,
+      );
+    }
+  }
+
+  const runOwner = new Map();
+  const targetRun = new Map();
+  for (const mapping of prepared) {
+    const existing = mapping.task.relay_ids && mapping.task.relay_ids.run;
+    const owner = tasks.find((task) => (
+      task.outcome_id !== mapping.outcome_id
+      && task.relay_ids
+      && task.relay_ids.run === mapping.run_id
+    ));
+    const requestedOwner = runOwner.get(mapping.run_id);
+    const requestedForTarget = targetRun.get(mapping.outcome_id);
+    if ((existing && existing !== mapping.run_id)
+      || owner
+      || (requestedOwner && requestedOwner !== mapping.outcome_id)
+      || (requestedForTarget && requestedForTarget !== mapping.run_id)) {
+      return reject(
+        "RESUME_CONFLICTING_MAPPING",
+        `relay run ${mapping.run_id} conflicts with an existing or requested mapping for outcome ${mapping.outcome_id}`,
+      );
+    }
+    targetRun.set(mapping.outcome_id, mapping.run_id);
+    runOwner.set(mapping.run_id, mapping.outcome_id);
+  }
+
+  return {
+    ok: true,
+    decision: null,
+    exitCode: 0,
+    mappings: [...targetRun].map(([outcome_id, run_id]) => ({ outcome_id, run_id })),
+  };
+}
+
+function applyRelayRunMappings(receipt, mappings) {
+  let changed = false;
+  const taskByOutcome = new Map((receipt.tasks || []).map((task) => [task.outcome_id, task]));
+  (mappings || []).forEach((mapping) => {
+    const task = taskByOutcome.get(mapping.outcome_id);
+    if (task.relay_ids.run !== mapping.run_id) {
+      task.relay_ids.run = mapping.run_id;
+      changed = true;
+    }
+  });
+  return changed;
+}
+
+module.exports = { MAPPABLE_KINDS, validateRelayRunMappings, applyRelayRunMappings };

--- a/skills/relay-orca/scripts/lib/resume-reasons.js
+++ b/skills/relay-orca/scripts/lib/resume-reasons.js
@@ -4,7 +4,7 @@
 // 60-range so it never collides with plan.js's 2-21 codes, the probe's 30-37, run's
 // 40-44, status/receipt's 50-52, or Node's own fatal/exec codes (<=125). Existing
 // reason modules stay untouched. 64 (usage errors) and 65 (stop's
-// COORDINATOR_STOP_FAILED) are deliberately avoided.
+// COORDINATOR_STOP_FAILED) retain their existing meanings.
 //
 // These are the ONLY conditions that make resumption unsafe. In any of them
 // resume performs NO automatic mutation: it emits a `decision_required` report and
@@ -19,6 +19,9 @@ const REASONS = Object.freeze({
   RESUME_CONFLICTING_MAPPING: 62, // duplicate or contradictory (changed) mappings
   RESUME_MISSING_PROVENANCE: 63, // a mapping's dispatch context/assignee is missing where a live dispatch exists
   RESUME_NO_OPERATOR_HANDLE: 66, // an outcome needs (re)dispatch but no --operator-handle was provided (64 = usage, 65 = stop's COORDINATOR_STOP_FAILED)
+  RESUME_MAP_TARGET_INVALID: 67, // requested outcome/kind/issue cannot safely accept a relay run mapping
+  RESUME_MAP_RUN_NOT_FOUND: 68, // requested run id has no runs-root manifest filename match
+  RESUME_MAP_ISSUE_MISMATCH: 69, // manifest issue number does not match the accepted outcome
 });
 
 // Bounded recovery options per decision code (D2). Each option names a concrete
@@ -50,6 +53,21 @@ const OPTIONS = Object.freeze({
     "Create an operator terminal running an agent CLI: `orca terminal create --command \"<agent-cli>\" --json`.",
     "Re-run resume with the terminal handle: `node scripts/resume.js --program-id <id> --operator-handle <handle> --json`.",
     "See references/recovery.md § RESUME_NO_OPERATOR_HANDLE for the bounded manual steps.",
+  ],
+  RESUME_MAP_TARGET_INVALID: [
+    "Inspect the accepted program and receipt: `node scripts/status.js --program-id <id> --json`.",
+    "Confirm the outcome exists, accepts a relay run mapping, and declares a tracker issue.",
+    "See references/recovery.md § Supervised relay run mapping intake.",
+  ],
+  RESUME_MAP_RUN_NOT_FOUND: [
+    "List the repository's relay run manifests and confirm the exact run id filename.",
+    "Re-run the mapping only after the intended relay run manifest exists.",
+    "See references/recovery.md § Supervised relay run mapping intake.",
+  ],
+  RESUME_MAP_ISSUE_MISMATCH: [
+    "Compare the accepted outcome issue with the relay manifest issue number.",
+    "Map only the relay run created for that accepted outcome's tracker issue.",
+    "See references/recovery.md § Supervised relay run mapping intake.",
   ],
 });
 

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -210,7 +210,7 @@ function dispatchOne(ctx) {
   // is durable coordination metadata, independent of whether the operator prompt lands),
   // so a later reconcile can recover the dispatch instead of re-materializing it.
   persistReceipt(report, options);
-  const prompt = buildOperatorPrompt(task, program, outcome);
+  const prompt = buildOperatorPrompt(task, program, outcome, options.programSegment);
   const sent = sendPrompt(options.runOrca, orcaBin, { orcaTaskId, handle, prompt });
   if (!sent.ok) {
     entry.status = STATUS.ESCALATED;

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -41,9 +41,10 @@ function programMarker(programId, programSegment) {
   return `relay-orca: ${programSegment(programId)}/`;
 }
 
-function referencesProgram(text, programId) {
+function referencesProgram(text, programId, programSegment) {
   const body = String(text || "");
-  return body.includes("relay-orca") && body.includes(programId);
+  const segment = typeof programSegment === "function" ? programSegment(programId) : "";
+  return body.includes("relay-orca") && (body.includes(programId) || (segment && body.includes(segment)));
 }
 
 // D4.1: a live task row's display string is the FIRST non-empty of `task_title`,
@@ -291,12 +292,12 @@ function detectDuplicateMappings(tasks) {
 
 // live→receipt back-pointer discovery (D7): a relay manifest referencing this program
 // but absent from the receipt's mappings. Text only; NO mutation is performed.
-function discoverBackPointers({ manifests, tasks, programId }) {
+function discoverBackPointers({ manifests, tasks, programId, programSegment }) {
   const knownRunIds = new Set(tasks.map((task) => task.relay_ids && task.relay_ids.run).filter(Boolean));
   const candidates = [];
   manifests.forEach((entry) => {
     if (!entry.run_id || knownRunIds.has(entry.run_id)) return;
-    if (!referencesProgram(entry.text, programId)) return;
+    if (!referencesProgram(entry.text, programId, programSegment)) return;
     candidates.push({
       kind: "adopt_relay_run",
       outcome_id: null,
@@ -313,12 +314,12 @@ function discoverBackPointers({ manifests, tasks, programId }) {
 // unmapped fleet cannot be attributed to a specific outcome, so resume must not re-dispatch
 // a relay_fleet outcome while it is present — that would duplicate the whole fleet (forbidden
 // by the drain invariant). Text only; NO mutation is performed.
-function discoverFleetBackPointers({ fleetManifests, tasks, programId }) {
+function discoverFleetBackPointers({ fleetManifests, tasks, programId, programSegment }) {
   const knownFleetIds = new Set(tasks.map((task) => task.relay_ids && task.relay_ids.fleet).filter(Boolean));
   const candidates = [];
   fleetManifests.forEach((entry) => {
     if (!entry.run_id || knownFleetIds.has(entry.run_id)) return;
-    if (!referencesProgram(entry.text, programId)) return;
+    if (!referencesProgram(entry.text, programId, programSegment)) return;
     candidates.push({
       kind: "adopt_relay_fleet",
       outcome_id: null,
@@ -383,8 +384,8 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
 
   const repairCandidates = [];
   entries.forEach((entry) => repairForOutcome(entry).forEach((repair) => repairCandidates.push(repair)));
-  discoverBackPointers({ manifests, tasks: receipt.tasks, programId }).forEach((candidate) => repairCandidates.push(candidate));
-  discoverFleetBackPointers({ fleetManifests, tasks: receipt.tasks, programId }).forEach((candidate) => repairCandidates.push(candidate));
+  discoverBackPointers({ manifests, tasks: receipt.tasks, programId, programSegment }).forEach((candidate) => repairCandidates.push(candidate));
+  discoverFleetBackPointers({ fleetManifests, tasks: receipt.tasks, programId, programSegment }).forEach((candidate) => repairCandidates.push(candidate));
 
   const report = {
     ok: true,

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -4,12 +4,14 @@
 // relay-orca `resume` — crash-safe, receipt-driven, reconcile-first, idempotent
 // resumption (issue #946). It loads the reconstructible bridge receipt through the
 // shipped receipt-io (fail-closed codes 50-52 verbatim), runs the SAME live
-// reconciliation as `status` (the imported #945 pipeline) BEFORE any mutation, and only
-// then plans and executes bounded restoration: valid live mappings are REUSED, a lost
+// reconciliation as `status` (the imported #945 pipeline) before any runtime restoration,
+// and only then plans and executes bounded restoration: valid live mappings are REUSED, a lost
 // operator terminal is REACQUIRED, and an outcome whose Orca dispatch is verifiably
 // absent AND whose relay side is clean is RE-DISPATCHED through the SAME verified path as
 // `run` (inject -> dispatch-show -> prompt). Reconciliation results that make resumption
-// unsafe fail closed with a `decision_required` report and ZERO mutation (codes 60-63).
+// unsafe fail closed with a `decision_required` report and ZERO automatic mutation
+// (codes 60-63). The explicit `--map-relay-run` coordination-metadata intake is validated
+// and atomically recorded before reconciliation by its separate supervised contract.
 // It NEVER invokes `orca orchestration reset` (D7) or any `orca worktree` subcommand
 // (D7), never deletes a task/worktree/branch/PR, and never force-closes a relay run.
 const fs = require("node:fs");
@@ -40,6 +42,7 @@ const { buildOperatorPrompt } = require("./lib/operator-prompt");
 const { routeFor, defaultEvidenceFor } = require("./lib/task-kinds");
 const { planResume } = require("./lib/resume-plan");
 const { orderReport } = require("./lib/resume-report");
+const { validateRelayRunMappings, applyRelayRunMappings } = require("./lib/resume-mapping");
 
 const READ_TIMEOUT_MS = 15000;
 const READ_MAX_BUFFER = 4 * 1024 * 1024;
@@ -50,6 +53,7 @@ function usageError(message) {
   process.stderr.write(`relay-orca resume: ${message}\n`);
   process.stderr.write(
     "usage: resume.js --program-id <id> [--json] [--operator-handle <handle> ...] " +
+      "[--program-file <accepted-program.json>] [--map-relay-run <outcome_id>=<run_id> ...] " +
       "[--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
   );
   process.exit(USAGE_EXIT);
@@ -58,6 +62,15 @@ function usageError(message) {
 function requireValue(value, flag) {
   if (!value || value.startsWith("-")) usageError(`${flag} requires a value`);
   return value;
+}
+
+function parseRelayRunMapping(value) {
+  const raw = requireValue(value, "--map-relay-run");
+  const separator = raw.indexOf("=");
+  if (separator < 0 || separator === 0 || separator === raw.length - 1) {
+    usageError("--map-relay-run requires <outcome_id>=<run_id> with both ids non-empty");
+  }
+  return { outcome_id: raw.slice(0, separator), run_id: raw.slice(separator + 1) };
 }
 
 function parseArgs(argv) {
@@ -79,6 +92,7 @@ function parseArgs(argv) {
     recordAuthorization: null,
     authorizer: null,
     programFile: null,
+    mapRelayRuns: [],
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -91,6 +105,7 @@ function parseArgs(argv) {
     else if (arg === "--record-authorization") opts.recordAuthorization = requireValue(argv[(i += 1)], "--record-authorization");
     else if (arg === "--authorizer") opts.authorizer = requireValue(argv[(i += 1)], "--authorizer");
     else if (arg === "--program-file") opts.programFile = requireValue(argv[(i += 1)], "--program-file");
+    else if (arg === "--map-relay-run") opts.mapRelayRuns.push(parseRelayRunMapping(argv[(i += 1)]));
     else if (arg === "--orca-bin") opts.orcaBin = requireValue(argv[(i += 1)], "--orca-bin");
     else if (arg === "--gh-bin") opts.ghBin = requireValue(argv[(i += 1)], "--gh-bin");
     else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
@@ -101,6 +116,7 @@ function parseArgs(argv) {
     usageError("--resolve-decision requires --resolution and --resolver");
   }
   if (opts.recordAuthorization && !opts.authorizer) usageError("--record-authorization requires --authorizer");
+  if (opts.mapRelayRuns.length > 0 && !opts.programFile) usageError("--map-relay-run requires --program-file");
   return opts;
 }
 
@@ -190,7 +206,8 @@ function loadReceipt(receiptPath, requestedProgramId) {
   return parsed.receipt;
 }
 
-// The imported #945 reconciliation, run BEFORE any mutation (D1). Reads only. The
+// The imported #945 reconciliation, run before any runtime restoration (D1). Reads only.
+// An explicit, already-validated relay run mapping may have been recorded up front. The
 // reconciliation's per-task dispatch-show reads are captured into `liveDispatch` and
 // returned alongside the report so the planner can decide "verifiably absent" from a live
 // read (owner amendment A1, #946 R1), never from a null receipt dispatch_id.
@@ -214,8 +231,8 @@ function reconcile({ receipt, opts, repo, receiptPath }) {
 }
 
 // Persist the live receipt object atomically, preserving created_at and any stop record
-// (D5/scenario 8) and bumping updated_at. Used at the A16 (terminal recorded) and A2
-// (provenance verified) write points during execution.
+// (D5/scenario 8) and bumping updated_at. Used for supervised mapping intake and at the
+// A16 (terminal recorded) / A2 (provenance verified) points during execution.
 function makeReceiptPersistor(receipt, receiptPath) {
   return function persist() {
     receipt.updated_at = new Date().toISOString();
@@ -239,6 +256,63 @@ function decisionGateDefFromFile(programFile, decisionId) {
   } catch {
     return null;
   }
+}
+
+function acceptedProgramFromFile(programFile, receiptProgramId) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(programFile, "utf-8"));
+  } catch (error) {
+    usageError(`cannot read program file ${programFile}: ${error.message}`);
+  }
+  const program = parsed && parsed.program && typeof parsed.program === "object" ? parsed.program : parsed;
+  if (!program || typeof program !== "object" || Array.isArray(program)) {
+    usageError(`program file ${programFile} is not a program object`);
+  }
+  if (program.id !== receiptProgramId) {
+    usageError(`program file id ${boundedExcerpt(program.id)} does not match the receipt program id ${boundedExcerpt(receiptProgramId)}`);
+  }
+  return program;
+}
+
+function mappingFailureReport(opts, receiptPath, receipt, validation) {
+  const decision = validation.decision;
+  return orderReport({
+    ok: false,
+    program_id: opts.programId,
+    receipt_path: receiptPath,
+    runtime: "unreachable",
+    reconciliation: [],
+    actions: receipt.tasks.map((task) => ({
+      outcome_id: task.outcome_id,
+      action: "decision_required",
+      reason: boundedExcerpt(`blocked: ${decision.reason_code}`),
+    })),
+    terminals_created: [],
+    decision_required: [decision],
+    blocking_reasons: [{ reason_code: decision.reason_code, message: decision.message }],
+    reconciliation_required: true,
+  });
+}
+
+function validateAndRecordRelayRunMappings(receipt, receiptPath, repo, opts) {
+  if (opts.mapRelayRuns.length === 0) return { ok: true, exitCode: 0 };
+  const program = acceptedProgramFromFile(opts.programFile, receipt.program_id);
+  const manifests = listManifestFiles(repo.slug).map((entry) => ({
+    run_id: entry.run_id,
+    parsed: parseManifest(entry.text),
+  }));
+  const validation = validateRelayRunMappings({
+    receipt,
+    program,
+    requested: opts.mapRelayRuns,
+    manifests,
+  });
+  if (!validation.ok) return validation;
+  if (applyRelayRunMappings(receipt, validation.mappings)) {
+    makeReceiptPersistor(receipt, receiptPath)();
+  }
+  return validation;
 }
 
 // #947 D4/D5: write an operator decision/authorization record into the live receipt when
@@ -303,7 +377,7 @@ function executeAction(action, ctx) {
   receiptTask.dispatch_id = show.dispatchId;
   receiptTask.assignee = show.assignee;
   ctx.persist();
-  const prompt = buildOperatorPrompt(syntheticTask(receiptTask), { id: ctx.receipt.program_id }, {});
+  const prompt = buildOperatorPrompt(syntheticTask(receiptTask), { id: ctx.receipt.program_id }, {}, programSegment);
   const sent = sendPrompt(ctx.runOrca, ctx.orcaBin, { orcaTaskId, handle, prompt });
   if (!sent.ok) ctx.blocking.push(blockingReason("RESUME_REDISPATCH_FAILED", `operator prompt hand-off failed for outcome ${action.outcome_id}`));
 }
@@ -383,6 +457,12 @@ function main() {
     receipt = loadReceipt(receiptPath, opts.programId);
     if (receipt.repo && receipt.repo.slug !== repo.slug) {
       rejectReceipt("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
+    }
+    const mappingValidation = validateAndRecordRelayRunMappings(receipt, receiptPath, repo, opts);
+    if (!mappingValidation.ok) {
+      printReport(mappingFailureReport(opts, receiptPath, receipt, mappingValidation), opts.json);
+      process.exitCode = mappingValidation.exitCode;
+      return;
     }
     // #947: an explicit --resolve-decision / --record-authorization writes its record to the
     // receipt up front, so the decision persists regardless of the reconciliation verdict.

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -10,6 +10,7 @@ const path = require("node:path");
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
 const RESUME_JS = path.join(SCRIPTS, "resume.js");
+const STATUS_JS = path.join(SCRIPTS, "status.js");
 
 const { REPORT_KEYS, ACTIONS } = require(path.join(SCRIPTS, "lib", "resume-report.js"));
 const { REASONS: RESUME_REASONS } = require(path.join(SCRIPTS, "lib", "resume-reasons.js"));
@@ -146,6 +147,7 @@ function buildWorld({ programId, receipt, manifests = [], fleetManifests = [], o
     repoRoot,
     programsRoot,
     runsRoot,
+    fleetsRoot,
     slug,
     receiptPath,
     orca,
@@ -180,6 +182,33 @@ function buildWorld({ programId, receipt, manifests = [], fleetManifests = [], o
 
 function actionFor(body, outcomeId) {
   return body.actions.find((entry) => entry.outcome_id === outcomeId);
+}
+
+function acceptedProgramFile(world, programId, outcomes) {
+  const programPath = path.join(world.base, "accepted-program.json");
+  fs.writeFileSync(programPath, `${JSON.stringify({ program: { id: programId, outcomes } }, null, 2)}\n`, "utf-8");
+  return programPath;
+}
+
+function mappedRun(world, outcomeId) {
+  const parsed = parseReceipt(world.receiptOnDisk());
+  assert.equal(parsed.ok, true, parsed.reason || "receipt parses");
+  return parsed.receipt.tasks.find((task) => task.outcome_id === outcomeId).relay_ids.run;
+}
+
+function runStatus(world, programId) {
+  const args = [STATUS_JS, "--program-id", programId, "--json", "--orca-bin", world.orca.orcaPath, "--gh-bin", world.gh.ghPath, "--repo-root", world.repoRoot];
+  const stdout = execFileSync(process.execPath, args, {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      RELAY_ORCA_PROGRAMS_ROOT: world.programsRoot,
+      RELAY_ORCA_RUNS_ROOT: world.runsRoot,
+      RELAY_ORCA_FLEETS_ROOT: world.fleetsRoot,
+    },
+    stdio: "pipe",
+  });
+  return JSON.parse(stdout);
 }
 
 // Mutating Orca subcommand lines (dispatch --inject / terminal create / terminal send /
@@ -803,6 +832,239 @@ test("usage: unknown flag exits 64", () => {
   try {
     const r = world.run(["--bogus"]);
     assert.equal(r.status, 64);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1008 — explicit, validated relay run mapping intake
+// ---------------------------------------------------------------------------
+
+test("#1008 usage: --map-relay-run requires a program file and a well-formed outcome=run value", () => {
+  const programId = "epic-resume-map-usage";
+  const world = buildWorld({ programId });
+  const programFile = acceptedProgramFile(world, programId, [{ id: "a", issue: 100 }]);
+  const before = world.receiptOnDisk();
+  try {
+    assert.equal(world.run(["--map-relay-run", "a=run-a"]).status, 64);
+    for (const malformed of ["a", "=run-a", "a="]) {
+      assert.equal(world.run(["--program-file", programFile, "--map-relay-run", malformed]).status, 64);
+    }
+    assert.equal(world.receiptOnDisk(), before, "usage failures leave the receipt byte-identical");
+    assert.deepEqual(world.orca.readLog(), [], "usage failures never reconcile live state");
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1008 target validation rejects unknown, non-mappable, and issue-less outcomes with exit 67", () => {
+  const cases = [
+    { name: "unknown", task: { outcome_id: "a" }, outcomes: [{ id: "a", issue: 100 }], mapping: "missing=run-a" },
+    { name: "non-mappable", task: { outcome_id: "a", kind: "advisory_review" }, outcomes: [{ id: "a", issue: 100 }], mapping: "a=run-a" },
+    { name: "issue-less", task: { outcome_id: "a" }, outcomes: [{ id: "a", issue: null }], mapping: "a=run-a" },
+  ];
+  for (const scenario of cases) {
+    const programId = `epic-resume-map-${scenario.name}`;
+    const world = buildWorld({
+      programId,
+      manifests: [{ run_id: "run-a", state: "dispatched", issue_number: 100 }],
+    });
+    const receipt = makeReceipt({
+      programId,
+      slug: world.slug,
+      root: fs.realpathSync(world.repoRoot),
+      tasks: [scenario.task],
+    });
+    fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+    const programFile = acceptedProgramFile(world, programId, scenario.outcomes);
+    const before = world.receiptOnDisk();
+    try {
+      const r = world.run(["--program-file", programFile, "--map-relay-run", scenario.mapping]);
+      assert.equal(r.status, RESUME_REASONS.RESUME_MAP_TARGET_INVALID);
+      assertReportShape(r.body);
+      assert.equal(r.body.decision_required[0].reason_code, "RESUME_MAP_TARGET_INVALID");
+      assert.equal(world.receiptOnDisk(), before, `${scenario.name} failure leaves receipt byte-identical`);
+      assert.deepEqual(world.orca.readLog(), [], `${scenario.name} failure happens before reconciliation`);
+      assert.deepEqual(world.gh.readLog(), [], `${scenario.name} failure makes no GitHub read`);
+    } finally {
+      world.cleanup();
+    }
+  }
+});
+
+test("#1008 manifest validation rejects a missing run with 68 and an issue mismatch with 69", () => {
+  const cases = [
+    { name: "missing", manifests: [], mapping: "a=run-missing", code: "RESUME_MAP_RUN_NOT_FOUND" },
+    { name: "mismatch", manifests: [{ run_id: "run-a", state: "dispatched", issue_number: 999 }], mapping: "a=run-a", code: "RESUME_MAP_ISSUE_MISMATCH" },
+  ];
+  for (const scenario of cases) {
+    const programId = `epic-resume-map-${scenario.name}`;
+    const world = buildWorld({ programId, manifests: scenario.manifests });
+    const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a" }] });
+    fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+    const programFile = acceptedProgramFile(world, programId, [{ id: "a", issue: 100 }]);
+    const before = world.receiptOnDisk();
+    try {
+      const r = world.run(["--program-file", programFile, "--map-relay-run", scenario.mapping]);
+      assert.equal(r.status, RESUME_REASONS[scenario.code]);
+      assert.equal(r.body.decision_required[0].reason_code, scenario.code);
+      assert.equal(world.receiptOnDisk(), before);
+      assert.deepEqual(world.orca.readLog(), [], "mapping validation precedes live reconciliation");
+      assert.deepEqual(world.gh.readLog(), []);
+    } finally {
+      world.cleanup();
+    }
+  }
+});
+
+test("#1008 duplicate or contradictory relay run mappings reuse exit 62", () => {
+  const cases = [
+    {
+      name: "target-changed",
+      tasks: [{ outcome_id: "a", run: "run-old" }],
+      outcomes: [{ id: "a", issue: 100 }],
+      manifests: [{ run_id: "run-new", state: "dispatched", issue_number: 100 }],
+      mapping: "a=run-new",
+    },
+    {
+      name: "run-on-other-task",
+      tasks: [{ outcome_id: "a", run: "run-shared" }, { outcome_id: "b" }],
+      outcomes: [{ id: "a", issue: 100 }, { id: "b", issue: 200 }],
+      manifests: [{ run_id: "run-shared", state: "dispatched", issue_number: 200 }],
+      mapping: "b=run-shared",
+    },
+    {
+      name: "run-twice-in-batch",
+      tasks: [{ outcome_id: "a" }, { outcome_id: "b" }],
+      outcomes: [{ id: "a", issue: 100 }, { id: "b", issue: 100 }],
+      manifests: [{ run_id: "run-shared", state: "dispatched", issue_number: 100 }],
+      mapping: ["a=run-shared", "b=run-shared"],
+    },
+  ];
+  for (const scenario of cases) {
+    const programId = `epic-resume-map-${scenario.name}`;
+    const world = buildWorld({ programId, manifests: scenario.manifests });
+    const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: scenario.tasks });
+    fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+    const programFile = acceptedProgramFile(world, programId, scenario.outcomes);
+    const before = world.receiptOnDisk();
+    try {
+      const mappings = Array.isArray(scenario.mapping) ? scenario.mapping : [scenario.mapping];
+      const mappingArgs = mappings.flatMap((mapping) => ["--map-relay-run", mapping]);
+      const r = world.run(["--program-file", programFile, ...mappingArgs]);
+      assert.equal(r.status, RESUME_REASONS.RESUME_CONFLICTING_MAPPING);
+      assert.equal(r.body.decision_required[0].reason_code, "RESUME_CONFLICTING_MAPPING");
+      assert.equal(world.receiptOnDisk(), before);
+      assert.deepEqual(world.orca.readLog(), []);
+    } finally {
+      world.cleanup();
+    }
+  }
+});
+
+test("#1008 mapping batches are all-or-nothing and idempotent same-mapping replay is byte-identical", () => {
+  const batchProgramId = "epic-resume-map-batch";
+  const batchWorld = buildWorld({
+    programId: batchProgramId,
+    manifests: [{ run_id: "run-a", state: "dispatched", issue_number: 100 }],
+  });
+  const batchReceipt = makeReceipt({
+    programId: batchProgramId,
+    slug: batchWorld.slug,
+    root: fs.realpathSync(batchWorld.repoRoot),
+    tasks: [{ outcome_id: "a" }, { outcome_id: "b" }],
+  });
+  fs.writeFileSync(batchWorld.receiptPath, serializeReceipt(batchReceipt), "utf-8");
+  const batchProgram = acceptedProgramFile(batchWorld, batchProgramId, [{ id: "a", issue: 100 }, { id: "b", issue: 200 }]);
+  const batchBefore = batchWorld.receiptOnDisk();
+  try {
+    const r = batchWorld.run([
+      "--program-file", batchProgram,
+      "--map-relay-run", "a=run-a",
+      "--map-relay-run", "b=run-missing",
+    ]);
+    assert.equal(r.status, RESUME_REASONS.RESUME_MAP_RUN_NOT_FOUND);
+    assert.equal(batchWorld.receiptOnDisk(), batchBefore, "a valid first mapping is not persisted when the batch fails");
+  } finally {
+    batchWorld.cleanup();
+  }
+
+  const replayProgramId = "epic-resume-map-replay";
+  const replayWorld = buildWorld({
+    programId: replayProgramId,
+    manifests: [{ run_id: "run-a", state: "dispatched", pr_number: 10, issue_number: 100 }],
+    orcaScenario: { tasks: [orcaTask(replayProgramId, "a")] },
+    ghScenario: { prs: { 10: { state: "OPEN" } }, issues: { 100: { state: "OPEN" } } },
+  });
+  const replayReceipt = makeReceipt({ programId: replayProgramId, slug: replayWorld.slug, root: fs.realpathSync(replayWorld.repoRoot), tasks: [{ outcome_id: "a", run: "run-a" }] });
+  fs.writeFileSync(replayWorld.receiptPath, serializeReceipt(replayReceipt), "utf-8");
+  const replayProgram = acceptedProgramFile(replayWorld, replayProgramId, [{ id: "a", issue: 100 }]);
+  const replayBefore = replayWorld.receiptOnDisk();
+  try {
+    const r = replayWorld.run(["--program-file", replayProgram, "--map-relay-run", "a=run-a"]);
+    assert.equal(r.status, 0);
+    assertReportShape(r.body);
+    assert.equal(replayWorld.receiptOnDisk(), replayBefore, "same mapping replay does not bump updated_at or rewrite bytes");
+  } finally {
+    replayWorld.cleanup();
+  }
+});
+
+test("#1008 a valid mapping persists before an unrelated outcome later requires a decision", () => {
+  const programId = "epic-resume-map-upfront";
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-a", state: "merged", pr_number: 10, issue_number: 100 },
+      { run_id: "run-b", state: "review_pending", pr_number: 20, issue_number: 200 },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "a", { status: "completed", worker_done: true }), orcaTask(programId, "b", { status: "completed", worker_done: true })] },
+    ghScenario: {
+      prs: { 10: { state: "MERGED", mergedAt: "2026-07-14T00:00:00Z" }, 20: { state: "OPEN" } },
+      issues: { 100: { state: "CLOSED" }, 200: { state: "OPEN" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "a" }, { outcome_id: "b", run: "run-b" }],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const programFile = acceptedProgramFile(world, programId, [{ id: "a", issue: 100 }, { id: "b", issue: 200 }]);
+  try {
+    const r = world.run(["--program-file", programFile, "--map-relay-run", "a=run-a"]);
+    assert.equal(r.status, RESUME_REASONS.RESUME_AMBIGUOUS_STATE);
+    assert.equal(mappedRun(world, "a"), "run-a", "mapping survives the later decision_required exit");
+    assert.ok(r.body.decision_required.some((entry) => entry.reason_code === "RESUME_AMBIGUOUS_STATE"));
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1008 mapping intake enables complete_with_evidence on the next status reconciliation", () => {
+  const programId = "epic-resume-map-complete";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-done", state: "merged", pr_number: 30, issue_number: 300 }],
+    orcaScenario: { tasks: [orcaTask(programId, "done", { status: "completed", worker_done: true })] },
+    ghScenario: {
+      prs: { 30: { state: "MERGED", mergedAt: "2026-07-14T00:00:00Z" } },
+      issues: { 300: { state: "CLOSED", stateReason: "COMPLETED" } },
+    },
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "done" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const programFile = acceptedProgramFile(world, programId, [{ id: "done", issue: 300 }]);
+  try {
+    const resumed = world.run(["--program-file", programFile, "--map-relay-run", "done=run-done"]);
+    assert.equal(resumed.status, 0);
+    assert.equal(mappedRun(world, "done"), "run-done");
+    const status = runStatus(world, programId);
+    const outcome = status.outcomes.find((entry) => entry.outcome_id === "done");
+    assert.equal(outcome.state, "complete_with_evidence");
+    assert.deepEqual(outcome.evidence, { manifest_terminal: true, pr_merged: true, issue_closed: true });
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -918,6 +918,61 @@ test("#1008 manifest validation rejects a missing run with 68 and an issue misma
   }
 });
 
+// R1 #1008: an empty/non-numeric declared outcome issue is UNDECLARED, not a zero-coercible
+// value that could slip past the target gate and then Number("")===Number(null)-match a
+// manifest with no issue_number. It must fail closed as RESUME_MAP_TARGET_INVALID (exit 67).
+test("#1008 an empty declared outcome issue is undeclared → RESUME_MAP_TARGET_INVALID exit 67, byte-identical receipt", () => {
+  const programId = "epic-resume-map-empty-issue";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-a", state: "dispatched", issue_number: 100 }],
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const programFile = acceptedProgramFile(world, programId, [{ id: "a", issue: "" }]);
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--program-file", programFile, "--map-relay-run", "a=run-a"]);
+    assert.equal(r.status, RESUME_REASONS.RESUME_MAP_TARGET_INVALID);
+    assert.equal(r.status, 67);
+    assertReportShape(r.body);
+    assert.equal(r.body.decision_required[0].reason_code, "RESUME_MAP_TARGET_INVALID");
+    assert.equal(world.receiptOnDisk(), before, "an empty declared issue leaves the receipt byte-identical");
+    assert.deepEqual(world.orca.readLog(), [], "target validation precedes live reconciliation");
+    assert.deepEqual(world.gh.readLog(), [], "an empty declared issue makes no GitHub read");
+  } finally {
+    world.cleanup();
+  }
+});
+
+// R1 #1008: a finite declared issue paired with a manifest that carries NO issue_number must
+// never coerce-match (both sides Number()->0). The mismatch gate fires (exit 69) instead of
+// persisting run tracking for an issue-less manifest.
+test("#1008 a declared finite issue vs a manifest without issue_number → RESUME_MAP_ISSUE_MISMATCH exit 69, byte-identical receipt", () => {
+  const programId = "epic-resume-map-manifest-no-issue";
+  const world = buildWorld({
+    programId,
+    // Manifest present (RUN_NOT_FOUND passes) but with no issue_number in frontmatter.
+    manifests: [{ run_id: "run-a", state: "dispatched" }],
+  });
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot), tasks: [{ outcome_id: "a" }] });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const programFile = acceptedProgramFile(world, programId, [{ id: "a", issue: 100 }]);
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--program-file", programFile, "--map-relay-run", "a=run-a"]);
+    assert.equal(r.status, RESUME_REASONS.RESUME_MAP_ISSUE_MISMATCH);
+    assert.equal(r.status, 69);
+    assertReportShape(r.body);
+    assert.equal(r.body.decision_required[0].reason_code, "RESUME_MAP_ISSUE_MISMATCH");
+    assert.equal(world.receiptOnDisk(), before, "a manifest without issue_number leaves the receipt byte-identical");
+    assert.deepEqual(world.orca.readLog(), [], "mapping validation precedes live reconciliation");
+    assert.deepEqual(world.gh.readLog(), [], "the mismatch makes no GitHub read");
+  } finally {
+    world.cleanup();
+  }
+});
+
 test("#1008 duplicate or contradictory relay run mappings reuse exit 62", () => {
   const cases = [
     {

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -481,7 +481,7 @@ test("D11.10: operator prompts carry the pinned literals and never name an engin
 
   const kinds = new Set();
   for (const task of plan.tasks) {
-    const prompt = buildOperatorPrompt(task, program, outcomeById.get(task.outcome_id));
+    const prompt = buildOperatorPrompt(task, program, outcomeById.get(task.outcome_id), programSegment);
     kinds.add(task.kind);
     // Every prompt: full payload contract + reconciliation + lifecycle literals (D8).
     PAYLOAD_FIELDS.forEach((field) => assert.ok(prompt.includes(field), `${task.kind} prompt missing payload field ${field}`));
@@ -502,6 +502,15 @@ test("D11.10: operator prompts carry the pinned literals and never name an engin
       assert.ok(prompt.includes("/tmp/leaf1-prompt.md"));
       assert.ok(prompt.includes("/tmp/leaf1-rubric.yaml"));
       assert.ok(prompt.includes("/tmp/leaf1-dc.md"));
+    }
+    if (task.kind === "relay_run" || task.kind === "relay_fleet") {
+      const destination = task.kind === "relay_fleet" ? "relay fleet manifest" : "relay run manifest";
+      const marker = `relay-orca: ${programSegment(program.id)}/${task.outcome_id}`;
+      assert.ok(prompt.includes(marker), `${task.kind} prompt missing the resolved program marker`);
+      assert.ok(prompt.includes(`in the ${destination}`), `${task.kind} prompt missing its marker destination`);
+      assert.equal(prompt.includes(`relay-orca: ${program.id}/${task.outcome_id}`), false, "the prompt marker never uses the raw program id");
+    } else {
+      assert.equal(prompt.includes("Embed this exact program marker line"), false, `${task.kind} read-only prompt must stay unchanged`);
     }
   }
   // All five kinds were exercised.

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -917,6 +917,37 @@ test("D10.11: duplicate mapping → DUPLICATE_MAPPING; unmapped manifest referen
   }
 });
 
+test("D10.11: segment-only markers discover unmapped run and fleet back-pointers", () => {
+  const programId = "epic status/segment";
+  const segment = programSegment(programId);
+  assert.equal(segment.includes(programId), false, "the raw id must not occur inside its sanitized segment");
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-segment", state: "dispatched", pr_number: 191, issue_number: 1901, body: `relay-orca: ${segment}/run-outcome` },
+      { run_id: "fleet-segment", fleet_state: "dispatching", children: [], body: `relay-orca: ${segment}/fleet-outcome` },
+    ],
+    orcaScenario: { tasks: [orcaTask(programId, "existing")] },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "existing" }],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  const before = fs.readFileSync(world.receiptPath, "utf-8");
+  try {
+    const r = world.run();
+    assert.equal(r.status, 0);
+    assert.ok(r.body.repair_candidates.some((candidate) => candidate.kind === "adopt_relay_run" && /run-segment/.test(candidate.proposal)));
+    assert.ok(r.body.repair_candidates.some((candidate) => candidate.kind === "adopt_relay_fleet" && /fleet-segment/.test(candidate.proposal)));
+    assert.equal(fs.readFileSync(world.receiptPath, "utf-8"), before, "segment discovery is mutation-free");
+  } finally {
+    world.cleanup();
+  }
+});
+
 // A2 (#946 R2, owner amendment A2) — an unmapped FLEET manifest under the SEPARATE fleets
 // root referencing the program → adopt_relay_fleet repair candidate (mirrors the runs-root
 // back-pointer discovery so resume can block a duplicate fleet redispatch).


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #1008.

Key changes:

- Added repeatable, atomic `resume --map-relay-run <outcome>=<run>` intake with exits 67–69 and conflict reuse of 62.
- Added segment-based manifest markers to relay run/fleet operator prompts.
- Added raw-ID or program-segment back-pointer discovery.
- Documented the supervised recovery recipe.
- Preserved receipt serialization, report shape, action taxonomy, and explicit-only semantics.

Verification:

- Relay-orca: 238/238 tests passed.
- 
```

## Score Log

- Run: issue-1008-20260714090444497-243cccbb
- Executor: codex
- Branch: issue-1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 실행 복구 시 릴레이 실행 매핑을 검증하고 안전하게 기록하는 기능을 추가했습니다.
  * 매핑 오류와 복구 불가 상태에 대해 구체적인 안내와 종료 사유를 제공합니다.
  * 릴레이 실행 및 플릿 매니페스트의 복구 후보 탐지가 개선되었습니다.
  * 매니페스트에 충돌을 줄이는 식별 마커가 표시됩니다.

* **문서**
  * 복구 제한 사항과 수동 매핑 절차를 구체화했습니다.
  * 다음 단계 작업 재실행 및 결과 재조정 방법을 명확히 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->