### PR TITLE
fix(relay-review): bind standard gating advisory audit events

### DIFF
--- a/backlog/sprints/2026-07-route-config-simplification.md
+++ b/backlog/sprints/2026-07-route-config-simplification.md
@@ -25,7 +25,7 @@ Route selection is one user-facing concept: a single routes.json schema drives d
 
 ### Batch 3 — stability rebaseline before more broad relay-config work
 
-- [~] #816 parallel full-suite / relay-fleet condition-wait rebaseline — Linux fleet solo 89/89; explicit parallel full suite reproduced an adjacent standard-gating advisory audit race, fixed without changing fleet waits or command shape; PR pending.
+- [x] #816 parallel full-suite / relay-fleet condition-wait rebaseline — Linux fleet solo 89/89; no fleet failure reproduced, so closed with evidence and no fleet wait or command-shape change. Adjacent advisory audit race split to #1039 → PR #1038 (reviewing).
 
 ### Batch 4 — self-audit (Phase C, now unblocked)
 
@@ -68,6 +68,7 @@ Route selection is one user-facing concept: a single routes.json schema drives d
 - The current CI globs without `--test-concurrency=1` reproduced no fleet wait failure. It exposed the tracked advisory-family race instead: the standard gating lane had already demoted the verdict while `ADVISORY_REVIEW` was still absent.
 - Added a deterministic RED→GREEN regression and reused the existing event-binding wait for decision-changing gating successes. Hardened behavior remains unchanged; standard non-gating paths remain lightweight.
 - Final Linux evidence: advisory file 81/81; explicit parallel full suite 2,555 tests, 2,553 passed, 0 failed, 2 skipped; fixture processes 0 before/after. Independent code review PASS with no findings.
+- Closed #816 on rebaseline evidence. Registered the distinct advisory defect as #1039 and kept its implementation/review lifecycle in PR #1038.
 
 ### 2026-07-08 (replanned after #825/#826/#815/#819 landed)
 - Refreshed the open follow-up set against current main and GitHub state: #825/#820-#824 closed by PR #831, #826/#827-#830 closed by PR #832, #819 closed by PR #835, and #815 closed by PR #836. The remaining sprint work should not rebuild those surfaces.

--- a/backlog/sprints/2026-07-route-config-simplification.md
+++ b/backlog/sprints/2026-07-route-config-simplification.md
@@ -25,7 +25,7 @@ Route selection is one user-facing concept: a single routes.json schema drives d
 
 ### Batch 3 — stability rebaseline before more broad relay-config work
 
-- [ ] #816 parallel full-suite / relay-fleet condition-wait rebaseline — S/M; run current-main evidence after #815/#819 fixes. If no longer reproducible, close with evidence. If still reproducible, make the smallest wait-window or command-shape fix with pgrep evidence.
+- [~] #816 parallel full-suite / relay-fleet condition-wait rebaseline — Linux fleet solo 89/89; explicit parallel full suite reproduced an adjacent standard-gating advisory audit race, fixed without changing fleet waits or command shape; PR pending.
 
 ### Batch 4 — self-audit (Phase C, now unblocked)
 
@@ -62,6 +62,12 @@ Route selection is one user-facing concept: a single routes.json schema drives d
 - Phase D (relay-plan route recommendation + fleet per-leaf fill) is NOT in this sprint — observe-gated on ≥~10 non-default-route runs over ~4 weeks after A–C ship.
 
 ## Progress
+
+### 2026-07-19 (#816 rebaseline and narrow audit fix)
+- Rebaselined `edcff70` in a clean WSL2 Linux ext4 clone with Node v22.22.3. Relay-fleet solo passed 89/89 with no fixture processes before or after.
+- The current CI globs without `--test-concurrency=1` reproduced no fleet wait failure. It exposed the tracked advisory-family race instead: the standard gating lane had already demoted the verdict while `ADVISORY_REVIEW` was still absent.
+- Added a deterministic RED→GREEN regression and reused the existing event-binding wait for decision-changing gating successes. Hardened behavior remains unchanged; standard non-gating paths remain lightweight.
+- Final Linux evidence: advisory file 81/81; explicit parallel full suite 2,555 tests, 2,553 passed, 0 failed, 2 skipped; fixture processes 0 before/after. Independent code review PASS with no findings.
 
 ### 2026-07-08 (replanned after #825/#826/#815/#819 landed)
 - Refreshed the open follow-up set against current main and GitHub state: #825/#820-#824 closed by PR #831, #826/#827-#830 closed by PR #832, #819 closed by PR #835, and #815 closed by PR #836. The remaining sprint work should not rebuild those surfaces.

