### PR TITLE
chore(backlog): close assurance integrity sprint

### DIFF
--- a/backlog/completed/RELAY-1037 - backlog-migrate-live-rubric-context-to-outcome-verification-earned-rubric-semantics.md
+++ b/backlog/completed/RELAY-1037 - backlog-migrate-live-rubric-context-to-outcome-verification-earned-rubric-semantics.md
@@ -1,7 +1,7 @@
 ---
 id: RELAY-1037
 title: 'backlog: migrate live rubric context to Outcome/Verification/Earned Rubric semantics'
-status: To Do
+status: Done
 labels:
   - documentation
   - enhancement
@@ -23,13 +23,13 @@ Migrate only live operator/backlog context to the current three-channel model. P
 ## Acceptance criteria
 
 <!-- AC:BEGIN -->
-- [ ] `backlog/sprints/_context.md` states that Outcome Contract and Verification are the mandatory execution contract.
-- [ ] The context states that Earned Rubric is optional, observation-derived, and scored only by the independent reviewer.
-- [ ] The context no longer describes executor self-scoring, mandatory rubric factor counts, Quality Card output, or test/build success as quality value.
-- [ ] Local task mirrors for closed GitHub issues #138–#146 are moved from `backlog/tasks/` to `backlog/completed/` with their historical content preserved.
-- [ ] Any live cross-reference to removed `quality-card.js` or mandatory `anchor.rubric_path` semantics is corrected; archived design/history files are not rewritten merely to match current policy.
-- [ ] Exactly one active sprint remains and its plan/progress are not silently broadened.
-- [ ] Backlog status/objective/component checks and skill reachability/lint checks remain green.
+- [x] `backlog/sprints/_context.md` states that Outcome Contract and Verification are the mandatory execution contract.
+- [x] The context states that Earned Rubric is optional, observation-derived, and scored only by the independent reviewer.
+- [x] The context no longer describes executor self-scoring, mandatory rubric factor counts, Quality Card output, or test/build success as quality value.
+- [x] Local task mirrors for closed GitHub issues #138–#146 are moved from `backlog/tasks/` to `backlog/completed/` with their historical content preserved.
+- [x] Any live cross-reference to removed `quality-card.js` or mandatory `anchor.rubric_path` semantics is corrected; archived design/history files are not rewritten merely to match current policy.
+- [x] Exactly one active sprint remains and its plan/progress are not silently broadened.
+- [x] Backlog status/objective/component checks and skill reachability/lint checks remain green.
 <!-- AC:END -->
 
 ## Verification

--- a/backlog/completed/RELAY-1040 - relay-merge-hardened-gate-misclassifies-advisory-metadata-and-rejects-adversarial-profiles.md
+++ b/backlog/completed/RELAY-1040 - relay-merge-hardened-gate-misclassifies-advisory-metadata-and-rejects-adversarial-profiles.md
@@ -1,7 +1,7 @@
 ---
 id: RELAY-1040
 title: 'relay-merge: hardened gate misclassifies advisory metadata and rejects adversarial profiles'
-status: To Do
+status: Done
 labels:
   - bug
   - workflow
@@ -39,13 +39,13 @@ infer trusted artifacts from a broad filename glob.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] For the latest reviewed round and HEAD, hardened merge validation selects advisory artifacts from matching durable `advisory_review` success events rather than `review-round-*-advisory-*.json` filename discovery.
-- [ ] `request`, `result`, `decision`, and other orchestration metadata JSON files are ignored unless they are explicitly bound as the successful advisory artifact.
-- [ ] The artifact payload profile must equal the event profile; valid `blindspot` and `adversarial` profiles are accepted without a hard-coded profile override.
-- [ ] The artifact must be a non-symlink regular file contained in the run directory and must match the event's path, round, reviewed HEAD, SHA-256 hash, success status, and zero required findings.
-- [ ] Multiple expected gating lanes remain fail-closed: one successful lane cannot mask a missing, failed, stale, or unbound required lane.
-- [ ] Regression coverage reproduces the #981 artifact set with `*-request.json`, `*-result.json`, `*-decision.json`, and a valid adversarial artifact, and proves the corrected gate passes it.
-- [ ] Existing forged, tampered, stale-HEAD, symlink, required-finding, and missing-provenance cases remain blocked.
+- [x] For the latest reviewed round and HEAD, hardened merge validation selects advisory artifacts from matching durable `advisory_review` success events rather than `review-round-*-advisory-*.json` filename discovery.
+- [x] `request`, `result`, `decision`, and other orchestration metadata JSON files are ignored unless they are explicitly bound as the successful advisory artifact.
+- [x] The artifact payload profile must equal the event profile; valid `blindspot` and `adversarial` profiles are accepted without a hard-coded profile override.
+- [x] The artifact must be a non-symlink regular file contained in the run directory and must match the event's path, round, reviewed HEAD, SHA-256 hash, success status, and zero required findings.
+- [x] Multiple expected gating lanes remain fail-closed: one successful lane cannot mask a missing, failed, stale, or unbound required lane.
+- [x] Regression coverage reproduces the #981 artifact set with `*-request.json`, `*-result.json`, `*-decision.json`, and a valid adversarial artifact, and proves the corrected gate passes it.
+- [x] Existing forged, tampered, stale-HEAD, symlink, required-finding, and missing-provenance cases remain blocked.
 <!-- AC:END -->
 
 ## Verification

