### PR TITLE
fix(relay-orca): harden proof snapshot identity

### DIFF
--- a/skills/relay-orca/references/closed-program-proof.md
+++ b/skills/relay-orca/references/closed-program-proof.md
@@ -20,7 +20,13 @@ verifyClosedProgram({
 of identity-bound artifacts). `durableOutcomeEvidence` is keyed by accepted
 `outcome_id` (or is an array of records). Each relay-run record carries structured
 `manifest`, `pr`, and `issue` facts; no `state`, `program_complete`, or diagnostic
-message in a caller summary is authority.
+message in a caller summary is authority. Durable evidence is also bound to the
+receipt mapping identity: the manifest `run_id`/`fleet_id` must match the
+receipt-mapped run/fleet (when present) and the manifest `pr_number`/`issue_number`
+must match the injected PR/issue records before the outcome counts as
+`complete_with_evidence`. An absent manifest `head_sha` is optional; only two present,
+disagreeing SHAs are stale. Any mismatch fails closed with a named `PROOF_STALE_EVIDENCE`
+reason, and `stopped_on` is the STOP_PRIORITY-most-severe token across all failures.
 
 `orcaSnapshot` must carry structured status, task-list, and gate-list reads. Their
 runtime IDs must all be present, non-empty, and identical. The verifier checks only

--- a/skills/relay-orca/references/closed-program-proof.md
+++ b/skills/relay-orca/references/closed-program-proof.md
@@ -1,0 +1,33 @@
+# Closed-program proof
+
+`scripts/lib/closed-program-proof.js` is the pure leaf-1 verifier for a retained
+relay-orca runtime. It accepts parsed values only; callers own the read boundary.
+
+```js
+verifyClosedProgram({
+  acceptedProgram,
+  receipt,
+  trustedGenericIntegrationEvidence,
+  durableOutcomeEvidence,
+  orcaSnapshot,
+  // Optional in tests; the shared collision-resistant encoder is the default.
+  programSegment,
+});
+```
+
+`acceptedProgram` may be the raw accepted program or `{ program: acceptedProgram }`.
+`trustedGenericIntegrationEvidence` is keyed by the raw `check_ref` (or is an array
+of identity-bound artifacts). `durableOutcomeEvidence` is keyed by accepted
+`outcome_id` (or is an array of records). Each relay-run record carries structured
+`manifest`, `pr`, and `issue` facts; no `state`, `program_complete`, or diagnostic
+message in a caller summary is authority.
+
+`orcaSnapshot` must carry structured status, task-list, and gate-list reads. Their
+runtime IDs must all be present, non-empty, and identical. The verifier checks only
+the exact receipt-mapped task IDs and integration-task gates; unrelated live rows are
+left for the admission-filter leaf.
+
+The successful result returns `program_id`, `runtime_id`, sorted `outcome_ids`,
+sorted `orca_task_ids`, and sorted `integration_gate_ids`. It also returns the
+recomputed four-field final-summary truth used by the later admission leaf. Existing
+receipt, gates-report, final-summary, and gate-entry serializers are not modified.

--- a/skills/relay-orca/scripts/lib/closed-program-proof.js
+++ b/skills/relay-orca/scripts/lib/closed-program-proof.js
@@ -359,8 +359,9 @@ function checkIdentity(record, programId, runtimeId) {
   return null;
 }
 
-// Pull the receipt-mapped relay/fleet id for this outcome. Null when the receipt task
-// or its relay_ids are absent so the binding stays optional ("when present").
+// Pull the receipt-mapped relay/fleet id for this outcome. Null ONLY when the receipt
+// (the authoritative mapping) declares no such id — in that case the comparison is
+// omitted. A non-null return is REQUIRED on the evidence side (see bindMappedId).
 function receiptRelayId(receiptTask, field) {
   const ids = isObject(receiptTask) && isObject(receiptTask.relay_ids) ? receiptTask.relay_ids : null;
   return ids && nonEmpty(ids[field]) ? ids[field] : null;
@@ -370,17 +371,65 @@ function numberLabel(value) {
   return typeof value === "number" ? `#${value}` : "with no number";
 }
 
+// #1021 uniform identity-binding rule (class closure). Whenever an authoritative mapping
+// declares an id, the durable evidence MUST carry the same id, non-empty and equal. An
+// evidence side that omits a declared id fails CLOSED — it is never skipped. The
+// comparison is omitted ONLY when the authoritative side itself declares no such id.
+//
+// bindMappedId binds a receipt-mapped relay/fleet id (authoritative) to a manifest id.
+function bindMappedId(mapped, actual, label, noun) {
+  if (!nonEmpty(mapped)) return null;
+  if (!nonEmpty(actual)) return reason("PROOF_STALE_EVIDENCE", `${label} manifest omits the ${noun} id required by the receipt-mapped ${noun} ${mapped}`);
+  if (actual !== mapped) return reason("PROOF_STALE_EVIDENCE", `${label} manifest ${noun} ${actual} does not match the receipt-mapped ${noun} ${mapped}`);
+  return null;
+}
+
+// bindDeclaredNumber binds a manifest-declared PR/issue number (authoritative) to an
+// injected GitHub record number. An absent record number fails closed (undefined never
+// equals a declared number).
+function bindDeclaredNumber(declared, actual, label, noun) {
+  if (declared == null) return null;
+  if (actual !== declared) return reason("PROOF_STALE_EVIDENCE", `${label} ${noun} ${numberLabel(actual)} does not match its declared manifest ${noun} #${declared}`);
+  return null;
+}
+
+// A fleet child's durable identity is its { run_id, leaf_ref } pair (#945 D4). Null when
+// the child declares neither id, so a manifest whose children carry no identities cannot
+// bind (the authoritative-has-no-id branch of the uniform rule).
+function fleetChildKey(child) {
+  if (!isObject(child)) return null;
+  const runId = [child.run_id, child.runId].find(nonEmpty) || "";
+  const leafRef = [child.leaf_ref, child.leafRef].find(nonEmpty) || "";
+  if (runId === "" && leafRef === "") return null;
+  return `${runId} ${leafRef}`;
+}
+
+// Sorted multiset of child identity keys (duplicates preserved so counts must match), or
+// null when any child in the set declares no identity.
+function fleetChildIdentities(children) {
+  const keys = [];
+  for (const child of children) {
+    const key = fleetChildKey(child);
+    if (key === null) return null;
+    keys.push(key);
+  }
+  return keys.sort((left, right) => left.localeCompare(right));
+}
+
+function childIdentitiesEqual(declared, supplied) {
+  return supplied !== null && declared.length === supplied.length && declared.every((key, index) => key === supplied[index]);
+}
+
 function checkRelayRun(record, receiptTask) {
   const manifest = record.manifest || record.relay_manifest;
   if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} has no durable relay manifest`);
   if (manifest.state === "closed" || manifest.state === "escalated" || manifest.state === "failed") return reason("PROOF_STOPPED", `relay outcome ${record.outcome_id} is ${manifest.state}`);
   if (manifest.state !== "merged") return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} is not durably merged`);
-  // Bind durable evidence to the receipt mapping identity: a merged/closed shape alone is
-  // not authority. When the manifest carries a run id it must equal the receipt-mapped run.
-  const mappedRun = receiptRelayId(receiptTask, "run");
-  if (mappedRun && nonEmpty(manifest.run_id) && manifest.run_id !== mappedRun) {
-    return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} manifest run ${manifest.run_id} does not match the receipt-mapped run ${mappedRun}`);
-  }
+  // Bind durable evidence to the receipt mapping identity: a merged shape alone is not
+  // authority. When the receipt maps a run id, the manifest MUST carry the same run id —
+  // an omitted manifest run id fails closed, never skips (see bindMappedId).
+  const runFailure = bindMappedId(receiptRelayId(receiptTask, "run"), manifest.run_id, `relay outcome ${record.outcome_id}`, "run");
+  if (runFailure) return runFailure;
   const pr = record.pr || (isObject(record.github) && record.github.pr);
   const issue = record.issue || (isObject(record.github) && record.github.issue);
   if (!isObject(pr) || !isObject(issue)) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} is missing GitHub evidence`);
@@ -391,9 +440,11 @@ function checkRelayRun(record, receiptTask) {
   if (nonEmpty(manifest.head_sha) && nonEmpty(pr.headRefOid) && manifest.head_sha !== pr.headRefOid) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} PR head differs from its merged manifest`);
   // The manifest's declared PR/issue numbers must match the injected GitHub records before
   // the outcome counts as complete_with_evidence — else foreign merged/closed records pass.
-  if (manifest.pr_number != null && pr.number !== manifest.pr_number) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} PR ${numberLabel(pr.number)} does not match its merged manifest PR #${manifest.pr_number}`);
+  const prNumberFailure = bindDeclaredNumber(manifest.pr_number, pr.number, `relay outcome ${record.outcome_id}`, "PR");
+  if (prNumberFailure) return prNumberFailure;
   if (issue.state !== "CLOSED") return reason("PROOF_OUTCOME_FAILED", `relay outcome ${record.outcome_id} issue is not closed`);
-  if (manifest.issue_number != null && issue.number !== manifest.issue_number) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} issue ${numberLabel(issue.number)} does not match its merged manifest issue #${manifest.issue_number}`);
+  const issueNumberFailure = bindDeclaredNumber(manifest.issue_number, issue.number, `relay outcome ${record.outcome_id}`, "issue");
+  if (issueNumberFailure) return issueNumberFailure;
   return null;
 }
 
@@ -402,13 +453,25 @@ function checkFleet(record, receiptTask) {
   if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no durable fleet manifest`);
   if (manifest.fleet_state === "escalated" || manifest.state === "escalated") return reason("PROOF_STOPPED", `fleet outcome ${record.outcome_id} is escalated`);
   if (!(isTerminalManifestState(manifest.fleet_state) || isTerminalManifestState(manifest.state))) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} is not terminal`);
