### PR TITLE
chore(backlog): activate multi-track interop sprint

### DIFF
--- a/backlog/completed/RELAY-1036 - dogfood-run-a-real-risk-adaptive-relay-observation-window.md
+++ b/backlog/completed/RELAY-1036 - dogfood-run-a-real-risk-adaptive-relay-observation-window.md
@@ -1,7 +1,7 @@
 ---
 id: RELAY-1036
 title: 'dogfood: run a real risk-adaptive relay observation window'
-status: To Do
+status: Done
 labels:
   - enhancement
   - backlog
@@ -30,14 +30,14 @@ For each target class, gather at least three compact runs and three compact-elig
 ## Acceptance criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1035 is complete and the report exposes comparable included/excluded cohorts.
-- [ ] Code, design, and documentation each have at least 3 real compact runs and 3 compact-eligible full controls, or the report explicitly records why a class remains under-sampled.
-- [ ] Design observations inspect rendered output, relevant flows/viewports, hierarchy, consistency, and task-specific user impact rather than relying on build/test success.
-- [ ] Routine test/build/lint success is recorded only as Verification, never as Earned Rubric value.
-- [ ] Zero-factor Earned Rubric runs remain valid when observation finds no consequential quality gradient.
-- [ ] Every earned factor is audited for task-specific evidence and a meaningful weak/adequate/strong distinction; generic filler is rejected.
-- [ ] The final report separates outcome quality, Verification, harness friction, independent-review yield, rubric decision value, and safety violations.
-- [ ] No automatic route promotion, safeguard deletion, publication, or merge occurs from the report.
+- [x] #1035 is complete and the report exposes comparable included/excluded cohorts.
+- [x] Code, design, and documentation each have at least 3 real compact runs and 3 compact-eligible full controls, or the report explicitly records why a class remains under-sampled.
+- [x] Design observations inspect rendered output, relevant flows/viewports, hierarchy, consistency, and task-specific user impact rather than relying on build/test success.
+- [x] Routine test/build/lint success is recorded only as Verification, never as Earned Rubric value.
+- [x] Zero-factor Earned Rubric runs remain valid when observation finds no consequential quality gradient.
+- [x] Every earned factor is audited for task-specific evidence and a meaningful weak/adequate/strong distinction; generic filler is rejected.
+- [x] The final report separates outcome quality, Verification, harness friction, independent-review yield, rubric decision value, and safety violations.
+- [x] No automatic route promotion, safeguard deletion, publication, or merge occurs from the report.
 <!-- AC:END -->
 
 ## Decision output

--- a/backlog/sprints/2026-07-multi-track-sprint-interop.md
+++ b/backlog/sprints/2026-07-multi-track-sprint-interop.md
@@ -1,0 +1,44 @@
+---
+milestone: 2026-07 multi-track sprint interop
+status: active
+started: 2026-07-20
+due: TBD
+objectives: []
+component: "merge-finalize"
+---
+
+# multi-track-sprint-interop
+
+## Goal
+
+Relay resolves and carries an owning sprint track explicitly across standalone finalize, operator prose, and fleet dispatch, so concurrent component-partitioned sprints no longer lose Learnings or update the wrong sprint.
+
+## Plan
+
+### Batch 0 — eliminate the finalize singleton
+
+- [ ] #955 append-learnings: resolve and carry the owning sprint without canonical-checkout branch dependence
+
+### Batch 1 — align operator contracts
+
+- [ ] #956 relay-merge/relay prose: resolve the owning sprint for every read/write
+
+### Batch 2 — carry track ownership through fleets
+
+- [ ] #957 relay-fleet: tag leaves before dispatch and reject or route mixed-track fleets
+
+### Batch 3 — integration proof and epic closeout
+
+- [ ] #954 verify standalone and fleet multi-track behavior, reconcile mirrors, and close the epic
+
+## Running Context
+
+- Dependency `sungjunlee/dev-backlog#291` is closed and its source checkout exposes `sprint-state.js --track/--component --json`. The globally installed dev-backlog skill may lag that source; implementation and tests must consume the JSON contract through an explicit, testable resolver seam rather than assume one installation path.
+- Resolution precedence for #955 is explicit sprint/track/component handle → merged issue `component:` resolved through dev-backlog → single-active fallback only when exactly one sprint is active.
+- PR #981 and the #1036 finalize of PR #1048 reproduced the same durability class: learnings/finalize can depend on the canonical checkout's current branch or lose a push race against the just-merged remote commit. #955 must remove current-branch dependence and durably integrate against the fetched remote default branch.
+- Execute in strict dependency order `#955 → #956 → #957 → #954`. Use the cursor executor + cline adversarial advisory route for #955 as the first real hardened-gate proof after #1040, subject to normal environment probe and review gates.
+- Keep N==1 behavior unchanged, add no second relay-side sprint markdown parser, and preserve explicit failure when N>1 has no resolvable owner.
+
+## Progress
+
+- 2026-07-21: Activated after #1036 merged in PR #1048. Live GitHub recheck confirmed #954–#957 remain open under milestone #13 and dev-backlog#291 is closed.

