### PR TITLE
fix(relay-config): widen fixture probe-timeout to deflake live-probe tests

### DIFF
--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -155,7 +155,7 @@ test("resolve-model passes through wrapper and resolves live short model names",
     relayHome,
     env: {
       PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
-      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "5000",
     },
   });
 
@@ -229,7 +229,7 @@ test("preset add resolves compact actor short-model and stores explicit route pr
     relayHome,
     env: {
       PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
-      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "5000",
     },
   });
 
@@ -291,7 +291,7 @@ test("strict preset add rejects unresolved unregistered compact routes", () => {
     relayHome,
     env: {
       PATH: `${binDir}${path.delimiter}/usr/bin:/bin`,
-      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "1000",
+      RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS: "5000",
     },
   });
 


### PR DESCRIPTION
Fixes #959

## Dispatch Summary

```text
Fixed and committed on `issue-959-probe-timeout-flake` (1e4c1ff): widened `RELAY_CONFIG_MODEL_PROBE_TIMEOUT_MS` from `"1000"` to `"5000"` at all three `writeFakeOpencode` call sites in `tests/relay-config/scripts/relay-config.test.js`. Verified with 2× default-concurrency + 2× `--test-concurrency=1` runs (all 15 tests pass, zero failures) plus the untouched sibling suite (40 tests pass). Diff is exactly the three intended literal changes; no other files touched. Orchestrator can now push and ope
```

## Score Log

- Run: issue-959-20260715002244514-e1bafbcb
- Executor: claude
- Branch: issue-959-probe-timeout-flake

