### PR TITLE
fix(calibration): compare compact with eligible full controls

### DIFF
--- a/docs/plans/2026-07-20-comparable-risk-calibration-design.md
+++ b/docs/plans/2026-07-20-comparable-risk-calibration-design.md
@@ -1,0 +1,73 @@
+# Comparable Risk Calibration
+
+## Problem
+
+Risk-path calibration currently compares every full-path run with compact runs in
+the same task class. Full runs can be medium or high risk, so this can measure
+risk mix instead of harness behavior.
+
+## Design principle
+
+Correct the comparison without creating another scoring or matching system.
+Reuse the task-derived assurance floor already stored in
+`task_profile_summary.minimum_review_assurance`. Do not persist new manifest
+state, inspect model/provider identity, mutate routes, or automate promotion.
+
+## Comparison boundary
+
+- A run is comparable when its derived minimum assurance is `compact`.
+- A `standard` or `hardened` floor is excluded from compact comparison.
+- A missing or unknown floor is excluded fail-closed.
+- Selected assurance remains independent: a low-risk run explicitly strengthened
+  to `standard` or `hardened` is a valid full-path control.
+
+`by_run` exposes one report-only `comparison_eligibility` value so an operator
+can see whether a run was included or why it was excluded. No new field is
+written back to the run manifest.
+
+## Reporting and decisions
+
+Keep the existing task-class and path structures. For each path:
+
+- `observed_sample_size` counts every observed run;
+- `sample_size` counts only comparable runs used by the existing metrics;
+- `excluded_sample_size` is the difference.
+
+All runs remain visible through `by_run`, coverage, and operational evidence.
+The existing comparison and promotion functions receive only compact-eligible
+entries.
+
+The safety boundary stays conservative:
+
+- any lightweight safety violation still rolls back lightweight immediately;
+- a compact-eligible full control can still trigger the existing safety rollback;
+- safety signals from excluded medium/high/unknown full runs remain visible but
+  cannot change the compact decision.
+
+If either comparable path is below the existing minimum sample, return
+`continue_calibration` with path-specific insufficient-comparable-sample
+reasons. Do not add a numeric quality score or another decision status.
+
+## Verification
+
+Focused tests cover:
+
+1. low-risk full controls participating even when their selected tier is
+   `standard` or `hardened`;
+2. medium/high full runs remaining visible but unable to produce promotion,
+   retention, or rollback;
+3. unknown floors being excluded fail-closed;
+4. risk-skewed observed cohorts returning `continue_calibration` when comparable
+   samples are insufficient;
+5. the operator report exposing observed, included, and excluded counts.
+
+Existing reliability-report and risk-assurance suites remain the regression
+boundary.
+
+## Non-goals
+
+- no propensity matching or risk weighting;
+- no model/provider-specific logic;
+- no new persisted schema;
+- no route mutation or automatic promotion;
+- no broader calibration rewrite or new module.

--- a/skills/relay-dispatch/references/risk-calibration.md
+++ b/skills/relay-dispatch/references/risk-calibration.md
@@ -9,6 +9,7 @@ Each run is reported with:
 - `task_class`: `code`, `design`, `documentation`, `operations_security`, or `data_change`
 - `behavior_path`: `lightweight` for compact assurance and `full` for standard or hardened assurance
 - `assurance_tier`: compact, standard, or hardened
+- `comparison_eligibility`: report-only inclusion or exclusion derived from the persisted assurance floor
 - Outcome quality: contract status plus observed user/domain surface status
 - Verification status, reported separately; routine Verification success is not rubric value
 - Harness friction: stalls, recovery actions, and explicit manual interventions
@@ -19,7 +20,9 @@ No-rubric runs are first-class samples. Coverage reports their count and does no
 
 ## Task-class decisions
 
-Promotion evidence is evaluated within each task class, never from one global pass rate. A class needs at least three observed runs in each path before ordinary quality or friction trends can produce a promotion candidate.
+Promotion evidence is evaluated within each task class, never from one global pass rate. A run is comparable only when its task-derived `minimum_review_assurance` is `compact`. A low-risk run explicitly strengthened to standard or hardened remains a valid full-path control. Medium-, high-, and unknown-risk full runs remain visible but are excluded from compact decisions.
+
+Each path reports `observed_sample_size` for all runs, `sample_size` for the comparable cohort, and `excluded_sample_size` for the difference. A class needs at least three comparable runs in each path before ordinary quality or friction trends can produce a promotion candidate.
 
 The conservative decisions are:
 