-  // Same receipt-mapping identity binding as relay runs: when the fleet manifest carries a
-  // fleet id it must equal the receipt-mapped fleet id.
-  const mappedFleet = receiptRelayId(receiptTask, "fleet");
-  if (mappedFleet && nonEmpty(manifest.fleet_id) && manifest.fleet_id !== mappedFleet) {
-    return reason("PROOF_STALE_EVIDENCE", `fleet outcome ${record.outcome_id} manifest fleet ${manifest.fleet_id} does not match the receipt-mapped fleet ${mappedFleet}`);
+  // Same uniform binding as relay runs: when the receipt maps a fleet id, the manifest MUST
+  // carry the same fleet id — an omitted manifest fleet id fails closed, never skips.
+  const fleetFailure = bindMappedId(receiptRelayId(receiptTask, "fleet"), manifest.fleet_id, `fleet outcome ${record.outcome_id}`, "fleet");
+  if (fleetFailure) return fleetFailure;
+  // The fleet manifest's declared children (#945 D4 `children:` frontmatter → { leaf_ref,
+  // run_id }) are the AUTHORITATIVE roster. When the record supplies its own child
+  // evidence, its child identities must equal the declared roster exactly — same
+  // { run_id, leaf_ref } set and same count — before any child state is trusted. A subset,
+  // superset, renamed, or identity-less child fails closed rather than passing on a forged
+  // roster. The binding is omitted only when the manifest declares no child identities.
+  const declaredChildren = Array.isArray(manifest.children) ? manifest.children : Array.isArray(manifest.fleet_children) ? manifest.fleet_children : null;
+  const suppliedChildren = Array.isArray(record.fleet_children) ? record.fleet_children : Array.isArray(record.fleetChildren) ? record.fleetChildren : null;
+  if (suppliedChildren && declaredChildren) {
+    const declaredKeys = fleetChildIdentities(declaredChildren);
+    if (declaredKeys && !childIdentitiesEqual(declaredKeys, fleetChildIdentities(suppliedChildren))) {
+      return reason("PROOF_STALE_EVIDENCE", `fleet outcome ${record.outcome_id} child evidence does not match the fleet manifest's declared children`);
+    }
   }
-  const children = Array.isArray(record.fleet_children) ? record.fleet_children : Array.isArray(record.fleetChildren) ? record.fleetChildren : Array.isArray(manifest.children) ? manifest.children : null;
+  const children = suppliedChildren || declaredChildren;
   if (!children || children.length === 0) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no child evidence`);
   for (const child of children) {
     const state = child && (child.state || (isObject(child.manifest) && child.manifest.state));
@@ -433,6 +496,13 @@ function checkDurableOutcome(record, kind, programId, runtimeId, receiptTask) {
     const manifest = record.manifest || record.relay_manifest;
     const issue = record.issue || (isObject(record.github) && record.github.issue);
     if (!manifest || !isTerminalManifestState(manifest.state) || !issue || issue.state !== "CLOSED") return reason("PROOF_OUTCOME_INCOMPLETE", `tracker outcome ${record.outcome_id} is not durably reconciled`);
+    // Uniform identity binding on the reconciled evidence: the receipt-mapped run and the
+    // manifest's declared issue number, when present, must equal the injected records so a
+    // foreign closed issue or manifest cannot satisfy the tracker outcome.
+    const runFailure = bindMappedId(receiptRelayId(receiptTask, "run"), manifest.run_id, `tracker outcome ${record.outcome_id}`, "run");
+    if (runFailure) return runFailure;
+    const issueFailure = bindDeclaredNumber(manifest.issue_number, issue.number, `tracker outcome ${record.outcome_id}`, "issue");
+    if (issueFailure) return issueFailure;
     return null;
   }
   if (kind === "integration_gate") {

--- a/skills/relay-orca/scripts/lib/closed-program-proof.js
+++ b/skills/relay-orca/scripts/lib/closed-program-proof.js
@@ -1,0 +1,544 @@
+"use strict";
+
+// Pure leaf-1 closure proof (#1021). This module accepts already-parsed structured
+// facts. It never reads a receipt, invokes Orca/GitHub, interprets diagnostic prose,
+// or treats a receipt stop record/live terminal bit/caller summary as completion
+// authority. The later admission leaf may use this proof while classifying unrelated
+// live rows globally.
+const { validateReceipt } = require("./receipt");
+const { SUPPORTED_KINDS } = require("./task-kinds");
+const { parseGate } = require("./gate-kinds");
+const {
+  canonicalIntegrationQuestion,
+  canonicalGateKey,
+  gateId,
+  gateResolution,
+  inspectCanonicalGates,
+} = require("./integration-lifecycle");
+const {
+  ARTIFACT_KEYS,
+  validateArtifact,
+  validateDeclaration,
+  INTEGRATION_EVIDENCE_VERSION,
+} = require("./integration-evidence");
+const { isTerminalManifestState } = require("./manifest-parse");
+const { taskDisplayString } = require("./status-derive");
+const { programSegment: defaultProgramSegment } = require("./program-segment");
+
+const PROOF_REASON_CODES = Object.freeze([
+  "PROOF_MALFORMED_INPUT",
+  "PROOF_DUPLICATE_CONFLICT",
+  "PROOF_CROSS_PROGRAM",
+  "PROOF_CROSS_RUNTIME",
+  "PROOF_STALE_EVIDENCE",
+  "PROOF_STOPPED",
+  "PROOF_INCOMPLETE",
+  "PROOF_OUTCOME_MISSING",
+  "PROOF_OUTCOME_FAILED",
+  "PROOF_OUTCOME_INCOMPLETE",
+  "PROOF_EVIDENCE_MISSING",
+  "PROOF_EVIDENCE_MALFORMED",
+  "PROOF_EVIDENCE_FAILED",
+  "PROOF_TASK_MISSING",
+  "PROOF_TASK_DUPLICATE",
+  "PROOF_TASK_FOREIGN",
+  "PROOF_TASK_ACTIVE",
+  "PROOF_TASK_FAILED",
+  "PROOF_TASK_MARKER_MISMATCH",
+  "PROOF_GATE_MISSING",
+  "PROOF_GATE_DUPLICATE",
+  "PROOF_GATE_NONCANONICAL",
+  "PROOF_GATE_CONFLICT",
+  "PROOF_GATE_PENDING",
+  "PROOF_GATE_FAILED",
+  "PROOF_GATE_MALFORMED",
+  "PROOF_GATE_UNEVALUABLE",
+]);
+
+const REASON_SET = new Set(PROOF_REASON_CODES);
+const STOPPED_CODES = new Set(["PROOF_STOPPED", "PROOF_TASK_FAILED", "PROOF_GATE_FAILED", "PROOF_EVIDENCE_FAILED"]);
+const LIFECYCLE_CODES = new Set([
+  "PROOF_CROSS_PROGRAM",
+  "PROOF_CROSS_RUNTIME",
+  "PROOF_STALE_EVIDENCE",
+  "PROOF_STOPPED",
+  "PROOF_TASK_MISSING",
+  "PROOF_TASK_DUPLICATE",
+  "PROOF_TASK_FOREIGN",
+  "PROOF_TASK_ACTIVE",
+  "PROOF_TASK_FAILED",
+  "PROOF_TASK_MARKER_MISMATCH",
+  "PROOF_OUTCOME_MISSING",
+  "PROOF_OUTCOME_FAILED",
+  "PROOF_OUTCOME_INCOMPLETE",
+  "PROOF_GATE_MISSING",
+  "PROOF_GATE_DUPLICATE",
+  "PROOF_GATE_NONCANONICAL",
+  "PROOF_GATE_CONFLICT",
+  "PROOF_GATE_PENDING",
+  "PROOF_GATE_FAILED",
+  "PROOF_GATE_MALFORMED",
+]);
+
+function isObject(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function sortedStrings(values) {
+  return [...new Set(values.filter(nonEmpty))].sort((left, right) => left.localeCompare(right));
+}
+
+function reason(code, message, details = {}) {
+  return { code: REASON_SET.has(code) ? code : "PROOF_MALFORMED_INPUT", message, ...details };
+}
+
+function stoppedOn(code) {
+  if (code === "PROOF_CROSS_RUNTIME" || code === "PROOF_CROSS_PROGRAM" || code === "PROOF_STALE_EVIDENCE") return "orca_lifecycle_failure";
+  if (STOPPED_CODES.has(code)) return code === "PROOF_GATE_FAILED" || code === "PROOF_EVIDENCE_FAILED" ? "integration_gate_failed" : "relay_escalated";
+  if (code.startsWith("PROOF_GATE_")) return "gate_unevaluable";
+  if (code.startsWith("PROOF_TASK_") || code.startsWith("PROOF_OUTCOME_")) return "outcomes_incomplete";
+  return "graph_ambiguous";
+}
+
+function emptySummary(ok, failures) {
+  const blocking = failures.map((failure) => ({ reason_code: failure.code, message: failure.message }));
+  const lifecycle = failures.filter((failure) => LIFECYCLE_CODES.has(failure.code)).map((failure) => ({
+    code: failure.code,
+    message: failure.message,
+  }));
+  return {
+    program_complete: ok,
+    stopped_on: ok ? null : stoppedOn(failures[0] ? failures[0].code : "PROOF_MALFORMED_INPUT"),
+    blocking_reasons: blocking,
+    lifecycle_diagnostics: lifecycle,
+  };
+}
+
+function result({ ok, programId = null, runtimeId = null, outcomeIds = [], taskIds = [], gateIds = [], failures = [] }) {
+  const orderedFailures = failures.slice().sort((left, right) => {
+    const code = left.code.localeCompare(right.code);
+    return code || left.message.localeCompare(right.message);
+  });
+  const first = orderedFailures[0] || null;
+  return {
+    ok,
+    reasonCode: first ? first.code : null,
+    message: first ? first.message : "closed program proof passed",
+    program_id: programId,
+    runtime_id: runtimeId,
+    outcome_ids: sortedStrings(outcomeIds),
+    orca_task_ids: sortedStrings(taskIds),
+    integration_gate_ids: sortedStrings(gateIds),
+    final_summary: emptySummary(ok, orderedFailures),
+  };
+}
+
+function unwrapProgram(input) {
+  const candidate = isObject(input) && isObject(input.program) ? input.program : input;
+  if (!isObject(candidate)) return { failure: reason("PROOF_MALFORMED_INPUT", "accepted program is not a structured object") };
+  const programId = nonEmpty(candidate.id) ? candidate.id : candidate.program_id;
+  if (!nonEmpty(programId)) return { failure: reason("PROOF_MALFORMED_INPUT", "accepted program id is missing") };
+  const rawOutcomes = Array.isArray(candidate.outcomes)
+    ? candidate.outcomes
+    : Array.isArray(candidate.tasks)
+      ? candidate.tasks.map((task) => ({ ...task, id: task && task.id !== undefined ? task.id : task && task.outcome_id, task_kind: task && (task.task_kind || task.kind) }))
+      : null;
+  if (!Array.isArray(rawOutcomes)) return { failure: reason("PROOF_MALFORMED_INPUT", "accepted program outcomes are missing") };
+  const outcomes = [];
+  const byId = new Map();
+  for (const raw of rawOutcomes) {
+    const id = raw && raw.id;
+    const kind = raw && (raw.task_kind || raw.kind);
+    if (!isObject(raw) || !nonEmpty(id) || !nonEmpty(kind) || !SUPPORTED_KINDS.includes(kind)) {
+      return { failure: reason("PROOF_MALFORMED_INPUT", "accepted program contains a malformed or unsupported outcome") };
+    }
+    if (byId.has(id)) return { failure: reason("PROOF_DUPLICATE_CONFLICT", `accepted program outcome ${id} is duplicated`) };
+    const outcome = { ...raw, id, task_kind: kind };
+    outcomes.push(outcome);
+    byId.set(id, outcome);
+  }
+  if (outcomes.length === 0) return { failure: reason("PROOF_MALFORMED_INPUT", "accepted program has no outcomes") };
+  const exitGates = candidate.exit_gates === undefined ? [] : candidate.exit_gates;
+  if (!Array.isArray(exitGates) || exitGates.length === 0 || exitGates.some((gate) => typeof gate !== "string" || gate.trim() === "")) {
+    return { failure: reason("PROOF_MALFORMED_INPUT", "accepted program exit_gates is malformed") };
+  }
+  return { program: candidate, programId, outcomes: outcomes.sort((left, right) => left.id.localeCompare(right.id)), byId, exitGates };
+}
+
+function normalizeSnapshot(input) {
+  if (!isObject(input)) return { failure: reason("PROOF_CROSS_RUNTIME", "injected Orca snapshot is missing") };
+  const status = isObject(input.status) ? input.status : input;
+  const taskList = isObject(input.task_list) ? input.task_list : isObject(input.taskList) ? input.taskList : input;
+  const gateList = isObject(input.gate_list) ? input.gate_list : isObject(input.gateList) ? input.gateList : input;
+  const runtimeFrom = (value) => {
+    if (!isObject(value)) return null;
+    const resultValue = isObject(value.result) ? value.result : {};
+    const meta = isObject(value._meta) ? value._meta : {};
+    return [value.runtime_id, value.runtimeId, resultValue.runtime_id, resultValue.runtimeId, meta.runtime_id, meta.runtimeId]
+      .find(nonEmpty) || null;
+  };
+  const runtimeId = runtimeFrom(status);
+  const taskRuntimeId = [input.taskRuntimeId, input.task_runtime_id, runtimeFrom(taskList)].find(nonEmpty) || null;
+  const gateRuntimeId = [input.gateRuntimeId, input.gate_runtime_id, runtimeFrom(gateList)].find(nonEmpty) || null;
+  if (!runtimeId || !taskRuntimeId || !gateRuntimeId || runtimeId !== taskRuntimeId || runtimeId !== gateRuntimeId) {
+    return { failure: reason("PROOF_CROSS_RUNTIME", "status, task-list, and gate-list runtime ids must be present, non-empty, and identical") };
+  }
+  const tasks = Array.isArray(taskList.tasks) ? taskList.tasks : null;
+  const gates = Array.isArray(gateList.gates) ? gateList.gates : null;
+  if (!tasks || !gates) return { failure: reason("PROOF_MALFORMED_INPUT", "Orca task-list and gate-list rows are missing or malformed") };
+  return { runtimeId, tasks: tasks.slice(), gates: gates.slice() };
+}
+
+function normalizeReceipt(receipt, programId, runtimeId) {
+  const structuralError = validateReceipt(receipt);
+  if (structuralError) return { failure: reason("PROOF_MALFORMED_INPUT", `canonical receipt is invalid: ${structuralError}`) };
+  if (receipt.program_id !== programId) return { failure: reason("PROOF_CROSS_PROGRAM", "receipt program_id does not match the accepted program") };
+  if (!nonEmpty(receipt.runtime_id) || receipt.runtime_id !== runtimeId) return { failure: reason("PROOF_CROSS_RUNTIME", "receipt runtime_id does not match the attributable Orca runtime") };
+  const byOutcome = new Map();
+  const byTask = new Map();
+  for (const entry of receipt.tasks) {
+    if (!isObject(entry) || !nonEmpty(entry.outcome_id) || !nonEmpty(entry.kind) || !nonEmpty(entry.orca_task_id)) {
+      return { failure: reason("PROOF_MALFORMED_INPUT", "receipt contains a malformed outcome/task mapping") };
+    }
+    if (byOutcome.has(entry.outcome_id) || byTask.has(entry.orca_task_id)) {
+      return { failure: reason("PROOF_DUPLICATE_CONFLICT", "receipt outcome and Orca task mappings must be unique") };
+    }
+    byOutcome.set(entry.outcome_id, entry);
+    byTask.set(entry.orca_task_id, entry);
+  }
+  return { receipt, byOutcome, byTask };
+}
+
+function normalizeRecords(input, label) {
+  const records = [];
+  if (input instanceof Map) {
+    for (const [key, value] of input.entries()) records.push({ key, value });
+  } else if (Array.isArray(input)) {
+    for (const record of input) records.push({ key: record && record.outcome_id, value: record });
+  } else if (isObject(input)) {
+    const source = isObject(input.outcomes) ? input.outcomes : input;
+    if (Array.isArray(source)) return normalizeRecords(source, label);
+    for (const [key, value] of Object.entries(source)) records.push({ key, value });
+  } else {
+    return { failure: reason("PROOF_MALFORMED_INPUT", `${label} is missing or malformed`) };
+  }
+  const byId = new Map();
+  for (const entry of records) {
+    if (!nonEmpty(entry.key) || !isObject(entry.value)) return { failure: reason("PROOF_MALFORMED_INPUT", `${label} has a malformed outcome record`) };
+    if (entry.value.outcome_id !== undefined && entry.value.outcome_id !== entry.key) {
+      return { failure: reason("PROOF_CROSS_PROGRAM", `${label} outcome record key and outcome_id disagree`) };
+    }
+    if (byId.has(entry.key)) return { failure: reason("PROOF_DUPLICATE_CONFLICT", `${label} contains duplicate outcome ${entry.key}`) };
+    byId.set(entry.key, { ...entry.value, outcome_id: entry.key });
+  }
+  return { byId };
+}
+
+function normalizeEvidenceArtifacts(input) {
+  const entries = [];
+  if (input instanceof Map) {
+    for (const [key, value] of input.entries()) entries.push({ key, value });
+  } else if (Array.isArray(input)) {
+    for (const value of input) entries.push({ key: value && value.check_ref, value });
+  } else if (isObject(input)) {
+    const source = isObject(input.artifacts) ? input.artifacts : input;
+    for (const [key, value] of Object.entries(source)) entries.push({ key, value });
+  } else if (input === undefined || input === null) {
+    return { byRef: new Map() };
+  } else {
+    return { failure: reason("PROOF_EVIDENCE_MALFORMED", "trusted generic integration evidence is malformed") };
+  }
+  const byRef = new Map();
+  for (const entry of entries) {
+    if (!nonEmpty(entry.key)) return { failure: reason("PROOF_EVIDENCE_MALFORMED", "generic integration evidence has no raw check ref") };
+    if (byRef.has(entry.key)) return { failure: reason("PROOF_DUPLICATE_CONFLICT", `generic integration evidence duplicates raw check ref ${entry.key}`) };
+    const source = entry.value;
+    if (source && source.present === false) continue;
+    const artifact = isObject(source) && source.artifact !== undefined ? source.artifact : source && source.value !== undefined ? source.value : source;
+    if (!isObject(artifact)) return { failure: reason("PROOF_EVIDENCE_MALFORMED", `generic integration evidence for ${entry.key} is not an artifact`) };
+    if (artifact.check_ref !== undefined && artifact.check_ref !== entry.key) return { failure: reason("PROOF_CROSS_PROGRAM", `generic integration evidence raw check ref ${entry.key} disagrees with its artifact`) };
+    byRef.set(entry.key, artifact);
+  }
+  return { byRef };
+}
+
+function classifyDeclarationFailure(declaration, programId, runtimeId) {
+  if (!isObject(declaration)) return "PROOF_EVIDENCE_MALFORMED";
+  if (declaration.program_id !== programId) return "PROOF_CROSS_PROGRAM";
+  if (declaration.runtime_id !== runtimeId) return "PROOF_CROSS_RUNTIME";
+  return "PROOF_EVIDENCE_MALFORMED";
+}
+
+function classifyArtifactFailure(artifact, programId, runtimeId, declaration) {
+  if (!isObject(artifact)) return "PROOF_EVIDENCE_MALFORMED";
+  if (artifact.schema !== INTEGRATION_EVIDENCE_VERSION || Object.keys(artifact).some((key) => !ARTIFACT_KEYS.includes(key)) || !artifact.verification) return "PROOF_EVIDENCE_MALFORMED";
+  if (artifact.program_id !== programId || (declaration && declaration.program_id !== programId)) return "PROOF_CROSS_PROGRAM";
+  if (artifact.runtime_id !== runtimeId || (declaration && declaration.runtime_id !== runtimeId)) return "PROOF_CROSS_RUNTIME";
+  if (declaration && artifact.verification) return "PROOF_STALE_EVIDENCE";
+  return "PROOF_EVIDENCE_MALFORMED";
+}
+
+function verifyGenericGates({ program, programId, runtimeId, exitGates, trustedEvidence }) {
+  const refs = [];
+  const seen = new Set();
+  for (const gate of exitGates) {
+    const parsed = parseGate(gate);
+    if (parsed.kind === "unevaluable") return { failures: [reason("PROOF_GATE_UNEVALUABLE", `exit gate ${gate} has no recognized structured kind`)] };
+    if (parsed.kind !== "integration") return { failures: [reason("PROOF_GATE_UNEVALUABLE", `exit gate ${gate} requires a structured proof contract not supplied to leaf 1`)] };
+    if (seen.has(parsed.ref)) return { failures: [reason("PROOF_DUPLICATE_CONFLICT", `integration exit gate ${parsed.ref} is duplicated`)] };
+    seen.add(parsed.ref);
+    refs.push(parsed.ref);
+  }
+  const declarations = program.integration_evidence;
+  const byDeclaration = new Map();
+  if (refs.length > 0 && program.integration_evidence_version !== INTEGRATION_EVIDENCE_VERSION) {
+    return { failures: [reason("PROOF_EVIDENCE_MALFORMED", `generic integration evidence version ${INTEGRATION_EVIDENCE_VERSION} is required`)] };
+  }
+  if (refs.length > 0 && !Array.isArray(declarations)) return { failures: [reason("PROOF_EVIDENCE_MISSING", "accepted program has no generic integration identity declarations")] };
+  for (const declaration of Array.isArray(declarations) ? declarations : []) {
+    if (!isObject(declaration) || !nonEmpty(declaration.check_ref)) return { failures: [reason("PROOF_EVIDENCE_MALFORMED", "generic integration identity declaration is malformed")] };
+    if (byDeclaration.has(declaration.check_ref)) return { failures: [reason("PROOF_DUPLICATE_CONFLICT", `generic integration identity declaration ${declaration.check_ref} is duplicated`)] };
+    byDeclaration.set(declaration.check_ref, declaration);
+  }
+  const artifacts = normalizeEvidenceArtifacts(trustedEvidence);
+  if (!artifacts.byRef) return { failures: [artifacts.failure] };
+  const failures = [];
+  for (const ref of refs.sort((left, right) => left.localeCompare(right))) {
+    const declaration = byDeclaration.get(ref);
+    if (!declaration) {
+      failures.push(reason("PROOF_EVIDENCE_MISSING", `generic integration identity declaration for ${ref} is missing`));
+      continue;
+    }
+    const declarationCheck = validateDeclaration(declaration, { programId, runtimeId, checkRef: ref });
+    if (!declarationCheck.valid) {
+      failures.push(reason(classifyDeclarationFailure(declaration, programId, runtimeId), `generic integration identity for ${ref} is invalid`));
+      continue;
+    }
+    const artifact = artifacts.byRef.get(ref);
+    if (!artifact) {
+      failures.push(reason("PROOF_EVIDENCE_MISSING", `generic integration evidence artifact for ${ref} is missing`));
+      continue;
+    }
+    const artifactCheck = validateArtifact(artifact, { declaration, programId, runtimeId, checkRef: ref });
+    if (!artifactCheck.valid) {
+      const code = classifyArtifactFailure(artifact, programId, runtimeId, declaration);
+      failures.push(reason(code, `generic integration evidence for ${ref} failed its #1046 identity contract`));
+    } else if (artifactCheck.passed !== true) {
+      failures.push(reason("PROOF_EVIDENCE_FAILED", `generic integration check ${ref} did not pass`));
+    }
+  }
+  for (const ref of artifacts.byRef.keys()) {
+    if (!seen.has(ref)) failures.push(reason("PROOF_CROSS_PROGRAM", `generic integration evidence ${ref} is not an accepted exit gate`));
+  }
+  for (const ref of byDeclaration.keys()) {
+    if (!seen.has(ref)) failures.push(reason("PROOF_CROSS_PROGRAM", `generic integration identity ${ref} is not an accepted exit gate`));
+  }
+  return { failures };
+}
+
+function checkIdentity(record, programId, runtimeId) {
+  if (record.program_id !== undefined && record.program_id !== programId) return reason("PROOF_CROSS_PROGRAM", `durable outcome ${record.outcome_id} belongs to another program`);
+  if (record.runtime_id !== undefined && record.runtime_id !== runtimeId) return reason("PROOF_CROSS_RUNTIME", `durable outcome ${record.outcome_id} belongs to another runtime`);
+  return null;
+}
+
+function checkRelayRun(record) {
+  const manifest = record.manifest || record.relay_manifest;
+  if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} has no durable relay manifest`);
+  if (manifest.state === "closed" || manifest.state === "escalated" || manifest.state === "failed") return reason("PROOF_STOPPED", `relay outcome ${record.outcome_id} is ${manifest.state}`);
+  if (manifest.state !== "merged") return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} is not durably merged`);
+  const pr = record.pr || (isObject(record.github) && record.github.pr);
+  const issue = record.issue || (isObject(record.github) && record.github.issue);
+  if (!isObject(pr) || !isObject(issue)) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} is missing GitHub evidence`);
+  if (!((pr.state === "MERGED") || nonEmpty(pr.mergedAt))) return reason("PROOF_OUTCOME_FAILED", `relay outcome ${record.outcome_id} does not have a merged PR`);
+  if (manifest.head_sha !== undefined && manifest.head_sha !== pr.headRefOid) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} PR head differs from its merged manifest`);
+  if (issue.state !== "CLOSED") return reason("PROOF_OUTCOME_FAILED", `relay outcome ${record.outcome_id} issue is not closed`);
+  return null;
+}
+
+function checkFleet(record) {
+  const manifest = record.fleet_manifest || record.fleetManifest;
+  if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no durable fleet manifest`);
+  if (manifest.fleet_state === "escalated" || manifest.state === "escalated") return reason("PROOF_STOPPED", `fleet outcome ${record.outcome_id} is escalated`);
+  if (!(isTerminalManifestState(manifest.fleet_state) || isTerminalManifestState(manifest.state))) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} is not terminal`);
+  const children = Array.isArray(record.fleet_children) ? record.fleet_children : Array.isArray(record.fleetChildren) ? record.fleetChildren : Array.isArray(manifest.children) ? manifest.children : null;
+  if (!children || children.length === 0) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no child evidence`);
+  for (const child of children) {
+    const state = child && (child.state || (isObject(child.manifest) && child.manifest.state));
+    if (state === "escalated" || state === "failed") return reason("PROOF_STOPPED", `fleet outcome ${record.outcome_id} has a failed child`);
+    if (!isTerminalManifestState(state)) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has an incomplete child`);
+  }
+  return null;
+}
+
+function checkDurableOutcome(record, kind, programId, runtimeId) {
+  const identityFailure = checkIdentity(record, programId, runtimeId);
+  if (identityFailure) return identityFailure;
+  if (kind === "relay_run") return checkRelayRun(record);
+  if (kind === "relay_fleet") return checkFleet(record);
+  if (kind === "advisory_review") {
+    const advisory = record.advisory || record;
+    return advisory.evidence_posted === true && advisory.blocking_findings_triaged === true
+      ? null
+      : reason("PROOF_OUTCOME_INCOMPLETE", `advisory outcome ${record.outcome_id} lacks posted and triaged evidence`);
+  }
+  if (kind === "tracker_reconciliation") {
+    const manifest = record.manifest || record.relay_manifest;
+    const issue = record.issue || (isObject(record.github) && record.github.issue);
+    if (!manifest || !isTerminalManifestState(manifest.state) || !issue || issue.state !== "CLOSED") return reason("PROOF_OUTCOME_INCOMPLETE", `tracker outcome ${record.outcome_id} is not durably reconciled`);
+    return null;
+  }
+  if (kind === "integration_gate") {
+    return record.integration || record.gate_report ? null : reason("PROOF_OUTCOME_INCOMPLETE", `integration outcome ${record.outcome_id} has no structured lifecycle evidence`);
+  }
+  return reason("PROOF_MALFORMED_INPUT", `outcome ${record.outcome_id} has an unsupported kind`);
+}
+
+function liveTaskId(task) {
+  return isObject(task) && nonEmpty(task.id) ? task.id : null;
+}
+
+function verifyLiveTasks({ tasks, receiptTasks, programId, segment }) {
+  const taskIds = [];
+  const failures = [];
+  const rowsById = new Map();
+  for (const row of tasks) {
+    const id = liveTaskId(row);
+    if (id) {
+      const rows = rowsById.get(id) || [];
+      rows.push(row);
+      rowsById.set(id, rows);
+    }
+  }
+  for (const entry of receiptTasks.slice().sort((left, right) => left.outcome_id.localeCompare(right.outcome_id))) {
+    const rows = rowsById.get(entry.orca_task_id) || [];
+    if (rows.length === 0) {
+      failures.push(reason("PROOF_TASK_MISSING", `mapped Orca task ${entry.orca_task_id} is absent from the live task-list`));
+      continue;
+    }
+    if (rows.length > 1) {
+      failures.push(reason("PROOF_TASK_DUPLICATE", `mapped Orca task ${entry.orca_task_id} appears more than once in the live task-list`));
+      continue;
+    }
+    const row = rows[0];
+    if (row.status === "failed") failures.push(reason("PROOF_TASK_FAILED", `mapped Orca task ${entry.orca_task_id} is failed`));
+    else if (row.status !== "completed") failures.push(reason("PROOF_TASK_ACTIVE", `mapped Orca task ${entry.orca_task_id} is ${nonEmpty(row.status) ? row.status : "malformed"}`));
+    const marker = `relay-orca: ${segment(programId)}/${entry.outcome_id}`;
+    if (taskDisplayString(row) !== marker) failures.push(reason("PROOF_TASK_MARKER_MISMATCH", `mapped Orca task ${entry.orca_task_id} does not have the exact accepted-program marker`));
+    taskIds.push(entry.orca_task_id);
+  }
+  return { failures, taskIds };
+}
+
+function verifyCanonicalGates({ gates, receiptTasks, outcomes, programId, segment }) {
+  const gateIds = [];
+  const seenGateIds = new Set();
+  const failures = [];
+  for (const entry of receiptTasks.filter((task) => task.kind === "integration_gate").sort((left, right) => left.outcome_id.localeCompare(right.outcome_id))) {
+    const outcome = outcomes.get(entry.outcome_id);
+    let identity;
+    try {
+      identity = canonicalGateKey({
+        taskId: entry.orca_task_id,
+        question: canonicalIntegrationQuestion(programId, outcome.id, segment),
+      });
+    } catch {
+      failures.push(reason("PROOF_GATE_MALFORMED", `canonical integration gate identity for ${entry.outcome_id} is unavailable`));
+      continue;
+    }
+    const inspected = inspectCanonicalGates(gates, identity);
+    if (!inspected.ok) {
+      const code = inspected.reasonCode === "INTEGRATION_GATE_DUPLICATE"
+        ? "PROOF_GATE_DUPLICATE"
+        : inspected.reasonCode === "INTEGRATION_GATE_NONCANONICAL"
+          ? "PROOF_GATE_NONCANONICAL"
+          : inspected.reasonCode === "INTEGRATION_GATE_CONFLICT"
+            ? "PROOF_GATE_CONFLICT"
+            : "PROOF_GATE_MALFORMED";
+      failures.push(reason(code, `canonical integration gate for ${entry.outcome_id} is not uniquely trustworthy`));
+      continue;
+    }
+    if (inspected.state === "missing") failures.push(reason("PROOF_GATE_MISSING", `canonical integration gate for ${entry.outcome_id} is missing`));
+    else if (inspected.state === "pending") failures.push(reason("PROOF_GATE_PENDING", `canonical integration gate for ${entry.outcome_id} is pending`));
+    else if (inspected.state === "failed") failures.push(reason("PROOF_GATE_FAILED", `canonical integration gate for ${entry.outcome_id} failed`));
+    else {
+      const gate = inspected.gate;
+      const explicit = [gate.resolution, gate.result, gate.outcome].filter((value) => value === "passed");
+      const id = gateId(gate);
+      if (!id || explicit.length === 0) failures.push(reason("PROOF_GATE_MALFORMED", `canonical integration gate for ${entry.outcome_id} lacks an explicit passed resolution`));
+      else if (seenGateIds.has(id)) failures.push(reason("PROOF_GATE_DUPLICATE", `physical canonical gate ${id} is mapped by more than one accepted outcome`));
+      else {
+        seenGateIds.add(id);
+        gateIds.push(id);
+      }
+    }
+  }
+  return { failures, gateIds };
+}
+
+function verifyClosedProgram(input = {}) {
+  const programInput = input.acceptedProgram !== undefined ? input.acceptedProgram : input.program;
+  const parsedProgram = unwrapProgram(programInput);
+  if (parsedProgram.failure) return result({ ok: false, failures: [parsedProgram.failure] });
+  const segment = input.programSegment || defaultProgramSegment;
+  if (typeof segment !== "function") return result({ ok: false, programId: parsedProgram.programId, failures: [reason("PROOF_MALFORMED_INPUT", "collision-resistant program segment encoder is unavailable")] });
+  const parsedSnapshot = normalizeSnapshot(input.orcaSnapshot !== undefined ? input.orcaSnapshot : input.snapshot);
+  if (parsedSnapshot.failure) return result({ ok: false, programId: parsedProgram.programId, failures: [parsedSnapshot.failure] });
+  if (parsedProgram.program.runtime_id !== undefined && parsedProgram.program.runtime_id !== parsedSnapshot.runtimeId) {
+    return result({ ok: false, programId: parsedProgram.programId, runtimeId: parsedSnapshot.runtimeId, failures: [reason("PROOF_CROSS_RUNTIME", "accepted program runtime_id does not match the attributable Orca runtime")] });
+  }
+  const parsedReceipt = normalizeReceipt(input.receipt, parsedProgram.programId, parsedSnapshot.runtimeId);
+  if (parsedReceipt.failure) return result({ ok: false, programId: parsedProgram.programId, runtimeId: parsedSnapshot.runtimeId, failures: [parsedReceipt.failure] });
+  const receiptOutcomeIds = new Set(parsedReceipt.byOutcome.keys());
+  const acceptedIds = new Set(parsedProgram.byId.keys());
+  const mappingFailures = [];
+  for (const id of [...acceptedIds].sort()) {
+    if (!receiptOutcomeIds.has(id)) mappingFailures.push(reason("PROOF_OUTCOME_MISSING", `accepted outcome ${id} has no receipt mapping`));
+    else if (parsedReceipt.byOutcome.get(id).kind !== parsedProgram.byId.get(id).task_kind) mappingFailures.push(reason("PROOF_CROSS_PROGRAM", `receipt mapping for ${id} has the wrong outcome kind`));
+  }
+  for (const id of [...receiptOutcomeIds].sort()) if (!acceptedIds.has(id)) mappingFailures.push(reason("PROOF_CROSS_PROGRAM", `receipt maps unaccepted outcome ${id}`));
+  if (mappingFailures.length > 0) return result({ ok: false, programId: parsedProgram.programId, runtimeId: parsedSnapshot.runtimeId, outcomeIds: [...acceptedIds], taskIds: [...parsedReceipt.byTask.keys()], failures: mappingFailures });
+
+  const generic = input.trustedGenericIntegrationEvidence !== undefined
+    ? input.trustedGenericIntegrationEvidence
+    : input.genericIntegrationEvidence !== undefined ? input.genericIntegrationEvidence : input.integrationEvidence;
+  const genericResult = verifyGenericGates({ program: parsedProgram.program, programId: parsedProgram.programId, runtimeId: parsedSnapshot.runtimeId, exitGates: parsedProgram.exitGates, trustedEvidence: generic });
+  const durableInput = input.durableOutcomeEvidence !== undefined
+    ? input.durableOutcomeEvidence
+    : input.outcomeEvidence !== undefined ? input.outcomeEvidence : input.durableEvidence;
+  const durable = normalizeRecords(durableInput, "durable outcome evidence");
+  if (durable.failure) return result({ ok: false, programId: parsedProgram.programId, runtimeId: parsedSnapshot.runtimeId, outcomeIds: [...acceptedIds], taskIds: [...parsedReceipt.byTask.keys()], failures: [durable.failure] });
+  const durableFailures = [];
+  for (const id of [...acceptedIds].sort()) {
+    const record = durable.byId.get(id);
+    if (!record) durableFailures.push(reason("PROOF_OUTCOME_MISSING", `durable evidence for accepted outcome ${id} is missing`));
+    else {
+      const failure = checkDurableOutcome(record, parsedProgram.byId.get(id).task_kind, parsedProgram.programId, parsedSnapshot.runtimeId);
+      if (failure) durableFailures.push(failure);
+    }
+  }
+  for (const id of durable.byId.keys()) if (!acceptedIds.has(id)) durableFailures.push(reason("PROOF_CROSS_PROGRAM", `durable evidence contains unaccepted outcome ${id}`));
+  const live = verifyLiveTasks({ tasks: parsedSnapshot.tasks, receiptTasks: [...parsedReceipt.byOutcome.values()], programId: parsedProgram.programId, segment });
+  const canonical = verifyCanonicalGates({ gates: parsedSnapshot.gates, receiptTasks: [...parsedReceipt.byOutcome.values()], outcomes: parsedProgram.byId, programId: parsedProgram.programId, segment });
+  const failures = [...genericResult.failures, ...durableFailures, ...live.failures, ...canonical.failures];
+  return result({
+    ok: failures.length === 0,
+    programId: parsedProgram.programId,
+    runtimeId: parsedSnapshot.runtimeId,
+    outcomeIds: [...acceptedIds],
+    taskIds: live.taskIds,
+    gateIds: canonical.gateIds,
+    failures,
+  });
+}
+
+module.exports = {
+  PROOF_REASON_CODES,
+  verifyClosedProgram,
+  recomputeClosedProgramProof: verifyClosedProgram,
+  verifyClosedProgramProof: verifyClosedProgram,
+};

