### PR TITLE
feat(relay-orca): enforce single-owner integration lifecycle

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -90,10 +90,12 @@ Dispatch provenance-injected operators for an accepted program (admission-gated;
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
   --program-file /tmp/accepted-program.json \
   --operator-handle term-a --operator-handle term-b \
+  --coordinator-handle coord-current \
+  --gate-evidence-dir /tmp/relay-orca-integration-gates \
   --json
 ```
 
-`run` compiles through the frozen plan library, requires probe admission before any mutation, materializes wave-1 tasks, and dispatches with fail-closed provenance verification. `run` also persists a minimal, versioned, atomically-written **receipt** (identity/mapping only) under `~/.relay/programs/<repo-slug>/<program-id>/`. Flags, run report shape, partial-wave semantics, and reason codes 40–44: [references/commands.md](references/commands.md) and [references/operator-dispatch.md](references/operator-dispatch.md).
+`run` compiles through the frozen plan library, requires probe admission before any mutation, materializes wave-1 tasks, and dispatches with fail-closed provenance verification. An `integration_gate` additionally requires the explicit current `--coordinator-handle` and prepares its coordinator-owned canonical gate before the read-only operator prompt. `--gate-evidence-dir` gives the operator a deterministic evidence path. `run` also persists a minimal, versioned, atomically-written **receipt** (identity/mapping only) under `~/.relay/programs/<repo-slug>/<program-id>/`. Flags, run report shape, partial-wave semantics, and reason codes 40–45: [references/commands.md](references/commands.md) and [references/operator-dispatch.md](references/operator-dispatch.md).
 
 Derive a read-only live program view from the receipt + relay manifests + GitHub + Orca (no mutation of any kind):
 
@@ -121,10 +123,12 @@ Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fa
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
   --program-id epic-941 \
+  --coordinator-handle coord-current \
+  --gate-evidence-dir /tmp/relay-orca-integration-gates \
   --json
 ```
 
-`resume` loads the receipt, runs the SAME reconciliation as `status` **before any mutation**, reuses valid mappings, reacquires lost operator terminals, and re-dispatches ONLY outcomes whose Orca dispatch is verifiably absent AND whose relay side is clean — through the verified path. It never resets Orca, deletes a task/worktree/branch/PR, or force-closes a relay run. Running it twice is idempotent. Fail-closed decision codes 60–63 and recovery steps: [references/commands.md](references/commands.md) and [references/recovery.md](references/recovery.md).
+`resume` loads the receipt, runs the SAME reconciliation as `status` **before any mutation**, reuses valid mappings, reacquires lost operator terminals, and re-dispatches ONLY outcomes whose Orca dispatch is verifiably absent AND whose relay side is clean — through the verified path. For integration tasks it re-generates all coordinator/dispatch/assignee/report provenance from fresh reads, adopts or resolves only the canonical gate, sends a fresh explicit `worker_done` instruction after resolution, and requires a task-list re-read of `completed`; it never retries or falls back to `task-update`. It never resets Orca, deletes a task/worktree/branch/PR, or force-closes a relay run. Running it twice is idempotent. Fail-closed decision codes 60–63 and recovery steps: [references/commands.md](references/commands.md) and [references/recovery.md](references/recovery.md).
 
 Coordinator-only stop (records a bounded stop record; never cancels outcomes):
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -104,7 +104,8 @@ shortens the budget for tests.
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
   --program-file <accepted-program.json> [--json] [--concurrency N] \
-  [--operator-handle <handle> ...] [--orca-bin <path>]
+  [--operator-handle <handle> ...] [--coordinator-handle <handle>] \
+  [--gate-evidence-dir <dir>] [--orca-bin <path>]
 ```
 
 | Flag | Meaning |
@@ -113,6 +114,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
 | `--json` | Emit the machine-readable run report as JSON on stdout. |
 | `--concurrency N` | Override the concurrency ceiling. Default 2, hard maximum 4 (rejected via the plan library). |
 | `--operator-handle <handle>` | Repeatable. An explicit operator terminal handle to dispatch to — REQUIRED. `run` dispatches ONLY to handles provided here and never creates its own terminal (a self-created terminal has no recognized agent and cannot accept `--inject`). With zero handles, `run` fails closed with `OPERATOR_DISPATCH_FAILED` (44) before any mutation. Each handle must be a terminal already running an agent CLI (`orca terminal create --command "<agent-cli>" --json`). |
+| `--coordinator-handle <handle>` | Required for `integration_gate`. Must be the live/current coordinator handle verified by fresh Orca reads; it is never inferred from receipt/history. |
+| `--gate-evidence-dir <dir>` | Deterministic root for integration evidence. The operator writes `<outcome-id>.json` there; `RELAY_ORCA_GATE_EVIDENCE_ROOT` is an equivalent environment override. |
 | `--orca-bin <path>` | Explicit Orca CLI override — passed to the capability probe and used for all orchestration calls. |
 | `--resolve-decision <id>` | (#947) Write a resolved `decision:` record for `<id>` into the receipt's `decisions[]`. Requires `--resolution` and `--resolver`; provenance (question/options/downstream_wave) is sourced from the program's declared `decision_gates[<id>]`. Never automatic. |
 | `--resolution <text>` | The decision resolution (with `--resolve-decision`). |
@@ -165,6 +168,7 @@ remaining eligible tasks `pending` for a follow-up `resume`.
 | `INJECTION_UNDELIVERED` | 42 | An `orca orchestration dispatch --inject` failed (or the post-verification prompt hand-off failed). |
 | `PROVENANCE_MISMATCH` | 43 | `dispatch-show` returned a null/empty/mismatched task id, dispatch id, or assignee. |
 | `OPERATOR_DISPATCH_FAILED` | 44 | No operator terminal was provided: `run` was invoked with zero `--operator-handle` (it never self-creates a terminal). Rejected upfront, before any mutation. |
+| `INTEGRATION_LIFECYCLE_FAILED` | 45 | The explicit coordinator, deterministic report, canonical gate, or fresh dispatch provenance cannot be verified safely; no fallback mutation is attempted. |
 
 A `42`/`43` failure records the failing task `escalated`, dispatches no further pending task,
 and does not touch already-verified running operators (stop semantics are #946). Plan-library
@@ -282,6 +286,7 @@ the completion rule, and the stop-condition table: [gates-and-completion.md](gat
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
   --program-id <program-id> [--json] [--operator-handle <handle> ...] \
+  [--coordinator-handle <handle>] [--gate-evidence-dir <dir>] \
   [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]
 ```
 
@@ -290,6 +295,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
 | `--program-id`, `-p` | The accepted program's stable id (required). Resolves the receipt under the programs root. |
 | `--json` | Emit the machine-readable resume report as JSON on stdout. |
 | `--operator-handle <handle>` | Repeatable. An explicit operator terminal to re-dispatch/reacquire to. `resume` never creates its own terminal and never adopts one it did not receive here: if an outcome needs (re)dispatch and no handle is provided, `resume` fails closed with a `decision_required` report (`RESUME_NO_OPERATOR_HANDLE`, exit 66) and performs zero mutation. Each handle must already run an agent CLI. |
+| `--coordinator-handle <handle>` | Required when the receipt contains an `integration_gate`. Fresh `status`, `dispatch-show --preamble`, task-list, and dispatch reads must confirm this handle before any gate mutation. |
+| `--gate-evidence-dir <dir>` | Deterministic root for `<outcome-id>.json` live integration evidence; defaults to the receipt's `integration-gates` directory, with `RELAY_ORCA_GATE_EVIDENCE_ROOT` as an override. |
 | `--orca-bin <path>` | Explicit Orca CLI override for the reconciliation reads and the restoration mutations. |
 | `--gh-bin <path>` | Explicit `gh` CLI override (or env `RELAY_ORCA_GH_BIN`). |
 | `--repo-root <path>` | Explicit repo root for slug derivation (defaults to the git repo of the cwd). |
@@ -304,9 +311,18 @@ It then reuses valid live mappings, reacquires a lost operator terminal, and re-
 outcome **only** when ALL of: its Orca dispatch is verifiably absent, its relay side shows no
 in-flight/durable work, and the wave rules allow it — through the SAME verified path as `run`
 (inject → dispatch-show → prompt), persisting the receipt at the same A-series write points.
-Running it twice is **idempotent**: no duplicate Orca tasks, dispatches, relay runs, fleets,
-branches, or PRs can result. It **never** invokes `orca orchestration reset`, any `orca
-worktree` subcommand, task deletion, or relay force-close, and it never creates Orca worktrees.
+For an `integration_gate`, resume reconstructs coordinator, runtime, task, dispatch, assignee,
+and report provenance from fresh reads. It uses one bounded lock and one canonical logical key
+(verified task id + exact #1016 marker question + `["passed","failed"]` options), lists before
+creating, re-lists after create even when the response is lost, and refuses duplicate,
+noncanonical, pending, failed, or conflicting gates. Only the coordinator creates/resolves the
+gate. After canonical `passed`, it sends the current operator a copy-paste
+`orca orchestration send ... --type worker_done --task-id ... --dispatch-id ... --report-path ...
+--phase integration_gate --json` command and requires a fresh task-list `status=completed` read.
+It never uses raw `--payload` JSON or `task-update`. Running it twice is **idempotent**: no
+duplicate Orca tasks, gates, dispatches, relay runs, fleets, branches, or PRs can result. It
+**never** invokes `orca orchestration reset`, any `orca worktree` subcommand, task deletion, or
+relay force-close, and it never creates Orca worktrees.
 
 ### Resume report (`--json`)
 

--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -121,8 +121,11 @@ The lifecycle ordering is terminal and one-way:
 ```text
 verified dispatch
   -> canonical gate create/adopt
-  -> operator writes <outcome-id>.json with {"passed":true,"evidence":"..."}
+  -> operator writes <outcome-id>.json with {"passed":true,"evidence":"...",
+       "runtime_id":"<live>","task_id":"<this task>","dispatch_id":"<this dispatch>"}
   -> fresh runtime/coordinator/task/dispatch/assignee/report revalidation
+       (the report's runtime_id/task_id/dispatch_id MUST match the live dispatch;
+        a reused or prior-run artifact fails closed and never resolves the gate)
   -> coordinator resolves that physical gate to passed
   -> fresh completion instruction
   -> operator sends explicit worker_done exactly once

--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -122,15 +122,38 @@ The lifecycle ordering is terminal and one-way:
 verified dispatch
   -> canonical gate create/adopt
   -> operator writes <outcome-id>.json with {"passed":true,"evidence":"...",
-       "runtime_id":"<live>","task_id":"<this task>","dispatch_id":"<this dispatch>"}
+       "runtime_id":"<live>","task_id":"<this task>","dispatch_id":"<this dispatch>",
+       "assignee":"<this pane>"}
   -> fresh runtime/coordinator/task/dispatch/assignee/report revalidation
-       (the report's runtime_id/task_id/dispatch_id MUST match the live dispatch;
+       (the report's runtime_id/task_id/dispatch_id/assignee MUST match the live dispatch;
         a reused or prior-run artifact fails closed and never resolves the gate)
   -> coordinator resolves that physical gate to passed
   -> fresh completion instruction
   -> operator sends explicit worker_done exactly once
   -> coordinator re-reads task-list and requires status=completed
 ```
+
+The evidence path is deterministic, so the same path is reused across runtimes, dispatches,
+and restarts. Each artifact is therefore **bound to the lifecycle that produced it**: it must
+carry `runtime_id`, `task_id`, `dispatch_id`, and `assignee` matching the freshly verified
+live provenance. A missing or contradicting field fails closed
+(`INTEGRATION_REPORT_PROVENANCE_MISSING` / `INTEGRATION_REPORT_PROVENANCE_MISMATCH`) **before**
+gate inspection or resolution, with zero lifecycle mutation. A restart of the SAME dispatch
+re-reads its own artifact and still matches, so crash recovery is unaffected.
+
+`resume` advances an integration gate only for outcomes that are wave-eligible under the same
+wave blanket `planResume` applies AND whose planned action is `reused` or `redispatched` —
+the two actions that leave a currently verified live dispatch behind. Receipt `dispatch_id` /
+`assignee` strings alone are not proof of a live dispatch. A pending later-wave, an
+undispatched, or a `skipped`/`decision_required` integration task is left untouched — no lock,
+no Orca read, no mutation.
+
+The bounded lifecycle lock records its owner pid. A lock whose owner is **provably gone**
+(signal 0 reports exactly `ESRCH`) is reclaimed automatically by rename-then-remove, so an
+abandoned lock never needs manual deletion and racing reclaimers cannot delete a newly
+acquired lock. A live owner, a foreign-user owner (`EPERM`), and any malformed, unreadable, or
+absent owner record are never stolen — that contention still times out fail-closed. There is
+no mtime-lease fallback: an old mtime is not evidence that the owner is gone.
 
 The completion instruction contains a concrete command in the authoritative shape, with
 `--from <fresh-assignee>`, `--to <current-coordinator>`, `--type worker_done`, `--task-id`,

--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -93,6 +93,56 @@ PROPOSED follow-up: `{ "id", "source_gate" | "source_outcome", "description",
 - A PROPOSED follow-up that targets accepted scope blocks completion; a follow-up recorded
   with `"status": "deferred"` is listed separately (a `deferred` section) and does not block.
 
+## Integration-gate lifecycle (#1019)
+
+`integration_gate` is a coordinator-owned terminal boundary. The read-only integration
+operator writes deterministic live evidence; it never creates or resolves an Orca gate.
+The coordinator must supply an explicit current `--coordinator-handle` and revalidate it
+from live runtime/dispatch reads on every run, resume, redispatch, and restart. A receipt,
+history entry, prior completion message, or stale assignee is never a source for coordinator
+identity.
+
+The physical gate id is not caller-selectable in the installed Orca CLI, so the stable
+logical identity is exactly:
+
+```text
+verified task id + "Integration evidence for relay-orca: <program-segment>/<outcome-id> passed?" + ["passed","failed"]
+```
+
+The coordinator holds a bounded per-program/outcome lock, performs `gate-list` first, and
+creates only when zero exact canonical gates exist. It always re-lists after `gate-create`,
+including a non-zero or lost response, then adopts exactly one physical id. One exact gate is
+adopted. Multiple exact gates, any other gate on the dedicated task, a missing physical id,
+or conflicting/noncanonical results fail closed with no further mutation. A generic
+`status=resolved` is not a passed integration result without the canonical resolution.
+
+The lifecycle ordering is terminal and one-way:
+
+```text
+verified dispatch
+  -> canonical gate create/adopt
+  -> operator writes <outcome-id>.json with {"passed":true,"evidence":"..."}
+  -> fresh runtime/coordinator/task/dispatch/assignee/report revalidation
+  -> coordinator resolves that physical gate to passed
+  -> fresh completion instruction
+  -> operator sends explicit worker_done exactly once
+  -> coordinator re-reads task-list and requires status=completed
+```
+
+The completion instruction contains a concrete command in the authoritative shape, with
+`--from <fresh-assignee>`, `--to <current-coordinator>`, `--type worker_done`, `--task-id`,
+`--dispatch-id`, `--report-path`, `--phase integration_gate`, and `--json`. It does not use
+raw `--payload` JSON. If gate identity, coordinator/dispatch/report provenance, completion
+delivery, or the terminal transition cannot be expressed by the installed contract, the
+coordinator reports the exact missing capability and stops. There is no `task-update`, reset,
+receipt-edit, or manual-dispatch-replay fallback.
+
+`status --final-summary` treats an active integration task, missing/pending/failed canonical
+gate, duplicate/noncanonical gate, generic resolved result, and conflicting result as
+`orca_lifecycle_failure`, even when durable evidence and exit-gate artifacts are green.
+Durable evidence remains completion authority; Orca task state and `worker_done` only prove
+that the lifecycle handoff reached its required terminal state.
+
 ### The `--record-proposals` boundary
 
 Proposals are written to the receipt (under `follow_ups`) ONLY by

--- a/skills/relay-orca/references/operator-dispatch.md
+++ b/skills/relay-orca/references/operator-dispatch.md
@@ -12,6 +12,8 @@ the ownership boundary. It is the reviewer's anchor for the `run` operator surfa
   implementation worktrees and durable run manifests** — `run` never invokes any
   `orca worktree` subcommand.
 - `orca orchestration reset` is never invoked on any path.
+- For `integration_gate`, only the coordinator creates/adopts/resolves the canonical gate;
+  the operator writes deterministic evidence and never mutates a gate or task.
 - Orca `worker_done` and task status are **lifecycle signals, never completion authority**. A
   program outcome is complete only when live relay manifests, PRs/issues, and program exit gates
   confirm it. `run` always reports `reconciliation_required: true`; live reconciliation is #945.
@@ -26,7 +28,7 @@ appears in a prompt — engine selection is `relay-config`, resolved at relay di
 | --- | --- | --- |
 | `relay_run` | `relay` | Drive the normal relay path: readiness → plan → dispatch → review → merge. Coordinator/terminals never edit code directly. |
 | `relay_fleet` | `relay-fleet` | Same relay path, plus the **already-prepared** leaf artifacts (prompt/rubric/done-criteria paths from the program contract). A fleet outcome lacking prepared leaves never reaches prompt building (the plan rejects `UNPREPARED_FLEET_LEAF`). |
-| `integration_gate` | `relay-review` | **read-only** integration-gate evidence; findings become tracker follow-ups. Review completion does not authorize coordinator file edits or silent fixes. |
+| `integration_gate` | `relay-review` | **read-only** integration-gate evidence; findings become tracker follow-ups. Review completion does not authorize coordinator file edits or silent fixes. The prompt includes the deterministic report path and, after gate resolution, one explicit worker_done command. |
 | `advisory_review` | `relay-review` | **read-only** advisory evidence; blocking findings triaged into tracker follow-ups. No file edits or fixes. |
 | `tracker_reconciliation` | `dev-backlog` | Reconcile tracker/issue state against live relay manifests. |
 
@@ -66,6 +68,35 @@ An unverified task is never reported `dispatched`. A step 1–2 failure records 
 `escalated`, dispatches no further pending task, and leaves already-verified running operators
 untouched (stop semantics are #946).
 
+## Integration-gate completion contract (#1019)
+
+An integration operator must write the live report at the exact path supplied in the prompt,
+using deterministic JSON such as `{"passed":true,"evidence":"suite green"}`. The operator
+does not create or resolve the gate. The coordinator uses the shared #1016 marker to derive
+the exact question and the exact options `["passed","failed"]`; it lists, creates/adopts,
+and re-lists under a bounded lock. Lost create responses are recovered by re-list/adopt, while
+duplicates, noncanonical gates, missing physical ids, and conflicting results stop the flow.
+
+After fresh runtime, coordinator, task, dispatch, assignee, and report validation, the
+coordinator resolves the adopted physical gate to the canonical `passed` resolution and sends
+a fresh instruction. That instruction includes one copy-paste command in the real CLI shape:
+
+```bash
+orca orchestration send \
+  --from <fresh-assignee> --to <current-coordinator> \
+  --subject '<marker>' --body '<completion text>' \
+  --type worker_done --task-id <task-id> --dispatch-id <dispatch-id> \
+  --report-path <deterministic-report> --phase integration_gate --json
+```
+
+The operator runs it exactly once from the current dispatched pane. The coordinator then
+re-reads `task-list` and accepts completion only when that task is `completed`. The command
+never uses raw `--payload` JSON. A stale runtime/coordinator/task/dispatch/assignee/report,
+unavailable gate identity, completion-delivery gap, or missing terminal transition fails closed
+with the exact capability gap. No `task-update`, reset, receipt edit, or manual dispatch replay
+is a repair path. Redispatch and restart regenerate every provenance field and the completion
+command from fresh reads.
+
 ## Terminal acquisition — explicit handles only
 
 `run` dispatches ONLY to operator terminals passed via a repeatable `--operator-handle`. It
@@ -87,5 +118,6 @@ remaining tasks stay `pending` (partial wave dispatch).
 | `INJECTION_UNDELIVERED` | 42 | A `dispatch --inject` step failed (or the post-verification prompt hand-off failed). |
 | `PROVENANCE_MISMATCH` | 43 | `dispatch-show` returned null/empty/mismatched provenance. |
 | `OPERATOR_DISPATCH_FAILED` | 44 | `run` was invoked with zero `--operator-handle` (it never self-creates a terminal). Rejected upfront, before any mutation. |
+| `INTEGRATION_LIFECYCLE_FAILED` | 45 | The coordinator-owned integration boundary cannot verify the current canonical gate/provenance/terminal transition safely. |
 
 Plan-library rejections (`2`–`21`) re-raise verbatim; usage errors exit `64`.

--- a/skills/relay-orca/references/operator-dispatch.md
+++ b/skills/relay-orca/references/operator-dispatch.md
@@ -71,8 +71,18 @@ untouched (stop semantics are #946).
 ## Integration-gate completion contract (#1019)
 
 An integration operator must write the live report at the exact path supplied in the prompt,
-using deterministic JSON such as `{"passed":true,"evidence":"suite green"}`. The operator
-does not create or resolve the gate. The coordinator uses the shared #1016 marker to derive
+using deterministic JSON that is bound to THIS dispatch — it MUST carry `passed`, `evidence`,
+and the exact `runtime_id`/`task_id`/`dispatch_id`/`assignee` of the live dispatch (the same
+required fields as the [gates-and-completion.md](gates-and-completion.md#integration-gate-lifecycle-1019)
+bound shape), e.g.:
+
+```json
+{"passed":true,"evidence":"suite green","runtime_id":"<live>","task_id":"<this task>","dispatch_id":"<this dispatch>","assignee":"<this pane>"}
+```
+
+An artifact omitting any provenance field, or carrying a reused/prior-run value, fails closed
+(`INTEGRATION_REPORT_PROVENANCE_MISSING` / `INTEGRATION_REPORT_PROVENANCE_MISMATCH`) and never
+resolves the gate. The operator does not create or resolve the gate. The coordinator uses the shared #1016 marker to derive
 the exact question and the exact options `["passed","failed"]`; it lists, creates/adopts,
 and re-lists under a bounded lock. Lost create responses are recovered by re-list/adopt, while
 duplicates, noncanonical gates, missing physical ids, and conflicting results stop the flow.

--- a/skills/relay-orca/scripts/lib/final-summary.js
+++ b/skills/relay-orca/scripts/lib/final-summary.js
@@ -28,6 +28,10 @@ const STOP_PRIORITY = Object.freeze([
 
 const LIFECYCLE_DIAGNOSTICS = new Set(["MISSING_TASK", "MISSING_DISPATCH", "MISSING_TERMINAL", "RUNTIME_MISMATCH"]);
 
+function isLifecycleDiagnostic(code) {
+  return LIFECYCLE_DIAGNOSTICS.has(code) || (typeof code === "string" && code.startsWith("INTEGRATION_"));
+}
+
 function diagnosticCodes(report) {
   return new Set((report.diagnostics || []).map((diagnostic) => diagnostic.code));
 }
@@ -43,7 +47,7 @@ function detectStops({ report, gates, followUps, outcomesComplete }) {
   const present = new Set();
   if (codes.has("DUPLICATE_MAPPING") || (report.repair_candidates || []).length > 0) present.add("graph_ambiguous");
   if (outcomes.some((outcome) => outcome.state === "escalated" || outcome.state === "inconsistent")) present.add("relay_escalated");
-  if (report.runtime === "mismatch" || report.runtime === "foreign_state" || [...codes].some((code) => LIFECYCLE_DIAGNOSTICS.has(code))) {
+  if (report.runtime === "mismatch" || report.runtime === "foreign_state" || [...codes].some(isLifecycleDiagnostic)) {
     present.add("orca_lifecycle_failure");
   }
   if (gatesOfKindFailed(gates, "integration")) present.add("integration_gate_failed");
@@ -108,6 +112,9 @@ function boundedDecision(record) {
 
 function buildBlockingReasons({ report, gateBlocking, followUps, outcomesComplete }) {
   const reasons = [];
+  (report.diagnostics || [])
+    .filter((diagnostic) => isLifecycleDiagnostic(diagnostic.code))
+    .forEach((diagnostic) => reasons.push({ reason_code: diagnostic.code, message: boundedExcerpt(diagnostic.message) }));
   (gateBlocking || []).forEach((reason) => reasons.push({ reason_code: reason.reason_code, message: boundedExcerpt(reason.message) }));
   (report.outcomes || []).forEach((outcome) => {
     if (outcome.state !== "complete_with_evidence" && !["running", "stale_missing"].includes(outcome.state)) {

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -1,0 +1,427 @@
+"use strict";
+
+// #1019 integration-gate lifecycle. This module owns the coordinator-side transition
+// boundary but receives the subprocess runner from run.js/resume.js. It deliberately
+// never builds task-update, reset, worktree, or raw-payload commands.
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { coordinationMarkerFor, shellQuote } = require("./coordination-marker");
+const { boundedExcerpt } = require("./bounded-excerpt");
+
+const CANONICAL_OPTIONS = Object.freeze(["passed", "failed"]);
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_POLL_MS = 10;
+
+class IntegrationLifecycleError extends Error {
+  constructor(reasonCode, message, details = {}) {
+    super(message);
+    this.name = "IntegrationLifecycleError";
+    this.reasonCode = reasonCode;
+    this.details = details;
+    this.mutationSafe = false;
+  }
+}
+
+function fail(reasonCode, message, details = {}) {
+  throw new IntegrationLifecycleError(reasonCode, boundedExcerpt(message), details);
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function unwrap(value) {
+  return value && typeof value === "object" ? value : {};
+}
+
+function parseEnvelope(proc, command) {
+  let parsed = null;
+  try {
+    parsed = JSON.parse(String(proc && proc.stdout ? proc.stdout : ""));
+  } catch (error) {
+    fail("INTEGRATION_CAPABILITY_GAP", `${command} returned non-JSON output: ${error.message}`);
+  }
+  if (!proc || proc.status !== 0 || !parsed || parsed.ok !== true) {
+    const detail = proc && proc.stderr ? `: ${boundedExcerpt(proc.stderr)}` : "";
+    fail("INTEGRATION_CAPABILITY_GAP", `${command} is unavailable or rejected by the installed Orca contract${detail}`);
+  }
+  return parsed;
+}
+
+function runJson(ctx, args, label) {
+  if (!ctx || typeof ctx.run !== "function" || !nonEmpty(ctx.orcaBin)) {
+    fail("INTEGRATION_CAPABILITY_GAP", `${label} cannot run: injected Orca runner is missing`);
+  }
+  const proc = ctx.run(ctx.orcaBin, args, {});
+  return parseEnvelope(proc, label);
+}
+
+function resultOf(payload) {
+  return unwrap(payload && payload.result);
+}
+
+function runtimeId(payload) {
+  const result = resultOf(payload);
+  const runtime = unwrap(result.runtime);
+  const meta = unwrap(payload && payload._meta);
+  return [runtime.runtimeId, result.runtime_id, meta.runtimeId].find(nonEmpty) || null;
+}
+
+function coordinatorFrom(payload) {
+  const result = resultOf(payload);
+  const coordinator = unwrap(result.coordinator);
+  const runtime = unwrap(result.runtime);
+  const preamble = unwrap(result.preamble);
+  return [
+    result.coordinator_handle,
+    result.coordinatorHandle,
+    coordinator.handle,
+    coordinator.id,
+    runtime.coordinator_handle,
+    runtime.coordinatorHandle,
+    preamble.coordinator_handle,
+    preamble.coordinatorHandle,
+  ].find(nonEmpty) || null;
+}
+
+function taskRows(payload) {
+  const result = resultOf(payload);
+  return Array.isArray(result.tasks) ? result.tasks : null;
+}
+
+function gateRows(payload) {
+  const result = resultOf(payload);
+  return Array.isArray(result.gates) ? result.gates : null;
+}
+
+function gateId(gate) {
+  return gate && [gate.id, gate.gate_id, gate.gateId].find(nonEmpty) || null;
+}
+
+function gateTaskId(gate) {
+  return gate && [gate.task_id, gate.task, gate.taskId].find(nonEmpty) || null;
+}
+
+function gateResolution(gate) {
+  if (!gate || typeof gate !== "object") return { state: "missing", value: null };
+  const explicitValues = [gate.resolution, gate.result, gate.outcome].filter(nonEmpty);
+  const explicitKinds = new Set(explicitValues);
+  if (explicitKinds.size > 1) return { state: "conflict", value: explicitValues.join(",") };
+  const explicit = explicitValues[0] || null;
+  const status = typeof gate.status === "string" ? gate.status : "";
+  if (explicit) {
+    if (!CANONICAL_OPTIONS.includes(explicit)) return { state: "conflict", value: explicit };
+    if (status === "passed" && explicit !== "passed") return { state: "conflict", value: explicit };
+    if (status === "failed" && explicit !== "failed") return { state: "conflict", value: explicit };
+    if (status && ["pending", "ready", "open"].includes(status)) return { state: "conflict", value: explicit };
+    return { state: explicit === "passed" ? "passed" : "failed", value: explicit };
+  }
+  // A status of passed/failed is an explicit terminal result. A generic resolved
+  // status is intentionally NOT completion evidence without its canonical resolution.
+  if (status === "passed") return { state: "passed", value: "passed" };
+  if (status === "failed") return { state: "failed", value: "failed" };
+  if (status === "resolved") return { state: "conflict", value: null };
+  return { state: "pending", value: null };
+}
+
+function sanitizeArtifactName(ref) {
+  return String(ref == null ? "" : ref)
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "gate";
+}
+
+function integrationReportPath(root, outcomeId) {
+  if (!nonEmpty(root) || !path.isAbsolute(root)) {
+    fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "integration evidence root must be an absolute deterministic path");
+  }
+  if (!nonEmpty(outcomeId)) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "integration evidence outcome id is missing");
+  return path.join(root, `${sanitizeArtifactName(outcomeId)}.json`);
+}
+
+function canonicalIntegrationQuestion(programId, outcomeId, segmentEncoder) {
+  if (!nonEmpty(programId) || !nonEmpty(outcomeId) || typeof segmentEncoder !== "function") {
+    fail("INTEGRATION_CAPABILITY_GAP", "canonical integration gate identity requires program id, outcome id, and the #1016 program-segment encoder");
+  }
+  const marker = coordinationMarkerFor(programId, outcomeId, segmentEncoder);
+  return `Integration evidence for ${marker} passed?`;
+}
+
+function canonicalGateKey({ taskId, question, options = CANONICAL_OPTIONS }) {
+  if (!nonEmpty(taskId) || !nonEmpty(question) || JSON.stringify(options) !== JSON.stringify(CANONICAL_OPTIONS)) {
+    fail("INTEGRATION_CAPABILITY_GAP", "canonical integration gate identity requires the verified task id, exact question, and options [\"passed\",\"failed\"]");
+  }
+  return { task_id: taskId, question, options: [...CANONICAL_OPTIONS] };
+}
+
+function gateIsCanonical(gate, identity) {
+  return gateTaskId(gate) === identity.task_id
+    && gate && gate.question === identity.question
+    && Array.isArray(gate.options)
+    && JSON.stringify(gate.options) === JSON.stringify(identity.options);
+}
+
+function inspectCanonicalGates(gates, identity) {
+  const rows = Array.isArray(gates) ? gates : [];
+  const dedicated = rows.filter((gate) => gateTaskId(gate) === identity.task_id);
+  const exact = dedicated.filter((gate) => gateIsCanonical(gate, identity));
+  if (dedicated.some((gate) => !gateIsCanonical(gate, identity))) {
+    return { ok: false, reasonCode: "INTEGRATION_GATE_NONCANONICAL", message: `dedicated integration task ${identity.task_id} has a noncanonical gate; refusing further mutation` };
+  }
+  if (exact.length > 1) {
+    return { ok: false, reasonCode: "INTEGRATION_GATE_DUPLICATE", message: `dedicated integration task ${identity.task_id} has ${exact.length} exact canonical gates; refusing further mutation` };
+  }
+  if (exact.length === 0) return { ok: true, state: "missing", gate: null, exact: [] };
+  const gate = exact[0];
+  if (!gateId(gate)) return { ok: false, reasonCode: "INTEGRATION_GATE_IDENTITY_UNAVAILABLE", message: "canonical gate has no physical id; the installed Orca contract cannot safely resolve it" };
+  const resolution = gateResolution(gate);
+  if (resolution.state === "conflict") {
+    return { ok: false, reasonCode: "INTEGRATION_GATE_CONFLICT", message: `canonical integration gate ${gateId(gate)} has a conflicting or noncanonical resolution` };
+  }
+  return { ok: true, state: resolution.state, gate, exact };
+}
+
+function lockName(ctx) {
+  const key = `${ctx.programId}\0${ctx.outcomeId}\0${ctx.taskId}`;
+  return crypto.createHash("sha256").update(key).digest("hex");
+}
+
+function sleep(ms) {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, ms);
+}
+
+function withBoundedLock(ctx, callback) {
+  const root = path.resolve(ctx.lockRoot || path.join(os.tmpdir(), "relay-orca-integration-locks"));
+  const lockPath = path.join(root, `${lockName(ctx)}.lock`);
+  const started = Date.now();
+  let acquired = false;
+  fs.mkdirSync(root, { recursive: true });
+  while (!acquired && Date.now() - started <= LOCK_TIMEOUT_MS) {
+    try {
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
+      acquired = true;
+    } catch (error) {
+      if (error.code !== "EEXIST") fail("INTEGRATION_LOCK_UNAVAILABLE", `integration lifecycle lock cannot be acquired: ${error.message}`);
+      sleep(LOCK_POLL_MS);
+    }
+  }
+  if (!acquired) fail("INTEGRATION_LOCK_UNAVAILABLE", `integration lifecycle lock timed out for ${ctx.programId}/${ctx.outcomeId}; no mutation was attempted`);
+  try {
+    return callback();
+  } finally {
+    fs.rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+function identityFor(ctx) {
+  return canonicalGateKey({
+    taskId: ctx.taskId,
+    question: canonicalIntegrationQuestion(ctx.programId, ctx.outcomeId, ctx.programSegment),
+  });
+}
+
+function listGates(ctx) {
+  const payload = runJson(ctx, ["orchestration", "gate-list", "--task", ctx.taskId, "--json"], "orca orchestration gate-list");
+  const rows = gateRows(payload);
+  if (!rows) fail("INTEGRATION_CAPABILITY_GAP", "orca orchestration gate-list returned no gates array");
+  const result = resultOf(payload);
+  if (result.count !== undefined && result.count !== rows.length) {
+    fail("INTEGRATION_GATE_CONFLICT", "orca orchestration gate-list count disagrees with its gate array; refusing mutation");
+  }
+  return rows;
+}
+
+function ensureCanonicalGateUnlocked(ctx, identity) {
+  const first = inspectCanonicalGates(listGates(ctx), identity);
+  if (!first.ok) fail(first.reasonCode, first.message);
+  if (first.state === "failed") {
+    fail("INTEGRATION_GATE_CONFLICT", `canonical integration gate ${gateId(first.gate)} resolved failed; refusing further mutation`);
+  }
+  if (first.state !== "missing") return { ...first, adopted: true };
+
+  const createArgs = [
+    "orchestration", "gate-create", "--task", identity.task_id,
+    "--question", identity.question, "--options", JSON.stringify(CANONICAL_OPTIONS), "--json",
+  ];
+  const created = ctx.run(ctx.orcaBin, createArgs, {});
+  // The create response is deliberately non-authoritative. Always re-list, including
+  // an exit/non-JSON response, so a lost response cannot cause a duplicate create.
+  const second = inspectCanonicalGates(listGates(ctx), identity);
+  if (!second.ok) fail(second.reasonCode, second.message);
+  if (second.state === "missing") {
+    const detail = created && created.stderr ? `: ${boundedExcerpt(created.stderr)}` : "";
+    fail("INTEGRATION_GATE_CREATE_UNCONFIRMED", `gate-create did not produce exactly one adoptable canonical gate${detail}`);
+  }
+  if (second.state === "failed") {
+    fail("INTEGRATION_GATE_CONFLICT", `canonical integration gate ${gateId(second.gate)} resolved failed; refusing further mutation`);
+  }
+  return { ...second, adopted: false, create_status: created && created.status };
+}
+
+function ensureCanonicalGate(ctx) {
+  const identity = identityFor(ctx);
+  return withBoundedLock(ctx, () => ensureCanonicalGateUnlocked(ctx, identity));
+}
+
+function currentProvenance(ctx, { requireActive = false } = {}) {
+  const statusPayload = runJson(ctx, ["status", "--json"], "orca status");
+  const currentRuntime = runtimeId(statusPayload);
+  if (!nonEmpty(currentRuntime)) fail("INTEGRATION_RUNTIME_PROVENANCE_MISSING", "live Orca runtime id is unavailable; coordinator mutation is unsafe");
+  if (ctx.runtimeId && currentRuntime !== ctx.runtimeId) fail("INTEGRATION_RUNTIME_PROVENANCE_MISMATCH", `live Orca runtime ${currentRuntime} does not match verified runtime ${ctx.runtimeId}`);
+  const currentCoordinator = coordinatorFrom(statusPayload);
+  if (nonEmpty(currentCoordinator) && currentCoordinator !== ctx.coordinatorHandle) {
+    fail("INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", `coordinator handle ${ctx.coordinatorHandle} is stale; live coordinator is ${currentCoordinator}`);
+  }
+
+  const taskPayload = runJson(ctx, ["orchestration", "task-list", "--json"], "orca orchestration task-list");
+  const tasks = taskRows(taskPayload);
+  if (!tasks) fail("INTEGRATION_CAPABILITY_GAP", "orca orchestration task-list returned no tasks array");
+  const task = tasks.find((candidate) => candidate && candidate.id === ctx.taskId);
+  if (!task) fail("INTEGRATION_TASK_PROVENANCE_MISMATCH", `verified integration task ${ctx.taskId} is absent from the current task-list`);
+  if (!nonEmpty(ctx.assignee) || !nonEmpty(ctx.dispatchId)) fail("INTEGRATION_DISPATCH_PROVENANCE_MISSING", "fresh integration dispatch id and assignee are required before lifecycle mutation");
+  const dispatchPayload = runJson(ctx, ["orchestration", "dispatch-show", "--task", ctx.taskId, "--preamble", "--from", ctx.assignee, "--json"], "orca orchestration dispatch-show");
+  const result = resultOf(dispatchPayload);
+  const dispatch = unwrap(result.dispatch);
+  const liveTask = dispatch.task_id || dispatch.taskId;
+  const liveDispatch = dispatch.id || dispatch.dispatch_id || dispatch.dispatchId;
+  const liveAssignee = dispatch.assignee_handle || dispatch.assignee || dispatch.to;
+  const dispatchCoordinator = coordinatorFrom(dispatchPayload);
+  const verifiedCoordinator = dispatchCoordinator || currentCoordinator;
+  if (!nonEmpty(verifiedCoordinator)) fail("INTEGRATION_COORDINATOR_PROVENANCE_MISSING", "live/current coordinator handle is unavailable; never infer it from stale receipt or history");
+  if (verifiedCoordinator !== ctx.coordinatorHandle) {
+    fail("INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", `coordinator handle ${ctx.coordinatorHandle} is stale; live coordinator is ${verifiedCoordinator}`);
+  }
+  if (liveTask !== ctx.taskId || liveDispatch !== ctx.dispatchId || liveAssignee !== ctx.assignee || dispatch.terminal_present === false || result.terminal_present === false) {
+    fail("INTEGRATION_DISPATCH_PROVENANCE_MISMATCH", `fresh dispatch provenance mismatch (task=${liveTask || "missing"}, dispatch=${liveDispatch || "missing"}, assignee=${liveAssignee || "missing"})`);
+  }
+  return { runtimeId: currentRuntime, coordinator: verifiedCoordinator, task, tasks, dispatch };
+}
+
+function readReport(reportPath) {
+  if (!nonEmpty(reportPath)) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "deterministic integration report path is required");
+  if (!fs.existsSync(reportPath)) return { present: false };
+  let value;
+  try {
+    value = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  } catch (error) {
+    fail("INTEGRATION_REPORT_INVALID", `integration report ${reportPath} is not valid JSON: ${error.message}`);
+  }
+  if (!value || value.passed !== true || !nonEmpty(value.evidence)) {
+    fail("INTEGRATION_REPORT_INVALID", `integration report ${reportPath} must contain passed:true and deterministic evidence text`);
+  }
+  return { present: true, passed: true, evidence: value.evidence };
+}
+
+function completionCommand(ctx) {
+  const marker = coordinationMarkerFor(ctx.programId, ctx.outcomeId, ctx.programSegment);
+  const subject = `worker_done: ${marker}`;
+  const body = `Canonical integration gate passed for ${marker}. Send this command exactly once from the current dispatched pane.`;
+  const argv = [
+    "orchestration", "send", "--to", ctx.coordinatorHandle, "--subject", subject,
+    "--from", ctx.assignee, "--body", body, "--type", "worker_done",
+    "--task-id", ctx.taskId, "--dispatch-id", ctx.dispatchId, "--report-path", ctx.reportPath,
+    "--phase", "integration_gate", "--json",
+  ];
+  const copyPaste = ["orca", ...argv.map((token) => shellQuote(token))].join(" ");
+  return { argv, copy_paste: copyPaste, subject, body };
+}
+
+function completionInstruction(ctx) {
+  const command = completionCommand(ctx);
+  return {
+    argv: [
+      "orchestration", "send", "--to", ctx.assignee, "--subject", `integration_gate ready: ${ctx.outcomeId}`,
+      "--from", ctx.coordinatorHandle, "--body", command.copy_paste,
+      "--type", "integration_gate_completion", "--task-id", ctx.taskId, "--dispatch-id", ctx.dispatchId,
+      "--report-path", ctx.reportPath, "--phase", "integration_gate", "--json",
+    ],
+    command,
+  };
+}
+
+function sendCompletionInstruction(ctx) {
+  const instruction = completionInstruction(ctx);
+  runJson(ctx, instruction.argv, "orca orchestration send integration completion instruction");
+  return instruction;
+}
+
+function prepareIntegrationGate(ctx) {
+  return withBoundedLock(ctx, () => {
+    const provenance = currentProvenance(ctx);
+    const gate = ensureCanonicalGateUnlocked(ctx, identityFor(ctx));
+    return {
+      ok: true,
+      state: gate.state,
+      gate: gate.gate,
+      adopted: gate.adopted,
+      task: provenance.task,
+      coordinator: provenance.coordinator,
+      question: identityFor(ctx).question,
+      report_path: ctx.reportPath,
+      completion_command: completionCommand(ctx),
+    };
+  });
+}
+
+function advanceIntegrationGate(ctx) {
+  return withBoundedLock(ctx, () => {
+    const provenance = currentProvenance(ctx);
+    const report = readReport(ctx.reportPath);
+    const identity = identityFor(ctx);
+    const first = inspectCanonicalGates(listGates(ctx), identity);
+    if (!first.ok) fail(first.reasonCode, first.message);
+    if (!report.present && first.state === "missing") {
+      return { ok: true, state: "awaiting_evidence", gate: null, report_path: ctx.reportPath };
+    }
+    if (!report.present && first.state === "pending") {
+      return { ok: true, state: "awaiting_evidence", gate: first.gate, report_path: ctx.reportPath };
+    }
+    const gate = first.state === "missing" ? ensureCanonicalGateUnlocked(ctx, identity) : first;
+    const resolution = gateResolution(gate.gate);
+    if (provenance.task.status === "completed" && resolution.state !== "passed") {
+      fail("INTEGRATION_WORKER_DONE_BEFORE_GATE", "integration task is already completed before the canonical gate resolved passed; refusing to reorder or repair lifecycle state");
+    }
+    if (resolution.state === "failed") fail("INTEGRATION_GATE_CONFLICT", "canonical integration gate resolved failed; no completion mutation is safe");
+    if (resolution.state === "conflict") fail("INTEGRATION_GATE_CONFLICT", "canonical integration gate has a noncanonical/conflicting resolution");
+    if (resolution.state === "pending") {
+      if (!report.present) return { ok: true, state: "awaiting_evidence", gate: gate.gate, report_path: ctx.reportPath };
+      const resolvePayload = runJson(ctx, ["orchestration", "gate-resolve", "--id", gateId(gate.gate), "--resolution", "passed", "--json"], "orca orchestration gate-resolve");
+      void resolvePayload;
+      const reread = inspectCanonicalGates(listGates(ctx), identityFor(ctx));
+      if (!reread.ok || reread.state !== "passed") fail(reread.reasonCode || "INTEGRATION_GATE_RESOLUTION_UNCONFIRMED", reread.message || "canonical gate resolution was not re-read as passed");
+      sendCompletionInstruction(ctx);
+      const afterInstruction = currentProvenance(ctx, { requireActive: true });
+      if (afterInstruction.task.status !== "completed") {
+        return {
+          ok: false,
+          state: "awaiting_worker_done",
+          reason_code: "INTEGRATION_WORKER_DONE_REQUIRED",
+          gate: reread.gate,
+          report_path: ctx.reportPath,
+          completion_command: completionCommand(ctx),
+        };
+      }
+      return { ok: true, state: "completed", gate: reread.gate, report_path: ctx.reportPath };
+    }
+    if (!report.present) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "canonical gate is passed but its deterministic live evidence report is unavailable");
+    if (provenance.task.status !== "completed") fail("INTEGRATION_WORKER_DONE_NOT_OBSERVED", "canonical gate is already passed but task-list is still active; refusing to resend worker_done and risk duplicate completion");
+    return { ok: true, state: "completed", gate: gate.gate, report_path: ctx.reportPath };
+  });
+}
+
+module.exports = {
+  CANONICAL_OPTIONS,
+  IntegrationLifecycleError,
+  canonicalIntegrationQuestion,
+  canonicalGateKey,
+  gateResolution,
+  integrationReportPath,
+  inspectCanonicalGates,
+  completionCommand,
+  ensureCanonicalGate,
+  prepareIntegrationGate,
+  advanceIntegrationGate,
+};

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -340,6 +340,27 @@ function prepareIntegrationGate(ctx) {
   });
 }
 
+// Re-issue the worker-owned completion instruction (never a coordinator-side worker_done)
+// after a fresh provenance re-read, then require task-list to observe status=completed. This
+// stays idempotent: the instruction only asks the operator to send the explicit worker_done
+// exactly once, so replaying it after a lost instruction or a second resume cannot
+// double-complete the task or create a duplicate gate.
+function reissueCompletionInstruction(ctx, gateRow) {
+  sendCompletionInstruction(ctx);
+  const afterInstruction = currentProvenance(ctx, { requireActive: true });
+  if (afterInstruction.task.status !== "completed") {
+    return {
+      ok: false,
+      state: "awaiting_worker_done",
+      reason_code: "INTEGRATION_WORKER_DONE_REQUIRED",
+      gate: gateRow,
+      report_path: ctx.reportPath,
+      completion_command: completionCommand(ctx),
+    };
+  }
+  return { ok: true, state: "completed", gate: gateRow, report_path: ctx.reportPath };
+}
+
 function advanceIntegrationGate(ctx) {
   return withBoundedLock(ctx, () => {
     const provenance = currentProvenance(ctx);
@@ -366,22 +387,14 @@ function advanceIntegrationGate(ctx) {
       void resolvePayload;
       const reread = inspectCanonicalGates(listGates(ctx), identityFor(ctx));
       if (!reread.ok || reread.state !== "passed") fail(reread.reasonCode || "INTEGRATION_GATE_RESOLUTION_UNCONFIRMED", reread.message || "canonical gate resolution was not re-read as passed");
-      sendCompletionInstruction(ctx);
-      const afterInstruction = currentProvenance(ctx, { requireActive: true });
-      if (afterInstruction.task.status !== "completed") {
-        return {
-          ok: false,
-          state: "awaiting_worker_done",
-          reason_code: "INTEGRATION_WORKER_DONE_REQUIRED",
-          gate: reread.gate,
-          report_path: ctx.reportPath,
-          completion_command: completionCommand(ctx),
-        };
-      }
-      return { ok: true, state: "completed", gate: reread.gate, report_path: ctx.reportPath };
+      return reissueCompletionInstruction(ctx, reread.gate);
     }
     if (!report.present) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "canonical gate is passed but its deterministic live evidence report is unavailable");
-    if (provenance.task.status !== "completed") fail("INTEGRATION_WORKER_DONE_NOT_OBSERVED", "canonical gate is already passed but task-list is still active; refusing to resend worker_done and risk duplicate completion");
+    // Passed canonical gate + valid live evidence + a still-active task is the exact live
+    // residue after a lost completion instruction or a second resume. Re-issue the worker-owned
+    // completion instruction idempotently (revalidating provenance) instead of failing closed,
+    // so the program-owned task can terminalize without a coordinator task-update. (#1019 R2)
+    if (provenance.task.status !== "completed") return reissueCompletionInstruction(ctx, gate.gate);
     return { ok: true, state: "completed", gate: gate.gate, report_path: ctx.reportPath };
   });
 }

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -189,6 +189,11 @@ function withBoundedLock(ctx, callback) {
   try {
     return ctx.withLock(lockName(ctx), callback);
   } catch (error) {
+    // A fail-closed decision from inside the locked section already carries its own specific
+    // reason code (e.g. gate/provenance/report codes); surfacing it verbatim is what makes the
+    // reason-code contract diagnosable. Only a genuine lock-acquisition failure — a non-lifecycle
+    // error from ctx.withLock itself — is mapped to INTEGRATION_LOCK_UNAVAILABLE.
+    if (error instanceof IntegrationLifecycleError) throw error;
     fail("INTEGRATION_LOCK_UNAVAILABLE", `integration lifecycle lock cannot be acquired: ${error.message}`);
   }
 }
@@ -243,7 +248,7 @@ function ensureCanonicalGate(ctx) {
   return withBoundedLock(ctx, () => ensureCanonicalGateUnlocked(ctx, identity));
 }
 
-function currentProvenance(ctx, { requireActive = false } = {}) {
+function currentProvenance(ctx) {
   const statusPayload = runJson(ctx, ["status", "--json"], "orca status");
   const currentRuntime = runtimeId(statusPayload);
   if (!nonEmpty(currentRuntime)) fail("INTEGRATION_RUNTIME_PROVENANCE_MISSING", "live Orca runtime id is unavailable; coordinator mutation is unsafe");
@@ -277,7 +282,43 @@ function currentProvenance(ctx, { requireActive = false } = {}) {
   return { runtimeId: currentRuntime, coordinator: verifiedCoordinator, task, tasks, dispatch };
 }
 
-function readReport(ctx) {
+function reportField(value, keys) {
+  for (const key of keys) {
+    if (value && Object.prototype.hasOwnProperty.call(value, key)) return value[key];
+  }
+  return undefined;
+}
+
+// Bind the evidence artifact to the live dispatch provenance. The deterministic
+// <outcome-id>.json path alone is NOT proof of freshness: a reused evidence directory or a
+// prior-run artifact for the same outcome would otherwise authorize gate-resolve on a new
+// canonical gate. The artifact must therefore carry the CURRENT runtime/task/dispatch identity
+// (already re-verified live by currentProvenance); a missing id fails closed as
+// INTEGRATION_REPORT_PROVENANCE_MISSING and a mismatched id as
+// INTEGRATION_REPORT_PROVENANCE_MISMATCH, so stale evidence can never resolve a gate. Crash
+// recovery for the SAME dispatch still passes because the ids are re-emitted unchanged.
+function bindReportProvenance(ctx, provenance, value) {
+  const expected = {
+    runtime_id: (provenance && provenance.runtimeId) || ctx.runtimeId || null,
+    task_id: ctx.taskId,
+    dispatch_id: ctx.dispatchId,
+  };
+  const recorded = {
+    runtime_id: reportField(value, ["runtime_id", "runtimeId"]),
+    task_id: reportField(value, ["task_id", "taskId"]),
+    dispatch_id: reportField(value, ["dispatch_id", "dispatchId"]),
+  };
+  for (const field of ["runtime_id", "task_id", "dispatch_id"]) {
+    if (!nonEmpty(recorded[field])) {
+      fail("INTEGRATION_REPORT_PROVENANCE_MISSING", `integration report ${ctx.reportPath} is missing ${field}; deterministic evidence must be bound to the live runtime/task/dispatch`);
+    }
+    if (!nonEmpty(expected[field]) || recorded[field] !== expected[field]) {
+      fail("INTEGRATION_REPORT_PROVENANCE_MISMATCH", `integration report ${field} ${recorded[field]} does not match the live dispatch provenance ${expected[field] || "missing"}; refusing to authorize gate-resolve on stale evidence`);
+    }
+  }
+}
+
+function readReport(ctx, provenance) {
   if (!ctx || !nonEmpty(ctx.reportPath)) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "deterministic integration report path is required");
   if (typeof ctx.readReport !== "function") fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "deterministic integration report reader is unavailable");
   const source = ctx.readReport(ctx.reportPath);
@@ -286,6 +327,7 @@ function readReport(ctx) {
   if (!value || value.passed !== true || !nonEmpty(value.evidence)) {
     fail("INTEGRATION_REPORT_INVALID", `integration report ${ctx.reportPath} must contain passed:true and deterministic evidence text`);
   }
+  bindReportProvenance(ctx, provenance, value);
   return { present: true, passed: true, evidence: value.evidence };
 }
 
@@ -336,6 +378,14 @@ function prepareIntegrationGate(ctx) {
       question: identityFor(ctx).question,
       report_path: ctx.reportPath,
       completion_command: completionCommand(ctx),
+      // The exact identity the deterministic evidence artifact must carry so a later advance
+      // can bind it to THIS dispatch (#1019 H2). Surfaced here so the operator prompt can quote
+      // the required values; without them the artifact fails closed instead of resolving a gate.
+      evidence_provenance: {
+        runtime_id: provenance.runtimeId,
+        task_id: ctx.taskId,
+        dispatch_id: ctx.dispatchId,
+      },
     };
   });
 }
@@ -347,7 +397,7 @@ function prepareIntegrationGate(ctx) {
 // double-complete the task or create a duplicate gate.
 function reissueCompletionInstruction(ctx, gateRow) {
   sendCompletionInstruction(ctx);
-  const afterInstruction = currentProvenance(ctx, { requireActive: true });
+  const afterInstruction = currentProvenance(ctx);
   if (afterInstruction.task.status !== "completed") {
     return {
       ok: false,
@@ -364,7 +414,7 @@ function reissueCompletionInstruction(ctx, gateRow) {
 function advanceIntegrationGate(ctx) {
   return withBoundedLock(ctx, () => {
     const provenance = currentProvenance(ctx);
-    const report = readReport(ctx);
+    const report = readReport(ctx, provenance);
     const identity = identityFor(ctx);
     const first = inspectCanonicalGates(listGates(ctx), identity);
     if (!first.ok) fail(first.reasonCode, first.message);

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -414,9 +414,32 @@ function reissueCompletionInstruction(ctx, gateRow) {
   return { ok: true, state: "completed", gate: gateRow, report_path: ctx.reportPath };
 }
 
+// The program-owned integration task may still advance toward `completed` ONLY from a live,
+// still-running status. This mirrors probe-orca's authoritative active-task set
+// (pending/ready/dispatched/blocked); `completed`/`failed` are the two terminal states, and only
+// `completed` is a legitimate integration success. Any status outside this set that is not
+// `completed` — a terminal `failed`, or any unrecognized/ambiguous status — fails closed rather
+// than being mutated toward completion. (#1019 R7)
+const ADVANCEABLE_TASK_STATUSES = Object.freeze(["pending", "ready", "dispatched", "blocked"]);
+
 function advanceIntegrationGate(ctx) {
   return withBoundedLock(ctx, () => {
     const provenance = currentProvenance(ctx);
+    // Refuse a task that can never legitimately complete BEFORE any gate materialization,
+    // gate-resolve, or completion send. `completed` is the ONE success terminal (the terminal
+    // paths below own it); every OTHER terminal or non-completable status — `failed`, or any
+    // status outside the still-advancing live set — is one-way. A still-verifying historical
+    // dispatch plus provenance-bound evidence must not flip the canonical gate to passed or
+    // re-issue worker_done against such a task: that strands a passed gate on a task that can
+    // never reach completion, a harder residue than failing closed. This fires here with zero
+    // further mutation. (#1019 R7)
+    const taskStatus = provenance.task && provenance.task.status;
+    if (taskStatus !== "completed" && !ADVANCEABLE_TASK_STATUSES.includes(taskStatus)) {
+      fail(
+        "INTEGRATION_TASK_NOT_COMPLETABLE",
+        `integration task ${ctx.taskId} is in terminal/non-completable status "${taskStatus}"; refusing to resolve the canonical gate passed or send worker_done against a task that cannot reach completion — resolve the task's failure at its source rather than forcing the integration gate`,
+      );
+    }
     // Evidence is validated and provenance-bound BEFORE any gate inspection or mutation,
     // so a stale artifact fails closed with zero lifecycle mutation.
     const report = readReport(ctx, provenance);

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -282,39 +282,45 @@ function currentProvenance(ctx) {
   return { runtimeId: currentRuntime, coordinator: verifiedCoordinator, task, tasks, dispatch };
 }
 
