### PR TITLE
test(relay-orca): make receipt hygiene field-aware

### DIFF
--- a/tests/relay-orca/scripts/receipt-hygiene.js
+++ b/tests/relay-orca/scripts/receipt-hygiene.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+// These tokens are forbidden only in receipt semantic fields and values. The receipt's
+// documented `source` and `repo.root` fields are paths, so a worktree directory such as
+// `/home/user/.codex/...` is not an engine/provider leak.
+const FORBIDDEN_RECEIPT_TOKENS = Object.freeze([
+  "codex",
+  "claude",
+  "gpt",
+  "opus",
+  "sonnet",
+  "haiku",
+  "gemini",
+  "cursor",
+  "cline",
+  "grok",
+  "glm",
+  "opencode",
+  "engine",
+  "model",
+  "reviewer",
+  "executor",
+  "provider",
+]);
+
+const PATH_BEARING_FIELDS = Object.freeze(new Set(["source", "repo.root"]));
+
+function containsForbiddenToken(value) {
+  const lowered = String(value).toLowerCase();
+  return FORBIDDEN_RECEIPT_TOKENS.find((token) => lowered.includes(token)) || null;
+}
+
+function fieldPath(parent, key) {
+  return parent ? `${parent}.${key}` : key;
+}
+
+function assertReceiptValueIsClean(value, currentPath) {
+  if (typeof value === "string") {
+    if (PATH_BEARING_FIELDS.has(currentPath)) return;
+    const token = containsForbiddenToken(value);
+    assert.equal(token, null, `receipt semantic value at ${currentPath} leaked ${token}`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertReceiptValueIsClean(entry, `${currentPath}[${index}]`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  Object.entries(value).forEach(([key, nested]) => {
+    const nestedPath = fieldPath(currentPath, key);
+    if (!PATH_BEARING_FIELDS.has(nestedPath)) {
+      const token = containsForbiddenToken(key);
+      assert.equal(token, null, `receipt semantic field ${nestedPath} leaked ${token}`);
+    }
+    assertReceiptValueIsClean(nested, nestedPath);
+  });
+}
+
+function assertReceiptEngineAgnostic(receipt) {
+  assertReceiptValueIsClean(receipt, "");
+}
+
+module.exports = {
+  FORBIDDEN_RECEIPT_TOKENS,
+  PATH_BEARING_FIELDS,
+  assertReceiptEngineAgnostic,
+};

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -14,7 +14,7 @@ const RUN_JS = path.join(SCRIPTS, "run.js");
 const { REASONS } = require(path.join(SCRIPTS, "lib", "run-reasons.js"));
 const { REPORT_KEYS } = require(path.join(SCRIPTS, "lib", "run-report.js"));
 const { compileProgram } = require(path.join(SCRIPTS, "lib", "compile-program.js"));
-const { RECEIPT_KEYS, TASK_KEYS, RECEIPT_NOTE, parseReceipt } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { RECEIPT_KEYS, TASK_KEYS, RECEIPT_NOTE, buildReceiptMapping, parseReceipt } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
 const { writeReceiptAtomic, programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
 const {
@@ -178,6 +178,24 @@ function assertNoMutations(fake) {
 function taskByOutcome(body, outcomeId) {
   return body.tasks.find((task) => task.outcome_id === outcomeId);
 }
+
+test("provider-named receipt paths are not semantic engine leaks", () => {
+  const receipt = buildReceiptMapping({
+    program_id: "epic-provider-paths",
+    source: "/tmp/.codex/accepted-program.json",
+    repo: { slug: "repo", root: "/tmp/.claude/worktree" },
+    runtimeId: "runtime-fixture",
+    tasks: [],
+    terminalsCreated: [],
+  });
+  receipt.created_at = "2026-07-12T00:00:00.000Z";
+  receipt.updated_at = receipt.created_at;
+
+  const serialized = JSON.stringify(receipt).toLowerCase();
+  FORBIDDEN_ENGINE_TOKENS.forEach((token) =>
+    assert.equal(serialized.includes(token), false, `receipt leaked engine/model token ${token}`),
+  );
+});
 
 // ---------------------------------------------------------------------------
 // D11.1 Successful injection — 2-task wave, provenance verified

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -29,6 +29,7 @@ const { showDispatch } = require(path.join(SCRIPTS, "lib", "run-orca.js"));
 const { provenanceMismatch } = require(path.join(SCRIPTS, "lib", "run-orchestrator.js"));
 const { installFakeOrcaRun } = require(path.join(__dirname, "..", "fixtures", "fake-orca-run.js"));
 const { readyStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+const { assertReceiptEngineAgnostic } = require("./receipt-hygiene.js");
 
 // Plan-library codes re-raised verbatim by run (D1/D9).
 const PLAN_CODES = { UNPREPARED_FLEET_LEAF: 12, CONCURRENCY_EXCEEDED: 16, NESTED_RELAY_ORCA: 20 };
@@ -179,22 +180,54 @@ function taskByOutcome(body, outcomeId) {
   return body.tasks.find((task) => task.outcome_id === outcomeId);
 }
 
-test("provider-named receipt paths are not semantic engine leaks", () => {
+function makeHygieneReceipt({ source = "/tmp/accepted-program.json", root = "/tmp/repo", tasks = [] } = {}) {
   const receipt = buildReceiptMapping({
-    program_id: "epic-provider-paths",
-    source: "/tmp/.codex/accepted-program.json",
-    repo: { slug: "repo", root: "/tmp/.claude/worktree" },
+    program_id: "epic-paths",
+    source,
+    repo: { slug: "repo", root },
     runtimeId: "runtime-fixture",
-    tasks: [],
+    tasks,
     terminalsCreated: [],
   });
   receipt.created_at = "2026-07-12T00:00:00.000Z";
   receipt.updated_at = receipt.created_at;
+  return receipt;
+}
 
-  const serialized = JSON.stringify(receipt).toLowerCase();
-  FORBIDDEN_ENGINE_TOKENS.forEach((token) =>
-    assert.equal(serialized.includes(token), false, `receipt leaked engine/model token ${token}`),
-  );
+test("provider-named receipt paths are allowed by the field-aware assertion", () => {
+  ["codex", "claude", "cursor", "grok", "opencode"].forEach((provider) => {
+    const receipt = makeHygieneReceipt({
+      source: `/tmp/.${provider}/accepted-program.json`,
+      root: `/tmp/.${provider}/worktree`,
+    });
+    assert.doesNotThrow(() => assertReceiptEngineAgnostic(receipt), provider);
+  });
+});
+
+test("field-aware receipt hygiene still rejects semantic engine/provider leaks", () => {
+  const task = {
+    outcome_id: "outcome-a",
+    task_id: "task-a",
+    kind: "relay_run",
+    wave: 1,
+    orca_task_id: "orca-task-a",
+    dispatch_id: "dispatch-a",
+    assignee: "terminal-a",
+    relay_ids: { request: null, run: null, fleet: null },
+  };
+  const cases = [
+    ["runtime semantic value", (receipt) => { receipt.runtime_id = "provider-codex"; }],
+    ["repo slug semantic value", (receipt) => { receipt.repo.slug = "claude-repo"; }],
+    ["task semantic value", (receipt) => { receipt.tasks[0].assignee = "reviewer"; }],
+    ["task semantic field", (receipt) => { receipt.tasks[0].model = "fixture"; }],
+    ["top-level semantic field", (receipt) => { receipt.executor = "fixture"; }],
+  ];
+
+  cases.forEach(([label, mutate]) => {
+    const receipt = makeHygieneReceipt({ tasks: [task] });
+    mutate(receipt);
+    assert.throws(() => assertReceiptEngineAgnostic(receipt), /leaked/, label);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -782,11 +815,9 @@ test("D2: a successful run persists a schema-1 receipt (identity/mapping only) a
     assert.equal(taskByOutcome(receipt, "alpha").assignee, "h1");
     assert.equal(taskByOutcome(receipt, "bravo").assignee, "h2");
 
-    // D11-style engine-agnostic proof over the written receipt bytes.
-    const lowered = fs.readFileSync(receiptPath, "utf-8").toLowerCase();
-    FORBIDDEN_ENGINE_TOKENS.forEach((token) =>
-      assert.equal(lowered.includes(token), false, `receipt leaked engine/model token ${token}`),
-    );
+    // D11-style engine-agnostic proof over receipt schema fields and task entries. The
+    // source path may legitimately include the executor worktree's provider directory.
+    assertReceiptEngineAgnostic(receipt);
   } finally {
     r.fake.cleanup();
   }

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -30,6 +30,7 @@ const { assertGhReadOnly } = require(STATUS_JS);
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+const { assertReceiptEngineAgnostic } = require("./receipt-hygiene.js");
 
 const FORBIDDEN_ENGINE_TOKENS = ["codex", "claude", "cursor", "cline", "opencode"];
 
@@ -1254,8 +1255,8 @@ test("D10.14: wave-1 complete, wave-2 pending → program ready_for_next_wave", 
 test("D11: neither the receipt fixture nor a rendered status report names an engine/model", () => {
   const world = completeWorld("epic-status-agnostic");
   try {
-    const receiptBytes = fs.readFileSync(world.receiptPath, "utf-8").toLowerCase();
-    FORBIDDEN_ENGINE_TOKENS.forEach((token) => assert.equal(receiptBytes.includes(token), false, `receipt leaked ${token}`));
+    const receipt = JSON.parse(fs.readFileSync(world.receiptPath, "utf-8"));
+    assertReceiptEngineAgnostic(receipt);
     const r = world.run();
     const reportBytes = JSON.stringify(r.body).toLowerCase();
     FORBIDDEN_ENGINE_TOKENS.forEach((token) => assert.equal(reportBytes.includes(token), false, `report leaked ${token}`));


### PR DESCRIPTION
## Summary

- replace whole-receipt provider-token scans with a field-aware receipt hygiene assertion
- allow provider-like substrings only in documented path-bearing fields (`source`, `repo.root`)
- retain negative coverage for semantic engine/model/provider leaks and cover `.codex`, `.claude`, `.cursor`, `.grok`, and `.opencode` paths
- keep the production receipt schema, writer, serialization, key order, stop records, and additive records unchanged

## Validation

- focused receipt-hygiene factor: pass
- `node --test tests/relay-orca/scripts/run.test.js tests/relay-orca/scripts/status.test.js`: 104/104 pass
- `node --test tests/skills-lint/scripts/*.test.js`: 33/33 pass
- internal Cursor Grok review: PASS, contract pass, quality 9/10

Fixes #1020


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 영수증 데이터의 의미 있는 필드에 엔진·제공자 관련 금지 문자열이 포함되는지 자동 검증합니다.
  * 경로 정보처럼 허용된 필드는 예외 처리해 정상적인 영수증을 정확히 판별합니다.
  * 실행 및 상태 검증 테스트에 새로운 영수증 무결성 검사를 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->