### PR TITLE
fix(relay-review): publish advisory JSON atomically

### DIFF
--- a/skills/relay-review/scripts/review-runner/advisory-lane-reap.js
+++ b/skills/relay-review/scripts/review-runner/advisory-lane-reap.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const {
   reapAdvisoryLaneLeases,
 } = require("../../../relay-dispatch/scripts/run-runtime-state");
+const { writeJson } = require("./common");
 
 function matchRoundReviewer(round, reviewer) {
   return (entry) => {
@@ -106,7 +107,9 @@ function reapTimeoutAdvisoryLane({
         : JSON.parse(fs.readFileSync(resultPath, "utf-8"));
       nextResult = { ...existing, lane_reap: laneReap };
       if (!dryRun) {
-        fs.writeFileSync(resultPath, `${JSON.stringify(nextResult, null, 2)}\n`, "utf-8");
+        // Same atomic publish as the worker: settlement readers must never see
+        // this artifact truncated mid-patch.
+        writeJson(resultPath, nextResult);
       }
     } catch {
       // Best-effort: reap still happened even if the artifact cannot be patched.

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -1,4 +1,5 @@
 const { execFileSync } = require("child_process");
+const { randomUUID } = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const { buildArtifactTimingFields } = require("../../../relay-dispatch/scripts/advisory-timing");
@@ -113,7 +114,24 @@ function buildAdvisoryReviewerPolicy(reviewerName) {
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+  );
+  try {
+    // Settlement readers may observe this file while the detached worker is
+    // publishing its result. Keep the final path either absent or complete;
+    // direct overwrite exposes truncated JSON between truncate and write.
+    fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: "utf-8",
+      flag: "wx",
+    });
+    fs.renameSync(tempPath, filePath);
+  } finally {
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {}
+  }
 }
 
 function readJsonIfExists(filePath) {
@@ -785,5 +803,6 @@ module.exports = {
   resolveAdvisoryModel,
   startAdvisoryReview,
   validateAdvisoryProfile,
+  writeJson,
   writeAdvisoryDecision,
 };

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -1,5 +1,4 @@
 const { execFileSync } = require("child_process");
-const { randomUUID } = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const { buildArtifactTimingFields } = require("../../../relay-dispatch/scripts/advisory-timing");
@@ -18,7 +17,7 @@ const { writeAdvisoryLaneLease } = require("../../../relay-dispatch/scripts/run-
 const { reapPriorAdvisoryLaneAttempts } = require("./advisory-lane-reap");
 const { parseAdvisoryReview, validateAdvisoryProfile } = require("../advisory-review-schema");
 const { captureGitStatus, resolveReviewerScript } = require("./reviewer-invoke");
-const { writeText } = require("./common");
+const { writeJson, writeText } = require("./common");
 
 const DEFAULT_ADVISORY_TIMEOUT_SECONDS = 900;
 const DEFAULT_ADVISORY_GRACE_SECONDS = 10;
@@ -110,28 +109,6 @@ function buildAdvisoryReviewerPolicy(reviewerName) {
       readOnly: true,
     },
   }));