-function reportField(value, keys) {
-  for (const key of keys) {
-    if (value && Object.prototype.hasOwnProperty.call(value, key)) return value[key];
-  }
-  return undefined;
-}
+// The evidence artifact lives at a DETERMINISTIC path derived from the program/outcome alone,
+// so the same path is reused across runtimes, dispatches, and restarts. The path is therefore
+// NOT proof of freshness: a reused evidence directory or a prior-run artifact for the same
+// outcome would otherwise authorize gate-resolve on a new canonical gate. Every field below
+// must be present AND equal to the freshly verified live provenance. (#1019 R3)
+const EVIDENCE_PROVENANCE_FIELDS = Object.freeze(["runtime_id", "task_id", "dispatch_id", "assignee"]);
 
-// Bind the evidence artifact to the live dispatch provenance. The deterministic
-// <outcome-id>.json path alone is NOT proof of freshness: a reused evidence directory or a
-// prior-run artifact for the same outcome would otherwise authorize gate-resolve on a new
-// canonical gate. The artifact must therefore carry the CURRENT runtime/task/dispatch identity
-// (already re-verified live by currentProvenance); a missing id fails closed as
-// INTEGRATION_REPORT_PROVENANCE_MISSING and a mismatched id as
-// INTEGRATION_REPORT_PROVENANCE_MISMATCH, so stale evidence can never resolve a gate. Crash
-// recovery for the SAME dispatch still passes because the ids are re-emitted unchanged.
-function bindReportProvenance(ctx, provenance, value) {
-  const expected = {
-    runtime_id: (provenance && provenance.runtimeId) || ctx.runtimeId || null,
+// `provenance` is the result of the immediately preceding currentProvenance() read, which has
+// already proven that ctx.taskId/dispatchId/assignee are the LIVE trio. Binding the artifact to
+// it therefore binds it to live state, not to caller-supplied hopes.
+function expectedEvidenceProvenance(ctx, provenance) {
+  return {
+    runtime_id: provenance.runtimeId,
     task_id: ctx.taskId,
     dispatch_id: ctx.dispatchId,
+    assignee: ctx.assignee,
   };
-  const recorded = {
-    runtime_id: reportField(value, ["runtime_id", "runtimeId"]),
-    task_id: reportField(value, ["task_id", "taskId"]),
-    dispatch_id: reportField(value, ["dispatch_id", "dispatchId"]),
-  };
-  for (const field of ["runtime_id", "task_id", "dispatch_id"]) {
-    if (!nonEmpty(recorded[field])) {
-      fail("INTEGRATION_REPORT_PROVENANCE_MISSING", `integration report ${ctx.reportPath} is missing ${field}; deterministic evidence must be bound to the live runtime/task/dispatch`);
-    }
-    if (!nonEmpty(expected[field]) || recorded[field] !== expected[field]) {
-      fail("INTEGRATION_REPORT_PROVENANCE_MISMATCH", `integration report ${field} ${recorded[field]} does not match the live dispatch provenance ${expected[field] || "missing"}; refusing to authorize gate-resolve on stale evidence`);
-    }
+}
+
+function describeProvenance(fields, source) {
+  return fields.map((field) => `${field}=${source[field]}`).join(", ");
+}
+
+// A missing id fails closed as INTEGRATION_REPORT_PROVENANCE_MISSING and a contradicting id as
+// INTEGRATION_REPORT_PROVENANCE_MISMATCH, so stale evidence can never resolve a gate. Crash
+// recovery for the SAME dispatch still passes: a restart of the same runtime/task/dispatch/
+// assignee re-reads its own artifact and still matches.
+function bindReportProvenance(ctx, provenance, value) {
+  const expected = expectedEvidenceProvenance(ctx, provenance || {});
+  const missing = EVIDENCE_PROVENANCE_FIELDS.filter((field) => !nonEmpty(value[field]));
+  if (missing.length) {
+    fail("INTEGRATION_REPORT_PROVENANCE_MISSING", `integration report ${ctx.reportPath} omits required lifecycle provenance (${missing.join(", ")}); deterministic evidence must be bound to the live runtime/task/dispatch/assignee`);
+  }
+  const mismatched = EVIDENCE_PROVENANCE_FIELDS.filter((field) => !nonEmpty(expected[field]) || value[field] !== expected[field]);
+  if (mismatched.length) {
+    fail(
+      "INTEGRATION_REPORT_PROVENANCE_MISMATCH",
+      `integration report ${ctx.reportPath} was written by a different lifecycle (${describeProvenance(mismatched, value)}); the current lifecycle is ${describeProvenance(mismatched, expected)}; refusing to authorize gate-resolve on stale evidence`,
+    );
   }
 }
 
@@ -381,11 +387,8 @@ function prepareIntegrationGate(ctx) {
       // The exact identity the deterministic evidence artifact must carry so a later advance
       // can bind it to THIS dispatch (#1019 H2). Surfaced here so the operator prompt can quote
       // the required values; without them the artifact fails closed instead of resolving a gate.
-      evidence_provenance: {
-        runtime_id: provenance.runtimeId,
-        task_id: ctx.taskId,
-        dispatch_id: ctx.dispatchId,
-      },
+      // The advance-side readReport rejects anything else. (#1019 R3)
+      evidence_provenance: expectedEvidenceProvenance(ctx, provenance),
     };
   });
 }
