### PR TITLE
docs: include relay-orca in final gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ node skills/relay-merge/scripts/finalize-run.js --run-id <id> --merge-method squ
 node skills/relay-merge/scripts/finalize-run.js --run-id <id> --force-finalize-nonready --reason "..." --json
 
 # Final gate for broad changes (serialize; fleet condition waits can flake under parallel file execution)
-node --test --test-concurrency=1 tests/relay-ready/scripts/*.test.js tests/relay-plan/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay/scripts/*.test.js tests/relay-config/scripts/*.test.js tests/relay-fleet/scripts/*.test.js tests/skills-lint/scripts/*.test.js
+node --test --test-concurrency=1 tests/relay-ready/scripts/*.test.js tests/relay-plan/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay/scripts/*.test.js tests/relay-config/scripts/*.test.js tests/relay-fleet/scripts/*.test.js tests/relay-orca/scripts/*.test.js tests/skills-lint/scripts/*.test.js
 ```
 
 ## Key Design Decisions


### PR DESCRIPTION
## Summary

- Align `CLAUDE.md`'s canonical broad final-gate command with the authoritative CI suite list.
- Add `tests/relay-orca/scripts/*.test.js` exactly once between relay-fleet and skills-lint.
- Preserve serialized execution with `--test-concurrency=1`.

## Test evidence

- `node --test tests/skills-lint/scripts/*.test.js` — 33 passed, 0 failed
- Internal independent review: Cursor Grok 4.5 xhigh, 10/10 contract and 10/10 quality
- Diff scope: `CLAUDE.md` only

Fixes #1018


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 광범위한 변경 사항에 대한 최종 검증 과정에 Orca 관련 테스트가 추가되었습니다.
  * 기존과 동일한 순차 실행 방식으로 테스트가 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->