-}
-
-function writeJson(filePath, value) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  const tempPath = path.join(
-    path.dirname(filePath),
-    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
-  );
-  try {
-    // Settlement readers may observe this file while the detached worker is
-    // publishing its result. Keep the final path either absent or complete;
-    // direct overwrite exposes truncated JSON between truncate and write.
-    fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
-      encoding: "utf-8",
-      flag: "wx",
-    });
-    fs.renameSync(tempPath, filePath);
-  } finally {
-    try {
-      fs.rmSync(tempPath, { force: true });
-    } catch {}
-  }
 }
 
 function readJsonIfExists(filePath) {

--- a/skills/relay-review/scripts/review-runner/common.js
+++ b/skills/relay-review/scripts/review-runner/common.js
@@ -1,3 +1,4 @@
+const { randomUUID } = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const { execGit, execGh } = require("../../../relay-dispatch/scripts/exec");
@@ -21,9 +22,36 @@ function writeText(filePath, text) {
   fs.writeFileSync(filePath, text, "utf-8");
 }
 
+/**
+ * Publish JSON so readers only ever observe an absent or complete file.
+ *
+ * Settlement readers may poll an advisory artifact while a detached worker (or
+ * the lane reaper) is publishing it. A direct overwrite exposes truncated JSON
+ * between truncate and write, so every advisory result publication routes here.
+ */
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: "utf-8",
+      flag: "wx",
+    });
+    fs.renameSync(tempPath, filePath);
+  } finally {
+    try {
+      fs.rmSync(tempPath, { force: true });
+    } catch {}
+  }
+}
+
 module.exports = {
   gh,
   git,
   readText,
+  writeJson,
   writeText,
 };

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -27,6 +27,7 @@ const {
   buildAdvisoryAdapterEnv,
   writeJson: writeAdvisoryJson,
 } = require("../../../skills/relay-review/scripts/review-runner/advisory");
+const { reapTimeoutAdvisoryLane } = require("../../../skills/relay-review/scripts/review-runner/advisory-lane-reap");
 const { buildAdvisoryPrompt } = require("../../../skills/relay-review/scripts/review-runner/advisory-prompt");
 const { applyReviewAssurancePolicy } = require("../../../skills/relay-review/scripts/review-runner/assurance");
 const { installFakeGhOnPath } = require("../fixtures/fake-gh");
@@ -2541,6 +2542,67 @@ test("advisory result writer never exposes partial JSON to settlement readers", 
     waitMs: 0,
   });
   assert.equal(consumed.status, "success");