--- a/backlog/tasks/RELAY-816 - parallel-full-suite-relay-fleet-condition-wait-rebaseline.md
+++ b/backlog/tasks/RELAY-816 - parallel-full-suite-relay-fleet-condition-wait-rebaseline.md
@@ -1,7 +1,7 @@
 ---
 id: RELAY-816
 title: 'Full-suite node --test file concurrency flakes relay-fleet condition waits'
-status: In Progress
+status: Done
 labels:
   - bug
   - workflow

--- a/backlog/tasks/RELAY-816 - parallel-full-suite-relay-fleet-condition-wait-rebaseline.md
+++ b/backlog/tasks/RELAY-816 - parallel-full-suite-relay-fleet-condition-wait-rebaseline.md
@@ -1,7 +1,7 @@
 ---
 id: RELAY-816
 title: 'Full-suite node --test file concurrency flakes relay-fleet condition waits'
-status: To Do
+status: In Progress
 labels:
   - bug
   - workflow
@@ -15,8 +15,8 @@ After #819 and #815, rebaseline the parallel full-suite flake report. If current
 
 ## Acceptance Criteria
 
-- [ ] Rebaseline current `main`: relay-fleet solo and at least one canonical parallel full-suite attempt, with fixture-process pgrep before/after.
-- [ ] If no failure reproduces, comment evidence and close without code changes.
-- [ ] Any widened wait window has a short deflake justification.
-- [ ] Document command shape only if it changes.
-- [ ] Final evidence confirms no `relay-codex` / `relay-final-gate` / `relay-child` fixture processes survive.
+- [x] Rebaseline current `main`: relay-fleet solo and at least one canonical parallel full-suite attempt, with fixture-process pgrep before/after.
+- [x] If no failure reproduces, comment evidence and close without code changes. (N/A: fleet waits did not reproduce, but the same parallel run reproduced the tracked advisory audit race.)
+- [x] Any widened wait window has a short deflake justification. (N/A: no fleet/advisory timeout was widened.)
+- [x] Document command shape only if it changes. (No command-shape change.)
+- [x] Final evidence confirms no `relay-codex` / `relay-final-gate` / `relay-child` fixture processes survive.

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -429,7 +429,7 @@ async function settleOneAdvisoryForVerdict({ advisoryRun, config, currentState, 
       phaseDecisionWaited: criticalPathWaitMs > 0,
     };
   }
