### PR TITLE
fix(relay-orca): stop treats no-active-coordinator-run as success-with-note (#1005)

### DIFF
--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -324,10 +324,14 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/stop.js" \
 | `--help`, `-h` | Print usage. |
 
 `stop` loads the receipt (fail-closed codes 50–52 verbatim) and invokes the **only** mutating
-Orca subcommand it may ever use — `orca orchestration run-stop` — then records a bounded stop
-record (`stopped_at`, `stop_reason`) in the receipt. Only those two fields change; every other
-field is byte-identical. A second stop is idempotent: it leaves the original stop record intact
-and rewrites nothing. `stop` **never** terminates relay executors, deletes worktrees, closes
+Orca subcommand it may ever use — `orca orchestration run-stop`. A genuine active-run stop and
+the stateless-v0 answer `ok:false` with an `error.message` containing `No active coordinator
+run` are both accepted stopped conditions. The latter reports `coordinator_stopped: false` and
+the note `coordinator run already not running; treated as stopped (stop record written)` because
+no live loop was stopped. Either accepted path records a bounded stop record (`stopped_at`,
+`stop_reason`) in the receipt; only those two fields change and every other field is
+byte-identical. A second stop is idempotent: it leaves the original stop record intact and
+rewrites nothing. `stop` **never** terminates relay executors, deletes worktrees, closes
 PRs/issues, invokes `reset`, invokes any `task-create`/`task-update`/`dispatch`/`terminal`
 subcommand, or emits language claiming the program or its outcomes are cancelled/complete —
 relay/fleet artifacts stay discoverable through normal relay tooling.
@@ -335,9 +339,15 @@ relay/fleet artifacts stay discoverable through normal relay tooling.
 ### Stop report (`--json`)
 
 Exactly these top-level keys: `ok`, `program_id`, `receipt_path`, `coordinator_stopped`
-(boolean from the live `run-stop` result), `stopped_at`, `stop_reason`, `blocking_reasons`. A
-`run-stop` that does not succeed reports `coordinator_stopped: false` with a
-`COORDINATOR_STOP_FAILED` (exit `65`) blocking reason and writes no stop record.
+(whether a live coordinator loop was stopped), `stopped_at`, `stop_reason`, `note`,
+`blocking_reasons`. `note` is
+`coordinator run already not running; treated as stopped (stop record written)` only for the
+accepted no-active-run envelope and is `""` on every other report path. That accepted path exits
+`0`, has no blocking reasons, and writes the stop record while keeping
+`coordinator_stopped: false`; genuine success also exits `0` and reports
+`coordinator_stopped: true`. Unparseable output, a different error message, timeout/nonzero exit
+without the accepted envelope, and `ok:true` with `result.stopped:false` remain fail-closed:
+`COORDINATOR_STOP_FAILED` (exit `65`) with no stop record.
 
 See [experimental-status.md](experimental-status.md) for the pilot boundary,
 [capability-probe.md](capability-probe.md) for admission details, and

--- a/skills/relay-orca/references/install-and-operate.md
+++ b/skills/relay-orca/references/install-and-operate.md
@@ -112,11 +112,12 @@ coordinator (a terminal session running relay-orca's CLI scripts)
 
 These are supervised limitations and open follow-ups surfaced by the pilot:
 
-- **`stop` cannot currently succeed in the v0 topology (#1005).** `stop`'s only mutation,
-  `orca orchestration run-stop`, assumes an always-on Orca coordinator loop that the stateless-CLI
-  v0 model never starts, so it exits 65 (`COORDINATOR_STOP_FAILED`) and writes no stop record. The
-  fail-closed behavior is honest, but the intent — durably recording an operator interruption — is
-  unreachable today.
+- **`stop` treats an already-not-running coordinator as the stopped condition in the v0 topology
+  (#1005).** `stop` still invokes its only Orca mutation, `orca orchestration run-stop`, exactly
+  once. When stateless-CLI v0 answers `No active coordinator run`, `stop` exits 0, reports that no
+  live coordinator was stopped, and writes the same durable `stopped_at`/`stop_reason` record as a
+  genuine active-run stop. Every other run-stop failure remains fail-closed with exit 65
+  (`COORDINATOR_STOP_FAILED`) and no stop-record write.
 - **Operator-driven outcomes need a supervised receipt-mapping reconcile before they classify
   complete (#1008).** `run` writes the receipt before the operator's relay run exists. The shipped
   supervised intake path is `resume --program-file <program> --map-relay-run

--- a/skills/relay-orca/scripts/stop.js
+++ b/skills/relay-orca/scripts/stop.js
@@ -27,6 +27,7 @@ const { StopError, REASONS: STOP_REASONS } = require("./lib/stop-reasons");
 
 const RUN_TIMEOUT_MS = 15000;
 const RUN_MAX_BUFFER = 4 * 1024 * 1024;
+const ALREADY_NOT_RUNNING_NOTE = "coordinator run already not running; treated as stopped (stop record written)";
 
 function usageError(message) {
   process.stderr.write(`relay-orca stop: ${message}\n`);
@@ -73,16 +74,23 @@ function assertRunStopOnly(argv) {
 }
 
 // Invoke `orca orchestration run-stop --json` and normalize the result. `coordinator_stopped`
-// is true only on a well-formed ok envelope; an explicit `stopped:false` keeps it false.
+// is true only on a well-formed ok envelope; an explicit `stopped:false` keeps it false. The
+// one accepted failure classification keys only on the parsed live no-active-run envelope,
+// independently of the subprocess exit status.
 function runStop(orcaBin) {
   const argv = ["orchestration", "run-stop", "--json"];
   assertRunStopOnly(argv);
   let proc;
   try {
     const stdout = execFileSync(orcaBin, argv, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], timeout: RUN_TIMEOUT_MS, maxBuffer: RUN_MAX_BUFFER });
-    proc = { status: 0, stdout: String(stdout || ""), stderr: "" };
+    proc = { status: 0, stdout: String(stdout || ""), stderr: "", timedOut: false };
   } catch (error) {
-    proc = { status: typeof error.status === "number" ? error.status : 1, stdout: error.stdout ? String(error.stdout) : "", stderr: error.stderr ? String(error.stderr) : "" };
+    proc = {
+      status: typeof error.status === "number" ? error.status : 1,
+      stdout: error.stdout ? String(error.stdout) : "",
+      stderr: error.stderr ? String(error.stderr) : "",
+      timedOut: error.code === "ETIMEDOUT" || error.signal === "SIGTERM",
+    };
   }
   let value = null;
   try {
@@ -92,7 +100,20 @@ function runStop(orcaBin) {
   }
   const ok = proc.status === 0 && value && value.ok === true;
   const result = ok && value.result && typeof value.result === "object" ? value.result : {};
-  return { ok: Boolean(ok), coordinatorStopped: Boolean(ok) && result.stopped !== false, proc };
+  const alreadyNotRunning = Boolean(
+    !proc.timedOut
+      && value
+      && value.ok === false
+      && value.error
+      && typeof value.error.message === "string"
+      && value.error.message.includes("No active coordinator run"),
+  );
+  return {
+    ok: Boolean(ok),
+    coordinatorStopped: Boolean(ok) && result.stopped !== false,
+    classification: alreadyNotRunning ? "already_not_running" : null,
+    proc,
+  };
 }
 
 function loadReceipt(receiptPath, requestedProgramId) {
@@ -123,7 +144,7 @@ function recordStop(receipt, receiptPath, reason) {
   writeReceiptAtomic(receiptPath, serializeReceiptWithStop(receipt));
 }
 
-function buildReport({ opts, receiptPath, coordinatorStopped, stoppedAt, stopReason, blockingReasons }) {
+function buildReport({ opts, receiptPath, coordinatorStopped, stoppedAt, stopReason, note, blockingReasons }) {
   return {
     ok: blockingReasons.length === 0,
     program_id: opts.programId,
@@ -131,6 +152,7 @@ function buildReport({ opts, receiptPath, coordinatorStopped, stoppedAt, stopRea
     coordinator_stopped: coordinatorStopped,
     stopped_at: stoppedAt,
     stop_reason: stopReason,
+    note,
     blocking_reasons: blockingReasons,
   };
 }
@@ -173,13 +195,15 @@ function main() {
 
   const alreadyStopped = existingStop(receipt);
   const stop = runStop(resolveOrca(opts));
+  const alreadyNotRunning = stop.classification === "already_not_running";
+  const stoppedCondition = stop.coordinatorStopped || alreadyNotRunning;
   const blockingReasons = [];
-  if (!stop.coordinatorStopped) {
+  if (!stoppedCondition) {
     blockingReasons.push({ reason_code: "COORDINATOR_STOP_FAILED", message: boundedExcerpt(`orca orchestration run-stop did not succeed${stop.proc.stderr ? `: ${stop.proc.stderr}` : ""}`) });
   } else if (!alreadyStopped) {
-    // First successful stop: record the bounded stop record once. A prior record is left
-    // byte-identical (idempotent) — a second stop reports the live run-stop result and the
-    // ORIGINAL stopped_at/stop_reason without rewriting the receipt.
+    // First accepted stop condition: record the bounded stop record once. A prior record is
+    // left byte-identical (idempotent) — a second stop reports the live run-stop result and
+    // the ORIGINAL stopped_at/stop_reason without rewriting the receipt.
     recordStop(receipt, receiptPath, opts.reason);
   }
 
@@ -189,10 +213,11 @@ function main() {
     coordinatorStopped: stop.coordinatorStopped,
     stoppedAt: existingStop(receipt) ? receipt.stopped_at : null,
     stopReason: existingStop(receipt) ? receipt.stop_reason : "",
+    note: alreadyNotRunning ? ALREADY_NOT_RUNNING_NOTE : "",
     blockingReasons,
   });
   printReport(body, opts.json);
-  process.exitCode = stop.coordinatorStopped ? 0 : STOP_REASONS.COORDINATOR_STOP_FAILED;
+  process.exitCode = stoppedCondition ? 0 : STOP_REASONS.COORDINATOR_STOP_FAILED;
 }
 
 if (require.main === module) main();

--- a/skills/relay-orca/scripts/stop.js
+++ b/skills/relay-orca/scripts/stop.js
@@ -19,7 +19,7 @@ const {
   receiptExists,
   writeReceiptAtomic,
 } = require("./receipt-io");
-const { parseReceipt, serializeReceiptWithStop, boundStopReason } = require("./lib/receipt");
+const { parseReceipt, serializeReceiptWithRecords, boundStopReason } = require("./lib/receipt");
 const { boundedExcerpt } = require("./lib/bounded-excerpt");
 const { StatusError, USAGE_EXIT, reject: rejectReceipt } = require("./lib/status-reasons");
 const { resolveOrcaBin } = require("./lib/resolve-orca-bin");
@@ -135,13 +135,18 @@ function existingStop(receipt) {
 
 // Record the bounded stop record into the receipt ONCE (D5). `stopped_at` is the only
 // generated timestamp in stop; `stop_reason` is the bounded operator reason. Preserves
-// every other field verbatim (serializeReceiptWithStop appends ONLY the two stop keys,
-// so a byte comparison shows exactly the stop fields changed). Idempotent: a receipt that
-// already carries a stop record is left byte-identical (D9.13) — no rewrite.
+// every other field verbatim: serializeReceiptWithRecords appends ONLY the two stop keys
+// plus any present #947 additive records (follow_ups/decisions/authorizations/counters),
+// carrying them through exactly as run/resume/status wrote them. A receipt WITHOUT additive
+// records serializes byte-identically to serializeReceiptWithStop, so a byte comparison shows
+// exactly the two stop fields changed; a receipt WITH additive records keeps them byte-for-byte
+// (this path is now reachable — the #1005 already_not_running success write must not silently
+// drop them). Idempotent: a receipt that already carries a stop record is left byte-identical
+// (D9.13) — no rewrite.
 function recordStop(receipt, receiptPath, reason) {
   receipt.stopped_at = new Date().toISOString();
   receipt.stop_reason = boundStopReason(reason);
-  writeReceiptAtomic(receiptPath, serializeReceiptWithStop(receipt));
+  writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
 }
 
 function buildReport({ opts, receiptPath, coordinatorStopped, stoppedAt, stopReason, note, blockingReasons }) {

--- a/tests/relay-orca/fixtures/fake-orca-stop.js
+++ b/tests/relay-orca/fixtures/fake-orca-stop.js
@@ -9,7 +9,8 @@
  * `terminal` subcommand. This is the restricted poison set D5 pins — "everything mutating
  * EXCEPT run-stop" — proving stop is coordinator-only.
  *
- * Behavior is scenario-driven (run-stop may succeed or fail); every invocation is logged.
+ * Behavior is scenario-driven with explicit success, no-active-run, and generic-failure
+ * modes; every invocation is logged.
  */
 const fs = require("node:fs");
 const os = require("node:os");
@@ -17,12 +18,12 @@ const path = require("node:path");
 
 function defaultStopScenario(overrides = {}) {
   return {
-    // run-stop outcome: ok envelope + result.stopped. `runStopOk:false` models a failed
-    // run-stop (coordinator_stopped:false); `stopped:false` models an ok envelope that
-    // reports the coordinator was not running.
-    runStopOk: overrides.runStopOk !== undefined ? overrides.runStopOk : true,
+    // `success` emits the existing ok envelope; `no-active-run` emits the real live-CLI
+    // error envelope on stdout; `generic-failure` emits a distinct error envelope.
+    mode: overrides.mode || "success",
     stopped: overrides.stopped !== undefined ? overrides.stopped : true,
     runId: overrides.runId || "coordinator-run-1",
+    exitCode: overrides.exitCode,
   };
 }
 
@@ -50,8 +51,17 @@ if (args[0] === "terminal") poison("TERMINAL_INVOKED", 96);
 const scenario = loadScenario();
 
 if (args[0] === "orchestration" && args[1] === "run-stop") {
-  if (!scenario.runStopOk) { process.stderr.write("run-stop failed\\n"); process.exit(1); }
-  emit({ id: "run-stop-1", ok: true, result: { stopped: scenario.stopped, run_id: scenario.runId } }, 0);
+  if (scenario.mode === "success") {
+    emit({ id: "run-stop-1", ok: true, result: { stopped: scenario.stopped, run_id: scenario.runId } }, typeof scenario.exitCode === "number" ? scenario.exitCode : 0);
+  }
+  if (scenario.mode === "no-active-run") {
+    emit({ id: "cb80f615-0000-4000-8000-000000001005", ok: false, error: { code: "runtime_error", message: "No active coordinator run" } }, typeof scenario.exitCode === "number" ? scenario.exitCode : 1);
+  }
+  if (scenario.mode === "generic-failure") {
+    emit({ id: "run-stop-failure", ok: false, error: { code: "runtime_error", message: "Coordinator stop failed" } }, typeof scenario.exitCode === "number" ? scenario.exitCode : 1);
+  }
+  process.stderr.write("Unsupported fake stop mode: " + scenario.mode + "\\n");
+  process.exit(2);
 }
 
 process.stderr.write("Unsupported fake orca (stop) invocation: " + args.join(" ") + "\\n");
@@ -84,6 +94,11 @@ function installFakeOrcaStop(scenarioOverrides = {}, options = {}) {
     readPoison() {
       if (!fs.existsSync(poisonPath)) return null;
       return fs.readFileSync(poisonPath, "utf-8");
+    },
+    writeScenario(next) {
+      const updated = defaultStopScenario(next);
+      fs.writeFileSync(scenarioPath, JSON.stringify(updated, null, 2), "utf-8");
+      return updated;
     },
     cleanup() {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/tests/relay-orca/scripts/stop.test.js
+++ b/tests/relay-orca/scripts/stop.test.js
@@ -11,7 +11,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
 const STOP_JS = path.join(SCRIPTS, "stop.js");
 
-const { RECEIPT_NOTE, parseReceipt, serializeReceipt, STOP_REASON_MAX } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { RECEIPT_NOTE, parseReceipt, serializeReceipt, serializeReceiptWithRecords, STOP_REASON_MAX } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { REASONS: STOP_REASONS } = require(path.join(SCRIPTS, "lib", "stop-reasons.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
 const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
@@ -242,6 +242,97 @@ test("#1005: no-active-run preserves an existing stop record byte-identically", 
     assert.deepEqual(second.body.blocking_reasons, []);
     assert.equal(world.receiptOnDisk(), afterFirst, "the existing receipt remains byte-identical");
     assert.deepEqual(world.orca.readLog(), ["orchestration run-stop --json", "orchestration run-stop --json"]);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1005 R1 — the stop write must NOT drop #947 additive record fields
+// (follow_ups/decisions/authorizations/counters). Before #1005 the v0 stop always
+// failed closed, so the write was unreachable; now the already_not_running success
+// path (and the genuine run-stop success path) write, and a stop on a receipt carrying
+// additive records must preserve them byte-for-byte — not silently delete them.
+// ---------------------------------------------------------------------------
+
+// Realistic #947 additive record shapes, mirroring the resume/status/gates write points.
+const SEEDED_FOLLOW_UPS = [
+  { id: "followup-later", source_outcome: "a", description: "operator deferred this", proposed_wave: 3, status: "deferred" },
+];
+const SEEDED_DECISIONS = [
+  { id: "signoff", question: "proceed?", options: ["y", "n"], resolution: "approved", resolver: "alice", resolved_at: "2026-07-13T02:00:00Z", downstream_wave: 2 },
+];
+
+// Seed a receipt that carries additive records onto disk via the SAME serializer the
+// run/resume/status write points use, so `before` is the real byte image a stop would meet.
+function seedReceiptWithRecords(world, programId) {
+  const receipt = makeReceipt({ programId, slug: world.slug, root: fs.realpathSync(world.repoRoot) });
+  receipt.follow_ups = SEEDED_FOLLOW_UPS;
+  receipt.decisions = SEEDED_DECISIONS;
+  fs.writeFileSync(world.receiptPath, serializeReceiptWithRecords(receipt), "utf-8");
+  return receipt;
+}
+
+// Strip the two stop fields and re-serialize WITH records, to prove that everything except
+// the two stop fields — including the additive records — is byte-identical after a stop.
+function receiptMinusStopWithRecords(text) {
+  const receipt = parseReceipt(text).receipt;
+  delete receipt.stopped_at;
+  delete receipt.stop_reason;
+  return serializeReceiptWithRecords(receipt);
+}
+
+test("#1005 R1: no-active-run stop preserves #947 additive records (follow_ups/decisions) byte-for-byte", () => {
+  const programId = "epic-stop-additive-no-active";
+  const world = buildWorld({ programId, stopScenario: { mode: "no-active-run" } });
+  const seeded = seedReceiptWithRecords(world, programId);
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--reason", "operator interruption"]);
+    assert.equal(r.status, 0, "no-active-run is an accepted stopped condition");
+    assert.equal(r.body.ok, true);
+    assert.equal(r.body.coordinator_stopped, false);
+    assert.match(r.body.stopped_at, ISO_RE);
+    assert.equal(r.body.note, ALREADY_NOT_RUNNING_NOTE);
+    assert.deepEqual(r.body.blocking_reasons, []);
+
+    const after = world.receiptOnDisk();
+    assert.notEqual(after, before, "the stop record is written");
+    // Everything except the two stop fields is byte-identical — the additive records survive.
+    assert.equal(receiptMinusStopWithRecords(after), before, "only stopped_at and stop_reason change; additive records are preserved");
+
+    const persisted = parseReceipt(after).receipt;
+    assert.deepEqual(persisted.follow_ups, seeded.follow_ups, "follow_ups survive the stop write byte-for-byte");
+    assert.deepEqual(persisted.decisions, seeded.decisions, "decisions survive the stop write byte-for-byte");
+    assert.equal(persisted.stopped_at, r.body.stopped_at);
+    assert.equal(persisted.stop_reason, "operator interruption");
+    // Strongest byte check: the on-disk image is exactly the seeded records + the two stop keys.
+    const expected = { ...seeded, stopped_at: r.body.stopped_at, stop_reason: r.body.stop_reason };
+    assert.equal(after, serializeReceiptWithRecords(expected), "the stop write is byte-identical to records + the two stop keys");
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1005 R1: genuine run-stop success preserves #947 additive records byte-for-byte", () => {
+  const programId = "epic-stop-additive-success";
+  const world = buildWorld({ programId });
+  const seeded = seedReceiptWithRecords(world, programId);
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--reason", "operator maintenance window"]);
+    assert.equal(r.status, 0);
+    assert.equal(r.body.coordinator_stopped, true);
+
+    const after = world.receiptOnDisk();
+    assert.notEqual(after, before, "the stop record is written");
+    assert.equal(receiptMinusStopWithRecords(after), before, "only stop fields change; additive records preserved");
+    const persisted = parseReceipt(after).receipt;
+    assert.deepEqual(persisted.follow_ups, seeded.follow_ups);
+    assert.deepEqual(persisted.decisions, seeded.decisions);
+    assert.deepEqual(world.orca.readLog(), ["orchestration run-stop --json"]);
+    assert.equal(world.orca.readPoison(), null);
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/stop.test.js
+++ b/tests/relay-orca/scripts/stop.test.js
@@ -18,7 +18,8 @@ const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
 const { installFakeOrcaStop } = require(path.join(__dirname, "..", "fixtures", "fake-orca-stop.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
 
-const STOP_REPORT_KEYS = ["ok", "program_id", "receipt_path", "coordinator_stopped", "stopped_at", "stop_reason", "blocking_reasons"];
+const STOP_REPORT_KEYS = ["ok", "program_id", "receipt_path", "coordinator_stopped", "stopped_at", "stop_reason", "note", "blocking_reasons"];
+const ALREADY_NOT_RUNNING_NOTE = "coordinator run already not running; treated as stopped (stop record written)";
 const CANCELLATION_TOKENS = ["cancel", "cancelled", "canceled", "complete", "completed", "aborted", "discard"];
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -112,10 +113,11 @@ test("D9.7: stop invokes run-stop, records bounded stopped_at/stop_reason, only 
   try {
     const r = world.run(["--reason", "operator maintenance window"]);
     assert.equal(r.status, 0);
-    assert.deepEqual(Object.keys(r.body).sort(), [...STOP_REPORT_KEYS].sort());
+    assert.deepEqual(Object.keys(r.body), STOP_REPORT_KEYS);
     assert.equal(r.body.coordinator_stopped, true);
     assert.match(r.body.stopped_at, ISO_RE);
     assert.equal(r.body.stop_reason, "operator maintenance window");
+    assert.equal(r.body.note, "");
     assert.deepEqual(r.body.blocking_reasons, []);
 
     // Exactly ONE mutating Orca subcommand — run-stop — was invoked.
@@ -190,6 +192,62 @@ test("D9.13: a second stop leaves the original stop record byte-identical and do
 });
 
 // ---------------------------------------------------------------------------
+// #1005 — the real no-active-run envelope is an accepted stopped condition
+// ---------------------------------------------------------------------------
+
+test("#1005: no-active-run succeeds with a note and writes only the stop record", () => {
+  const programId = "epic-stop-no-active-run";
+  const world = buildWorld({ programId, stopScenario: { mode: "no-active-run" } });
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--reason", "operator interruption"]);
+    assert.equal(r.status, 0, "the parsed envelope wins over the fixture's nonzero exit");
+    assert.deepEqual(Object.keys(r.body), STOP_REPORT_KEYS);
+    assert.equal(r.body.ok, true);
+    assert.equal(r.body.coordinator_stopped, false);
+    assert.match(r.body.stopped_at, ISO_RE);
+    assert.equal(r.body.stop_reason, "operator interruption");
+    assert.equal(r.body.note, ALREADY_NOT_RUNNING_NOTE);
+    assert.deepEqual(r.body.blocking_reasons, []);
+
+    const after = world.receiptOnDisk();
+    assert.notEqual(after, before, "the stop record is written");
+    assert.equal(receiptMinusStop(after), before, "only stopped_at and stop_reason change");
+    const persisted = parseReceipt(after).receipt;
+    assert.equal(persisted.note, RECEIPT_NOTE, "the report note is never persisted to the receipt");
+    assert.equal(Object.hasOwn(persisted, "coordinator_stopped"), false);
+    assert.deepEqual(world.orca.readLog(), ["orchestration run-stop --json"]);
+    assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1005: no-active-run preserves an existing stop record byte-identically", () => {
+  const programId = "epic-stop-no-active-idempotent";
+  const world = buildWorld({ programId });
+  try {
+    const first = world.run(["--reason", "original pause"]);
+    assert.equal(first.status, 0);
+    const afterFirst = world.receiptOnDisk();
+
+    world.orca.writeScenario({ mode: "no-active-run" });
+    const second = world.run(["--reason", "replacement reason must be ignored"]);
+    assert.equal(second.status, 0);
+    assert.equal(second.body.ok, true);
+    assert.equal(second.body.coordinator_stopped, false);
+    assert.equal(second.body.stopped_at, first.body.stopped_at);
+    assert.equal(second.body.stop_reason, "original pause");
+    assert.equal(second.body.note, ALREADY_NOT_RUNNING_NOTE);
+    assert.deepEqual(second.body.blocking_reasons, []);
+    assert.equal(world.receiptOnDisk(), afterFirst, "the existing receipt remains byte-identical");
+    assert.deepEqual(world.orca.readLog(), ["orchestration run-stop --json", "orchestration run-stop --json"]);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // stop_reason is bounded (<=256)
 // ---------------------------------------------------------------------------
 
@@ -212,7 +270,7 @@ test("D5: stop_reason is bounded to <=256 chars", () => {
 
 test("run-stop failure → coordinator_stopped false, blocking_reasons, exit 65, receipt untouched", () => {
   const programId = "epic-stop-fail";
-  const world = buildWorld({ programId, stopScenario: { runStopOk: false } });
+  const world = buildWorld({ programId, stopScenario: { mode: "generic-failure" } });
   const before = world.receiptOnDisk();
   try {
     const r = world.run(["--reason", "attempted"]);
@@ -220,10 +278,28 @@ test("run-stop failure → coordinator_stopped false, blocking_reasons, exit 65,
     assert.equal(r.status, 65);
     assert.equal(r.body.coordinator_stopped, false);
     assert.equal(r.body.ok, false);
+    assert.equal(r.body.note, "");
     assert.ok(r.body.blocking_reasons.some((b) => b.reason_code === "COORDINATOR_STOP_FAILED"));
     assert.equal(r.body.stopped_at, null, "no stop record is written when run-stop fails");
     assert.equal(world.receiptOnDisk(), before, "the receipt is untouched on a failed stop");
     assert.equal(world.orca.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("run-stop ok envelope with stopped:false remains fail-closed", () => {
+  const programId = "epic-stop-explicit-not-stopped";
+  const world = buildWorld({ programId, stopScenario: { mode: "success", stopped: false } });
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--reason", "attempted"]);
+    assert.equal(r.status, 65);
+    assert.equal(r.body.ok, false);
+    assert.equal(r.body.coordinator_stopped, false);
+    assert.equal(r.body.note, "");
+    assert.equal(r.body.stopped_at, null);
+    assert.equal(world.receiptOnDisk(), before);
   } finally {
     world.cleanup();
   }


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed issue #1005 option (a).

- Recognizes only the parsed `No active coordinator run` envelope as `already_not_running`.
- Writes the existing stop record, exits 0, and reports the exact note while keeping `coordinator_stopped: false`.
- All other failures remain fail-closed with exit 65 and no receipt mutation.
- Added realistic fixture modes, idempotency/byte-identity coverage, and documentation updates.
- Receipt schema and `assertRunStopOnly` remain unchanged.

Validati
```

## Score Log

- Run: issue-1005-20260714124825424-7f84f3e4
- Executor: codex
- Branch: issue-1005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 이미 실행 중이 아닌 경우에도 `stop`을 정상 완료로 처리합니다.
  - 해당 상황에서는 종료 코드 0을 반환하고, 관련 안내 메시지를 보고서에 표시합니다.
  - 중복 실행 시 기존 중지 기록을 덮어쓰지 않습니다.
  - 유효하지 않거나 예상과 다른 중지 결과는 안전하게 실패 처리하며, 중지 기록을 생성하지 않습니다.

- **문서**
  - `stop` 명령의 허용 결과, 멱등성, 보고서 필드 및 실패 조건을 명확히 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->