### PR TITLE
fix(relay-orca): completion-driven wave advancement in resume (#1009)

### DIFF
--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -147,11 +147,14 @@ see [receipt-and-status.md](receipt-and-status.md).
 
 ### Partial-wave semantics
 
-Only wave-1 tasks (all dependency-satisfied) are dispatch-eligible in v0; later waves are
-materialized but reported `pending`. At most `concurrency` tasks are dispatched at once — excess
-eligible tasks stay `pending` with **no error** (exit 0). A handle carries at most one active
-task; an explicit-handle shortfall also leaves the remaining eligible tasks `pending`.
-Completion-driven wave advancement is #945/#947 scope.
+`run` dispatches only wave-1 tasks (all dependency-satisfied); it materializes every later-wave
+Orca task at program start and reports those tasks `pending`. `resume` makes a pending later-wave
+outcome dispatch-eligible once every receipt outcome in every earlier wave classifies
+`complete_with_evidence` in the same live reconciliation. Advancement uses the already-materialized
+task and requires one explicit `--operator-handle` per dispatched outcome. At most `concurrency`
+tasks are dispatched by `run` at once — excess eligible tasks stay `pending` with **no error**
+(exit 0). A handle carries at most one active task; an explicit-handle shortfall also leaves the
+remaining eligible tasks `pending` for a follow-up `resume`.
 
 ### Run rejection matrix
 

--- a/skills/relay-orca/references/install-and-operate.md
+++ b/skills/relay-orca/references/install-and-operate.md
@@ -124,13 +124,15 @@ These are supervised limitations and open follow-ups surfaced by the pilot:
   issue is CLOSED before invoking it. The flag validates the outcome, manifest, and tracker issue,
   then atomically records `relay_ids.run`; only the following #945 live reconciliation can report
   `complete_with_evidence`. See [recovery.md](recovery.md#supervised-relay-run-mapping-intake).
-- **Waves beyond wave 1 need a supervised manual dispatch (#1009).** No shipped code path advances
-  a program past wave 1: `run` dispatches wave 1 only (and cannot re-run under empty-runtime
-  admission), `resume` re-dispatches only crash-lost wave-1 outcomes, and the #947 gate/completion
-  modes are read-only. The supervised workaround is to replay `run`'s exact verified sequence for
-  the next-wave task — `dispatch --inject` → `dispatch-show` provenance verify → `terminal send`
-  prompt — then reconcile the receipt with `resume --program-file <program> --map-relay-run
-  <outcome_id>=<run_id>` per #1008.
+- **Waves beyond wave 1 advance through supervised `resume` (#1009).** `run` still dispatches wave 1
+  only, but it materializes every later-wave Orca task as `pending`. Once every earlier-wave outcome
+  classifies `complete_with_evidence`, invoke `resume` with an explicit `--operator-handle` for each
+  outcome to advance; it injects the already-materialized task, verifies dispatch provenance,
+  persists that provenance, and sends the operator prompt through the same fail-closed path as a
+  crash-lost wave-1 redispatch. Only if that path itself needs manual recovery should an operator
+  replay the bounded `dispatch --inject` → `dispatch-show` provenance verify → `terminal send`
+  sequence. Map the resulting relay run with `resume --program-file <program> --map-relay-run
+  <outcome_id>=<run_id>` per #1008 when durable coordination evidence is ready.
 
 `resume` and `stop` never reset Orca, delete a task/worktree/branch/PR, or force-close a relay
 run on any path. Manual decision recovery: [recovery.md](recovery.md).

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -3,9 +3,10 @@
 `resume` is **reconcile-first and fail-closed for runtime restoration**: it loads the
 reconstructible receipt, runs the SAME live reconciliation as `status` before restoring an Orca
 dispatch, and only then restores what is safe (reuse valid mappings, reacquire a lost operator
-terminal, re-dispatch a verifiably-absent, relay-clean, wave-1 outcome through the verified path —
-always to an explicitly provided `--operator-handle`, never a self-created terminal). The explicit
-`--map-relay-run` intake described below is the narrow exception: it validates and atomically
+terminal, re-dispatch a verifiably-absent, relay-clean wave-1 outcome, or advance an equivalent
+later-wave outcome after every earlier wave is `complete_with_evidence`, through the same verified
+path — always to an explicitly provided `--operator-handle`, never a self-created terminal). The
+explicit `--map-relay-run` intake described below is the narrow exception: it validates and atomically
 records supervised coordination metadata before live reconciliation. **"Verifiably absent" means a live
 `dispatch-show` read for that task, taken during the reconciliation pass, reported NO dispatch —
 a null `dispatch_id` in the receipt alone NEVER qualifies.** In the crash window (a

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -104,22 +104,36 @@ function needsTerminalReacquire(task, diags) {
 }
 
 // D3 re-dispatch: the Orca dispatch is VERIFIABLY absent, the materialized task still
-// exists, the relay side is clean, and the wave rule allows it (v0 dispatches only wave
-// 1, matching the #944 run anchor). "Verifiably absent" (owner amendment A1, #946 R1) is
+// exists, the relay side is clean, and the wave rule allows it (wave 1, or a later wave
+// after every earlier-wave outcome is durably complete). "Verifiably absent" (owner
+// amendment A1, #946 R1) is
 // satisfied ONLY by `liveAbsent` — a live dispatch-show read for THIS task, threaded from
 // the reconciliation pass, that reports NO dispatch. A null receipt `dispatch_id` alone
 // NEVER qualifies: in the crash window (dispatch --inject landed a live dispatch but the
 // receipt write that records it never happened) the receipt id is null yet a live dispatch
 // is present, and re-injecting there would duplicate operator work — that case fails closed
 // as RESUME_MISSING_PROVENANCE in planDecisions instead of re-dispatching here.
-function isRedispatchCandidate(task, diags, outcome, liveAbsent) {
+function isRedispatchCandidate(task, diags, outcome, liveAbsent, report) {
   return (
     liveAbsent === true &&
     !isNonEmpty(task.dispatch_id) &&
     isNonEmpty(task.orca_task_id) &&
     !hasDiag(diags, "MISSING_TASK") &&
-    task.wave === 1 &&
+    (task.wave === 1 ||
+      (task.wave > 1 &&
+        (report.outcomes || [])
+          .filter((reportOutcome) => reportOutcome.wave < task.wave)
+          .every((reportOutcome) => reportOutcome.state === "complete_with_evidence"))) &&
     relayClean(task, outcome)
+  );
+}
+
+function earlierWavesComplete(task, report) {
+  return (
+    task.wave > 1 &&
+    (report.outcomes || [])
+      .filter((outcome) => outcome.wave < task.wave)
+      .every((outcome) => outcome.state === "complete_with_evidence")
   );
 }
 
@@ -185,9 +199,9 @@ function hasUnmappedRelayWork(report) {
 
 // Classify ONE outcome into a safe action (only reached when NO program-level decision
 // fired). Completion/escalation are terminal (skipped); a live mapping is reused; a lost
-// terminal is reacquired; a verifiably-absent, relay-clean, wave-1 outcome is
-// re-dispatched; everything else (in-flight/durable child, later wave, or unattributable
-// unmapped relay work) is left untouched.
+// terminal is reacquired; a verifiably-absent, relay-clean, advance-eligible outcome is
+// re-dispatched; everything else (in-flight/durable child, not-yet-eligible wave, or
+// unattributable unmapped relay work) is left untouched.
 function classifyAction(task, report, unmappedRelayWork, liveDispatch) {
   const outcome = reportOutcomeById(report, task.outcome_id) || {};
   const diags = diagsFor(report, task.outcome_id);
@@ -196,11 +210,14 @@ function classifyAction(task, report, unmappedRelayWork, liveDispatch) {
   if (outcome.state === "escalated") return makeAction(task, "skipped", "escalated; requires operator action, not automatic resume");
   if (needsTerminalReacquire(task, diags)) return makeAction(task, "redispatched", `outcome ${task.outcome_id} operator terminal is gone; reacquiring through the verified inject->dispatch-show->prompt path`, execPlan(task, "reacquire_terminal"));
   if (mappingLive(task, diags)) return makeAction(task, "reused", `outcome ${task.outcome_id} has a valid live mapping (task+dispatch+terminal); reused, not re-dispatched`);
-  if (isRedispatchCandidate(task, diags, outcome, live.absent)) {
+  if (isRedispatchCandidate(task, diags, outcome, live.absent, report)) {
     if (unmappedRelayWork) return makeAction(task, "skipped", `outcome ${task.outcome_id} is absent, but unmapped relay work references this program; not re-dispatched to avoid duplicating it`);
     return makeAction(task, "redispatched", `outcome ${task.outcome_id} Orca dispatch verifiably absent and relay side clean; re-dispatching through the verified path`, execPlan(task, "redispatch"));
   }
-  return makeAction(task, "skipped", `outcome ${task.outcome_id} has in-flight/durable relay work or is a later wave; left untouched`);
+  if (task.wave > 1 && !earlierWavesComplete(task, report)) {
+    return makeAction(task, "skipped", `outcome ${task.outcome_id} is in wave ${task.wave}; earlier waves are not yet complete_with_evidence; left untouched`);
+  }
+  return makeAction(task, "skipped", `outcome ${task.outcome_id} has in-flight/durable relay work; left untouched`);
 }
 
 // D3.3: an outcome that needs a fresh operator surface (a redispatch or a terminal

--- a/tests/relay-orca/fixtures/resume-three-wave.json
+++ b/tests/relay-orca/fixtures/resume-three-wave.json
@@ -1,0 +1,36 @@
+{
+  "program": {
+    "id": "epic-resume-three-wave",
+    "source": "file:///tmp/epic-resume-three-wave.md",
+    "repo": "example/repo",
+    "tracker": "github",
+    "concurrency": 2,
+    "exit_gates": ["integration:e2e-suite", "tracker:milestone-clean"],
+    "outcomes": [
+      {
+        "id": "foundation",
+        "issue": 7101,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["foundation merged"],
+        "depends_on": [],
+        "wave": 1
+      },
+      {
+        "id": "independent-followup",
+        "issue": 7102,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["independent follow-up merged"],
+        "depends_on": [],
+        "wave": 2
+      },
+      {
+        "id": "final-hardening",
+        "issue": 7103,
+        "task_kind": "relay_run",
+        "accepted_outcomes": ["final hardening merged"],
+        "depends_on": ["independent-followup"],
+        "wave": 3
+      }
+    ]
+  }
+}

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -21,6 +21,9 @@ const { installFakeOrcaResume } = require(path.join(__dirname, "..", "fixtures",
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
 
+const FOLLOWUP_LATER_WAVE = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "fixtures", "followup-later-wave.json"), "utf-8")).program;
+const RESUME_THREE_WAVE = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "fixtures", "resume-three-wave.json"), "utf-8")).program;
+
 const FORBIDDEN_ENGINE_TOKENS = ["codex", "claude", "gpt", "opus", "sonnet", "haiku", "gemini", "cursor", "cline", "grok", "glm", "opencode"];
 const CANCELLATION_TOKENS = ["cancel", "cancelled", "canceled", "complete", "completed", "aborted", "discard"];
 
@@ -406,6 +409,276 @@ test("D9.6: partial dispatch → only the absent+clean outcome dispatches, throu
     assert.equal(injects.length, 1, "exactly one re-dispatch");
     assert.ok(injects[0].includes("orca-live-b"), "only the absent outcome b is dispatched");
     assert.ok(!injects.some((l) => l.includes("orca-live-a")), "the reused outcome a is never re-dispatched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1009 — completion-driven advancement of already-materialized later waves
+// ---------------------------------------------------------------------------
+
+function completedFirstWaveWorld(program = FOLLOWUP_LATER_WAVE) {
+  const first = program.outcomes.find((outcome) => outcome.wave === 1);
+  const later = program.outcomes.find((outcome) => outcome.wave === 2);
+  const runId = `run-${first.id}`;
+  const prNumber = Number(first.issue) + 10000;
+  const world = buildWorld({
+    programId: program.id,
+    manifests: [{ run_id: runId, state: "merged", pr_number: prNumber, issue_number: first.issue }],
+    orcaScenario: {
+      tasks: [
+        orcaTask(program.id, first.id, { status: "completed", worker_done: true }),
+        orcaTask(program.id, later.id, { status: "pending" }),
+      ],
+      dispatch: absentDispatch(later.id),
+    },
+    ghScenario: {
+      prs: { [prNumber]: { state: "MERGED", mergedAt: "2026-07-14T01:00:00Z" } },
+      issues: { [first.issue]: { state: "CLOSED" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId: program.id,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: first.id, kind: first.task_kind, wave: first.wave, run: runId },
+      { outcome_id: later.id, kind: later.task_kind, wave: later.wave, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  return { world, first, later };
+}
+
+test("#1009: wave 2 advances through the existing verified path and a second resume is idempotent", () => {
+  const { world, first, later } = completedFirstWaveWorld();
+  try {
+    assert.equal(runStatus(world, FOLLOWUP_LATER_WAVE.id).program_state, "ready_for_next_wave");
+    const firstRun = world.run(["--operator-handle", "h-wave-2"]);
+    assert.equal(firstRun.status, 0);
+    assertReportShape(firstRun.body);
+    assert.equal(actionFor(firstRun.body, first.id).action, "skipped");
+    assert.equal(actionFor(firstRun.body, later.id).action, "redispatched");
+
+    const firstLog = world.orca.readLog();
+    const injectIndex = firstLog.findIndex((line) => line.startsWith(`orchestration dispatch --task orca-live-${later.id}`));
+    const verifyIndex = firstLog.findIndex((line, index) => index > injectIndex && line.startsWith(`orchestration dispatch-show --task orca-live-${later.id}`));
+    const promptIndex = firstLog.findIndex((line, index) => index > verifyIndex && line.startsWith("terminal send"));
+    assert.ok(injectIndex >= 0, "the already-materialized wave-2 Orca task is injected");
+    assert.ok(verifyIndex > injectIndex, "dispatch provenance is verified after injection");
+    assert.ok(promptIndex > verifyIndex, "the operator prompt is delivered after provenance verification");
+    assert.ok(!firstLog.some((line) => line.startsWith("orchestration task-create")), "resume never creates a later-wave task");
+    assert.ok(!firstLog.some((line) => line.startsWith("terminal create")), "resume uses only the explicit operator handle");
+
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    const advanced = persisted.tasks.find((task) => task.outcome_id === later.id);
+    assert.equal(advanced.orca_task_id, `orca-live-${later.id}`);
+    assert.equal(advanced.dispatch_id, `disp-orca-live-${later.id}`);
+    assert.equal(advanced.assignee, "h-wave-2");
+
+    const beforeSecond = world.receiptOnDisk();
+    const secondLogStart = firstLog.length;
+    const secondRun = world.run(["--operator-handle", "h-wave-2"]);
+    assert.equal(secondRun.status, 0);
+    assert.equal(actionFor(secondRun.body, later.id).action, "reused");
+    assert.deepEqual(mutationLines(world.orca.readLog().slice(secondLogStart)), [], "the second resume performs no duplicate inject or prompt send");
+    assert.equal(world.receiptOnDisk(), beforeSecond, "the second resume leaves the receipt byte-identical");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1009: an eligible wave-2 outcome without an explicit operator handle fails closed with exit 66", () => {
+  const { world, later } = completedFirstWaveWorld();
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run();
+    assert.equal(r.status, RESUME_REASONS.RESUME_NO_OPERATOR_HANDLE);
+    assert.equal(r.status, 66);
+    assert.equal(actionFor(r.body, later.id).action, "decision_required");
+    assert.ok(r.body.decision_required.some((decision) => decision.reason_code === "RESUME_NO_OPERATOR_HANDLE"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "no handle means zero mutating Orca calls");
+    assert.equal(world.receiptOnDisk(), before, "no-handle advancement leaves the receipt byte-identical");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1009: a started wave-2 sibling does not block another absent wave-2 outcome", () => {
+  const programId = "epic-resume-partial-wave-two";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-wave-one", state: "merged", pr_number: 17201, issue_number: 7201 }],
+    orcaScenario: {
+      tasks: [
+        orcaTask(programId, "wave-one", { status: "completed", worker_done: true }),
+        orcaTask(programId, "wave-two-started"),
+        orcaTask(programId, "wave-two-pending", { status: "pending" }),
+      ],
+      dispatch: absentDispatch("wave-two-pending"),
+    },
+    ghScenario: {
+      prs: { 17201: { state: "MERGED", mergedAt: "2026-07-14T01:10:00Z" } },
+      issues: { 7201: { state: "CLOSED" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "wave-one", wave: 1, run: "run-wave-one" },
+      { outcome_id: "wave-two-started", wave: 2 },
+      { outcome_id: "wave-two-pending", wave: 2, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    assert.equal(runStatus(world, programId).program_state, "running", "the started sibling deliberately prevents the aggregate ready_for_next_wave label");
+    const r = world.run(["--operator-handle", "h-wave-2-pending"]);
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "wave-two-started").action, "reused");
+    assert.equal(actionFor(r.body, "wave-two-pending").action, "redispatched", "eligibility is per-outcome, not coupled to program_state");
+    const injects = world.orca.readLog().filter((line) => line.startsWith("orchestration dispatch --task"));
+    assert.equal(injects.length, 1);
+    assert.ok(injects[0].includes("orca-live-wave-two-pending"));
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1009: wave 3 stays skipped while wave 2 advances because wave 2 is not yet complete", () => {
+  const [waveOne, waveTwo, waveThree] = RESUME_THREE_WAVE.outcomes;
+  assert.deepEqual(waveTwo.depends_on, [], "the declared-wave fixture proves eligibility is wave-blanket, not dependency-scoped");
+  const world = buildWorld({
+    programId: RESUME_THREE_WAVE.id,
+    manifests: [{ run_id: "run-foundation", state: "merged", pr_number: 17101, issue_number: waveOne.issue }],
+    orcaScenario: {
+      tasks: [
+        orcaTask(RESUME_THREE_WAVE.id, waveOne.id, { status: "completed", worker_done: true }),
+        orcaTask(RESUME_THREE_WAVE.id, waveTwo.id, { status: "pending" }),
+        orcaTask(RESUME_THREE_WAVE.id, waveThree.id, { status: "pending" }),
+      ],
+      dispatch: absentDispatch(waveTwo.id, waveThree.id),
+    },
+    ghScenario: {
+      prs: { 17101: { state: "MERGED", mergedAt: "2026-07-14T01:20:00Z" } },
+      issues: { [waveOne.issue]: { state: "CLOSED" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId: RESUME_THREE_WAVE.id,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: waveOne.id, wave: waveOne.wave, run: "run-foundation" },
+      { outcome_id: waveTwo.id, wave: waveTwo.wave, dispatch_id: null, assignee: null },
+      { outcome_id: waveThree.id, wave: waveThree.wave, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const r = world.run(["--operator-handle", "h-wave-2"]);
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, waveTwo.id).action, "redispatched");
+    assert.equal(actionFor(r.body, waveThree.id).action, "skipped");
+    assert.equal(
+      actionFor(r.body, waveThree.id).reason,
+      `outcome ${waveThree.id} is in wave ${waveThree.wave}; earlier waves are not yet complete_with_evidence; left untouched`,
+    );
+    const injects = world.orca.readLog().filter((line) => line.startsWith("orchestration dispatch --task"));
+    assert.equal(injects.length, 1, "only wave 2 consumes the explicit handle");
+    assert.ok(injects[0].includes(`orca-live-${waveTwo.id}`));
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1009 masking: worker_done with an open PR keeps wave 2 fail-closed and untouched", () => {
+  const [waveOne, waveTwo] = FOLLOWUP_LATER_WAVE.outcomes;
+  const world = buildWorld({
+    programId: FOLLOWUP_LATER_WAVE.id,
+    manifests: [{ run_id: "run-stale-worker", state: "review_pending", pr_number: 17301, issue_number: waveOne.issue }],
+    orcaScenario: {
+      tasks: [
+        orcaTask(FOLLOWUP_LATER_WAVE.id, waveOne.id, { status: "completed", worker_done: true }),
+        orcaTask(FOLLOWUP_LATER_WAVE.id, waveTwo.id, { status: "pending" }),
+      ],
+      dispatch: absentDispatch(waveTwo.id),
+    },
+    ghScenario: {
+      prs: { 17301: { state: "OPEN" } },
+      issues: { [waveOne.issue]: { state: "OPEN" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId: FOLLOWUP_LATER_WAVE.id,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: waveOne.id, wave: 1, run: "run-stale-worker" },
+      { outcome_id: waveTwo.id, wave: 2, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--operator-handle", "h-must-not-be-used"]);
+    assert.equal(r.status, RESUME_REASONS.RESUME_AMBIGUOUS_STATE);
+    assert.equal(r.status, 61);
+    assert.equal(r.body.reconciliation.find((outcome) => outcome.outcome_id === waveOne.id).state, "inconsistent");
+    assert.equal(actionFor(r.body, waveTwo.id).action, "decision_required");
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "an inconsistent earlier wave causes zero mutation");
+    assert.equal(world.receiptOnDisk(), before, "the later-wave receipt mapping is untouched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1009 masking: worker_done with all-null evidence does not unlock wave 2", () => {
+  const [waveOne, waveTwo] = FOLLOWUP_LATER_WAVE.outcomes;
+  const world = buildWorld({
+    programId: FOLLOWUP_LATER_WAVE.id,
+    orcaScenario: {
+      tasks: [
+        orcaTask(FOLLOWUP_LATER_WAVE.id, waveOne.id, { status: "completed", worker_done: true }),
+        orcaTask(FOLLOWUP_LATER_WAVE.id, waveTwo.id, { status: "pending" }),
+      ],
+      dispatch: absentDispatch(waveTwo.id),
+    },
+  });
+  const receipt = makeReceipt({
+    programId: FOLLOWUP_LATER_WAVE.id,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: waveOne.id, wave: 1 },
+      { outcome_id: waveTwo.id, wave: 2, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--operator-handle", "h-must-not-be-used"]);
+    assert.equal(r.status, 0);
+    const reconciledWaveOne = r.body.reconciliation.find((outcome) => outcome.outcome_id === waveOne.id);
+    assert.notEqual(reconciledWaveOne.state, "complete_with_evidence");
+    assert.ok(Object.values(reconciledWaveOne.evidence).every((value) => value === null), "all durable evidence is unresolved");
+    assert.equal(actionFor(r.body, waveOne.id).action, "reused");
+    assert.equal(actionFor(r.body, waveTwo.id).action, "skipped");
+    assert.equal(
+      actionFor(r.body, waveTwo.id).reason,
+      `outcome ${waveTwo.id} is in wave ${waveTwo.wave}; earlier waves are not yet complete_with_evidence; left untouched`,
+    );
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "worker_done alone never dispatches the next wave");
+    assert.equal(world.receiptOnDisk(), before);
     assertNoPoison(world);
   } finally {
     world.cleanup();


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #1009.

- `resume` now advances later waves once all earlier outcomes are `complete_with_evidence`.
- Preserved explicit handles, verified dispatch path, masking behavior, report schema, and exit codes.
- Added multi-wave, masking, no-handle, partial-wave, and idempotence coverage.
- Updated all three requested references.
- Relay-orca tests: 246/246 passed.
- Skills lint: 33/33 passed.
- Worktree clean, ahead by one commit.

Commit: `32add43 fix(relay-orca): comp
```

## Score Log

- Run: issue-1009-20260714112946045-f32c98b1
- Executor: codex
- Branch: issue-1009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - `run` 실행 시 이후 웨이브 작업도 미리 생성되며, 준비 전에는 대기 상태로 표시됩니다.
  - 이전 웨이브가 증거와 함께 완료된 경우에만 `resume`으로 다음 웨이브를 안전하게 진행할 수 있습니다.
  - 지정한 운영자 터미널에서만 작업 복구 및 재전송이 수행됩니다.
  - 동시성 한도나 터미널 부족으로 실행되지 못한 작업은 오류 없이 대기 상태로 유지됩니다.
  - 동일한 `resume`을 반복 실행해도 중복 작업이나 중복 전송이 발생하지 않습니다.

- **문서**
  - 웨이브 진행, 복구 조건, 수동 정리 절차를 최신 동작에 맞게 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->