-  if (hardenedAssurance && advisoryResult?.status === "success") {
+  if ((hardenedAssurance || advisoryRun.gating) && advisoryResult?.status === "success") {
     advisoryResult = await finishAdvisoryReview({
       advisoryRun,
       consumedByPhase: "review",

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -429,6 +429,7 @@ async function settleOneAdvisoryForVerdict({ advisoryRun, config, currentState, 
       phaseDecisionWaited: criticalPathWaitMs > 0,
     };
   }
+  // Gating success can change the verdict, so do not expose it before its audit event is durable.
   if ((hardenedAssurance || advisoryRun.gating) && advisoryResult?.status === "success") {
     advisoryResult = await finishAdvisoryReview({
       advisoryRun,

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -29,6 +29,7 @@ const {
 } = require("../../../skills/relay-review/scripts/review-runner/advisory");
 const { reapTimeoutAdvisoryLane } = require("../../../skills/relay-review/scripts/review-runner/advisory-lane-reap");
 const { buildAdvisoryPrompt } = require("../../../skills/relay-review/scripts/review-runner/advisory-prompt");
+const { settleAdvisoryForVerdict } = require("../../../skills/relay-review/scripts/review-runner/advisory-orchestration");
 const { applyReviewAssurancePolicy } = require("../../../skills/relay-review/scripts/review-runner/assurance");
 const { installFakeGhOnPath } = require("../fixtures/fake-gh");
 
@@ -2246,6 +2247,99 @@ test("standard review applies the primary verdict when advisory times out during
   assert.match(result.advisoryReview.failureReason, /reviewer advisory_review timed out after 1s/);
   assert.equal(event.status, "timeout");
   assert.equal(event.consumed_by_phase, "review");
+});
+
+test("standard gating advisory waits for its audit event before returning decision-changing success", async () => {
+  const { repoRoot, manifestPath, runDir, runId } = setupRepo();
+  const manifest = readManifest(manifestPath).data;
+  const artifactPath = path.join(runDir, "review-round-1-advisory-opencode.json");
+  const resultPath = path.join(runDir, "review-round-1-advisory-opencode-result.json");
+  const decisionPath = path.join(runDir, "review-round-1-advisory-opencode-decision.json");
+  fs.writeFileSync(artifactPath, `${JSON.stringify({
+    profile: "blindspot",
+    summary: "One required finding.",
+    required_findings: [{
+      title: "Decision-changing advisory finding",
+      body: "The gating lane must leave durable audit provenance.",
+      file: "README.md",
+      line: 1,
+      severity: "P1",
+      category: "correctness",
+      confidence: 0.95,
+    }],
+    advisory_findings: [],
+    duplicate_or_low_confidence: [],
+  }, null, 2)}\n`, "utf-8");
+  const result = {
+    artifactHash: hashFile(artifactPath),
+    artifactPath,
+    advisory_count: 0,
+    duplicate_low_confidence_count: 0,
+    failureReason: null,
+    gating: true,
+    lane_index: 1,
+    model: "example/opencode-model-fast",
+    profile: "blindspot",
+    rawResponsePath: null,
+    required_count: 1,
+    reviewer: "opencode",
+    status: "success",
+    trigger: "on_pass",
+  };
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf-8");
+
+  setTimeout(() => {
+    appendRunEvent(repoRoot, runId, {
+      event: EVENTS.ADVISORY_REVIEW,
+      state_from: STATES.REVIEW_PENDING,
+      state_to: STATES.REVIEW_PENDING,
+      head_sha: manifest.git.head_sha,
+      round: 1,
+      lane_index: 1,
+      reviewer: "opencode",
+      model: "example/opencode-model-fast",
+      profile: "blindspot",
+      trigger: "on_pass",
+      gating: true,
+      status: "success",
+      artifact_path: artifactPath,
+      advisory_artifact_hash: result.artifactHash,
+      raw_response_path: null,
+      failure_reason: null,
+      required_count: 1,
+      advisory_count: 0,
+      duplicate_low_confidence_count: 0,
+    });
+  }, 75);
+
+  const settled = await settleAdvisoryForVerdict({
+    advisoryRun: {
+      decisionPath,
+      gating: true,
+      headSha: manifest.git.head_sha,
+      laneIndex: 1,
+      profile: "blindspot",
+      resultPath,
+      reviewerModel: "example/opencode-model-fast",
+      reviewerName: "opencode",
+      round: 1,
+      runId,
+      runRepoPath: repoRoot,
+      startedAt: Date.now(),
+      trigger: "on_pass",
+    },
+    config: { graceSeconds: 1, timeoutSeconds: 1 },
+    currentState: STATES.REVIEW_PENDING,
+    hardenedAssurance: false,
+    verdict: passVerdict(),
+  });
+
+  assert.equal(settled.advisoryResult.status, "success");
+  assert.equal(
+    readRunEvents(repoRoot, runId).filter((event) => event.event === EVENTS.ADVISORY_REVIEW).length,
+    1,
+    "decision-changing gating success returned before its advisory audit event was durable"
+  );
 });
 
 test("hardened advisory finish does not expose success before event provenance is written", async () => {


### PR DESCRIPTION
## Outcome

Rebaseline #816 against current `main` without widening relay-fleet waits or changing the CI command shape.

- Relay-fleet solo passed 89/89 on clean WSL2 Linux ext4; no fixture process survived.
- The explicit default-parallel full suite did not reproduce the reported fleet wait failure.
- That run did expose an adjacent, tracked advisory-family race: a standard gating advisory could change the verdict before its `ADVISORY_REVIEW` audit event was durable.
- Standard gating success now reuses the existing event-binding settlement path. Hardened behavior is unchanged, and standard non-gating lanes remain lightweight.

## Root cause

The advisory worker writes a successful result before appending the audit event. Standard gating settlement consumed that result immediately because event binding was previously required only for hardened assurance.

## Verification

- Deterministic regression: RED before the fix, GREEN after it.
- Focused regression: 1/1 passed.
- Advisory test file on Linux: 81/81 passed.
- Explicit default-parallel Linux suite: 2,555 tests; 2,553 passed; 0 failed; 2 skipped.
- Relay-fleet solo on Linux: 89/89 passed.
- Fixture-process check: 0 before and after.
- Independent review: PASS; no Critical, Important, or Minor findings.
- `git diff --check`: clean.
- Backlog component lint: 14/14 sprint files checked, no issues.

Closes #816


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 표준 게이팅 검토 결과가 관련 감사 이벤트의 영구 기록이 완료된 후에만 성공으로 확정되도록 안정성을 개선했습니다.
  * 병렬 전체 테스트 환경에서 발생하던 감사 이벤트 경합을 재현·검증하고, 정상 실행 흐름을 유지했습니다.

* **문서**
  * 릴리스 계획과 작업 상태를 최신 검증 결과로 갱신했습니다.
  * 병렬 테스트, 감사 검증, 잔여 프로세스 확인 결과를 구체적인 수치와 함께 기록했습니다.

* **테스트**
  * 지연된 이벤트 기록 상황에서도 결정 변경 결과가 올바르게 처리되는 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->