@@ -29,6 +32,8 @@ The conservative decisions are:
 - `rollback_lightweight`: any lightweight safety boundary violation. This immediate rollback does not wait for a trend.
 
 A candidate is an operator decision artifact. The report does not auto-promote a route, weaken a gate, publish, or merge.
+
+Safety violations from excluded medium/high/unknown full runs remain operational evidence but cannot change the compact decision. Compact-eligible full controls retain the existing conservative safety behavior.
 
 ## Safety evidence
 

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -1809,6 +1809,16 @@ function main() {
       + `no_rubric_runs=${calibration.coverage.no_rubric_runs}`
     );
     console.log(
+      `    comparable (included/observed/excluded): ${Object.entries(calibration.by_task_class)
+        .filter(([, summary]) => Object.values(summary.paths)
+          .some((pathSummary) => pathSummary.observed_sample_size > 0))
+        .map(([taskClass, summary]) => (
+          `${taskClass}=full:${summary.paths.full.sample_size}/${summary.paths.full.observed_sample_size}/${summary.paths.full.excluded_sample_size},`
+          + `lightweight:${summary.paths.lightweight.sample_size}/${summary.paths.lightweight.observed_sample_size}/${summary.paths.lightweight.excluded_sample_size}`
+        ))
+        .join(" ") || "n/a"}`
+    );
+    console.log(
       `    decisions: ${Object.entries(calibration.promotion_decisions)
         .map(([taskClass, decision]) => `${taskClass}=${decision.status}`)
         .join(", ")}`

--- a/skills/relay-dispatch/scripts/reliability/calibration.js
+++ b/skills/relay-dispatch/scripts/reliability/calibration.js
@@ -82,6 +82,15 @@ function frictionFor(events) {
   };
 }
 