+});
+
+test("advisory lane reap publishes lane_reap without exposing partial JSON to settlement readers", () => {
+  const { runDir } = setupRepo();
+  const resultPath = path.join(runDir, "review-round-1-advisory-opencode-result.json");
+  const settled = {
+    completed_at: new Date().toISOString(),
+    failureReason: "fixture timeout",
+    profile: "blindspot",
+    reviewer: "opencode",
+    status: "timeout",
+  };
+  writeAdvisoryJson(resultPath, settled);
+
+  const originalWriteFileSync = fs.writeFileSync;
+  const directWrites = [];
+  let partialRead = null;
+
+  fs.writeFileSync = (filePath, data, options) => {
+    if (path.resolve(filePath) !== path.resolve(resultPath)) {
+      return originalWriteFileSync(filePath, data, options);
+    }
+    // Writing the published path directly is the defect under test: truncate the
+    // payload so a reader racing this write observes partial JSON.
+    directWrites.push(filePath);
+    const text = String(data);
+    originalWriteFileSync(filePath, text.slice(0, Math.max(1, Math.floor(text.length / 2))), options);
+    try {
+      JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    } catch (error) {
+      partialRead = error;
+    }
+    return originalWriteFileSync(filePath, data, options);
+  };
+
+  let reaped;
+  try {
+    reaped = reapTimeoutAdvisoryLane({
+      runDir,
+      round: 1,
+      reviewer: "opencode",
+      resultPath,
+      result: settled,
+    });
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+  }
+
+  assert.deepEqual(directWrites, [], "lane reap must publish via temp-plus-rename, not a direct overwrite");
+  assert.equal(partialRead, null, "no reader may observe partial JSON during lane-reap publication");
+
+  const onDisk = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+  assert.equal(onDisk.status, "timeout");
+  assert.equal(onDisk.failureReason, "fixture timeout");
+  assert.equal(onDisk.lane_reap.outcome, "stale");
+  assert.equal(reaped.result.lane_reap.outcome, "stale");
+  assert.deepEqual(
+    fs.readdirSync(runDir).filter((name) => name.endsWith(".tmp")),
+    [],
+    "atomic publish must not leave temp files behind",
+  );
 });
 
 test("invalid advisory JSON is recorded as advisory failure while primary pass still applies", () => {

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -21,7 +21,12 @@ const {
   createEnforcementFixture,
 } = require("../../relay-dispatch/scripts/test-support");
 const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
-const { executeAdvisoryRequest, finishAdvisoryReview, buildAdvisoryAdapterEnv } = require("../../../skills/relay-review/scripts/review-runner/advisory");
+const {
+  executeAdvisoryRequest,
+  finishAdvisoryReview,
+  buildAdvisoryAdapterEnv,
+  writeJson: writeAdvisoryJson,
+} = require("../../../skills/relay-review/scripts/review-runner/advisory");
 const { buildAdvisoryPrompt } = require("../../../skills/relay-review/scripts/review-runner/advisory-prompt");
 const { applyReviewAssurancePolicy } = require("../../../skills/relay-review/scripts/review-runner/assurance");
 const { installFakeGhOnPath } = require("../fixtures/fake-gh");
@@ -2490,6 +2495,52 @@ test("result whose completed_at is after the deadline is deferred, not consumed"
   });
 
   assert.equal(deferred.status, "deferred");
+});
+
+test("advisory result writer never exposes partial JSON to settlement readers", async () => {
+  const { runDir } = setupRepo();
+  const resultPath = path.join(runDir, "review-round-1-advisory-opencode-result.json");
+  const result = {
+    artifactHash: null,
+    artifactPath: null,
+    completed_at: new Date().toISOString(),
+    failureReason: null,
+    profile: "blindspot",
+    rawResponsePath: null,
+    required_count: 0,
+    advisory_count: 0,
+    duplicate_low_confidence_count: 0,
+    reviewer: "opencode",
+    status: "success",
+  };
+  const originalWriteFileSync = fs.writeFileSync;
+  let partialReader = null;
+
+  fs.writeFileSync = (filePath, data, options) => {
+    if (path.resolve(filePath) !== path.resolve(resultPath)) {
+      return originalWriteFileSync(filePath, data, options);
+    }
+    const text = String(data);
+    originalWriteFileSync(filePath, text.slice(0, Math.max(1, Math.floor(text.length / 2))), options);
+    partialReader = finishAdvisoryReview({
+      advisoryRun: { resultPath, startedAt: Date.now() },
+      waitMs: 0,
+    }).catch((error) => error);
+    return originalWriteFileSync(filePath, data, options);
+  };
+
+  try {
+    writeAdvisoryJson(resultPath, result);
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+  }
+
+  assert.equal(partialReader, null, "the final result path must not be written directly");
+  const consumed = await finishAdvisoryReview({
+    advisoryRun: { resultPath, startedAt: Date.now() },
+    waitMs: 0,
+  });
+  assert.equal(consumed.status, "success");
 });
 
 test("invalid advisory JSON is recorded as advisory failure while primary pass still applies", () => {


### PR DESCRIPTION
## Root cause

The advisory result artifact (`review-round-1-advisory-opencode-result.json`) was written by `skills/relay-review/scripts/review-runner/advisory.js:writeJson` with a direct overwrite while `finishAdvisoryReview` read it through `readJsonIfExistsBefore` and `JSON.parse`. A settlement reader could therefore observe the truncated JSON between file truncation and completion of the write.

## Fix

`writeJson` now writes a same-directory uniquely named temporary file with exclusive creation and publishes it with `renameSync`, so the final result path is absent or complete. Existing advisory settlement, timeout, failure, and demotion semantics are unchanged. The focused regression test proves a settlement reader cannot observe a partial final-path write.

## Verification

- Solo and concurrent reproduction attempts: 3 runs per side under default and serialized concurrency; the live flake did not reproduce.
- Host context: 8 cores; observed load approximately 2.26–3.77.
- Default-concurrency targeted rubric loop: 20/20, exit 0.
- `--test-concurrency=1` targeted rubric loop: 20/20, exit 0.
- Commit: `25f17a9364b804c35317d63c5a8b1a8b46939cde`.

Fixes #971
