### PR TITLE
relay-orca: bind generic integration evidence to accepted-program identity

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -116,11 +116,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
   --program-id epic-941 --final-summary --program-file /tmp/accepted-program.json --json
 ```
 
-Exit gates come ONLY from the program's `exit_gates`; generic `integration:<check>` evidence is accepted only
-through the version-1 accepted-program identity/freshness contract (exact program/runtime/raw-ref plus immutable
-verification binding); a failing integration gate is never masked by task completion. Follow-up proposals are
-advisory (accepted by the operator as a new later wave). Gate kinds, ordering/masking, follow-up lifecycle,
-decision/budget/authorization records, the completion rule, stop conditions, and fail-closed codes 70–72: [references/gates-and-completion.md](references/gates-and-completion.md).
+Exit gates come ONLY from the program's `exit_gates`; generic `integration:<check>` evidence is accepted only through the version-1 accepted-program identity/freshness contract (exact program/runtime/raw-ref plus immutable verification binding); a failing integration gate is never masked by task completion. Follow-up proposals are advisory (accepted by the operator as a new later wave). Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization records, the completion rule, stop conditions, and fail-closed codes 70–72: [references/gates-and-completion.md](references/gates-and-completion.md).
 
 Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fail closed on ambiguity):
 

--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -116,7 +116,13 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
   --program-id epic-941 --final-summary --program-file /tmp/accepted-program.json --json
 ```
 
-Exit gates come ONLY from the program's `exit_gates`; a failing integration gate is never masked by task completion; follow-up proposals are advisory (accepted by the operator as a new later wave). Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization records, the completion rule, stop conditions, and fail-closed codes 70–72: [references/gates-and-completion.md](references/gates-and-completion.md).
+Exit gates come ONLY from the program's `exit_gates`; generic `integration:<check>` evidence is
+accepted only through the version-1 accepted-program identity/freshness contract (exact
+program/runtime/raw-ref plus immutable verification binding); a failing integration gate is
+never masked by task completion. Follow-up proposals are advisory (accepted by the operator as
+a new later wave). Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization
+records, the completion rule, stop conditions, and fail-closed codes 70–72:
+[references/gates-and-completion.md](references/gates-and-completion.md).
 
 Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fail closed on ambiguity):
 

