### PR TITLE
fix: persist and recover relay-orca coordination markers

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -93,6 +93,9 @@ issue:
   number: 42
   source: github               # github | unknown
 
+coordination:
+  marker: relay-orca: example-program-1234abcd/outcome-a  # optional opaque single-line integration correlation
+
 git:
   base_branch: main
   working_branch: issue-42

--- a/skills/relay-dispatch/references/cli-schema.md
+++ b/skills/relay-dispatch/references/cli-schema.md
@@ -52,6 +52,7 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--by-role` | `parsed` | Presence flag; no value is consumed. |
 | `--contract-file` | `verbatim` | Operator-supplied artifact path; keep the literal argv token. |
 | `--copy` | `verbatim` | Operator-supplied file list; keep the literal argv token. |
+| `--coordination-marker` | `verbatim` | Opaque single-line coordination marker persisted in the relay manifest; keep the literal argv token. |
 | `--diff-file` | `verbatim` | Operator-supplied fixture path; keep the literal argv token. |
 | `--done-criteria-file` | `verbatim` | Operator-supplied anchor path; keep the literal argv token. |
 | `--dry-run` | `parsed` | Presence flag; no value is consumed. |
@@ -122,6 +123,7 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--by-role` | `parsed` | Presence flag; no value is consumed. |
 | `--contract-file` | `verbatim` | Operator-supplied artifact path; keep the literal argv token. |
 | `--copy` | `verbatim` | Operator-supplied file list; keep the literal argv token. |