--- a/skills/relay-orca/scripts/lib/closed-program-proof.js
+++ b/skills/relay-orca/scripts/lib/closed-program-proof.js
@@ -24,6 +24,7 @@ const {
 const { isTerminalManifestState } = require("./manifest-parse");
 const { taskDisplayString } = require("./status-derive");
 const { programSegment: defaultProgramSegment } = require("./program-segment");
+const { pickStoppedOn } = require("./final-summary");
 
 const PROOF_REASON_CODES = Object.freeze([
   "PROOF_MALFORMED_INPUT",
@@ -110,9 +111,16 @@ function emptySummary(ok, failures) {
     code: failure.code,
     message: failure.message,
   }));
+  // `blocking_reasons` stays the deterministic sorted listing produced by result(); the
+  // single `stopped_on` token is the MOST SEVERE stop present, not the alphabetically-first
+  // failure. Map every failure code to its stop token and defer the severity ordering to
+  // lib/final-summary.js STOP_PRIORITY via pickStoppedOn (no forked severity policy). Every
+  // stoppedOn() token is a STOP_PRIORITY member, so a non-empty failure set always resolves.
+  const stopTokens = new Set(failures.map((failure) => stoppedOn(failure.code)));
+  if (stopTokens.size === 0) stopTokens.add(stoppedOn("PROOF_MALFORMED_INPUT"));
   return {
     program_complete: ok,
-    stopped_on: ok ? null : stoppedOn(failures[0] ? failures[0].code : "PROOF_MALFORMED_INPUT"),
+    stopped_on: ok ? null : pickStoppedOn(stopTokens),
     blocking_reasons: blocking,
     lifecycle_diagnostics: lifecycle,
   };
@@ -351,25 +359,55 @@ function checkIdentity(record, programId, runtimeId) {
   return null;
 }
 
-function checkRelayRun(record) {
+// Pull the receipt-mapped relay/fleet id for this outcome. Null when the receipt task
+// or its relay_ids are absent so the binding stays optional ("when present").
+function receiptRelayId(receiptTask, field) {
+  const ids = isObject(receiptTask) && isObject(receiptTask.relay_ids) ? receiptTask.relay_ids : null;
+  return ids && nonEmpty(ids[field]) ? ids[field] : null;
+}
+
+function numberLabel(value) {
+  return typeof value === "number" ? `#${value}` : "with no number";
+}
+
+function checkRelayRun(record, receiptTask) {
   const manifest = record.manifest || record.relay_manifest;
   if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} has no durable relay manifest`);
   if (manifest.state === "closed" || manifest.state === "escalated" || manifest.state === "failed") return reason("PROOF_STOPPED", `relay outcome ${record.outcome_id} is ${manifest.state}`);
   if (manifest.state !== "merged") return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} is not durably merged`);
+  // Bind durable evidence to the receipt mapping identity: a merged/closed shape alone is
+  // not authority. When the manifest carries a run id it must equal the receipt-mapped run.
+  const mappedRun = receiptRelayId(receiptTask, "run");
+  if (mappedRun && nonEmpty(manifest.run_id) && manifest.run_id !== mappedRun) {
+    return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} manifest run ${manifest.run_id} does not match the receipt-mapped run ${mappedRun}`);
+  }
   const pr = record.pr || (isObject(record.github) && record.github.pr);
   const issue = record.issue || (isObject(record.github) && record.github.issue);
   if (!isObject(pr) || !isObject(issue)) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} is missing GitHub evidence`);
   if (!((pr.state === "MERGED") || nonEmpty(pr.mergedAt))) return reason("PROOF_OUTCOME_FAILED", `relay outcome ${record.outcome_id} does not have a merged PR`);