--- a/backlog/tasks/RELAY-954 - epic-multi-track-sprint-interop.md
+++ b/backlog/tasks/RELAY-954 - epic-multi-track-sprint-interop.md
@@ -1,0 +1,38 @@
+---
+id: RELAY-954
+title: 'Epic: Multi-track sprint interop — make relay track-aware'
+status: To Do
+labels:
+  - enhancement
+  - backlog
+  - workflow
+  - epic
+priority: high
+milestone: 2026-07 multi-track sprint interop
+component: merge-finalize
+created_date: '2026-07-20'
+---
+## Description
+
+Close the multi-track interoperability epic with integrated evidence that standalone and fleet relay paths select the correct component-partitioned sprint.
+
+## Acceptance criteria
+
+<!-- AC:BEGIN -->
+- [ ] #955, #956, and #957 are merged and closed with relay manifests and task mirrors reconciled.
+- [ ] Integration evidence covers N==1 compatibility and N>1 standalone resolution without lost Learnings.
+- [ ] Integration evidence covers pre-dispatch fleet ownership and the chosen mixed-track policy.
+- [ ] No relay-side duplicate parser exists; dev-backlog JSON remains the ownership source of truth.
+- [ ] Sprint state, milestone state, GitHub issue checklist, and repository backlog agree.
+- [ ] The sprint is closed through the normal dev-backlog closeout workflow and milestone #13 is complete.
+<!-- AC:END -->
+
+## Dependencies
+
+- #955
+- #956
+- #957
+
+## Related
+
+- `sungjunlee/dev-backlog#289`

--- a/backlog/tasks/RELAY-955 - append-learnings-kill-the-hard-singleton.md
+++ b/backlog/tasks/RELAY-955 - append-learnings-kill-the-hard-singleton.md
@@ -1,0 +1,37 @@
+---
+id: RELAY-955
+title: 'append-learnings: kill the hard singleton (--sprint/--track + thread from finalize-run)'
+status: To Do
+labels:
+  - enhancement
+  - backlog
+  - workflow
+priority: high
+milestone: 2026-07 multi-track sprint interop
+component: merge-finalize
+created_date: '2026-07-20'
+---
+## Description
+
+Replace relay-merge's global active-sprint assumption with an explicit owning-track contract that works for standalone and fleet runs.
+
+## Acceptance criteria
+
+<!-- AC:BEGIN -->
+- [ ] `append-learnings` accepts explicit sprint, track, and component handles and resolves them in that precedence before any fallback.
+- [ ] A standalone merge derives the issue component and consumes dev-backlog `sprint-state.js --component --json` to resolve the owning sprint.
+- [ ] `finalize-run` threads the resolved owner into `appendLearnings`; the seam also accepts the pre-dispatch fleet owner added by #957.
+- [ ] Exactly one active sprint remains a compatible no-flag fallback; multiple active sprints fail only when no explicit or derived owner resolves.
+- [ ] Relay adds no independent sprint markdown resolver for track/component ownership.
+- [ ] Learnings durability does not depend on the canonical checkout's current branch and integrates safely with the remote default branch after the PR merge, covering `unexpected_branch` and non-fast-forward push races.
+- [ ] Tests cover disjoint concurrent tracks, each resolution source and precedence, standalone issue derivation, the fleet handle seam, single-active compatibility, unresolved multi-active failure, and branch/race-independent durability.
+<!-- AC:END -->
+
+## Dependencies
+
+- `sungjunlee/dev-backlog#291` (closed)
+
+## Related
+
+- Parent #954
+- Enables #957