--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -116,13 +116,11 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
   --program-id epic-941 --final-summary --program-file /tmp/accepted-program.json --json
 ```
 
-Exit gates come ONLY from the program's `exit_gates`; generic `integration:<check>` evidence is
-accepted only through the version-1 accepted-program identity/freshness contract (exact
-program/runtime/raw-ref plus immutable verification binding); a failing integration gate is
-never masked by task completion. Follow-up proposals are advisory (accepted by the operator as
-a new later wave). Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization
-records, the completion rule, stop conditions, and fail-closed codes 70–72:
-[references/gates-and-completion.md](references/gates-and-completion.md).
+Exit gates come ONLY from the program's `exit_gates`; generic `integration:<check>` evidence is accepted only
+through the version-1 accepted-program identity/freshness contract (exact program/runtime/raw-ref plus immutable
+verification binding); a failing integration gate is never masked by task completion. Follow-up proposals are
+advisory (accepted by the operator as a new later wave). Gate kinds, ordering/masking, follow-up lifecycle,
+decision/budget/authorization records, the completion rule, stop conditions, and fail-closed codes 70–72: [references/gates-and-completion.md](references/gates-and-completion.md).
 
 Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fail closed on ambiguity):
 

--- a/skills/relay-orca/references/accepted-program-schema.md
+++ b/skills/relay-orca/references/accepted-program-schema.md
@@ -21,6 +21,20 @@ at operator dispatch time — not part of this schema (D11).
     "tracker": "github",                  // tracker identity
     "concurrency": 2,                     // optional; default 2, hard maximum 4
     "exit_gates": ["...", "..."],         // REQUIRED — >= 1 non-empty program exit gate
+    "integration_evidence_version": 1,    // REQUIRED when exit_gates contains integration:<check>
+    "integration_evidence": [             // REQUIRED, exactly one declaration per raw check ref
+      {
+        "program_id": "epic-941",         // exact accepted program id
+        "runtime_id": "runtime-...",      // non-empty, must match the receipt runtime_id
+        "check_ref": "full-suite",        // exact unsanitized text after integration:
+        "verification": {
+          "input_sha256": "sha256:...",   // immutable verification input binding
+          "result_sha256": "sha256:...",  // immutable verification result binding
+          "passed": true,                 // bound by binding_sha256; not free-standing authority
+          "binding_sha256": "sha256:..."  // SHA-256 of the three fields above
+        }
+      }
+    ],
     "decision_gates": [                    // optional program-level gates / auth boundaries
       { "id": "signoff", "description": "operator approves completion", "authorization": "operator" }
     ],
@@ -50,6 +64,21 @@ The root may be the program object directly or wrapped under a `program` key.
   `orca-task-<slugified-id>`; duplicate outcome ids (or ids that collide after slugging)
   are rejected.
 - `exit_gates` — required, at least one non-empty string. Missing → rejection (D7b).
+- Generic `integration:<check>` exit gates require `integration_evidence_version: 1` and
+  `integration_evidence[]`. There must be exactly one declaration for each exact raw check ref
+  (the substring after the first `integration:`); a declaration carries the accepted
+  `program_id`, a non-empty receipt-matching `runtime_id`, that exact `check_ref`, and the
+  immutable verification binding shown above. Identity-less or versionless evidence is never
+  completion evidence.
+- `integration_evidence[].verification` is content-based, not time-based. `input_sha256` and
+  `result_sha256` are producer-defined content addresses; `binding_sha256` is SHA-256 over the
+  canonical JSON object `{ input_sha256, result_sha256, passed }` with lexicographically sorted
+  object keys. Status recomputes and compares this binding and the full declaration exactly.
+- Evidence artifacts use the same identity and verification fields plus `schema: 1` and optional
+  human-readable `evidence`. They are stored as
+  `<sanitized-readable-prefix>-<sha256(raw-check-ref)>.json`; the readable prefix is never
+  authority. Raw refs are checked before path lookup, allow `a/b`, and reject absolute paths,
+  traversal segments, backslashes, controls, empty segments, and duplicate/conflicting artifacts.
 - `concurrency` — integer in `[1, 4]`; default `2`. Above `4` → rejection (D7g). `--concurrency`
   overrides the program value.
 - `outcomes[].accepted_outcomes` — required, at least one non-empty string. Empty/absent means

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -262,8 +262,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
 | --- | --- |
 | `--gates` | Evaluate the program's exit gates (read-only). Mutually exclusive with `--final-summary`. |
 | `--final-summary` | Declare evidence-backed program completion (read-only). |
-| `--program-file <path>` | The accepted program — the ONLY source of `exit_gates` (required by both modes; its `id` must match the receipt). |
-| `--gate-evidence-dir <dir>` | Directory of live `integration:` evidence artifacts (`<check>.json` → `{ "passed": bool }`); also env `RELAY_ORCA_GATE_EVIDENCE_ROOT`. |
+| `--program-file <path>` | The accepted program — the ONLY source of `exit_gates` and generic integration trust declarations (required by both modes; its `id` must match the receipt). |
+| `--gate-evidence-dir <dir>` | Directory of live identity-bound `integration:` artifacts (`<sanitized-ref>-<sha256(raw-ref)>.json`); also env `RELAY_ORCA_GATE_EVIDENCE_ROOT`. |
 | `--record-proposals` | (`--gates` only) Append discovered follow-up proposals to the receipt's `follow_ups`. WITHOUT it, both modes are strictly read-only. |
 | `--strict` | Turn the fail-closed conditions below into non-zero exits. Without it, both modes exit `0` with the truthful report. |
 
@@ -278,8 +278,9 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
 | `GATE_FAILED` | 71 | Any exit gate failed. |
 | `COMPLETION_BLOCKED` | 72 | `--final-summary` and `program_complete` is false. |
 
-Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization records,
-the completion rule, and the stop-condition table: [gates-and-completion.md](gates-and-completion.md).
+Gate kinds, generic integration identity/freshness validation, ordering/masking, follow-up
+lifecycle, decision/budget/authorization records, the completion rule, and the stop-condition
+table: [gates-and-completion.md](gates-and-completion.md).
 
 ## `resume` — crash-safe, reconcile-first, idempotent resumption
 

--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -23,7 +23,7 @@ Each gate is keyed by a pinned, verbatim prefix on the gate string:
 
 | Prefix | Meaning | Evidence source |
 | --- | --- | --- |
-| `integration:<check>` | a named check / evidence artifact must pass **live** | a live evidence artifact under `--gate-evidence-dir` (`<check>.json` → `{ "passed": true/false }`); never task/worker status |
+| `integration:<check>` | a named check / evidence artifact must pass **live** | a version-1 identity-bound artifact under `--gate-evidence-dir`; never task/worker status |
 | `advisory:<ref>` | advisory evidence posted + blocking findings triaged (reuses the #945 advisory contract) | the reconciled `advisory_review` outcomes |
 | `tracker:<ref>` | tracker reconciliation clean for the program's issues | no reopened issue / duplicate-or-lost mapping / unreconciled back-pointer in the reconciliation |
 | `decision:<id>` | an explicit, resolved user decision record exists | the receipt's `decisions[]` (six provenance keys) |
@@ -33,6 +33,31 @@ Each gate is keyed by a pinned, verbatim prefix on the gate string:
 A gate string **without a recognized prefix evaluates as `unevaluable`** — NEVER as passed
 (fail closed) — with a diagnostic naming it. A `budget:` ref that does not parse, or names
 an unknown counter, is likewise `unevaluable`.
+
+### Generic integration evidence trust contract (#1046)
+
+`integration:<check>` is a generic named exit check. It is not an implicit
+`integration_gate` outcome and does not inherit that outcome's `task_id`, `dispatch_id`, or
+`assignee` contract. A newly accepted program that declares an integration gate must set
+`integration_evidence_version: 1` and declare exactly one entry in
+`integration_evidence[]` for the exact raw `<check>` ref. The declaration must contain the
+accepted `program_id`, a non-empty `runtime_id` equal to the receipt runtime, the exact raw
+`check_ref`, and the verification binding. The artifact repeats those fields and is accepted
+only when all identity fields and the full verification binding match the declaration.
+
+The binding contains `input_sha256`, `result_sha256`, and `passed`; `binding_sha256` is the
+SHA-256 of their canonical, lexicographically keyed JSON object. A timestamp, mtime,
+`passed:true` by itself, free-form `evidence`, sanitized basename, or lifecycle outcome name
+is never authority. The artifact filename includes the full SHA-256 of the raw ref, so `a/b`
+and `a-b` cannot share storage. Unsafe refs, duplicate declarations, duplicate artifacts,
+malformed identities, and path aliases fail closed through the existing gate state/message
+fields.
+
+The real closure topology remains explicit: `integration:full-suite` binds the generic check
+artifact while the separate `integration-main-suite` outcome retains its own lifecycle
+provenance. Status does not infer one identity from the other. Older identity-less programs
+and artifacts are read only as fail-closed legacy input; they cannot yield
+`program_complete:true`.
 
 Gate states (verbatim enum): `passed`, `failed`, `not_yet_evaluable`, `awaiting_decision`,
 `unevaluable`.

--- a/skills/relay-orca/scripts/lib/compile-program.js
+++ b/skills/relay-orca/scripts/lib/compile-program.js
@@ -3,6 +3,8 @@
 const { reject } = require("./reasons");
 const { assertSupportedKind, assertPreparedFleet, routeFor, defaultEvidenceFor } = require("./task-kinds");
 const { normalizeDependsOn, edgesFor, assertAcyclic, computeLevels, declaredLevels, groupIntoWaves } = require("./waves");
+const { indexDeclarations } = require("./integration-evidence");
+const { parseGate } = require("./gate-kinds");
 
 const DEFAULT_CONCURRENCY = 2;
 const MAX_CONCURRENCY = 4;
@@ -47,6 +49,25 @@ function assertExitGates(program) {
   const gates = program.exit_gates;
   if (!Array.isArray(gates) || gates.filter((gate) => typeof gate === "string" && gate.trim()).length === 0) {
     reject("MISSING_EXIT_GATES", "program.exit_gates must list at least one non-empty exit gate");
+  }
+}
+
+function assertIntegrationEvidence(program) {
+  const refs = program.exit_gates
+    .filter((gate) => typeof gate === "string" && parseGate(gate).kind === "integration")
+    .map((gate) => parseGate(gate).ref);
+  if (refs.length === 0) return;
+  const contract = indexDeclarations({
+    programId: program.id,
+    runtimeId: null,
+    requireRuntime: false,
+    refs,
+    version: program.integration_evidence_version,
+    declarations: program.integration_evidence,
+  });
+  const firstError = [...contract.errors.entries()][0];
+  if (firstError) {
+    reject("INVALID_INPUT", `integration evidence declaration for raw check ref "${firstError[0]}" is invalid: ${firstError[1]}`);
   }
 }
 
@@ -131,6 +152,7 @@ function compileProgram(input, options = {}) {
   const program = unwrapProgram(input);
   const concurrency = resolveConcurrency(program, options.concurrency);
   assertExitGates(program);
+  assertIntegrationEvidence(program);
   assertOutcomes(program);
 
   const seenIds = new Set();

--- a/skills/relay-orca/scripts/lib/gate-evaluate.js
+++ b/skills/relay-orca/scripts/lib/gate-evaluate.js
@@ -18,6 +18,7 @@ const { boundedExcerpt } = require("./bounded-excerpt");
 const { parseGate } = require("./gate-kinds");
 const { effectiveCounters, parseBudgetRef, COUNTER_NAMES } = require("./budget-counters");
 const { validateDecisionRecord, isResolved, findById } = require("./decision-records");
+const { indexDeclarations, validateArtifact } = require("./integration-evidence");
 
 function result(state, evidence, message) {
   return { state, evidence: boundedExcerpt(evidence), message: boundedExcerpt(message) };
@@ -26,15 +27,42 @@ function result(state, evidence, message) {
 // integration: a named live check / evidence artifact must PASS live. The artifact is read
 // through the injected reader (top-level fs), NEVER from task status. Absent artifact →
 // failed (no live pass evidence), never passed.
-function evalIntegration(ref, readIntegrationEvidence) {
+function evalIntegration(ref, readIntegrationEvidence, integrationContract, programId, runtimeId) {
+  const declarationError = integrationContract && integrationContract.errors
+    ? integrationContract.errors.get(ref)
+    : "accepted program has no integration identity contract";
+  if (declarationError) {
+    return result(
+      "failed",
+      `identity:${declarationError}`,
+      `integration check "${ref}" rejected: identity contract ${declarationError}`,
+    );
+  }
+  const declaration = integrationContract && integrationContract.byRef ? integrationContract.byRef.get(ref) : null;
   const evidence = typeof readIntegrationEvidence === "function" ? readIntegrationEvidence(ref) : null;
   if (!evidence || evidence.present !== true) {
     return result("failed", `no live evidence artifact for ${ref}`, `integration check "${ref}" has no live evidence artifact; gate cannot pass`);
   }
-  if (evidence.passed === true) {
-    return result("passed", evidence.evidence || `check ${ref} passed`, `integration check "${ref}" passed live`);
+  if (evidence.valid !== true) {
+    const reason = evidence.reason || "artifact identity or verification binding is invalid";
+    return result(
+      "failed",
+      `identity:${reason}`,
+      `integration check "${ref}" rejected: identity contract ${reason}`,
+    );
   }
-  return result("failed", evidence.evidence || `check ${ref} failed`, `integration check "${ref}" failed live`);
+  const checked = validateArtifact(evidence.artifact, { declaration, programId, runtimeId, checkRef: ref });
+  if (!checked.valid) {
+    return result(
+      "failed",
+      `identity:${checked.reason}`,
+      `integration check "${ref}" rejected: identity contract ${checked.reason}`,
+    );
+  }
+  if (checked.passed === true) {
+    return result("passed", checked.evidence, `integration check "${ref}" passed live`);
+  }
+  return result("failed", checked.evidence, `integration check "${ref}" failed live`);
 }
 
 // advisory: reuse the #945 advisory contract — advisory evidence posted AND every blocking
@@ -112,7 +140,7 @@ function evaluateOneGate(gateString, ctx) {
   let evaluated;
   switch (kind) {
     case "integration":
-      evaluated = evalIntegration(ref, ctx.readIntegrationEvidence);
+      evaluated = evalIntegration(ref, ctx.readIntegrationEvidence, ctx.integrationContract, ctx.programId, ctx.runtimeId);
       break;
     case "advisory":
       evaluated = evalAdvisory(ref, ctx.facts.advisory);
@@ -149,7 +177,7 @@ const BLOCKING_REASON_BY_STATE = Object.freeze({
 // after every accepted outcome reconciles complete_with_evidence; before that they are
 // `not_yet_evaluable` with the blocking outcomes listed. Returns { prerequisites_met,
 // gates, blocking_reasons, blocking_outcomes }.
-function evaluateGates({ report, receipt, exitGates, readIntegrationEvidence }) {
+function evaluateGates({ report, receipt, exitGates, readIntegrationEvidence, integrationEvidenceVersion, integrationEvidence }) {
   const gateStrings = Array.isArray(exitGates) ? exitGates : [];
   const outcomes = report.outcomes || [];
   const blockingOutcomes = outcomes.filter((outcome) => outcome.state !== "complete_with_evidence");
@@ -173,7 +201,25 @@ function evaluateGates({ report, receipt, exitGates, readIntegrationEvidence }) 
     return { prerequisites_met: false, gates, blocking_reasons: blocking, blocking_outcomes: blockingOutcomes.map((outcome) => outcome.outcome_id) };
   }
 
-  const ctx = { receipt, readIntegrationEvidence, facts: reconciliationFacts(report) };
+  const integrationRefs = gateStrings
+    .map((gateString) => parseGate(gateString))
+    .filter((parsed) => parsed.kind === "integration")
+    .map((parsed) => parsed.ref);
+  const integrationContract = indexDeclarations({
+    programId: report.program_id,
+    runtimeId: receipt && receipt.runtime_id,
+    refs: integrationRefs,
+    version: integrationEvidenceVersion,
+    declarations: integrationEvidence,
+  });
+  const ctx = {
+    receipt,
+    readIntegrationEvidence,
+    integrationContract,
+    programId: report.program_id,
+    runtimeId: receipt && receipt.runtime_id,
+    facts: reconciliationFacts(report),
+  };
   const gates = gateStrings.map((gateString) => evaluateOneGate(gateString, ctx));
   const blocking = gates
     .filter((gate) => gate.state !== "passed")

--- a/skills/relay-orca/scripts/lib/integration-evidence.js
+++ b/skills/relay-orca/scripts/lib/integration-evidence.js
@@ -1,0 +1,185 @@
+"use strict";
+
+// Pure trust-contract helpers for generic integration:<check> evidence (#1046).
+// Filesystem reads stay in status.js; these helpers only validate injected values and
+// derive collision-resistant names. The accepted program is the authority for the
+// exact raw reference and the immutable verification binding.
+const crypto = require("node:crypto");
+
+const INTEGRATION_EVIDENCE_VERSION = 1;
+const VERIFICATION_KEYS = Object.freeze(["binding_sha256", "input_sha256", "passed", "result_sha256"]);
+const ARTIFACT_KEYS = Object.freeze(["check_ref", "evidence", "program_id", "runtime_id", "schema", "verification"]);
+const SHA256 = /^sha256:[0-9a-f]{64}$/;
+const MAX_RAW_REF_LENGTH = 256;
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function sha256(value) {
+  return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
+}
+
+function verificationBinding({ input_sha256, result_sha256, passed }) {
+  const binding = { input_sha256, result_sha256, passed };
+  return { ...binding, binding_sha256: sha256(canonicalJson(binding)) };
+}
+
+function rawRefError(ref) {
+  if (typeof ref !== "string" || ref.length === 0) return "raw check ref must be a non-empty string";
+  if (ref.length > MAX_RAW_REF_LENGTH) return `raw check ref exceeds ${MAX_RAW_REF_LENGTH} characters`;
+  if (/[\u0000-\u001f\u007f]/.test(ref)) return "raw check ref contains a control character";
+  if (ref.includes("\\")) return "raw check ref contains a backslash";
+  if (ref.startsWith("/") || /^[A-Za-z]:[\\/]/.test(ref)) return "raw check ref must not be an absolute path";
+  const segments = ref.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    return "raw check ref contains an unsafe path segment";
+  }
+  return null;
+}
+
+function isSafeRawRef(ref) {
+  return rawRefError(ref) === null;
+}
+
+function sanitizeArtifactName(ref) {
+  return String(ref == null ? "" : ref).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "gate";
+}
+
+// The readable prefix is not authority. The full raw-ref hash is always part of the
+// filename, so refs such as a/b and a-b cannot address the same artifact.
+function artifactFileName(ref) {
+  return `${sanitizeArtifactName(ref)}-${crypto.createHash("sha256").update(ref).digest("hex")}.json`;
+}
+
+function sameJson(left, right) {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function validateVerification(verification) {
+  if (!verification || typeof verification !== "object" || Array.isArray(verification)) {
+    return { valid: false, reason: "verification binding is missing or not an object" };
+  }
+  const keys = Object.keys(verification).sort();
+  if (keys.length !== VERIFICATION_KEYS.length || keys.some((key, index) => key !== [...VERIFICATION_KEYS].sort()[index])) {
+    return { valid: false, reason: `verification binding must contain exactly ${VERIFICATION_KEYS.join(", ")}` };
+  }
+  if (!SHA256.test(verification.input_sha256) || !SHA256.test(verification.result_sha256) || !SHA256.test(verification.binding_sha256)) {
+    return { valid: false, reason: "verification input/result/binding must use sha256 digests" };
+  }
+  if (typeof verification.passed !== "boolean") return { valid: false, reason: "verification.passed must be boolean" };
+  const expected = verificationBinding(verification);
+  if (expected.binding_sha256 !== verification.binding_sha256) {
+    return { valid: false, reason: "verification binding digest does not match its input/result" };
+  }
+  return { valid: true };
+}
+
+function validateDeclaration(declaration, { programId, runtimeId, checkRef, requireRuntime = true }) {
+  if (!declaration || typeof declaration !== "object" || Array.isArray(declaration)) {
+    return { valid: false, reason: "integration evidence declaration is missing or not an object" };
+  }
+  const refError = rawRefError(declaration.check_ref);
+  if (refError) return { valid: false, reason: refError };
+  if (declaration.program_id !== programId) return { valid: false, reason: "program_id does not match the accepted program" };
+  if (typeof declaration.runtime_id !== "string" || declaration.runtime_id.length === 0) {
+    return { valid: false, reason: "runtime_id does not match the accepted runtime" };
+  }
+  if (requireRuntime && (typeof runtimeId !== "string" || runtimeId.length === 0 || declaration.runtime_id !== runtimeId)) {
+    return { valid: false, reason: "runtime_id does not match the accepted runtime" };
+  }
+  if (declaration.check_ref !== checkRef) return { valid: false, reason: "check_ref does not match the exact raw gate reference" };
+  const verification = validateVerification(declaration.verification);
+  if (!verification.valid) return verification;
+  return { valid: true };
+}
+
+// Index the accepted program's generic integration declarations. Every required raw ref
+// gets one deterministic entry or one deterministic error; duplicates and unbound extras
+// are never silently ignored.
+function indexDeclarations({ programId, runtimeId, refs, version, declarations, requireRuntime = true }) {
+  const requiredRefs = [...new Set(Array.isArray(refs) ? refs : [])];
+  const byRef = new Map();
+  const errors = new Map();
+  if (requiredRefs.length === 0) return { byRef, errors };
+  const setAll = (message) => requiredRefs.forEach((ref) => errors.set(ref, message));
+  if (version !== INTEGRATION_EVIDENCE_VERSION) {
+    setAll(`integration evidence contract version ${INTEGRATION_EVIDENCE_VERSION} is required`);
+    return { byRef, errors };
+  }
+  if (!Array.isArray(declarations)) {
+    setAll("accepted program has no integration_evidence declarations");
+    return { byRef, errors };
+  }
+
+  const grouped = new Map();
+  let invalidDeclaration = null;
+  declarations.forEach((declaration) => {
+    const ref = declaration && typeof declaration === "object" ? declaration.check_ref : null;
+    if (typeof ref !== "string") {
+      invalidDeclaration = invalidDeclaration || "integration evidence declaration has no check_ref";
+      return;
+    }
+    const entries = grouped.get(ref) || [];
+    entries.push(declaration);
+    grouped.set(ref, entries);
+  });
+  if (invalidDeclaration) setAll(invalidDeclaration);
+
+  requiredRefs.forEach((ref) => {
+    const entries = grouped.get(ref) || [];
+    if (entries.length === 0) {
+      errors.set(ref, "accepted program has no identity declaration for this raw check ref");
+    } else if (entries.length > 1) {
+      errors.set(ref, "accepted program has duplicate/conflicting identity declarations for this raw check ref");
+    } else {
+      const check = validateDeclaration(entries[0], { programId, runtimeId, checkRef: ref, requireRuntime });
+      if (!check.valid) errors.set(ref, check.reason);
+      else byRef.set(ref, entries[0]);
+    }
+  });
+  for (const [ref] of grouped) {
+    if (!requiredRefs.includes(ref)) setAll(`accepted program declares unbound integration check ref "${ref}"`);
+  }
+  return { byRef, errors };
+}
+
+function validateArtifact(artifact, { declaration, programId, runtimeId, checkRef }) {
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) {
+    return { valid: false, reason: "integration evidence artifact is not an object" };
+  }
+  if (artifact.schema !== INTEGRATION_EVIDENCE_VERSION) return { valid: false, reason: "integration evidence artifact schema is unsupported" };
+  if (Object.keys(artifact).some((key) => !ARTIFACT_KEYS.includes(key))) {
+    return { valid: false, reason: "integration evidence artifact contains an unsupported authority field" };
+  }
+  const identity = validateDeclaration(artifact, { programId, runtimeId, checkRef });
+  if (!identity.valid) return { valid: false, reason: identity.reason };
+  if (!declaration || !sameJson(artifact.verification, declaration.verification)) {
+    return { valid: false, reason: "verification input/result binding does not match the accepted declaration" };
+  }
+  return {
+    valid: true,
+    passed: artifact.verification.passed === true,
+    evidence: typeof artifact.evidence === "string" && artifact.evidence ? artifact.evidence : `check ${checkRef}`,
+  };
+}
+
+module.exports = {
+  ARTIFACT_KEYS,
+  INTEGRATION_EVIDENCE_VERSION,
+  MAX_RAW_REF_LENGTH,
+  VERIFICATION_KEYS,
+  artifactFileName,
+  canonicalJson,
+  indexDeclarations,
+  isSafeRawRef,
+  rawRefError,
+  sanitizeArtifactName,
+  sha256,
+  validateArtifact,
+  validateDeclaration,
+  validateVerification,
+  verificationBinding,
+};

--- a/skills/relay-orca/scripts/status.js
+++ b/skills/relay-orca/scripts/status.js
@@ -34,6 +34,7 @@ const { orderGatesReport, orderFinalSummary } = require("./lib/gate-report");
 const { deriveProposals, mergeFollowUps, upsertRecordedFollowUps } = require("./lib/follow-ups");
 const { buildFinalSummary } = require("./lib/final-summary");
 const { REASONS: GATE_REASONS } = require("./lib/gate-reasons");
+const { artifactFileName, rawRefError } = require("./lib/integration-evidence");
 
 const fs = require("node:fs");
 const path = require("node:path");
@@ -308,30 +309,63 @@ function readProgramExitGates(programFile, receiptProgramId) {
   if (!Array.isArray(program.exit_gates) || program.exit_gates.length === 0) {
     usageError(`program file ${programFile} has no exit_gates array`);
   }
-  return { exitGates: program.exit_gates, decisionGates: Array.isArray(program.decision_gates) ? program.decision_gates : [] };
-}
-
-function sanitizeArtifactName(ref) {
-  return String(ref == null ? "" : ref).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "gate";
+  return {
+    exitGates: program.exit_gates,
+    decisionGates: Array.isArray(program.decision_gates) ? program.decision_gates : [],
+    integrationEvidenceVersion: program.integration_evidence_version,
+    integrationEvidence: program.integration_evidence,
+  };
 }
 
 // Build the injected integration-evidence reader (#947 D1/D2). An `integration:` gate's
-// live evidence is an artifact FILE under the gate-evidence directory; the gate result
-// derives from that artifact, NEVER from Orca task/worker status. A missing dir/file →
-// { present: false } so the gate fails closed (never passed). This is the ONLY new
-// filesystem read the gate modes perform, and it is strictly read-only.
+// live evidence is an identity-bound artifact FILE under the gate-evidence directory; the
+// gate result derives from that artifact, NEVER from Orca task/worker status. A missing
+// dir/file returns { present: false }; malformed, aliased, or duplicate artifacts return a
+// validation failure so the gate fails closed. This is the ONLY new filesystem read the
+// gate modes perform, and it is strictly read-only.
 function makeIntegrationEvidenceReader(dir) {
   const root = dir || (process.env.RELAY_ORCA_GATE_EVIDENCE_ROOT || "").trim() || null;
   return (ref) => {
     if (!root) return { present: false };
-    const artifact = path.join(root, `${sanitizeArtifactName(ref)}.json`);
-    if (!fs.existsSync(artifact)) return { present: false };
+    const unsafe = rawRefError(ref);
+    if (unsafe) return { present: true, valid: false, reason: unsafe };
+    const expectedName = artifactFileName(ref);
+    const expectedPath = path.join(root, expectedName);
+    if (!fs.existsSync(root)) return { present: false };
     try {
-      const json = JSON.parse(fs.readFileSync(artifact, "utf-8"));
-      return { present: true, passed: json.passed === true, evidence: typeof json.evidence === "string" ? json.evidence : `check ${ref}` };
+      const names = fs.readdirSync(root).filter((name) => name.endsWith(".json")).sort();
+      const candidates = [];
+      let expectedParseError = null;
+      for (const name of names) {
+        const file = path.join(root, name);
+        if (name !== expectedName) {
+          let parsed;
+          try {
+            parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+          } catch {
+            continue;
+          }
+          if (!parsed || typeof parsed !== "object" || parsed.check_ref !== ref) continue;
+          candidates.push({ file, artifact: parsed });
+          continue;
+        }
+        try {
+          candidates.push({ file, artifact: JSON.parse(fs.readFileSync(file, "utf-8")) });
+        } catch {
+          expectedParseError = "expected integration evidence artifact is not valid JSON";
+        }
+      }
+      if (expectedParseError) return { present: true, valid: false, reason: expectedParseError };
+      if (candidates.length === 0) return { present: false };
+      if (candidates.length > 1) {
+        return { present: true, valid: false, reason: "duplicate/conflicting integration evidence artifacts address the same raw check ref" };
+      }
+      if (candidates[0].file !== expectedPath) {
+        return { present: true, valid: false, reason: `integration evidence artifact is stored under the wrong raw-ref path; expected ${expectedName}` };
+      }
+      return { present: true, valid: true, artifact: candidates[0].artifact };
     } catch (error) {
-      // A corrupt artifact is unusable live evidence → not present → fail closed.
-      return { present: false };
+      return { present: true, valid: false, reason: `cannot inspect integration evidence directory: ${error.message}` };
     }
   };
 }
@@ -360,8 +394,15 @@ function strictExitCode(opts, gateEval, programComplete) {
 }
 
 function runGatesMode(opts, { report, receipt, receiptPath }) {
-  const { exitGates } = readProgramExitGates(opts.programFile, opts.programId);
-  const gateEval = evaluateGates({ report, receipt, exitGates, readIntegrationEvidence: makeIntegrationEvidenceReader(opts.gateEvidenceDir) });
+  const program = readProgramExitGates(opts.programFile, opts.programId);
+  const gateEval = evaluateGates({
+    report,
+    receipt,
+    exitGates: program.exitGates,
+    integrationEvidenceVersion: program.integrationEvidenceVersion,
+    integrationEvidence: program.integrationEvidence,
+    readIntegrationEvidence: makeIntegrationEvidenceReader(opts.gateEvidenceDir),
+  });
   const proposals = deriveProposals({ report, gates: gateEval.gates, receipt });
   if (opts.recordProposals && proposals.length > 0) recordProposals(receipt, receiptPath, proposals);
   const body = orderGatesReport({
@@ -378,8 +419,15 @@ function runGatesMode(opts, { report, receipt, receiptPath }) {
 }
 
 function runFinalSummaryMode(opts, { report, receipt, receiptPath }) {
-  const { exitGates } = readProgramExitGates(opts.programFile, opts.programId);
-  const gateEval = evaluateGates({ report, receipt, exitGates, readIntegrationEvidence: makeIntegrationEvidenceReader(opts.gateEvidenceDir) });
+  const program = readProgramExitGates(opts.programFile, opts.programId);
+  const gateEval = evaluateGates({
+    report,
+    receipt,
+    exitGates: program.exitGates,
+    integrationEvidenceVersion: program.integrationEvidenceVersion,
+    integrationEvidence: program.integrationEvidence,
+    readIntegrationEvidence: makeIntegrationEvidenceReader(opts.gateEvidenceDir),
+  });
   const derived = deriveProposals({ report, gates: gateEval.gates, receipt });
   const followUps = mergeFollowUps({ derived, recorded: receipt.follow_ups });
   const summary = buildFinalSummary({

--- a/tests/relay-orca/fixtures/followup-later-wave.json
+++ b/tests/relay-orca/fixtures/followup-later-wave.json
@@ -6,6 +6,20 @@
     "tracker": "github",
     "concurrency": 2,
     "exit_gates": ["integration:e2e-suite", "tracker:milestone-clean"],
+    "integration_evidence_version": 1,
+    "integration_evidence": [
+      {
+        "program_id": "epic-followup-later-wave",
+        "runtime_id": "runtime-fixture",
+        "check_ref": "e2e-suite",
+        "verification": {
+          "input_sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "result_sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "passed": true,
+          "binding_sha256": "sha256:8b6dc253475d8f602bf9d5c018b150ab3d5447352b462e572caed118e4402daa"
+        }
+      }
+    ],
     "outcomes": [
       {
         "id": "base-widget",

--- a/tests/relay-orca/fixtures/resume-three-wave.json
+++ b/tests/relay-orca/fixtures/resume-three-wave.json
@@ -6,6 +6,20 @@
     "tracker": "github",
     "concurrency": 2,
     "exit_gates": ["integration:e2e-suite", "tracker:milestone-clean"],
+    "integration_evidence_version": 1,
+    "integration_evidence": [
+      {
+        "program_id": "epic-resume-three-wave",
+        "runtime_id": "runtime-fixture",
+        "check_ref": "e2e-suite",
+        "verification": {
+          "input_sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "result_sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "passed": true,
+          "binding_sha256": "sha256:8b6dc253475d8f602bf9d5c018b150ab3d5447352b462e572caed118e4402daa"
+        }
+      }
+    ],
     "outcomes": [
       {
         "id": "foundation",

--- a/tests/relay-orca/scripts/gates.test.js
+++ b/tests/relay-orca/scripts/gates.test.js
@@ -6,6 +6,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync } = require("node:child_process");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -102,10 +103,25 @@ function sanitizeArtifact(ref) {
   return String(ref == null ? "" : ref).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "gate";
 }
 
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function verificationBinding(passed = true) {
+  const binding = { input_sha256: `sha256:${"a".repeat(64)}`, result_sha256: `sha256:${"b".repeat(64)}`, passed };
+  return { ...binding, binding_sha256: `sha256:${crypto.createHash("sha256").update(canonicalJson(binding)).digest("hex")}` };
+}
+
+function boundArtifactName(ref) {
+  return `${sanitizeArtifact(ref)}-${crypto.createHash("sha256").update(ref).digest("hex")}.json`;
+}
+
 // Build a hermetic gate world: real tiny git repo, receipt at the collision-resistant
 // segment path, run/fleet manifests, fake read-only orca + gh, an accepted program file
 // carrying the exit_gates verbatim, and a gate-evidence directory of live artifacts.
-function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, exitGates = [], decisionGates = [], gateEvidence = {} }) {
+function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {}, ghScenario = {}, exitGates = [], decisionGates = [], gateEvidence = {}, integrationEvidenceVersion, integrationEvidence = [] }) {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-gates-"));
   const repoRoot = path.join(base, "repo");
   const programsRoot = path.join(base, "programs");
@@ -132,11 +148,10 @@ function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {},
 
   // The accepted program file — the ONLY source of exit_gates (input artifacts).
   const programFile = path.join(base, "accepted-program.json");
-  fs.writeFileSync(
-    programFile,
-    `${JSON.stringify({ program: { id: programId, exit_gates: exitGates, decision_gates: decisionGates, outcomes: receiptObject.tasks.map((task) => ({ id: task.outcome_id, task_kind: task.kind, accepted_outcomes: ["x"] })) } }, null, 2)}\n`,
-    "utf-8",
-  );
+  const acceptedProgram = { id: programId, exit_gates: exitGates, decision_gates: decisionGates, outcomes: receiptObject.tasks.map((task) => ({ id: task.outcome_id, task_kind: task.kind, accepted_outcomes: ["x"] })) };
+  if (integrationEvidenceVersion !== undefined) acceptedProgram.integration_evidence_version = integrationEvidenceVersion;
+  if (integrationEvidence.length > 0) acceptedProgram.integration_evidence = integrationEvidence;
+  fs.writeFileSync(programFile, `${JSON.stringify({ program: acceptedProgram }, null, 2)}\n`, "utf-8");
 
   Object.entries(gateEvidence).forEach(([name, value]) => {
     fs.writeFileSync(path.join(evidenceDir, `${sanitizeArtifact(name)}.json`), `${JSON.stringify(value, null, 2)}\n`, "utf-8");
@@ -224,6 +239,8 @@ function greenWorld(programId, opts = {}) {
     exitGates: opts.exitGates || [],
     decisionGates: opts.decisionGates || [],
     gateEvidence: opts.gateEvidence || {},
+    integrationEvidenceVersion: opts.integrationEvidenceVersion,
+    integrationEvidence: opts.integrationEvidence || [],
   });
 }
 
@@ -258,6 +275,38 @@ test("D9.1: passing integration gate after all outcomes complete → passed; rep
     assert.deepEqual(Object.keys(gate).sort(), [...GATE_ENTRY_KEYS].sort());
     assert.equal(world.orca.readPoison(), null);
     assert.equal(world.gh.readPoison(), null);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1046 red: a well-formed-looking cross-program identity artifact cannot pass a generic integration gate", () => {
+  const programId = "epic-1046-red";
+  const expected = { program_id: programId, runtime_id: DEFAULT_RUNTIME_ID, check_ref: "e2e", verification: verificationBinding(true) };
+  const artifact = {
+    schema: 1,
+    program_id: "different-program",
+    runtime_id: DEFAULT_RUNTIME_ID,
+    check_ref: "e2e",
+    verification: verificationBinding(true),
+    passed: true,
+    evidence: "suite green",
+  };
+  const world = greenWorld(programId, {
+    exitGates: ["integration:e2e"],
+    integrationEvidenceVersion: 1,
+    integrationEvidence: [expected],
+    gateEvidence: { e2e: artifact },
+  });
+  try {
+    // Keep the legacy sanitized copy that the current reader consumes, and add the
+    // collision-resistant location the new reader must inspect. Before the fix the
+    // current implementation trusts only passed:true and incorrectly reports passed.
+    fs.writeFileSync(path.join(world.evidenceDir, boundArtifactName("e2e")), `${JSON.stringify(artifact, null, 2)}\n`, "utf-8");
+    const result = world.run("--gates");
+    assert.equal(result.status, 0);
+    assert.equal(gateByString(result.body, "integration:e2e").state, "failed");
+    assert.match(gateByString(result.body, "integration:e2e").message, /identity|program/i);
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/gates.test.js
+++ b/tests/relay-orca/scripts/gates.test.js
@@ -149,12 +149,37 @@ function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {},
   // The accepted program file — the ONLY source of exit_gates (input artifacts).
   const programFile = path.join(base, "accepted-program.json");
   const acceptedProgram = { id: programId, exit_gates: exitGates, decision_gates: decisionGates, outcomes: receiptObject.tasks.map((task) => ({ id: task.outcome_id, task_kind: task.kind, accepted_outcomes: ["x"] })) };
-  if (integrationEvidenceVersion !== undefined) acceptedProgram.integration_evidence_version = integrationEvidenceVersion;
-  if (integrationEvidence.length > 0) acceptedProgram.integration_evidence = integrationEvidence;
+  const integrationRefs = exitGates
+    .filter((gate) => typeof gate === "string" && gate.startsWith("integration:"))
+    .map((gate) => gate.slice("integration:".length));
+  const defaultIntegrationEvidence = integrationRefs.map((checkRef) => {
+    const supplied = gateEvidence[checkRef];
+    const passed = supplied && supplied.schema === 1
+      ? supplied.verification && supplied.verification.passed === true
+      : supplied && supplied.passed === true;
+    return {
+      program_id: programId,
+      runtime_id: receiptObject.runtime_id,
+      check_ref: checkRef,
+      verification: verificationBinding(passed),
+    };
+  });
+  if (integrationRefs.length > 0 || integrationEvidenceVersion !== undefined) acceptedProgram.integration_evidence_version = integrationEvidenceVersion === undefined ? 1 : integrationEvidenceVersion;
+  if (integrationEvidence.length > 0 || integrationRefs.length > 0) acceptedProgram.integration_evidence = integrationEvidence.length > 0 ? integrationEvidence : defaultIntegrationEvidence;
   fs.writeFileSync(programFile, `${JSON.stringify({ program: acceptedProgram }, null, 2)}\n`, "utf-8");
 
   Object.entries(gateEvidence).forEach(([name, value]) => {
-    fs.writeFileSync(path.join(evidenceDir, `${sanitizeArtifact(name)}.json`), `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+    const artifact = value && value.schema === 1
+      ? value
+      : {
+        schema: 1,
+        program_id: programId,
+        runtime_id: receiptObject.runtime_id,
+        check_ref: name,
+        verification: verificationBinding(value && value.passed === true),
+        ...(value && typeof value.evidence === "string" ? { evidence: value.evidence } : {}),
+      };
+    fs.writeFileSync(path.join(evidenceDir, boundArtifactName(name)), `${JSON.stringify(artifact, null, 2)}\n`, "utf-8");
   });
 
   const orca = installFakeOrcaStatus({ runtimeId: DEFAULT_RUNTIME_ID, ...orcaScenario });