-  if (manifest.head_sha !== undefined && manifest.head_sha !== pr.headRefOid) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} PR head differs from its merged manifest`);
+  // Absent manifest head_sha is optional, not stale (parseManifest nulls a missing
+  // git.head_sha). Flag stale only when BOTH SHAs are present non-empty strings and
+  // disagree — mirrors the status-classify PR_CHANGED head comparison.
+  if (nonEmpty(manifest.head_sha) && nonEmpty(pr.headRefOid) && manifest.head_sha !== pr.headRefOid) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} PR head differs from its merged manifest`);
+  // The manifest's declared PR/issue numbers must match the injected GitHub records before
+  // the outcome counts as complete_with_evidence — else foreign merged/closed records pass.
+  if (manifest.pr_number != null && pr.number !== manifest.pr_number) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} PR ${numberLabel(pr.number)} does not match its merged manifest PR #${manifest.pr_number}`);
   if (issue.state !== "CLOSED") return reason("PROOF_OUTCOME_FAILED", `relay outcome ${record.outcome_id} issue is not closed`);
+  if (manifest.issue_number != null && issue.number !== manifest.issue_number) return reason("PROOF_STALE_EVIDENCE", `relay outcome ${record.outcome_id} issue ${numberLabel(issue.number)} does not match its merged manifest issue #${manifest.issue_number}`);
   return null;
 }
 