+function comparisonEligibility(profile) {
+  const floor = normalizedText(profile.minimum_review_assurance);
+  if (floor === "compact") return "included";
+  if (floor === "standard" || floor === "hardened") {
+    return "excluded_non_compact_floor";
+  }
+  return "excluded_unknown_floor";
+}
+
 function runRecord(manifest, events, verdictsByRun) {
   const data = manifest?.data || manifest || {};
   const runId = data.run_id;
@@ -112,6 +121,7 @@ function runRecord(manifest, events, verdictsByRun) {
     task_class: taskClassFor(profile),
     behavior_path: behaviorPath,
     assurance_tier: assurance,
+    comparison_eligibility: comparisonEligibility(profile),
     rubric_mode: factors.earned > 0 ? "earned" : "none",
     outcome_quality: {
       contract: latest.contract_status || "not_observed",
@@ -138,10 +148,12 @@ function runRecord(manifest, events, verdictsByRun) {
   };
 }
 
-function summarizePath(entries) {
+function summarizePath(entries, observedSampleSize = entries.length) {
   const records = entries.map((entry) => entry.record);
   return {
     sample_size: records.length,
+    observed_sample_size: observedSampleSize,
+    excluded_sample_size: observedSampleSize - records.length,
     outcome_quality_pass_rate: ratio(
       records.filter((record) => record.outcome_quality.pass).length,
       records.length
@@ -183,15 +195,28 @@ function uniqueMechanismDefects(entry) {
     + entry.adversarialUniqueDefects;
 }
 
-function promotionDecision(full, lightweight, fullEntries, minimumSampleSize) {
+function promotionDecision(
+  full,
+  lightweight,
+  fullEntries,
+  minimumSampleSize,
+  lightweightSafetyViolations
+) {
   if (
-    lightweight.safety_boundary_violations > 0
+    lightweightSafetyViolations > 0
     || full.safety_boundary_violations > 0
   ) {
     return { status: "rollback_lightweight", reasons: ["safety_boundary_violation"] };
   }
-  if (full.sample_size < minimumSampleSize || lightweight.sample_size < minimumSampleSize) {
-    return { status: "continue_calibration", reasons: ["insufficient_path_samples"] };
+  const insufficientReasons = [];
+  if (full.sample_size < minimumSampleSize) {
+    insufficientReasons.push("insufficient_comparable_full_samples");
+  }
+  if (lightweight.sample_size < minimumSampleSize) {
+    insufficientReasons.push("insufficient_comparable_lightweight_samples");
+  }
+  if (insufficientReasons.length > 0) {
+    return { status: "continue_calibration", reasons: insufficientReasons };
   }
   if (lightweight.outcome_quality_pass_rate < full.outcome_quality_pass_rate) {
     return { status: "retain_full", reasons: ["lightweight_outcome_trend_is_lower"] };
@@ -222,16 +247,30 @@ function buildCalibrationReport({
   const promotionDecisions = {};
   for (const taskClass of TASK_CLASSES) {
     const classEntries = entries.filter((entry) => entry.record.task_class === taskClass);
-    const fullEntries = classEntries.filter((entry) => entry.record.behavior_path === "full");
-    const lightEntries = classEntries.filter((entry) => entry.record.behavior_path === "lightweight");
-    const full = summarizePath(fullEntries);
-    const lightweight = summarizePath(lightEntries);
+    const observedFullEntries = classEntries.filter(
+      (entry) => entry.record.behavior_path === "full"
+    );
+    const observedLightEntries = classEntries.filter(
+      (entry) => entry.record.behavior_path === "lightweight"
+    );
+    const fullEntries = observedFullEntries.filter(
+      (entry) => entry.record.comparison_eligibility === "included"
+    );
+    const lightEntries = observedLightEntries.filter(
+      (entry) => entry.record.comparison_eligibility === "included"
+    );
+    const full = summarizePath(fullEntries, observedFullEntries.length);
+    const lightweight = summarizePath(lightEntries, observedLightEntries.length);
     byTaskClass[taskClass] = { paths: { full, lightweight } };
     promotionDecisions[taskClass] = promotionDecision(
       full,
       lightweight,
       fullEntries,
-      minimumSampleSize
+      minimumSampleSize,
+      observedLightEntries.reduce(
+        (sum, entry) => sum + entry.record.safety_boundary_violations.length,
+        0
+      )
     );
   }
   const coverageCounts = Object.fromEntries(TASK_CLASSES.map((taskClass) => [

--- a/tests/relay-dispatch/scripts/reliability-calibration-reference.test.js
+++ b/tests/relay-dispatch/scripts/reliability-calibration-reference.test.js
@@ -28,6 +28,9 @@ test("calibration reference defines class-local promotion and evidence boundarie
   }
   assert.match(reference, /Verification.*not.*rubric value/is);
   assert.match(reference, /three.*each path/is);
+  assert.match(reference, /minimum_review_assurance.*compact/is);
+  assert.match(reference, /medium.*high.*unknown.*excluded/is);
+  assert.match(reference, /observed_sample_size.*excluded_sample_size/is);
   assert.match(reference, /safety boundary violation.*immediate rollback/is);
   assert.match(reference, /unique material defects.*friction/is);
   assert.match(reference, /does not.*auto.*promot/is);

--- a/tests/relay-dispatch/scripts/reliability-calibration.test.js
+++ b/tests/relay-dispatch/scripts/reliability-calibration.test.js
@@ -6,6 +6,14 @@ const {
 } = require("../../../skills/relay-dispatch/scripts/reliability/calibration");
 
 function manifest(runId, taskClass, assurance, overrides = {}) {
+  const taskProfileSummary = {
+    task_class: taskClass,
+    behavior_path: assurance === "compact" ? "lightweight" : "full",
+  };
+  if (overrides.minimumReviewAssurance !== null) {
+    taskProfileSummary.minimum_review_assurance =
+      overrides.minimumReviewAssurance || "compact";
+  }
   return {
     data: {
       run_id: runId,
@@ -14,10 +22,7 @@ function manifest(runId, taskClass, assurance, overrides = {}) {
       review: { rounds: overrides.rounds || 1 },
       advisory: {
         guidance: {
-          task_profile_summary: {
-            task_class: taskClass,
-            behavior_path: assurance === "compact" ? "lightweight" : "full",
-          },
+          task_profile_summary: taskProfileSummary,
         },
       },
     },
@@ -93,6 +98,7 @@ test("calibration records behavior path and assurance while separating verificat
     task_class: "documentation",
     behavior_path: "lightweight",
     assurance_tier: "compact",
+    comparison_eligibility: "included",
     rubric_mode: "none",
     outcome_quality: {
       contract: "pass",
@@ -161,6 +167,85 @@ test("calibration covers representative task classes and makes promotion decisio
   );
   assert.equal(report.by_task_class.code.paths.lightweight.sample_size, 3);
   assert.equal(report.by_task_class.code.paths.full.sample_size, 4);
+  assert.equal(report.by_task_class.code.paths.full.observed_sample_size, 4);
+  assert.equal(report.by_task_class.code.paths.full.excluded_sample_size, 0);
+});
+
+test("risk-skewed full observations stay visible without deciding for the compact cohort", () => {
+  const manifests = [];
+  const verdictsByRun = new Map();
+  for (let index = 1; index <= 3; index += 1) {
+    const lightRun = `skew-light-${index}`;
+    const highFullRun = `skew-high-full-${index}`;
+    manifests.push(manifest(lightRun, "code", "compact"));
+    manifests.push(manifest(highFullRun, "code", "hardened", {
+      minimumReviewAssurance: "hardened",
+    }));
+    verdictsByRun.set(lightRun, [verdict()]);
+    verdictsByRun.set(highFullRun, [verdict({
+      contract: "fail",
+      issues: [materialIssue()],
+    })]);
+  }
+  for (let index = 1; index <= 2; index += 1) {
+    const comparableFullRun = `skew-comparable-full-${index}`;
+    manifests.push(manifest(comparableFullRun, "code", "standard"));
+    verdictsByRun.set(comparableFullRun, [verdict()]);
+  }
+
+  const report = buildCalibrationReport({
+    manifests,
+    verdictsByRun,
+    events: [{
+      run_id: "skew-high-full-1",
+      event: "safety_boundary_violation",
+      boundary: "stale_sha",
+    }],
+  });
+
+  assert.deepEqual(report.promotion_decisions.code, {
+    status: "continue_calibration",
+    reasons: ["insufficient_comparable_full_samples"],
+  });
+  assert.equal(report.by_task_class.code.paths.full.observed_sample_size, 5);
+  assert.equal(report.by_task_class.code.paths.full.sample_size, 2);
+  assert.equal(report.by_task_class.code.paths.full.excluded_sample_size, 3);
+  assert.equal(
+    report.by_run["skew-high-full-1"].comparison_eligibility,
+    "excluded_non_compact_floor"
+  );
+  assert.deepEqual(
+    report.by_run["skew-high-full-1"].safety_boundary_violations,
+    ["stale_sha"]
+  );
+});
+
+test("unknown risk floors are excluded fail-closed from compact comparison", () => {
+  const manifests = [];
+  const verdictsByRun = new Map();
+  for (let index = 1; index <= 3; index += 1) {
+    const lightRun = `unknown-light-${index}`;
+    const unknownFullRun = `unknown-full-${index}`;
+    manifests.push(manifest(lightRun, "documentation", "compact"));
+    manifests.push(manifest(unknownFullRun, "documentation", "standard", {
+      minimumReviewAssurance: null,
+    }));
+    verdictsByRun.set(lightRun, [verdict()]);
+    verdictsByRun.set(unknownFullRun, [verdict()]);
+  }
+
+  const report = buildCalibrationReport({ manifests, events: [], verdictsByRun });
+
+  assert.deepEqual(report.promotion_decisions.documentation, {
+    status: "continue_calibration",
+    reasons: ["insufficient_comparable_full_samples"],
+  });
+  assert.equal(
+    report.by_run["unknown-full-1"].comparison_eligibility,
+    "excluded_unknown_floor"
+  );
+  assert.equal(report.by_task_class.documentation.paths.full.sample_size, 0);
+  assert.equal(report.by_task_class.documentation.paths.full.observed_sample_size, 3);
 });
 
 test("a single lightweight safety violation rolls back its task class", () => {
@@ -212,7 +297,7 @@ test("success without required observation is an immediate lightweight rollback"
   );
 });
 
-test("full-path adversarial defects block lightweight promotion for that class", () => {
+test("compact-eligible full-path adversarial defects block lightweight promotion", () => {
   const manifests = [];
   const verdictsByRun = new Map();
   for (let index = 1; index <= 3; index += 1) {

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -2427,6 +2427,7 @@ test("reliability-report publishes path-aware calibration and class decisions", 
   setManifestGuidance(repoRoot, runId, [], {
     task_class: "documentation",
     behavior_path: "lightweight",
+    minimum_review_assurance: "compact",
     review_assurance: "compact",
   });
   const { manifestPath } = ensureRunLayout(repoRoot, runId);
@@ -2451,11 +2452,24 @@ test("reliability-report publishes path-aware calibration and class decisions", 
 
   assert.equal(report.calibration.by_run[runId].behavior_path, "lightweight");
   assert.equal(report.calibration.by_run[runId].assurance_tier, "compact");
+  assert.equal(report.calibration.by_run[runId].comparison_eligibility, "included");
   assert.equal(report.calibration.by_run[runId].rubric_mode, "none");
+  assert.equal(
+    report.calibration.by_task_class.documentation.paths.lightweight.observed_sample_size,
+    1
+  );
+  assert.equal(
+    report.calibration.by_task_class.documentation.paths.lightweight.excluded_sample_size,
+    0
+  );
   assert.equal(
     report.calibration.promotion_decisions.documentation.status,
     "continue_calibration"
   );
   assert.match(text, /calibration:/);
+  assert.match(
+    text,
+    /comparable \(included\/observed\/excluded\):.*documentation=full:0\/0\/0,lightweight:1\/1\/0/
+  );
   assert.match(text, /documentation=continue_calibration/);
 });


### PR DESCRIPTION
## Outcome

Make compact/full calibration compare like-for-like low-risk cohorts without adding a score, matching system, persisted state, or route automation.

- Derive report-only `comparison_eligibility` from the existing task-derived `minimum_review_assurance`.
- Include explicitly strengthened standard/hardened runs when their derived floor was compact.
- Keep medium/high/unknown full runs visible in `by_run`, coverage, and observed/excluded counts, but remove them from compact quality, friction, unique-defect, and safety decisions.
- Preserve immediate rollback for any lightweight safety violation and for compact-eligible full controls.
- Report existing path counts as included/observed/excluded; no parallel comparison schema or new production module.

## Why this is lean

The manifest schema and route behavior are unchanged. The implementation filters the entries passed to the existing summary and promotion functions. Model/provider identity is never consulted. No numeric quality score, propensity matching, automatic promotion, or route mutation is introduced.

## Verification

- RED before implementation:
  - risk-skewed high-risk full safety produced `rollback_lightweight`;
  - unknown-risk full controls incorrectly produced `promote_lightweight_candidate`;
  - eligibility and cohort counts were absent.
- GREEN after implementation:
  - calibration, reference, risk-assurance, guidance, and dispatch-risk suites: 23/23 passed;
  - full reliability-report suite: 36/36 passed;
  - total relevant verification: 59/59 passed;
  - `node --check` on both changed scripts passed;
  - `git diff --check` passed;
  - independent review: PASS, no Critical/Important/Minor findings.

A local all-relay-dispatch serial attempt was stopped after the existing `recover-commit` fixture path stalled beyond the tool window; all spawned test/fixture processes were cleaned to zero. GitHub CI is the broad full-suite gate.

Closes #1035


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 캘리브레이션 보고서에 비교 가능 여부와 경로별 관측·포함·제외 샘플 수를 표시합니다.
  * 태스크 클래스별로 비교 가능한 실행만 사용해 프로모션 및 캘리브레이션을 판단합니다.
  * 비교 샘플이 부족하면 경로별 사유와 함께 `continue_calibration`을 반환합니다.

* **문서**
  * 위험 보정 기준, 안전 경계, 샘플 집계 및 운영자 보고 형식을 명확히 설명했습니다.

* **테스트**
  * 위험 수준 누락, 비교 제외, 샘플 부족, 보고서 출력 시나리오를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->