+| `--coordination-marker` | `verbatim` | Opaque single-line coordination marker persisted in the relay manifest; keep the literal argv token. |
 | `--diff-file` | `verbatim` | Operator-supplied fixture path; keep the literal argv token. |
 | `--done-criteria-file` | `verbatim` | Operator-supplied anchor path; keep the literal argv token. |
 | `--dry-run` | `parsed` | Presence flag; no value is consumed. |

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -35,6 +35,7 @@ const FLAGS = [
   { flag: "--by-role", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--contract-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path; keep the literal argv token." },
   { flag: "--copy", kind: VALUE, mode: MODE_VERBATIM, valueName: "<file,...>", rationale: "Operator-supplied file list; keep the literal argv token." },
+  { flag: "--coordination-marker", kind: VALUE, mode: MODE_VERBATIM, valueName: "<marker>", rationale: "Opaque single-line coordination marker persisted in the relay manifest; keep the literal argv token." },
   { flag: "--diff-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied fixture path; keep the literal argv token." },
   { flag: "--dispatch", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--detach", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Launch the run (dispatch or review round) under a detached supervisor and return a receipt; no value is consumed." },
@@ -152,7 +153,7 @@ const COMMAND_FLAGS = {
   dispatch: [
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
     "--model", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
-    "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
+    "--test-command", "--coordination-marker", "--rubric-grandfathered", "--request-id", "--leaf-id",
     "--fleet-id", "--done-criteria-file", "--publish-policy", "--review-assurance", "--register", "--auto-recover-commit", "--no-auto-recover-commit",
     "--tags", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help",
   ],

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -1881,6 +1881,7 @@ async function main() {
   let handlingSignal = false;
   let runtime = null;
   let runDirClaimPath = null;
+  let provisionalMarkerSetup = false;
 
   function releaseRunDirClaim() {
     if (!runDirClaimPath) return;
@@ -1896,6 +1897,55 @@ async function main() {
     if (!fleetIssueLock) return;
     releaseIssueLock(fleetIssueLock);
     fleetIssueLock = null;
+  }
+
+  function cleanupProvisionalMarkerSetup() {
+    const errors = [];
+    const runDir = runId ? getRunDir(repoRoot, runId) : null;
+
+    try { releaseRunDirClaim(); } catch (error) { errors.push(`run-dir claim release failed: ${error.message}`); }
+    try { releaseFleetIssueLock(); } catch (error) { errors.push(`issue lock release failed: ${error.message}`); }
+
+    if (wtPath && fs.existsSync(wtPath)) {
+      try {
+        removeWorktree({ repoRoot, worktreePath: wtPath });
+        if (fs.existsSync(wtPath)) {
+          const relative = path.relative(path.resolve(wtBase), path.resolve(wtPath));
+          if (relative && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) {
+            fs.rmSync(wtPath, { recursive: true, force: true });
+          }
+        }
+      } catch (error) {
+        errors.push(`worktree cleanup failed: ${error.message}`);
+      }
+    }
+    if (wtPath) {
+      try {
+        const worktreeShell = path.dirname(wtPath);
+        if (fs.existsSync(worktreeShell) && fs.readdirSync(worktreeShell).length === 0) {
+          fs.rmdirSync(worktreeShell);
+        }
+      } catch (error) {
+        errors.push(`worktree shell cleanup failed: ${error.message}`);
+      }
+    }
+
+    try {
+      if (manifestPath) fs.rmSync(manifestPath, { force: true });
+      if (runDir) fs.rmSync(runDir, { recursive: true, force: true });
+    } catch (error) {
+      errors.push(`provisional run cleanup failed: ${error.message}`);
+    }
+    return errors;
+  }
+
+  function failBeforeAdmission(message, extra = {}) {
+    const cleanupErrors = provisionalMarkerSetup ? cleanupProvisionalMarkerSetup() : [];
+    failEarly(message, {
+      ...extra,
+      recoverable: cleanupErrors.length === 0,
+      ...(cleanupErrors.length ? { cleanup_error: cleanupErrors.join("; ") } : {}),
+    });
   }
 
   function persistInterruptedManifestForSignal() {
@@ -1924,18 +1974,18 @@ async function main() {
     }
   }
 
-  function journalDispatchInterrupted(signal, executorTerminated) {
-    if (!manifest || !runId) return;
+  function journalDispatchInterrupted(signal, executorTerminated, { reason = "signal", coordinationMarker = undefined } = {}) {
+    if (!manifest || !runId) return false;
     let runDir;
     try {
-      if (!persistInterruptedManifestForSignal()) return;
+      if (!persistInterruptedManifestForSignal()) return false;
       runDir = getRunDir(repoRoot, runId);
-      if (!fs.existsSync(runDir)) return;
+      if (!fs.existsSync(runDir)) return false;
       appendRunEvent(repoRoot, runId, {
         event: EVENTS.DISPATCH_INTERRUPTED,
         state_from: manifest.state || null,
         state_to: manifest.state || null,
-        reason: "signal",
+        reason,
         signal,
         executor_pid: executorPid,
         executor_pgid: executorPgid,
@@ -1943,8 +1993,10 @@ async function main() {
         timeout_s: TIMEOUT,
         executor_terminated: executorTerminated,
         worktree: wtPath || null,
+        ...(coordinationMarker !== undefined ? { coordination_marker: coordinationMarker } : {}),
       });
-    } catch {}
+      return true;
+    } catch { return false; }
   }
 
   function printSignalRecoveryHint(signal, executorTerminated) {
@@ -2049,6 +2101,16 @@ async function main() {
     const interruptibleResumeState = manifest.state === STATES.DISPATCHED || manifest.state === STATES.DRAFT;
     const latestEvent = interruptibleResumeState ? latestRunEvent(repoRoot, runId) : null;
     const resumesInterruptedDispatch = interruptibleResumeState && latestEvent?.event === EVENTS.DISPATCH_INTERRUPTED;
+    const markerDurabilityRecoveryPending = resumesInterruptedDispatch
+      && latestEvent?.reason === "coordination_marker_not_persisted_before_executor_spawn"
+      && coordinationMarkerFromManifest(manifest) === undefined;
+    if (markerDurabilityRecoveryPending) {
+      console.error(
+        "Error: coordination marker durability recovery is incomplete; " +
+        "attach the exact marker with relay-orca attach-marker.js before resuming",
+      );
+      process.exit(1);
+    }
     if (resumesInterruptedDispatch && isProcessGroupAlive(latestEvent.executor_pgid)) {
       console.error(
         `Error: interrupted executor process group is still alive for run '${runId}' ` +
@@ -2566,6 +2628,7 @@ async function main() {
     // environment/path metadata after worktree creation and preserves the marker
     // through the shared manifest writer boundary.
     if (COORDINATION_MARKER !== undefined) {
+      provisionalMarkerSetup = true;
       try {
         writeManifest(manifestPath, manifest);
         const persistedManifest = readManifest(manifestPath).data;
@@ -2576,7 +2639,7 @@ async function main() {
           );
         }
       } catch (error) {
-        failEarly(
+        failBeforeAdmission(
           `coordination marker persistence failed before worktree creation: ${error.message}`,
           { error_code: "coordination_marker_persistence_failed" },
         );
@@ -2592,11 +2655,21 @@ async function main() {
         copyFiles: COPY_FILES,
         register: false,
         assertWithin,
+        ...(process.env.RELAY_TEST_FAIL_CREATE_WORKTREE === "1"
+          ? {
+              dependencies: {
+                gitRunner: () => {
+                  throw new Error("injected create-worktree failure");
+                },
+              },
+            }
+          : {}),
       });
       copiedFiles = created.copiedFiles;
     } catch (error) {
-      console.error(`Error: ${error.message}`);
-      process.exit(1);
+      failBeforeAdmission(`worktree creation failed after coordination marker persistence: ${error.message}`, {
+        error_code: "worktree_creation_failed",
+      });
     }
     await maybePauseAfterWorktreeCreateForTest();
 
@@ -2615,13 +2688,19 @@ async function main() {
     }
     if (fetchSucceeded) {
       try {
+        if (process.env.RELAY_TEST_FAIL_BASE_MERGE === "1") {
+          const injected = new Error("injected base-branch merge failure");
+          injected.stderr = "injected base-branch merge failure\n";
+          throw injected;
+        }
         execGit(wtPath, ["merge", `origin/${baseBranch}`, "--no-edit"]);
       } catch (mergeErr) {
         try { execGit(wtPath, ["merge", "--abort"]); } catch {}
         removeWorktree({ repoRoot, worktreePath: wtPath });
         const reason = (mergeErr.stderr || mergeErr.message || String(mergeErr)).split("\n")[0];
-        console.error(`Error: failed to merge origin/${baseBranch} into worktree: ${reason}`);
-        process.exit(1);
+        failBeforeAdmission(`failed to merge origin/${baseBranch} into worktree: ${reason}`, {
+          error_code: "base_branch_merge_failed",
+        });
       }
     }
 
@@ -2843,10 +2922,32 @@ async function main() {
   writeManifest(manifestPath, manifest);
   if (COORDINATION_MARKER !== undefined) {
     const persistedManifest = readManifest(manifestPath).data;
-    if (coordinationMarkerFromManifest(persistedManifest) !== COORDINATION_MARKER) {
+    const markerPersisted = process.env.RELAY_TEST_FAIL_FINAL_COORDINATION_MARKER_VERIFY === "1"
+      ? false
+      : coordinationMarkerFromManifest(persistedManifest) === COORDINATION_MARKER;
+    if (!markerPersisted) {
+      const audited = journalDispatchInterrupted(null, false, {
+        reason: "coordination_marker_not_persisted_before_executor_spawn",
+        coordinationMarker: COORDINATION_MARKER,
+      });
+      if (!audited) {
+        failBeforeAdmission(
+          "coordination marker was not durably persisted before executor spawn and interruption audit failed",
+          {
+            error_code: "coordination_marker_not_persisted",
+            interruption_audit: "failed",
+          },
+        );
+      }
+      releaseRunDirClaim();
+      releaseFleetIssueLock();
       failEarly(
-        "coordination marker was not durably persisted before executor spawn",
-        { error_code: "coordination_marker_not_persisted" },
+        "coordination marker was not durably persisted before executor spawn; dispatch was interrupted for recovery",
+        {
+          error_code: "coordination_marker_not_persisted",
+          interruption_audit: "dispatch_interrupted",
+          recovery: "attach the exact marker, then resume the interrupted run",
+        },
       );
     }
   }
@@ -2863,6 +2964,7 @@ async function main() {
     executor_policy: executorPolicy,
     policy_decision: policyDecision,
   });
+  provisionalMarkerSetup = false;
   writeDetachReceiptIfRequested({
     repoRoot,
     runId,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -2560,6 +2560,28 @@ async function main() {
         summary: summarizeRoutePlan(routePlan),
       },
     };
+    // A coordination marker is an admission invariant. Publish and verify the
+    // manifest before creating a relay-owned worktree so a persistence failure
+    // cannot reach any worktree or executor mutation. The later write refreshes
+    // environment/path metadata after worktree creation and preserves the marker
+    // through the shared manifest writer boundary.
+    if (COORDINATION_MARKER !== undefined) {
+      try {
+        writeManifest(manifestPath, manifest);
+        const persistedManifest = readManifest(manifestPath).data;
+        if (coordinationMarkerFromManifest(persistedManifest) !== COORDINATION_MARKER) {
+          failEarly(
+            "coordination marker was not durably persisted before worktree creation",
+            { error_code: "coordination_marker_not_persisted" },
+          );
+        }
+      } catch (error) {
+        failEarly(
+          `coordination marker persistence failed before worktree creation: ${error.message}`,
+          { error_code: "coordination_marker_persistence_failed" },
+        );
+      }
+    }
     try {
       const created = createWorktree({
         repoRoot,

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -28,6 +28,7 @@
  *   --reasoning <level>    Codex reasoning effort override (default by rubric size: S=medium, M=high, L/XL=xhigh)
  *   --rubric-file <path>   REQUIRED: copy rubric YAML to run dir (persists for review)
  *   --test-command <cmd>   Record the executor-side test command in execution evidence
+ *   --coordination-marker <marker>  Persist one safe single-line marker in the raw manifest
  *   --publish-policy <mode> immediate | after-internal-review (default: immediate)
  *   --review-assurance <level> compact | standard | hardened (default: standard)
  *   --tags <csv>          Explicit routing tags; override inferred routing tags
@@ -85,6 +86,11 @@ const {
   readManifest,
   writeManifest,
 } = require("./manifest/store");
+const {
+  coordinationMarkerFromManifest,
+  validateCoordinationMarker,
+  withCoordinationMarker,
+} = require("./manifest/coordination");
 const { parseModelHints } = require("./model-hints");
 const { resolveExecutorDefaultModel } = require("./executor-model-config");
 const {
@@ -177,7 +183,7 @@ const args = process.argv.slice(2);
 
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
-  "--model", "-m", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
+  "--model", "-m", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--coordination-marker", "--rubric-grandfathered",
   "--request-id", "--leaf-id", "--fleet-id", "--done-criteria-file", "--publish-policy", "--review-assurance", "--tags",
   "--register", "--auto-recover-commit", "--no-auto-recover-commit", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help", "-h",
 ];
@@ -208,6 +214,7 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --reasoning        ${modeLabel("--reasoning")} Codex reasoning effort (default by rubric size: S=medium, M=high, L/XL=xhigh)`);
   console.log(`  --rubric-file      ${modeLabel("--rubric-file")} REQUIRED: copy rubric YAML to run dir (persists for review)`);
   console.log(`  --test-command     ${modeLabel("--test-command")} Record the executor-side test command in execution evidence`);
+  console.log(`  --coordination-marker ${modeLabel("--coordination-marker")} Persist one safe single-line marker in the raw manifest before executor spawn`);
   console.log(`  --publish-policy   ${modeLabel("--publish-policy")} PR publication policy: immediate | after-internal-review (default: immediate)`);
   console.log(`  --review-assurance ${modeLabel("--review-assurance")} Review assurance: compact | standard | hardened (default: standard)`);
   console.log(`  --tags             ${modeLabel("--tags")} Explicit routing tags; override inferred routing tags`);
@@ -257,6 +264,20 @@ function failEarly(message, extra = {}) {
     console.error(`Error: ${message}`);
   }
   process.exit(1);
+}
+
+// Validate this optional integration value before route resolution, worktree creation,
+// run-dir claims, or executor probing. An absent flag preserves ordinary dispatch.
+const COORDINATION_MARKER_FLAG = hasCliFlag("--coordination-marker");
+let COORDINATION_MARKER;
+try {
+  COORDINATION_MARKER = readArg(args, "--coordination-marker", undefined, CLI_ARG_OPTIONS);
+  if (COORDINATION_MARKER_FLAG && COORDINATION_MARKER === undefined) {
+    failEarly("--coordination-marker requires a value", { error_code: "missing_coordination_marker" });
+  }
+  if (COORDINATION_MARKER !== undefined) validateCoordinationMarker(COORDINATION_MARKER);
+} catch (error) {
+  failEarly(error.message, { error_code: "invalid_coordination_marker" });
 }
 
 function readRouteIntentFile(filePath) {
@@ -1995,6 +2016,16 @@ async function main() {
         worktree: validatedPaths.worktree,
       },
     };
+    if (COORDINATION_MARKER !== undefined) {
+      const existingMarker = coordinationMarkerFromManifest(manifest);
+      if (existingMarker !== COORDINATION_MARKER) {
+        console.error(
+          "Error: same-run resume cannot add or replace a coordination marker; " +
+          "use the supported relay-orca attach-marker recovery command"
+        );
+        process.exit(1);
+      }
+    }
     const manifestPublishPolicy = manifest.dispatch?.publish_policy || "immediate";
     if (PUBLISH_POLICY_ARG && PUBLISH_POLICY_ARG !== manifestPublishPolicy) {
       console.error(
@@ -2503,6 +2534,9 @@ async function main() {
       modelHints: MODEL_HINTS,
       fleetId: FLEET_ID,
     });
+    if (COORDINATION_MARKER !== undefined) {
+      manifest = withCoordinationMarker(manifest, COORDINATION_MARKER);
+    }
     ensureRunLayout(repoRoot, runId);
     manifest = persistDoneCriteria(manifest, manifestRunDir, resolvedDoneCriteriaPath, doneCriteriaSource);
     manifest = {
@@ -2785,6 +2819,15 @@ async function main() {
     },
   };
   writeManifest(manifestPath, manifest);
+  if (COORDINATION_MARKER !== undefined) {
+    const persistedManifest = readManifest(manifestPath).data;
+    if (coordinationMarkerFromManifest(persistedManifest) !== COORDINATION_MARKER) {
+      failEarly(
+        "coordination marker was not durably persisted before executor spawn",
+        { error_code: "coordination_marker_not_persisted" },
+      );
+    }
+  }
   appendRunEvent(repoRoot, runId, {
     event: EVENTS.DISPATCH_START,
     state_from: dispatchFromState,

--- a/skills/relay-dispatch/scripts/manifest/coordination.js
+++ b/skills/relay-dispatch/scripts/manifest/coordination.js
@@ -1,0 +1,48 @@
+"use strict";
+
+// Generic relay coordination metadata. The value is opaque to relay: integrations may
+// use it for correlation, while relay guarantees a validated single-line marker survives
+// ordinary manifest rewrites.
+const MAX_COORDINATION_MARKER_LENGTH = 256;
+
+function validateCoordinationMarker(value) {
+  if (typeof value !== "string" || value.length === 0 || value.trim() === "") {
+    throw new Error("coordination marker must be a non-empty single-line string");
+  }
+  if (value !== value.trim()) {
+    throw new Error("coordination marker must not have leading or trailing whitespace");
+  }
+  if (value.length > MAX_COORDINATION_MARKER_LENGTH) {
+    throw new Error(`coordination marker must be at most ${MAX_COORDINATION_MARKER_LENGTH} characters`);
+  }
+  for (const character of value) {
+    const code = character.codePointAt(0);
+    if (code <= 0x1f || code === 0x7f || code === 0x2028 || code === 0x2029) {
+      throw new Error("coordination marker must be a safe single-line string without control characters");
+    }
+  }
+  return value;
+}
+
+function coordinationMarkerFromManifest(manifest) {
+  return manifest && manifest.coordination && typeof manifest.coordination === "object"
+    ? manifest.coordination.marker
+    : undefined;
+}
+
+function withCoordinationMarker(manifest, marker) {
+  return {
+    ...manifest,
+    coordination: {
+      ...(manifest.coordination || {}),
+      marker: validateCoordinationMarker(marker),
+    },
+  };
+}
+
+module.exports = {
+  MAX_COORDINATION_MARKER_LENGTH,
+  coordinationMarkerFromManifest,
+  validateCoordinationMarker,
+  withCoordinationMarker,
+};

--- a/skills/relay-dispatch/scripts/manifest/paths.js
+++ b/skills/relay-dispatch/scripts/manifest/paths.js
@@ -448,6 +448,7 @@ function getTrustRootRepoBasename(expectedGitCommonDir) {
 function validateManifestPaths(paths, {
   expectedRepoRoot,
   manifestPath,
+  expectedRunsBase,
   runId,
   requireWorktree = false,
   allowMissingWorktree = false,
@@ -508,7 +509,9 @@ function validateManifestPaths(paths, {
   }
 
   if (normalizedManifestPath) {
-    const expectedManifestPath = getManifestPath(effectiveRepoRoot, normalizedRunId);
+    const expectedManifestPath = expectedRunsBase
+      ? path.join(path.resolve(expectedRunsBase), getRepoSlug(effectiveRepoRoot), `${normalizedRunId}.md`)
+      : getManifestPath(effectiveRepoRoot, normalizedRunId);
     if (normalizedManifestPath !== expectedManifestPath) {
       throw new Error(
         `${caller}: manifest paths.repo_root ${JSON.stringify(effectiveRepoRoot)} does not match the manifest storage path ` +

--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -1,5 +1,7 @@
 const { execFileSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 const {
@@ -16,6 +18,158 @@ const {
 
 const RELAY_VERSION = 2;
 const NOTES_TEMPLATE = "# Notes\n\n## Context\n\n## Review History\n";
+const MANIFEST_LOCK_NAME = ".coordination_marker.lock";
+const DEFAULT_MANIFEST_LOCK_TIMEOUT_MS = 5000;
+const DEFAULT_MANIFEST_LOCK_POLL_MS = 50;
+const DEFAULT_MANIFEST_LOCK_STALE_MS = 1000;
+const LOCK_WAIT_STATE = new Int32Array(new SharedArrayBuffer(4));
+
+function positiveEnv(name, fallback, aliases = []) {
+  const names = [name, ...aliases];
+  for (const candidate of names) {
+    const parsed = Number.parseInt(process.env[candidate] || "", 10);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return fallback;
+}
+
+function getManifestLockPath(manifestPath) {
+  if (typeof manifestPath !== "string" || !manifestPath.trim()) {
+    throw new Error("manifestPath is required for the manifest lock");
+  }
+  const manifestName = path.basename(manifestPath);
+  const runId = manifestName.endsWith(".md") ? manifestName.slice(0, -3) : manifestName;
+  return path.join(path.dirname(manifestPath), runId, MANIFEST_LOCK_NAME);
+}
+
+function readLockOwner(lockPath) {
+  try {
+    const stat = fs.statSync(lockPath);
+    let owner = null;
+    try {
+      owner = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+    } catch {}
+    return { stat, owner };
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+function lockIsAbandoned(lockPath) {
+  const observed = readLockOwner(lockPath);
+  if (!observed) return false;
+  const staleMs = positiveEnv(
+    "RELAY_MANIFEST_LOCK_STALE_MS",
+    DEFAULT_MANIFEST_LOCK_STALE_MS,
+    ["RELAY_COORDINATION_MARKER_LOCK_STALE_MS"],
+  );
+  if (Date.now() - observed.stat.mtimeMs < staleMs) return false;
+
+  const owner = observed.owner;
+  if (owner && owner.host === os.hostname() && Number.isInteger(owner.pid)) {
+    return !isProcessAlive(owner.pid);
+  }
+  // A malformed or foreign-host lock has no live-owner proof. The lease age is
+  // the bounded recovery contract for those crash leftovers.
+  return true;
+}
+
+function reclaimAbandonedLock(lockPath) {
+  const quarantinePath = `${lockPath}.stale.${process.pid}.${Date.now()}.${crypto.randomBytes(4).toString("hex")}`;
+  try {
+    fs.renameSync(lockPath, quarantinePath);
+  } catch (error) {
+    if (error.code === "ENOENT") return true;
+    return false;
+  }
+  try {
+    fs.unlinkSync(quarantinePath);
+  } catch (error) {
+    if (error.code !== "ENOENT") return false;
+  }
+  return true;
+}
+
+function acquireManifestLock(manifestPath) {
+  const lockPath = getManifestLockPath(manifestPath);
+  const timeoutMs = positiveEnv(
+    "RELAY_MANIFEST_LOCK_TIMEOUT_MS",
+    DEFAULT_MANIFEST_LOCK_TIMEOUT_MS,
+    ["RELAY_COORDINATION_MARKER_LOCK_TIMEOUT_MS"],
+  );
+  const pollMs = positiveEnv(
+    "RELAY_MANIFEST_LOCK_POLL_MS",
+    DEFAULT_MANIFEST_LOCK_POLL_MS,
+    ["RELAY_COORDINATION_MARKER_LOCK_POLL_MS"],
+  );
+  const deadline = Date.now() + timeoutMs;
+
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  while (Date.now() <= deadline) {
+    let fd;
+    const token = crypto.randomBytes(16).toString("hex");
+    try {
+      fd = fs.openSync(lockPath, "wx", 0o600);
+      const owner = {
+        pid: process.pid,
+        host: os.hostname(),
+        token,
+        acquired_at: new Date().toISOString(),
+      };
+      fs.writeFileSync(fd, `${JSON.stringify(owner)}\n`, "utf-8");
+      fs.fsyncSync(fd);
+      return { fd, lockPath, token };
+    } catch (error) {
+      if (fd !== undefined) {
+        try { fs.closeSync(fd); } catch {}
+      }
+      if (error.code !== "EEXIST") throw error;
+      if (lockIsAbandoned(lockPath) && reclaimAbandonedLock(lockPath)) continue;
+      if (Date.now() >= deadline) break;
+      Atomics.wait(LOCK_WAIT_STATE, 0, 0, pollMs);
+    }
+  }
+
+  const error = new Error(`timed out acquiring manifest lock ${lockPath}`);
+  error.code = "MANIFEST_LOCK_TIMEOUT";
+  error.lockPath = lockPath;
+  throw error;
+}
+
+function releaseManifestLock(lock) {
+  if (!lock) return;
+  try { fs.closeSync(lock.fd); } catch {}
+  try {
+    const owner = JSON.parse(fs.readFileSync(lock.lockPath, "utf-8"));
+    if (owner.token !== lock.token) return;
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    return;
+  }
+  try { fs.unlinkSync(lock.lockPath); } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+function withManifestTransaction(manifestPath, callback) {
+  const lock = acquireManifestLock(manifestPath);
+  try {
+    return callback();
+  } finally {
+    releaseManifestLock(lock);
+  }
+}
 
 function getActorName(repoRoot) {
   if (!repoRoot || typeof repoRoot !== "string") {
@@ -132,13 +286,54 @@ function toFrontmatter(data, indent = 0) {
     .join("\n");
 }
 
-function writeManifest(manifestPath, data, body = NOTES_TEMPLATE) {
+function preserveCoordinationMarker(manifestPath, data) {
+  if (!fs.existsSync(manifestPath)) return data;
+  let current;
+  try {
+    current = readManifest(manifestPath).data;
+  } catch {
+    return data;
+  }
+  const currentMarker = current?.coordination?.marker;
+  if (currentMarker === undefined) return data;
+  const incomingMarker = data?.coordination?.marker;
+  if (incomingMarker === undefined) {
+    return {
+      ...data,
+      coordination: {
+        ...(data.coordination || {}),
+        marker: currentMarker,
+      },
+    };
+  }
+  if (incomingMarker !== currentMarker) {
+    const error = new Error(
+      `coordination marker conflict while writing ${manifestPath}; refusing to replace the persisted marker`,
+    );
+    error.code = "COORDINATION_MARKER_CONFLICT";
+    throw error;
+  }
+  return data;
+}
+
+function writeManifestUnlocked(manifestPath, data, body = NOTES_TEMPLATE, { preserveMarker = true } = {}) {
   const dir = path.dirname(manifestPath);
   fs.mkdirSync(dir, { recursive: true });
   const tmpPath = `${manifestPath}.tmp.${process.pid}`;
-  const content = `---\n${toFrontmatter(data)}\n---\n${body.endsWith("\n") ? body : `${body}\n`}`;
-  fs.writeFileSync(tmpPath, content, "utf-8");
-  fs.renameSync(tmpPath, manifestPath);
+  const nextData = preserveMarker ? preserveCoordinationMarker(manifestPath, data) : data;
+  const content = `---\n${toFrontmatter(nextData)}\n---\n${body.endsWith("\n") ? body : `${body}\n`}`;
+  try {
+    fs.writeFileSync(tmpPath, content, "utf-8");
+    fs.renameSync(tmpPath, manifestPath);
+  } catch (error) {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    throw error;
+  }
+  return manifestPath;
+}
+
+function writeManifest(manifestPath, data, body = NOTES_TEMPLATE) {
+  return withManifestTransaction(manifestPath, () => writeManifestUnlocked(manifestPath, data, body));
 }
 
 function readManifest(manifestPath) {
@@ -271,11 +466,16 @@ module.exports = {
   NOTES_TEMPLATE,
   RELAY_VERSION,
   createManifestSkeleton,
+  acquireManifestLock,
   ensureRunLayout,
   getActorName,
+  getManifestLockPath,
   listManifestRecords,
   nowIso,
   parseFrontmatter,
   readManifest,
+  releaseManifestLock,
+  withManifestTransaction,
   writeManifest,
+  writeManifestUnlocked,
 };

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -23,6 +23,8 @@ const EVENTS = Object.freeze({
   CLEANUP_RESULT: "cleanup_result",
   CLOSE: "close",
   CONFLICTING_RUN_OVERRIDE: "conflicting_run_override",
+  // Consumer: relay-orca attach-marker audits supervised correlation-marker recovery.
+  COORDINATION_MARKER_ATTACHED: "coordination_marker_attached",
   // Consumer: dispatch resume gate and Phase 2 reconciler use this to resume or reconcile interrupted dispatches.
   DISPATCH_INTERRUPTED: "dispatch_interrupted",
   DISPATCH_RESULT: "dispatch_result",
@@ -274,6 +276,21 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
     ...(eventData.policy_decision !== undefined
       ? { policy_decision: normalizeEventValue(eventData.policy_decision) }
+      : {}),
+    ...(eventData.program_id !== undefined
+      ? { program_id: normalizeEventValue(eventData.program_id) }
+      : {}),
+    ...(eventData.outcome_id !== undefined
+      ? { outcome_id: normalizeEventValue(eventData.outcome_id) }
+      : {}),
+    ...(eventData.issue_number !== undefined
+      ? { issue_number: normalizeEventValue(eventData.issue_number) }
+      : {}),
+    ...(eventData.coordination_marker !== undefined
+      ? { coordination_marker: normalizeEventValue(eventData.coordination_marker) }
+      : {}),
+    ...(eventData.result !== undefined
+      ? { result: normalizeEventValue(eventData.result) }
       : {}),
     ...(eventData.route_plan_path !== undefined
       ? { route_plan_path: normalizeEventValue(eventData.route_plan_path) }

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -1,7 +1,10 @@
 const fs = require("fs");
 const path = require("path");
-const { getActorName } = require("./manifest/store");
-const { ensureRunLayout, getEventsPath, getRunsDir } = require("./manifest/paths");
+const {
+  getActorName,
+  withManifestTransaction,
+} = require("./manifest/store");
+const { ensureRunLayout, getEventsPath, getManifestPath, getRunsDir } = require("./manifest/paths");
 const { timingFieldsFromEventData } = require("./advisory-timing");
 const {
   appendTextFileWithoutFollowingSymlinks,
@@ -124,7 +127,7 @@ function validateOverrideAuditFields(eventData) {
   }
 }
 
-function appendRunEvent(repoRoot, runId, eventData) {
+function appendRunEventUnlocked(repoRoot, runId, eventData, { eventsPath = null } = {}) {
   if (!runId) {
     throw new Error("run_id is required to append a relay event");
   }
@@ -139,7 +142,7 @@ function appendRunEvent(repoRoot, runId, eventData) {
   }
   validateOverrideAuditFields(eventData);
 
-  ensureRunLayout(repoRoot, runId);
+  if (!eventsPath) ensureRunLayout(repoRoot, runId);
   const record = {
     ts: eventData.ts || new Date().toISOString(),
     event: eventData.event,
@@ -445,8 +448,18 @@ function appendRunEvent(repoRoot, runId, eventData) {
       : {}),
   };
 
-  appendEventLine(repoRoot, runId, record);
+  if (eventsPath) appendEventLineToPath(eventsPath, record);
+  else appendEventLine(repoRoot, runId, record);
   return record;
+}
+
+// Manifest and journal writers share the same per-run transaction lock. Callers
+// already inside a transaction (notably attach-marker's manifest+audit pair) set
+// lockHeld and may target an explicitly resolved events path.
+function appendRunEvent(repoRoot, runId, eventData, { eventsPath = null, lockHeld = false } = {}) {
+  if (lockHeld) return appendRunEventUnlocked(repoRoot, runId, eventData, { eventsPath });
+  const manifestPath = getManifestPath(repoRoot, runId);
+  return withManifestTransaction(manifestPath, () => appendRunEventUnlocked(repoRoot, runId, eventData, { eventsPath }));
 }
 
 function appendUnregisteredRouteUsedEvent(repoRoot, runId, {

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -173,6 +173,31 @@ git-canonicalized fails closed with `RECEIPT_REPO_MISMATCH` (exit `52`) — ther
 realpath fallback (A24). Full operator prompt contract and provenance rules:
 [operator-dispatch.md](operator-dispatch.md).
 
+## `attach-marker` — supervised relay manifest correlation repair
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/attach-marker.js" \
+  --program-file <accepted-program.json> --outcome-id <outcome-id> --run-id <run-id> \
+  [--repo-root <path>] [--json]
+```
+
+`attach-marker` is the supported recovery command for an initially unmarked
+`relay_run`. It derives the exact `relay-orca: <program-segment>/<outcome-id>` marker and
+the outcome's expected issue from the accepted program, then atomically attaches it to the
+exact relay manifest named by `--run-id`.
+
+It validates the accepted program, exact run identity, manifest storage/path ownership, and
+issue match before mutation. A bounded per-run lock and fresh-read/recheck make concurrent
+callers idempotent: the first caller returns `attached`, an exact repeat returns
+`already_present`, and a different existing marker fails closed. Successful attachment
+adds a `coordination_marker_attached` event containing the run/program/outcome/issue/marker
+and result needed to reconstruct the repair.
+
+This command does not read or write the relay-orca receipt, invoke Orca or GitHub, replay a
+dispatch, adopt a run into a receipt, or weaken `resume --map-relay-run`'s terminal PR/issue
+evidence checks. It only repairs the relay manifest correlation boundary; mapping remains a
+separate explicit operator action.
+
 ## `status` — read-only live reconciler
 
 ```bash

--- a/skills/relay-orca/references/install-and-operate.md
+++ b/skills/relay-orca/references/install-and-operate.md
@@ -28,6 +28,20 @@ and [commands.md](commands.md) for the full flag tables referenced throughout.
 All five intents are invoked directly, by hand. `plan` is read-only and needs no Orca. The four
 runtime intents require probe admission first. Full flag tables: [commands.md](commands.md).
 
+`attach-marker` is a separate supervised recovery utility, not a sixth runtime intent and not
+an implicit part of `run`, `status`, or `resume`:
+
+```bash
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/attach-marker.js" \
+  --program-file /tmp/accepted-program.json \
+  --outcome-id outcome-a --run-id <relay-run-id> --repo-root <repo-root> --json
+```
+
+It repairs only the relay manifest's coordination marker and its audit event. It does not
+invoke Orca or GitHub, replay a dispatch, mutate a receipt, or perform receipt adoption;
+follow [recovery.md](recovery.md#supervised-relay-marker-recovery) for the required
+marker-then-mapping sequence.
+
 ```bash
 # plan — compile an accepted program into an immutable, read-only wave plan
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/plan.js" \

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -93,6 +93,33 @@ performs **zero** mutation and asks for a terminal. Bounded steps:
 3. Provide one handle per outcome that needs a fresh operator surface; a shortfall leaves the
    excess outcomes untouched for a follow-up resume.
 
+## Supervised relay marker recovery
+
+When a relay operator was dispatched without the first-class marker, repair the correlation
+boundary before attempting receipt mapping:
+
+```bash
+node scripts/attach-marker.js \
+  --program-file <accepted-program.json> \
+  --outcome-id <outcome_id> \
+  --run-id <run_id> \
+  --repo-root <repo-root> --json
+```
+
+The command accepts only an existing `relay_run` outcome and an exact relay manifest. It
+derives the marker from the accepted program id and outcome id, requires the manifest issue
+to equal the outcome's declared issue, and uses atomic manifest writing plus a bounded
+per-run lock/fresh-read check. Exact repeats are explicit and idempotent (`already_present`);
+a different marker, wrong outcome/program input, malformed file, invalid path/run identity,
+or issue mismatch fails before manifest or event mutation. A successful `attached` result
+writes only the manifest's generic `coordination.marker` surface and one
+`coordination_marker_attached` audit event. It never invokes Orca or `gh`, replays dispatch,
+or edits the relay-orca receipt.
+
+After marker recovery, use the existing read-only `status` command to inspect the emitted
+`adopt_relay_run` repair candidate, then independently live-verify terminal evidence before
+the explicit mapping intake below. Marker attachment does not implicitly adopt a run.
+
 ## Supervised relay run mapping intake
 
 Operator-driven relay work is adopted into the receipt only through an explicit, supervised

--- a/skills/relay-orca/scripts/attach-marker.js
+++ b/skills/relay-orca/scripts/attach-marker.js
@@ -10,6 +10,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { resolveRepoContext, runsRoot, programSegment } = require("./receipt-io");
+const { coordinationMarkerFor } = require("./lib/coordination-marker");
 const {
   requireValidRunId,
   validateManifestPaths,
@@ -122,7 +123,7 @@ function deriveTarget(program, outcomeId) {
   if (issueNumber === null) {
     throw new AttachMarkerError("OUTCOME_INVALID", `outcome ${JSON.stringify(outcomeId)} has no finite declared issue`);
   }
-  const marker = `relay-orca: ${programSegment(program.id)}/${outcome.id}`;
+  const marker = coordinationMarkerFor(program.id, outcome.id, programSegment);
   try {
     validateCoordinationMarker(marker);
   } catch (error) {
@@ -190,15 +191,45 @@ function resolveRunPaths(repo, runId) {
 }
 
 function snapshotFile(filePath) {
+  let entry;
   try {
-    return { exists: true, text: fs.readFileSync(filePath, "utf-8") };
+    entry = fs.lstatSync(filePath);
   } catch (error) {
-    if (error.code === "ENOENT") return { exists: false, text: null };
+    if (error.code === "ENOENT") return { exists: false, kind: "missing", text: null };
+    throw error;
+  }
+  if (entry.isSymbolicLink()) {
+    return {
+      exists: true,
+      kind: "symlink",
+      linkTarget: fs.readlinkSync(filePath),
+      text: null,
+    };
+  }
+  try {
+    return { exists: true, kind: "regular", text: fs.readFileSync(filePath, "utf-8") };
+  } catch (error) {
+    if (error.code === "ENOENT") return { exists: false, kind: "missing", text: null };
     throw error;
   }
 }
 
 function restoreFile(filePath, snapshot) {
+  if (snapshot.kind === "symlink") {
+    let entry;
+    try {
+      entry = fs.lstatSync(filePath);
+    } catch (error) {
+      throw new Error(`rollback refused to recreate journal symlink ${filePath}: ${error.message}`);
+    }
+    if (!entry.isSymbolicLink() || fs.readlinkSync(filePath) !== snapshot.linkTarget) {
+      throw new Error(`rollback refused to replace changed journal boundary ${filePath}`);
+    }
+    // appendRunEvent refuses this boundary before writing. If a future writer
+    // partially fails after opening it, leave the original symlink inode and
+    // target untouched rather than replacing the boundary with a regular file.
+    return;
+  }
   if (!snapshot.exists) {
     try { fs.unlinkSync(filePath); } catch (error) {
       if (error.code !== "ENOENT") throw error;

--- a/skills/relay-orca/scripts/attach-marker.js
+++ b/skills/relay-orca/scripts/attach-marker.js
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+"use strict";
+
+// relay-orca `attach-marker` — supervised repair of the relay/orca correlation
+// boundary. It reads an accepted program and one existing relay run, derives the
+// canonical marker, then updates only the relay manifest and its audit journal.
+// It deliberately does not read or write an Orca receipt and never replays a
+// dispatch. The manifest is re-read while holding a bounded per-run lock so a
+// stale caller cannot overwrite a concurrent marker or unrelated manifest edit.
+const fs = require("node:fs");
+const path = require("node:path");
+const { resolveRepoContext, programSegment } = require("./receipt-io");
+const {
+  getManifestPath,
+  getRunDir,
+  requireValidRunId,
+  validateManifestPaths,
+} = require("../../relay-dispatch/scripts/manifest/paths");
+const { readManifest, writeManifest } = require("../../relay-dispatch/scripts/manifest/store");
+const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
+const {
+  coordinationMarkerFromManifest,
+  validateCoordinationMarker,
+  withCoordinationMarker,
+} = require("../../relay-dispatch/scripts/manifest/coordination");
+
+const USAGE_EXIT = 64;
+const LOCK_NAME = ".coordination_marker.lock";
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+const DEFAULT_LOCK_POLL_MS = 50;
+const LOCK_WAIT_STATE = new Int32Array(new SharedArrayBuffer(4));
+
+class AttachMarkerError extends Error {
+  constructor(reasonCode, message) {
+    super(message);
+    this.name = "AttachMarkerError";
+    this.reasonCode = reasonCode;
+  }
+}
+
+function usageError(message) {
+  process.stderr.write(`relay-orca attach-marker: ${message}\n`);
+  process.stderr.write(
+    "usage: attach-marker.js --program-file <accepted-program.json> " +
+      "--outcome-id <outcome-id> --run-id <run-id> [--repo-root <path>] [--json]\n",
+  );
+  process.exit(USAGE_EXIT);
+}
+
+function requireValue(value, flag) {
+  if (!value || value.startsWith("-")) usageError(`${flag} requires a value`);
+  return value;
+}
+
+function parseArgs(argv) {
+  const opts = { programFile: null, outcomeId: null, runId: null, repoRoot: null, json: false, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--program-file" || arg === "-f") opts.programFile = requireValue(argv[(i += 1)], "--program-file");
+    else if (arg === "--outcome-id" || arg === "-o") opts.outcomeId = requireValue(argv[(i += 1)], "--outcome-id");
+    else if (arg === "--run-id" || arg === "-r") opts.runId = requireValue(argv[(i += 1)], "--run-id");
+    else if (arg === "--repo-root") opts.repoRoot = requireValue(argv[(i += 1)], "--repo-root");
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else usageError(`unrecognized argument: ${arg}`);
+  }
+  if (opts.help) return opts;
+  if (!opts.programFile) usageError("--program-file is required");
+  if (!opts.outcomeId) usageError("--outcome-id is required");
+  if (!opts.runId) usageError("--run-id is required");
+  return opts;
+}
+
+function positiveEnv(name, fallback) {
+  const parsed = Number.parseInt(process.env[name] || "", 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function unwrapProgram(value) {
+  return value && value.program && typeof value.program === "object" && !Array.isArray(value.program)
+    ? value.program
+    : value;
+}
+
+function normalizeIssueNumber(value) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && /^-?\d+$/.test(value.trim())) return Number(value.trim());
+  return null;
+}
+
+function readAcceptedProgram(programFile) {
+  const resolved = path.resolve(programFile);
+  let stat;
+  try {
+    stat = fs.statSync(resolved);
+  } catch (error) {
+    throw new AttachMarkerError("PROGRAM_FILE_INVALID", `cannot read accepted program file ${resolved}: ${error.message}`);
+  }
+  if (!stat.isFile()) throw new AttachMarkerError("PROGRAM_FILE_INVALID", `accepted program path is not a file: ${resolved}`);
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(resolved, "utf-8"));
+  } catch (error) {
+    throw new AttachMarkerError("PROGRAM_FILE_INVALID", `accepted program file is not valid JSON: ${error.message}`);
+  }
+  const program = unwrapProgram(parsed);
+  if (!program || typeof program !== "object" || Array.isArray(program)) {
+    throw new AttachMarkerError("PROGRAM_FILE_INVALID", "accepted program must be a JSON object");
+  }
+  if (typeof program.id !== "string" || program.id.trim() === "") {
+    throw new AttachMarkerError("PROGRAM_FILE_INVALID", "accepted program id must be a non-empty string");
+  }
+  if (!Array.isArray(program.outcomes)) {
+    throw new AttachMarkerError("PROGRAM_FILE_INVALID", "accepted program outcomes must be an array");
+  }
+  return program;
+}
+
+function deriveTarget(program, outcomeId) {
+  const outcome = program.outcomes.find((entry) => entry && entry.id === outcomeId);
+  if (!outcome) {
+    throw new AttachMarkerError("OUTCOME_INVALID", `outcome ${JSON.stringify(outcomeId)} is not present in the accepted program`);
+  }
+  if (outcome.task_kind !== "relay_run") {
+    throw new AttachMarkerError("OUTCOME_INVALID", `outcome ${JSON.stringify(outcomeId)} is not a relay_run task`);
+  }
+  const issueNumber = normalizeIssueNumber(outcome.issue);
+  if (issueNumber === null) {
+    throw new AttachMarkerError("OUTCOME_INVALID", `outcome ${JSON.stringify(outcomeId)} has no finite declared issue`);
+  }
+  const marker = `relay-orca: ${programSegment(program.id)}/${outcome.id}`;
+  try {
+    validateCoordinationMarker(marker);
+  } catch (error) {
+    throw new AttachMarkerError("MARKER_INVALID", error.message);
+  }
+  return { issueNumber, marker, outcomeId, programId: program.id };
+}
+
+function readAndValidateManifest(manifestPath, runId, repoRoot, expectedIssue) {
+  let record;
+  try {
+    record = readManifest(manifestPath);
+  } catch (error) {
+    throw new AttachMarkerError("MANIFEST_INVALID", `cannot read relay manifest: ${error.message}`);
+  }
+  const manifest = record.data;
+  if (manifest.run_id !== runId) {
+    throw new AttachMarkerError(
+      "RUN_ID_MISMATCH",
+      `manifest run_id ${JSON.stringify(manifest.run_id)} does not match requested run ${JSON.stringify(runId)}`,
+    );
+  }
+  try {
+    validateManifestPaths(manifest.paths, {
+      expectedRepoRoot: repoRoot,
+      manifestPath,
+      runId,
+      allowMissingWorktree: true,
+      caller: "relay-orca attach-marker",
+    });
+  } catch (error) {
+    throw new AttachMarkerError("MANIFEST_PATH_INVALID", error.message);
+  }
+  const manifestIssue = normalizeIssueNumber(manifest.issue && manifest.issue.number);
+  if (manifestIssue === null || manifestIssue !== expectedIssue) {
+    throw new AttachMarkerError(
+      "ISSUE_MISMATCH",
+      `relay run ${runId} issue ${JSON.stringify(manifestIssue)} does not match accepted outcome issue ${JSON.stringify(expectedIssue)}`,
+    );
+  }
+  const existingMarker = coordinationMarkerFromManifest(manifest);
+  if (existingMarker !== undefined) {
+    try {
+      validateCoordinationMarker(existingMarker);
+    } catch (error) {
+      throw new AttachMarkerError("MARKER_INVALID", `existing manifest marker is invalid: ${error.message}`);
+    }
+  }
+  return { ...record, data: manifest };
+}
+
+function waitForLock(lockPath) {
+  const deadline = Date.now() + positiveEnv("RELAY_COORDINATION_MARKER_LOCK_TIMEOUT_MS", DEFAULT_LOCK_TIMEOUT_MS);
+  while (Date.now() < deadline) {
+    try {
+      return fs.openSync(lockPath, "wx");
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      Atomics.wait(
+        LOCK_WAIT_STATE,
+        0,
+        0,
+        positiveEnv("RELAY_COORDINATION_MARKER_LOCK_POLL_MS", DEFAULT_LOCK_POLL_MS),
+      );
+    }
+  }
+  return null;
+}
+
+function releaseLock(lockFd, lockPath) {
+  try { fs.closeSync(lockFd); } catch {}
+  try { fs.unlinkSync(lockPath); } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+function attachMarker({ opts, repo, target }) {
+  const runId = requireValidRunId(opts.runId);
+  const manifestPath = getManifestPath(repo.root, runId);
+  const initial = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
+  const initialMarker = coordinationMarkerFromManifest(initial.data);
+  if (initialMarker === target.marker) return resultFor(target, runId, "already_present");
+  if (initialMarker !== undefined) {
+    throw new AttachMarkerError(
+      "MARKER_CONFLICT",
+      `relay run ${runId} already has a different coordination marker`,
+    );
+  }
+
+  const runDir = getRunDir(repo.root, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  const lockPath = path.join(runDir, LOCK_NAME);
+  const lockFd = waitForLock(lockPath);
+  if (lockFd === null) {
+    const afterTimeout = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
+    const timeoutMarker = coordinationMarkerFromManifest(afterTimeout.data);
+    if (timeoutMarker === target.marker) return resultFor(target, runId, "already_present");
+    throw new AttachMarkerError(
+      "LOCK_TIMEOUT",
+      `timed out acquiring ${lockPath}; refusing to overwrite a concurrently changing manifest`,
+    );
+  }
+
+  try {
+    // The caller's first read is only an admission check. Always validate and use
+    // the fresh record inside the lock before the atomic write.
+    const fresh = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
+    const freshMarker = coordinationMarkerFromManifest(fresh.data);
+    if (freshMarker === target.marker) return resultFor(target, runId, "already_present");
+    if (freshMarker !== undefined) {
+      throw new AttachMarkerError("MARKER_CONFLICT", `relay run ${runId} already has a different coordination marker`);
+    }
+
+    const updated = withCoordinationMarker(fresh.data, target.marker);
+    writeManifest(manifestPath, updated, fresh.body);
+    appendRunEvent(repo.root, runId, {
+      event: EVENTS.COORDINATION_MARKER_ATTACHED,
+      state_from: updated.state || null,
+      state_to: updated.state || null,
+      head_sha: updated.git?.head_sha || null,
+      reason: "supervised_relay_orca_marker_recovery",
+      program_id: target.programId,
+      outcome_id: target.outcomeId,
+      issue_number: target.issueNumber,
+      coordination_marker: target.marker,
+      result: "attached",
+    });
+    return resultFor(target, runId, "attached");
+  } finally {
+    releaseLock(lockFd, lockPath);
+  }
+}
+
+function resultFor(target, runId, result) {
+  return {
+    ok: true,
+    result,
+    run_id: runId,
+    program_id: target.programId,
+    outcome_id: target.outcomeId,
+    issue_number: target.issueNumber,
+    coordination_marker: target.marker,
+    receipt_mutated: false,
+    executor_replayed: false,
+  };
+}
+
+function printFailure(error, json) {
+  const body = {
+    ok: false,
+    reason_code: error.reasonCode || "ATTACH_MARKER_FAILED",
+    message: error.message,
+  };
+  if (json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+  else process.stderr.write(`relay-orca attach-marker rejected [${body.reason_code}]: ${body.message}\n`);
+  process.exitCode = 1;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) usageError("attach a derived relay-orca coordination marker to an existing relay run");
+  try {
+    const runId = requireValidRunId(opts.runId);
+    const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+    // Resolve the exact manifest path before any run-dir or journal mutation.
+    const manifestPath = getManifestPath(repo.root, runId);
+    if (!fs.existsSync(manifestPath)) {
+      throw new AttachMarkerError("RUN_NOT_FOUND", `relay run manifest was not found at ${manifestPath}`);
+    }
+    const program = readAcceptedProgram(opts.programFile);
+    const target = deriveTarget(program, opts.outcomeId);
+    const result = attachMarker({ opts: { ...opts, runId }, repo, target });
+    if (opts.json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    else process.stdout.write(`attached coordination marker ${target.marker} to relay run ${runId} (${result.result})\n`);
+  } catch (error) {
+    printFailure(error, opts.json);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  deriveTarget,
+  readAndValidateManifest,
+  attachMarker,
+  waitForLock,
+};

--- a/skills/relay-orca/scripts/attach-marker.js
+++ b/skills/relay-orca/scripts/attach-marker.js
@@ -9,14 +9,16 @@
 // stale caller cannot overwrite a concurrent marker or unrelated manifest edit.
 const fs = require("node:fs");
 const path = require("node:path");
-const { resolveRepoContext, programSegment } = require("./receipt-io");
+const { resolveRepoContext, runsRoot, programSegment } = require("./receipt-io");
 const {
-  getManifestPath,
-  getRunDir,
   requireValidRunId,
   validateManifestPaths,
 } = require("../../relay-dispatch/scripts/manifest/paths");
-const { readManifest, writeManifest } = require("../../relay-dispatch/scripts/manifest/store");
+const {
+  readManifest,
+  withManifestTransaction,
+  writeManifestUnlocked,
+} = require("../../relay-dispatch/scripts/manifest/store");
 const { appendRunEvent, EVENTS } = require("../../relay-dispatch/scripts/relay-events");
 const {
   coordinationMarkerFromManifest,
@@ -25,10 +27,6 @@ const {
 } = require("../../relay-dispatch/scripts/manifest/coordination");
 
 const USAGE_EXIT = 64;
-const LOCK_NAME = ".coordination_marker.lock";
-const DEFAULT_LOCK_TIMEOUT_MS = 5000;
-const DEFAULT_LOCK_POLL_MS = 50;
-const LOCK_WAIT_STATE = new Int32Array(new SharedArrayBuffer(4));
 
 class AttachMarkerError extends Error {
   constructor(reasonCode, message) {
@@ -69,11 +67,6 @@ function parseArgs(argv) {
   if (!opts.outcomeId) usageError("--outcome-id is required");
   if (!opts.runId) usageError("--run-id is required");
   return opts;
-}
-
-function positiveEnv(name, fallback) {
-  const parsed = Number.parseInt(process.env[name] || "", 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function unwrapProgram(value) {
@@ -156,6 +149,7 @@ function readAndValidateManifest(manifestPath, runId, repoRoot, expectedIssue) {
     validateManifestPaths(manifest.paths, {
       expectedRepoRoot: repoRoot,
       manifestPath,
+      expectedRunsBase: runsRoot(),
       runId,
       allowMissingWorktree: true,
       caller: "relay-orca attach-marker",
@@ -181,34 +175,50 @@ function readAndValidateManifest(manifestPath, runId, repoRoot, expectedIssue) {
   return { ...record, data: manifest };
 }
 
-function waitForLock(lockPath) {
-  const deadline = Date.now() + positiveEnv("RELAY_COORDINATION_MARKER_LOCK_TIMEOUT_MS", DEFAULT_LOCK_TIMEOUT_MS);
-  while (Date.now() < deadline) {
-    try {
-      return fs.openSync(lockPath, "wx");
-    } catch (error) {
-      if (error.code !== "EEXIST") throw error;
-      Atomics.wait(
-        LOCK_WAIT_STATE,
-        0,
-        0,
-        positiveEnv("RELAY_COORDINATION_MARKER_LOCK_POLL_MS", DEFAULT_LOCK_POLL_MS),
-      );
-    }
-  }
-  return null;
+function resolveRunPaths(repo, runId) {
+  // Keep this resolver in lockstep with status/resume: receipt-io.runsRoot()
+  // honors RELAY_ORCA_RUNS_ROOT before the relay-wide fallbacks. The slug and
+  // run id remain canonical/single-segment values, so the recovery override
+  // cannot broaden the target outside one repository/run path.
+  const root = path.resolve(runsRoot());
+  const repoDir = path.join(root, repo.slug);
+  return {
+    manifestPath: path.join(repoDir, `${runId}.md`),
+    runDir: path.join(repoDir, runId),
+    eventsPath: path.join(repoDir, runId, "events.jsonl"),
+  };
 }
 
-function releaseLock(lockFd, lockPath) {
-  try { fs.closeSync(lockFd); } catch {}
-  try { fs.unlinkSync(lockPath); } catch (error) {
-    if (error.code !== "ENOENT") throw error;
+function snapshotFile(filePath) {
+  try {
+    return { exists: true, text: fs.readFileSync(filePath, "utf-8") };
+  } catch (error) {
+    if (error.code === "ENOENT") return { exists: false, text: null };
+    throw error;
+  }
+}
+
+function restoreFile(filePath, snapshot) {
+  if (!snapshot.exists) {
+    try { fs.unlinkSync(filePath); } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    return;
+  }
+  const tmpPath = `${filePath}.rollback.${process.pid}`;
+  try {
+    fs.writeFileSync(tmpPath, snapshot.text, "utf-8");
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    throw error;
   }
 }
 
 function attachMarker({ opts, repo, target }) {
   const runId = requireValidRunId(opts.runId);
-  const manifestPath = getManifestPath(repo.root, runId);
+  const paths = resolveRunPaths(repo, runId);
+  const { manifestPath, runDir, eventsPath } = paths;
   const initial = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
   const initialMarker = coordinationMarkerFromManifest(initial.data);
   if (initialMarker === target.marker) return resultFor(target, runId, "already_present");
@@ -219,47 +229,58 @@ function attachMarker({ opts, repo, target }) {
     );
   }
 
-  const runDir = getRunDir(repo.root, runId);
   fs.mkdirSync(runDir, { recursive: true });
-  const lockPath = path.join(runDir, LOCK_NAME);
-  const lockFd = waitForLock(lockPath);
-  if (lockFd === null) {
-    const afterTimeout = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
-    const timeoutMarker = coordinationMarkerFromManifest(afterTimeout.data);
-    if (timeoutMarker === target.marker) return resultFor(target, runId, "already_present");
-    throw new AttachMarkerError(
-      "LOCK_TIMEOUT",
-      `timed out acquiring ${lockPath}; refusing to overwrite a concurrently changing manifest`,
-    );
-  }
-
   try {
-    // The caller's first read is only an admission check. Always validate and use
-    // the fresh record inside the lock before the atomic write.
-    const fresh = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
-    const freshMarker = coordinationMarkerFromManifest(fresh.data);
-    if (freshMarker === target.marker) return resultFor(target, runId, "already_present");
-    if (freshMarker !== undefined) {
-      throw new AttachMarkerError("MARKER_CONFLICT", `relay run ${runId} already has a different coordination marker`);
-    }
+    return withManifestTransaction(manifestPath, () => {
+      // The caller's first read is only an admission check. Always validate and
+      // use the fresh record inside the shared manifest transaction before the
+      // atomic write; lifecycle writers use this same transaction boundary.
+      const fresh = readAndValidateManifest(manifestPath, runId, repo.root, target.issueNumber);
+      const freshMarker = coordinationMarkerFromManifest(fresh.data);
+      if (freshMarker === target.marker) return resultFor(target, runId, "already_present");
+      if (freshMarker !== undefined) {
+        throw new AttachMarkerError("MARKER_CONFLICT", `relay run ${runId} already has a different coordination marker`);
+      }
 
-    const updated = withCoordinationMarker(fresh.data, target.marker);
-    writeManifest(manifestPath, updated, fresh.body);
-    appendRunEvent(repo.root, runId, {
-      event: EVENTS.COORDINATION_MARKER_ATTACHED,
-      state_from: updated.state || null,
-      state_to: updated.state || null,
-      head_sha: updated.git?.head_sha || null,
-      reason: "supervised_relay_orca_marker_recovery",
-      program_id: target.programId,
-      outcome_id: target.outcomeId,
-      issue_number: target.issueNumber,
-      coordination_marker: target.marker,
-      result: "attached",
+      const manifestBefore = snapshotFile(manifestPath);
+      const eventsBefore = snapshotFile(eventsPath);
+      const updated = withCoordinationMarker(fresh.data, target.marker);
+      try {
+        writeManifestUnlocked(manifestPath, updated, fresh.body, { preserveMarker: false });
+        appendRunEvent(repo.root, runId, {
+          event: EVENTS.COORDINATION_MARKER_ATTACHED,
+          state_from: updated.state || null,
+          state_to: updated.state || null,
+          head_sha: updated.git?.head_sha || null,
+          reason: "supervised_relay_orca_marker_recovery",
+          program_id: target.programId,
+          outcome_id: target.outcomeId,
+          issue_number: target.issueNumber,
+          coordination_marker: target.marker,
+          result: "attached",
+        }, { eventsPath, lockHeld: true });
+      } catch (error) {
+        try {
+          restoreFile(manifestPath, manifestBefore);
+          restoreFile(eventsPath, eventsBefore);
+        } catch (rollbackError) {
+          throw new AttachMarkerError(
+            "ATTACH_MARKER_ROLLBACK_FAILED",
+            `marker persistence failed and rollback failed: ${rollbackError.message}; original error: ${error.message}`,
+          );
+        }
+        throw new AttachMarkerError(
+          "ATTACH_MARKER_PERSISTENCE_FAILED",
+          `marker persistence failed; manifest and audit journal were restored: ${error.message}`,
+        );
+      }
+      return resultFor(target, runId, "attached");
     });
-    return resultFor(target, runId, "attached");
-  } finally {
-    releaseLock(lockFd, lockPath);
+  } catch (error) {
+    if (error?.code === "MANIFEST_LOCK_TIMEOUT") {
+      throw new AttachMarkerError("LOCK_TIMEOUT", `${error.message}; refusing to overwrite a concurrently changing manifest`);
+    }
+    throw error;
   }
 }
 
@@ -295,7 +316,7 @@ function main() {
     const runId = requireValidRunId(opts.runId);
     const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
     // Resolve the exact manifest path before any run-dir or journal mutation.
-    const manifestPath = getManifestPath(repo.root, runId);
+    const manifestPath = resolveRunPaths(repo, runId).manifestPath;
     if (!fs.existsSync(manifestPath)) {
       throw new AttachMarkerError("RUN_NOT_FOUND", `relay run manifest was not found at ${manifestPath}`);
     }
@@ -315,5 +336,5 @@ module.exports = {
   deriveTarget,
   readAndValidateManifest,
   attachMarker,
-  waitForLock,
+  resolveRunPaths,
 };

--- a/skills/relay-orca/scripts/lib/coordination-marker.js
+++ b/skills/relay-orca/scripts/lib/coordination-marker.js
@@ -1,0 +1,17 @@
+"use strict";
+
+function coordinationMarkerFor(programId, outcomeId, segmentEncoder) {
+  if (typeof segmentEncoder !== "function") {
+    throw new TypeError("coordination marker requires a program segment encoder");
+  }
+  return `relay-orca: ${segmentEncoder(programId)}/${outcomeId}`;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+module.exports = {
+  coordinationMarkerFor,
+  shellQuote,
+};

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -83,7 +83,7 @@ function relayDispatchMarkerContract(task, program, segmentEncoder) {
     "Relay coordination-marker contract (fail closed before dispatch):",
     `Exact resolved marker: ${marker}`,
     "Authoritative relay dispatch CLI shape:",
-    `node skills/relay-dispatch/scripts/dispatch.js <repo-root> --branch <branch> --prompt-file <prompt-file> --rubric-file <rubric-file> --coordination-marker ${JSON.stringify(marker)}`,
+    `node "\${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" <repo-root> --branch <branch> --prompt-file <prompt-file> --rubric-file <rubric-file> --coordination-marker ${JSON.stringify(marker)}`,
     "Use that --coordination-marker value on the initial relay dispatch. If the flag is unavailable or its exact marker cannot be persisted before executor spawn, stop before worktree/executor mutation; do not dispatch or replay.",
   ].join("\n");
 }

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -75,6 +75,19 @@ function manifestMarkerBlock(task, program, segmentEncoder) {
   return `Embed this exact program marker line in the ${destination}:\n${marker}`;
 }
 
+function relayDispatchMarkerContract(task, program, segmentEncoder) {
+  if (task.kind !== "relay_run") return null;
+  if (typeof segmentEncoder !== "function") throw new TypeError("operator prompt requires the shared program segment encoder");
+  const marker = `relay-orca: ${segmentEncoder(program.id)}/${task.outcome_id}`;
+  return [
+    "Relay coordination-marker contract (fail closed before dispatch):",
+    `Exact resolved marker: ${marker}`,
+    "Authoritative relay dispatch CLI shape:",
+    `node skills/relay-dispatch/scripts/dispatch.js <repo-root> --branch <branch> --prompt-file <prompt-file> --rubric-file <rubric-file> --coordination-marker ${JSON.stringify(marker)}`,
+    "Use that --coordination-marker value on the initial relay dispatch. If the flag is unavailable or its exact marker cannot be persisted before executor spawn, stop before worktree/executor mutation; do not dispatch or replay.",
+  ].join("\n");
+}
+
 function bodyBlock(task, program, outcome, segmentEncoder) {
   const route = task.recommended_route || {};
   if (route.read_only) {
@@ -84,7 +97,9 @@ function bodyBlock(task, program, outcome, segmentEncoder) {
   if (task.kind === "relay_fleet") {
     return [RELAY_PATH, fleetLeavesBlock(outcome), OWNERSHIP_NOTE, marker].join("\n");
   }
-  return [RELAY_PATH, OWNERSHIP_NOTE, marker].filter(Boolean).join("\n");
+  return [RELAY_PATH, OWNERSHIP_NOTE, marker, relayDispatchMarkerContract(task, program, segmentEncoder)]
+    .filter(Boolean)
+    .join("\n");
 }
 
 // Build the full operator prompt for a single task. `outcome` is the original
@@ -105,5 +120,6 @@ module.exports = {
   READ_ONLY_MARKER,
   NO_EDIT_CLAUSE,
   RELAY_PATH,
+  relayDispatchMarkerContract,
   buildOperatorPrompt,
 };

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { coordinationMarkerFor, shellQuote } = require("./coordination-marker");
+
 // Engine-agnostic operator prompt builder (D8). One prompt per task kind. The
 // operator SURFACE is sourced from the plan's recommended_route (operator name +
 // mode only). NO executor/reviewer engine name, model name, or engine-specific
@@ -71,19 +73,19 @@ function manifestMarkerBlock(task, program, segmentEncoder) {
   if (task.kind !== "relay_run" && task.kind !== "relay_fleet") return null;
   if (typeof segmentEncoder !== "function") throw new TypeError("operator prompt requires the shared program segment encoder");
   const destination = task.kind === "relay_fleet" ? "relay fleet manifest" : "relay run manifest";
-  const marker = `relay-orca: ${segmentEncoder(program.id)}/${task.outcome_id}`;
+  const marker = coordinationMarkerFor(program.id, task.outcome_id, segmentEncoder);
   return `Embed this exact program marker line in the ${destination}:\n${marker}`;
 }
 
 function relayDispatchMarkerContract(task, program, segmentEncoder) {
   if (task.kind !== "relay_run") return null;
   if (typeof segmentEncoder !== "function") throw new TypeError("operator prompt requires the shared program segment encoder");
-  const marker = `relay-orca: ${segmentEncoder(program.id)}/${task.outcome_id}`;
+  const marker = coordinationMarkerFor(program.id, task.outcome_id, segmentEncoder);
   return [
     "Relay coordination-marker contract (fail closed before dispatch):",
     `Exact resolved marker: ${marker}`,
     "Authoritative relay dispatch CLI shape:",
-    `node "\${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" <repo-root> --branch <branch> --prompt-file <prompt-file> --rubric-file <rubric-file> --coordination-marker ${JSON.stringify(marker)}`,
+    `node "\${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" <repo-root> --branch <branch> --prompt-file <prompt-file> --rubric-file <rubric-file> --coordination-marker ${shellQuote(marker)}`,
     "Use that --coordination-marker value on the initial relay dispatch. If the flag is unavailable or its exact marker cannot be persisted before executor spawn, stop before worktree/executor mutation; do not dispatch or replay.",
   ].join("\n");
 }

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -19,6 +19,7 @@ const {
   sendPrompt,
 } = require("./run-orca");
 const { buildOperatorPrompt } = require("./operator-prompt");
+const { coordinationMarkerFor } = require("./coordination-marker");
 
 // The CLI-invocation boundary is injected by run.js (the Node subprocess module
 // may not live under scripts/lib/ — plan.js's frozen D6 source scan forbids it).
@@ -68,7 +69,7 @@ function taskTitle(program, task, programSegment) {
   // task titled for `alpha/child`. The segment is slash-free, so `status`'s
   // `title.includes("relay-orca: <segment>/")` foreign-task check can never confuse two
   // distinct programs. `programSegment` is injected (pure) so lib/ stays subprocess-free.
-  return `relay-orca: ${programSegment(program.id)}/${task.outcome_id}`;
+  return coordinationMarkerFor(program.id, task.outcome_id, programSegment);
 }
 
 function taskSpec(program, task) {

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -12,6 +12,7 @@
 const fs = require("node:fs");
 const { execFileSync } = require("node:child_process");
 const { PlanError } = require("./lib/reasons");
+const { COMMAND_FLAGS, FLAGS } = require("../../relay-dispatch/scripts/cli-schema");
 const { orchestrate } = require("./lib/run-orchestrator");
 const { orderedReport } = require("./lib/run-report");
 const { buildReceiptMapping, serializeReceiptWithRecords } = require("./lib/receipt");
@@ -196,6 +197,21 @@ function readProgram(programFile) {
   }
 }
 
+function assertRelayMarkerPersistenceCapability() {
+  const definition = FLAGS.find((entry) => entry.flag === "--coordination-marker");
+  if (
+    !COMMAND_FLAGS.dispatch.includes("--coordination-marker")
+    || !definition
+    || definition.kind !== "value"
+    || definition.mode !== "verbatim"
+  ) {
+    throw new PlanError(
+      "INVALID_INPUT",
+      "relay-orca relay_run dispatch requires the first-class relay --coordination-marker CLI surface; refusing to dispatch without exact marker persistence",
+    );
+  }
+}
+
 function printReport(report, json) {
   if (json) {
     process.stdout.write(`${JSON.stringify(orderedReport(report), null, 2)}\n`);
@@ -228,6 +244,9 @@ function main() {
   const program = readProgram(opts.programFile);
   let result;
   try {
+    // Check the local authoritative relay CLI/schema before admission or any
+    // Orca materialization. The operator contract is fail-closed at this boundary.
+    assertRelayMarkerPersistenceCapability();
     // A27: build the persistor FIRST. This eagerly canonicalizes the repo and resolves the
     // receipt path before orchestrate runs ANY admission/materialization mutation — a
     // git-canonicalization failure exits 52 here (CanonicalizationError, caught below) with

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -716,7 +716,6 @@ function executeAdvisoryRequest(request) {
     trigger: request.trigger || "every_round",
     ...counts,
   };
-  writeJson(request.resultPath, result);
   const timingFields = waitForDecisionTiming(request);
   Object.assign(result, {
     consumedByPhase: timingFields.consumed_by_phase,
@@ -724,6 +723,9 @@ function executeAdvisoryRequest(request) {
     elapsedMs: timingFields.elapsed_ms,
     phaseDecisionWaited: timingFields.phase_decision_waited,
   });
+  // The advisory result is the settlement signal. Publish it only after the
+  // required audit event has been durably appended under the shared manifest
+  // transaction lock, so settlement cannot consume success without provenance.
   try {
     appendRunEvent(request.runRepoPath, request.runId, {
       event: EVENTS.ADVISORY_REVIEW,

--- a/tests/relay-dispatch/scripts/dispatch-marker-recovery.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-marker-recovery.test.js
@@ -1,0 +1,159 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const DISPATCH_JS = path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "dispatch.js");
+const { getRepoSlug } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "paths.js"));
+const { readManifest } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js"));
+
+function setupRepo() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-recovery-dispatch-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const remoteRoot = path.join(base, "origin.git");
+  const binDir = path.join(base, "bin");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  const git = (args, cwd = repoRoot) => execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" });
+  git(["init", "-q", "-b", "main"]);
+  git(["init", "--bare", remoteRoot], base);
+  git(["config", "user.name", "dispatch-marker-test"]);
+  git(["config", "user.email", "dispatch-marker-test@example.com"]);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "marker recovery\n", "utf-8");
+  git(["add", "README.md"]);
+  git(["commit", "-m", "initial"]);
+  git(["remote", "add", "origin", remoteRoot]);
+  git(["push", "-u", "origin", "main"]);
+
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!${process.execPath}
+const fs = require("fs");
+const cp = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("codex-fixture\\n"); process.exit(0); }
+if (args[0] !== "exec") process.exit(2);
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+fs.writeFileSync(process.env.RELAY_TEST_EXECUTOR_MARKER, "spawned\\n", "utf-8");
+fs.writeFileSync(cwd + "/executor.txt", "done\\n", "utf-8");
+cp.execFileSync("git", ["-C", cwd, "add", "executor.txt"]);
+cp.execFileSync("git", ["-C", cwd, "commit", "-m", "fixture executor"]);
+fs.writeFileSync(output, "done\\n", "utf-8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+
+  const rubricPath = path.join(base, "rubric.yaml");
+  fs.writeFileSync(rubricPath, "rubric:\n  factors:\n    - name: marker recovery\n      target: exit 0\n", "utf-8");
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:/usr/bin:/bin`,
+    RELAY_HOME: relayHome,
+    RELAY_TEST_EXECUTOR_MARKER: path.join(base, "executor-spawned"),
+  };
+  return { base, repoRoot, relayHome, rubricPath, env };
+}
+
+function runDispatch(fixture, extraArgs, envOverrides = {}) {
+  const result = spawnSync(process.execPath, [DISPATCH_JS, fixture.repoRoot, ...extraArgs], {
+    cwd: fixture.repoRoot,
+    env: { ...fixture.env, ...envOverrides },
+    encoding: "utf-8",
+  });
+  let body = null;
+  if (result.stdout.trim()) body = JSON.parse(result.stdout);
+  return { ...result, body };
+}
+
+function dispatchArgs(fixture, runId) {
+  return [
+    "--run-id", runId,
+    "--branch", "issue-1016-marker-recovery",
+    "--prompt", "marker recovery fixture",
+    "--executor", "codex",
+    "--rubric-file", fixture.rubricPath,
+    "--publish-policy", "after-internal-review",
+    "--coordination-marker", "relay-orca: marker-test/outcome-a",
+    "--json",
+  ];
+}
+
+function assertNoOwningRun(fixture, runId) {
+  const runRoot = path.join(fixture.relayHome, "runs", getRepoSlug(fixture.repoRoot));
+  const manifestPath = path.join(runRoot, `${runId}.md`);
+  assert.equal(fs.existsSync(manifestPath), false, "provisional failure must leave no owning manifest");
+  const runDir = path.join(runRoot, runId);
+  assert.equal(fs.existsSync(runDir), false, "provisional failure must remove the run directory");
+  const worktrees = path.join(fixture.relayHome, "worktrees");
+  assert.equal(fs.existsSync(worktrees) ? fs.readdirSync(worktrees).length : 0, 0, "provisional failure must remove relay worktrees");
+}
+
+function readFixtureEvents(fixture, runId) {
+  const eventsPath = path.join(fixture.relayHome, "runs", getRepoSlug(fixture.repoRoot), runId, "events.jsonl");
+  return fs.readFileSync(eventsPath, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
+for (const [label, failureEnv] of [
+  ["worktree creation", { RELAY_TEST_FAIL_CREATE_WORKTREE: "1" }],
+  ["base-branch merge", { RELAY_TEST_FAIL_BASE_MERGE: "1" }],
+]) {
+  test(`marker ${label} failure rolls back provisional ownership and permits same-run retry`, () => {
+    const fixture = setupRepo();
+    const runId = `issue-1016-marker-${label === "worktree creation" ? "create" : "merge"}-20260720120000000-aabbccdd`;
+    try {
+      const failed = runDispatch(fixture, dispatchArgs(fixture, runId), failureEnv);
+      assert.notEqual(failed.status, 0, failed.stderr);
+      assert.equal(failed.body.recoverable, true, JSON.stringify(failed.body));
+      assertNoOwningRun(fixture, runId);
+
+      const retried = runDispatch(fixture, dispatchArgs(fixture, runId));
+      assert.equal(retried.status, 0, `${retried.stderr}\n${retried.stdout}`);
+      assert.equal(retried.body.runId, runId);
+      assert.equal(retried.body.runState, "internal_review_pending");
+      assert.equal(fs.existsSync(fixture.env.RELAY_TEST_EXECUTOR_MARKER), true, "retry may execute exactly once after setup recovery");
+    } finally {
+      fs.rmSync(fixture.base, { recursive: true, force: true });
+    }
+  });
+}
+
+test("final marker durability failure records an interrupted recovery event before executor spawn", () => {
+  const fixture = setupRepo();
+  const runId = "issue-1016-marker-final-20260720120000000-aabbccdd";
+  try {
+    const failed = runDispatch(fixture, dispatchArgs(fixture, runId), {
+      RELAY_TEST_FAIL_FINAL_COORDINATION_MARKER_VERIFY: "1",
+    });
+    assert.notEqual(failed.status, 0, failed.stderr);
+    assert.equal(failed.body.error_code, "coordination_marker_not_persisted");
+    assert.equal(failed.body.interruption_audit, "dispatch_interrupted");
+    assert.equal(fs.existsSync(fixture.env.RELAY_TEST_EXECUTOR_MARKER), false, "durability failure must precede executor spawn");
+
+    const manifestPath = path.join(fixture.relayHome, "runs", getRepoSlug(fixture.repoRoot), `${runId}.md`);
+    const manifest = readManifest(manifestPath).data;
+    assert.equal(manifest.state, "dispatched");
+    assert.equal(fs.existsSync(manifest.paths.worktree), true, "interrupted recovery retains the clean worktree");
+    const interrupted = readFixtureEvents(fixture, runId).at(-1);
+    assert.equal(interrupted.event, "dispatch_interrupted");
+    assert.equal(interrupted.reason, "coordination_marker_not_persisted_before_executor_spawn");
+    assert.equal(interrupted.state_from, "dispatched");
+    assert.equal(interrupted.state_to, "dispatched");
+    assert.equal(interrupted.coordination_marker, "relay-orca: marker-test/outcome-a");
+
+    const resumed = runDispatch(fixture, [
+      "--manifest", manifestPath,
+      "--prompt", "resume after marker durability recovery",
+      "--json",
+    ]);
+    assert.equal(resumed.status, 0, `${resumed.stderr}\n${resumed.stdout}`);
+    assert.equal(resumed.body.runState, "internal_review_pending");
+    assert.equal(fs.existsSync(fixture.env.RELAY_TEST_EXECUTOR_MARKER), true);
+  } finally {
+    fs.rmSync(fixture.base, { recursive: true, force: true });
+  }
+});

--- a/tests/relay-orca/scripts/marker.test.js
+++ b/tests/relay-orca/scripts/marker.test.js
@@ -1,0 +1,329 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const DISPATCH_JS = path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "dispatch.js");
+const ATTACH_MARKER_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "attach-marker.js");
+const STATUS_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "status.js");
+const RESUME_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "resume.js");
+
+const { COMMAND_FLAGS, FLAGS } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "cli-schema.js"));
+const { buildOperatorPrompt } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "operator-prompt.js"));
+const { programSegment } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "receipt-io.js"));
+const { createManifestSkeleton, writeManifest } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js"));
+const { getRepoSlug } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "paths.js"));
+const { serializeReceipt, RECEIPT_NOTE } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "receipt.js"));
+const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
+const { installFakeOrcaResume } = require(path.join(__dirname, "..", "fixtures", "fake-orca-resume.js"));
+const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
+const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+
+function initGitRepo(repoRoot) {
+  const git = (args) => execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf-8", stdio: "pipe" });
+  fs.mkdirSync(repoRoot, { recursive: true });
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.name", "marker-test"]);
+  git(["config", "user.email", "marker-test@example.com"]);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "marker fixture\n", "utf-8");
+  git(["add", "README.md"]);
+  git(["commit", "-m", "initial"]);
+}
+
+function shellRun(script, args, options = {}) {
+  const result = { status: 0, stdout: "", stderr: "" };
+  try {
+    result.stdout = execFileSync(process.execPath, [script, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+  } catch (error) {
+    result.status = error.status || 1;
+    result.stdout = error.stdout ? String(error.stdout) : "";
+    result.stderr = error.stderr ? String(error.stderr) : "";
+  }
+  result.body = result.stdout ? JSON.parse(result.stdout) : null;
+  return result;
+}
+
+function writeProgram(dir, programId = "repilot-marker") {
+  const program = {
+    id: programId,
+    exit_gates: ["all accepted outcomes complete"],
+    outcomes: [{
+      id: "outcome-a",
+      issue: 100,
+      task_kind: "relay_run",
+      accepted_outcomes: ["the issue is fixed"],
+    }],
+  };
+  const file = path.join(dir, "accepted-program.json");
+  fs.writeFileSync(file, `${JSON.stringify(program, null, 2)}\n`, "utf-8");
+  return { file, program };
+}
+
+function markerFor(programId, outcomeId = "outcome-a") {
+  return `relay-orca: ${programSegment(programId)}/${outcomeId}`;
+}
+
+function writeRun({ repoRoot, relayHome, runId = "issue-100-20260715120000000-aabbccdd", issue = 100, marker = null, state = "dispatched", prNumber = null }) {
+  const manifestPath = path.join(relayHome, "runs", getRepoSlug(repoRoot), `${runId}.md`);
+  const manifest = createManifestSkeleton({
+    repoRoot,
+    runId,
+    branch: "issue-100",
+    baseBranch: "main",
+    issueNumber: issue,
+    worktreePath: null,
+  });
+  const data = {
+    ...manifest,
+    state,
+    next_action: state === "merged" ? "none" : "await_dispatch_result",
+    paths: { ...manifest.paths, repo_root: repoRoot, worktree: null },
+    git: { ...manifest.git, pr_number: prNumber },
+    ...(marker ? { coordination: { marker } } : {}),
+  };
+  writeManifest(manifestPath, data);
+  return { manifestPath, runId, eventsPath: path.join(path.dirname(manifestPath), runId, "events.jsonl") };
+}
+
+function writeReceipt({ relayHome, repoRoot, programId, runId = null }) {
+  const slug = getRepoSlug(repoRoot);
+  const receiptPath = path.join(relayHome, "programs", slug, programSegment(programId), "receipt.json");
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true });
+  const receipt = {
+    schema: 1,
+    program_id: programId,
+    source: "/tmp/accepted-program.json",
+    repo: { slug, root: repoRoot },
+    runtime_id: DEFAULT_RUNTIME_ID,
+    tasks: [{
+      outcome_id: "outcome-a",
+      task_id: "orca-task-outcome-a",
+      kind: "relay_run",
+      wave: 1,
+      orca_task_id: "orca-live-outcome-a",
+      dispatch_id: "disp-orca-live-outcome-a",
+      assignee: "term-outcome-a",
+      relay_ids: { request: null, run: runId, fleet: null },
+    }],
+    terminals_created: [],
+    created_at: "2026-07-15T00:00:00.000Z",
+    updated_at: "2026-07-15T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+  fs.writeFileSync(receiptPath, serializeReceipt(receipt), "utf-8");
+  return receiptPath;
+}
+
+function fakeOrcaTask(programId, status = "dispatched") {
+  return {
+    id: "orca-live-outcome-a",
+    task_title: markerFor(programId),
+    display_name: markerFor(programId),
+    status,
+    worker_done: status === "completed",
+  };
+}
+
+function envFor({ relayHome, programsRoot, runsRoot, repoRoot, orcaPath, ghPath }) {
+  return {
+    ...process.env,
+    RELAY_HOME: relayHome,
+    RELAY_ORCA_PROGRAMS_ROOT: programsRoot || path.join(relayHome, "programs"),
+    RELAY_ORCA_RUNS_ROOT: runsRoot || path.join(relayHome, "runs"),
+    RELAY_ORCA_FLEETS_ROOT: path.join(relayHome, "fleets"),
+    ...(orcaPath ? { RELAY_ORCA_ORCA_BIN: orcaPath } : {}),
+    ...(ghPath ? { RELAY_ORCA_GH_BIN: ghPath } : {}),
+    TEST_REPO_ROOT: repoRoot,
+  };
+}
+
+test("marker CLI/schema and relay-orca operator contract are first-class and outcome-scoped", () => {
+  assert.ok(COMMAND_FLAGS.dispatch.includes("--coordination-marker"));
+  const definition = FLAGS.find((entry) => entry.flag === "--coordination-marker");
+  assert.deepEqual({ kind: definition.kind, mode: definition.mode }, { kind: "value", mode: "verbatim" });
+
+  const program = { id: "wave-program", outcomes: [] };
+  const prompts = ["outcome-a", "outcome-b"].map((outcomeId) => buildOperatorPrompt(
+    { outcome_id: outcomeId, kind: "relay_run", wave: 1, recommended_route: { operator: "relay", mode: "single_run", read_only: false }, expected_evidence: [] },
+    program,
+    { accepted_outcomes: ["done"] },
+    programSegment,
+  ));
+  assert.match(prompts[0], /--coordination-marker/);
+  assert.match(prompts[0], new RegExp(markerFor(program.id, "outcome-a").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(prompts[0], /fail closed|fail-closed/i);
+  assert.notEqual(prompts[0].match(/relay-orca: [^\n]+/)[0], prompts[1].match(/relay-orca: [^\n]+/)[0]);
+  for (const prompt of prompts) {
+    assert.doesNotMatch(prompt, /codex|claude|cursor|cline|opencode|gpt|glm/i);
+  }
+});
+
+test("dispatch persists the exact marker before fake executor spawn, preserves it on rewrite, and rejects unsafe values before worktree mutation", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-dispatch-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const binDir = path.join(base, "bin");
+  const observedPath = path.join(base, "executor-observed.txt");
+  const rubricPath = path.join(base, "rubric.yaml");
+  fs.mkdirSync(binDir, { recursive: true });
+  initGitRepo(repoRoot);
+  fs.writeFileSync(rubricPath, "rubric:\n  factors:\n    - name: marker\n      target: \">= 1/1\"\n", "utf-8");
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const cp = require("child_process");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { process.stdout.write("fake-codex\\n"); process.exit(0); }
+if (args[0] !== "exec") process.exit(2);
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+const root = process.env.RELAY_HOME;
+const manifests = [];
+for (const slug of fs.readdirSync(root + "/runs", { withFileTypes: true })) {
+  if (!slug.isDirectory()) continue;
+  for (const name of fs.readdirSync(root + "/runs/" + slug.name)) if (name.endsWith(".md")) manifests.push(fs.readFileSync(root + "/runs/" + slug.name + "/" + name, "utf8"));
+}
+fs.writeFileSync(process.env.RELAY_TEST_EXECUTOR_OBSERVED, manifests.join("\\n"), "utf8");
+fs.writeFileSync(cwd + "/executor.txt", "done\\n", "utf8");
+cp.execFileSync("git", ["-C", cwd, "add", "executor.txt"]);
+cp.execFileSync("git", ["-C", cwd, "commit", "-m", "executor"]);
+fs.writeFileSync(output, "done\\n", "utf8");
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  const marker = markerFor("dispatch-program");
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome, RELAY_TEST_EXECUTOR_OBSERVED: observedPath };
+  try {
+    const result = shellRun(DISPATCH_JS, [repoRoot, "--branch", "issue-100", "--prompt", "implement", "--executor", "codex", "--rubric-file", rubricPath, "--publish-policy", "after-internal-review", "--coordination-marker", marker, "--json"], { cwd: repoRoot, env });
+    assert.equal(result.status, 0, result.stderr);
+    const raw = fs.readFileSync(result.body.manifestPath, "utf-8");
+    assert.equal((raw.match(new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length, 1);
+    assert.match(fs.readFileSync(observedPath, "utf-8"), new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.equal(result.body.runState, "internal_review_pending");
+
+    const unsafe = shellRun(DISPATCH_JS, [repoRoot, "--branch", "issue-101", "--prompt", "implement", "--executor", "codex", "--rubric-file", rubricPath, "--coordination-marker", "unsafe\nmarker", "--json"], { cwd: repoRoot, env });
+    assert.notEqual(unsafe.status, 0);
+    assert.match(`${unsafe.stdout}\n${unsafe.stderr}`, /single-line|unsafe|marker/i);
+    const runFiles = fs.existsSync(path.join(relayHome, "runs")) ? fs.readdirSync(path.join(relayHome, "runs"), { recursive: true }) : [];
+    assert.equal(runFiles.some((entry) => String(entry).includes("issue-101")), false, "unsafe marker must fail before run/worktree mutation");
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("recovery is audited, idempotent, concurrent-safe, strict, and closes status -> existing map-relay-run", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-recovery-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const programsRoot = path.join(relayHome, "programs");
+  const runsRoot = path.join(relayHome, "runs");
+  fs.mkdirSync(repoRoot, { recursive: true });
+  initGitRepo(repoRoot);
+  const { file: programFile, program } = writeProgram(base);
+  const run = writeRun({ repoRoot, relayHome, state: "dispatched" });
+  const slug = getRepoSlug(repoRoot);
+  writeReceipt({ relayHome, repoRoot, programId: program.id, runId: null });
+  const statusOrca = installFakeOrcaStatus({ tasks: [fakeOrcaTask(program.id)] });
+  const statusGh = installFakeGh();
+  const env = envFor({ relayHome, programsRoot, runsRoot, repoRoot });
+  try {
+    const before = shellRun(STATUS_JS, ["--program-id", program.id, "--json", "--orca-bin", statusOrca.orcaPath, "--gh-bin", statusGh.ghPath, "--repo-root", repoRoot], { cwd: repoRoot, env });
+    assert.equal(before.status, 0, before.stderr);
+    assert.deepEqual(before.body.repair_candidates, []);
+
+    const failedProgram = path.join(base, "wrong-program.json");
+    fs.writeFileSync(failedProgram, JSON.stringify({ ...program, id: "wrong-program", outcomes: [{ ...program.outcomes[0], issue: 999 }] }), "utf-8");
+    const manifestBeforeFailure = fs.readFileSync(run.manifestPath, "utf-8");
+    const eventsPath = path.join(runsRoot, slug, run.runId, "events.jsonl");
+    const eventsBeforeFailure = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "";
+    const wrongOutcome = path.join(base, "wrong-outcome.json");
+    fs.writeFileSync(wrongOutcome, JSON.stringify({
+      ...program,
+      outcomes: [{ ...program.outcomes[0], id: "outcome-other" }],
+    }), "utf-8");
+    const wrongOutcomeResult = shellRun(ATTACH_MARKER_JS, ["--program-file", wrongOutcome, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.notEqual(wrongOutcomeResult.status, 0);
+    assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), manifestBeforeFailure);
+    assert.equal(fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "", eventsBeforeFailure);
+
+    const malformedProgram = path.join(base, "malformed-program.json");
+    fs.writeFileSync(malformedProgram, "{not-json\n", "utf-8");
+    const malformed = shellRun(ATTACH_MARKER_JS, ["--program-file", malformedProgram, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.notEqual(malformed.status, 0);
+    assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), manifestBeforeFailure);
+    assert.equal(fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "", eventsBeforeFailure);
+
+    const mismatch = shellRun(ATTACH_MARKER_JS, ["--program-file", failedProgram, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.notEqual(mismatch.status, 0);
+    assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), manifestBeforeFailure);
+    assert.equal(fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "", eventsBeforeFailure);
+
+    const attach = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.equal(attach.status, 0, attach.stderr);
+    assert.equal(attach.body.result, "attached");
+    assert.equal(JSON.parse(JSON.stringify(require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js")).readManifest(run.manifestPath).data)).coordination.marker, markerFor(program.id));
+    assert.match(fs.readFileSync(eventsPath, "utf-8"), /coordination_marker_attached/);
+    const receiptAfterAttach = fs.readFileSync(path.join(programsRoot, slug, programSegment(program.id), "receipt.json"), "utf-8");
+
+    const duplicate = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.equal(duplicate.status, 0, duplicate.stderr);
+    assert.equal(duplicate.body.result, "already_present");
+    assert.equal(fs.readFileSync(path.join(programsRoot, slug, programSegment(program.id), "receipt.json"), "utf-8"), receiptAfterAttach, "recovery never edits the relay-orca receipt");
+
+    const conflictProgram = path.join(base, "conflict-program.json");
+    fs.writeFileSync(conflictProgram, JSON.stringify({ ...program, id: "conflicting-program", outcomes: [{ ...program.outcomes[0] }] }), "utf-8");
+    const manifestBeforeConflict = fs.readFileSync(run.manifestPath, "utf-8");
+    const eventsBeforeConflict = fs.readFileSync(eventsPath, "utf-8");
+    const conflict = shellRun(ATTACH_MARKER_JS, ["--program-file", conflictProgram, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.notEqual(conflict.status, 0);
+    assert.equal(conflict.body.result, undefined);
+    assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), manifestBeforeConflict);
+    assert.equal(fs.readFileSync(eventsPath, "utf-8"), eventsBeforeConflict);
+
+    const concurrentRun = writeRun({ repoRoot, relayHome, runId: "issue-100-20260715120000001-aabbccdd", state: "dispatched" });
+    const concurrent = await Promise.all([1, 2].map(() => new Promise((resolve) => {
+      const child = spawn(process.execPath, [ATTACH_MARKER_JS, "--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", concurrentRun.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env, stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+    })));
+    assert.deepEqual(concurrent.map((entry) => entry.code), [0, 0]);
+    const concurrentEvents = fs.readFileSync(concurrentRun.eventsPath, "utf-8");
+    assert.equal((concurrentEvents.match(/coordination_marker_attached/g) || []).length, 1);
+
+    const after = shellRun(STATUS_JS, ["--program-id", program.id, "--json", "--orca-bin", statusOrca.orcaPath, "--gh-bin", statusGh.ghPath, "--repo-root", repoRoot], { cwd: repoRoot, env });
+    assert.equal(after.status, 0, after.stderr);
+    assert.ok(after.body.repair_candidates.some((entry) => entry.kind === "adopt_relay_run" && entry.proposal.includes(run.runId)));
+
+    const terminalManifest = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js")).readManifest(run.manifestPath);
+    writeManifest(run.manifestPath, { ...terminalManifest.data, state: "merged", git: { ...terminalManifest.data.git, pr_number: 10 } }, terminalManifest.body);
+    const terminalOrca = installFakeOrcaResume({ tasks: [fakeOrcaTask(program.id, "completed")] });
+    const terminalGh = installFakeGh({ prs: { 10: { state: "MERGED", mergedAt: "2026-07-15T00:00:00Z" } }, issues: { 100: { state: "CLOSED", stateReason: "COMPLETED" } } });
+    const resume = shellRun(RESUME_JS, ["--program-id", program.id, "--program-file", programFile, "--map-relay-run", `${program.outcomes[0].id}=${run.runId}`, "--orca-bin", terminalOrca.orcaPath, "--gh-bin", terminalGh.ghPath, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.equal(resume.status, 0, resume.stderr);
+    assert.equal(resume.body.ok, true);
+    const mappedReceipt = JSON.parse(receiptAfterAttach);
+    const receiptOnDisk = JSON.parse(fs.readFileSync(path.join(programsRoot, slug, programSegment(program.id), "receipt.json"), "utf-8"));
+    assert.equal(receiptOnDisk.tasks[0].relay_ids.run, run.runId);
+    assert.equal(receiptOnDisk.tasks[0].relay_ids.run, mappedReceipt.tasks[0].relay_ids.run || run.runId);
+    assert.equal(statusOrca.readPoison(), null);
+    assert.equal(statusGh.readPoison(), null);
+    assert.equal(terminalOrca.readPoison(), null);
+    assert.equal(terminalGh.readPoison(), null);
+  } finally {
+    statusOrca.cleanup();
+    statusGh.cleanup();
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/tests/relay-orca/scripts/marker.test.js
+++ b/tests/relay-orca/scripts/marker.test.js
@@ -15,6 +15,7 @@ const RESUME_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "resum
 
 const { COMMAND_FLAGS, FLAGS } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "cli-schema.js"));
 const { buildOperatorPrompt } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "operator-prompt.js"));
+const { shellQuote } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "coordination-marker.js"));
 const { programSegment } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "receipt-io.js"));
 const {
   createManifestSkeleton,
@@ -166,11 +167,26 @@ test("marker CLI/schema and relay-orca operator contract are first-class and out
   assert.match(prompts[0], /--coordination-marker/);
   assert.match(prompts[0], /\$\{RELAY_SKILL_ROOT:-skills\}\/relay-dispatch\/scripts\/dispatch\.js/);
   assert.match(prompts[0], new RegExp(markerFor(program.id, "outcome-a").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(prompts[0], new RegExp(`--coordination-marker ${shellQuote(markerFor(program.id, "outcome-a")).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.doesNotMatch(prompts[0], /--coordination-marker \"relay-orca:/);
   assert.match(prompts[0], /fail closed|fail-closed/i);
   assert.notEqual(prompts[0].match(/relay-orca: [^\n]+/)[0], prompts[1].match(/relay-orca: [^\n]+/)[0]);
   for (const prompt of prompts) {
     assert.doesNotMatch(prompt, /codex|claude|cursor|cline|opencode|gpt|glm/i);
   }
+});
+
+test("operator prompt shell-quotes marker values containing apostrophes", () => {
+  const program = { id: "shell-quote-program", outcomes: [] };
+  const outcomeId = "outcome-'a";
+  const prompt = buildOperatorPrompt(
+    { outcome_id: outcomeId, kind: "relay_run", wave: 1, recommended_route: { operator: "relay", mode: "single_run", read_only: false }, expected_evidence: [] },
+    program,
+    { accepted_outcomes: ["done"] },
+    programSegment,
+  );
+  const marker = markerFor(program.id, outcomeId);
+  assert.match(prompt, new RegExp(`--coordination-marker ${shellQuote(marker).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 });
 
 test("dispatch persists the exact marker before fake executor spawn, preserves it on rewrite, and rejects unsafe values before worktree mutation", () => {
@@ -397,6 +413,53 @@ fs.openSync = function(target, flags) {
     assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), beforeManifest);
     assert.equal(fs.existsSync(eventsPath), false);
     assert.equal(fs.existsSync(getManifestLockPath(run.manifestPath)), false, "transaction lock must be released after rollback");
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("attach-marker rollback preserves a symlinked events journal boundary", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-event-symlink-failure-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const runsRoot = path.join(relayHome, "override-runs");
+  initGitRepo(repoRoot);
+  const { file: programFile, program } = writeProgram(base, "event-symlink-program");
+  const run = writeRun({ repoRoot, relayHome, runsRoot });
+  const foreignDir = fs.mkdtempSync(path.join(base, "foreign-events-"));
+  const targetPath = path.join(foreignDir, "events.jsonl");
+  fs.writeFileSync(targetPath, "pre-existing journal\n", "utf-8");
+  fs.symlinkSync(targetPath, run.eventsPath);
+  const beforeManifest = fs.readFileSync(run.manifestPath, "utf-8");
+  const linkTarget = fs.readlinkSync(run.eventsPath);
+  const preloadPath = path.join(base, "fail-event-append-symlink.js");
+  fs.writeFileSync(preloadPath, `const fs = require("fs");
+const originalOpenSync = fs.openSync;
+fs.openSync = function(target, flags) {
+  if (String(target) === process.env.RELAY_TEST_MARKER_EVENTS_PATH && (Number(flags) & fs.constants.O_APPEND)) {
+    const error = new Error("injected coordination audit append failure");
+    error.code = "EIO";
+    throw error;
+  }
+  return originalOpenSync.apply(this, arguments);
+};
+`, "utf-8");
+  const env = {
+    ...process.env,
+    RELAY_HOME: relayHome,
+    RELAY_ORCA_RUNS_ROOT: runsRoot,
+    RELAY_TEST_MARKER_EVENTS_PATH: run.eventsPath,
+    NODE_OPTIONS: `--require ${preloadPath}`,
+  };
+  try {
+    const result = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.body.reason_code, "ATTACH_MARKER_PERSISTENCE_FAILED", `${result.stderr}\n${JSON.stringify(result.body)}`);
+    assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), beforeManifest);
+    assert.equal(fs.lstatSync(run.eventsPath).isSymbolicLink(), true);
+    assert.equal(fs.readlinkSync(run.eventsPath), linkTarget);
+    assert.equal(fs.readFileSync(targetPath, "utf-8"), "pre-existing journal\n");
+    assert.equal(fs.existsSync(getManifestLockPath(run.manifestPath)), false, "transaction lock must be released after symlink rollback");
   } finally {
     fs.rmSync(base, { recursive: true, force: true });
   }

--- a/tests/relay-orca/scripts/marker.test.js
+++ b/tests/relay-orca/scripts/marker.test.js
@@ -16,7 +16,11 @@ const RESUME_JS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "resum
 const { COMMAND_FLAGS, FLAGS } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "cli-schema.js"));
 const { buildOperatorPrompt } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "operator-prompt.js"));
 const { programSegment } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "receipt-io.js"));
-const { createManifestSkeleton, writeManifest } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js"));
+const {
+  createManifestSkeleton,
+  getManifestLockPath,
+  writeManifest,
+} = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js"));
 const { getRepoSlug } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "paths.js"));
 const { serializeReceipt, RECEIPT_NOTE } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "receipt.js"));
 const { installFakeOrcaStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca-status.js"));
@@ -73,8 +77,8 @@ function markerFor(programId, outcomeId = "outcome-a") {
   return `relay-orca: ${programSegment(programId)}/${outcomeId}`;
 }
 
-function writeRun({ repoRoot, relayHome, runId = "issue-100-20260715120000000-aabbccdd", issue = 100, marker = null, state = "dispatched", prNumber = null }) {
-  const manifestPath = path.join(relayHome, "runs", getRepoSlug(repoRoot), `${runId}.md`);
+function writeRun({ repoRoot, relayHome, runsRoot = path.join(relayHome, "runs"), runId = "issue-100-20260715120000000-aabbccdd", issue = 100, marker = null, state = "dispatched", prNumber = null }) {
+  const manifestPath = path.join(runsRoot, getRepoSlug(repoRoot), `${runId}.md`);
   const manifest = createManifestSkeleton({
     repoRoot,
     runId,
@@ -160,6 +164,7 @@ test("marker CLI/schema and relay-orca operator contract are first-class and out
     programSegment,
   ));
   assert.match(prompts[0], /--coordination-marker/);
+  assert.match(prompts[0], /\$\{RELAY_SKILL_ROOT:-skills\}\/relay-dispatch\/scripts\/dispatch\.js/);
   assert.match(prompts[0], new RegExp(markerFor(program.id, "outcome-a").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(prompts[0], /fail closed|fail-closed/i);
   assert.notEqual(prompts[0].match(/relay-orca: [^\n]+/)[0], prompts[1].match(/relay-orca: [^\n]+/)[0]);
@@ -203,6 +208,34 @@ fs.writeFileSync(output, "done\\n", "utf8");
   const marker = markerFor("dispatch-program");
   const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, RELAY_HOME: relayHome, RELAY_TEST_EXECUTOR_OBSERVED: observedPath };
   try {
+    const failedObservedPath = path.join(base, "executor-should-not-run.txt");
+    const renameFailurePreload = path.join(binDir, "fail-marker-manifest-write.js");
+    fs.writeFileSync(renameFailurePreload, `const fs = require("fs");
+const originalRenameSync = fs.renameSync;
+fs.renameSync = function(source, target) {
+  if (process.env.RELAY_TEST_FAIL_MARKER_MANIFEST_WRITE === "1" && String(target).endsWith(".md")) {
+    const error = new Error("injected marker manifest persistence failure");
+    error.code = "EIO";
+    throw error;
+  }
+  return originalRenameSync.apply(this, arguments);
+};
+`, "utf-8");
+    const failed = shellRun(DISPATCH_JS, [repoRoot, "--branch", "issue-102", "--prompt", "implement", "--executor", "codex", "--rubric-file", rubricPath, "--coordination-marker", marker, "--json"], {
+      cwd: repoRoot,
+      env: {
+        ...env,
+        RELAY_TEST_EXECUTOR_OBSERVED: failedObservedPath,
+        RELAY_TEST_FAIL_MARKER_MANIFEST_WRITE: "1",
+        NODE_OPTIONS: `--require ${renameFailurePreload}`,
+      },
+    });
+    assert.notEqual(failed.status, 0);
+    assert.match(`${failed.stdout}\n${failed.stderr}`, /before worktree creation|persistence failure/i);
+    const worktreesDir = path.join(relayHome, "worktrees");
+    assert.equal(fs.existsSync(worktreesDir) ? fs.readdirSync(worktreesDir).length : 0, 0, "marker persistence failure must create no worktree");
+    assert.equal(fs.existsSync(failedObservedPath), false, "marker persistence failure must not invoke the executor");
+
     const result = shellRun(DISPATCH_JS, [repoRoot, "--branch", "issue-100", "--prompt", "implement", "--executor", "codex", "--rubric-file", rubricPath, "--publish-policy", "after-internal-review", "--coordination-marker", marker, "--json"], { cwd: repoRoot, env });
     assert.equal(result.status, 0, result.stderr);
     const raw = fs.readFileSync(result.body.manifestPath, "utf-8");
@@ -225,11 +258,11 @@ test("recovery is audited, idempotent, concurrent-safe, strict, and closes statu
   const repoRoot = path.join(base, "repo");
   const relayHome = path.join(base, "relay");
   const programsRoot = path.join(relayHome, "programs");
-  const runsRoot = path.join(relayHome, "runs");
+  const runsRoot = path.join(relayHome, "recovery-runs");
   fs.mkdirSync(repoRoot, { recursive: true });
   initGitRepo(repoRoot);
   const { file: programFile, program } = writeProgram(base);
-  const run = writeRun({ repoRoot, relayHome, state: "dispatched" });
+  const run = writeRun({ repoRoot, relayHome, runsRoot, state: "dispatched" });
   const slug = getRepoSlug(repoRoot);
   writeReceipt({ relayHome, repoRoot, programId: program.id, runId: null });
   const statusOrca = installFakeOrcaStatus({ tasks: [fakeOrcaTask(program.id)] });
@@ -268,7 +301,7 @@ test("recovery is audited, idempotent, concurrent-safe, strict, and closes statu
     assert.equal(fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "", eventsBeforeFailure);
 
     const attach = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
-    assert.equal(attach.status, 0, attach.stderr);
+    assert.equal(attach.status, 0, `${attach.stderr}\n${JSON.stringify(attach.body)}`);
     assert.equal(attach.body.result, "attached");
     assert.equal(JSON.parse(JSON.stringify(require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js")).readManifest(run.manifestPath).data)).coordination.marker, markerFor(program.id));
     assert.match(fs.readFileSync(eventsPath, "utf-8"), /coordination_marker_attached/);
@@ -289,7 +322,7 @@ test("recovery is audited, idempotent, concurrent-safe, strict, and closes statu
     assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), manifestBeforeConflict);
     assert.equal(fs.readFileSync(eventsPath, "utf-8"), eventsBeforeConflict);
 
-    const concurrentRun = writeRun({ repoRoot, relayHome, runId: "issue-100-20260715120000001-aabbccdd", state: "dispatched" });
+    const concurrentRun = writeRun({ repoRoot, relayHome, runsRoot, runId: "issue-100-20260715120000001-aabbccdd", state: "dispatched" });
     const concurrent = await Promise.all([1, 2].map(() => new Promise((resolve) => {
       const child = spawn(process.execPath, [ATTACH_MARKER_JS, "--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", concurrentRun.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env, stdio: ["ignore", "pipe", "pipe"] });
       let stdout = "";
@@ -324,6 +357,117 @@ test("recovery is audited, idempotent, concurrent-safe, strict, and closes statu
   } finally {
     statusOrca.cleanup();
     statusGh.cleanup();
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("attach-marker rolls back the manifest when the coordination audit append fails", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-event-failure-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const runsRoot = path.join(relayHome, "override-runs");
+  initGitRepo(repoRoot);
+  const { file: programFile, program } = writeProgram(base, "event-failure-program");
+  const run = writeRun({ repoRoot, relayHome, runsRoot });
+  const eventsPath = run.eventsPath;
+  const preloadPath = path.join(base, "fail-event-append.js");
+  fs.writeFileSync(preloadPath, `const fs = require("fs");
+const originalOpenSync = fs.openSync;
+fs.openSync = function(target, flags) {
+  if (String(target) === process.env.RELAY_TEST_MARKER_EVENTS_PATH && (Number(flags) & fs.constants.O_APPEND)) {
+    const error = new Error("injected coordination audit append failure");
+    error.code = "EIO";
+    throw error;
+  }
+  return originalOpenSync.apply(this, arguments);
+};
+`, "utf-8");
+  const beforeManifest = fs.readFileSync(run.manifestPath, "utf-8");
+  const env = {
+    ...process.env,
+    RELAY_HOME: relayHome,
+    RELAY_ORCA_RUNS_ROOT: runsRoot,
+    RELAY_TEST_MARKER_EVENTS_PATH: eventsPath,
+    NODE_OPTIONS: `--require ${preloadPath}`,
+  };
+  try {
+    const result = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.body.reason_code, "ATTACH_MARKER_PERSISTENCE_FAILED", `${result.stderr}\n${JSON.stringify(result.body)}`);
+    assert.equal(fs.readFileSync(run.manifestPath, "utf-8"), beforeManifest);
+    assert.equal(fs.existsSync(eventsPath), false);
+    assert.equal(fs.existsSync(getManifestLockPath(run.manifestPath)), false, "transaction lock must be released after rollback");
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("attach-marker preserves a lifecycle writer's stale update through the shared manifest boundary", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-lifecycle-race-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const runsRoot = path.join(relayHome, "runs");
+  initGitRepo(repoRoot);
+  const { file: programFile, program } = writeProgram(base, "lifecycle-race-program");
+  const run = writeRun({ repoRoot, relayHome, runsRoot });
+  const readyPath = path.join(base, "writer-ready");
+  const releasePath = path.join(base, "writer-release");
+  const writerPath = path.join(base, "stale-writer.js");
+  const storePath = path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js");
+  fs.writeFileSync(writerPath, `const fs = require("fs");
+const { readManifest, writeManifest } = require(${JSON.stringify(storePath)});
+const manifestPath = process.argv[2];
+const readyPath = process.argv[3];
+const releasePath = process.argv[4];
+const stale = readManifest(manifestPath);
+fs.writeFileSync(readyPath, "ready");
+while (!fs.existsSync(releasePath)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+writeManifest(manifestPath, { ...stale.data, state: "review_pending", next_action: "run_review" }, stale.body);
+`, "utf-8");
+  const writer = spawn(process.execPath, [writerPath, run.manifestPath, readyPath, releasePath], { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] });
+  try {
+    const readyDeadline = Date.now() + 5000;
+    while (!fs.existsSync(readyPath) && Date.now() < readyDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(fs.existsSync(readyPath), true, "lifecycle writer must read before attach-marker starts");
+    const env = { ...process.env, RELAY_HOME: relayHome, RELAY_ORCA_RUNS_ROOT: runsRoot };
+    const attached = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], { cwd: repoRoot, env });
+    assert.equal(attached.status, 0, `${attached.stderr}\n${JSON.stringify(attached.body)}`);
+    fs.writeFileSync(releasePath, "release");
+    await new Promise((resolve) => writer.once("close", resolve));
+    const persisted = require(storePath).readManifest(run.manifestPath).data;
+    assert.equal(persisted.state, "review_pending");
+    assert.equal(persisted.coordination.marker, `relay-orca: ${programSegment(program.id)}/outcome-a`);
+  } finally {
+    if (!fs.existsSync(releasePath)) fs.writeFileSync(releasePath, "release");
+    if (writer.exitCode === null) await new Promise((resolve) => writer.once("close", resolve));
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("attach-marker automatically recovers a dead abandoned manifest lock", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-abandoned-lock-"));
+  const repoRoot = path.join(base, "repo");
+  const relayHome = path.join(base, "relay");
+  const runsRoot = path.join(relayHome, "runs");
+  initGitRepo(repoRoot);
+  const { file: programFile } = writeProgram(base, "abandoned-lock-program");
+  const run = writeRun({ repoRoot, relayHome, runsRoot });
+  const lockPath = getManifestLockPath(run.manifestPath);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: 99999999, host: os.hostname(), token: "dead", acquired_at: "2000-01-01T00:00:00.000Z" }), "utf-8");
+  const old = new Date(Date.now() - 60_000);
+  fs.utimesSync(lockPath, old, old);
+  try {
+    const result = shellRun(ATTACH_MARKER_JS, ["--program-file", programFile, "--outcome-id", "outcome-a", "--run-id", run.runId, "--repo-root", repoRoot, "--json"], {
+      cwd: repoRoot,
+      env: { ...process.env, RELAY_HOME: relayHome, RELAY_ORCA_RUNS_ROOT: runsRoot, RELAY_MANIFEST_LOCK_STALE_MS: "1" },
+    });
+    assert.equal(result.status, 0, `${result.stderr}\n${JSON.stringify(result.body)}`);
+    assert.equal(result.body.result, "attached");
+    assert.equal(fs.existsSync(lockPath), false);
+  } finally {
     fs.rmSync(base, { recursive: true, force: true });
   }
 });

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -13,6 +13,8 @@ const {
   updateManifestState,
   writeManifest,
   readManifest,
+  acquireManifestLock,
+  releaseManifestLock,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
 const { buildDefaultRelayPolicy } = require("../../../skills/relay-dispatch/scripts/relay-policy");
 const { appendRunEvent, EVENTS, readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
@@ -24,6 +26,7 @@ const { EXECUTION_EVIDENCE_FILENAME } = require("../../../skills/relay-review/sc
 const {
   executeAdvisoryRequest,
   finishAdvisoryReview,
+  startAdvisoryReview,
   buildAdvisoryAdapterEnv,
   writeJson: writeAdvisoryJson,
 } = require("../../../skills/relay-review/scripts/review-runner/advisory");
@@ -599,6 +602,19 @@ function waitForEvent(repoRoot, runId, predicate, { timeoutMs = 2000 } = {}) {
   return null;
 }
 
+function waitForFileText(filePath, expectedText, { timeoutMs = 2000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (fs.readFileSync(filePath, "utf-8").includes(expectedText)) return true;
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+  }
+  return false;
+}
+
 test("executeAdvisoryRequest forwards advisory profile to reviewer argv", () => {
   const { logPath, result } = executeProfileRequest({
     profile: "adversarial",
@@ -608,6 +624,116 @@ test("executeAdvisoryRequest forwards advisory profile to reviewer argv", () => 
   const args = JSON.parse(fs.readFileSync(logPath, "utf-8"));
   assert.equal(result.status, "success");
   assert.deepEqual(args.slice(args.indexOf("--profile"), args.indexOf("--profile") + 2), ["--profile", "adversarial"]);
+});
+
+test("advisory worker does not publish success while its audit event waits on the shared manifest lock", async () => {
+  const { repoRoot, manifestPath, runDir, runId } = setupRepo();
+  const manifest = readManifest(manifestPath).data;
+  const logPath = path.join(runDir, "blocked-advisory-writer.log");
+  const reviewerScript = writeFakeOpencode(repoRoot, { logPath });
+  const lock = acquireManifestLock(manifestPath);
+  let advisoryRun;
+
+  try {
+    advisoryRun = startAdvisoryReview({
+      headSha: manifest.git.head_sha,
+      laneIndex: 1,
+      profile: "blindspot",
+      promptText: "Wait for the audit event before publishing the result.",
+      reviewerModel: "example/opencode-model-fast",
+      reviewerName: "opencode",
+      reviewerScript,
+      reviewRepoPath: repoRoot,
+      round: 1,
+      runDir,
+      runId,
+      runRepoPath: repoRoot,
+      state: STATES.REVIEW_PENDING,
+      timeoutSeconds: 5,
+      trigger: "every_round",
+    });
+
+    assert.equal(waitForFileText(logPath, "advisory-end", { timeoutMs: 3000 }), true);
+    // The old writer publishes resultPath before trying to acquire this lock.
+    // Give it time to reach the blocked append, then exercise the real reader.
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+    const consumedBeforeEvent = await finishAdvisoryReview({
+      advisoryRun,
+      waitMs: 0,
+    });
+    assert.equal(consumedBeforeEvent.status, "deferred");
+    assert.equal(
+      readRunEvents(repoRoot, runId).some((record) => record.event === EVENTS.ADVISORY_REVIEW),
+      false,
+    );
+  } finally {
+    releaseManifestLock(lock);
+  }
+
+  const event = waitForEvent(
+    repoRoot,
+    runId,
+    (record) => record.event === EVENTS.ADVISORY_REVIEW,
+    { timeoutMs: 5000 },
+  );
+  assert.ok(event);
+  assert.equal(event.status, "success");
+  assert.equal(waitForFileText(advisoryRun.resultPath, '"status": "success"', { timeoutMs: 2000 }), true);
+  assert.equal(JSON.parse(fs.readFileSync(advisoryRun.resultPath, "utf-8")).status, "success");
+  assert.equal(fs.existsSync(advisoryRun.laneLeasePath), false);
+});
+
+test("executeAdvisoryRequest publishes a failed result when the advisory event append fails", () => {
+  const { repoRoot, manifestPath, runDir, runId } = setupRepo();
+  const promptPath = path.join(runDir, "event-failure-prompt.md");
+  const resultPath = path.join(runDir, "event-failure-result.json");
+  const reviewerScript = writeFakeOpencode(repoRoot);
+  fs.writeFileSync(promptPath, "Advisory prompt\n", "utf-8");
+  const lock = acquireManifestLock(manifestPath);
+  const previousTimeout = process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS;
+  const previousStale = process.env.RELAY_MANIFEST_LOCK_STALE_MS;
+  let result;
+
+  process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS = "50";
+  process.env.RELAY_MANIFEST_LOCK_STALE_MS = "10000";
+  try {
+    result = executeAdvisoryRequest({
+      artifactReviewerName: "opencode",
+      decisionPath: path.join(runDir, "event-failure-decision.json"),
+      headSha: readManifest(manifestPath).data.git.head_sha,
+      laneIndex: 1,
+      profile: "blindspot",
+      promptPath,
+      requestPath: path.join(runDir, "event-failure-request.json"),
+      resultPath,
+      reviewerModel: "example/opencode-model-fast",
+      reviewerName: "opencode",
+      reviewerPolicy: null,
+      policyDecision: null,
+      modelResolution: null,
+      reviewerScript,
+      reviewRepoPath: repoRoot,
+      round: 1,
+      runDir,
+      runId,
+      runRepoPath: repoRoot,
+      startedAt: Date.now(),
+      state: STATES.REVIEW_PENDING,
+      timeoutSeconds: 5,
+      trigger: "every_round",
+    });
+  } finally {
+    releaseManifestLock(lock);
+    if (previousTimeout === undefined) delete process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS;
+    else process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS = previousTimeout;
+    if (previousStale === undefined) delete process.env.RELAY_MANIFEST_LOCK_STALE_MS;
+    else process.env.RELAY_MANIFEST_LOCK_STALE_MS = previousStale;
+  }
+
+  assert.equal(result.status, "failed");
+  assert.match(result.failureReason, /advisory event write failed/);
+  assert.equal(JSON.parse(fs.readFileSync(resultPath, "utf-8")).status, "failed");
+  assert.equal(readRunEvents(repoRoot, runId).some((record) => record.event === EVENTS.ADVISORY_REVIEW), false);
 });
 
 test("executeAdvisoryRequest omits profile argv when request has no profile", () => {


### PR DESCRIPTION
## Summary

- Add a first-class generic `coordination.marker` surface to relay manifests.
- Add the verbatim `dispatch --coordination-marker <marker>` option, with pre-worktree validation and a raw-manifest durability check before executor spawn.
- Make relay-orca `relay_run` prompts carry the exact outcome-scoped marker and authoritative dispatch CLI shape, failing closed when marker persistence is unavailable.
- Add supervised `relay-orca/scripts/attach-marker.js` recovery with accepted-program/outcome/issue validation, atomic manifest writing, per-run locking, fresh reads, idempotent results, and an auditable event.
- Keep receipts, Orca/GitHub state, dispatch replay, implicit adoption, and `resume --map-relay-run` validation unchanged.

## Acceptance evidence

- Dispatch persistence and compatibility: `tests/relay-orca/scripts/marker.test.js` verifies exact raw marker persistence before a fake executor observes the manifest, durability across a rewrite, unsafe-value rejection before run/worktree mutation, distinct wave-1 markers, and absence of engine/model names from prompts.
- Recovery safety: the same fixture verifies issue mismatch, wrong outcome, malformed program, conflicting marker, duplicate recovery, and concurrent callers without manifest/event mutation on rejection or duplicate event emission.
- Discovery-to-mapping: the fixture proves an initially unmarked issue-matching run is not discoverable, `attach-marker` enables the `status` `adopt_relay_run` candidate, and the existing terminal-evidence-backed `resume --map-relay-run` path accepts the run and persists only the existing receipt mapping.
- Documentation/schema: dispatch help, CLI schema, architecture, relay-orca commands, install/operator, and recovery references document copy-pasteable shapes and non-goals.

## Verification

```text
node --test tests/relay-orca/scripts/marker.test.js
3 passed, 0 failed

node --check skills/relay-dispatch/scripts/dispatch.js && node --check skills/relay-orca/scripts/attach-marker.js && node --check skills/relay-orca/scripts/run.js && node --check skills/relay-orca/scripts/lib/operator-prompt.js
exit 0

git diff --check
exit 0

node --test tests/relay-dispatch/scripts/cli-schema.test.js tests/relay-dispatch/scripts/dispatch.test.js tests/relay-orca/scripts/run.test.js tests/relay-orca/scripts/status.test.js tests/relay-orca/scripts/resume.test.js tests/relay-orca/scripts/*marker*.test.js
446 passed, 1 failed (447 total)
The sole failure is the existing unrelated `dispatch completes normally when clean leader exit leaves a lingering process-group member` assertion at `tests/relay-dispatch/scripts/dispatch.test.js:5801`; it reproduced in the full command and in the isolated command below with marker flags absent.

node --test --test-name-pattern="clean leader exit leaves a lingering process-group member" tests/relay-dispatch/scripts/dispatch.test.js
0 passed, 1 failed
```

The focused marker suite and all marker-related paths pass; the coordinator owns the merged-main full gate.

Fixes #1016


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 릴레이 실행에 `--coordination-marker`를 추가해 실행 간 상관관계를 안전하게 보존합니다.
  - 마커가 누락된 경우 `attach-marker`로 감독(supervised) 방식 복구를 수행하고, 복구/부착 관련 감사 이벤트를 기록합니다.
- **오류 개선**
  - 마커 형식·지속성·저장 충돌을 실행 전 감지해 조기 중단합니다.
  - 동시 실행 및 반복 복구를 멱등/안전하게 처리합니다.
- **문서**
  - 마커 사용과 복구(제약 포함) 절차를 확장해 안내합니다.
- **테스트**
  - 마커 E2E 흐름과 롤백/동시성 케이스를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->