-function checkFleet(record) {
+function checkFleet(record, receiptTask) {
   const manifest = record.fleet_manifest || record.fleetManifest;
   if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no durable fleet manifest`);
   if (manifest.fleet_state === "escalated" || manifest.state === "escalated") return reason("PROOF_STOPPED", `fleet outcome ${record.outcome_id} is escalated`);
   if (!(isTerminalManifestState(manifest.fleet_state) || isTerminalManifestState(manifest.state))) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} is not terminal`);
+  // Same receipt-mapping identity binding as relay runs: when the fleet manifest carries a
+  // fleet id it must equal the receipt-mapped fleet id.
+  const mappedFleet = receiptRelayId(receiptTask, "fleet");
+  if (mappedFleet && nonEmpty(manifest.fleet_id) && manifest.fleet_id !== mappedFleet) {
+    return reason("PROOF_STALE_EVIDENCE", `fleet outcome ${record.outcome_id} manifest fleet ${manifest.fleet_id} does not match the receipt-mapped fleet ${mappedFleet}`);
+  }
   const children = Array.isArray(record.fleet_children) ? record.fleet_children : Array.isArray(record.fleetChildren) ? record.fleetChildren : Array.isArray(manifest.children) ? manifest.children : null;
   if (!children || children.length === 0) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no child evidence`);
   for (const child of children) {
@@ -380,11 +418,11 @@ function checkFleet(record) {
   return null;
 }
 
-function checkDurableOutcome(record, kind, programId, runtimeId) {
+function checkDurableOutcome(record, kind, programId, runtimeId, receiptTask) {
   const identityFailure = checkIdentity(record, programId, runtimeId);
   if (identityFailure) return identityFailure;
-  if (kind === "relay_run") return checkRelayRun(record);
-  if (kind === "relay_fleet") return checkFleet(record);
+  if (kind === "relay_run") return checkRelayRun(record, receiptTask);
+  if (kind === "relay_fleet") return checkFleet(record, receiptTask);
   if (kind === "advisory_review") {
     const advisory = record.advisory || record;
     return advisory.evidence_posted === true && advisory.blocking_findings_triaged === true
@@ -522,7 +560,7 @@ function verifyClosedProgram(input = {}) {
     const record = durable.byId.get(id);
     if (!record) durableFailures.push(reason("PROOF_OUTCOME_MISSING", `durable evidence for accepted outcome ${id} is missing`));
     else {
-      const failure = checkDurableOutcome(record, parsedProgram.byId.get(id).task_kind, parsedProgram.programId, parsedSnapshot.runtimeId);
+      const failure = checkDurableOutcome(record, parsedProgram.byId.get(id).task_kind, parsedProgram.programId, parsedSnapshot.runtimeId, parsedReceipt.byOutcome.get(id));
       if (failure) durableFailures.push(failure);
     }
   }

--- a/skills/relay-orca/scripts/lib/closed-program-proof.js
+++ b/skills/relay-orca/scripts/lib/closed-program-proof.js
@@ -178,7 +178,8 @@ function normalizeSnapshot(input) {
     if (!isObject(value)) return null;
     const resultValue = isObject(value.result) ? value.result : {};
     const meta = isObject(value._meta) ? value._meta : {};
-    return [value.runtime_id, value.runtimeId, resultValue.runtime_id, resultValue.runtimeId, meta.runtime_id, meta.runtimeId]
+    const runtime = isObject(resultValue.runtime) ? resultValue.runtime : {};
+    return [value.runtime_id, value.runtimeId, resultValue.runtime_id, resultValue.runtimeId, runtime.runtime_id, runtime.runtimeId, meta.runtime_id, meta.runtimeId]
       .find(nonEmpty) || null;
   };
   const runtimeId = runtimeFrom(status);
@@ -187,8 +188,10 @@ function normalizeSnapshot(input) {
   if (!runtimeId || !taskRuntimeId || !gateRuntimeId || runtimeId !== taskRuntimeId || runtimeId !== gateRuntimeId) {
     return { failure: reason("PROOF_CROSS_RUNTIME", "status, task-list, and gate-list runtime ids must be present, non-empty, and identical") };
   }
-  const tasks = Array.isArray(taskList.tasks) ? taskList.tasks : null;
-  const gates = Array.isArray(gateList.gates) ? gateList.gates : null;
+  const taskResult = isObject(taskList.result) ? taskList.result : {};
+  const gateResult = isObject(gateList.result) ? gateList.result : {};
+  const tasks = Array.isArray(taskList.tasks) ? taskList.tasks : Array.isArray(taskResult.tasks) ? taskResult.tasks : null;
+  const gates = Array.isArray(gateList.gates) ? gateList.gates : Array.isArray(gateResult.gates) ? gateResult.gates : null;
   if (!tasks || !gates) return { failure: reason("PROOF_MALFORMED_INPUT", "Orca task-list and gate-list rows are missing or malformed") };
   return { runtimeId, tasks: tasks.slice(), gates: gates.slice() };
 }
@@ -200,15 +203,17 @@ function normalizeReceipt(receipt, programId, runtimeId) {
   if (!nonEmpty(receipt.runtime_id) || receipt.runtime_id !== runtimeId) return { failure: reason("PROOF_CROSS_RUNTIME", "receipt runtime_id does not match the attributable Orca runtime") };
   const byOutcome = new Map();
   const byTask = new Map();
+  const byRelayTask = new Map();
   for (const entry of receipt.tasks) {
-    if (!isObject(entry) || !nonEmpty(entry.outcome_id) || !nonEmpty(entry.kind) || !nonEmpty(entry.orca_task_id)) {
+    if (!isObject(entry) || !nonEmpty(entry.outcome_id) || !nonEmpty(entry.kind) || !nonEmpty(entry.task_id) || !nonEmpty(entry.orca_task_id)) {
       return { failure: reason("PROOF_MALFORMED_INPUT", "receipt contains a malformed outcome/task mapping") };
     }
-    if (byOutcome.has(entry.outcome_id) || byTask.has(entry.orca_task_id)) {
+    if (byOutcome.has(entry.outcome_id) || byTask.has(entry.orca_task_id) || byRelayTask.has(entry.task_id)) {
       return { failure: reason("PROOF_DUPLICATE_CONFLICT", "receipt outcome and Orca task mappings must be unique") };
     }
     byOutcome.set(entry.outcome_id, entry);
     byTask.set(entry.orca_task_id, entry);
+    byRelayTask.set(entry.task_id, entry);
   }
   return { receipt, byOutcome, byTask };
 }

--- a/skills/relay-orca/scripts/lib/closed-program-proof.js
+++ b/skills/relay-orca/scripts/lib/closed-program-proof.js
@@ -401,7 +401,7 @@ function fleetChildKey(child) {
   const runId = [child.run_id, child.runId].find(nonEmpty) || "";
   const leafRef = [child.leaf_ref, child.leafRef].find(nonEmpty) || "";
   if (runId === "" && leafRef === "") return null;
-  return `${runId} ${leafRef}`;
+  return `${runId}\0${leafRef}`;
 }
 
 // Sorted multiset of child identity keys (duplicates preserved so counts must match), or

--- a/skills/relay-orca/scripts/lib/closed-program-proof.js
+++ b/skills/relay-orca/scripts/lib/closed-program-proof.js
@@ -180,8 +180,13 @@ function unwrapProgram(input) {
 function normalizeSnapshot(input) {
   if (!isObject(input)) return { failure: reason("PROOF_CROSS_RUNTIME", "injected Orca snapshot is missing") };
   const status = isObject(input.status) ? input.status : input;
-  const taskList = isObject(input.task_list) ? input.task_list : isObject(input.taskList) ? input.taskList : input;
-  const gateList = isObject(input.gate_list) ? input.gate_list : isObject(input.gateList) ? input.gateList : input;
+  // A distinct task-list/gate-list object vs a compact snapshot that shares the top-level
+  // object. taskList/gateList still fall back to `input` for the tasks/gates rows below, but
+  // the shared object is NEVER used as a runtime-id source — see the compact rule below.
+  const taskListObj = isObject(input.task_list) ? input.task_list : isObject(input.taskList) ? input.taskList : null;
+  const gateListObj = isObject(input.gate_list) ? input.gate_list : isObject(input.gateList) ? input.gateList : null;
+  const taskList = taskListObj || input;
+  const gateList = gateListObj || input;
   const runtimeFrom = (value) => {
     if (!isObject(value)) return null;
     const resultValue = isObject(value.result) ? value.result : {};
@@ -190,10 +195,20 @@ function normalizeSnapshot(input) {
     return [value.runtime_id, value.runtimeId, resultValue.runtime_id, resultValue.runtimeId, runtime.runtime_id, runtime.runtimeId, meta.runtime_id, meta.runtimeId]
       .find(nonEmpty) || null;
   };
-  const runtimeId = runtimeFrom(status);
-  const taskRuntimeId = [input.taskRuntimeId, input.task_runtime_id, runtimeFrom(taskList)].find(nonEmpty) || null;
-  const gateRuntimeId = [input.gateRuntimeId, input.gate_runtime_id, runtimeFrom(gateList)].find(nonEmpty) || null;
-  if (!runtimeId || !taskRuntimeId || !gateRuntimeId || runtimeId !== taskRuntimeId || runtimeId !== gateRuntimeId) {
+  // DC #1: the status, task-list, and gate-list runtime ids are three INDEPENDENT reads that
+  // must each be present and agree. Collect every present runtime id from each read's own
+  // sources — for the task/gate reads that means the top-level explicit override plus, only
+  // when a distinct task_list/gate_list object exists, that object's own runtime id. A compact
+  // snapshot has no distinct object, so its task/gate ids MUST come from the explicit override
+  // and are never invented from the shared status object (which would make all three trivially
+  // agree). Every collected id must be non-empty and equal, and each read must supply at least
+  // one — so a disagreeing override or a missing read fails PROOF_CROSS_RUNTIME.
+  const statusIds = [runtimeFrom(status)].filter(nonEmpty);
+  const taskIds = [input.taskRuntimeId, input.task_runtime_id, taskListObj ? runtimeFrom(taskListObj) : null].filter(nonEmpty);
+  const gateIds = [input.gateRuntimeId, input.gate_runtime_id, gateListObj ? runtimeFrom(gateListObj) : null].filter(nonEmpty);
+  const runtimeId = statusIds[0] || null;
+  const allIds = [...statusIds, ...taskIds, ...gateIds];
+  if (statusIds.length === 0 || taskIds.length === 0 || gateIds.length === 0 || allIds.some((id) => id !== runtimeId)) {
     return { failure: reason("PROOF_CROSS_RUNTIME", "status, task-list, and gate-list runtime ids must be present, non-empty, and identical") };
   }
   const taskResult = isObject(taskList.result) ? taskList.result : {};
@@ -420,6 +435,19 @@ function childIdentitiesEqual(declared, supplied) {
   return supplied !== null && declared.length === supplied.length && declared.every((key, index) => key === supplied[index]);
 }
 
+// Classify how completely a declared child roster carries identity: "none" (no child declares
+// a { run_id, leaf_ref } — the authoritative-has-no-id branch, binding omitted as before),
+// "all" (every child declares identity — bind exact multiset equality), or "mixed" (some
+// declare identity and some do not — a partially unidentified roster that fails closed as
+// stale/malformed rather than being silently trusted). Per DC #3, once ANY declared child
+// carries identity, EVERY declared child must.
+function rosterIdentityCoverage(children) {
+  const identified = children.filter((child) => fleetChildKey(child) !== null).length;
+  if (identified === 0) return "none";
+  if (identified === children.length) return "all";
+  return "mixed";
+}
+
 function checkRelayRun(record, receiptTask) {
   const manifest = record.manifest || record.relay_manifest;
   if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `relay outcome ${record.outcome_id} has no durable relay manifest`);
@@ -452,7 +480,10 @@ function checkFleet(record, receiptTask) {
   const manifest = record.fleet_manifest || record.fleetManifest;
   if (!isObject(manifest)) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} has no durable fleet manifest`);
   if (manifest.fleet_state === "escalated" || manifest.state === "escalated") return reason("PROOF_STOPPED", `fleet outcome ${record.outcome_id} is escalated`);
-  if (!(isTerminalManifestState(manifest.fleet_state) || isTerminalManifestState(manifest.state))) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} is not terminal`);
+  // DC #1: `fleet_state` is the ONLY fleet closed authority. A live/derived `manifest.state`
+  // is never sufficient authority for terminality, so it must NOT substitute for `fleet_state`
+  // here (the escalated stop above still honors either field, which only ever fails closed).
+  if (!isTerminalManifestState(manifest.fleet_state)) return reason("PROOF_OUTCOME_INCOMPLETE", `fleet outcome ${record.outcome_id} is not terminal`);
   // Same uniform binding as relay runs: when the receipt maps a fleet id, the manifest MUST
   // carry the same fleet id — an omitted manifest fleet id fails closed, never skips.
   const fleetFailure = bindMappedId(receiptRelayId(receiptTask, "fleet"), manifest.fleet_id, `fleet outcome ${record.outcome_id}`, "fleet");
@@ -466,8 +497,16 @@ function checkFleet(record, receiptTask) {
   const declaredChildren = Array.isArray(manifest.children) ? manifest.children : Array.isArray(manifest.fleet_children) ? manifest.fleet_children : null;
   const suppliedChildren = Array.isArray(record.fleet_children) ? record.fleet_children : Array.isArray(record.fleetChildren) ? record.fleetChildren : null;
   if (suppliedChildren && declaredChildren) {
-    const declaredKeys = fleetChildIdentities(declaredChildren);
-    if (declaredKeys && !childIdentitiesEqual(declaredKeys, fleetChildIdentities(suppliedChildren))) {
+    const coverage = rosterIdentityCoverage(declaredChildren);
+    // A partially identified declared roster is malformed authority — it fails closed rather
+    // than skipping the binding, so a forged child cannot hide behind an identity-less sibling.
+    if (coverage === "mixed") {
+      return reason("PROOF_STALE_EVIDENCE", `fleet outcome ${record.outcome_id} declared children are only partially identified`);
+    }
+    // "all" → every declared child carries identity, so require exact multiset equality with the
+    // supplied roster before any child state is trusted. "none" → authoritative-has-no-id branch,
+    // binding omitted (existing behavior for a fully identity-less roster).
+    if (coverage === "all" && !childIdentitiesEqual(fleetChildIdentities(declaredChildren), fleetChildIdentities(suppliedChildren))) {
       return reason("PROOF_STALE_EVIDENCE", `fleet outcome ${record.outcome_id} child evidence does not match the fleet manifest's declared children`);
     }
   }

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -485,6 +485,7 @@ module.exports = {
   CANONICAL_OPTIONS,
   EVIDENCE_PROVENANCE_FIELDS,
   IntegrationLifecycleError,
+  gateId,
   canonicalIntegrationQuestion,
   canonicalGateKey,
   gateResolution,

--- a/skills/relay-orca/scripts/lib/program-segment.js
+++ b/skills/relay-orca/scripts/lib/program-segment.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// Pure collision-resistant accepted-program segment shared by receipt paths and
+// runtime task markers. The readable prefix is bounded; the hash is over the full
+// program id so sanitization never aliases two programs.
+const crypto = require("node:crypto");
+
+const MAX_SEGMENT_PREFIX = 64;
+
+function programSegment(programId) {
+  const raw = String(programId == null ? "" : programId);
+  const sanitized = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  const readable = sanitized === "" || sanitized === "." || sanitized === ".." ? "program" : sanitized;
+  const base = readable.slice(0, MAX_SEGMENT_PREFIX).replace(/-+$/, "");
+  const hash = crypto.createHash("sha256").update(raw).digest("hex").slice(0, 8);
+  return `${base}-${hash}`;
+}
+
+module.exports = { MAX_SEGMENT_PREFIX, programSegment };

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -421,4 +421,4 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
   return orderReport(report);
 }
 