@@ -414,6 +417,8 @@ function reissueCompletionInstruction(ctx, gateRow) {
 function advanceIntegrationGate(ctx) {
   return withBoundedLock(ctx, () => {
     const provenance = currentProvenance(ctx);
+    // Evidence is validated and provenance-bound BEFORE any gate inspection or mutation,
+    // so a stale artifact fails closed with zero lifecycle mutation.
     const report = readReport(ctx, provenance);
     const identity = identityFor(ctx);
     const first = inspectCanonicalGates(listGates(ctx), identity);
@@ -451,6 +456,7 @@ function advanceIntegrationGate(ctx) {
 
 module.exports = {
   CANONICAL_OPTIONS,
+  EVIDENCE_PROVENANCE_FIELDS,
   IntegrationLifecycleError,
   canonicalIntegrationQuestion,
   canonicalGateKey,

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -4,16 +4,11 @@
 // boundary but receives the subprocess runner from run.js/resume.js. It deliberately
 // never builds task-update, reset, worktree, or raw-payload commands.
 const crypto = require("node:crypto");
-const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 const { coordinationMarkerFor, shellQuote } = require("./coordination-marker");
 const { boundedExcerpt } = require("./bounded-excerpt");
 
 const CANONICAL_OPTIONS = Object.freeze(["passed", "failed"]);
-const LOCK_TIMEOUT_MS = 5000;
-const LOCK_POLL_MS = 10;
-
 class IntegrationLifecycleError extends Error {
   constructor(reasonCode, message, details = {}) {
     super(message);
@@ -187,32 +182,14 @@ function lockName(ctx) {
   return crypto.createHash("sha256").update(key).digest("hex");
 }
 
-function sleep(ms) {
-  const shared = new Int32Array(new SharedArrayBuffer(4));
-  Atomics.wait(shared, 0, 0, ms);
-}
-
 function withBoundedLock(ctx, callback) {
-  const root = path.resolve(ctx.lockRoot || path.join(os.tmpdir(), "relay-orca-integration-locks"));
-  const lockPath = path.join(root, `${lockName(ctx)}.lock`);
-  const started = Date.now();
-  let acquired = false;
-  fs.mkdirSync(root, { recursive: true });
-  while (!acquired && Date.now() - started <= LOCK_TIMEOUT_MS) {
-    try {
-      fs.mkdirSync(lockPath);
-      fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
-      acquired = true;
-    } catch (error) {
-      if (error.code !== "EEXIST") fail("INTEGRATION_LOCK_UNAVAILABLE", `integration lifecycle lock cannot be acquired: ${error.message}`);
-      sleep(LOCK_POLL_MS);
-    }
+  if (!ctx || typeof ctx.withLock !== "function") {
+    fail("INTEGRATION_LOCK_UNAVAILABLE", "bounded integration lifecycle lock is unavailable; no mutation was attempted");
   }
-  if (!acquired) fail("INTEGRATION_LOCK_UNAVAILABLE", `integration lifecycle lock timed out for ${ctx.programId}/${ctx.outcomeId}; no mutation was attempted`);
   try {
-    return callback();
-  } finally {
-    fs.rmSync(lockPath, { recursive: true, force: true });
+    return ctx.withLock(lockName(ctx), callback);
+  } catch (error) {
+    fail("INTEGRATION_LOCK_UNAVAILABLE", `integration lifecycle lock cannot be acquired: ${error.message}`);
   }
 }
 
@@ -300,17 +277,14 @@ function currentProvenance(ctx, { requireActive = false } = {}) {
   return { runtimeId: currentRuntime, coordinator: verifiedCoordinator, task, tasks, dispatch };
 }
 
-function readReport(reportPath) {
-  if (!nonEmpty(reportPath)) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "deterministic integration report path is required");
-  if (!fs.existsSync(reportPath)) return { present: false };
-  let value;
-  try {
-    value = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-  } catch (error) {
-    fail("INTEGRATION_REPORT_INVALID", `integration report ${reportPath} is not valid JSON: ${error.message}`);
-  }
+function readReport(ctx) {
+  if (!ctx || !nonEmpty(ctx.reportPath)) fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "deterministic integration report path is required");
+  if (typeof ctx.readReport !== "function") fail("INTEGRATION_REPORT_PROVENANCE_MISSING", "deterministic integration report reader is unavailable");
+  const source = ctx.readReport(ctx.reportPath);
+  if (!source || source.present === false) return { present: false };
+  const value = source.value !== undefined ? source.value : source;
   if (!value || value.passed !== true || !nonEmpty(value.evidence)) {
-    fail("INTEGRATION_REPORT_INVALID", `integration report ${reportPath} must contain passed:true and deterministic evidence text`);
+    fail("INTEGRATION_REPORT_INVALID", `integration report ${ctx.reportPath} must contain passed:true and deterministic evidence text`);
   }
   return { present: true, passed: true, evidence: value.evidence };
 }
@@ -369,7 +343,7 @@ function prepareIntegrationGate(ctx) {
 function advanceIntegrationGate(ctx) {
   return withBoundedLock(ctx, () => {
     const provenance = currentProvenance(ctx);
-    const report = readReport(ctx.reportPath);
+    const report = readReport(ctx);
     const identity = identityFor(ctx);
     const first = inspectCanonicalGates(listGates(ctx), identity);
     if (!first.ok) fail(first.reasonCode, first.message);

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -423,21 +423,25 @@ function advanceIntegrationGate(ctx) {
     const identity = identityFor(ctx);
     const first = inspectCanonicalGates(listGates(ctx), identity);
     if (!first.ok) fail(first.reasonCode, first.message);
-    if (!report.present && first.state === "missing") {
-      return { ok: true, state: "awaiting_evidence", gate: null, report_path: ctx.reportPath };
-    }
-    if (!report.present && first.state === "pending") {
-      return { ok: true, state: "awaiting_evidence", gate: first.gate, report_path: ctx.reportPath };
-    }
+    // A verified live integration dispatch must always carry exactly one canonical gate, and the
+    // documented operator ordering is gate-before-evidence. Materialize it here — create-or-adopt
+    // through the same post-create re-read and duplicate/conflict defenses — instead of returning
+    // awaiting_evidence against no gate at all, which left the lifecycle contract unsatisfied and
+    // gave the operator nothing to write evidence against. (#1019 R4)
     const gate = first.state === "missing" ? ensureCanonicalGateUnlocked(ctx, identity) : first;
     const resolution = gateResolution(gate.gate);
+    // The canonical gate now exists but no live evidence has landed: resolve nothing, complete
+    // nothing, and hand the operator back the same gate on every later pass (idempotent).
+    if (!report.present && resolution.state === "pending") {
+      return { ok: true, state: "awaiting_evidence", gate: gate.gate, report_path: ctx.reportPath };
+    }
     if (provenance.task.status === "completed" && resolution.state !== "passed") {
       fail("INTEGRATION_WORKER_DONE_BEFORE_GATE", "integration task is already completed before the canonical gate resolved passed; refusing to reorder or repair lifecycle state");
     }
     if (resolution.state === "failed") fail("INTEGRATION_GATE_CONFLICT", "canonical integration gate resolved failed; no completion mutation is safe");
     if (resolution.state === "conflict") fail("INTEGRATION_GATE_CONFLICT", "canonical integration gate has a noncanonical/conflicting resolution");
     if (resolution.state === "pending") {
-      if (!report.present) return { ok: true, state: "awaiting_evidence", gate: gate.gate, report_path: ctx.reportPath };
+      // report.present is guaranteed here: a pending gate without evidence already returned above.
       const resolvePayload = runJson(ctx, ["orchestration", "gate-resolve", "--id", gateId(gate.gate), "--resolution", "passed", "--json"], "orca orchestration gate-resolve");
       void resolvePayload;
       const reread = inspectCanonicalGates(listGates(ctx), identityFor(ctx));

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -114,9 +114,11 @@ function integrationGateBlock(lifecycle) {
   if (!lifecycle || !lifecycle.completion_command) {
     return base.concat("Wait for a fresh coordinator instruction containing the current dispatch provenance before sending worker_done.").join("\n");
   }
+  const provenance = lifecycle.evidence_provenance || {};
   return base.concat([
     `Write the live evidence JSON at this exact path: ${lifecycle.report_path}`,
-    "The JSON must contain passed:true and deterministic evidence text.",
+    "The JSON must contain passed:true, deterministic evidence text, and these exact provenance fields binding it to THIS dispatch (a reused or prior-run artifact is rejected):",
+    `  "runtime_id": ${JSON.stringify(provenance.runtime_id || null)}, "task_id": ${JSON.stringify(provenance.task_id || null)}, "dispatch_id": ${JSON.stringify(provenance.dispatch_id || null)}`,
     "After the coordinator resolves this exact gate to passed, copy-paste the following command exactly once from the current dispatched pane:",
     lifecycle.completion_command.copy_paste,
   ]).join("\n");

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { coordinationMarkerFor, shellQuote } = require("./coordination-marker");
+const { EVIDENCE_PROVENANCE_FIELDS } = require("./integration-lifecycle");
 
 // Engine-agnostic operator prompt builder (D8). One prompt per task kind. The
 // operator SURFACE is sourced from the plan's recommended_route (operator name +
@@ -104,6 +105,18 @@ function bodyBlock(task, program, outcome, segmentEncoder) {
     .join("\n");
 }
 
+// The evidence path is deterministic and therefore reused across runtimes, dispatches, and
+// restarts, so the coordinator binds each artifact to the dispatch that produced it. The field
+// list is sourced from the lifecycle's OWN constant, so what this prompt asks the operator to
+// write can never drift from what readReport enforces. (#1019 R3)
+function evidenceProvenanceLine(provenance) {
+  const source = provenance || {};
+  const pairs = EVIDENCE_PROVENANCE_FIELDS
+    .map((field) => `${JSON.stringify(field)}: ${JSON.stringify(source[field] !== undefined ? source[field] : null)}`)
+    .join(", ");
+  return `  ${pairs}`;
+}
+
 function integrationGateBlock(lifecycle) {
   const base = [
     "Integration-gate lifecycle contract (coordinator-owned):",
@@ -114,11 +127,10 @@ function integrationGateBlock(lifecycle) {
   if (!lifecycle || !lifecycle.completion_command) {
     return base.concat("Wait for a fresh coordinator instruction containing the current dispatch provenance before sending worker_done.").join("\n");
   }
-  const provenance = lifecycle.evidence_provenance || {};
   return base.concat([
     `Write the live evidence JSON at this exact path: ${lifecycle.report_path}`,
     "The JSON must contain passed:true, deterministic evidence text, and these exact provenance fields binding it to THIS dispatch (a reused or prior-run artifact is rejected):",
-    `  "runtime_id": ${JSON.stringify(provenance.runtime_id || null)}, "task_id": ${JSON.stringify(provenance.task_id || null)}, "dispatch_id": ${JSON.stringify(provenance.dispatch_id || null)}`,
+    evidenceProvenanceLine(lifecycle.evidence_provenance),
     "After the coordinator resolves this exact gate to passed, copy-paste the following command exactly once from the current dispatched pane:",
     lifecycle.completion_command.copy_paste,
   ]).join("\n");

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -104,14 +104,34 @@ function bodyBlock(task, program, outcome, segmentEncoder) {
     .join("\n");
 }
 
+function integrationGateBlock(lifecycle) {
+  const base = [
+    "Integration-gate lifecycle contract (coordinator-owned):",
+    "The coordinator alone creates/adopts and resolves the canonical Orca gate. The operator writes only deterministic live evidence and sends no gate mutation.",
+    "The canonical gate question is tied to the shared #1016 program-segment/outcome marker and its exact options are [\"passed\",\"failed\"].",
+    "Gate resolution must be observed before worker_done; never use task-update, reset, receipt edits, or manual dispatch replay.",
+  ];
+  if (!lifecycle || !lifecycle.completion_command) {
+    return base.concat("Wait for a fresh coordinator instruction containing the current dispatch provenance before sending worker_done.").join("\n");
+  }
+  return base.concat([
+    `Write the live evidence JSON at this exact path: ${lifecycle.report_path}`,
+    "The JSON must contain passed:true and deterministic evidence text.",
+    "After the coordinator resolves this exact gate to passed, copy-paste the following command exactly once from the current dispatched pane:",
+    lifecycle.completion_command.copy_paste,
+  ]).join("\n");
+}
+
 // Build the full operator prompt for a single task. `outcome` is the original
 // program outcome (carries relay_fleet leaves); `task` is the compiled plan task.
-function buildOperatorPrompt(task, program, outcome = {}, segmentEncoder) {
+function buildOperatorPrompt(task, program, outcome = {}, segmentEncoder, options = {}) {
+  const lifecycle = task.kind === "integration_gate" ? integrationGateBlock(options.integrationGate) : null;
   return [
     headerBlock(task, program, outcome),
     bodyBlock(task, program, outcome, segmentEncoder),
+    lifecycle,
     payloadContractBlock(),
-  ].join("\n\n");
+  ].filter(Boolean).join("\n\n");
 }
 
 module.exports = {

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -261,6 +261,7 @@ module.exports = {
   planResume,
   planDecisions,
   classifyAction,
+  earlierWavesComplete,
   hasUnmappedRelayWork,
   relayClean,
   mappingLive,

--- a/skills/relay-orca/scripts/lib/resume-plan.js
+++ b/skills/relay-orca/scripts/lib/resume-plan.js
@@ -119,11 +119,7 @@ function isRedispatchCandidate(task, diags, outcome, liveAbsent, report) {
     !isNonEmpty(task.dispatch_id) &&
     isNonEmpty(task.orca_task_id) &&
     !hasDiag(diags, "MISSING_TASK") &&
-    (task.wave === 1 ||
-      (task.wave > 1 &&
-        (report.outcomes || [])
-          .filter((reportOutcome) => reportOutcome.wave < task.wave)
-          .every((reportOutcome) => reportOutcome.state === "complete_with_evidence"))) &&
+    waveEligible(task, report) &&
     relayClean(task, outcome)
   );
 }
@@ -135,6 +131,14 @@ function earlierWavesComplete(task, report) {
       .filter((outcome) => outcome.wave < task.wave)
       .every((outcome) => outcome.state === "complete_with_evidence")
   );
+}
+
+// THE wave blanket. Wave 1 is always eligible; a later wave only once every earlier-wave
+// outcome is durably `complete_with_evidence`. Re-dispatch, the `skipped` classification, and
+// the #1019 integration-gate advancement all consume this SINGLE predicate so the eligibility
+// policies cannot drift apart. (#1019 R3)
+function waveEligible(task, report) {
+  return task.wave === 1 || earlierWavesComplete(task, report);
 }
 
 // Program-level fail-closed decisions (D2). Deduped by reason_code and ordered by exit
@@ -214,7 +218,7 @@ function classifyAction(task, report, unmappedRelayWork, liveDispatch) {
     if (unmappedRelayWork) return makeAction(task, "skipped", `outcome ${task.outcome_id} is absent, but unmapped relay work references this program; not re-dispatched to avoid duplicating it`);
     return makeAction(task, "redispatched", `outcome ${task.outcome_id} Orca dispatch verifiably absent and relay side clean; re-dispatching through the verified path`, execPlan(task, "redispatch"));
   }
-  if (task.wave > 1 && !earlierWavesComplete(task, report)) {
+  if (!waveEligible(task, report)) {
     return makeAction(task, "skipped", `outcome ${task.outcome_id} is in wave ${task.wave}; earlier waves are not yet complete_with_evidence; left untouched`);
   }
   return makeAction(task, "skipped", `outcome ${task.outcome_id} has in-flight/durable relay work; left untouched`);
@@ -261,7 +265,9 @@ module.exports = {
   planResume,
   planDecisions,
   classifyAction,
-  earlierWavesComplete,
+  // Only the blanket is exported. `earlierWavesComplete` stays module-private so no caller can
+  // re-fork wave eligibility as a second, drifting policy. (#1019 R3)
+  waveEligible,
   hasUnmappedRelayWork,
   relayClean,
   mappingLive,

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -175,6 +175,13 @@ function requireIntegrationCoordinator(program, options) {
       "Provide --gate-evidence-dir or RELAY_ORCA_GATE_EVIDENCE_ROOT so the operator can write the live report at a deterministic path.",
     );
   }
+  if (integrationTasks(program).length > 0 && typeof options.withIntegrationLifecycleLock !== "function") {
+    reject(
+      "INTEGRATION_LIFECYCLE_FAILED",
+      "integration_gate requires the bounded lifecycle lock adapter; no mutation was attempted",
+      "Use the shipped run/resume entry point so the coordinator lifecycle lock is installed; do not bypass it with a manual bridge.",
+    );
+  }
 }
 
 // D6.2 provenance trio verification. Returns a bounded description of the first
@@ -248,6 +255,14 @@ function dispatchOne(ctx) {
         runtimeId: report.admission.runtime_id,
         reportPath: options.integrationReportPath(task.outcome_id),
         programSegment: options.programSegment,
+        withLock: (lockKey, callback) => options.withIntegrationLifecycleLock({
+          programId: program.id,
+          outcomeId: task.outcome_id,
+          taskId: orcaTaskId,
+          lockRoot: options.integrationLockRoot,
+          lockKey,
+        }, callback),
+        readReport: () => ({ present: false }),
       });
     } catch (error) {
       if (!(error instanceof IntegrationLifecycleError)) throw error;

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -20,6 +20,7 @@ const {
 } = require("./run-orca");
 const { buildOperatorPrompt } = require("./operator-prompt");
 const { coordinationMarkerFor } = require("./coordination-marker");
+const { IntegrationLifecycleError, prepareIntegrationGate } = require("./integration-lifecycle");
 
 // The CLI-invocation boundary is injected by run.js (the Node subprocess module
 // may not live under scripts/lib/ — plan.js's frozen D6 source scan forbids it).
@@ -155,6 +156,27 @@ function requireOperatorHandles(options) {
   }
 }
 
+function integrationTasks(program) {
+  return (Array.isArray(program.outcomes) ? program.outcomes : []).filter((outcome) => outcome && outcome.task_kind === "integration_gate");
+}
+
+function requireIntegrationCoordinator(program, options) {
+  if (integrationTasks(program).length > 0 && !isNonEmptyString(options.coordinatorHandle)) {
+    reject(
+      "INTEGRATION_LIFECYCLE_FAILED",
+      "integration_gate requires an explicit --coordinator-handle; the coordinator is never inferred from a receipt, history, or stale dispatch",
+      "Re-run with the verified current coordinator handle and a deterministic --gate-evidence-dir; do not use task-update, reset, receipt edits, or manual dispatch replay.",
+    );
+  }
+  if (integrationTasks(program).length > 0 && typeof options.integrationReportPath !== "function") {
+    reject(
+      "INTEGRATION_LIFECYCLE_FAILED",
+      "integration_gate requires a deterministic integration report path before dispatch",
+      "Provide --gate-evidence-dir or RELAY_ORCA_GATE_EVIDENCE_ROOT so the operator can write the live report at a deterministic path.",
+    );
+  }
+}
+
 // D6.2 provenance trio verification. Returns a bounded description of the first
 // null/empty/mismatched value, or null when the task/dispatch/assignee trio is
 // fully verified.
@@ -211,7 +233,33 @@ function dispatchOne(ctx) {
   // is durable coordination metadata, independent of whether the operator prompt lands),
   // so a later reconcile can recover the dispatch instead of re-materializing it.
   persistReceipt(report, options);
-  const prompt = buildOperatorPrompt(task, program, outcome, options.programSegment);
+  let integrationGate = null;
+  if (task.kind === "integration_gate") {
+    try {
+      integrationGate = prepareIntegrationGate({
+        run: options.runOrca,
+        orcaBin,
+        programId: program.id,
+        outcomeId: task.outcome_id,
+        taskId: orcaTaskId,
+        dispatchId: show.dispatchId,
+        assignee: show.assignee,
+        coordinatorHandle: options.coordinatorHandle,
+        runtimeId: report.admission.runtime_id,
+        reportPath: options.integrationReportPath(task.outcome_id),
+        programSegment: options.programSegment,
+      });
+    } catch (error) {
+      if (!(error instanceof IntegrationLifecycleError)) throw error;
+      entry.status = STATUS.ESCALATED;
+      reject(
+        "INTEGRATION_LIFECYCLE_FAILED",
+        `integration lifecycle failed before operator prompt for outcome ${task.outcome_id}: ${error.reasonCode}: ${error.message}`,
+        "Re-read the current runtime/coordinator/task/dispatch/assignee and canonical gate; do not use task-update, reset, receipt edits, or manual dispatch replay.",
+      );
+    }
+  }
+  const prompt = buildOperatorPrompt(task, program, outcome, options.programSegment, { integrationGate });
   const sent = sendPrompt(options.runOrca, orcaBin, { orcaTaskId, handle, prompt });
   if (!sent.ok) {
     entry.status = STATUS.ESCALATED;
@@ -259,6 +307,7 @@ function orchestrate(rawProgram, options = {}) {
   const report = initReport(plan);
   try {
     const orcaBin = admit(report, options);
+    requireIntegrationCoordinator(program, options);
     // D3.1: reject a zero-handle run AFTER admission (probe result) and BEFORE any
     // materialization mutation, so no task-create/dispatch/terminal-create ever runs.
     requireOperatorHandles(options);

--- a/skills/relay-orca/scripts/lib/run-reasons.js
+++ b/skills/relay-orca/scripts/lib/run-reasons.js
@@ -11,6 +11,7 @@ const REASONS = {
   INJECTION_UNDELIVERED: 42, // D6 dispatch --inject step failed / prompt hand-off failed
   PROVENANCE_MISMATCH: 43, // D6 dispatch-show null/empty/mismatched provenance
   OPERATOR_DISPATCH_FAILED: 44, // D7 no valid operator target for an eligible task
+  INTEGRATION_LIFECYCLE_FAILED: 45, // #1019 coordinator-owned gate/terminal boundary failed closed
 };
 
 const REMEDIATION = {
@@ -24,6 +25,8 @@ const REMEDIATION = {
     "Reconcile the dispatch-show provenance (task id, dispatch id, assignee); never advance a program on unverified provenance.",
   OPERATOR_DISPATCH_FAILED:
     "Provide an --operator-handle or ensure orca terminal create yields a usable handle for the eligible task.",
+  INTEGRATION_LIFECYCLE_FAILED:
+    "Re-read the current runtime, coordinator, task, dispatch, assignee, canonical gate, and deterministic report; never use task-update, reset, receipt edits, or manual replay to repair the lifecycle.",
 };
 
 class RunError extends Error {

--- a/skills/relay-orca/scripts/lib/status-classify.js
+++ b/skills/relay-orca/scripts/lib/status-classify.js
@@ -71,9 +71,25 @@ function gatePasses(gate) {
 // receipt-and-status.md). When Orca is untrusted the checks degrade to null.
 function integrationGateEvidence(facts, orcaTrusted) {
   if (!orcaTrusted) return { gate_report_present: null, gate_check_passes: null };
+  if (facts.strictIntegration) {
+    const audit = facts.integrationAudit;
+    return {
+      gate_report_present: Boolean(audit && audit.state !== "missing"),
+      gate_check_passes: Boolean(audit && audit.ok === true && audit.state === "passed"),
+    };
+  }
   const gates = Array.isArray(facts.outcomeGates) ? facts.outcomeGates : [];
   const gate = gates.find((candidate) => !candidate.kind || candidate.kind === "integration") || null;
-  return { gate_report_present: Boolean(gate), gate_check_passes: gate ? gatePasses(gate) : false };
+  return { gate_report_present: Boolean(gate), gate_check_passes: gate ? integrationGatePasses(gate) : false };
+}
+
+// Integration gates have the exact ["passed","failed"] resolution contract. A generic
+// status=resolved is deliberately insufficient; only the canonical resolution (or the
+// explicit legacy-compatible status=passed shape) can classify this outcome as passed.
+function integrationGatePasses(gate) {
+  if (!gate || typeof gate !== "object") return false;
+  const explicit = [gate.resolution, gate.result, gate.outcome].find((value) => typeof value === "string" && value.trim() !== "");
+  return explicit === "passed" || gate.status === "passed";
 }
 
 // advisory_review (read-only): advisory evidence posted AND every blocking finding
@@ -176,6 +192,17 @@ function detectOutcome(facts, evidence, orcaTrusted, complete) {
   }
   if (mappedRunMissing) {
     diagnostics.push(diag("MISSING_RELAY_RUN", outcomeId, `mapped relay run ${mappedRunId} has no manifest`, { run: mappedRunId }));
+  }
+
+  if (facts.strictIntegration) {
+    if (!orcaTrusted && receiptTask.kind === "integration_gate") {
+      diagnostics.push(diag("INTEGRATION_GATE_UNVERIFIED", outcomeId, "canonical integration gate cannot be verified because the live Orca runtime is not attributable", { orca_task_id: orcaTaskId }));
+    } else if (facts.integrationAudit && !facts.integrationAudit.ok) {
+      diagnostics.push(diag(facts.integrationAudit.reasonCode, outcomeId, facts.integrationAudit.message, { orca_task_id: orcaTaskId }));
+    }
+    if (receiptTask.kind === "integration_gate" && orcaTask && orcaTask.status !== "completed") {
+      diagnostics.push(diag("INTEGRATION_TASK_ACTIVE", outcomeId, `integration task ${orcaTaskId} is still ${orcaTask.status || "active"}; completed task-list status is required after worker_done`, { orca_task_id: orcaTaskId, status: orcaTask.status || null }));
+    }
   }
 
   const taskCompleted = Boolean(orcaTask && (orcaTask.status === "completed" || orcaTask.worker_done === true));

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -16,6 +16,7 @@ const { ghIssueView, ghPrView } = require("./gh-reads");
 const { classifyOutcome, deriveProgramState, requiredEvidenceFor } = require("./status-classify");
 const { isTerminalManifestState, isEscalatedManifestState } = require("./manifest-parse");
 const { orderReport } = require("./status-report");
+const { canonicalIntegrationQuestion, inspectCanonicalGates } = require("./integration-lifecycle");
 
 // A17: two runtime ids attribute to the SAME runtime only when both are non-empty
 // strings AND identical. Used to prove every adopted read (task-list, gate-list, and
@@ -131,9 +132,25 @@ function gateBlocksTask(gate, orcaTaskId) {
   return Array.isArray(gate.blocks) && gate.blocks.includes(orcaTaskId);
 }
 
+function canonicalIntegrationAudit(task, runtime, programId, programSegment, strictIntegration) {
+  if (!strictIntegration || task.kind !== "integration_gate") return null;
+  if (!runtime.orcaTrusted) return { ok: false, reasonCode: "INTEGRATION_GATE_UNVERIFIED", state: "unknown", message: "canonical integration gate cannot be verified until the live Orca runtime is attributable" };
+  if (!isNonEmptyString(task.orca_task_id)) {
+    return { ok: false, reasonCode: "INTEGRATION_GATE_IDENTITY_UNAVAILABLE", state: "missing", message: "integration outcome has no verified Orca task id for canonical gate identity" };
+  }
+  const question = canonicalIntegrationQuestion(programId, task.outcome_id, programSegment);
+  const identity = { task_id: task.orca_task_id, question, options: ["passed", "failed"] };
+  const inspected = inspectCanonicalGates(runtime.gates.filter((gate) => gateBlocksTask(gate, task.orca_task_id)), identity);
+  if (!inspected.ok) return { ok: false, reasonCode: inspected.reasonCode, state: "conflict", message: inspected.message };
+  if (inspected.state === "missing") return { ok: false, reasonCode: "INTEGRATION_GATE_MISSING", state: "missing", message: `canonical integration gate for task ${task.orca_task_id} is missing` };
+  if (inspected.state === "pending") return { ok: false, reasonCode: "INTEGRATION_GATE_PENDING", state: "pending", message: `canonical integration gate ${inspected.gate.id} is pending; it must resolve passed before worker_done` };
+  if (inspected.state === "failed") return { ok: false, reasonCode: "INTEGRATION_GATE_FAILED", state: "failed", message: `canonical integration gate ${inspected.gate.id} resolved failed` };
+  return { ok: true, state: "passed", gate: inspected.gate, question, options: identity.options };
+}
+
 // Build the gathered fact bundle for one receipt task.
 function gatherOutcomeFacts(task, ctx) {
-  const { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor } = ctx;
+  const { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor, programId, programSegment, strictIntegration } = ctx;
   const mappedRunId = task.relay_ids && task.relay_ids.run ? task.relay_ids.run : null;
   let manifest = null;
   let mappedRunMissing = false;
@@ -174,6 +191,7 @@ function gatherOutcomeFacts(task, ctx) {
   const outcomeGates = runtime.orcaTrusted && task.orca_task_id
     ? runtime.gates.filter((gate) => gateBlocksTask(gate, task.orca_task_id))
     : [];
+  const integrationAudit = canonicalIntegrationAudit(task, runtime, programId, programSegment, strictIntegration);
 
   // relay_fleet outcomes map via relay_ids.fleet to a fleet manifest under the SEPARATE
   // FLEETS root (see receipt-and-status.md § A8) — NOT the runs root. Its `children`
@@ -253,6 +271,8 @@ function gatherOutcomeFacts(task, ctx) {
     dispatchRuntimeUnknown,
     gateBlocking,
     outcomeGates,
+    integrationAudit,
+    strictIntegration: Boolean(strictIntegration),
     fleetManifest,
     mappedFleetId,
     fleetChildren,
@@ -362,7 +382,7 @@ function summarizeLiveDispatch(runtime, facts) {
 // from the SEPARATE fleets root (#945 A8), keyed by fleet id. `liveDispatchSink` is an
 // OPTIONAL Map that, when provided (only `resume` passes it), is populated per outcome
 // with the reconciliation's live dispatch fact — it never changes the returned report.
-function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment, liveDispatchSink }) {
+function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment, liveDispatchSink, strictIntegration = false }) {
   const resolvedUrlFor = typeof urlFor === "function" ? urlFor : () => null;
   const manifestByRunId = new Map(manifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
   const fleetManifestById = new Map(fleetManifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
@@ -370,7 +390,7 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
   const { diagnostics: duplicateDiagnostics, duplicateOutcomeIds } = detectDuplicateMappings(receipt.tasks);
 
   const entries = receipt.tasks.map((task) => {
-    const facts = gatherOutcomeFacts(task, { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor: resolvedUrlFor });
+    const facts = gatherOutcomeFacts(task, { manifestByRunId, fleetManifestById, runtime, gh, orca, urlFor: resolvedUrlFor, programId, programSegment, strictIntegration });
     if (liveDispatchSink && typeof liveDispatchSink.set === "function") {
       liveDispatchSink.set(task.outcome_id, summarizeLiveDispatch(runtime, facts));
     }

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -182,52 +182,55 @@ function integrationSleep(ms) {
   Atomics.wait(shared, 0, 0, ms);
 }
 
+// Read the recorded owner pid of a held lock. Returns null for EVERY ambiguous shape — an
+// absent owner file (the crash window between `mkdirSync` publishing the lock and the owner
+// write landing), an unreadable file, or a non-numeric/out-of-range/trailing-garbage value.
+// A null owner is NEVER reclaimed: an ambiguous lock is left to time out fail-closed rather
+// than stolen from a possibly-live holder. There is deliberately no mtime lease fallback —
+// an old mtime is not evidence that the owner is gone. (#1019 R3)
 function readIntegrationLockOwnerPid(lockPath) {
+  let raw;
   try {
-    const raw = fs.readFileSync(path.join(lockPath, "owner"), "utf8").trim();
-    const pid = Number.parseInt(raw, 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
+    raw = fs.readFileSync(path.join(lockPath, "owner"), "utf8");
   } catch {
     return null;
   }
+  const trimmed = raw.trim();
+  if (!/^[1-9][0-9]*$/.test(trimmed)) return null;
+  const pid = Number(trimmed);
+  return Number.isSafeInteger(pid) ? pid : null;
 }
 
-// `process.kill(pid, 0)` performs the OS liveness check without delivering a signal:
-// ESRCH means the owner is gone, EPERM means it exists under another user (still alive).
-// Anything ambiguous is treated as alive so a live holder is never stolen (fail closed).
-function integrationLockOwnerAlive(pid) {
-  if (pid === process.pid) return true;
+// A process is "provably gone" ONLY when `process.kill(pid, 0)` — the OS liveness check that
+// delivers no signal — reports exactly ESRCH. EPERM means the pid is live under another user,
+// and any other error is ambiguous; both are treated as alive so contention still fails closed.
+// Our own pid is never considered gone.
+function integrationLockOwnerIsGone(pid) {
+  if (pid === process.pid) return false;
   try {
     process.kill(pid, 0);
-    return true;
+    return false;
   } catch (error) {
-    return error && error.code === "ESRCH" ? false : true;
+    return Boolean(error) && error.code === "ESRCH";
   }
 }
 
-// A lock directory is reclaimable ONLY when its owner is provably gone. A readable owner PID
-// that no longer maps to a live process (a crashed/killed coordinator) is stale. An unreadable
-// owner — the narrow window where a crash struck between mkdir and the owner write, or a torn
-// write — falls back to a bounded mtime lease so the directory can never strand the lifecycle
-// forever, while a lock younger than the lease is left alone (a live holder mid-acquisition).
-function integrationLockIsStale(lockPath, timeoutMs) {
+// Reclaim a lock whose recorded owner is provably dead. The rename-then-remove makes the
+// reclaim atomic: among racing reclaimers exactly one rename succeeds, and every loser sees
+// ENOENT and simply keeps polling (it can then contend for the lock normally). Renaming
+// rather than removing in place also means a lock freshly acquired by a competitor can never
+// be deleted out from under it by a half-completed reclaim.
+function reclaimAbandonedIntegrationLock(root, lockPath) {
   const pid = readIntegrationLockOwnerPid(lockPath);
-  if (pid !== null) return !integrationLockOwnerAlive(pid);
+  if (pid === null || !integrationLockOwnerIsGone(pid)) return false;
+  const grave = path.join(root, `.reclaimed-${process.pid}-${crypto.randomBytes(6).toString("hex")}`);
   try {
-    return Date.now() - fs.statSync(lockPath).mtimeMs > timeoutMs;
+    fs.renameSync(lockPath, grave);
   } catch {
     return false;
   }
-}
-
-function reclaimStaleIntegrationLock(lockPath, timeoutMs) {
-  if (!integrationLockIsStale(lockPath, timeoutMs)) return false;
-  try {
-    fs.rmSync(lockPath, { recursive: true, force: true });
-    return true;
-  } catch {
-    return false;
-  }
+  fs.rmSync(grave, { recursive: true, force: true });
+  return true;
 }
 
 function withIntegrationLifecycleLock({ programId, outcomeId, taskId, lockRoot, timeoutMs, pollMs }, callback) {
@@ -237,24 +240,34 @@ function withIntegrationLifecycleLock({ programId, outcomeId, taskId, lockRoot, 
   const poll = Number.isInteger(pollMs) && pollMs > 0 ? pollMs : INTEGRATION_LOCK_POLL_MS;
   const started = Date.now();
   let acquired = false;
+  let lastOwner = null;
   fs.mkdirSync(root, { recursive: true });
   while (!acquired) {
     try {
+      // `mkdirSync` is the atomic publish; the owner stamp follows immediately so an
+      // abandoned lock is reclaimable without manual deletion.
       fs.mkdirSync(lockPath);
       fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
       acquired = true;
     } catch (error) {
       if (error.code !== "EEXIST") throw error;
+      lastOwner = readIntegrationLockOwnerPid(lockPath);
       // A crash/kill between mkdirSync and the finally rmSync would otherwise strand this
       // directory forever, failing every later run/resume closed with no reset-free recovery.
-      // Reclaim it iff its owner is provably gone, then retry immediately; a live owner keeps
-      // the lock and we fall through to the bounded poll/timeout.
-      if (reclaimStaleIntegrationLock(lockPath, timeout)) continue;
+      // Reclaim it iff its owner is provably gone; a live or ambiguous owner keeps the lock.
+      const reclaimed = reclaimAbandonedIntegrationLock(root, lockPath);
+      // The timeout bounds EVERY path, reclaim included, so a pathological stream of
+      // dead-owner locks can never spin here forever.
       if (Date.now() - started > timeout) break;
-      integrationSleep(poll);
+      // Retry immediately after a successful reclaim; otherwise back off and let the live (or
+      // ambiguous) owner finish, which fails closed at the timeout.
+      if (!reclaimed) integrationSleep(poll);
     }
   }
-  if (!acquired) throw new Error(`integration lifecycle lock timed out for ${programId}/${outcomeId}`);
+  if (!acquired) {
+    const held = lastOwner === null ? "an unidentifiable owner" : `owner pid ${lastOwner}`;
+    throw new Error(`integration lifecycle lock timed out for ${programId}/${outcomeId} (held by ${held})`);
+  }
   try {
     return callback();
   } finally {

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -182,20 +182,76 @@ function integrationSleep(ms) {
   Atomics.wait(shared, 0, 0, ms);
 }
 
-function withIntegrationLifecycleLock({ programId, outcomeId, taskId, lockRoot }, callback) {
+function readIntegrationLockOwnerPid(lockPath) {
+  try {
+    const raw = fs.readFileSync(path.join(lockPath, "owner"), "utf8").trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+// `process.kill(pid, 0)` performs the OS liveness check without delivering a signal:
+// ESRCH means the owner is gone, EPERM means it exists under another user (still alive).
+// Anything ambiguous is treated as alive so a live holder is never stolen (fail closed).
+function integrationLockOwnerAlive(pid) {
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === "ESRCH" ? false : true;
+  }
+}
+
+// A lock directory is reclaimable ONLY when its owner is provably gone. A readable owner PID
+// that no longer maps to a live process (a crashed/killed coordinator) is stale. An unreadable
+// owner — the narrow window where a crash struck between mkdir and the owner write, or a torn
+// write — falls back to a bounded mtime lease so the directory can never strand the lifecycle
+// forever, while a lock younger than the lease is left alone (a live holder mid-acquisition).
+function integrationLockIsStale(lockPath, timeoutMs) {
+  const pid = readIntegrationLockOwnerPid(lockPath);
+  if (pid !== null) return !integrationLockOwnerAlive(pid);
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs > timeoutMs;
+  } catch {
+    return false;
+  }
+}
+
+function reclaimStaleIntegrationLock(lockPath, timeoutMs) {
+  if (!integrationLockIsStale(lockPath, timeoutMs)) return false;
+  try {
+    fs.rmSync(lockPath, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function withIntegrationLifecycleLock({ programId, outcomeId, taskId, lockRoot, timeoutMs, pollMs }, callback) {
   const root = path.resolve(lockRoot || path.join(os.tmpdir(), "relay-orca-integration-locks"));
   const lockPath = path.join(root, `${integrationLockName({ programId, outcomeId, taskId })}.lock`);
+  const timeout = Number.isInteger(timeoutMs) && timeoutMs >= 0 ? timeoutMs : INTEGRATION_LOCK_TIMEOUT_MS;
+  const poll = Number.isInteger(pollMs) && pollMs > 0 ? pollMs : INTEGRATION_LOCK_POLL_MS;
   const started = Date.now();
   let acquired = false;
   fs.mkdirSync(root, { recursive: true });
-  while (!acquired && Date.now() - started <= INTEGRATION_LOCK_TIMEOUT_MS) {
+  while (!acquired) {
     try {
       fs.mkdirSync(lockPath);
       fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
       acquired = true;
     } catch (error) {
       if (error.code !== "EEXIST") throw error;
-      integrationSleep(INTEGRATION_LOCK_POLL_MS);
+      // A crash/kill between mkdirSync and the finally rmSync would otherwise strand this
+      // directory forever, failing every later run/resume closed with no reset-free recovery.
+      // Reclaim it iff its owner is provably gone, then retry immediately; a live owner keeps
+      // the lock and we fall through to the bounded poll/timeout.
+      if (reclaimStaleIntegrationLock(lockPath, timeout)) continue;
+      if (Date.now() - started > timeout) break;
+      integrationSleep(poll);
     }
   }
   if (!acquired) throw new Error(`integration lifecycle lock timed out for ${programId}/${outcomeId}`);
@@ -275,6 +331,7 @@ module.exports = {
   receiptPathFor,
   writeReceiptAtomic,
   readReceiptFile,
+  integrationLockName,
   withIntegrationLifecycleLock,
   readIntegrationEvidenceFile,
   receiptExists,

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -166,6 +166,55 @@ function readReceiptFile(finalPath) {
   return fs.readFileSync(finalPath, "utf-8");
 }
 
+// #1019 integration lifecycle I/O stays at the top-level script boundary. The pure
+// lifecycle state machine receives these adapters so plan.js's lib source-scan remains
+// intact while run/resume still get a bounded per-program/outcome lock and deterministic
+// evidence reads.
+const INTEGRATION_LOCK_TIMEOUT_MS = 5000;
+const INTEGRATION_LOCK_POLL_MS = 10;
+
+function integrationLockName({ programId, outcomeId, taskId }) {
+  return crypto.createHash("sha256").update(`${programId}\0${outcomeId}\0${taskId}`).digest("hex");
+}
+
+function integrationSleep(ms) {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, ms);
+}
+
+function withIntegrationLifecycleLock({ programId, outcomeId, taskId, lockRoot }, callback) {
+  const root = path.resolve(lockRoot || path.join(os.tmpdir(), "relay-orca-integration-locks"));
+  const lockPath = path.join(root, `${integrationLockName({ programId, outcomeId, taskId })}.lock`);
+  const started = Date.now();
+  let acquired = false;
+  fs.mkdirSync(root, { recursive: true });
+  while (!acquired && Date.now() - started <= INTEGRATION_LOCK_TIMEOUT_MS) {
+    try {
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
+      acquired = true;
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      integrationSleep(INTEGRATION_LOCK_POLL_MS);
+    }
+  }
+  if (!acquired) throw new Error(`integration lifecycle lock timed out for ${programId}/${outcomeId}`);
+  try {
+    return callback();
+  } finally {
+    fs.rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+function readIntegrationEvidenceFile(filePath) {
+  if (!fs.existsSync(filePath)) return { present: false };
+  try {
+    return { present: true, value: JSON.parse(fs.readFileSync(filePath, "utf8")) };
+  } catch (error) {
+    return { present: true, invalid: true, error: error.message };
+  }
+}
+
 function receiptExists(finalPath) {
   return fs.existsSync(finalPath);
 }
@@ -226,6 +275,8 @@ module.exports = {
   receiptPathFor,
   writeReceiptAtomic,
   readReceiptFile,
+  withIntegrationLifecycleLock,
+  readIntegrationEvidenceFile,
   receiptExists,
   listManifestFiles,
   listFleetManifestFiles,

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -43,7 +43,7 @@ const { dispatchTask, showDispatch, sendPrompt } = require("./lib/run-orca");
 const { provenanceMismatch } = require("./lib/run-orchestrator");
 const { buildOperatorPrompt } = require("./lib/operator-prompt");
 const { routeFor, defaultEvidenceFor } = require("./lib/task-kinds");
-const { planResume, earlierWavesComplete } = require("./lib/resume-plan");
+const { planResume, waveEligible } = require("./lib/resume-plan");
 const { orderReport } = require("./lib/resume-report");
 const { validateRelayRunMappings, applyRelayRunMappings } = require("./lib/resume-mapping");
 const {
@@ -484,24 +484,43 @@ function isNonEmptyStr(value) {
   return typeof value === "string" && value.trim() !== "";
 }
 
-// Advance ONLY a currently-dispatched, wave-eligible integration gate. A materialized but
-// undispatched integration_gate (null dispatch_id/assignee — the #1019 live shape, where the
-// integration gate is wave 2 and wave-1 resume has not reached it) stays INERT: advancing it
-// would hit INTEGRATION_DISPATCH_PROVENANCE_MISSING and flip an otherwise-idempotent wave-1
-// resume to ok:false. A gate whose earlier waves are not yet complete_with_evidence is never
-// advanced either — even if it was dispatched out of band — so its canonical gate can never be
-// resolved ahead of the program's wave order. planResume already skips these outcomes; this is
-// the matching guard on the coordinator-owned lifecycle advance.
-function integrationGateAdvanceable(task, report) {
-  const dispatched = isNonEmptyStr(task.dispatch_id) && isNonEmptyStr(task.assignee);
-  const waveEligible = task.wave === 1 || earlierWavesComplete(task, report);
-  return dispatched && waveEligible;
+// Actions that leave the outcome holding a CURRENTLY VERIFIED live dispatch: `reused` proved
+// task+dispatch+terminal are all live this run, and `redispatched` just re-established them
+// through the verified inject -> dispatch-show -> prompt path. Every other action (`skipped`,
+// `decision_required`) means planResume deliberately left the outcome alone. Receipt strings
+// alone are NOT proof — a stale receipt can carry a dispatch_id whose Orca dispatch is gone.
+const ADVANCEABLE_ACTIONS = new Set(["reused", "redispatched"]);
+
+// Advance ONLY an integration gate that is wave-eligible AND holds a verified live dispatch.
+// Eligibility is read straight off the plan `planResume` already computed, plus that same
+// module's shared `waveEligible` blanket — never a second policy that could drift from it.
+//
+// A materialized but undispatched integration_gate (null dispatch_id/assignee — the #1019 live
+// shape, where the integration gate is wave 2 and wave-1 resume has not reached it) stays
+// INERT: advancing it would hit INTEGRATION_DISPATCH_PROVENANCE_MISSING and flip an
+// otherwise-idempotent wave-1 resume to ok:false. A gate whose earlier waves are not yet
+// complete_with_evidence is never advanced either — even if it was dispatched out of band — so
+// its canonical gate can never be resolved ahead of the program's wave order. Both are left
+// COMPLETELY untouched: no lock, no Orca read, no lifecycle mutation. (#1019 R3)
+function integrationGateAdvanceable(task, report, actionByOutcome) {
+  return (
+    ADVANCEABLE_ACTIONS.has(actionByOutcome.get(task.outcome_id))
+    && waveEligible(task, report)
+    && isNonEmptyStr(task.dispatch_id)
+    && isNonEmptyStr(task.assignee)
+  );
 }
 
-function advanceIntegrationTasks({ receipt, opts, orcaBin, report }) {
+function integrationTasksToAdvance({ receipt, report, actions }) {
+  const actionByOutcome = new Map((actions || []).map((action) => [action.outcome_id, action.action]));
+  return receipt.tasks.filter((task) => (
+    task && task.kind === "integration_gate" && integrationGateAdvanceable(task, report, actionByOutcome)
+  ));
+}
+
+function advanceIntegrationTasks({ receipt, opts, orcaBin, report, actions }) {
   const blocking = [];
-  receipt.tasks
-    .filter((task) => task && task.kind === "integration_gate" && integrationGateAdvanceable(task, report))
+  integrationTasksToAdvance({ receipt, report, actions })
     .forEach((task) => {
     try {
       const result = advanceIntegrationGate({
@@ -622,7 +641,7 @@ function main() {
     const executed = executeActions({ receipt, actions: plan.actions, opts, orcaBin: resolveOrca(opts), persist });
     terminalsCreated = executed.reportTerminals;
     blockingReasons = executed.blocking;
-    blockingReasons = blockingReasons.concat(advanceIntegrationTasks({ receipt, opts, orcaBin: resolveOrca(opts), report }));
+    blockingReasons = blockingReasons.concat(advanceIntegrationTasks({ receipt, opts, orcaBin: resolveOrca(opts), report, actions: plan.actions }));
   }
 
   const body = buildReport({ opts, receiptPath, report, plan, terminalsCreated, blockingReasons, decisions: plan.decisions });
@@ -638,4 +657,4 @@ function main() {
 // without triggering a real resume run.
 if (require.main === module) main();
 
-module.exports = { syntheticTask, reportActions, integrationBlockingEntry, integrationGateAdvanceable, advanceIntegrationTasks };
+module.exports = { syntheticTask, reportActions, integrationBlockingEntry, integrationGateAdvanceable, integrationTasksToAdvance, advanceIntegrationTasks };

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -28,6 +28,8 @@ const {
   makeUrlResolver,
   writeReceiptAtomic,
   programSegment,
+  withIntegrationLifecycleLock,
+  readIntegrationEvidenceFile,
 } = require("./receipt-io");
 const { parseReceipt, serializeReceiptWithRecords } = require("./lib/receipt");
 const { applyOperatorRecords } = require("./lib/operator-records");
@@ -423,6 +425,14 @@ function executeAction(action, ctx) {
         runtimeId: ctx.receipt.runtime_id,
         reportPath: ctx.integrationReportPath(receiptTask.outcome_id),
         programSegment,
+        withLock: (lockKey, callback) => withIntegrationLifecycleLock({
+          programId: ctx.receipt.program_id,
+          outcomeId: receiptTask.outcome_id,
+          taskId: orcaTaskId,
+          lockRoot: ctx.integrationLockRoot,
+          lockKey,
+        }, callback),
+        readReport: readIntegrationEvidenceFile,
       });
     } catch (error) {
       if (!(error instanceof IntegrationLifecycleError)) throw error;
@@ -450,6 +460,7 @@ function executeActions({ receipt, actions, opts, orcaBin, persist }) {
     persist,
     coordinatorHandle: opts.coordinatorHandle,
     integrationReportPath: opts.integrationReportPath,
+    integrationLockRoot: opts.integrationLockRoot,
     taskByOutcome: new Map(receipt.tasks.map((task) => [task.outcome_id, task])),
   };
   actions.forEach((action) => {
@@ -474,6 +485,14 @@ function advanceIntegrationTasks({ receipt, opts, orcaBin, persist }) {
         runtimeId: receipt.runtime_id,
         reportPath: opts.integrationReportPath(task.outcome_id),
         programSegment,
+        withLock: (lockKey, callback) => withIntegrationLifecycleLock({
+          programId: receipt.program_id,
+          outcomeId: task.outcome_id,
+          taskId: task.orca_task_id,
+          lockRoot: opts.integrationLockRoot,
+          lockKey,
+        }, callback),
+        readReport: readIntegrationEvidenceFile,
       });
       if (!result.ok) {
         blocking.push(blockingReason(result.reason_code, `${result.reason_code}: operator must send the fresh explicit worker_done command exactly once after gate resolution`));

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -15,6 +15,7 @@
 // It NEVER invokes `orca orchestration reset` (D7) or any `orca worktree` subcommand
 // (D7), never deletes a task/worktree/branch/PR, and never force-closes a relay run.
 const fs = require("node:fs");
+const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 const {
   CanonicalizationError,
@@ -43,6 +44,12 @@ const { routeFor, defaultEvidenceFor } = require("./lib/task-kinds");
 const { planResume } = require("./lib/resume-plan");
 const { orderReport } = require("./lib/resume-report");
 const { validateRelayRunMappings, applyRelayRunMappings } = require("./lib/resume-mapping");
+const {
+  IntegrationLifecycleError,
+  prepareIntegrationGate,
+  advanceIntegrationGate,
+  integrationReportPath,
+} = require("./lib/integration-lifecycle");
 
 const READ_TIMEOUT_MS = 15000;
 const READ_MAX_BUFFER = 4 * 1024 * 1024;
@@ -54,7 +61,7 @@ function usageError(message) {
   process.stderr.write(
     "usage: resume.js --program-id <id> [--json] [--operator-handle <handle> ...] " +
       "[--program-file <accepted-program.json>] [--map-relay-run <outcome_id>=<run_id> ...] " +
-      "[--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
+      "[--coordinator-handle <handle>] [--gate-evidence-dir <dir>] [--orca-bin <path>] [--gh-bin <path>] [--repo-root <path>]\n",
   );
   process.exit(USAGE_EXIT);
 }
@@ -78,6 +85,8 @@ function parseArgs(argv) {
     programId: null,
     json: false,
     operatorHandles: [],
+    coordinatorHandle: null,
+    gateEvidenceDir: null,
     orcaBin: null,
     ghBin: null,
     repoRoot: null,
@@ -99,6 +108,8 @@ function parseArgs(argv) {
     if (arg === "--program-id" || arg === "-p") opts.programId = requireValue(argv[(i += 1)], "--program-id");
     else if (arg === "--json") opts.json = true;
     else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
+    else if (arg === "--coordinator-handle") opts.coordinatorHandle = requireValue(argv[(i += 1)], "--coordinator-handle");
+    else if (arg === "--gate-evidence-dir") opts.gateEvidenceDir = requireValue(argv[(i += 1)], "--gate-evidence-dir");
     else if (arg === "--resolve-decision") opts.resolveDecision = requireValue(argv[(i += 1)], "--resolve-decision");
     else if (arg === "--resolution") opts.resolution = requireValue(argv[(i += 1)], "--resolution");
     else if (arg === "--resolver") opts.resolver = requireValue(argv[(i += 1)], "--resolver");
@@ -135,6 +146,7 @@ function runOrcaMutating(orcaBin, args, options = {}) {
   const argv = Array.isArray(args) ? args.map(String) : [];
   if (argv.includes("reset")) throw new Error("relay-orca resume must never invoke orca orchestration reset (D7)");
   if (argv.includes("worktree")) throw new Error("relay-orca resume must never invoke any orca worktree subcommand (D7)");
+  if (argv.includes("task-update")) throw new Error("relay-orca resume must never invoke orca orchestration task-update (#1019)");
   const hasInput = options.input !== undefined && options.input !== null;
   try {
     const stdout = execFileSync(orcaBin, argv, {
@@ -226,8 +238,27 @@ function reconcile({ receipt, opts, repo, receiptPath }) {
     urlFor: makeUrlResolver(repo.root),
     programSegment,
     liveDispatchSink: liveDispatch,
+    strictIntegration: true,
   });
   return { report, liveDispatch };
+}
+
+function makeIntegrationReportPathResolver(opts, receiptPath) {
+  const configured = opts.gateEvidenceDir || (process.env.RELAY_ORCA_GATE_EVIDENCE_ROOT || "").trim();
+  const root = path.resolve(configured || path.join(path.dirname(receiptPath), "integration-gates"));
+  return (outcomeId) => integrationReportPath(root, outcomeId);
+}
+
+function requireIntegrationOptions(receipt, opts, receiptPath) {
+  const hasIntegration = receipt.tasks.some((task) => task && task.kind === "integration_gate");
+  if (!hasIntegration) return () => null;
+  if (!opts.coordinatorHandle) {
+    throw new IntegrationLifecycleError(
+      "INTEGRATION_COORDINATOR_PROVENANCE_MISSING",
+      "integration_gate resume requires explicit --coordinator-handle; never infer coordinator identity from stale receipt/history",
+    );
+  }
+  return makeIntegrationReportPathResolver(opts, receiptPath);
 }
 
 // Persist the live receipt object atomically, preserving created_at and any stop record
@@ -377,7 +408,29 @@ function executeAction(action, ctx) {
   receiptTask.dispatch_id = show.dispatchId;
   receiptTask.assignee = show.assignee;
   ctx.persist();
-  const prompt = buildOperatorPrompt(syntheticTask(receiptTask), { id: ctx.receipt.program_id }, {}, programSegment);
+  let integrationGate = null;
+  if (receiptTask.kind === "integration_gate") {
+    try {
+      integrationGate = prepareIntegrationGate({
+        run: ctx.runOrca,
+        orcaBin: ctx.orcaBin,
+        programId: ctx.receipt.program_id,
+        outcomeId: receiptTask.outcome_id,
+        taskId: orcaTaskId,
+        dispatchId: show.dispatchId,
+        assignee: show.assignee,
+        coordinatorHandle: ctx.coordinatorHandle,
+        runtimeId: ctx.receipt.runtime_id,
+        reportPath: ctx.integrationReportPath(receiptTask.outcome_id),
+        programSegment,
+      });
+    } catch (error) {
+      if (!(error instanceof IntegrationLifecycleError)) throw error;
+      ctx.blocking.push(blockingReason(error.reasonCode, `integration lifecycle failed before operator prompt for outcome ${receiptTask.outcome_id}: ${error.message}`));
+      return;
+    }
+  }
+  const prompt = buildOperatorPrompt(syntheticTask(receiptTask), { id: ctx.receipt.program_id }, {}, programSegment, { integrationGate });
   const sent = sendPrompt(ctx.runOrca, ctx.orcaBin, { orcaTaskId, handle, prompt });
   if (!sent.ok) ctx.blocking.push(blockingReason("RESUME_REDISPATCH_FAILED", `operator prompt hand-off failed for outcome ${action.outcome_id}`));
 }
@@ -395,12 +448,42 @@ function executeActions({ receipt, actions, opts, orcaBin, persist }) {
     reportTerminals: [],
     blocking: [],
     persist,
+    coordinatorHandle: opts.coordinatorHandle,
+    integrationReportPath: opts.integrationReportPath,
     taskByOutcome: new Map(receipt.tasks.map((task) => [task.outcome_id, task])),
   };
   actions.forEach((action) => {
     if (action.exec) executeAction(action, ctx);
   });
   return { reportTerminals: ctx.reportTerminals, blocking: ctx.blocking };
+}
+
+function advanceIntegrationTasks({ receipt, opts, orcaBin, persist }) {
+  const blocking = [];
+  receipt.tasks.filter((task) => task && task.kind === "integration_gate").forEach((task) => {
+    try {
+      const result = advanceIntegrationGate({
+        run: runOrcaMutating,
+        orcaBin,
+        programId: receipt.program_id,
+        outcomeId: task.outcome_id,
+        taskId: task.orca_task_id,
+        dispatchId: task.dispatch_id,
+        assignee: task.assignee,
+        coordinatorHandle: opts.coordinatorHandle,
+        runtimeId: receipt.runtime_id,
+        reportPath: opts.integrationReportPath(task.outcome_id),
+        programSegment,
+      });
+      if (!result.ok) {
+        blocking.push(blockingReason(result.reason_code, `${result.reason_code}: operator must send the fresh explicit worker_done command exactly once after gate resolution`));
+      }
+    } catch (error) {
+      if (!(error instanceof IntegrationLifecycleError)) throw error;
+      blocking.push(blockingReason(error.reasonCode, error.message));
+    }
+  });
+  return blocking;
 }
 
 function reportActions(actions) {
@@ -458,6 +541,7 @@ function main() {
     if (receipt.repo && receipt.repo.slug !== repo.slug) {
       rejectReceipt("RECEIPT_REPO_MISMATCH", `receipt repo.slug ${receipt.repo.slug} does not match the current repo slug ${repo.slug}`);
     }
+    opts.integrationReportPath = requireIntegrationOptions(receipt, opts, receiptPath);
     const mappingValidation = validateAndRecordRelayRunMappings(receipt, receiptPath, repo, opts);
     if (!mappingValidation.ok) {
       printReport(mappingFailureReport(opts, receiptPath, receipt, mappingValidation), opts.json);
@@ -470,6 +554,13 @@ function main() {
     ({ report, liveDispatch } = reconcile({ receipt, opts, repo, receiptPath }));
   } catch (error) {
     if (error instanceof StatusError || error instanceof CanonicalizationError) failReceipt(error, opts.json);
+    if (error instanceof IntegrationLifecycleError) {
+      const body = { ok: false, reason_code: error.reasonCode, message: error.message, remediation: "Re-run with fresh coordinator provenance and never use task-update, reset, receipt edits, or manual dispatch replay." };
+      if (opts.json) process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+      else process.stderr.write(`relay-orca resume rejected [${error.reasonCode}]: ${error.message}\n`);
+      process.exitCode = 63;
+      return;
+    }
     throw error;
   }
 
@@ -483,6 +574,7 @@ function main() {
     const executed = executeActions({ receipt, actions: plan.actions, opts, orcaBin: resolveOrca(opts), persist });
     terminalsCreated = executed.reportTerminals;
     blockingReasons = executed.blocking;
+    blockingReasons = blockingReasons.concat(advanceIntegrationTasks({ receipt, opts, orcaBin: resolveOrca(opts), persist }));
   }
 
   const body = buildReport({ opts, receiptPath, report, plan, terminalsCreated, blockingReasons, decisions: plan.decisions });

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -43,7 +43,7 @@ const { dispatchTask, showDispatch, sendPrompt } = require("./lib/run-orca");
 const { provenanceMismatch } = require("./lib/run-orchestrator");
 const { buildOperatorPrompt } = require("./lib/operator-prompt");
 const { routeFor, defaultEvidenceFor } = require("./lib/task-kinds");
-const { planResume } = require("./lib/resume-plan");
+const { planResume, earlierWavesComplete } = require("./lib/resume-plan");
 const { orderReport } = require("./lib/resume-report");
 const { validateRelayRunMappings, applyRelayRunMappings } = require("./lib/resume-mapping");
 const {
@@ -480,9 +480,29 @@ function executeActions({ receipt, actions, opts, orcaBin, persist }) {
   return { reportTerminals: ctx.reportTerminals, blocking: ctx.blocking };
 }
 
-function advanceIntegrationTasks({ receipt, opts, orcaBin, persist }) {
+function isNonEmptyStr(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+// Advance ONLY a currently-dispatched, wave-eligible integration gate. A materialized but
+// undispatched integration_gate (null dispatch_id/assignee — the #1019 live shape, where the
+// integration gate is wave 2 and wave-1 resume has not reached it) stays INERT: advancing it
+// would hit INTEGRATION_DISPATCH_PROVENANCE_MISSING and flip an otherwise-idempotent wave-1
+// resume to ok:false. A gate whose earlier waves are not yet complete_with_evidence is never
+// advanced either — even if it was dispatched out of band — so its canonical gate can never be
+// resolved ahead of the program's wave order. planResume already skips these outcomes; this is
+// the matching guard on the coordinator-owned lifecycle advance.
+function integrationGateAdvanceable(task, report) {
+  const dispatched = isNonEmptyStr(task.dispatch_id) && isNonEmptyStr(task.assignee);
+  const waveEligible = task.wave === 1 || earlierWavesComplete(task, report);
+  return dispatched && waveEligible;
+}
+
+function advanceIntegrationTasks({ receipt, opts, orcaBin, report }) {
   const blocking = [];
-  receipt.tasks.filter((task) => task && task.kind === "integration_gate").forEach((task) => {
+  receipt.tasks
+    .filter((task) => task && task.kind === "integration_gate" && integrationGateAdvanceable(task, report))
+    .forEach((task) => {
     try {
       const result = advanceIntegrationGate({
         run: runOrcaMutating,
@@ -602,7 +622,7 @@ function main() {
     const executed = executeActions({ receipt, actions: plan.actions, opts, orcaBin: resolveOrca(opts), persist });
     terminalsCreated = executed.reportTerminals;
     blockingReasons = executed.blocking;
-    blockingReasons = blockingReasons.concat(advanceIntegrationTasks({ receipt, opts, orcaBin: resolveOrca(opts), persist }));
+    blockingReasons = blockingReasons.concat(advanceIntegrationTasks({ receipt, opts, orcaBin: resolveOrca(opts), report }));
   }
 
   const body = buildReport({ opts, receiptPath, report, plan, terminalsCreated, blockingReasons, decisions: plan.decisions });
@@ -618,4 +638,4 @@ function main() {
 // without triggering a real resume run.
 if (require.main === module) main();
 
-module.exports = { syntheticTask, reportActions, integrationBlockingEntry };
+module.exports = { syntheticTask, reportActions, integrationBlockingEntry, integrationGateAdvanceable, advanceIntegrationTasks };

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -394,6 +394,17 @@ function blockingReason(reasonCode, message) {
   return { reason_code: reasonCode, message: boundedExcerpt(message) };
 }
 
+// Blocking entry for a non-ok integration lifecycle advance. When the lifecycle is awaiting
+// the operator's explicit worker_done, surface the authoritative explicit-flag command
+// (complete, not bounded/truncated) so a restarted coordinator/operator can recover it
+// straight from the resume report instead of a prior pane message. (#1019 R2)
+function integrationBlockingEntry(result) {
+  const entry = blockingReason(result.reason_code, `${result.reason_code}: operator must send the fresh explicit worker_done command exactly once after gate resolution`);
+  const copyPaste = result.completion_command && result.completion_command.copy_paste;
+  if (copyPaste) entry.completion_command = copyPaste;
+  return entry;
+}
+
 // Execute ONE re-dispatch / terminal-reacquisition action through the SAME verified path
 // as run: inject -> dispatch-show (provenance trio) -> prompt, persisting the receipt at
 // A16 (handle) and A2 (verified provenance) write points.
@@ -494,9 +505,7 @@ function advanceIntegrationTasks({ receipt, opts, orcaBin, persist }) {
         }, callback),
         readReport: readIntegrationEvidenceFile,
       });
-      if (!result.ok) {
-        blocking.push(blockingReason(result.reason_code, `${result.reason_code}: operator must send the fresh explicit worker_done command exactly once after gate resolution`));
-      }
+      if (!result.ok) blocking.push(integrationBlockingEntry(result));
     } catch (error) {
       if (!(error instanceof IntegrationLifecycleError)) throw error;
       blocking.push(blockingReason(error.reasonCode, error.message));
@@ -609,4 +618,4 @@ function main() {
 // without triggering a real resume run.
 if (require.main === module) main();
 
-module.exports = { syntheticTask, reportActions };
+module.exports = { syntheticTask, reportActions, integrationBlockingEntry };

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -10,6 +10,7 @@
 // (D5) and never invokes orchestration reset (D2). Relay remains the sole creator
 // of implementation worktrees and manifests.
 const fs = require("node:fs");
+const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 const { PlanError } = require("./lib/reasons");
 const { COMMAND_FLAGS, FLAGS } = require("../../relay-dispatch/scripts/cli-schema");
@@ -26,6 +27,7 @@ const {
   receiptExists,
   programSegment,
 } = require("./receipt-io");
+const { integrationReportPath } = require("./lib/integration-lifecycle");
 
 const USAGE_EXIT = 64;
 const RUN_MAX_BUFFER = 4 * 1024 * 1024;
@@ -47,6 +49,7 @@ function runOrca(orcaBin, args, options = {}) {
   const argv = Array.isArray(args) ? args.map(String) : [];
   if (argv.includes("reset")) throw new Error("relay-orca run must never invoke orca orchestration reset (D2)");
   if (argv.includes("worktree")) throw new Error("relay-orca run must never invoke any orca worktree subcommand (D5)");
+  if (argv.includes("task-update")) throw new Error("relay-orca run must never invoke orca orchestration task-update (#1019)");
   const hasInput = options.input !== undefined && options.input !== null;
   try {
     const stdout = execFileSync(orcaBin, argv, {
@@ -70,7 +73,7 @@ function usageError(message) {
   process.stderr.write(`relay-orca run: ${message}\n`);
   process.stderr.write(
     "usage: run.js --program-file <accepted-program.json> [--json] [--concurrency N] " +
-      "[--operator-handle <handle> ...] [--orca-bin <path>]\n",
+      "[--operator-handle <handle> ...] [--coordinator-handle <handle>] [--gate-evidence-dir <dir>] [--orca-bin <path>]\n",
   );
   process.exit(USAGE_EXIT);
 }
@@ -81,6 +84,8 @@ function parseArgs(argv) {
     json: false,
     concurrency: undefined,
     operatorHandles: [],
+    coordinatorHandle: null,
+    gateEvidenceDir: null,
     orcaBin: null,
     repoRoot: null,
     // #947 additive operator-record flags. A decision/authorization record is written
@@ -97,6 +102,8 @@ function parseArgs(argv) {
     else if (arg === "--json") opts.json = true;
     else if (arg === "--concurrency") opts.concurrency = Number(argv[(i += 1)]);
     else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
+    else if (arg === "--coordinator-handle") opts.coordinatorHandle = requireValue(argv[(i += 1)], "--coordinator-handle");
+    else if (arg === "--gate-evidence-dir") opts.gateEvidenceDir = requireValue(argv[(i += 1)], "--gate-evidence-dir");
     else if (arg === "--resolve-decision") opts.resolveDecision = requireValue(argv[(i += 1)], "--resolve-decision");
     else if (arg === "--resolution") opts.resolution = requireValue(argv[(i += 1)], "--resolution");
     else if (arg === "--resolver") opts.resolver = requireValue(argv[(i += 1)], "--resolver");
@@ -175,6 +182,14 @@ function makeReceiptPersistor(opts, program) {
     writeReceiptAtomic(finalPath, serializeReceiptWithRecords(mapping));
     return finalPath;
   };
+}
+
+function makeIntegrationReportPathResolver(opts, program) {
+  const repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
+  const receiptPath = receiptPathFor(repo.slug, program.id);
+  const configured = opts.gateEvidenceDir || (process.env.RELAY_ORCA_GATE_EVIDENCE_ROOT || "").trim();
+  const root = path.resolve(configured || path.join(path.dirname(receiptPath), "integration-gates"));
+  return (outcomeId) => integrationReportPath(root, outcomeId);
 }
 
 function requireValue(value, flag) {
@@ -258,6 +273,8 @@ function main() {
       orcaBin: opts.orcaBin,
       runOrca,
       persistReceipt,
+      coordinatorHandle: opts.coordinatorHandle,
+      integrationReportPath: makeIntegrationReportPathResolver(opts, program),
       // A26: the task-title program marker embeds the SAME collision-resistant segment
       // used for the receipt path, injected as a pure function (lib/ stays subprocess-free).
       programSegment,

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -26,6 +26,8 @@ const {
   readReceiptFile,
   receiptExists,
   programSegment,
+  withIntegrationLifecycleLock,
+  readIntegrationEvidenceFile,
 } = require("./receipt-io");
 const { integrationReportPath } = require("./lib/integration-lifecycle");
 
@@ -275,6 +277,8 @@ function main() {
       persistReceipt,
       coordinatorHandle: opts.coordinatorHandle,
       integrationReportPath: makeIntegrationReportPathResolver(opts, program),
+      withIntegrationLifecycleLock,
+      readIntegrationEvidenceFile,
       // A26: the task-title program marker embeds the SAME collision-resistant segment
       // used for the receipt path, injected as a pure function (lib/ stays subprocess-free).
       programSegment,

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -282,6 +282,7 @@ function gatherReconciliation(opts) {
     // A26: the foreign-task marker embeds the SAME collision-resistant segment used for
     // the receipt path, injected as a pure function (lib/ stays subprocess-free).
     programSegment,
+    strictIntegration: opts.gates || opts.finalSummary || opts.strict,
   });
   return { report, receipt, receiptPath, repo };
 }

--- a/tests/relay-orca/fixtures/fake-orca-integration-lifecycle.js
+++ b/tests/relay-orca/fixtures/fake-orca-integration-lifecycle.js
@@ -1,0 +1,162 @@
+"use strict";
+
+// Stateful, hermetic Orca fixture for #1019. It intentionally models only the
+// authoritative mid-2026 integration lifecycle shapes. Any unsupported or unsafe
+// command poisons the fixture so a test cannot pass through an accidental fallback.
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const DEFAULT_RUNTIME_ID = "runtime-integration-fixture";
+
+function defaultScenario(overrides = {}) {
+  return {
+    runtimeId: overrides.runtimeId || DEFAULT_RUNTIME_ID,
+    coordinator: overrides.coordinator || "coord-current",
+    tasks: overrides.tasks || [],
+    dispatch: overrides.dispatch || {},
+    gates: overrides.gates || [],
+    createResponseLoss: overrides.createResponseLoss === true,
+    createFailure: overrides.createFailure === true,
+    taskListAfterWorkerDone: overrides.taskListAfterWorkerDone || "completed",
+  };
+}
+
+function script({ scenarioPath, logPath, statePath, poisonPath, sendPath }) {
+  return `#!/usr/bin/env node
+"use strict";
+const fs = require("fs");
+const args = process.argv.slice(2);
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const logPath = ${JSON.stringify(logPath)};
+const statePath = ${JSON.stringify(statePath)};
+const poisonPath = ${JSON.stringify(poisonPath)};
+const sendPath = ${JSON.stringify(sendPath)};
+function readState() { return JSON.parse(fs.readFileSync(statePath, "utf8")); }
+function writeState(value) { fs.writeFileSync(statePath, JSON.stringify(value, null, 2), "utf8"); }
+function log() { fs.appendFileSync(logPath, JSON.stringify(args) + "\\n", "utf8"); }
+function poison(reason) { fs.writeFileSync(poisonPath, reason + ":" + args.join(" "), "utf8"); process.exit(99); }
+function value(flag) { const index = args.indexOf(flag); return index >= 0 ? args[index + 1] : null; }
+function has(flag) { return args.includes(flag); }
+function emit(body, code = 0) { if (body !== null) process.stdout.write(JSON.stringify(body)); process.exit(code); }
+function envelope(result) { return { ok: true, result, _meta: { runtimeId: readState().runtimeId } }; }
+function taskFor(state, taskId) {
+  return state.tasks.find((task) => task.id === taskId) || null;
+}
+function gateTaskId(gate) { return gate.task_id || gate.task || null; }
+function gateOptions(gate) { return Array.isArray(gate.options) ? gate.options : []; }
+function validateSend() {
+  const valueFlags = new Set(["--to", "--subject", "--from", "--body", "--type", "--task-id", "--dispatch-id", "--report-path", "--phase"]);
+  const boolFlags = new Set(["--json"]);
+  for (let i = 2; i < args.length; i += 1) {
+    const token = args[i];
+    if (valueFlags.has(token)) {
+      if (i + 1 >= args.length) emit({ ok: false, error: token + " requires a value" }, 2);
+      i += 1;
+    } else if (!boolFlags.has(token)) {
+      emit({ ok: false, error: "orchestration send does not accept " + token }, 2);
+    }
+  }
+  const required = ["--to", "--subject", "--type", "--task-id", "--dispatch-id", "--report-path", "--phase"];
+  required.forEach((flag) => { if (!has(flag)) emit({ ok: false, error: "missing " + flag }, 2); });
+}
+
+log();
+if (has("reset")) poison("RESET_INVOKED");
+if (has("worktree")) poison("WORKTREE_INVOKED");
+if (has("task-update")) poison("TASK_UPDATE_INVOKED");
+const state = readState();
+
+if (args[0] === "status" && args[1] === "--json") {
+  emit(envelope({ runtime: { runtimeId: state.runtimeId }, coordinator: { handle: state.coordinator } }));
+}
+if (args[0] === "orchestration" && args[1] === "task-list") {
+  emit(envelope({ tasks: state.tasks }));
+}
+if (args[0] === "orchestration" && args[1] === "dispatch-show") {
+  if (!has("--task") || !has("--json")) emit({ ok: false, error: "dispatch-show requires --task and --json" }, 2);
+  const taskId = value("--task");
+  const dispatch = state.dispatch[taskId] || {};
+  if (has("--from") && value("--from") !== dispatch.assignee) emit({ ok: false, error: "dispatch-show stale --from" }, 3);
+  emit(envelope({ dispatch: { task_id: taskId, id: dispatch.dispatch_id, assignee_handle: dispatch.assignee, terminal_present: dispatch.terminal_present !== false }, preamble: { coordinator_handle: state.coordinator } }));
+}
+if (args[0] === "orchestration" && args[1] === "gate-list") {
+  if (!has("--task") || !has("--json")) emit({ ok: false, error: "gate-list requires --task and --json" }, 2);
+  const taskId = value("--task");
+  emit(envelope({ gates: state.gates.filter((gate) => gateTaskId(gate) === taskId), count: state.gates.filter((gate) => gateTaskId(gate) === taskId).length }));
+}
+if (args[0] === "orchestration" && args[1] === "gate-create") {
+  if (!has("--task") || !has("--question") || !has("--options") || !has("--json")) emit({ ok: false, error: "gate-create shape rejected" }, 2);
+  const gate = { id: "physical-gate-" + (state.gates.length + 1), task_id: value("--task"), question: value("--question"), options: JSON.parse(value("--options")), status: "pending" };
+  if (!state.createFailure) state.gates.push(gate);
+  writeState(state);
+  if (state.createFailure) emit({ ok: false, error: "gate-create failed" }, 1);
+  if (state.createResponseLoss) emit(null, 1);
+  emit(envelope({ gate }));
+}
+if (args[0] === "orchestration" && args[1] === "gate-resolve") {
+  if (!has("--id") || !has("--resolution") || !has("--json")) emit({ ok: false, error: "gate-resolve shape rejected" }, 2);
+  const gate = state.gates.find((candidate) => candidate.id === value("--id"));
+  if (!gate) emit({ ok: false, error: "gate not found" }, 1);
+  gate.status = "resolved";
+  gate.resolution = value("--resolution");
+  writeState(state);
+  emit(envelope({ gate }));
+}
+if (args[0] === "orchestration" && args[1] === "send") {
+  validateSend();
+  const type = value("--type");
+  fs.appendFileSync(sendPath, JSON.stringify(args) + "\\n", "utf8");
+  if (type === "worker_done") {
+    const taskId = value("--task-id");
+    const dispatch = state.dispatch[taskId] || {};
+    if (value("--from") !== dispatch.assignee || value("--to") !== state.coordinator) emit({ ok: false, error: "worker_done provenance rejected" }, 3);
+    if (value("--dispatch-id") !== dispatch.dispatch_id) emit({ ok: false, error: "worker_done dispatch rejected" }, 3);
+    const task = taskFor(state, taskId);
+    if (task) { task.status = state.taskListAfterWorkerDone; task.worker_done = true; }
+    writeState(state);
+  }
+  emit(envelope({ delivered: true, type }));
+}
+process.stderr.write("Unsupported integration fixture invocation: " + args.join(" ") + "\\n");
+process.exit(2);
+`;
+}
+
+function installFakeOrcaIntegrationLifecycle(overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-integration-lifecycle-"));
+  const scenarioPath = path.join(dir, "scenario.json");
+  const statePath = path.join(dir, "state.json");
+  const orcaPath = path.join(dir, "orca");
+  const logPath = path.join(dir, "invocations.jsonl");
+  const sendPath = path.join(dir, "sends.jsonl");
+  const poisonPath = path.join(dir, "poison.txt");
+  const state = defaultScenario(overrides);
+  fs.writeFileSync(scenarioPath, JSON.stringify(state), "utf8");
+  fs.writeFileSync(statePath, JSON.stringify(state), "utf8");
+  fs.writeFileSync(orcaPath, script({ scenarioPath, statePath, logPath, poisonPath, sendPath }), "utf8");
+  fs.chmodSync(orcaPath, 0o755);
+  return {
+    dir,
+    orcaPath,
+    statePath,
+    logPath,
+    sendPath,
+    poisonPath,
+    run(args) {
+      const { execFileSync } = require("node:child_process");
+      try {
+        return { status: 0, stdout: execFileSync(orcaPath, args, { encoding: "utf8", stdio: "pipe" }), stderr: "" };
+      } catch (error) {
+        return { status: error.status || 1, stdout: error.stdout ? String(error.stdout) : "", stderr: error.stderr ? String(error.stderr) : "" };
+      }
+    },
+    readState() { return JSON.parse(fs.readFileSync(statePath, "utf8")); },
+    readLog() { return fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse) : []; },
+    readSends() { return fs.existsSync(sendPath) ? fs.readFileSync(sendPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse) : []; },
+    readPoison() { return fs.existsSync(poisonPath) ? fs.readFileSync(poisonPath, "utf8") : null; },
+    cleanup() { fs.rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+module.exports = { DEFAULT_RUNTIME_ID, installFakeOrcaIntegrationLifecycle };

--- a/tests/relay-orca/fixtures/fake-orca-resume.js
+++ b/tests/relay-orca/fixtures/fake-orca-resume.js
@@ -49,6 +49,12 @@ function defaultResumeScenario(overrides = {}) {
     terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
     terminalCreateEmptyHandle: overrides.terminalCreateEmptyHandle || false,
     terminalSendOkFalse: overrides.terminalSendOkFalse || false,
+    // #1019: the live coordinator handle. UNDEFINED by default, which keeps `status` and
+    // `dispatch-show` byte-identical for every pre-#1019 scenario (the integration lifecycle
+    // then fails closed on missing coordinator provenance, as it should). Setting it opts a
+    // scenario into a runtime that can actually complete the integration-gate lifecycle, so
+    // an over-broad advancement filter really does create/resolve gates and get caught.
+    coordinator: overrides.coordinator,
   };
 }
 
@@ -66,10 +72,13 @@ const stateDir = ${JSON.stringify(stateDir)};
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
 appendLog(args.join(" "));
 // The real dispatch-show payload nests provenance under result.dispatch (D4.3/D5.2).
-function nestDispatch(flat) {
+function nestDispatch(flat, coordinator) {
   const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
   const result = { dispatch: dispatch };
   if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
+  // #1019: the real --preamble read carries the live coordinator handle. Emitted only when
+  // the scenario defines one, so pre-#1019 scenarios keep their exact previous payload.
+  if (coordinator !== undefined) result.preamble = { coordinator_handle: coordinator };
   return result;
 }
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
@@ -79,18 +88,28 @@ function stateFile(taskId) { return path.join(stateDir, "disp-" + String(taskId)
 function poison(marker, code) { if (poisonPath) fs.writeFileSync(poisonPath, marker + ":" + args.join(" "), "utf-8"); process.stderr.write("POISON: " + marker + "\\n"); process.exit(code); }
 
 // D7 poison: reset + worktree only (resume MAY dispatch/terminal). Active on every path.
+// #1019 adds task-update: the integration lifecycle must reach completion through the
+// operator's explicit worker_done, never a coordinator-side task status write.
 if (args.includes("reset")) poison("RESET_INVOKED", 99);
 if (args.includes("worktree")) poison("WORKTREE_INVOKED", 98);
+if (args.includes("task-update")) poison("TASK_UPDATE_INVOKED", 97);
 
 const scenario = loadScenario();
 const meta = { runtimeId: scenario.runtimeId };
+const gatesFile = path.join(stateDir, "gates.json");
+function loadGates() {
+  try { return JSON.parse(fs.readFileSync(gatesFile, "utf-8")); } catch (e) { return Array.isArray(scenario.gates) ? scenario.gates : []; }
+}
+function saveGates(gates) { try { fs.writeFileSync(gatesFile, JSON.stringify(gates), "utf-8"); } catch (e) { /* ignore */ } }
 
 if (args[0] === "status") {
   if (!scenario.statusOk) { process.stderr.write("orca status unreachable\\n"); process.exit(1); }
   const runtime = { state: "ready", reachable: true };
   if (!scenario.omitRuntimeId) runtime.runtimeId = scenario.runtimeId;
   const statusMeta = scenario.omitRuntimeId ? {} : meta;
-  emit({ id: "status-1", ok: true, result: { app: { running: true, pid: 1 }, runtime, graph: { state: "ready" } }, _meta: statusMeta }, 0);
+  const statusResult = { app: { running: true, pid: 1 }, runtime, graph: { state: "ready" } };
+  if (scenario.coordinator !== undefined) statusResult.coordinator = { handle: scenario.coordinator };
+  emit({ id: "status-1", ok: true, result: statusResult, _meta: statusMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "task-list") {
   if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }
@@ -100,9 +119,52 @@ if (args[0] === "orchestration" && args[1] === "task-list") {
 }
 if (args[0] === "orchestration" && args[1] === "gate-list") {
   if (scenario.gateListOk === false) { process.stderr.write("orca gate-list unreachable\\n"); process.exit(1); }
-  const gates = Array.isArray(scenario.gates) ? scenario.gates : [];
+  const all = loadGates();
+  // The real CLI scopes to --task when given; unscoped reconciliation reads see every gate.
+  const task = argValue("--task");
+  const gates = task === undefined ? all : all.filter((g) => (g.task_id || g.task) === task);
   const gateMeta = scenario.gateListRuntimeId !== undefined ? { runtimeId: scenario.gateListRuntimeId } : meta;
   emit({ id: "gate-list-1", ok: true, result: { gates, count: gates.length }, _meta: gateMeta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "gate-create") {
+  if (!args.includes("--task") || !args.includes("--question") || !args.includes("--options") || !args.includes("--json")) {
+    emit({ ok: false, error: "gate-create shape rejected" }, 2);
+  }
+  const gates = loadGates();
+  const gate = { id: "physical-gate-" + (gates.length + 1), task_id: argValue("--task"), question: argValue("--question"), options: JSON.parse(argValue("--options")), status: "pending" };
+  gates.push(gate);
+  saveGates(gates);
+  emit({ id: "gc-1", ok: true, result: { gate }, _meta: meta }, 0);
+}
+if (args[0] === "orchestration" && args[1] === "gate-resolve") {
+  if (!args.includes("--id") || !args.includes("--resolution") || !args.includes("--json")) {
+    emit({ ok: false, error: "gate-resolve shape rejected" }, 2);
+  }
+  const gates = loadGates();
+  const gate = gates.find((g) => g.id === argValue("--id"));
+  if (!gate) emit({ ok: false, error: "gate not found" }, 1);
+  gate.status = "resolved";
+  gate.resolution = argValue("--resolution");
+  saveGates(gates);
+  emit({ id: "gr-1", ok: true, result: { gate }, _meta: meta }, 0);
+}
+// #1019 orchestration send: validated against the authoritative explicit-flag shape. Raw
+// --payload and any unknown flag are rejected exactly as the real CLI would.
+if (args[0] === "orchestration" && args[1] === "send") {
+  const VALUE_FLAGS = ["--to", "--subject", "--from", "--body", "--type", "--task-id", "--dispatch-id", "--report-path", "--phase"];
+  const BOOL_FLAGS = ["--json"];
+  const sendArgs = args.slice(2);
+  for (let i = 0; i < sendArgs.length; i++) {
+    const flag = sendArgs[i];
+    if (VALUE_FLAGS.indexOf(flag) >= 0) {
+      if (i + 1 >= sendArgs.length) emit({ ok: false, error: "orchestration send: flag " + flag + " requires a value" }, 2);
+      i++;
+    } else if (BOOL_FLAGS.indexOf(flag) < 0) {
+      process.stderr.write("orchestration send: unrecognized flag " + flag + "\\n");
+      emit({ ok: false, error: "orchestration send does not accept " + flag }, 2);
+    }
+  }
+  emit({ id: "send-1", ok: true, result: { delivered: true, type: argValue("--type") }, _meta: meta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   const task = argValue("--task");
@@ -114,7 +176,7 @@ if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   Object.keys(seed).forEach((k) => { if (k === "runtimeId") seedRuntime = seed[k]; else result[k] = seed[k]; });
   try { Object.assign(result, JSON.parse(fs.readFileSync(stateFile(task), "utf-8"))); } catch (e) { /* no real dispatch yet */ }
   const dispatchMeta = seedRuntime !== undefined ? { runtimeId: seedRuntime } : meta;
-  emit({ id: "ds-" + task, ok: true, result: nestDispatch(result), _meta: dispatchMeta }, 0);
+  emit({ id: "ds-" + task, ok: true, result: nestDispatch(result, scenario.coordinator), _meta: dispatchMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "dispatch") {
   const task = argValue("--task");

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -160,6 +160,57 @@ test("#1019 repeated resume on passed gate + active task re-issues the completio
   }
 });
 
+// #1019 R7: the live integration task is already terminal `failed` (or otherwise
+// non-completable), yet a historical dispatch still verifies and provenance-bound evidence
+// exists. Resolving the canonical gate passed and re-issuing worker_done would strand a passed
+// gate on a task that can never legitimately complete — a harder residue than failing closed. The
+// advance must refuse BEFORE any gate-create/resolve/send, with an actionable reason and zero mutation.
+test("#1019 R7 a terminal non-completable integration task fails closed before any gate mutation", () => {
+  const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
+  // A pending canonical gate already exists AND the operator's provenance-bound evidence landed;
+  // only the still-live task status stops the flow.
+  for (const status of ["failed", "cancelled"]) {
+    const fake = installFakeOrcaIntegrationLifecycle(initialState({
+      tasks: [{ id: TASK_ID, status, worker_done: false }],
+      gates: [{ id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" }],
+    }));
+    const report = reportFile();
+    try {
+      assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), (error) => {
+        assert.ok(error instanceof IntegrationLifecycleError, status);
+        assert.equal(error.reasonCode, "INTEGRATION_TASK_NOT_COMPLETABLE", status);
+        return true;
+      }, status);
+      const mutations = fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1]));
+      assert.deepEqual(mutations, [], `${status} must have zero lifecycle mutation`);
+      assert.equal(fake.readState().gates[0].status, "pending", `${status} must leave the canonical gate unresolved`);
+      assert.equal(fake.readPoison(), null);
+    } finally {
+      fake.cleanup();
+      fs.rmSync(report.dir, { recursive: true, force: true });
+    }
+  }
+
+  // The same guard holds when the canonical gate is still MISSING: a non-completable task must
+  // never even materialize a gate to write evidence against.
+  const fake = installFakeOrcaIntegrationLifecycle(initialState({
+    tasks: [{ id: TASK_ID, status: "failed", worker_done: false }],
+  }));
+  const report = reportFile();
+  try {
+    assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), (error) => {
+      assert.equal(error.reasonCode, "INTEGRATION_TASK_NOT_COMPLETABLE");
+      return true;
+    });
+    assert.deepEqual(fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1])), []);
+    assert.equal(fake.readState().gates.length, 0, "a failed task must not even create a gate");
+    assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
 test("#1019 create response loss is recovered by re-list/adopt without a second create", () => {
   const fake = installFakeOrcaIntegrationLifecycle(initialState({ createResponseLoss: true }));
   try {

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -29,20 +29,31 @@ const DISPATCH_ID = "dispatch_integration_1019";
 const ASSIGNEE = "term-integration-fresh";
 const COORDINATOR = "coord-current";
 
-// Evidence artifacts are provenance-bound (#1019 H2): the deterministic path alone is not
-// proof of freshness, so the artifact must carry the live runtime/task/dispatch identity.
-// `provenance` overrides let a test forge a stale/incomplete artifact.
+// The lifecycle provenance the CURRENT fixture dispatch stamps into its evidence artifact.
+const LIVE_PROVENANCE = Object.freeze({
+  runtime_id: DEFAULT_RUNTIME_ID,
+  task_id: TASK_ID,
+  dispatch_id: DISPATCH_ID,
+  assignee: ASSIGNEE,
+});
+
+function writeReport(reportPath, body) {
+  fs.writeFileSync(reportPath, JSON.stringify(body) + "\n", "utf8");
+}
+
+// Evidence artifacts are provenance-bound (#1019 H2/R3): the deterministic path alone is not
+// proof of freshness, so the artifact must carry the live runtime/task/dispatch/assignee
+// identity. `provenance` overrides let a test forge a stale/incomplete artifact; a key present
+// with value `undefined` forges an OMITTED field.
 function reportFile(passed = true, provenance = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-integration-report-"));
   const reportPath = path.join(dir, "integration.json");
-  const body = {
+  writeReport(reportPath, {
     passed,
     evidence: passed ? "integration fixture passed" : "integration fixture failed",
-    runtime_id: "runtime_id" in provenance ? provenance.runtime_id : DEFAULT_RUNTIME_ID,
-    task_id: "task_id" in provenance ? provenance.task_id : TASK_ID,
-    dispatch_id: "dispatch_id" in provenance ? provenance.dispatch_id : DISPATCH_ID,
-  };
-  fs.writeFileSync(reportPath, JSON.stringify(body) + "\n", "utf8");
+    ...LIVE_PROVENANCE,
+    ...provenance,
+  });
   return { dir, reportPath };
 }
 
@@ -304,13 +315,19 @@ test("#1019 final summary vetoes active integration task and generic resolved ga
   }
 });
 
-test("#1019 H2 evidence not bound to the live runtime/task/dispatch fails closed before gate-resolve", () => {
+// #1019 R3: the evidence path is deterministic, so an artifact left behind by an EARLIER
+// runtime/task/dispatch/assignee sits exactly where the current lifecycle looks. Each stale
+// variant must be rejected BEFORE gate inspection or resolution, with a provenance reason code
+// (not the lock's) and a completely clean invocation log.
+test("#1019 H2/R3 evidence not bound to the live runtime/task/dispatch/assignee fails closed before gate-resolve", () => {
   const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
   const staleCases = [
     { label: "prior-run runtime", provenance: { runtime_id: "runtime-prior-run" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
     { label: "prior-run task", provenance: { task_id: "task-prior-run" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
     { label: "reused-dir dispatch", provenance: { dispatch_id: "dispatch-prior-run" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
+    { label: "previous pane assignee", provenance: { assignee: "term-previous-pane" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
     { label: "missing dispatch id", provenance: { dispatch_id: undefined }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISSING" },
+    { label: "missing assignee", provenance: { assignee: undefined }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISSING" },
   ];
   for (const scenario of staleCases) {
     // A canonical gate already exists pending; only fresh, provenance-bound evidence may resolve it.
@@ -332,6 +349,26 @@ test("#1019 H2 evidence not bound to the live runtime/task/dispatch fails closed
       fs.rmSync(report.dir, { recursive: true, force: true });
     }
   }
+
+  // An artifact with no provenance at all cannot be attributed to any dispatch, so it is a
+  // missing-provenance failure rather than a silently-accepted legacy shape. The gate is
+  // absent here too, proving the rejection precedes gate CREATION as well as resolution.
+  const unbound = installFakeOrcaIntegrationLifecycle(initialState());
+  const unboundReport = reportFile();
+  writeReport(unboundReport.reportPath, { passed: true, evidence: "unbound legacy evidence" });
+  try {
+    assert.throws(() => advanceIntegrationGate(context(unbound, unboundReport.reportPath)), (error) => {
+      assert.equal(error.reasonCode, "INTEGRATION_REPORT_PROVENANCE_MISSING");
+      return true;
+    });
+    assert.deepEqual(unbound.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1])), []);
+    assert.equal(unbound.readState().gates.length, 0, "an unbound artifact must not even create a gate");
+    assert.equal(unbound.readPoison(), null);
+  } finally {
+    unbound.cleanup();
+    fs.rmSync(unboundReport.dir, { recursive: true, force: true });
+  }
+
   // The SAME dispatch's fresh, provenance-bound evidence still resolves the gate (crash recovery preserved).
   const fresh = installFakeOrcaIntegrationLifecycle(initialState({
     gates: [{ id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" }],
@@ -349,7 +386,38 @@ test("#1019 H2 evidence not bound to the live runtime/task/dispatch fails closed
   }
 });
 
-test("#1019 H1 resume leaves a materialized, undispatched or wave-ineligible integration gate inert", () => {
+// The counterpart guarantee: binding evidence to the dispatch must NOT break crash recovery.
+// A restart against the SAME runtime/task/dispatch/assignee re-reads its own artifact and
+// drives the lifecycle all the way to completed.
+test("#1019 R3 same-dispatch evidence stays valid across a coordinator restart", () => {
+  const fake = installFakeOrcaIntegrationLifecycle(initialState());
+  const report = reportFile();
+  try {
+    // "Restart": a brand-new context object over the same live dispatch and the artifact the
+    // previous coordinator process already wrote.
+    const first = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(first.ok, false);
+    assert.equal(first.reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-resolve").length, 1);
+
+    const command = completionCommand(context(fake, report.reportPath));
+    assert.equal(fake.run(command.argv).status, 0);
+    const completed = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(completed.ok, true);
+    assert.equal(completed.state, "completed");
+    assert.equal(fake.readState().tasks[0].status, "completed");
+    assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
+// The advancement selection matrix. Eligibility is the CONJUNCTION of planResume's own verdict
+// (only `reused`/`redispatched` leave a currently verified live dispatch behind), the shared
+// wave blanket, and recorded dispatch provenance. Each inert row below flips exactly one
+// conjunct while the others stay satisfied, so a filter that drops any conjunct fails here.
+test("#1019 H1/R3 resume leaves an action-ineligible, undispatched, or wave-ineligible integration gate inert", () => {
   const receiptFor = (integrationTask) => ({
     program_id: PROGRAM_ID,
     runtime_id: DEFAULT_RUNTIME_ID,
@@ -358,27 +426,42 @@ test("#1019 H1 resume leaves a materialized, undispatched or wave-ineligible int
       integrationTask,
     ],
   });
-  // Wave 1 has not completed_with_evidence, so the wave-2 integration gate is not yet eligible.
-  const report = { outcomes: [{ outcome_id: "impl", wave: 1, state: "reused" }, { outcome_id: OUTCOME_ID, wave: 2, state: "pending" }] };
+  // Wave 1 has not completed_with_evidence, so a wave-2 integration gate is not yet eligible.
+  const waveShut = { outcomes: [{ outcome_id: "impl", wave: 1, state: "reused" }, { outcome_id: OUTCOME_ID, wave: 2, state: "pending" }] };
+  // Wave 1 durably complete: the wave blanket is OPEN, so only the other conjuncts can hold.
+  const waveOpen = { outcomes: [{ outcome_id: "impl", wave: 1, state: "complete_with_evidence" }] };
   const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-h1-lock-"));
   const opts = {
     coordinatorHandle: COORDINATOR,
     integrationLockRoot: lockRoot,
     integrationReportPath: () => path.join(os.tmpdir(), "relay-orca-h1-nonexistent-report.json"),
   };
+  const dispatched = { dispatch_id: DISPATCH_ID, assignee: ASSIGNEE };
   const inertCases = [
-    { label: "undispatched wave-2 gate (the #1019 live shape)", task: { outcome_id: OUTCOME_ID, kind: "integration_gate", wave: 2, orca_task_id: TASK_ID, dispatch_id: null, assignee: null } },
-    { label: "dispatched wave-2 gate before earlier waves complete", task: { outcome_id: OUTCOME_ID, kind: "integration_gate", wave: 2, orca_task_id: TASK_ID, dispatch_id: DISPATCH_ID, assignee: ASSIGNEE } },
+    // The wave blanket alone holds these back: the plan reused/re-established a live dispatch.
+    { label: "undispatched wave-2 gate (the #1019 live shape)", report: waveShut, action: "redispatched", task: { wave: 2, dispatch_id: null, assignee: null } },
+    { label: "dispatched wave-2 gate before earlier waves complete", report: waveShut, action: "reused", task: { wave: 2, ...dispatched } },
+    // The dispatch-provenance conjunct alone holds these back.
+    { label: "wave-eligible gate with no dispatch_id", report: waveOpen, action: "reused", task: { wave: 2, dispatch_id: null, assignee: ASSIGNEE } },
+    { label: "wave-eligible gate with no assignee", report: waveOpen, action: "reused", task: { wave: 2, dispatch_id: DISPATCH_ID, assignee: null } },
+    { label: "wave-eligible gate with blank dispatch provenance", report: waveOpen, action: "reused", task: { wave: 2, dispatch_id: "   ", assignee: ASSIGNEE } },
+    // The planResume action conjunct alone holds these back: receipt strings look complete and
+    // the wave blanket is open, but the plan deliberately left the outcome alone this run, so
+    // the recorded dispatch is NOT a currently verified live dispatch.
+    { label: "plan skipped the outcome", report: waveOpen, action: "skipped", task: { wave: 2, ...dispatched } },
+    { label: "plan requires a decision", report: waveOpen, action: "decision_required", task: { wave: 2, ...dispatched } },
+    { label: "outcome absent from the plan entirely", report: waveOpen, action: undefined, task: { wave: 2, ...dispatched } },
   ];
   try {
     for (const scenario of inertCases) {
       // orcaBin points at an absent binary: an inert gate must never reach it, so a broken
       // filter would surface as an INTEGRATION_CAPABILITY_GAP blocking entry, not [].
       const blocking = advanceIntegrationTasks({
-        receipt: receiptFor(scenario.task),
+        receipt: receiptFor({ outcome_id: OUTCOME_ID, kind: "integration_gate", orca_task_id: TASK_ID, ...scenario.task }),
         opts,
         orcaBin: path.join(os.tmpdir(), "relay-orca-h1-absent-orca-bin"),
-        report,
+        report: scenario.report,
+        actions: scenario.action === undefined ? [] : [{ outcome_id: OUTCOME_ID, action: scenario.action }],
       });
       assert.deepEqual(blocking, [], scenario.label);
     }
@@ -387,7 +470,7 @@ test("#1019 H1 resume leaves a materialized, undispatched or wave-ineligible int
   }
 });
 
-test("#1019 H1 resume advances a dispatched, wave-eligible integration gate", () => {
+test("#1019 H1/R3 resume advances a dispatched, wave-eligible integration gate the plan reused", () => {
   const fake = installFakeOrcaIntegrationLifecycle(initialState({
     gates: [{ id: "g1", task_id: TASK_ID, question: canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment), options: ["passed", "failed"], status: "pending" }],
   }));
@@ -403,8 +486,11 @@ test("#1019 H1 resume advances a dispatched, wave-eligible integration gate", ()
       opts: { coordinatorHandle: COORDINATOR, integrationLockRoot: lockRoot, integrationReportPath: () => report.reportPath },
       orcaBin: fake.orcaPath,
       report: { outcomes: [{ outcome_id: OUTCOME_ID, wave: 1, state: "pending" }] },
+      actions: [{ outcome_id: OUTCOME_ID, action: "reused" }],
     });
-    // Wave-1 eligible + dispatched → the gate resolves and the operator is asked for worker_done.
+    // Wave-1 eligible + `reused` + dispatched → the gate resolves and the operator is asked for
+    // worker_done. This is the positive control for the inert matrix above: without it, those
+    // assertions could pass for the wrong reason (a lifecycle that never runs at all).
     assert.equal(blocking.length, 1);
     assert.equal(blocking[0].reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
     assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-resolve").length, 1);
@@ -416,30 +502,77 @@ test("#1019 H1 resume advances a dispatched, wave-eligible integration gate", ()
   }
 });
 
-test("#1019 M3 integration lifecycle lock reclaims a dead owner but never steals a live one", () => {
+function lockPathFor(lockRoot) {
+  return path.join(lockRoot, `${integrationLockName({ programId: PROGRAM_ID, outcomeId: OUTCOME_ID, taskId: TASK_ID })}.lock`);
+}
+
+function holdLock(lockRoot, ownerContent) {
+  const lockPath = lockPathFor(lockRoot);
+  fs.mkdirSync(lockPath, { recursive: true });
+  if (ownerContent !== null) fs.writeFileSync(path.join(lockPath, "owner"), ownerContent, "utf8");
+  return lockPath;
+}
+
+// A coordinator killed mid-critical-section leaves its lock directory behind. Its recorded
+// owner pid is provably gone (kill(pid,0) → ESRCH), so the next coordinator reclaims it
+// automatically — an abandoned lock must never require manual deletion to recover the program.
+test("#1019 M3/R3 a lock abandoned by a provably dead owner is reclaimed automatically", () => {
   const { execFileSync } = require("node:child_process");
   const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-m3-lock-"));
   const lockArgs = { programId: PROGRAM_ID, outcomeId: OUTCOME_ID, taskId: TASK_ID, lockRoot };
-  const lockPath = path.join(lockRoot, `${integrationLockName(lockArgs)}.lock`);
-  // A guaranteed-dead PID: a child process that has already exited by the time execFileSync returns.
+  // A guaranteed-dead PID: a child process that has already been reaped by the time
+  // execFileSync returns, so kill(pid, 0) reports exactly ESRCH.
   const deadPid = Number(execFileSync(process.execPath, ["-e", "process.stdout.write(String(process.pid))"], { encoding: "utf8" }));
+  const lockPath = holdLock(lockRoot, `${deadPid}\n`);
+  assert.ok(fs.existsSync(lockPath), "precondition: the abandoned lock exists");
   try {
-    // Dead owner: a crash left the lock dir + the PID of a process that no longer exists.
-    fs.mkdirSync(lockPath);
-    fs.writeFileSync(path.join(lockPath, "owner"), `${deadPid}\n`, "utf8");
-    const reclaimed = withIntegrationLifecycleLock({ ...lockArgs, timeoutMs: 300, pollMs: 5 }, () => "acquired");
+    let ran = false;
+    const reclaimed = withIntegrationLifecycleLock({ ...lockArgs, timeoutMs: 300, pollMs: 5 }, () => {
+      ran = true;
+      return "acquired";
+    });
+    assert.equal(ran, true, "the critical section must run after reclaiming a dead owner's lock");
     assert.equal(reclaimed, "acquired", "a dead owner's lock is reclaimed, not stranded");
     assert.equal(fs.existsSync(lockPath), false, "the reclaiming holder releases the lock when it finishes");
-
-    // Live owner: the current process holds the lock; a competing acquire must fail closed.
-    fs.mkdirSync(lockPath);
-    fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
-    assert.throws(
-      () => withIntegrationLifecycleLock({ ...lockArgs, timeoutMs: 60, pollMs: 5 }, () => "should-not-run"),
-      /integration lifecycle lock timed out/,
-    );
-    assert.equal(fs.existsSync(lockPath), true, "a live owner's lock is never stolen");
+    // The rename-then-remove reclaim leaves no staging residue behind.
+    assert.deepEqual(fs.readdirSync(lockRoot), [], "the reclaim leaves no rename staging residue");
   } finally {
     fs.rmSync(lockRoot, { recursive: true, force: true });
+  }
+});
+
+// The safety counterpart: a lock held by a LIVE owner is never stolen, and neither is one whose
+// ownership record is absent or malformed — that could belong to a live holder whose owner stamp
+// has not landed yet, and an old mtime is not evidence the owner is gone. All fail closed at the
+// bounded timeout with the lock left in place.
+test("#1019 M3/R3 live-owner and ambiguous-owner locks are never stolen", () => {
+  const lockArgs = { programId: PROGRAM_ID, outcomeId: OUTCOME_ID, taskId: TASK_ID };
+  const cases = [
+    { label: "live owner", owner: `${process.pid}\n` },
+    { label: "absent owner record", owner: null },
+    { label: "non-numeric owner", owner: "not-a-pid\n" },
+    { label: "trailing-garbage owner", owner: "123abc\n" },
+    { label: "zero owner", owner: "0\n" },
+    { label: "negative owner", owner: "-5\n" },
+  ];
+  for (const scenario of cases) {
+    const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-lock-held-"));
+    const lockPath = holdLock(lockRoot, scenario.owner);
+    // An mtime far in the past: a lease-based reclaim would steal these; an ESRCH-only reclaim
+    // must not.
+    const stale = new Date(Date.now() - 3600_000);
+    fs.utimesSync(lockPath, stale, stale);
+    try {
+      let ran = false;
+      assert.throws(
+        () => withIntegrationLifecycleLock({ ...lockArgs, lockRoot, timeoutMs: 60, pollMs: 5 }, () => { ran = true; }),
+        /integration lifecycle lock timed out/,
+        scenario.label,
+      );
+      assert.equal(ran, false, `${scenario.label} must never enter the critical section`);
+      assert.ok(fs.existsSync(lockPath), `${scenario.label} must leave the held lock in place`);
+    } finally {
+      fs.rmSync(lockRoot, { recursive: true, force: true });
+    }
   }
 });

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -1,0 +1,182 @@
+"use strict";
+
+// #1019 focused lifecycle matrix. Every Orca invocation goes through the stateful fake;
+// the fake rejects task-update/reset/worktree and every unsupported argument shape.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const SCRIPTS = path.resolve(__dirname, "..", "..", "..", "skills", "relay-orca", "scripts");
+const {
+  canonicalIntegrationQuestion,
+  completionCommand,
+  prepareIntegrationGate,
+  advanceIntegrationGate,
+  IntegrationLifecycleError,
+} = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
+const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { installFakeOrcaIntegrationLifecycle } = require(path.join(__dirname, "..", "fixtures", "fake-orca-integration-lifecycle.js"));
+
+const PROGRAM_ID = "repilot-941-20260715";
+const OUTCOME_ID = "integration-check";
+const TASK_ID = "task_integration_1019";
+const DISPATCH_ID = "dispatch_integration_1019";
+const ASSIGNEE = "term-integration-fresh";
+const COORDINATOR = "coord-current";
+
+function reportFile(passed = true) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-integration-report-"));
+  const reportPath = path.join(dir, "integration.json");
+  fs.writeFileSync(reportPath, JSON.stringify({ passed, evidence: passed ? "integration fixture passed" : "integration fixture failed" }) + "\n", "utf8");
+  return { dir, reportPath };
+}
+
+function context(fake, reportPath, extra = {}) {
+  return {
+    run: (_bin, args) => fake.run(args),
+    orcaBin: fake.orcaPath,
+    programId: PROGRAM_ID,
+    outcomeId: OUTCOME_ID,
+    taskId: TASK_ID,
+    dispatchId: DISPATCH_ID,
+    assignee: ASSIGNEE,
+    coordinatorHandle: COORDINATOR,
+    reportPath,
+    programSegment,
+    lockRoot: fake.dir,
+    ...extra,
+  };
+}
+
+function initialState(extra = {}) {
+  return {
+    coordinator: COORDINATOR,
+    tasks: [{ id: TASK_ID, status: "ready", worker_done: false }],
+    dispatch: { [TASK_ID]: { dispatch_id: DISPATCH_ID, assignee: ASSIGNEE, terminal_present: true } },
+    gates: [],
+    ...extra,
+  };
+}
+
+test("#1019 happy path is gate-create, evidence, resolve, fresh instruction, worker_done, completed re-read", () => {
+  const fake = installFakeOrcaIntegrationLifecycle(initialState());
+  const report = reportFile();
+  try {
+    const first = prepareIntegrationGate(context(fake, report.reportPath));
+    assert.equal(first.ok, true);
+    const advanced = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(advanced.ok, false);
+    assert.equal(advanced.reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+    const command = completionCommand(context(fake, report.reportPath));
+    const workerDone = fake.run(command.argv);
+    assert.equal(workerDone.status, 0);
+    const completed = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(completed.ok, true);
+    const log = fake.readLog().map((argv) => argv.slice(0, 2).join(" "));
+    assert.ok(log.includes("orchestration gate-create"));
+    assert.ok(log.includes("orchestration gate-resolve"));
+    assert.ok(log.includes("orchestration send"));
+    assert.equal(fake.readSends().filter((argv) => argv.includes("worker_done")).length, 1);
+    assert.equal(fake.readState().tasks[0].status, "completed");
+    assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
+test("#1019 create response loss is recovered by re-list/adopt without a second create", () => {
+  const fake = installFakeOrcaIntegrationLifecycle(initialState({ createResponseLoss: true }));
+  try {
+    const report = reportFile();
+    const result = prepareIntegrationGate(context(fake, report.reportPath));
+    assert.equal(result.ok, true);
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-create").length, 1);
+    assert.equal(fake.readState().gates.length, 1);
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  } catch (error) {
+    fake.cleanup();
+    throw error;
+  }
+});
+
+test("#1019 duplicate or noncanonical gates fail closed before further mutation", () => {
+  const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
+  const cases = [
+    { label: "duplicate", gates: [
+      { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" },
+      { id: "g2", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" },
+    ] },
+    { label: "wrong question", gates: [
+      { id: "g1", task_id: TASK_ID, question: "stale question", options: ["passed", "failed"], status: "pending" },
+    ] },
+    { label: "conflicting result", gates: [
+      { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "resolved", resolution: "failed" },
+    ] },
+  ];
+  for (const scenario of cases) {
+    const fake = installFakeOrcaIntegrationLifecycle(initialState({ gates: scenario.gates }));
+    const report = reportFile();
+    try {
+      assert.throws(() => prepareIntegrationGate(context(fake, report.reportPath)), (error) => {
+        assert.ok(error instanceof IntegrationLifecycleError);
+        return true;
+      }, scenario.label);
+      const mutations = fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1]));
+      assert.deepEqual(mutations, [], `${scenario.label} must have zero further mutation`);
+      assert.equal(fake.readPoison(), null);
+    } finally {
+      fake.cleanup();
+      fs.rmSync(report.dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("#1019 stale coordinator, dispatch, assignee, and report provenance fail closed", () => {
+  const cases = [
+    { label: "coordinator", state: initialState({ coordinator: "coord-stale" }) },
+    { label: "dispatch", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: "dispatch-other", assignee: ASSIGNEE } } }) },
+    { label: "assignee", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: DISPATCH_ID, assignee: "term-other" } } }) },
+  ];
+  for (const scenario of cases) {
+    const fake = installFakeOrcaIntegrationLifecycle(scenario.state);
+    const report = reportFile();
+    try {
+      assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), /provenance|coordinator|dispatch|assignee/i, scenario.label);
+      const mutations = fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1]));
+      assert.deepEqual(mutations, [], `${scenario.label} must have zero lifecycle mutation`);
+      assert.equal(fake.readPoison(), null);
+    } finally {
+      fake.cleanup();
+      fs.rmSync(report.dir, { recursive: true, force: true });
+    }
+  }
+  const fake = installFakeOrcaIntegrationLifecycle(initialState());
+  const report = reportFile();
+  fs.writeFileSync(report.reportPath, "not-json\n", "utf8");
+  try {
+    assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), /report|evidence/i);
+    assert.deepEqual(fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1])), []);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
+test("#1019 completion command is explicit and never raw-payload shaped", () => {
+  const report = reportFile();
+  try {
+    const command = completionCommand(context({ dir: "locks" }, report.reportPath));
+    assert.deepEqual(command.argv.slice(0, 2), ["orchestration", "send"]);
+    ["--from", ASSIGNEE, "--to", COORDINATOR, "--type", "worker_done", "--task-id", TASK_ID, "--dispatch-id", DISPATCH_ID, "--report-path", report.reportPath, "--phase", "integration_gate", "--json"].forEach((token) => assert.ok(command.argv.includes(token), token));
+    assert.equal(command.argv.includes("--payload"), false);
+    assert.match(command.copy_paste, /--from/);
+    assert.match(command.copy_paste, /--to/);
+    assert.match(command.copy_paste, /--report-path/);
+  } finally {
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -91,6 +91,53 @@ test("#1019 happy path is gate-create, evidence, resolve, fresh instruction, wor
   }
 });
 
+test("#1019 repeated resume on passed gate + active task re-issues the completion instruction idempotently", () => {
+  const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
+  // Live residue after a lost completion instruction / second resume: the canonical gate is
+  // already resolved passed, evidence is valid, yet the program-owned task is still active.
+  const gate = { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "resolved", resolution: "passed" };
+  const fake = installFakeOrcaIntegrationLifecycle(initialState({
+    tasks: [{ id: TASK_ID, status: "ready", worker_done: false }],
+    gates: [gate],
+  }));
+  const report = reportFile();
+  try {
+    const firstResume = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(firstResume.ok, false);
+    assert.equal(firstResume.state, "awaiting_worker_done");
+    assert.equal(firstResume.reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+    assert.ok(firstResume.completion_command, "awaiting_worker_done must carry a copy-paste completion command");
+    assert.match(firstResume.completion_command.copy_paste, /worker_done/);
+    // It re-issued the worker-owned completion instruction, never a coordinator-side worker_done.
+    assert.equal(fake.readSends().filter((argv) => argv.includes("worker_done")).length, 0);
+    assert.equal(fake.readSends().filter((argv) => argv.includes("integration_gate_completion")).length, 1);
+    // No duplicate gate creation and no gate re-resolution — the gate was already passed.
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-create").length, 0);
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-resolve").length, 0);
+
+    // A second resume is idempotent: it re-issues again, still no duplicate gate.
+    const secondResume = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(secondResume.ok, false);
+    assert.equal(secondResume.state, "awaiting_worker_done");
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-create").length, 0);
+    assert.equal(fake.readState().gates.length, 1);
+    assert.equal(fake.readSends().filter((argv) => argv.includes("integration_gate_completion")).length, 2);
+
+    // Once the operator finally sends the explicit worker_done, the task terminalizes with no task-update.
+    const command = completionCommand(context(fake, report.reportPath));
+    assert.equal(fake.run(command.argv).status, 0);
+    const completed = advanceIntegrationGate(context(fake, report.reportPath));
+    assert.equal(completed.ok, true);
+    assert.equal(completed.state, "completed");
+    assert.equal(fake.readState().tasks[0].status, "completed");
+    assert.equal(fake.readSends().filter((argv) => argv.includes("worker_done")).length, 1);
+    assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
 test("#1019 create response loss is recovered by re-list/adopt without a second create", () => {
   const fake = installFakeOrcaIntegrationLifecycle(initialState({ createResponseLoss: true }));
   try {

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -16,7 +16,7 @@ const {
   advanceIntegrationGate,
   IntegrationLifecycleError,
 } = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
-const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { programSegment, withIntegrationLifecycleLock, readIntegrationEvidenceFile } = require(path.join(SCRIPTS, "receipt-io.js"));
 const { deriveStatusReport } = require(path.join(SCRIPTS, "lib", "status-derive.js"));
 const { buildFinalSummary } = require(path.join(SCRIPTS, "lib", "final-summary.js"));
 const { installFakeOrcaIntegrationLifecycle } = require(path.join(__dirname, "..", "fixtures", "fake-orca-integration-lifecycle.js"));
@@ -48,6 +48,8 @@ function context(fake, reportPath, extra = {}) {
     reportPath,
     programSegment,
     lockRoot: fake.dir,
+    withLock: (lockKey, callback) => withIntegrationLifecycleLock({ programId: PROGRAM_ID, outcomeId: OUTCOME_ID, taskId: TASK_ID, lockRoot: fake.dir, lockKey }, callback),
+    readReport: readIntegrationEvidenceFile,
     ...extra,
   };
 }

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -16,10 +16,11 @@ const {
   advanceIntegrationGate,
   IntegrationLifecycleError,
 } = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
-const { programSegment, withIntegrationLifecycleLock, readIntegrationEvidenceFile } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { programSegment, withIntegrationLifecycleLock, readIntegrationEvidenceFile, integrationLockName } = require(path.join(SCRIPTS, "receipt-io.js"));
 const { deriveStatusReport } = require(path.join(SCRIPTS, "lib", "status-derive.js"));
 const { buildFinalSummary } = require(path.join(SCRIPTS, "lib", "final-summary.js"));
-const { installFakeOrcaIntegrationLifecycle } = require(path.join(__dirname, "..", "fixtures", "fake-orca-integration-lifecycle.js"));
+const { advanceIntegrationTasks } = require(path.join(SCRIPTS, "resume.js"));
+const { installFakeOrcaIntegrationLifecycle, DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca-integration-lifecycle.js"));
 
 const PROGRAM_ID = "repilot-941-20260715";
 const OUTCOME_ID = "integration-check";
@@ -28,10 +29,20 @@ const DISPATCH_ID = "dispatch_integration_1019";
 const ASSIGNEE = "term-integration-fresh";
 const COORDINATOR = "coord-current";
 
-function reportFile(passed = true) {
+// Evidence artifacts are provenance-bound (#1019 H2): the deterministic path alone is not
+// proof of freshness, so the artifact must carry the live runtime/task/dispatch identity.
+// `provenance` overrides let a test forge a stale/incomplete artifact.
+function reportFile(passed = true, provenance = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-integration-report-"));
   const reportPath = path.join(dir, "integration.json");
-  fs.writeFileSync(reportPath, JSON.stringify({ passed, evidence: passed ? "integration fixture passed" : "integration fixture failed" }) + "\n", "utf8");
+  const body = {
+    passed,
+    evidence: passed ? "integration fixture passed" : "integration fixture failed",
+    runtime_id: "runtime_id" in provenance ? provenance.runtime_id : DEFAULT_RUNTIME_ID,
+    task_id: "task_id" in provenance ? provenance.task_id : TASK_ID,
+    dispatch_id: "dispatch_id" in provenance ? provenance.dispatch_id : DISPATCH_ID,
+  };
+  fs.writeFileSync(reportPath, JSON.stringify(body) + "\n", "utf8");
   return { dir, reportPath };
 }
 
@@ -157,14 +168,14 @@ test("#1019 create response loss is recovered by re-list/adopt without a second 
 test("#1019 duplicate or noncanonical gates fail closed before further mutation", () => {
   const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
   const cases = [
-    { label: "duplicate", gates: [
+    { label: "duplicate", reasonCode: "INTEGRATION_GATE_DUPLICATE", gates: [
       { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" },
       { id: "g2", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" },
     ] },
-    { label: "wrong question", gates: [
+    { label: "wrong question", reasonCode: "INTEGRATION_GATE_NONCANONICAL", gates: [
       { id: "g1", task_id: TASK_ID, question: "stale question", options: ["passed", "failed"], status: "pending" },
     ] },
-    { label: "conflicting result", gates: [
+    { label: "conflicting result", reasonCode: "INTEGRATION_GATE_CONFLICT", gates: [
       { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "resolved", resolution: "failed" },
     ] },
   ];
@@ -173,7 +184,8 @@ test("#1019 duplicate or noncanonical gates fail closed before further mutation"
     const report = reportFile();
     try {
       assert.throws(() => prepareIntegrationGate(context(fake, report.reportPath)), (error) => {
-        assert.ok(error instanceof IntegrationLifecycleError);
+        assert.ok(error instanceof IntegrationLifecycleError, scenario.label);
+        assert.equal(error.reasonCode, scenario.reasonCode, scenario.label);
         return true;
       }, scenario.label);
       const mutations = fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1]));
@@ -188,15 +200,20 @@ test("#1019 duplicate or noncanonical gates fail closed before further mutation"
 
 test("#1019 stale coordinator, dispatch, assignee, and report provenance fail closed", () => {
   const cases = [
-    { label: "coordinator", state: initialState({ coordinator: "coord-stale" }) },
-    { label: "dispatch", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: "dispatch-other", assignee: ASSIGNEE } } }) },
-    { label: "assignee", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: DISPATCH_ID, assignee: "term-other" } } }) },
+    { label: "coordinator", reasonCode: "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", state: initialState({ coordinator: "coord-stale" }) },
+    { label: "dispatch", reasonCode: "INTEGRATION_DISPATCH_PROVENANCE_MISMATCH", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: "dispatch-other", assignee: ASSIGNEE } } }) },
+    // A stale --from is rejected at the dispatch-show CLI boundary, surfacing as a capability gap.
+    { label: "assignee", reasonCode: "INTEGRATION_CAPABILITY_GAP", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: DISPATCH_ID, assignee: "term-other" } } }) },
   ];
   for (const scenario of cases) {
     const fake = installFakeOrcaIntegrationLifecycle(scenario.state);
     const report = reportFile();
     try {
-      assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), /provenance|coordinator|dispatch|assignee/i, scenario.label);
+      assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), (error) => {
+        assert.ok(error instanceof IntegrationLifecycleError, scenario.label);
+        assert.equal(error.reasonCode, scenario.reasonCode, scenario.label);
+        return true;
+      }, scenario.label);
       const mutations = fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1]));
       assert.deepEqual(mutations, [], `${scenario.label} must have zero lifecycle mutation`);
       assert.equal(fake.readPoison(), null);
@@ -209,7 +226,11 @@ test("#1019 stale coordinator, dispatch, assignee, and report provenance fail cl
   const report = reportFile();
   fs.writeFileSync(report.reportPath, "not-json\n", "utf8");
   try {
-    assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), /report|evidence/i);
+    assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), (error) => {
+      assert.ok(error instanceof IntegrationLifecycleError);
+      assert.equal(error.reasonCode, "INTEGRATION_REPORT_INVALID");
+      return true;
+    });
     assert.deepEqual(fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1])), []);
   } finally {
     fake.cleanup();
@@ -280,5 +301,145 @@ test("#1019 final summary vetoes active integration task and generic resolved ga
     assert.ok(generic.report.diagnostics.some((diagnostic) => diagnostic.code === "INTEGRATION_GATE_CONFLICT"));
   } finally {
     generic.fake.cleanup();
+  }
+});
+
+test("#1019 H2 evidence not bound to the live runtime/task/dispatch fails closed before gate-resolve", () => {
+  const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
+  const staleCases = [
+    { label: "prior-run runtime", provenance: { runtime_id: "runtime-prior-run" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
+    { label: "prior-run task", provenance: { task_id: "task-prior-run" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
+    { label: "reused-dir dispatch", provenance: { dispatch_id: "dispatch-prior-run" }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISMATCH" },
+    { label: "missing dispatch id", provenance: { dispatch_id: undefined }, reasonCode: "INTEGRATION_REPORT_PROVENANCE_MISSING" },
+  ];
+  for (const scenario of staleCases) {
+    // A canonical gate already exists pending; only fresh, provenance-bound evidence may resolve it.
+    const fake = installFakeOrcaIntegrationLifecycle(initialState({
+      gates: [{ id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" }],
+    }));
+    const report = reportFile(true, scenario.provenance);
+    try {
+      assert.throws(() => advanceIntegrationGate(context(fake, report.reportPath)), (error) => {
+        assert.ok(error instanceof IntegrationLifecycleError, scenario.label);
+        assert.equal(error.reasonCode, scenario.reasonCode, scenario.label);
+        return true;
+      }, scenario.label);
+      // Stale evidence must NEVER authorize a gate-create, gate-resolve, or worker_done.
+      assert.deepEqual(fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1])), [], scenario.label);
+      assert.equal(fake.readPoison(), null);
+    } finally {
+      fake.cleanup();
+      fs.rmSync(report.dir, { recursive: true, force: true });
+    }
+  }
+  // The SAME dispatch's fresh, provenance-bound evidence still resolves the gate (crash recovery preserved).
+  const fresh = installFakeOrcaIntegrationLifecycle(initialState({
+    gates: [{ id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "pending" }],
+  }));
+  const freshReport = reportFile();
+  try {
+    const advanced = advanceIntegrationGate(context(fresh, freshReport.reportPath));
+    assert.equal(advanced.ok, false);
+    assert.equal(advanced.reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+    assert.equal(fresh.readLog().filter((argv) => argv[1] === "gate-resolve").length, 1);
+    assert.equal(fresh.readPoison(), null);
+  } finally {
+    fresh.cleanup();
+    fs.rmSync(freshReport.dir, { recursive: true, force: true });
+  }
+});
+
+test("#1019 H1 resume leaves a materialized, undispatched or wave-ineligible integration gate inert", () => {
+  const receiptFor = (integrationTask) => ({
+    program_id: PROGRAM_ID,
+    runtime_id: DEFAULT_RUNTIME_ID,
+    tasks: [
+      { outcome_id: "impl", kind: "implementation", wave: 1, orca_task_id: "orca-impl", dispatch_id: "d-impl", assignee: "term-impl" },
+      integrationTask,
+    ],
+  });
+  // Wave 1 has not completed_with_evidence, so the wave-2 integration gate is not yet eligible.
+  const report = { outcomes: [{ outcome_id: "impl", wave: 1, state: "reused" }, { outcome_id: OUTCOME_ID, wave: 2, state: "pending" }] };
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-h1-lock-"));
+  const opts = {
+    coordinatorHandle: COORDINATOR,
+    integrationLockRoot: lockRoot,
+    integrationReportPath: () => path.join(os.tmpdir(), "relay-orca-h1-nonexistent-report.json"),
+  };
+  const inertCases = [
+    { label: "undispatched wave-2 gate (the #1019 live shape)", task: { outcome_id: OUTCOME_ID, kind: "integration_gate", wave: 2, orca_task_id: TASK_ID, dispatch_id: null, assignee: null } },
+    { label: "dispatched wave-2 gate before earlier waves complete", task: { outcome_id: OUTCOME_ID, kind: "integration_gate", wave: 2, orca_task_id: TASK_ID, dispatch_id: DISPATCH_ID, assignee: ASSIGNEE } },
+  ];
+  try {
+    for (const scenario of inertCases) {
+      // orcaBin points at an absent binary: an inert gate must never reach it, so a broken
+      // filter would surface as an INTEGRATION_CAPABILITY_GAP blocking entry, not [].
+      const blocking = advanceIntegrationTasks({
+        receipt: receiptFor(scenario.task),
+        opts,
+        orcaBin: path.join(os.tmpdir(), "relay-orca-h1-absent-orca-bin"),
+        report,
+      });
+      assert.deepEqual(blocking, [], scenario.label);
+    }
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+  }
+});
+
+test("#1019 H1 resume advances a dispatched, wave-eligible integration gate", () => {
+  const fake = installFakeOrcaIntegrationLifecycle(initialState({
+    gates: [{ id: "g1", task_id: TASK_ID, question: canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment), options: ["passed", "failed"], status: "pending" }],
+  }));
+  const report = reportFile();
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-h1-pos-lock-"));
+  try {
+    const blocking = advanceIntegrationTasks({
+      receipt: {
+        program_id: PROGRAM_ID,
+        runtime_id: DEFAULT_RUNTIME_ID,
+        tasks: [{ outcome_id: OUTCOME_ID, kind: "integration_gate", wave: 1, orca_task_id: TASK_ID, dispatch_id: DISPATCH_ID, assignee: ASSIGNEE }],
+      },
+      opts: { coordinatorHandle: COORDINATOR, integrationLockRoot: lockRoot, integrationReportPath: () => report.reportPath },
+      orcaBin: fake.orcaPath,
+      report: { outcomes: [{ outcome_id: OUTCOME_ID, wave: 1, state: "pending" }] },
+    });
+    // Wave-1 eligible + dispatched → the gate resolves and the operator is asked for worker_done.
+    assert.equal(blocking.length, 1);
+    assert.equal(blocking[0].reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-resolve").length, 1);
+    assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+    fs.rmSync(lockRoot, { recursive: true, force: true });
+  }
+});
+
+test("#1019 M3 integration lifecycle lock reclaims a dead owner but never steals a live one", () => {
+  const { execFileSync } = require("node:child_process");
+  const lockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-m3-lock-"));
+  const lockArgs = { programId: PROGRAM_ID, outcomeId: OUTCOME_ID, taskId: TASK_ID, lockRoot };
+  const lockPath = path.join(lockRoot, `${integrationLockName(lockArgs)}.lock`);
+  // A guaranteed-dead PID: a child process that has already exited by the time execFileSync returns.
+  const deadPid = Number(execFileSync(process.execPath, ["-e", "process.stdout.write(String(process.pid))"], { encoding: "utf8" }));
+  try {
+    // Dead owner: a crash left the lock dir + the PID of a process that no longer exists.
+    fs.mkdirSync(lockPath);
+    fs.writeFileSync(path.join(lockPath, "owner"), `${deadPid}\n`, "utf8");
+    const reclaimed = withIntegrationLifecycleLock({ ...lockArgs, timeoutMs: 300, pollMs: 5 }, () => "acquired");
+    assert.equal(reclaimed, "acquired", "a dead owner's lock is reclaimed, not stranded");
+    assert.equal(fs.existsSync(lockPath), false, "the reclaiming holder releases the lock when it finishes");
+
+    // Live owner: the current process holds the lock; a competing acquire must fail closed.
+    fs.mkdirSync(lockPath);
+    fs.writeFileSync(path.join(lockPath, "owner"), `${process.pid}\n`, "utf8");
+    assert.throws(
+      () => withIntegrationLifecycleLock({ ...lockArgs, timeoutMs: 60, pollMs: 5 }, () => "should-not-run"),
+      /integration lifecycle lock timed out/,
+    );
+    assert.equal(fs.existsSync(lockPath), true, "a live owner's lock is never stolen");
+  } finally {
+    fs.rmSync(lockRoot, { recursive: true, force: true });
   }
 });

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -17,6 +17,8 @@ const {
   IntegrationLifecycleError,
 } = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
 const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { deriveStatusReport } = require(path.join(SCRIPTS, "lib", "status-derive.js"));
+const { buildFinalSummary } = require(path.join(SCRIPTS, "lib", "final-summary.js"));
 const { installFakeOrcaIntegrationLifecycle } = require(path.join(__dirname, "..", "fixtures", "fake-orca-integration-lifecycle.js"));
 
 const PROGRAM_ID = "repilot-941-20260715";
@@ -178,5 +180,56 @@ test("#1019 completion command is explicit and never raw-payload shaped", () => 
     assert.match(command.copy_paste, /--report-path/);
   } finally {
     fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
+test("#1019 final summary vetoes active integration task and generic resolved gate", () => {
+  const question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment);
+  const makeReport = (taskStatus, gate) => {
+    const fake = installFakeOrcaIntegrationLifecycle(initialState({
+      tasks: [{ id: TASK_ID, task_title: `relay-orca: ${programSegment(PROGRAM_ID)}/${OUTCOME_ID}`, display_name: `relay-orca: ${programSegment(PROGRAM_ID)}/${OUTCOME_ID}`, status: taskStatus, worker_done: taskStatus === "completed" }],
+      gates: [gate],
+    }));
+    const receipt = {
+      program_id: PROGRAM_ID,
+      runtime_id: "runtime-integration-fixture",
+      tasks: [{ outcome_id: OUTCOME_ID, task_id: "orca-task-integration-check", kind: "integration_gate", wave: 1, orca_task_id: TASK_ID, dispatch_id: DISPATCH_ID, assignee: ASSIGNEE, relay_ids: { request: null, run: null, fleet: null } }],
+    };
+    const report = deriveStatusReport({
+      receipt,
+      programId: PROGRAM_ID,
+      receiptPath: "/tmp/receipt.json",
+      manifests: [],
+      orca: (_bin, args) => fake.run(args[0] === "orchestration" && args[1] === "gate-list" && !args.includes("--task") ? ["orchestration", "gate-list", "--task", TASK_ID, "--json"] : args),
+      gh: null,
+      urlFor: () => null,
+      programSegment,
+      strictIntegration: true,
+    });
+    return { fake, report };
+  };
+  const gate = { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "resolved", resolution: "passed" };
+  const active = makeReport("ready", gate);
+  try {
+    const summary = buildFinalSummary({
+      programId: PROGRAM_ID,
+      receiptPath: "/tmp/receipt.json",
+      report: active.report,
+      gateEval: { prerequisites_met: true, gates: [{ gate: "integration:integration-check", kind: "integration", state: "passed", evidence: { passed: true }, message: "" }], blocking_reasons: [] },
+      followUps: { blocking: [], deferred: [] },
+      decisions: [],
+    });
+    assert.equal(active.report.runtime, "ok", JSON.stringify({ diagnostics: active.report.diagnostics, log: active.fake.readLog() }));
+    assert.equal(summary.program_complete, false);
+    assert.equal(summary.stopped_on, "orca_lifecycle_failure");
+    assert.ok(summary.blocking_reasons.some((reason) => reason.reason_code === "INTEGRATION_TASK_ACTIVE"), JSON.stringify({ diagnostics: active.report.diagnostics, outcomes: active.report.outcomes }));
+  } finally {
+    active.fake.cleanup();
+  }
+  const generic = makeReport("completed", { id: "g1", task_id: TASK_ID, question, options: ["passed", "failed"], status: "resolved" });
+  try {
+    assert.ok(generic.report.diagnostics.some((diagnostic) => diagnostic.code === "INTEGRATION_GATE_CONFLICT"));
+  } finally {
+    generic.fake.cleanup();
   }
 });

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -413,6 +413,62 @@ test("#1019 R3 same-dispatch evidence stays valid across a coordinator restart",
   }
 });
 
+// #1019 R4: exactly one canonical gate is a lifecycle invariant of a verified live integration
+// dispatch, and the operator ordering is gate-before-evidence. Awaiting evidence against NO gate
+// left the invariant unsatisfied and gave the operator nothing to write evidence against, so the
+// gate must be materialized first — and materialized only once, however many times resume runs.
+test("#1019 R4 a live dispatch with no gate and no evidence materializes exactly one canonical gate and still awaits evidence", () => {
+  const fake = installFakeOrcaIntegrationLifecycle(initialState());
+  const absentDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-r4-absent-report-"));
+  const reportPath = path.join(absentDir, "integration.json");
+  try {
+    assert.equal(fake.readState().gates.length, 0, "precondition: the live dispatch carries no canonical gate");
+    assert.equal(fs.existsSync(reportPath), false, "precondition: no deterministic evidence artifact exists yet");
+
+    const first = advanceIntegrationGate(context(fake, reportPath));
+    assert.equal(first.ok, true);
+    assert.equal(first.state, "awaiting_evidence");
+    assert.ok(first.gate, "awaiting_evidence must carry the materialized canonical gate, never null");
+    assert.equal(first.gate.question, canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment));
+    assert.deepEqual(first.gate.options, ["passed", "failed"]);
+    assert.equal(first.report_path, reportPath);
+    assert.equal(fake.readState().gates.length, 1, "exactly one canonical gate is created");
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-create").length, 1);
+    // Materializing the gate must resolve and complete nothing.
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-resolve").length, 0);
+    assert.deepEqual(fake.readSends(), [], "no completion instruction or worker_done before evidence");
+    assert.equal(fake.readState().tasks[0].status, "ready");
+    assert.equal(fake.readPoison(), null);
+
+    // Idempotency: the next pass adopts the same gate instead of creating a second one.
+    const second = advanceIntegrationGate(context(fake, reportPath));
+    assert.equal(second.ok, true);
+    assert.equal(second.state, "awaiting_evidence");
+    assert.equal(second.gate.id, first.gate.id, "the same canonical gate is adopted, not duplicated");
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-create").length, 1, "no duplicate gate-create");
+    assert.equal(fake.readState().gates.length, 1);
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-resolve").length, 0);
+    assert.deepEqual(fake.readSends(), []);
+    assert.equal(fake.readState().tasks[0].status, "ready");
+    assert.equal(fake.readPoison(), null);
+
+    // The gate materialized ahead of the evidence is the very gate that evidence later resolves:
+    // no second gate appears once the operator writes its provenance-bound artifact.
+    writeReport(reportPath, { passed: true, evidence: "integration fixture passed", ...LIVE_PROVENANCE });
+    const advanced = advanceIntegrationGate(context(fake, reportPath));
+    assert.equal(advanced.ok, false);
+    assert.equal(advanced.reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+    assert.equal(fake.readLog().filter((argv) => argv[1] === "gate-create").length, 1);
+    assert.equal(fake.readState().gates.length, 1);
+    assert.equal(fake.readState().gates[0].id, first.gate.id);
+    assert.equal(fake.readState().gates[0].resolution, "passed");
+    assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(absentDir, { recursive: true, force: true });
+  }
+});
+
 // The advancement selection matrix. Eligibility is the CONJUNCTION of planResume's own verdict
 // (only `reused`/`redispatched` leave a currently verified live dispatch behind), the shared
 // wave blanket, and recorded dispatch provenance. Each inert row below flips exactly one

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -17,7 +17,7 @@ const { REASONS: RESUME_REASONS } = require(path.join(SCRIPTS, "lib", "resume-re
 const { RECEIPT_NOTE, parseReceipt, serializeReceipt, serializeReceiptWithStop } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
 const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
-const { integrationBlockingEntry } = require(RESUME_JS);
+const { integrationBlockingEntry, integrationTasksToAdvance } = require(RESUME_JS);
 const { installFakeOrcaResume } = require(path.join(__dirname, "..", "fixtures", "fake-orca-resume.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
@@ -1422,4 +1422,226 @@ test("#1019 integrationBlockingEntry omits completion_command when the lifecycle
   });
   assert.equal(entry.reason_code, "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH");
   assert.equal("completion_command" in entry, false);
+});
+
+// --- #1019 R3: integration-gate advancement eligibility -----------------------------
+
+// The selection matrix for advancement. Eligibility is the CONJUNCTION of the plan's own
+// verdict (only `reused`/`redispatched` leave a live dispatch behind), the shared wave
+// blanket, and recorded dispatch provenance. Each row below flips exactly one conjunct.
+test("#1019 R3 only wave-eligible integration tasks holding a verified live dispatch advance", () => {
+  const dispatched = { dispatch_id: "disp-1", assignee: "term-1" };
+  const report = {
+    outcomes: [
+      { outcome_id: "w1", wave: 1, state: "dispatched" },
+      { outcome_id: "w1done", wave: 1, state: "complete_with_evidence" },
+    ],
+  };
+  const cases = [
+    { label: "wave 1, reused, dispatched", task: { wave: 1, ...dispatched }, action: "reused", expected: true },
+    { label: "wave 1, redispatched, dispatched", task: { wave: 1, ...dispatched }, action: "redispatched", expected: true },
+    // Wave 2 while a wave-1 outcome is still incomplete: ineligible even though the plan
+    // reused a perfectly live mapping. This is the conjunct a mapping-only filter misses.
+    { label: "wave 2 with wave 1 incomplete", task: { wave: 2, ...dispatched }, action: "reused", expected: false },
+    { label: "undispatched (no dispatch_id)", task: { wave: 1, dispatch_id: null, assignee: "term-1" }, action: "reused", expected: false },
+    { label: "undispatched (no assignee)", task: { wave: 1, dispatch_id: "disp-1", assignee: null }, action: "reused", expected: false },
+    { label: "blank dispatch provenance", task: { wave: 1, dispatch_id: "   ", assignee: "term-1" }, action: "reused", expected: false },
+    { label: "plan skipped the outcome", task: { wave: 1, ...dispatched }, action: "skipped", expected: false },
+    { label: "plan requires a decision", task: { wave: 1, ...dispatched }, action: "decision_required", expected: false },
+  ];
+  for (const scenario of cases) {
+    const receipt = { tasks: [{ outcome_id: "w1", kind: "integration_gate", ...scenario.task }] };
+    const actions = [{ outcome_id: "w1", action: scenario.action }];
+    const selected = integrationTasksToAdvance({ receipt, report, actions });
+    assert.equal(selected.length, scenario.expected ? 1 : 0, scenario.label);
+  }
+
+  // The wave blanket opens once every earlier-wave outcome is durably complete.
+  const eligibleWave2 = integrationTasksToAdvance({
+    receipt: { tasks: [{ outcome_id: "w2", kind: "integration_gate", wave: 2, ...dispatched }] },
+    report: { outcomes: [{ outcome_id: "w1done", wave: 1, state: "complete_with_evidence" }] },
+    actions: [{ outcome_id: "w2", action: "reused" }],
+  });
+  assert.equal(eligibleWave2.length, 1, "wave 2 advances once wave 1 is complete_with_evidence");
+
+  // Non-integration kinds are never advanced regardless of how eligible they look.
+  const nonIntegration = integrationTasksToAdvance({
+    receipt: { tasks: [{ outcome_id: "w1", kind: "relay_run", wave: 1, ...dispatched }] },
+    report,
+    actions: [{ outcome_id: "w1", action: "reused" }],
+  });
+  assert.deepEqual(nonIntegration, []);
+});
+
+// Lifecycle-mutating Orca subcommands. gate-LIST is a READ the status reconciliation
+// performs for every integration outcome, so it is deliberately excluded — only creation,
+// resolution, and orchestration sends mutate the lifecycle.
+function integrationMutationLines(log) {
+  return log.filter(
+    (line) =>
+      line.startsWith("orchestration gate-create") ||
+      line.startsWith("orchestration gate-resolve") ||
+      line.startsWith("orchestration send"),
+  );
+}
+
+// A wave-2 integration gate with a fully live mapping would be `reused` by the plan, so a
+// kind-only filter advances it — resolving a gate and driving a task to completion while
+// wave 1 is still running. The wave blanket must hold it back with zero lifecycle mutation.
+// Write the evidence artifact the integration lifecycle would consume, stamped with the
+// provenance of the outcome's live fixture dispatch. Its presence is what makes these
+// scenarios DISCRIMINATING: with a live coordinator and valid evidence, an over-broad
+// advancement filter really does create and resolve a gate, which the log audit catches.
+function writeGateEvidence(world, outcomeId, overrides = {}) {
+  const dir = path.join(world.base, "gate-evidence");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${outcomeId}.json`),
+    `${JSON.stringify({
+      passed: true,
+      evidence: `integration evidence for ${outcomeId}`,
+      runtime_id: DEFAULT_RUNTIME_ID,
+      task_id: `orca-live-${outcomeId}`,
+      dispatch_id: `disp-orca-live-${outcomeId}`,
+      assignee: `term-orca-live-${outcomeId}`,
+      ...overrides,
+    })}\n`,
+    "utf-8",
+  );
+  return dir;
+}
+
+test("#1019 R3 a wave-2 integration task is not advanced while wave 1 is incomplete", () => {
+  const programId = "epic-1019-r3-wave-blanket";
+  const world = buildWorld({
+    programId,
+    orcaScenario: {
+      // A runtime that CAN complete the lifecycle: live coordinator + resolvable gates.
+      coordinator: "coord-current",
+      tasks: [orcaTask(programId, "w1"), orcaTask(programId, "w2int")],
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "w1", kind: "relay_run", wave: 1 },
+      { outcome_id: "w2int", kind: "integration_gate", wave: 2, assignee: "term-orca-live-w2int" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const evidenceDir = writeGateEvidence(world, "w2int");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--coordinator-handle", "coord-current", "--gate-evidence-dir", evidenceDir]);
+    assert.equal(r.status, 0);
+    // wave 1 is merely dispatched — never complete_with_evidence — so wave 2 stays shut.
+    assert.notEqual(actionFor(r.body, "w1").action, "skipped");
+    assert.deepEqual(
+      integrationMutationLines(world.orca.readLog()),
+      [],
+      "an ineligible later-wave integration gate must never be created, resolved, or sent to",
+    );
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "no dispatch/terminal mutation either");
+    assert.deepEqual(r.body.blocking_reasons, [], "an ineligible outcome is left untouched, not failed closed");
+    assert.equal(r.body.ok, true);
+    assert.equal(world.receiptOnDisk(), before, "the receipt is left byte-identical");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// The same world with wave 1 durably complete is the positive control: the wave blanket
+// opens and the very same integration outcome DOES advance through the lifecycle. Without
+// it, the test above could pass for the wrong reason (e.g. a lifecycle that never runs).
+test("#1019 R3 positive control: the same integration task advances once wave 1 is complete", () => {
+  const programId = "epic-1019-r3-wave-open";
+  const runId = "run-w1";
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: runId, state: "merged", pr_number: 77, issue_number: 777 }],
+    orcaScenario: {
+      coordinator: "coord-current",
+      tasks: [
+        orcaTask(programId, "w1", { status: "completed", worker_done: true }),
+        orcaTask(programId, "w2int"),
+      ],
+    },
+    ghScenario: {
+      prs: { 77: { state: "MERGED", mergedAt: "2026-07-14T01:00:00Z" } },
+      issues: { 777: { state: "CLOSED" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "w1", kind: "relay_run", wave: 1, run: runId },
+      { outcome_id: "w2int", kind: "integration_gate", wave: 2, assignee: "term-orca-live-w2int" },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const evidenceDir = writeGateEvidence(world, "w2int");
+  try {
+    world.run(["--coordinator-handle", "coord-current", "--gate-evidence-dir", evidenceDir]);
+    const log = world.orca.readLog();
+    assert.ok(
+      log.some((line) => line.startsWith("orchestration gate-create")),
+      `the eligible integration gate is created: ${JSON.stringify(log)}`,
+    );
+    assert.ok(log.some((line) => line.startsWith("orchestration gate-resolve")), "and resolved once evidence is valid");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// An integration outcome that was never dispatched has no live dispatch to bind evidence
+// or a completion instruction to. It must be left completely untouched — not merely fail
+// closed after reading live state.
+test("#1019 R3 an undispatched integration task is skipped with zero lifecycle mutation", () => {
+  const programId = "epic-1019-r3-undispatched";
+  const world = buildWorld({
+    programId,
+    // An unmapped relay run back-pointer keeps the absent outcome `skipped` rather than
+    // re-dispatched, so the plan stays at exit 0 and advancement is actually reached.
+    manifests: [{ run_id: "run-unmapped", state: "dispatched", pr_number: 40, issue_number: 400, body: `relay-orca program ${programId} operator run` }],
+    orcaScenario: {
+      coordinator: "coord-current",
+      tasks: [orcaTask(programId, "w1int")],
+      dispatch: absentDispatch("w1int"),
+    },
+    ghScenario: { prs: { 40: { state: "OPEN" } }, issues: { 400: { state: "OPEN" } } },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "w1int", kind: "integration_gate", wave: 1, dispatch_id: null, assignee: null }],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const evidenceDir = writeGateEvidence(world, "w1int");
+  const before = world.receiptOnDisk();
+  try {
+    const r = world.run(["--coordinator-handle", "coord-current", "--gate-evidence-dir", evidenceDir]);
+    assert.equal(r.status, 0);
+    assert.equal(actionFor(r.body, "w1int").action, "skipped");
+    assert.deepEqual(
+      integrationMutationLines(world.orca.readLog()),
+      [],
+      "an undispatched integration task must not create, resolve, or send anything",
+    );
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "and must not be re-dispatched");
+    // Left UNTOUCHED, not merely failed closed: an undispatched outcome that reached the
+    // lifecycle would surface INTEGRATION_DISPATCH_PROVENANCE_MISSING here.
+    assert.deepEqual(r.body.blocking_reasons, []);
+    assert.equal(r.body.ok, true);
+    assert.equal(world.receiptOnDisk(), before, "the receipt is left byte-identical");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
 });

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -17,6 +17,7 @@ const { REASONS: RESUME_REASONS } = require(path.join(SCRIPTS, "lib", "resume-re
 const { RECEIPT_NOTE, parseReceipt, serializeReceipt, serializeReceiptWithStop } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
 const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { integrationBlockingEntry } = require(RESUME_JS);
 const { installFakeOrcaResume } = require(path.join(__dirname, "..", "fixtures", "fake-orca-resume.js"));
 const { installFakeGh } = require(path.join(__dirname, "..", "fixtures", "fake-gh.js"));
 const { DEFAULT_RUNTIME_ID } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
@@ -1396,4 +1397,29 @@ test("#1008 mapping intake enables complete_with_evidence on the next status rec
   } finally {
     world.cleanup();
   }
+});
+
+// --- #1019 R2: resume surfaces the copy-paste worker_done command while awaiting completion ---
+
+test("#1019 integrationBlockingEntry surfaces the full copy-paste worker_done command while awaiting completion", () => {
+  const copyPaste = "orca orchestration send --to coord-current --subject 'worker_done: relay-orca: seg/out' --from term-fresh --body 'send once' --type worker_done --task-id task_x --dispatch-id disp_x --report-path /runs/out.json --phase integration_gate --json";
+  const entry = integrationBlockingEntry({
+    ok: false,
+    state: "awaiting_worker_done",
+    reason_code: "INTEGRATION_WORKER_DONE_REQUIRED",
+    completion_command: { copy_paste: copyPaste },
+  });
+  assert.equal(entry.reason_code, "INTEGRATION_WORKER_DONE_REQUIRED");
+  // The authoritative explicit-flag command is surfaced verbatim (not truncated) in the report.
+  assert.equal(entry.completion_command, copyPaste);
+  assert.match(entry.message, /worker_done/);
+});
+
+test("#1019 integrationBlockingEntry omits completion_command when the lifecycle failed without one", () => {
+  const entry = integrationBlockingEntry({
+    ok: false,
+    reason_code: "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH",
+  });
+  assert.equal(entry.reason_code, "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH");
+  assert.equal("completion_command" in entry, false);
 });


### PR DESCRIPTION
## Summary

- Make integration-gate lifecycle coordinator-owned and terminal.
- Add canonical gate identity, bounded locking, create/adopt recovery, and fail-closed conflict handling.
- Require fresh coordinator/runtime/dispatch/assignee/report provenance.
- Enforce canonical gate resolution before explicit `worker_done`.
- Veto final summaries on active or contradictory integration lifecycle state.
- Add stateful fake-Orca fixtures, focused tests, CLI help, and operator documentation.

## Verification

- `node --test tests/relay-orca/scripts/run.test.js tests/relay-orca/scripts/resume.test.js tests/relay-orca/scripts/status.test.js tests/relay-orca/scripts/gates.test.js tests/relay-orca/scripts/*integration-lifecycle*.test.js`
  - 171 passed, 0 failed
- `node --test tests/relay-orca/scripts/plan.test.js tests/relay-orca/scripts/integration-lifecycle.test.js`
  - 38 passed, 0 failed
- `git diff --check`
  - passed
- Fixture invocation audit
  - no `task-update`, reset, worktree, raw `--payload`, or unsupported send shape
  - fake Orca poison: clean

## Trust-boundary scope adjudication

- This PR owns the per-outcome `integration_gate` lifecycle: current runtime/task/dispatch/assignee provenance, exactly one canonical gate, passed resolution before `worker_done`, terminal task state, and final-summary lifecycle vetoes.
- A generic #947 `integration:<check>` exit gate remains a distinct named-check contract. The real closure topology deliberately uses `integration:full-suite` while its Orca lifecycle outcome is `integration-main-suite`; identity must not be inferred from equal names or sanitized basenames.
- Review round 5 found that generic integration evidence lacks an explicit program/runtime/check trust identity. That finding is tracked as #1046 and is not implemented by this PR because applying lifecycle task provenance globally would break generic non-Orca checks and would not protect the real differing-name topology.
- The owner discarded the uncommitted R6 experiment that attempted to couple these contracts. Fresh independent review should adjudicate this scope boundary against #1019's frozen acceptance criteria and the unchanged green HEAD `22826fd8fe0fa2cfc5a12f66f0b8877cfa348453`.

Fixes #1019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * `integration_gate`의 생성·검증·완료까지의 통합 라이프사이클을 지원합니다.
  * `run`/`resume`에 `--coordinator-handle`, `--gate-evidence-dir` 옵션을 추가했습니다.
* **개선 사항**
  * 통합 라이프사이클 실패를 종료코드 `45`(INTEGRATION_LIFECYCLE_FAILED)로 명확히 표시합니다.
  * 증거/프로베넌스 불일치 시 fail-closed로 중단하고, `resume`는 멱등적으로 안전한 범위에서만 완료 지시를 재발행합니다.
  * `status` 최종 요약/차단 사유 진단 범위를 확장했습니다.
* **문서**
  * `#1019` integration gate 운영·완료 계약을 상세히 보강했습니다.
* **테스트**
  * `#1019` 통합 라이프사이클 매트릭스 테스트와 가짜 Orca 시나리오를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