--- a/backlog/tasks/RELAY-956 - relay-merge-relay-prose-per-track-sprint-resolution.md
+++ b/backlog/tasks/RELAY-956 - relay-merge-relay-prose-per-track-sprint-resolution.md
@@ -1,0 +1,35 @@
+---
+id: RELAY-956
+title: 'relay-merge/relay prose: per-track sprint resolution for reads/writes'
+status: To Do
+labels:
+  - enhancement
+  - backlog
+  - workflow
+priority: high
+milestone: 2026-07 multi-track sprint interop
+component: merge-finalize
+created_date: '2026-07-20'
+---
+## Description
+
+Make the relay and relay-merge operator contracts select the sprint that owns the task instead of referring ambiguously to “the active sprint.”
+
+## Acceptance criteria
+
+<!-- AC:BEGIN -->
+- [ ] Relay reads Running Context and batch information from the owning track resolved through dev-backlog JSON.
+- [ ] Relay marks in-flight work in the owning track rather than an arbitrary active sprint.
+- [ ] Relay-merge writes Plan completion, Progress, and Running Context to the owning track.
+- [ ] Component/track resolution uses dev-backlog `sprint-state.js`; exactly one active sprint remains the N==1 fallback.
+- [ ] No relay-side track/component markdown parser is introduced.
+- [ ] SKILL.md files remain within the repository line limit and relevant lint/tests pass.
+<!-- AC:END -->
+
+## Dependencies
+
+- #955
+
+## Related
+
+- Parent #954

--- a/backlog/tasks/RELAY-957 - relay-fleet-tag-leaves-with-owning-track.md
+++ b/backlog/tasks/RELAY-957 - relay-fleet-tag-leaves-with-owning-track.md
@@ -1,0 +1,35 @@
+---
+id: RELAY-957
+title: 'relay-fleet: tag leaves with owning track; reject/route mixed-track fleets'
+status: To Do
+labels:
+  - enhancement
+  - backlog
+  - workflow
+priority: high
+milestone: 2026-07 multi-track sprint interop
+component: merge-finalize
+created_date: '2026-07-20'
+---
+## Description
+
+Determine and carry each fleet leaf's owning track before dispatch so downstream finalize can append Learnings to the correct sprint.
+
+## Acceptance criteria
+
+<!-- AC:BEGIN -->
+- [ ] Each fleet leaf receives a deterministic owning-track tag at planning/dispatch time.
+- [ ] A single-track fleet preserves existing behavior while carrying the owner through the #955 finalize seam.
+- [ ] A mixed-track fleet is rejected before dispatch with a clear diagnostic or routes every leaf with its own correct owner.
+- [ ] Missing or ambiguous ownership fails before executor work begins.
+- [ ] `relay-fleet/references/design.md` replaces the unresolved opportunistic wiring note with the implemented rule.
+- [ ] Tests prove pre-dispatch tagging, single-track compatibility, mixed-track behavior, and downstream owner propagation.
+<!-- AC:END -->
+
+## Dependencies
+
+- #955
+
+## Related
+
+- Parent #954


### PR DESCRIPTION
## Summary
- reconcile #1036 as completed after PR #1048
- activate milestone #13 as the sole active sprint
- add task mirrors and dependency-ordered batches for #955 → #956 → #957 → #954
- preserve the observed canonical-branch and post-merge push-race regressions in #955's acceptance contract

## Verification
- backlog-doctor: pass (one pre-existing capability learning-count warning)
- skills lint: 33/33 pass