-module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers, discoverFleetBackPointers, summarizeLiveDispatch };
+module.exports = { deriveStatusReport, attributeRuntime, detectDuplicateMappings, discoverBackPointers, discoverFleetBackPointers, summarizeLiveDispatch, taskDisplayString };

--- a/skills/relay-orca/scripts/receipt-io.js
+++ b/skills/relay-orca/scripts/receipt-io.js
@@ -12,6 +12,7 @@ const crypto = require("node:crypto");
 const { execFileSync } = require("node:child_process");
 const { computeRepoSlug } = require("./lib/repo-slug");
 const { boundedExcerpt } = require("./lib/bounded-excerpt");
+const { programSegment } = require("./lib/program-segment");
 
 const GIT_TIMEOUT_MS = 10000;
 
@@ -118,32 +119,6 @@ function fleetsRoot() {
   const relayHome = absoluteEnvDir(process.env.RELAY_HOME);
   if (relayHome) return path.join(relayHome, "fleets");
   return path.join(os.homedir(), ".relay", "fleets");
-}
-
-// Program id → a single safe path segment (never traverses) that is ALSO
-// collision-resistant (#945 A6). A pure sanitize is lossy — `"a b"` and `"a+b"` both
-// collapse to `"a-b"`, which would silently point two distinct programs at ONE receipt.
-// So the segment is the sanitized base joined to the first 8 hex of sha256(raw id): the
-// hash disambiguates ids that sanitize identically while the sanitized prefix keeps the
-// path human-readable. run.js and status.js apply this identically, so a `run`-written
-// receipt resolves back for `status`. `.` and `..` (and empty) collapse to `program`
-// so a pathological id can never escape <programs-root>/<repo-slug>/<segment>/, and the
-// hash still keeps `.` and `..` on distinct paths.
-// A15: the readable prefix is bounded to at most 64 chars so a very long program id can
-// never overflow the filesystem per-segment name limit (NAME_MAX, typically 255). The
-// 8-hex hash is ALWAYS appended and is computed over the FULL raw id, so two long ids
-// that share a 64-char prefix still resolve to DISTINCT segments.
-const MAX_SEGMENT_PREFIX = 64;
-
-function programSegment(programId) {
-  const raw = String(programId == null ? "" : programId);
-  const sanitized = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  const readable = sanitized === "" || sanitized === "." || sanitized === ".." ? "program" : sanitized;
-  // Truncate to the readable-prefix bound, re-trimming any trailing dash the cut exposes
-  // (the first char is always non-dash, so the result is never empty).
-  const base = readable.slice(0, MAX_SEGMENT_PREFIX).replace(/-+$/, "");
-  const hash = crypto.createHash("sha256").update(raw).digest("hex").slice(0, 8);
-  return `${base}-${hash}`;
 }
 
 function receiptPathFor(slug, programId) {

--- a/tests/relay-orca/scripts/closed-program-proof.test.js
+++ b/tests/relay-orca/scripts/closed-program-proof.test.js
@@ -134,6 +134,59 @@ function verify(overrides = {}) {
   return PROOF.verifyClosedProgram(fixture(overrides));
 }
 
+const FLEET_OUTCOME_ID = "fleet-leaf";
+const FLEET_ID = "fleet-xyz";
+const TRACKER_OUTCOME_ID = "tracker-recon";
+const TRACKER_RUN_ID = "run-tracker";
+
+function liveRow(outcomeId, orcaTaskId) {
+  return { id: orcaTaskId, task_title: `relay-orca: ${programSegment(PROGRAM_ID)}/${outcomeId}`, status: "completed", worker_done: true };
+}
+
+// A relay_fleet outcome added alongside the base relay_run + integration_gate outcomes so
+// the shared exit-gate/generic-evidence machinery stays satisfied while checkFleet runs.
+function fleetFixture() {
+  const inputs = fixture();
+  inputs.acceptedProgram.outcomes.push({ id: FLEET_OUTCOME_ID, task_kind: "relay_fleet", accepted_outcomes: ["closed"] });
+  inputs.receipt.tasks.push({
+    ...receiptTask(FLEET_OUTCOME_ID, "relay_fleet", "orca-fleet"),
+    relay_ids: { request: null, run: null, fleet: FLEET_ID },
+  });
+  inputs.orcaSnapshot.task_list.tasks.push(liveRow(FLEET_OUTCOME_ID, "orca-fleet"));
+  inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID] = {
+    fleet_manifest: {
+      fleet_state: "closed",
+      fleet_id: FLEET_ID,
+      children: [
+        { run_id: "child-run-1", leaf_ref: "leaf-1" },
+        { run_id: "child-run-2", leaf_ref: "leaf-2" },
+      ],
+    },
+    fleet_children: [
+      { run_id: "child-run-1", leaf_ref: "leaf-1", state: "merged" },
+      { run_id: "child-run-2", leaf_ref: "leaf-2", state: "merged" },
+    ],
+  };
+  return inputs;
+}
+
+// A tracker_reconciliation outcome added the same way so checkDurableOutcome's tracker
+// branch runs against a fully consistent program.
+function trackerFixture() {
+  const inputs = fixture();
+  inputs.acceptedProgram.outcomes.push({ id: TRACKER_OUTCOME_ID, task_kind: "tracker_reconciliation", accepted_outcomes: ["closed"] });
+  inputs.receipt.tasks.push({
+    ...receiptTask(TRACKER_OUTCOME_ID, "tracker_reconciliation", "orca-tracker"),
+    relay_ids: { request: null, run: TRACKER_RUN_ID, fleet: null },
+  });
+  inputs.orcaSnapshot.task_list.tasks.push(liveRow(TRACKER_OUTCOME_ID, "orca-tracker"));
+  inputs.durableOutcomeEvidence[TRACKER_OUTCOME_ID] = {
+    manifest: { state: "closed", run_id: TRACKER_RUN_ID, issue_number: 303 },
+    issue: { state: "CLOSED", number: 303 },
+  };
+  return inputs;
+}
+
 test("closed-program proof recomputes the exact identity and keeps generic/lifecycle names distinct", () => {
   const result = verify();
   assert.equal(result.ok, true);
@@ -325,4 +378,116 @@ test("the verifier does not change the frozen receipt or report shapes", () => {
   assert.equal(result.ok, true);
   assert.equal(JSON.stringify(inputs.receipt), receiptBefore);
   assert.deepEqual(Object.keys(result.final_summary).sort(), ["blocking_reasons", "lifecycle_diagnostics", "program_complete", "stopped_on"].sort());
+});
+
+// #1021 class closure: whenever a receipt maps a run id, the manifest MUST carry the same
+// run id — an absent manifest run id is a fail-closed mismatch, never a skip.
+test("relay run identity: mapped run id requires a matching manifest run id; absent or mismatched manifest run id fails closed", () => {
+  const cases = [
+    // mapping present, manifest run id ABSENT (the R4 class-closure case) → fail closed.
+    { mutate: (inputs) => { delete inputs.durableOutcomeEvidence["relay-build"].manifest.run_id; }, ok: false, match: /omits the run id/ },
+    // mapping present, manifest run id MISMATCH → fail closed.
+    { mutate: (inputs) => { inputs.durableOutcomeEvidence["relay-build"].manifest.run_id = "run-foreign"; }, ok: false, match: /does not match/ },
+    // mapping present, manifest run id MATCH → accepted.
+    { mutate: () => {}, ok: true },
+    // mapping ABSENT (receipt declares no run id) → comparison skipped, existing behavior.
+    {
+      mutate: (inputs) => {
+        inputs.receipt.tasks.find((task) => task.outcome_id === "relay-build").relay_ids.run = null;
+        delete inputs.durableOutcomeEvidence["relay-build"].manifest.run_id;
+      },
+      ok: true,
+    },
+  ];
+  for (const { mutate, ok, match } of cases) {
+    const inputs = fixture();
+    mutate(inputs);
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, ok);
+    if (!ok) {
+      assert.equal(result.reasonCode, "PROOF_STALE_EVIDENCE");
+      assert.match(result.message, match);
+      assert.equal(result.final_summary.program_complete, false);
+      assert.notEqual(result.final_summary.stopped_on, null);
+    }
+  }
+});
+
+test("fleet identity: mapped fleet id requires a matching manifest fleet id; absent or mismatched manifest fleet id fails closed", () => {
+  assert.equal(PROOF.verifyClosedProgram(fleetFixture()).ok, true); // mapping present + match → accepted
+  for (const { mutate, match } of [
+    { mutate: (inputs) => { delete inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.fleet_id; }, match: /omits the fleet id/ },
+    { mutate: (inputs) => { inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.fleet_id = "fleet-foreign"; }, match: /does not match/ },
+  ]) {
+    const inputs = fleetFixture();
+    mutate(inputs);
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_STALE_EVIDENCE");
+    assert.match(result.message, match);
+  }
+  // mapping ABSENT (receipt declares no fleet id) → comparison skipped even when manifest id absent.
+  const skip = fleetFixture();
+  skip.receipt.tasks.find((task) => task.outcome_id === FLEET_OUTCOME_ID).relay_ids.fleet = null;
+  delete skip.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.fleet_id;
+  assert.equal(PROOF.verifyClosedProgram(skip).ok, true);
+});
+
+test("fleet children must equal the manifest's declared roster exactly before any child state is trusted", () => {
+  for (const mutate of [
+    // subset: supplied drops a declared child.
+    (inputs) => { inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_children = [{ run_id: "child-run-1", leaf_ref: "leaf-1", state: "merged" }]; },
+    // superset: supplied adds a child the manifest never declared.
+    (inputs) => { inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_children.push({ run_id: "child-run-3", leaf_ref: "leaf-3", state: "merged" }); },
+    // renamed: supplied forges one declared child's run id.
+    (inputs) => { inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_children[1].run_id = "child-run-forged"; },
+    // identity-less: a supplied child omits both ids the manifest declares.
+    (inputs) => { inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_children[1] = { state: "merged" }; },
+    // duplicated: supplied repeats one child so it no longer matches the declared roster.
+    (inputs) => { inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_children[1] = { run_id: "child-run-1", leaf_ref: "leaf-1", state: "merged" }; },
+  ]) {
+    const inputs = fleetFixture();
+    mutate(inputs);
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_STALE_EVIDENCE");
+    assert.match(result.message, /does not match the fleet manifest's declared children/);
+  }
+  // Identity is checked BEFORE child state: an exactly-matching roster with a failed child
+  // still surfaces the child-state stop, proving the identity gate did not mask it.
+  const failedChild = fleetFixture();
+  failedChild.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_children[1].state = "failed";
+  assert.equal(PROOF.verifyClosedProgram(failedChild).reasonCode, "PROOF_STOPPED");
+  // Binding is OMITTED when the manifest declares no child identities (authoritative-has-no-id).
+  const noDeclaredIds = fleetFixture();
+  noDeclaredIds.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.children = [{ state: "merged" }, { state: "merged" }];
+  assert.equal(PROOF.verifyClosedProgram(noDeclaredIds).ok, true);
+});
+
+test("tracker reconciliation binds the receipt-mapped run and the declared issue number", () => {
+  assert.equal(PROOF.verifyClosedProgram(trackerFixture()).ok, true); // both mappings present + match → accepted
+  for (const { mutate, match } of [
+    // receipt-mapped run present, manifest run id ABSENT → fail closed.
+    { mutate: (inputs) => { delete inputs.durableOutcomeEvidence[TRACKER_OUTCOME_ID].manifest.run_id; }, match: /omits the run id/ },
+    // receipt-mapped run present, manifest run id MISMATCH → fail closed.
+    { mutate: (inputs) => { inputs.durableOutcomeEvidence[TRACKER_OUTCOME_ID].manifest.run_id = "run-foreign"; }, match: /does not match/ },
+    // declared issue number present, injected issue number ABSENT → fail closed.
+    { mutate: (inputs) => { delete inputs.durableOutcomeEvidence[TRACKER_OUTCOME_ID].issue.number; }, match: /does not match/ },
+    // declared issue number present, injected issue number MISMATCH → fail closed.
+    { mutate: (inputs) => { inputs.durableOutcomeEvidence[TRACKER_OUTCOME_ID].issue.number = 999; }, match: /does not match/ },
+  ]) {
+    const inputs = trackerFixture();
+    mutate(inputs);
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_STALE_EVIDENCE");
+    assert.match(result.message, match);
+  }
+  // Both mappings ABSENT → comparisons skipped (existing behavior preserved).
+  const skip = trackerFixture();
+  skip.receipt.tasks.find((task) => task.outcome_id === TRACKER_OUTCOME_ID).relay_ids.run = null;
+  delete skip.durableOutcomeEvidence[TRACKER_OUTCOME_ID].manifest.run_id;
+  skip.durableOutcomeEvidence[TRACKER_OUTCOME_ID].manifest.issue_number = null;
+  skip.durableOutcomeEvidence[TRACKER_OUTCOME_ID].issue.number = 999;
+  assert.equal(PROOF.verifyClosedProgram(skip).ok, true);
 });

--- a/tests/relay-orca/scripts/closed-program-proof.test.js
+++ b/tests/relay-orca/scripts/closed-program-proof.test.js
@@ -1,0 +1,248 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
+const PROOF = require(path.join(SCRIPTS, "lib", "closed-program-proof.js"));
+const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
+const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
+const { verificationBinding, canonicalJson, sha256 } = require(path.join(SCRIPTS, "lib", "integration-evidence.js"));
+const { canonicalIntegrationQuestion } = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
+
+const PROGRAM_ID = "proof-program/2026-07";
+const RUNTIME_ID = "runtime-proof-1";
+const OUTCOME_ID = "integration-main-suite";
+const RAW_CHECK_REF = "full-suite";
+
+function receiptTask(outcomeId, kind, orcaTaskId) {
+  return {
+    outcome_id: outcomeId,
+    task_id: `relay-task-${outcomeId}`,
+    kind,
+    wave: 1,
+    orca_task_id: orcaTaskId,
+    dispatch_id: `dispatch-${outcomeId}`,
+    assignee: `operator-${outcomeId}`,
+    relay_ids: { request: null, run: kind === "relay_run" ? `run-${outcomeId}` : null, fleet: null },
+  };
+}
+
+function makeVerification(passed = true) {
+  return verificationBinding({
+    input_sha256: `sha256:${"a".repeat(64)}`,
+    result_sha256: `sha256:${passed ? "b" : "c"}`.repeat(64),
+    passed,
+  });
+}
+
+function genericArtifact({ programId = PROGRAM_ID, runtimeId = RUNTIME_ID, checkRef = RAW_CHECK_REF, passed = true } = {}) {
+  return {
+    schema: 1,
+    program_id: programId,
+    runtime_id: runtimeId,
+    check_ref: checkRef,
+    verification: makeVerification(passed),
+    evidence: "fixture evidence; not parsed by the verifier",
+  };
+}
+
+function acceptedProgram() {
+  return {
+    id: PROGRAM_ID,
+    outcomes: [
+      { id: "relay-build", task_kind: "relay_run", accepted_outcomes: ["merged"] },
+      { id: OUTCOME_ID, task_kind: "integration_gate", accepted_outcomes: ["passed"] },
+    ],
+    exit_gates: [`integration:${RAW_CHECK_REF}`],
+    integration_evidence_version: 1,
+    integration_evidence: [{
+      program_id: PROGRAM_ID,
+      runtime_id: RUNTIME_ID,
+      check_ref: RAW_CHECK_REF,
+      verification: makeVerification(true),
+    }],
+  };
+}
+
+function receipt(stopped = {}) {
+  return {
+    schema: 1,
+    program_id: PROGRAM_ID,
+    source: "/tmp/accepted-program.json",
+    repo: { slug: "fixture-repo", root: "/tmp/fixture-repo" },
+    runtime_id: RUNTIME_ID,
+    tasks: [
+      receiptTask("relay-build", "relay_run", "orca-build"),
+      receiptTask(OUTCOME_ID, "integration_gate", "orca-integration"),
+    ],
+    terminals_created: [],
+    created_at: "2026-07-20T00:00:00.000Z",
+    updated_at: "2026-07-20T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+    ...stopped,
+  };
+}
+
+function canonicalGate({ id = "gate-integration", resolution = "passed", status = "passed", question = canonicalIntegrationQuestion(PROGRAM_ID, OUTCOME_ID, programSegment) } = {}) {
+  return {
+    id,
+    task_id: "orca-integration",
+    question,
+    options: ["passed", "failed"],
+    resolution,
+    status,
+  };
+}
+
+function fixture(overrides = {}) {
+  const program = acceptedProgram();
+  const baseReceipt = receipt();
+  const outcomeEvidence = {
+    "relay-build": {
+      manifest: { state: "merged", pr_number: 101, issue_number: 202, head_sha: "abc" },
+      pr: { state: "MERGED", mergedAt: "2026-07-20T00:01:00.000Z", headRefOid: "abc" },
+      issue: { state: "CLOSED" },
+    },
+    [OUTCOME_ID]: { integration: { report_present: true } },
+  };
+  const tasks = [
+    { id: "orca-build", task_title: `relay-orca: ${programSegment(PROGRAM_ID)}/relay-build`, status: "completed", worker_done: true },
+    { id: "orca-integration", task_title: `relay-orca: ${programSegment(PROGRAM_ID)}/${OUTCOME_ID}`, status: "completed", worker_done: true },
+  ];
+  const snapshot = {
+    status: { runtime_id: RUNTIME_ID },
+    task_list: { runtime_id: RUNTIME_ID, tasks },
+    gate_list: { runtime_id: RUNTIME_ID, gates: [canonicalGate()] },
+  };
+  const inputs = {
+    acceptedProgram: program,
+    receipt: baseReceipt,
+    trustedGenericIntegrationEvidence: { [RAW_CHECK_REF]: genericArtifact() },
+    durableOutcomeEvidence: outcomeEvidence,
+    orcaSnapshot: snapshot,
+    programSegment,
+    ...overrides,
+  };
+  return inputs;
+}
+
+function verify(overrides = {}) {
+  return PROOF.verifyClosedProgram(fixture(overrides));
+}
+
+test("closed-program proof recomputes the exact identity and keeps generic/lifecycle names distinct", () => {
+  const result = verify();
+  assert.equal(result.ok, true);
+  assert.equal(result.program_id, PROGRAM_ID);
+  assert.equal(result.runtime_id, RUNTIME_ID);
+  assert.deepEqual(result.outcome_ids, [OUTCOME_ID, "relay-build"].sort());
+  assert.deepEqual(result.orca_task_ids, ["orca-build", "orca-integration"]);
+  assert.deepEqual(result.integration_gate_ids, ["gate-integration"]);
+  assert.equal(result.final_summary.program_complete, true);
+  assert.equal(result.final_summary.stopped_on, null);
+  assert.deepEqual(result.final_summary.blocking_reasons, []);
+  assert.deepEqual(result.final_summary.lifecycle_diagnostics, []);
+});
+
+test("proof is byte-deterministic across accepted, receipt, live, and evidence ordering", () => {
+  const first = verify();
+  const inputs = fixture();
+  inputs.acceptedProgram.outcomes.reverse();
+  inputs.receipt.tasks.reverse();
+  inputs.orcaSnapshot.task_list.tasks.reverse();
+  inputs.orcaSnapshot.gate_list.gates.reverse();
+  inputs.trustedGenericIntegrationEvidence = [{ ...genericArtifact() }];
+  inputs.durableOutcomeEvidence = [
+    { outcome_id: OUTCOME_ID, integration: { report_present: true } },
+    { outcome_id: "relay-build", manifest: { state: "merged", pr_number: 101, issue_number: 202, head_sha: "abc" }, pr: { state: "MERGED", mergedAt: "2026-07-20T00:01:00.000Z", headRefOid: "abc" }, issue: { state: "CLOSED" } },
+  ];
+  const second = PROOF.verifyClosedProgram(inputs);
+  assert.deepEqual(second, first);
+});
+
+test("receipt stop drill and caller false-complete bits are not proof authority", () => {
+  const inputs = fixture({ receipt: receipt({ stopped_at: "2026-07-20T00:02:00.000Z", stop_reason: "operator drill" }), program_complete: true, finalSummary: { program_complete: true, stopped_on: null } });
+  const result = PROOF.verifyClosedProgram(inputs);
+  assert.equal(result.ok, true);
+  assert.equal(result.receipt_stopped_at, undefined);
+});
+
+test("failed or active live task fails even when durable evidence claims closure", () => {
+  for (const status of ["failed", "dispatched"]) {
+    const inputs = fixture();
+    inputs.orcaSnapshot.task_list.tasks.find((task) => task.id === "orca-build").status = status;
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false, status);
+    assert.match(result.reasonCode, /^PROOF_TASK_/);
+  }
+});
+
+test("missing, cross-runtime, stale, and failed generic evidence fail closed", () => {
+  for (const overrides of [
+    { trustedGenericIntegrationEvidence: {} },
+    { trustedGenericIntegrationEvidence: { [RAW_CHECK_REF]: genericArtifact({ runtimeId: "other-runtime" }) } },
+    { trustedGenericIntegrationEvidence: { [RAW_CHECK_REF]: { ...genericArtifact(), verification: makeVerification(false) } } },
+    { trustedGenericIntegrationEvidence: { [RAW_CHECK_REF]: genericArtifact({ programId: "other-program" }) } },
+  ]) {
+    const result = verify(overrides);
+    assert.equal(result.ok, false);
+    assert.match(result.reasonCode, /^PROOF_EVIDENCE_/);
+  }
+});
+
+test("canonical integration gate must be exactly one, passed, and canonical", () => {
+  for (const gates of [
+    [canonicalGate({ status: "pending", resolution: undefined })],
+    [canonicalGate({ status: "failed", resolution: "failed" })],
+    [canonicalGate({ question: "same words, wrong identity" })],
+    [canonicalGate(), canonicalGate({ id: "gate-duplicate" })],
+  ]) {
+    const result = verify({ orcaSnapshot: { ...fixture().orcaSnapshot, gate_list: { runtime_id: RUNTIME_ID, gates } } });
+    assert.equal(result.ok, false);
+    assert.match(result.reasonCode, /^PROOF_GATE_/);
+  }
+});
+
+test("runtime identity requires all three structured Orca reads to be present and identical", () => {
+  for (const snapshot of [
+    { status: { runtime_id: RUNTIME_ID }, task_list: { runtime_id: "other", tasks: [] }, gate_list: { runtime_id: RUNTIME_ID, gates: [] } },
+    { status: { runtime_id: "" }, task_list: { runtime_id: RUNTIME_ID, tasks: [] }, gate_list: { runtime_id: RUNTIME_ID, gates: [] } },
+  ]) {
+    const result = verify({ orcaSnapshot: { ...fixture().orcaSnapshot, ...snapshot } });
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_CROSS_RUNTIME");
+  }
+});
+
+test("a false-complete durable summary cannot mask an incomplete manifest", () => {
+  const inputs = fixture();
+  inputs.durableOutcomeEvidence["relay-build"].manifest.state = "review_pending";
+  inputs.finalSummary = { program_complete: true, stopped_on: null, blocking_reasons: [] };
+  const result = PROOF.verifyClosedProgram(inputs);
+  assert.equal(result.ok, false);
+  assert.equal(result.reasonCode, "PROOF_OUTCOME_INCOMPLETE");
+  assert.equal(result.final_summary.program_complete, false);
+  assert.notEqual(result.final_summary.stopped_on, null);
+});
+
+test("pure verifier has no filesystem, Orca, or GitHub mutation boundary", () => {
+  const source = fs.readFileSync(path.join(SCRIPTS, "lib", "closed-program-proof.js"), "utf8");
+  assert.doesNotMatch(source, /node:fs|node:child_process|execSync|spawn|writeFile|unlink|reset|task-create|gate-resolve/);
+  const before = JSON.stringify(fixture());
+  verify();
+  assert.equal(JSON.stringify(fixture()), before);
+});
+
+test("the verifier does not change the frozen receipt or report shapes", () => {
+  const inputs = fixture();
+  const receiptBefore = JSON.stringify(inputs.receipt);
+  const result = PROOF.verifyClosedProgram(inputs);
+  assert.equal(result.ok, true);
+  assert.equal(JSON.stringify(inputs.receipt), receiptBefore);
+  assert.deepEqual(Object.keys(result.final_summary).sort(), ["blocking_reasons", "lifecycle_diagnostics", "program_complete", "stopped_on"].sort());
+});
+

--- a/tests/relay-orca/scripts/closed-program-proof.test.js
+++ b/tests/relay-orca/scripts/closed-program-proof.test.js
@@ -103,9 +103,9 @@ function fixture(overrides = {}) {
   const baseReceipt = receipt();
   const outcomeEvidence = {
     "relay-build": {
-      manifest: { state: "merged", pr_number: 101, issue_number: 202, head_sha: "abc" },
-      pr: { state: "MERGED", mergedAt: "2026-07-20T00:01:00.000Z", headRefOid: "abc" },
-      issue: { state: "CLOSED" },
+      manifest: { state: "merged", run_id: "run-relay-build", pr_number: 101, issue_number: 202, head_sha: "abc" },
+      pr: { state: "MERGED", mergedAt: "2026-07-20T00:01:00.000Z", headRefOid: "abc", number: 101 },
+      issue: { state: "CLOSED", number: 202 },
     },
     [OUTCOME_ID]: { integration: { report_present: true } },
   };
@@ -158,7 +158,7 @@ test("proof is byte-deterministic across accepted, receipt, live, and evidence o
   inputs.trustedGenericIntegrationEvidence = [{ ...genericArtifact() }];
   inputs.durableOutcomeEvidence = [
     { outcome_id: OUTCOME_ID, integration: { report_present: true } },
-    { outcome_id: "relay-build", manifest: { state: "merged", pr_number: 101, issue_number: 202, head_sha: "abc" }, pr: { state: "MERGED", mergedAt: "2026-07-20T00:01:00.000Z", headRefOid: "abc" }, issue: { state: "CLOSED" } },
+    { outcome_id: "relay-build", manifest: { state: "merged", run_id: "run-relay-build", pr_number: 101, issue_number: 202, head_sha: "abc" }, pr: { state: "MERGED", mergedAt: "2026-07-20T00:01:00.000Z", headRefOid: "abc", number: 101 }, issue: { state: "CLOSED", number: 202 } },
   ];
   const second = PROOF.verifyClosedProgram(inputs);
   assert.deepEqual(second, first);
@@ -248,6 +248,66 @@ test("a false-complete durable summary cannot mask an incomplete manifest", () =
   assert.equal(result.reasonCode, "PROOF_OUTCOME_INCOMPLETE");
   assert.equal(result.final_summary.program_complete, false);
   assert.notEqual(result.final_summary.stopped_on, null);
+});
+
+test("durable evidence must match the receipt-mapped run/PR/issue identity, not a generic merged shape", () => {
+  const cases = [
+    // Manifest run id disagrees with the receipt-mapped run-relay-build.
+    (evidence) => { evidence["relay-build"].manifest.run_id = "run-foreign"; },
+    // Injected PR record number disagrees with the merged manifest's declared PR number.
+    (evidence) => { evidence["relay-build"].pr.number = 999; },
+    // Injected PR record carries no number at all, so identity cannot be confirmed.
+    (evidence) => { delete evidence["relay-build"].pr.number; },
+    // Injected issue record number disagrees with the merged manifest's declared issue number.
+    (evidence) => { evidence["relay-build"].issue.number = 888; },
+  ];
+  for (const mutate of cases) {
+    const inputs = fixture();
+    mutate(inputs.durableOutcomeEvidence);
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_STALE_EVIDENCE");
+    assert.match(result.message, /does not match/);
+    assert.equal(result.final_summary.program_complete, false);
+    assert.notEqual(result.final_summary.stopped_on, null);
+  }
+});
+
+test("absent manifest head_sha is optional, but two present disagreeing SHAs stay stale", () => {
+  // A valid merged manifest whose head_sha is null/absent (parseManifest nulls a missing
+  // git.head_sha) is accepted, and a present-but-absent live head is not treated as stale.
+  for (const mutate of [
+    (record) => { record.manifest.head_sha = null; },
+    (record) => { delete record.manifest.head_sha; },
+    (record) => { delete record.pr.headRefOid; },
+  ]) {
+    const inputs = fixture();
+    mutate(inputs.durableOutcomeEvidence["relay-build"]);
+    assert.equal(PROOF.verifyClosedProgram(inputs).ok, true);
+  }
+  // Both SHAs present and disagreeing is still stale evidence.
+  const stale = fixture();
+  stale.durableOutcomeEvidence["relay-build"].pr.headRefOid = "moved-after-merge";
+  const staleResult = PROOF.verifyClosedProgram(stale);
+  assert.equal(staleResult.ok, false);
+  assert.equal(staleResult.reasonCode, "PROOF_STALE_EVIDENCE");
+});
+
+test("stopped_on is the STOP_PRIORITY-most-severe token while blocking_reasons stay deterministically listed", () => {
+  const inputs = fixture();
+  // Two failures with distinct stop tokens: PROOF_STOPPED (relay_escalated, severe) and
+  // PROOF_OUTCOME_INCOMPLETE (outcomes_incomplete, least severe). Alphabetically
+  // PROOF_OUTCOME_INCOMPLETE sorts first, so a first-failure policy would pick the WEAK token.
+  inputs.durableOutcomeEvidence["relay-build"].manifest.state = "closed";
+  inputs.durableOutcomeEvidence[OUTCOME_ID] = {};
+  const result = PROOF.verifyClosedProgram(inputs);
+  assert.equal(result.ok, false);
+  const codes = result.final_summary.blocking_reasons.map((entry) => entry.reason_code);
+  assert.deepEqual(codes, ["PROOF_OUTCOME_INCOMPLETE", "PROOF_STOPPED"]);
+  assert.deepEqual(codes, [...codes].sort());
+  assert.equal(result.reasonCode, "PROOF_OUTCOME_INCOMPLETE");
+  assert.equal(result.final_summary.stopped_on, "relay_escalated");
+  assert.notEqual(result.final_summary.stopped_on, "outcomes_incomplete");
 });
 
 test("pure verifier has no filesystem, Orca, or GitHub mutation boundary", () => {

--- a/tests/relay-orca/scripts/closed-program-proof.test.js
+++ b/tests/relay-orca/scripts/closed-program-proof.test.js
@@ -10,7 +10,7 @@ const SCRIPTS = path.join(REPO_ROOT, "skills", "relay-orca", "scripts");
 const PROOF = require(path.join(SCRIPTS, "lib", "closed-program-proof.js"));
 const { programSegment } = require(path.join(SCRIPTS, "receipt-io.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
-const { verificationBinding, canonicalJson, sha256 } = require(path.join(SCRIPTS, "lib", "integration-evidence.js"));
+const { verificationBinding, sha256 } = require(path.join(SCRIPTS, "lib", "integration-evidence.js"));
 const { canonicalIntegrationQuestion } = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
 
 const PROGRAM_ID = "proof-program/2026-07";
@@ -34,7 +34,7 @@ function receiptTask(outcomeId, kind, orcaTaskId) {
 function makeVerification(passed = true) {
   return verificationBinding({
     input_sha256: `sha256:${"a".repeat(64)}`,
-    result_sha256: `sha256:${passed ? "b" : "c"}`.repeat(64),
+    result_sha256: sha256(passed ? "fixture-result-passed" : "fixture-result-failed"),
     passed,
   });
 }
@@ -190,7 +190,7 @@ test("missing, cross-runtime, stale, and failed generic evidence fail closed", (
   ]) {
     const result = verify(overrides);
     assert.equal(result.ok, false);
-    assert.match(result.reasonCode, /^PROOF_EVIDENCE_/);
+    assert.match(result.reasonCode, /^(PROOF_EVIDENCE_|PROOF_CROSS_|PROOF_STALE_)/);
   }
 });
 
@@ -216,6 +216,27 @@ test("runtime identity requires all three structured Orca reads to be present an
     assert.equal(result.ok, false);
     assert.equal(result.reasonCode, "PROOF_CROSS_RUNTIME");
   }
+});
+
+test("program-scoped proof ignores unrelated foreign rows for the later admission filter", () => {
+  const inputs = fixture();
+  inputs.orcaSnapshot.task_list.tasks.push({ id: "foreign-active", task_title: "relay-orca: another-program/old", status: "dispatched" });
+  inputs.orcaSnapshot.gate_list.gates.push({ id: "foreign-gate", task_id: "foreign-active", question: "unrelated", options: ["yes", "no"], status: "pending" });
+  const result = PROOF.verifyClosedProgram(inputs);
+  assert.equal(result.ok, true);
+});
+
+test("the compact injected snapshot shape used by the admission boundary is supported", () => {
+  const inputs = fixture();
+  const snapshot = inputs.orcaSnapshot;
+  inputs.orcaSnapshot = {
+    runtimeId: RUNTIME_ID,
+    taskRuntimeId: RUNTIME_ID,
+    gateRuntimeId: RUNTIME_ID,
+    tasks: snapshot.task_list.tasks,
+    gates: snapshot.gate_list.gates,
+  };
+  assert.equal(PROOF.verifyClosedProgram(inputs).ok, true);
 });
 
 test("a false-complete durable summary cannot mask an incomplete manifest", () => {
@@ -245,4 +266,3 @@ test("the verifier does not change the frozen receipt or report shapes", () => {
   assert.equal(JSON.stringify(inputs.receipt), receiptBefore);
   assert.deepEqual(Object.keys(result.final_summary).sort(), ["blocking_reasons", "lifecycle_diagnostics", "program_complete", "stopped_on"].sort());
 });
-

--- a/tests/relay-orca/scripts/closed-program-proof.test.js
+++ b/tests/relay-orca/scripts/closed-program-proof.test.js
@@ -292,6 +292,31 @@ test("the compact injected snapshot shape used by the admission boundary is supp
   assert.equal(PROOF.verifyClosedProgram(inputs).ok, true);
 });
 
+// DC #1: the three Orca reads must supply INDEPENDENT, agreeing runtime ids. A compact snapshot
+// shares one object, so its task/gate runtime ids must be explicit — never invented from the
+// shared status object (which would make all three trivially agree).
+test("a compact snapshot must supply explicit, agreeing task/gate runtime ids or fail closed", () => {
+  const base = fixture().orcaSnapshot;
+  const tasks = base.task_list.tasks;
+  const gates = base.gate_list.gates;
+  for (const compact of [
+    { runtimeId: RUNTIME_ID, tasks, gates }, // no task/gate runtime override at all
+    { runtimeId: RUNTIME_ID, taskRuntimeId: RUNTIME_ID, tasks, gates }, // gate override still missing
+    { runtimeId: RUNTIME_ID, gateRuntimeId: RUNTIME_ID, tasks, gates }, // task override still missing
+    { runtimeId: RUNTIME_ID, taskRuntimeId: "other-runtime", gateRuntimeId: RUNTIME_ID, tasks, gates }, // present but different
+  ]) {
+    const inputs = fixture();
+    inputs.orcaSnapshot = compact;
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_CROSS_RUNTIME");
+  }
+  // All three explicit runtime ids present and equal → the compact shape passes.
+  const ok = fixture();
+  ok.orcaSnapshot = { runtimeId: RUNTIME_ID, taskRuntimeId: RUNTIME_ID, gateRuntimeId: RUNTIME_ID, tasks, gates };
+  assert.equal(PROOF.verifyClosedProgram(ok).ok, true);
+});
+
 test("a false-complete durable summary cannot mask an incomplete manifest", () => {
   const inputs = fixture();
   inputs.durableOutcomeEvidence["relay-build"].manifest.state = "review_pending";
@@ -462,6 +487,43 @@ test("fleet children must equal the manifest's declared roster exactly before an
   const noDeclaredIds = fleetFixture();
   noDeclaredIds.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.children = [{ state: "merged" }, { state: "merged" }];
   assert.equal(PROOF.verifyClosedProgram(noDeclaredIds).ok, true);
+});
+
+// DC #1: `fleet_state` is the ONLY fleet closed authority; a live/derived `manifest.state` is
+// never sufficient and must not substitute for it.
+test("fleet_state is the only closed authority — a terminal manifest.state cannot substitute", () => {
+  for (const mutate of [
+    // fleet_state non-terminal while a derived state claims closed.
+    (m) => { m.fleet_state = "review_pending"; m.state = "closed"; },
+    // fleet_state absent entirely while a derived state claims merged.
+    (m) => { delete m.fleet_state; m.state = "merged"; },
+  ]) {
+    const inputs = fleetFixture();
+    mutate(inputs.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest);
+    const result = PROOF.verifyClosedProgram(inputs);
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, "PROOF_OUTCOME_INCOMPLETE");
+    assert.match(result.message, /is not terminal/);
+  }
+});
+
+// DC #3: once ANY declared child carries identity, EVERY declared child must — a partially
+// identified roster is malformed authority and fails closed, while a fully identity-less roster
+// keeps the existing authoritative-has-no-id skip.
+test("a partially identified declared fleet roster fails closed; a fully identity-less roster keeps existing behavior", () => {
+  const mixed = fleetFixture();
+  mixed.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.children = [
+    { run_id: "child-run-1", leaf_ref: "leaf-1" },
+    { state: "merged" },
+  ];
+  const mixedResult = PROOF.verifyClosedProgram(mixed);
+  assert.equal(mixedResult.ok, false);
+  assert.equal(mixedResult.reasonCode, "PROOF_STALE_EVIDENCE");
+  assert.match(mixedResult.message, /only partially identified/);
+  // Fully identity-less declared roster: binding omitted, existing behavior preserved.
+  const none = fleetFixture();
+  none.durableOutcomeEvidence[FLEET_OUTCOME_ID].fleet_manifest.children = [{ state: "merged" }, { state: "merged" }];
+  assert.equal(PROOF.verifyClosedProgram(none).ok, true);
 });
 
 test("tracker reconciliation binds the receipt-mapped run and the declared issue number", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
완료했습니다. `closed-program-proof` leaf-1만 구현했으며 `probe-orca` admission/filtering과 sprint 파일은 변경하지 않았습니다.

- Pure verifier: [closed-program-proof.js](/Users/sjlee/.relay/worktrees/6754b08f/dev-relay/skills/relay-orca/scripts/lib/closed-program-proof.js)
- #1019/#1046 identity, runtime, task/gate, evidence 검증 및 deterministic reason codes 구현
- Fixture 테스트 12개 추가
- 전체 relay-orca 테스트: 307/307 통과
- `git diff --check` 통과, worktree clean
- 커밋 3개 생성, 모두 `Refs #1021` 사용 (`Fixes` 없음)
- Push/PR 생성은 하지 않았습니다.
```

## Dispatch Metadata

- Run: issue-1021-20260721115504597-779a049e
- Executor: codex
- Branch: issue-1021-closed-program-proof

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 프로그램 완료 증명을 검증하는 기능을 추가했습니다.
  - 실행 결과, 작업 상태, 통합 게이트 및 증거 간 일치 여부를 종합적으로 확인합니다.
  - 검증 성공 시 후속 처리에 필요한 정리된 결과 정보를 제공합니다.
  - 프로그램 식별자를 기반으로 충돌 가능성을 줄인 일관된 세그먼트를 생성합니다.

- **버그 수정**
  - 오래되거나 불일치하는 증거, 중복 매핑, 누락된 실행 정보를 완료로 잘못 판단하지 않도록 검증을 강화했습니다.

- **문서**
  - 완료 증명의 입력 규칙, 판단 기준, 실패 사유 및 결과 형식을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->