@@ -172,7 +197,7 @@ function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {},
     receiptOnDisk() {
       return fs.readFileSync(receiptPath, "utf-8");
     },
-    run(mode, extraArgs = []) {
+    run(mode, extraArgs = [], options = {}) {
       const args = [
         STATUS_JS,
         "--program-id",
@@ -181,8 +206,6 @@ function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {},
         mode,
         "--program-file",
         programFile,
-        "--gate-evidence-dir",
-        evidenceDir,
         "--orca-bin",
         orca.orcaPath,
         "--gh-bin",
@@ -191,11 +214,21 @@ function buildGateWorld({ programId, receipt, manifests = [], orcaScenario = {},
         repoRoot,
         ...extraArgs,
       ];
+      if (!options.omitEvidenceDir) {
+        const evidenceFlagIndex = args.indexOf("--orca-bin");
+        args.splice(evidenceFlagIndex, 0, "--gate-evidence-dir", evidenceDir);
+      }
       const result = { status: 0, stdout: "", stderr: "" };
       try {
         result.stdout = execFileSync(process.execPath, args, {
           encoding: "utf-8",
-          env: { ...process.env, RELAY_ORCA_PROGRAMS_ROOT: programsRoot, RELAY_ORCA_RUNS_ROOT: runsRoot, RELAY_ORCA_FLEETS_ROOT: fleetsRoot },
+          env: {
+            ...process.env,
+            RELAY_ORCA_PROGRAMS_ROOT: programsRoot,
+            RELAY_ORCA_RUNS_ROOT: runsRoot,
+            RELAY_ORCA_FLEETS_ROOT: fleetsRoot,
+            RELAY_ORCA_GATE_EVIDENCE_ROOT: evidenceDir,
+          },
           stdio: "pipe",
         });
       } catch (error) {
@@ -299,14 +332,229 @@ test("#1046 red: a well-formed-looking cross-program identity artifact cannot pa
     gateEvidence: { e2e: artifact },
   });
   try {
-    // Keep the legacy sanitized copy that the current reader consumes, and add the
-    // collision-resistant location the new reader must inspect. Before the fix the
-    // current implementation trusts only passed:true and incorrectly reports passed.
+    // The artifact is in the collision-resistant location, but its explicit identity is
+    // for another program. The pre-fix reader ignored that identity and trusted passed:true.
     fs.writeFileSync(path.join(world.evidenceDir, boundArtifactName("e2e")), `${JSON.stringify(artifact, null, 2)}\n`, "utf-8");
     const result = world.run("--gates");
     assert.equal(result.status, 0);
     assert.equal(gateByString(result.body, "integration:e2e").state, "failed");
     assert.match(gateByString(result.body, "integration:e2e").message, /identity|program/i);
+  } finally {
+    world.cleanup();
+  }
+});
+
+function identityDeclaration(programId, checkRef, verification = verificationBinding(true), runtimeId = DEFAULT_RUNTIME_ID) {
+  return { program_id: programId, runtime_id: runtimeId, check_ref: checkRef, verification };
+}
+
+function identityArtifact(programId, checkRef, verification = verificationBinding(true), runtimeId = DEFAULT_RUNTIME_ID) {
+  return { schema: 1, program_id: programId, runtime_id: runtimeId, check_ref: checkRef, verification, evidence: "fixture verification" };
+}
+
+function assertReadOnly(world, result, expectedStatus = 0) {
+  assert.equal(result.status, expectedStatus);
+  assert.equal(world.receiptOnDisk(), world.receiptBefore, "identity failure must not rewrite the receipt");
+  assert.equal(world.orca.readPoison(), null, "identity failure must not mutate Orca");
+  assert.equal(world.gh.readPoison(), null, "identity failure must not mutate GitHub");
+}
+
+test("#1046: stale, cross-runtime, cross-check, and tampered-result artifacts fail closed with strict precedence", () => {
+  const cases = [
+    ["stale-program", identityArtifact("earlier-program", "e2e")],
+    ["cross-runtime", identityArtifact("epic-1046-matrix-cross-runtime", "e2e", verificationBinding(true), "runtime-other")],
+    ["cross-check", identityArtifact("epic-1046-matrix-cross-check", "other")],
+    ["tampered-result", identityArtifact("epic-1046-matrix-tampered-result", "e2e", verificationBinding(false))],
+  ];
+  cases.forEach(([name, artifact]) => {
+    const programId = artifact.program_id === "earlier-program" ? "epic-1046-matrix-stale" : artifact.program_id;
+    const expected = identityDeclaration(programId, "e2e", verificationBinding(true));
+    const world = greenWorld(programId, {
+      exitGates: ["integration:e2e"],
+      integrationEvidenceVersion: 1,
+      integrationEvidence: [expected],
+      gateEvidence: { e2e: artifact },
+    });
+    world.receiptBefore = world.receiptOnDisk();
+    try {
+      const loose = world.run("--gates");
+      assertReadOnly(world, loose, 0);
+      assert.equal(gateByString(loose.body, "integration:e2e").state, "failed", name);
+      assert.match(gateByString(loose.body, "integration:e2e").message, /identity contract/);
+      const strict = world.run("--gates", ["--strict"]);
+      assertReadOnly(world, strict, 71);
+      const final = world.run("--final-summary", ["--strict"]);
+      assertReadOnly(world, final, 71);
+      assert.equal(final.body.program_complete, false);
+    } finally {
+      world.cleanup();
+    }
+  });
+});
+
+test("#1046: missing identity and legacy identity-less evidence never pass a newly accepted program", () => {
+  const programId = "epic-1046-missing-identity";
+  const expected = identityDeclaration(programId, "e2e");
+  const missing = greenWorld(programId, {
+    exitGates: ["integration:e2e"],
+    integrationEvidenceVersion: 1,
+    integrationEvidence: [expected],
+    gateEvidence: { e2e: { schema: 1, passed: true } },
+  });
+  try {
+    missing.receiptBefore = missing.receiptOnDisk();
+    const result = missing.run("--gates");
+    assertReadOnly(missing, result);
+    assert.equal(gateByString(result.body, "integration:e2e").state, "failed");
+    assert.match(gateByString(result.body, "integration:e2e").message, /identity contract/);
+  } finally {
+    missing.cleanup();
+  }
+
+  const legacy = greenWorld("epic-1046-legacy", { exitGates: ["integration:e2e"], gateEvidence: { e2e: { passed: true } } });
+  try {
+    const program = JSON.parse(fs.readFileSync(legacy.programFile, "utf-8"));
+    delete program.program.integration_evidence_version;
+    delete program.program.integration_evidence;
+    fs.writeFileSync(legacy.programFile, `${JSON.stringify(program, null, 2)}\n`, "utf-8");
+    fs.writeFileSync(path.join(legacy.evidenceDir, boundArtifactName("e2e")), `${JSON.stringify({ passed: true }, null, 2)}\n`, "utf-8");
+    legacy.receiptBefore = legacy.receiptOnDisk();
+    const result = legacy.run("--final-summary");
+    assertReadOnly(legacy, result);
+    assert.equal(result.body.program_complete, false);
+    assert.equal(result.body.stopped_on, "integration_gate_failed");
+  } finally {
+    legacy.cleanup();
+  }
+});
+
+test("#1046: duplicate declarations and duplicate artifacts fail closed without adding report keys", () => {
+  const programId = "epic-1046-duplicates";
+  const declaration = identityDeclaration(programId, "e2e");
+  const world = greenWorld(programId, {
+    exitGates: ["integration:e2e"],
+    integrationEvidenceVersion: 1,
+    integrationEvidence: [declaration, { ...declaration, verification: verificationBinding(false) }],
+    gateEvidence: { e2e: identityArtifact(programId, "e2e") },
+  });
+  try {
+    world.receiptBefore = world.receiptOnDisk();
+    const declarationResult = world.run("--gates");
+    assertReadOnly(world, declarationResult);
+    assert.equal(gateByString(declarationResult.body, "integration:e2e").state, "failed");
+    assert.deepEqual(Object.keys(gateByString(declarationResult.body, "integration:e2e")).sort(), [...GATE_ENTRY_KEYS].sort());
+  } finally {
+    world.cleanup();
+  }
+
+  const artifacts = greenWorld("epic-1046-duplicate-artifacts", {
+    exitGates: ["integration:e2e"],
+    gateEvidence: { e2e: { passed: true } },
+  });
+  try {
+    fs.writeFileSync(path.join(artifacts.evidenceDir, "e2e-duplicate.json"), `${JSON.stringify(identityArtifact("epic-1046-duplicate-artifacts", "e2e"), null, 2)}\n`, "utf-8");
+    artifacts.receiptBefore = artifacts.receiptOnDisk();
+    const result = artifacts.run("--gates");
+    assertReadOnly(artifacts, result);
+    assert.equal(gateByString(result.body, "integration:e2e").state, "failed");
+    assert.match(gateByString(result.body, "integration:e2e").message, /duplicate/);
+  } finally {
+    artifacts.cleanup();
+  }
+});
+
+test("#1046: unsafe traversal refs are rejected before path lookup, and a/b is distinct from a-b", () => {
+  const unsafe = greenWorld("epic-1046-traversal", {
+    exitGates: ["integration:a/../secret"],
+    integrationEvidenceVersion: 1,
+    integrationEvidence: [identityDeclaration("epic-1046-traversal", "a/../secret")],
+    gateEvidence: {},
+  });
+  try {
+    unsafe.receiptBefore = unsafe.receiptOnDisk();
+    const result = unsafe.run("--gates");
+    assertReadOnly(unsafe, result);
+    assert.equal(gateByString(result.body, "integration:a/../secret").state, "failed");
+    assert.match(gateByString(result.body, "integration:a/../secret").message, /unsafe|identity contract/);
+  } finally {
+    unsafe.cleanup();
+  }
+
+  const programId = "epic-1046-collision";
+  const refs = ["a/b", "a-b"];
+  const collision = greenWorld(programId, {
+    exitGates: refs.map((ref) => `integration:${ref}`),
+    integrationEvidenceVersion: 1,
+    integrationEvidence: refs.map((ref) => identityDeclaration(programId, ref)),
+    gateEvidence: { "a/b": { passed: true }, "a-b": { passed: true } },
+  });
+  try {
+    const result = collision.run("--gates");
+    assert.equal(result.status, 0);
+    assert.equal(gateByString(result.body, "integration:a/b").state, "passed");
+    assert.equal(gateByString(result.body, "integration:a-b").state, "passed");
+    assert.notEqual(boundArtifactName("a/b"), boundArtifactName("a-b"));
+  } finally {
+    collision.cleanup();
+  }
+});
+
+test("#1046: generic full-suite evidence stays distinct from the integration-main-suite lifecycle outcome", () => {
+  const programId = "epic-1046-topology";
+  const world = greenWorld(programId, {
+    extraTasks: [{ outcome_id: "integration-main-suite", kind: "relay_run", run: "run-integration" }],
+    manifests: [{ run_id: "run-integration", state: "merged", pr_number: 11, issue_number: 101, head_sha: "def" }],
+    orcaTasks: [orcaTask(programId, "integration-main-suite", { status: "completed", worker_done: true })],
+    prs: { 11: { state: "MERGED", mergedAt: "2026-07-13T01:00:00Z", headRefOid: "def" } },
+    issues: { 101: { state: "CLOSED", stateReason: "COMPLETED" } },
+    exitGates: ["integration:full-suite"],
+    integrationEvidenceVersion: 1,
+    integrationEvidence: [identityDeclaration(programId, "full-suite")],
+    gateEvidence: { "full-suite": { passed: true } },
+  });
+  try {
+    const result = world.run("--final-summary");
+    assert.equal(result.status, 0);
+    assert.equal(result.body.program_complete, true);
+    assert.equal(gateByString(result.body, "integration:full-suite").state, "passed");
+    assert.equal(result.body.gates.some((gate) => gate.gate === "integration:integration-main-suite"), false);
+    assert.ok(result.body.outcomes.some((outcome) => outcome.outcome_id === "integration-main-suite"));
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1046: declaration input ordering does not change deterministic gate output", () => {
+  const programId = "epic-1046-ordering";
+  const refs = ["z-suite", "a-suite"];
+  const world = greenWorld(programId, {
+    exitGates: refs.map((ref) => `integration:${ref}`),
+    integrationEvidenceVersion: 1,
+    integrationEvidence: refs.slice().reverse().map((ref) => identityDeclaration(programId, ref)),
+    gateEvidence: { "z-suite": { passed: true }, "a-suite": { passed: true } },
+  });
+  try {
+    const first = world.run("--gates");
+    const second = world.run("--gates");
+    assert.deepEqual(first.body.gates, second.body.gates);
+    assert.deepEqual(first.body.blocking_reasons, second.body.blocking_reasons);
+    assert.deepEqual(first.body.gates.map((gate) => gate.gate), ["integration:z-suite", "integration:a-suite"]);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1046: RELAY_ORCA_GATE_EVIDENCE_ROOT remains the read-only evidence fallback", () => {
+  const world = greenWorld("epic-1046-evidence-fallback", {
+    exitGates: ["integration:e2e"],
+    gateEvidence: { e2e: { passed: true } },
+  });
+  try {
+    const result = world.run("--gates", [], { omitEvidenceDir: true });
+    assert.equal(result.status, 0);
+    assert.equal(gateByString(result.body, "integration:e2e").state, "passed");
+    assert.equal(world.orca.readPoison(), null);
+    assert.equal(world.gh.readPoison(), null);
   } finally {
     world.cleanup();
   }

--- a/tests/relay-orca/scripts/integration-evidence.test.js
+++ b/tests/relay-orca/scripts/integration-evidence.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  artifactFileName,
+  indexDeclarations,
+  rawRefError,
+  validateArtifact,
+  validateVerification,
+  verificationBinding,
+} = require("../../../skills/relay-orca/scripts/lib/integration-evidence.js");
+const { compileProgram } = require("../../../skills/relay-orca/scripts/lib/compile-program.js");
+
+const RUNTIME = "runtime-fixture";
+const PROGRAM = "epic-evidence-unit";
+
+function trustedVerification(passed = true) {
+  return verificationBinding({
+    input_sha256: `sha256:${"a".repeat(64)}`,
+    result_sha256: `sha256:${"b".repeat(64)}`,
+    passed,
+  });
+}
+
+function declaration(checkRef = "full-suite", verification = trustedVerification(true)) {
+  return { program_id: PROGRAM, runtime_id: RUNTIME, check_ref: checkRef, verification };
+}
+
+function artifact(overrides = {}) {
+  return {
+    schema: 1,
+    ...declaration(),
+    evidence: "fixture",
+    ...overrides,
+  };
+}
+
+test("verification binding is canonical and changes when the result changes", () => {
+  const passing = trustedVerification(true);
+  const failing = trustedVerification(false);
+  assert.equal(validateVerification(passing).valid, true);
+  assert.equal(validateVerification(failing).valid, true);
+  assert.notEqual(passing.binding_sha256, failing.binding_sha256);
+  assert.equal(validateVerification({ ...passing, passed: false }).valid, false);
+});
+
+test("artifact validation requires exact identity, schema, and the accepted verification binding", () => {
+  const expected = declaration();
+  assert.equal(validateArtifact(artifact(), { declaration: expected, programId: PROGRAM, runtimeId: RUNTIME, checkRef: "full-suite" }).passed, true);
+  assert.equal(validateArtifact(artifact({ program_id: "other-program" }), { declaration: expected, programId: PROGRAM, runtimeId: RUNTIME, checkRef: "full-suite" }).valid, false);
+  assert.equal(validateArtifact(artifact({ check_ref: "integration-main-suite" }), { declaration: expected, programId: PROGRAM, runtimeId: RUNTIME, checkRef: "full-suite" }).valid, false);
+  assert.equal(validateArtifact(artifact({ verification: trustedVerification(false) }), { declaration: expected, programId: PROGRAM, runtimeId: RUNTIME, checkRef: "full-suite" }).valid, false);
+  assert.equal(validateArtifact({ ...artifact(), passed: true }, { declaration: expected, programId: PROGRAM, runtimeId: RUNTIME, checkRef: "full-suite" }).valid, false);
+});
+
+test("declaration indexing rejects missing, duplicate, unbound, and unsafe raw refs", () => {
+  const missing = indexDeclarations({ programId: PROGRAM, runtimeId: RUNTIME, refs: ["full-suite"], version: 1, declarations: [] });
+  assert.match(missing.errors.get("full-suite"), /no identity declaration/);
+  const duplicate = indexDeclarations({
+    programId: PROGRAM,
+    runtimeId: RUNTIME,
+    refs: ["full-suite"],
+    version: 1,
+    declarations: [declaration(), declaration()],
+  });
+  assert.match(duplicate.errors.get("full-suite"), /duplicate\/conflicting/);
+  const unsafe = indexDeclarations({
+    programId: PROGRAM,
+    runtimeId: RUNTIME,
+    refs: ["a/../secret"],
+    version: 1,
+    declarations: [declaration("a/../secret")],
+  });
+  assert.match(unsafe.errors.get("a/../secret"), /unsafe/);
+  const extra = indexDeclarations({
+    programId: PROGRAM,
+    runtimeId: RUNTIME,
+    refs: ["full-suite"],
+    version: 1,
+    declarations: [declaration(), declaration("unbound")],
+  });
+  assert.match(extra.errors.get("full-suite"), /unbound/);
+});
+
+test("accepted-program compilation rejects identity-less generic integration gates", () => {
+  assert.throws(
+    () => compileProgram({
+      id: PROGRAM,
+      exit_gates: ["integration:full-suite"],
+      outcomes: [{ id: "outcome", task_kind: "relay_run", accepted_outcomes: ["merged"] }],
+    }),
+    (error) => error && error.reasonCode === "INVALID_INPUT" && /integration evidence/.test(error.message),
+  );
+  assert.throws(
+    () => compileProgram({
+      id: PROGRAM,
+      integration_evidence_version: 1,
+      integration_evidence: [{ ...declaration("full-suite", trustedVerification(true)), runtime_id: "" }],
+      exit_gates: ["integration:full-suite"],
+      outcomes: [{ id: "outcome", task_kind: "relay_run", accepted_outcomes: ["merged"] }],
+    }),
+    (error) => error && error.reasonCode === "INVALID_INPUT" && /runtime_id/.test(error.message),
+  );
+});
+
+test("raw refs are checked before lookup and collision-resistant names preserve a/b versus a-b", () => {
+  assert.equal(rawRefError("a/b"), null);
+  assert.match(rawRefError("a/../b"), /unsafe/);
+  assert.match(rawRefError("/absolute"), /absolute/);
+  assert.notEqual(artifactFileName("a/b"), artifactFileName("a-b"));
+});


### PR DESCRIPTION
## Summary

- Bind every `integration:<check>` gate to an accepted-program declaration containing the exact `program_id`, non-empty receipt-matching `runtime_id`, raw `check_ref`, and content-based verification binding.
- Validate identity-bound artifacts through a pure validator and a read-only collision-resistant evidence reader.
- Keep generic `integration:full-suite` evidence separate from the `integration-main-suite` lifecycle outcome.
- Reject identity-less, stale, cross-program/runtime/check, tampered, duplicate, unsafe, and sanitize-colliding evidence without changing the frozen report shapes.

The implementation preserves strict exit precedence `70 > 71 > 72`, the `RELAY_ORCA_GATE_EVIDENCE_ROOT` fallback, and fixture-only Orca/GitHub execution.

## Verification

- `node --test tests/relay-orca/scripts/plan.test.js tests/relay-orca/scripts/gates.test.js tests/relay-orca/scripts/status.test.js tests/relay-orca/scripts/*integration*evidence*.test.js` — 139 passed, 0 failed.
- `git diff --check` — passed.
- Red test commit is separate: `a23b085`.
- Implementation commit: `b2493eb`.

Fixes #1046


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 통합 게이트 증거에 프로그램·런타임·검사 식별자와 불변 검증 바인딩을 적용했습니다.
  * 안전하지 않은 참조, 중복·충돌 아티팩트, 누락되거나 변조된 증거를 엄격히 거부합니다.
  * 게이트 상태 및 최종 요약에서 통합 증거를 더욱 정확하게 판정합니다.

* **문서**
  * 통합 증거 형식, 파일 식별 규칙, 검증 및 실패 처리 기준을 명확히 했습니다.

* **테스트**
  * 식별자 불일치, 경로 탐색, 충돌, 변조, 레거시 증거 등 경계 사례 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->