--- a/backlog/sprints/2026-07-assurance-calibration-integrity.md
+++ b/backlog/sprints/2026-07-assurance-calibration-integrity.md
@@ -1,6 +1,6 @@
 ---
 milestone: 2026-07 Assurance and Calibration Integrity
-status: active
+status: completed
 started: 2026-07-20
 due: 2026-07-31
 objectives: []
@@ -21,7 +21,7 @@ Make decision-changing advisory evidence and risk-path calibration trustworthy e
 
 ### Batch 1 — restore the hardened merge path
 
-- [ ] #1040 make successful advisory events the hardened gate's provenance root — S/M, ~1 relay run; must accept event-matched `blindspot` and `adversarial` artifacts while preserving all forged/tampered/stale fail-closed cases
+- [x] #1040 make successful advisory events the hardened gate's provenance root — merged in PR #1045 and closed on 2026-07-21 → PR #1045 (merged)
 
 ### Batch 2 — make risk-path calibration comparable
 
@@ -29,7 +29,7 @@ Make decision-changing advisory evidence and risk-path calibration trustworthy e
 
 ### Batch 3 — clean live execution context
 
-- [ ] #1037 migrate live backlog context to Outcome/Verification/Earned Rubric semantics — S, ~1 compact relay run; run after #1035 so the live context describes the calibrated model without reviving superseded mandatory-rubric assumptions
+- [x] #1037 migrate live backlog context to Outcome/Verification/Earned Rubric semantics — merged in PR #1044 and closed on 2026-07-20 → PR #1044 (merged)
 
 ## Running Context
 
@@ -44,6 +44,9 @@ Make decision-changing advisory evidence and risk-path calibration trustworthy e
 
 ## Progress
 
+- 2026-07-21: #1040 dispatched → PR #1045 → reviewed (LGTM, round 11 after four post-publication trust-boundary deepenings) → merged. Durable advisory success events now bind the actual round-resolved lane snapshot, artifact profile/hash/path, reviewed HEAD, and all configured hardened lanes.
+- 2026-07-20: #1037 dispatched → PR #1044 → reviewed (LGTM, round 3) → merged. Live context now uses Outcome Contract + Verification as the mandatory contract and optional reviewer-only Earned Rubric semantics.
 - 2026-07-20: Activated as the single active sprint after the Route Config closeout. Next actionable item is #1040; #1039 and #1035 are already complete.
 - 2026-07-20: External progress reconciled: PR #1038 merged and #1039 closed; PR #1042 merged and #1035 closed. Remaining sprint implementation is #1040; #1037 is implemented and locally verified in its relay worktree, awaiting review/publication.
 - 2026-07-19 planning state: Planned from live GitHub and `origin/main` `edcff70`. Created #1040 with the preserved #981 reproduction contract, created milestone #15, assigned #1039/#1040/#1035/#1037, and kept #954–#957 on their existing multi-track milestone. At that time the sprint remained `planned` pending normal closure of the route-config sprint; it was activated the following day.
+- 2026-07-21: Sprint closed. 4/4 tasks completed.

--- a/backlog/sprints/_context.md
+++ b/backlog/sprints/_context.md
@@ -32,6 +32,12 @@ Sprint files and `_context.md` are human-curated. Relay reports candidates at sp
 ### Route-facing documentation requires the full repository gate
 Relay configuration vocabulary is exposed through both `skills/relay-config/` and the delegated core under `skills/relay-dispatch/`. Changes to either surface, especially SKILL.md wording, must run the serialized full repository suite because sibling suites pin the public prose and aliases.
 
+### Hardened advisory evidence is event-rooted
+For hardened review, filenames and advisory request/result/decision metadata are untrusted claims. Merge validation starts from the latest round's durable advisory success event, uses its HEAD/round-bound resolved-lane snapshot, and cross-checks every configured lane against the event-bound artifact's contained regular-file path, profile, hash, reviewed HEAD, status, and required findings. Both `blindspot` and `adversarial` profiles are valid when the bindings agree.
+
+### Calibration cohorts must preserve real task risk
+Risk-path observation compares compact runs only with compact-eligible full-path controls. Never lower a task's risk classification or manufacture examples to fill a cohort; record an under-sampled class explicitly and continue calibration instead.
+
 ## Known Gotchas
 
 ### `rubric-lifecycle-gap`


### PR DESCRIPTION
## Summary
- mark #1037 and #1040 mirrors complete and move them to backlog/completed
- close the 4/4 Assurance and Calibration Integrity sprint with merged PR evidence
- promote hardened advisory provenance and calibration cohort rules to cross-sprint context

## Verification
- sprint-close.sh backlog --close-milestone
- backlog-doctor post-close: no hard failures
- skills-lint: 33/33 pass
- milestone #15 closed with 0 open / 4 closed issues