### PR TITLE
Recover relay run issue-1021-20260721145439815-b094a7e7

### DIFF
--- a/skills/relay-orca/references/capability-probe.md
+++ b/skills/relay-orca/references/capability-probe.md
@@ -14,7 +14,7 @@ on Orca upgrades**.
 | --- | --- |
 | Desktop app / runtime graph is ready | `orca status --json` readiness conjuncts |
 | Orchestration commands exist and are enabled | `orchestration task-list --json` |
-| Runtime-global state has no **active** program | task-list active (non-terminal) count `=== 0`, gate-list count `=== 0`, and each list `count` equals its own array length |
+| Runtime-global state has no **unverified** program residue | task-list active count is zero; with explicit prior-program contexts, only rows covered by recomputed closed-program proofs are filtered |
 | Injected dispatch returns provenance IDs | Explicit `--smoke --smoke-to <live-handle>` create + `dispatch --inject` to that handle |
 
 ## Targeted CLI surface (mid-2026)
@@ -49,7 +49,7 @@ Real CLI constraints the probe honors:
    is raised only when all three ordered branches miss.
 2. Runtime readiness (`status --json`)
 3. Orchestration availability (`task-list --json`)
-4. Existing global state (`task-list` + `gate-list` counts / runtimeId consistency)
+4. Existing global state (`task-list` + `gate-list` counts / runtimeId consistency), then optional explicit historical-proof filtering
 5. Optional smoke (only when `--smoke --smoke-to <handle>` and all prior checks passed)
 
 Checks after a failed check may be skipped and are recorded as `skipped` in `checks[]`.
@@ -65,8 +65,42 @@ Admission counts only **active** (non-terminal) task states as existing orchestr
 | `completed`, `failed` | Ignored (historical; do not brick later probes) |
 | missing / unknown / malformed | Fail-closed (`AMBIGUOUS_GLOBAL_STATE`) |
 
-Gate list ambiguity and any non-empty live gate count still fail closed. The
-`existing_state.tasks` field reports the **active** task count used for admission.
+Without a prior-program context, gate list ambiguity and any non-empty live gate count still
+fail closed. The `existing_state.tasks` field reports the **active** task count used for
+admission in that frozen path.
+
+### Explicit prior-program contexts
+
+`--prior-program-context <context.json>` is repeatable on both `probe-orca.js` and
+`run.js`. A context is a read-only locator, not a completion claim:
+
+```json
+{
+  "schema": 1,
+  "repo_root": "/absolute/path/to/repo",
+  "accepted_program": { "path": "/path/accepted-program.json" },
+  "canonical_receipt": { "path": "/path/receipt.json" },
+  "trusted_evidence": {
+    "durable_outcomes": { "path": "/path/durable-outcomes.json" },
+    "generic_integration": { "path": "/path/generic-integration.json" }
+  }
+}
+```
+
+Every attempt rereads these files and recomputes Leaf 1's `verifyClosedProgram` against
+the one live status/task-list/gate-list snapshot. Context success/proof bits are ignored.
+Missing, duplicate, malformed, unreadable, cross-repository, contradictory, or
+cross-runtime inputs fail closed with `AMBIGUOUS_GLOBAL_STATE` (35). No context keeps the
+original #942 policy byte-for-byte: terminal completed/failed tasks are ignored and any
+gate or active task blocks.
+
+With contexts, only a uniquely owned task whose proof mapping and exact
+`relay-orca: <program-segment>/<outcome>` marker agree and whose live state is exactly
+`completed` is exempt. A gate is exempt only when its unique physical id links to that
+exempt task and the recomputed proof includes it; all other terminal/foreign/orphaned or
+unresolved rows remain in the post-filter `existing_state.tasks` / `existing_state.gates`
+counts. Multiple contexts are sorted by program identity, and task/gate rows are sorted by
+physical id before classification.
 
 ### Remediation (no automatic reset)
 
@@ -87,8 +121,8 @@ When active tasks or gates block admission:
 | `RUNTIME_NOT_READY` | 31 | Well-formed status fails a readiness conjunct, or `status` exits non-zero with shape-valid stdout |
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent/disabled/`ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
-| `EXISTING_ORCHESTRATION_STATE` | 34 | Active task count or gate `count > 0` (never adopted) |
-| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer `count`, a `count` that disagrees with its own array length, unknown/missing task status, or a runtime id that is missing/empty on any probed response or disagrees across them — the status `runtime.runtimeId` and every `_meta.runtimeId` (status, task-list, gate-list) must all be present, non-empty, and identical |
+| `EXISTING_ORCHESTRATION_STATE` | 34 | Active task/gate residue, or validly classified rows not covered by a recomputed closed-program proof |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Contradictory counts, unknown/missing identity or status, duplicate/malformed/foreign attribution, unreadable or cross-repository context, proof/runtime mismatch, or inconsistent runtime ids |
 | `SMOKE_FAILED` | 36 | Smoke provenance verification failed |
 | `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
 
@@ -128,9 +162,10 @@ exit codes are unaffected.
 ## Guarantees
 
 - **D1 read-only default** — without `--smoke`, the probe spawns only `status`,
-  `orchestration task-list`, and `orchestration gate-list`. It creates no Orca task,
-  terminal, worktree, relay request/run, PR, or tracker issue, and writes nothing to the
-  filesystem (stdout/stderr only).
+  `orchestration task-list`, and `orchestration gate-list`. With explicit contexts it also
+  rereads only the locator, accepted-program, canonical receipt, and trusted evidence files.
+  It creates no Orca task, terminal, worktree, relay request/run, PR, or tracker issue, and
+  writes nothing to the filesystem.
 - **D2 no-reset** — no code path invokes `orca orchestration reset`, including error and
   smoke-cleanup-failure paths. Scoped manual reset remains an operator remediation step only.
 - **D9 smoke** — runs only under `--smoke --smoke-to <live-handle>`, only after default
@@ -151,6 +186,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json \
   --smoke --smoke-to <live-agent-terminal-handle>
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json --orca-bin /path/to/orca
+node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" --json \
+  --orca-bin /path/to/orca --prior-program-context /path/prior-context.json
 ```
 
 `--smoke-to` must name a terminal already running a recognized agent CLI (e.g. claude,

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -58,7 +58,8 @@ unknown flags exit `64` (usage).
 
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" \
-  [--json] [--smoke --smoke-to <handle>] [--orca-bin <path>]
+  [--json] [--smoke --smoke-to <handle>] [--orca-bin <path>] \
+  [--repo-root <path>] [--prior-program-context <context.json> ...]
 ```
 
 | Flag | Meaning |
@@ -67,14 +68,17 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/probe-orca.js" \
 | `--smoke` | After default checks pass, run a self-cleaning synthetic injection smoke. Requires `--smoke-to`. |
 | `--smoke-to <handle>` | Live Orca terminal handle already running a recognized agent CLI. Required with `--smoke`; the smoke path dispatches `--inject` to this handle and verifies assignee provenance against it. Bare `--smoke` fails fast (exit 64) before creating smoke task state. |
 | `--orca-bin <path>` | Explicit Orca CLI override (wins over PATH and the macOS bundle fallback). |
+| `--repo-root <path>` | Target git checkout used to validate each context's repository identity. |
+| `--prior-program-context <context.json>` | Repeatable read-only locator for an accepted program, canonical receipt, and trusted evidence. The probe recomputes Leaf 1's proof every attempt; it never trusts a context success bit. |
 | `--help`, `-h` | Print usage. |
 
 Default mode is **READ-ONLY**: it spawns only `orca status --json`,
-`orca orchestration task-list --json`, and `orca orchestration gate-list --json`. It never
-invokes `orca orchestration reset`. Admission ignores historical `completed`/`failed` tasks
-and blocks only active task states (`pending`/`ready`/`dispatched`/`blocked`) plus any live
-gates. Smoke cleanup uses `--status failed` (a real CLI terminal status). Full rationale,
-check order, smoke semantics, terminal-task filtering, and the reason-code table:
+`orca orchestration task-list --json`, and `orca orchestration gate-list --json`; explicit
+contexts add only durable file reads. It never invokes `orca orchestration reset`. Without
+contexts, admission ignores historical `completed`/`failed` tasks and blocks active tasks
+plus gates exactly as #942 did. With contexts, only rows covered by a recomputed closed-
+program proof are filtered. Smoke cleanup uses `--status failed` (a real CLI terminal
+status). Full rationale, check order, smoke semantics, context schema, and the reason-code table:
 [capability-probe.md](capability-probe.md).
 
 ### Probe rejection matrix
@@ -85,8 +89,8 @@ check order, smoke semantics, terminal-task filtering, and the reason-code table
 | `RUNTIME_NOT_READY` | 31 | Well-formed `status` fails a readiness conjunct |
 | `ORCHESTRATION_UNAVAILABLE` | 32 | Orchestration absent, disabled, or `ok:false` |
 | `MALFORMED_OUTPUT` | 33 | Unparseable or shape-invalid JSON |
-| `EXISTING_ORCHESTRATION_STATE` | 34 | Active task count or gate count `> 0` (never adopted) |
-| `AMBIGUOUS_GLOBAL_STATE` | 35 | Non-integer count, a count that disagrees with its own array length, unknown/missing task status, or `_meta.runtimeId` mismatch |
+| `EXISTING_ORCHESTRATION_STATE` | 34 | Active/unverified post-filter task or gate residue |
+| `AMBIGUOUS_GLOBAL_STATE` | 35 | Contradictory counts, malformed/duplicate/foreign attribution, context/proof/runtime mismatch, or missing identity |
 | `SMOKE_FAILED` | 36 | Smoke provenance (task/dispatch/assignee vs `--smoke-to`) failed |
 | `SMOKE_CLEANUP_FAILED` | 37 | Smoke cleanup of self-created state failed |
 
@@ -105,7 +109,7 @@ shortens the budget for tests.
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
   --program-file <accepted-program.json> [--json] [--concurrency N] \
   [--operator-handle <handle> ...] [--coordinator-handle <handle>] \
-  [--gate-evidence-dir <dir>] [--orca-bin <path>]
+  [--gate-evidence-dir <dir>] [--prior-program-context <context.json> ...] [--orca-bin <path>]
 ```
 
 | Flag | Meaning |
@@ -116,6 +120,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/run.js" \
 | `--operator-handle <handle>` | Repeatable. An explicit operator terminal handle to dispatch to — REQUIRED. `run` dispatches ONLY to handles provided here and never creates its own terminal (a self-created terminal has no recognized agent and cannot accept `--inject`). With zero handles, `run` fails closed with `OPERATOR_DISPATCH_FAILED` (44) before any mutation. Each handle must be a terminal already running an agent CLI (`orca terminal create --command "<agent-cli>" --json`). |
 | `--coordinator-handle <handle>` | Required for `integration_gate`. Must be the live/current coordinator handle verified by fresh Orca reads; it is never inferred from receipt/history. |
 | `--gate-evidence-dir <dir>` | Deterministic root for integration evidence. The operator writes `<outcome-id>.json` there; `RELAY_ORCA_GATE_EVIDENCE_ROOT` is an equivalent environment override. |
+| `--prior-program-context <context.json>` | Repeatable. Forward the exact read-only prior-program locators to admission; no implicit receipt/history discovery occurs. |
 | `--orca-bin <path>` | Explicit Orca CLI override — passed to the capability probe and used for all orchestration calls. |
 | `--resolve-decision <id>` | (#947) Write a resolved `decision:` record for `<id>` into the receipt's `decisions[]`. Requires `--resolution` and `--resolver`; provenance (question/options/downstream_wave) is sourced from the program's declared `decision_gates[<id>]`. Never automatic. |
 | `--resolution <text>` | The decision resolution (with `--resolve-decision`). |

--- a/skills/relay-orca/scripts/lib/admission-history.js
+++ b/skills/relay-orca/scripts/lib/admission-history.js
@@ -97,9 +97,34 @@ function exactOutcome(program, outcomeId) {
   return matches.length === 1 ? matches[0] : null;
 }
 
+// Reserve every physical task/gate row a prior-program proof — passing OR failing — claims in
+// a registry shared across all contexts. Exemption authority stays limited to passing proofs
+// (proof.ok === true) alone; this registry only detects CROSS-CONTEXT overlap. If two contexts
+// claim the same physical id, one proof would necessarily mask a live row another program also
+// claims, so the whole snapshot is unclassifiable (AMBIGUOUS_GLOBAL_STATE, DC #6). A failing or
+// absent proof registers its claims too — otherwise a later passing proof could silently exempt
+// (mask) a row a failed, unproven program already claimed. Physical ids come from the proof's
+// own recomputed `orca_task_ids`/`integration_gate_ids`: a failed proof only ever lists the live
+// rows it actually resolved, so a claim always corresponds to a real row that could be masked.
+function registerProofClaims({ proof, programId, claimedTasks, claimedGates }) {
+  const taskIds = proof && Array.isArray(proof.orca_task_ids) ? proof.orca_task_ids : [];
+  for (const taskId of taskIds) {
+    if (claimedTasks.has(taskId)) return failure("AMBIGUOUS_GLOBAL_STATE", `task ${taskId} is claimed by multiple prior-program contexts`);
+    claimedTasks.set(taskId, programId);
+  }
+  const physicalGateIds = proof && Array.isArray(proof.integration_gate_ids) ? proof.integration_gate_ids : [];
+  for (const physicalGateId of physicalGateIds) {
+    if (claimedGates.has(physicalGateId)) return failure("AMBIGUOUS_GLOBAL_STATE", `gate ${physicalGateId} is claimed by multiple prior-program contexts`);
+    claimedGates.set(physicalGateId, programId);
+  }
+  return null;
+}
+
 function proofIndexes(contexts, gates, segment) {
   const taskOwners = new Map();
   const gateOwners = new Map();
+  const claimedTasks = new Map();
+  const claimedGates = new Map();
   const seenPrograms = new Set();
   const ordered = contexts.slice().sort((left, right) => {
     const program = String(left.program.id).localeCompare(String(right.program.id));
@@ -111,10 +136,15 @@ function proofIndexes(contexts, gates, segment) {
     if (seenPrograms.has(programId)) return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program context ${programId} is duplicated or contradictory`);
     seenPrograms.add(programId);
     const proof = context.proof;
-    // A recomputed proof that describes a known failed/pending lifecycle is not
-    // authority for any exemption, but its live residue is still a valid blocking
-    // state and must be reported through exit 34. Loader failures and identity
-    // contradictions never reach this branch; they fail closed as exit 35.
+    // Reserve this context's claimed physical rows FIRST — before granting any exemption below —
+    // so a passing proof can never mask a row a failing/earlier program also claimed (DC #6).
+    // Cross-context overlap on any physical id fails closed as AMBIGUOUS_GLOBAL_STATE (exit 35).
+    const claimed = registerProofClaims({ proof, programId, claimedTasks, claimedGates });
+    if (claimed) return claimed;
+    // A recomputed proof that describes a known failed/pending lifecycle is not authority for any
+    // exemption (that stays limited to proof.ok === true), but its live residue is still a valid
+    // blocking state reported through exit 34, and its claims are already registered above. Loader
+    // failures and identity contradictions never reach this branch; they fail closed as exit 35.
     if (!proof || proof.ok !== true) continue;
     const receiptTasks = Array.isArray(context.receipt.tasks) ? context.receipt.tasks : [];
     const proofTasks = new Set(proof.orca_task_ids || []);
@@ -125,7 +155,8 @@ function proofIndexes(contexts, gates, segment) {
       if (!exactOutcome(context.program, entry.outcome_id)) {
         return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program proof ${programId} maps an unaccepted outcome`);
       }
-      if (taskOwners.has(taskId)) return failure("AMBIGUOUS_GLOBAL_STATE", `task ${taskId} is covered by multiple prior-program proofs`);
+      // Cross-context task overlap is already caught by registerProofClaims; a single proof's
+      // orca_task_ids is a deduped set, so no within-context duplicate can reach here.
       taskOwners.set(taskId, { context, taskId, outcomeId: entry.outcome_id });
     }
 
@@ -146,7 +177,9 @@ function proofIndexes(contexts, gates, segment) {
       if (!inspected.ok || inspected.state === "missing" || !inspected.gate) continue;
       const physicalId = gateId(inspected.gate);
       if (!physicalId || !proofGates.has(physicalId)) continue;
-      if (gateOwners.has(physicalId)) return failure("AMBIGUOUS_GLOBAL_STATE", `gate ${physicalId} is covered by multiple prior-program proofs`);
+      // Cross-context gate overlap is already caught by registerProofClaims; a passing proof's
+      // integration_gate_ids is a deduped set with a program-specific canonical identity, so no
+      // within-context (or cross-program) duplicate physical gate can reach here.
       gateOwners.set(physicalId, { context, taskId: entry.orca_task_id });
     }
   }

--- a/skills/relay-orca/scripts/lib/admission-history.js
+++ b/skills/relay-orca/scripts/lib/admission-history.js
@@ -1,0 +1,205 @@
+"use strict";
+
+// Pure admission filtering for explicitly supplied, already-verified closure proofs.
+// Filesystem and proof recomputation live at the top-level probe boundary. This module
+// only classifies the one live task/gate snapshot, so no durable fact can become an
+// authority merely by being present in a context file.
+const {
+  canonicalIntegrationQuestion,
+  canonicalGateKey,
+  gateId,
+  inspectCanonicalGates,
+} = require("./integration-lifecycle");
+
+const ACTIVE_STATUSES = new Set(["pending", "ready", "dispatched", "blocked"]);
+const TERMINAL_STATUSES = new Set(["completed", "failed"]);
+const LEGACY_MESSAGE = "v0 admits only one active program per runtime and never adopts pre-existing state";
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function failure(reasonCode, message) {
+  return { ok: false, reasonCode, message };
+}
+
+function stableId(row, keys, label) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    return failure("AMBIGUOUS_GLOBAL_STATE", `${label} row is not an object`);
+  }
+  const supplied = keys.filter((key) => key in row).map((key) => row[key]);
+  if (supplied.some((value) => value !== null && !nonEmpty(value))) {
+    return failure("AMBIGUOUS_GLOBAL_STATE", `${label} has a malformed stable id`);
+  }
+  const ids = [...new Set(supplied.filter(nonEmpty))];
+  if (ids.length !== 1) return failure("AMBIGUOUS_GLOBAL_STATE", `${label} must have exactly one stable id`);
+  return { ok: true, id: ids[0] };
+}
+
+function normalizeTasks(tasks) {
+  if (!Array.isArray(tasks)) return failure("AMBIGUOUS_GLOBAL_STATE", "task-list tasks are not an array");
+  const rows = [];
+  const ids = new Set();
+  for (const task of tasks) {
+    const identified = stableId(task, ["id", "task_id", "taskId"], "task");
+    if (!identified.ok) return identified;
+    if (ids.has(identified.id)) return failure("AMBIGUOUS_GLOBAL_STATE", `task ${identified.id} appears more than once`);
+    ids.add(identified.id);
+    if (!nonEmpty(task.status) || (!TERMINAL_STATUSES.has(task.status) && !ACTIVE_STATUSES.has(task.status))) {
+      return failure("AMBIGUOUS_GLOBAL_STATE", `task ${identified.id} has an unknown or missing status`);
+    }
+    rows.push({ ...task, id: identified.id });
+  }
+  rows.sort((left, right) => left.id.localeCompare(right.id));
+  return { ok: true, rows, byId: new Map(rows.map((task) => [task.id, task])) };
+}
+
+function taskLink(gate) {
+  if (!gate || typeof gate !== "object" || Array.isArray(gate)) {
+    return failure("AMBIGUOUS_GLOBAL_STATE", "gate row is not an object");
+  }
+  const links = ["task_id", "task", "taskId"].filter((key) => key in gate).map((key) => gate[key]);
+  if ("blocks" in gate) {
+    if (!Array.isArray(gate.blocks)) return failure("AMBIGUOUS_GLOBAL_STATE", "gate blocks is not an array");
+    links.push(...gate.blocks);
+  }
+  if (links.some((value) => !nonEmpty(value))) return failure("AMBIGUOUS_GLOBAL_STATE", "gate has a malformed task link");
+  const ids = [...new Set(links)];
+  if (ids.length !== 1) return failure("AMBIGUOUS_GLOBAL_STATE", "gate must link to exactly one task");
+  return { ok: true, taskId: ids[0] };
+}
+
+function normalizeGates(gates) {
+  if (!Array.isArray(gates)) return failure("AMBIGUOUS_GLOBAL_STATE", "gate-list gates are not an array");
+  const rows = [];
+  const ids = new Set();
+  for (const gate of gates) {
+    const identified = stableId(gate, ["id", "gate_id", "gateId"], "gate");
+    if (!identified.ok) return identified;
+    if (ids.has(identified.id)) return failure("AMBIGUOUS_GLOBAL_STATE", `gate ${identified.id} appears more than once`);
+    ids.add(identified.id);
+    const linked = taskLink(gate);
+    if (!linked.ok) return linked;
+    rows.push({ ...gate, id: identified.id, taskId: linked.taskId });
+  }
+  rows.sort((left, right) => left.id.localeCompare(right.id));
+  return { ok: true, rows, byId: new Map(rows.map((gate) => [gate.id, gate])) };
+}
+
+function unwrapProgram(value) {
+  return value && value.program && typeof value.program === "object" ? value.program : value;
+}
+
+function exactOutcome(program, outcomeId) {
+  const candidate = unwrapProgram(program);
+  const outcomes = candidate && Array.isArray(candidate.outcomes) ? candidate.outcomes : [];
+  const matches = outcomes.filter((outcome) => outcome && outcome.id === outcomeId);
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function proofIndexes(contexts, gates, segment) {
+  const taskOwners = new Map();
+  const gateOwners = new Map();
+  const seenPrograms = new Set();
+  const ordered = contexts.slice().sort((left, right) => {
+    const program = String(left.program.id).localeCompare(String(right.program.id));
+    return program || String(left.contextPath).localeCompare(String(right.contextPath));
+  });
+
+  for (const context of ordered) {
+    const programId = context.program.id;
+    if (seenPrograms.has(programId)) return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program context ${programId} is duplicated or contradictory`);
+    seenPrograms.add(programId);
+    const proof = context.proof;
+    // A recomputed proof that describes a known failed/pending lifecycle is not
+    // authority for any exemption, but its live residue is still a valid blocking
+    // state and must be reported through exit 34. Loader failures and identity
+    // contradictions never reach this branch; they fail closed as exit 35.
+    if (!proof || proof.ok !== true) continue;
+    const receiptTasks = Array.isArray(context.receipt.tasks) ? context.receipt.tasks : [];
+    const proofTasks = new Set(proof.orca_task_ids || []);
+    for (const taskId of proofTasks) {
+      const entries = receiptTasks.filter((entry) => entry && entry.orca_task_id === taskId);
+      if (entries.length !== 1) return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program proof ${programId} has an ambiguous task mapping`);
+      const entry = entries[0];
+      if (!exactOutcome(context.program, entry.outcome_id)) {
+        return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program proof ${programId} maps an unaccepted outcome`);
+      }
+      if (taskOwners.has(taskId)) return failure("AMBIGUOUS_GLOBAL_STATE", `task ${taskId} is covered by multiple prior-program proofs`);
+      taskOwners.set(taskId, { context, taskId, outcomeId: entry.outcome_id });
+    }
+
+    const proofGates = new Set(proof.integration_gate_ids || []);
+    for (const entry of receiptTasks.filter((candidate) => candidate && candidate.kind === "integration_gate")) {
+      const outcome = exactOutcome(context.program, entry.outcome_id);
+      if (!outcome) return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program proof ${programId} has an invalid integration mapping`);
+      let identity;
+      try {
+        identity = canonicalGateKey({
+          taskId: entry.orca_task_id,
+          question: canonicalIntegrationQuestion(programId, entry.outcome_id, segment),
+        });
+      } catch {
+        return failure("AMBIGUOUS_GLOBAL_STATE", `prior-program proof ${programId} has an unavailable canonical gate identity`);
+      }
+      const inspected = inspectCanonicalGates(gates, identity);
+      if (!inspected.ok || inspected.state === "missing" || !inspected.gate) continue;
+      const physicalId = gateId(inspected.gate);
+      if (!physicalId || !proofGates.has(physicalId)) continue;
+      if (gateOwners.has(physicalId)) return failure("AMBIGUOUS_GLOBAL_STATE", `gate ${physicalId} is covered by multiple prior-program proofs`);
+      gateOwners.set(physicalId, { context, taskId: entry.orca_task_id });
+    }
+  }
+  return { ok: true, taskOwners, gateOwners };
+}
+
+function classifyHistoricalState({ tasks, gates, contexts, programSegment: segment }) {
+  const normalizedTasks = normalizeTasks(tasks);
+  if (!normalizedTasks.ok) return normalizedTasks;
+  const normalizedGates = normalizeGates(gates);
+  if (!normalizedGates.ok) return normalizedGates;
+  const indexes = proofIndexes(contexts, normalizedGates.rows, segment);
+  if (!indexes.ok) return indexes;
+
+  let blockingTasks = 0;
+  for (const task of normalizedTasks.rows) {
+    const owner = indexes.taskOwners.get(task.id);
+    const marker = owner && `relay-orca: ${segment(owner.context.program.id)}/${owner.outcomeId}`;
+    const exempt = Boolean(owner && task.status === "completed" && taskDisplay(task) === marker);
+    if (!exempt) blockingTasks += 1;
+  }
+
+  let blockingGates = 0;
+  for (const gate of normalizedGates.rows) {
+    const owner = indexes.gateOwners.get(gate.id);
+    const taskOwner = indexes.taskOwners.get(gate.taskId);
+    const exempt = Boolean(owner && taskOwner && owner.taskId === gate.taskId && taskOwner.context === owner.context
+      && normalizedTasks.byId.get(gate.taskId)?.status === "completed"
+      && taskDisplay(normalizedTasks.byId.get(gate.taskId)) === `relay-orca: ${segment(taskOwner.context.program.id)}/${taskOwner.outcomeId}`);
+    if (!exempt) blockingGates += 1;
+  }
+
+  if (blockingTasks > 0 || blockingGates > 0) {
+    return {
+      ok: false,
+      reasonCode: "EXISTING_ORCHESTRATION_STATE",
+      message: `existing orchestration state rejected (active_tasks=${blockingTasks}, gates=${blockingGates}); ${LEGACY_MESSAGE}`,
+      activeTasks: blockingTasks,
+      blockingGates,
+    };
+  }
+  return { ok: true, activeTasks: 0, blockingGates: 0 };
+}
+
+function taskDisplay(task) {
+  return [task && task.task_title, task && task.display_name, task && task.title].find(nonEmpty) || "";
+}
+
+module.exports = {
+  ACTIVE_STATUSES,
+  TERMINAL_STATUSES,
+  normalizeTasks,
+  normalizeGates,
+  classifyHistoricalState,
+  taskDisplay,
+};

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -46,7 +46,12 @@ function procDetail(proc, note) {
 function admit(report, options) {
   const result = emptyResult(false);
   try {
-    probe({ orcaBin: options.orcaBin, _result: result });
+    probe({
+      orcaBin: options.orcaBin,
+      priorProgramContexts: options.priorProgramContexts,
+      repoRoot: options.repoRoot,
+      _result: result,
+    });
   } catch (error) {
     if (!(error instanceof ProbeError)) throw error;
     report.admission = { admitted: false, runtime_id: result.runtime_id };

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -43,13 +43,16 @@ function procDetail(proc, note) {
 // D3 admission gate: every mutation is preceded by capability admission from the
 // FROZEN #942 probe (imported, never modified). Any probe rejection or
 // admitted:false fails closed as ADMISSION_REJECTED, before any task/terminal.
-function admit(report, options) {
+function admit(report, options, launchedProgramId) {
   const result = emptyResult(false);
   try {
     probe({
       orcaBin: options.orcaBin,
       priorProgramContexts: options.priorProgramContexts,
       repoRoot: options.repoRoot,
+      // The launched program's own id: admission rejects a prior-program context that is
+      // self-referential to it (a context cannot vouch for the program it launches).
+      launchedProgramId,
       _result: result,
     });
   } catch (error) {
@@ -326,7 +329,7 @@ function orchestrate(rawProgram, options = {}) {
   const program = unwrapProgram(rawProgram);
   const report = initReport(plan);
   try {
-    const orcaBin = admit(report, options);
+    const orcaBin = admit(report, options, program.id);
     requireIntegrationCoordinator(program, options);
     // D3.1: reject a zero-handle run AFTER admission (probe result) and BEFORE any
     // materialization mutation, so no task-create/dispatch/terminal-create ever runs.

--- a/skills/relay-orca/scripts/prior-program-context.js
+++ b/skills/relay-orca/scripts/prior-program-context.js
@@ -14,12 +14,15 @@ const { programSegment } = require("./lib/program-segment");
 // authority for any exemption, but its live residue is still a valid blocking state:
 // the loader keeps the (ok:false) proof so the admission filter skips ownership and
 // classifies the unproven completed/foreign rows through EXISTING_ORCHESTRATION_STATE
-// (exit 34) with post-filter counts (DC #5). Only loader failures and identity/runtime
-// contradictions (cross-program/cross-runtime/duplicate/malformed/stale/unevaluable)
-// fall through to a thrown PriorProgramContextError → AMBIGUOUS_GLOBAL_STATE (exit 35).
-// The gate-lifecycle subset must be COMPLETE — a missing canonical gate is as much a
-// known blocking residue as a pending or failed one, so PROOF_GATE_MISSING belongs here
-// alongside PROOF_GATE_PENDING/FAILED, never on the exit-35 path.
+// (exit 34) with post-filter counts (DC #5). The proof is retained as exit-34 residue
+// ONLY when EVERY failure reason code is a known blocking code — the whole failure set,
+// not just the primary `proof.reasonCode`. Loader failures, identity/runtime
+// contradictions (cross-program/cross-runtime/duplicate/malformed/stale/unevaluable), and
+// ANY mixed-failure proof carrying at least one such unclassifiable co-failure alongside a
+// blocking one fall through to a thrown PriorProgramContextError → AMBIGUOUS_GLOBAL_STATE
+// (exit 35): ambiguity dominates. The gate-lifecycle subset must be COMPLETE — a missing
+// canonical gate is as much a known blocking residue as a pending or failed one, so
+// PROOF_GATE_MISSING belongs here alongside PROOF_GATE_PENDING/FAILED, never on the exit-35 path.
 const BLOCKING_PROOF_CODES = new Set([
   "PROOF_TASK_ACTIVE",
   "PROOF_TASK_FAILED",
@@ -143,7 +146,7 @@ function contextLocator(value, contextPath) {
   return { schema: 1, repoRoot, repoSlug, programPath, receiptPath, durablePath, genericPath };
 }
 
-function loadOne(locatorInput, contextPath, targetRepo, snapshot) {
+function loadOne(locatorInput, contextPath, targetRepo, snapshot, launchedProgramId) {
   const locator = contextLocator(locatorInput, contextPath);
   const contextRepo = resolveRepoContext({ repoRootOverride: locator.repoRoot });
   if (contextRepo.root !== targetRepo.root || contextRepo.slug !== targetRepo.slug || (locator.repoSlug !== null && locator.repoSlug !== contextRepo.slug)) {
@@ -153,6 +156,15 @@ function loadOne(locatorInput, contextPath, targetRepo, snapshot) {
   const program = programValue && programValue.program && object(programValue.program) ? programValue.program : programValue;
   if (!object(program) || typeof program.id !== "string" || program.id.trim() === "") {
     throw new PriorProgramContextError("accepted program id is missing");
+  }
+  // A prior-program context is a record of a DIFFERENT, already-closed program that this run
+  // must treat as historical residue. A context whose accepted program id equals the program
+  // being launched is self-referential — it would vouch for the very program it launches — so
+  // fail closed BEFORE reading its receipt/evidence (→ AMBIGUOUS_GLOBAL_STATE, exit 35). The
+  // guard is scoped to `run`: only a launching program supplies `launchedProgramId`; the
+  // standalone probe (no launched program) passes none and skips it.
+  if (typeof launchedProgramId === "string" && launchedProgramId.trim() !== "" && program.id === launchedProgramId) {
+    throw new PriorProgramContextError(`prior-program context ${program.id} is self-referential to the launching program`);
   }
   const receipt = readJson(locator.receiptPath, "canonical receipt");
   const receiptError = validateReceipt(receipt);
@@ -172,13 +184,27 @@ function loadOne(locatorInput, contextPath, targetRepo, snapshot) {
     orcaSnapshot: snapshot,
     programSegment,
   });
-  if (proof.ok !== true && !BLOCKING_PROOF_CODES.has(proof.reasonCode)) {
-    throw new PriorProgramContextError(`prior-program proof ${program.id} failed with ${proof.reasonCode || "PROOF_MALFORMED_INPUT"}`);
+  if (proof.ok !== true) {
+    // Ambiguity dominates a mixed-failure proof. A recomputed failing proof is retained as
+    // exit-34 classifiable blocking residue ONLY when EVERY failure reason code is a KNOWN
+    // blocking lifecycle code — not just the primary `proof.reasonCode`. Checking only the
+    // primary would let a blocking code that happens to sort first mask an unclassifiable
+    // co-failure (identity/runtime/malformed/stale/unevaluable/missing/duplicate). A single
+    // such co-failure makes the WHOLE context unclassifiable, so it falls through to a thrown
+    // PriorProgramContextError → AMBIGUOUS_GLOBAL_STATE (exit 35), never silently reported as
+    // classifiable blocking through exit 34.
+    const codes = proof.final_summary && Array.isArray(proof.final_summary.blocking_reasons) && proof.final_summary.blocking_reasons.length > 0
+      ? proof.final_summary.blocking_reasons.map((entry) => (entry ? entry.reason_code : undefined))
+      : [proof.reasonCode];
+    if (!codes.every((code) => BLOCKING_PROOF_CODES.has(code))) {
+      const ambiguous = codes.find((code) => !BLOCKING_PROOF_CODES.has(code));
+      throw new PriorProgramContextError(`prior-program proof ${program.id} failed with ${ambiguous || proof.reasonCode || "PROOF_MALFORMED_INPUT"}`);
+    }
   }
   return { contextPath, program, receipt, proof };
 }
 
-function loadPriorProgramContexts({ inputs, repoRoot, snapshot }) {
+function loadPriorProgramContexts({ inputs, repoRoot, snapshot, launchedProgramId }) {
   const rawInputs = Array.isArray(inputs) ? inputs.slice() : [];
   if (rawInputs.length === 0) return [];
   const targetRepo = resolveRepoContext({ repoRootOverride: repoRoot });
@@ -188,7 +214,7 @@ function loadPriorProgramContexts({ inputs, repoRoot, snapshot }) {
   });
   const unique = new Set(paths);
   if (unique.size !== paths.length) throw new PriorProgramContextError("prior-program context is duplicated");
-  const contexts = paths.map((contextPath) => loadOne(readJson(contextPath, "prior-program context"), contextPath, targetRepo, snapshot));
+  const contexts = paths.map((contextPath) => loadOne(readJson(contextPath, "prior-program context"), contextPath, targetRepo, snapshot, launchedProgramId));
   contexts.sort((left, right) => left.program.id.localeCompare(right.program.id) || left.contextPath.localeCompare(right.contextPath));
   return contexts;
 }

--- a/skills/relay-orca/scripts/prior-program-context.js
+++ b/skills/relay-orca/scripts/prior-program-context.js
@@ -1,0 +1,185 @@
+"use strict";
+
+// Read-only context locator boundary for #1021. A context contains paths only;
+// the accepted program, receipt, and evidence are parsed afresh and passed to
+// Leaf 1's pure verifier on every probe attempt.
+const fs = require("node:fs");
+const path = require("node:path");
+const { verifyClosedProgram } = require("./lib/closed-program-proof");
+const { validateReceipt } = require("./lib/receipt");
+const { resolveRepoContext } = require("./receipt-io");
+const { programSegment } = require("./lib/program-segment");
+
+const BLOCKING_PROOF_CODES = new Set([
+  "PROOF_TASK_ACTIVE",
+  "PROOF_TASK_FAILED",
+  "PROOF_TASK_MARKER_MISMATCH",
+  "PROOF_GATE_PENDING",
+  "PROOF_GATE_FAILED",
+  "PROOF_GATE_DUPLICATE",
+  "PROOF_GATE_NONCANONICAL",
+  "PROOF_GATE_CONFLICT",
+  "PROOF_GATE_MALFORMED",
+  "PROOF_OUTCOME_FAILED",
+  "PROOF_OUTCOME_INCOMPLETE",
+  "PROOF_STOPPED",
+  "PROOF_EVIDENCE_FAILED",
+]);
+
+class PriorProgramContextError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PriorProgramContextError";
+  }
+}
+
+function object(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function requiredPath(value, label, baseDir) {
+  const candidate = object(value) ? value.path : value;
+  if (typeof candidate !== "string" || candidate.trim() === "") {
+    throw new PriorProgramContextError(`${label} must locate a non-empty path`);
+  }
+  if (candidate.includes("\0")) throw new PriorProgramContextError(`${label} contains a control character`);
+  return path.resolve(baseDir, candidate);
+}
+
+function optionalPath(value, label, baseDir) {
+  if (value === undefined || value === null) return null;
+  return requiredPath(value, label, baseDir);
+}
+
+function readJson(filePath, label) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    throw new PriorProgramContextError(`${label} is unreadable: ${error.message}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new PriorProgramContextError(`${label} is not valid JSON: ${error.message}`);
+  }
+}
+
+function contextLocator(value, contextPath) {
+  if (typeof value === "string") return value;
+  if (!object(value)) throw new PriorProgramContextError("prior-program context is not an object");
+  if (value.schema !== 1) throw new PriorProgramContextError("prior-program context schema must be 1");
+  const baseDir = path.dirname(contextPath);
+  const repoValue = value.repo_root !== undefined ? value.repo_root : value.repo;
+  const repoSlug = object(repoValue) && repoValue.slug !== undefined ? repoValue.slug : null;
+  const repoRoot = requiredPath(object(repoValue) ? repoValue.root : repoValue, "context repo_root", baseDir);
+  const accepted = value.accepted_program !== undefined
+    ? value.accepted_program
+    : value.acceptedProgram !== undefined
+      ? value.acceptedProgram
+      : value.accepted_program_path !== undefined
+        ? value.accepted_program_path
+      : value.program_path !== undefined
+        ? value.program_path
+        : value.program;
+  const receipt = value.canonical_receipt !== undefined ? value.canonical_receipt : value.receipt;
+  const evidence = value.trusted_evidence !== undefined
+    ? value.trusted_evidence
+    : value.evidence !== undefined
+      ? value.evidence
+      : value.trusted_evidence_path !== undefined
+        ? value.trusted_evidence_path
+        : (value.durable_outcome_evidence !== undefined || value.durable_outcome_evidence_path !== undefined || value.trusted_generic_integration_evidence !== undefined || value.trusted_generic_integration_evidence_path !== undefined)
+          ? {
+              durable_outcomes: value.durable_outcome_evidence !== undefined ? value.durable_outcome_evidence : value.durable_outcome_evidence_path,
+              generic_integration: value.trusted_generic_integration_evidence !== undefined ? value.trusted_generic_integration_evidence : value.trusted_generic_integration_evidence_path,
+            }
+          : undefined;
+  const programPath = requiredPath(accepted, "accepted program", baseDir);
+  const receiptPath = requiredPath(value.receipt_path !== undefined ? value.receipt_path : value.canonical_receipt_path !== undefined ? value.canonical_receipt_path : receipt, "canonical receipt", baseDir);
+  if (typeof evidence === "string" || object(evidence) && "path" in evidence) {
+    return {
+      schema: 1,
+      repoRoot,
+      repoSlug,
+      programPath,
+      receiptPath,
+      durablePath: requiredPath(evidence, "durable outcome evidence", baseDir),
+      genericPath: null,
+    };
+  }
+  if (!object(evidence)) throw new PriorProgramContextError("trusted_evidence must locate evidence files");
+  const durableValue = evidence.durable_outcomes !== undefined
+    ? evidence.durable_outcomes
+    : evidence.durable_outcome_evidence !== undefined
+      ? evidence.durable_outcome_evidence
+      : evidence.durable_outcome_evidence_path !== undefined
+        ? evidence.durable_outcome_evidence_path
+      : evidence.durable_evidence !== undefined
+        ? evidence.durable_evidence
+        : evidence.durable;
+  const durablePath = requiredPath(durableValue, "durable outcome evidence", baseDir);
+  const genericValue = evidence.generic_integration !== undefined
+    ? evidence.generic_integration
+    : evidence.generic_integration_evidence !== undefined
+      ? evidence.generic_integration_evidence
+      : evidence.generic_integration_evidence_path !== undefined
+        ? evidence.generic_integration_evidence_path
+      : evidence.trusted_generic_integration_evidence !== undefined
+        ? evidence.trusted_generic_integration_evidence
+        : evidence.generic;
+  const genericPath = optionalPath(genericValue, "generic integration evidence", baseDir);
+  return { schema: 1, repoRoot, repoSlug, programPath, receiptPath, durablePath, genericPath };
+}
+
+function loadOne(locatorInput, contextPath, targetRepo, snapshot) {
+  const locator = contextLocator(locatorInput, contextPath);
+  const contextRepo = resolveRepoContext({ repoRootOverride: locator.repoRoot });
+  if (contextRepo.root !== targetRepo.root || contextRepo.slug !== targetRepo.slug || (locator.repoSlug !== null && locator.repoSlug !== contextRepo.slug)) {
+    throw new PriorProgramContextError(`prior-program context repo does not match the target repository`);
+  }
+  const programValue = readJson(locator.programPath, "accepted program");
+  const program = programValue && programValue.program && object(programValue.program) ? programValue.program : programValue;
+  if (!object(program) || typeof program.id !== "string" || program.id.trim() === "") {
+    throw new PriorProgramContextError("accepted program id is missing");
+  }
+  const receipt = readJson(locator.receiptPath, "canonical receipt");
+  const receiptError = validateReceipt(receipt);
+  if (receiptError) throw new PriorProgramContextError(`canonical receipt is invalid: ${receiptError}`);
+  if (receipt.program_id !== program.id || receipt.repo.slug !== targetRepo.slug || receipt.repo.root !== targetRepo.root) {
+    throw new PriorProgramContextError(`canonical receipt identity does not match the target repository and accepted program`);
+  }
+  const durableOutcomeEvidence = readJson(locator.durablePath, "durable outcome evidence");
+  const trustedGenericIntegrationEvidence = locator.genericPath
+    ? readJson(locator.genericPath, "generic integration evidence")
+    : undefined;
+  const proof = verifyClosedProgram({
+    acceptedProgram: program,
+    receipt,
+    durableOutcomeEvidence,
+    trustedGenericIntegrationEvidence,
+    orcaSnapshot: snapshot,
+    programSegment,
+  });
+  if (proof.ok !== true && !BLOCKING_PROOF_CODES.has(proof.reasonCode)) {
+    throw new PriorProgramContextError(`prior-program proof ${program.id} failed with ${proof.reasonCode || "PROOF_MALFORMED_INPUT"}`);
+  }
+  return { contextPath, program, receipt, proof };
+}
+
+function loadPriorProgramContexts({ inputs, repoRoot, snapshot }) {
+  const rawInputs = Array.isArray(inputs) ? inputs.slice() : [];
+  if (rawInputs.length === 0) return [];
+  const targetRepo = resolveRepoContext({ repoRootOverride: repoRoot });
+  const paths = rawInputs.map((input) => {
+    if (typeof input !== "string" || input.trim() === "") throw new PriorProgramContextError("prior-program context path is missing");
+    return path.resolve(process.cwd(), input);
+  });
+  const unique = new Set(paths);
+  if (unique.size !== paths.length) throw new PriorProgramContextError("prior-program context is duplicated");
+  const contexts = paths.map((contextPath) => loadOne(readJson(contextPath, "prior-program context"), contextPath, targetRepo, snapshot));
+  contexts.sort((left, right) => left.program.id.localeCompare(right.program.id) || left.contextPath.localeCompare(right.contextPath));
+  return contexts;
+}
+
+module.exports = { PriorProgramContextError, loadPriorProgramContexts, contextLocator };

--- a/skills/relay-orca/scripts/prior-program-context.js
+++ b/skills/relay-orca/scripts/prior-program-context.js
@@ -10,10 +10,21 @@ const { validateReceipt } = require("./lib/receipt");
 const { resolveRepoContext } = require("./receipt-io");
 const { programSegment } = require("./lib/program-segment");
 
+// A recomputed Leaf-1 proof that fails on a KNOWN lifecycle-residue code is not
+// authority for any exemption, but its live residue is still a valid blocking state:
+// the loader keeps the (ok:false) proof so the admission filter skips ownership and
+// classifies the unproven completed/foreign rows through EXISTING_ORCHESTRATION_STATE
+// (exit 34) with post-filter counts (DC #5). Only loader failures and identity/runtime
+// contradictions (cross-program/cross-runtime/duplicate/malformed/stale/unevaluable)
+// fall through to a thrown PriorProgramContextError → AMBIGUOUS_GLOBAL_STATE (exit 35).
+// The gate-lifecycle subset must be COMPLETE — a missing canonical gate is as much a
+// known blocking residue as a pending or failed one, so PROOF_GATE_MISSING belongs here
+// alongside PROOF_GATE_PENDING/FAILED, never on the exit-35 path.
 const BLOCKING_PROOF_CODES = new Set([
   "PROOF_TASK_ACTIVE",
   "PROOF_TASK_FAILED",
   "PROOF_TASK_MARKER_MISMATCH",
+  "PROOF_GATE_MISSING",
   "PROOF_GATE_PENDING",
   "PROOF_GATE_FAILED",
   "PROOF_GATE_DUPLICATE",

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -872,7 +872,7 @@ function probe(options = {}) {
         tasks: history.activeTasks ?? null,
         gates: history.blockingGates ?? null,
       };
-      reject(history.reasonCode, history.message);
+      reject(history.reasonCode, boundedExcerpt(history.message));
     }
     result.existing_state = { tasks: history.activeTasks, gates: history.blockingGates };
   } else if (activeTaskInfo.count > 0 || gateCountInfo.count > 0) {

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -9,6 +9,9 @@
 const { execFileSync } = require("node:child_process");
 const { resolveOrcaBin, isRunnableFile, MACOS_BUNDLE_FALLBACK } = require("./lib/resolve-orca-bin");
 const { REASONS, USAGE_EXIT, ProbeError, reject } = require("./lib/probe-reasons");
+const { classifyHistoricalState } = require("./lib/admission-history");
+const { loadPriorProgramContexts, PriorProgramContextError } = require("./prior-program-context");
+const { programSegment } = require("./lib/program-segment");
 
 const SMOKE_TITLE_MARKER = "relay-orca-probe-smoke";
 const SMOKE_SPEC = "relay-orca capability probe synthetic smoke (self-cleaning)";
@@ -101,6 +104,8 @@ function parseArgs(argv) {
     smoke: false,
     smokeTo: null,
     orcaBin: null,
+    repoRoot: null,
+    priorProgramContexts: [],
     help: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -117,6 +122,14 @@ function parseArgs(argv) {
       const value = argv[(i += 1)];
       if (!value || value.startsWith("-")) usageError("--orca-bin requires a path");
       opts.orcaBin = value;
+    } else if (arg === "--repo-root") {
+      const value = argv[(i += 1)];
+      if (!value || value.startsWith("-")) usageError("--repo-root requires a path");
+      opts.repoRoot = value;
+    } else if (arg === "--prior-program-context") {
+      const value = argv[(i += 1)];
+      if (!value || value.startsWith("-")) usageError("--prior-program-context requires a path");
+      opts.priorProgramContexts.push(value);
     } else if (arg === "--help" || arg === "-h") opts.help = true;
     else usageError(`unrecognized argument: ${arg}`);
   }
@@ -137,7 +150,8 @@ function parseArgs(argv) {
 function usageError(message) {
   process.stderr.write(`relay-orca probe: ${message}\n`);
   process.stderr.write(
-    "usage: probe-orca.js [--json] [--smoke --smoke-to <handle>] [--orca-bin <path>]\n",
+    "usage: probe-orca.js [--json] [--smoke --smoke-to <handle>] [--orca-bin <path>] " +
+      "[--repo-root <path>] [--prior-program-context <context.json>] ...\n",
   );
   process.exit(USAGE_EXIT);
 }
@@ -807,8 +821,9 @@ function probe(options = {}) {
     );
   }
 
-  // Only non-terminal tasks block admission. Historical completed/failed tasks stay
-  // listed by the real CLI but must not brick later probes. Unknown status fails closed.
+  // Only non-terminal tasks block admission in the frozen no-context mode. Historical
+  // completed/failed tasks stay listed by the real CLI but must not brick later probes.
+  // Unknown status fails closed. Keep this path byte-identical for #942 callers.
   const activeTaskInfo = countActiveTasks(taskCountInfo.items || []);
   if (activeTaskInfo.ambiguous) {
     recordCheck(result.checks, "existing_state", "failed");
@@ -818,7 +833,45 @@ function probe(options = {}) {
   }
   result.existing_state = { tasks: activeTaskInfo.count, gates: gateCountInfo.count };
 
-  if (activeTaskInfo.count > 0 || gateCountInfo.count > 0) {
+  const priorProgramContexts = Array.isArray(options.priorProgramContexts)
+    ? options.priorProgramContexts
+    : [];
+  if (priorProgramContexts.length > 0) {
+    let history;
+    try {
+      const contexts = loadPriorProgramContexts({
+        inputs: priorProgramContexts,
+        repoRoot: options.repoRoot,
+        snapshot: {
+          status: statusShape.payload,
+          task_list: taskListShape.payload,
+          gate_list: gateListShape.payload,
+        },
+      });
+      history = classifyHistoricalState({
+        tasks: taskCountInfo.items || [],
+        gates: gateCountInfo.items || [],
+        contexts,
+        programSegment,
+      });
+    } catch (error) {
+      recordCheck(result.checks, "existing_state", "failed");
+      skipRemaining(result.checks, ["smoke"]);
+      result.existing_state = { tasks: null, gates: null };
+      const detail = error instanceof PriorProgramContextError ? error.message : "context could not be read";
+      reject("AMBIGUOUS_GLOBAL_STATE", `prior-program context is untrustworthy: ${boundedExcerpt(detail)}`);
+    }
+    if (!history.ok) {
+      recordCheck(result.checks, "existing_state", "failed");
+      skipRemaining(result.checks, ["smoke"]);
+      result.existing_state = {
+        tasks: history.activeTasks ?? null,
+        gates: history.blockingGates ?? null,
+      };
+      reject(history.reasonCode, history.message);
+    }
+    result.existing_state = { tasks: history.activeTasks, gates: history.blockingGates };
+  } else if (activeTaskInfo.count > 0 || gateCountInfo.count > 0) {
     recordCheck(result.checks, "existing_state", "failed");
     skipRemaining(result.checks, ["smoke"]);
     reject(
@@ -850,6 +903,8 @@ function runMain(argv = process.argv.slice(2), runtime = {}) {
       smoke: opts.smoke,
       smokeTo: opts.smokeTo,
       orcaBin: opts.orcaBin,
+      priorProgramContexts: opts.priorProgramContexts,
+      repoRoot: opts.repoRoot || runtime.repoRoot,
       pathEnv: runtime.pathEnv,
       isRunnableFile: runtime.isRunnableFile,
       pathDelimiter: runtime.pathDelimiter,

--- a/skills/relay-orca/scripts/probe-orca.js
+++ b/skills/relay-orca/scripts/probe-orca.js
@@ -842,6 +842,10 @@ function probe(options = {}) {
       const contexts = loadPriorProgramContexts({
         inputs: priorProgramContexts,
         repoRoot: options.repoRoot,
+        // Only a launching `run` supplies launchedProgramId; loadOne fails closed on a
+        // prior-program context that is self-referential to it. The standalone probe passes
+        // none, so its historical-admission behavior is unchanged.
+        launchedProgramId: options.launchedProgramId,
         snapshot: {
           status: statusShape.payload,
           task_list: taskListShape.payload,

--- a/skills/relay-orca/scripts/run.js
+++ b/skills/relay-orca/scripts/run.js
@@ -75,7 +75,8 @@ function usageError(message) {
   process.stderr.write(`relay-orca run: ${message}\n`);
   process.stderr.write(
     "usage: run.js --program-file <accepted-program.json> [--json] [--concurrency N] " +
-      "[--operator-handle <handle> ...] [--coordinator-handle <handle>] [--gate-evidence-dir <dir>] [--orca-bin <path>]\n",
+      "[--operator-handle <handle> ...] [--coordinator-handle <handle>] [--gate-evidence-dir <dir>] " +
+      "[--prior-program-context <context.json> ...] [--orca-bin <path>]\n",
   );
   process.exit(USAGE_EXIT);
 }
@@ -88,6 +89,7 @@ function parseArgs(argv) {
     operatorHandles: [],
     coordinatorHandle: null,
     gateEvidenceDir: null,
+    priorProgramContexts: [],
     orcaBin: null,
     repoRoot: null,
     // #947 additive operator-record flags. A decision/authorization record is written
@@ -106,6 +108,7 @@ function parseArgs(argv) {
     else if (arg === "--operator-handle") opts.operatorHandles.push(requireValue(argv[(i += 1)], "--operator-handle"));
     else if (arg === "--coordinator-handle") opts.coordinatorHandle = requireValue(argv[(i += 1)], "--coordinator-handle");
     else if (arg === "--gate-evidence-dir") opts.gateEvidenceDir = requireValue(argv[(i += 1)], "--gate-evidence-dir");
+    else if (arg === "--prior-program-context") opts.priorProgramContexts.push(requireValue(argv[(i += 1)], "--prior-program-context"));
     else if (arg === "--resolve-decision") opts.resolveDecision = requireValue(argv[(i += 1)], "--resolve-decision");
     else if (arg === "--resolution") opts.resolution = requireValue(argv[(i += 1)], "--resolution");
     else if (arg === "--resolver") opts.resolver = requireValue(argv[(i += 1)], "--resolver");
@@ -273,6 +276,8 @@ function main() {
       concurrency: opts.concurrency,
       operatorHandles: opts.operatorHandles,
       orcaBin: opts.orcaBin,
+      priorProgramContexts: opts.priorProgramContexts,
+      repoRoot: opts.repoRoot,
       runOrca,
       persistReceipt,
       coordinatorHandle: opts.coordinatorHandle,

--- a/tests/relay-orca/fixtures/fake-orca.js
+++ b/tests/relay-orca/fixtures/fake-orca.js
@@ -160,19 +160,26 @@ function argValue(flag) {
 
 const scenario = loadScenario();
 
+// AC8 read-only surface: the historical-admission path may ONLY read status/task-list/
+// gate-list. Every mutation, foreign adoption, and worktree/terminal touch is poisoned so
+// a read-only admission test hard-fails the moment relay-orca reaches for one. The list
+// mirrors DC #8: reset, task-create/update/delete, gate create/resolve/delete, dispatch,
+// worktree, terminal, and foreign adoption (adopt).
 if (scenario.poisonMutations && (
   args.includes("reset") ||
   args.includes("task-create") ||
   args.includes("task-update") ||
+  args.includes("task-delete") ||
   args.includes("gate-create") ||
   args.includes("gate-resolve") ||
   args.includes("gate-delete") ||
   args.includes("dispatch") ||
   args.includes("worktree") ||
-  args.includes("terminal")
+  args.includes("terminal") ||
+  args.includes("adopt")
 )) {
   if (poisonPath) fs.writeFileSync(poisonPath, "MUTATION_INVOKED:" + args.join(" "), "utf-8");
-  process.stderr.write("POISON: mutation must never be invoked by read-only admission\\n");
+  process.stderr.write("POISON: mutation/adoption must never be invoked by read-only admission\\n");
   process.exit(98);
 }
 

--- a/tests/relay-orca/fixtures/fake-orca.js
+++ b/tests/relay-orca/fixtures/fake-orca.js
@@ -111,6 +111,10 @@ function defaultScenario(overrides = {}) {
         },
     taskUpdateExit: overrides.taskUpdateExit !== undefined ? overrides.taskUpdateExit : 0,
     taskUpdateStderr: overrides.taskUpdateStderr || "",
+    // Admission tests can turn every mutation into a poison pill.  The normal
+    // smoke fixture keeps its historical behavior; this opt-in guard makes
+    // reset-free admission tests prove the complete read-only surface.
+    poisonMutations: overrides.poisonMutations === true,
   };
 }
 
@@ -154,6 +158,24 @@ function argValue(flag) {
   return args[idx + 1];
 }
 
+const scenario = loadScenario();
+
+if (scenario.poisonMutations && (
+  args.includes("reset") ||
+  args.includes("task-create") ||
+  args.includes("task-update") ||
+  args.includes("gate-create") ||
+  args.includes("gate-resolve") ||
+  args.includes("gate-delete") ||
+  args.includes("dispatch") ||
+  args.includes("worktree") ||
+  args.includes("terminal")
+)) {
+  if (poisonPath) fs.writeFileSync(poisonPath, "MUTATION_INVOKED:" + args.join(" "), "utf-8");
+  process.stderr.write("POISON: mutation must never be invoked by read-only admission\\n");
+  process.exit(98);
+}
+
 // D2 poison: any reset invocation hard-fails the fixture (and thus the test).
 if (args.includes("reset")) {
   if (poisonPath) fs.writeFileSync(poisonPath, "RESET_INVOKED:" + args.join(" "), "utf-8");
@@ -169,8 +191,6 @@ const stallCmd = process.env.RELAY_FAKE_ORCA_STALL_CMD || "status";
 if (Number.isInteger(stallMs) && stallMs > 0 && args[0] === stallCmd) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, stallMs);
 }
-
-const scenario = loadScenario();
 
 if (args[0] === "status") {
   emit(scenario.status, scenario.statusExit, scenario.statusStdout, scenario.statusStderr);

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -841,9 +841,16 @@ test("#1021 missing, duplicate, and malformed contexts fail closed before any mu
   const malformedPath = path.join(history.root, "malformed.json");
   const crossRepoPath = path.join(history.root, "cross-repo.json");
   fs.writeFileSync(malformedPath, JSON.stringify({ schema: 1 }), "utf8");
+  // Portable cross-repo fixture: a per-test temporary git repo whose canonical slug/root differ
+  // from the target repository on ANY host — never a host-specific absolute path. The context
+  // points a valid, loadable locator at this unrelated checkout, so admission fails closed on the
+  // repo-identity mismatch (→ AMBIGUOUS_GLOBAL_STATE) rather than depending on a path only present
+  // on one developer's machine.
+  const crossRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-cross-repo-"));
+  execFileSync("git", ["-C", crossRepoRoot, "init", "-q"], { stdio: "ignore" });
   fs.writeFileSync(crossRepoPath, JSON.stringify({
     ...JSON.parse(fs.readFileSync(history.contextPath, "utf8")),
-    repo_root: "/Users/sjlee/gstack",
+    repo_root: crossRepoRoot,
   }), "utf8");
   try {
     for (const inputs of [
@@ -862,6 +869,110 @@ test("#1021 missing, duplicate, and malformed contexts fail closed before any mu
   } finally {
     fake.restore();
     fs.rmSync(history.root, { recursive: true, force: true });
+    fs.rmSync(crossRepoRoot, { recursive: true, force: true });
+  }
+});
+
+test("#1021 R5 finding 1: a FAILED prior context that claims the SAME physical task as a PASSING one is AMBIGUOUS (exit 35), never masked", () => {
+  // Program A's proof passes and would exempt the live `shared-task` row. Program B's proof FAILS
+  // (its marker/canonical gate do not match the shared live rows) yet its recomputed proof still
+  // CLAIMS the same physical `shared-task`. A passing proof must never mask a live row an unproven
+  // program also claims (DC #6), so admission fails closed AMBIGUOUS_GLOBAL_STATE with zero
+  // mutation — it must NOT silently admit by letting A's exemption cover B's unproven claim.
+  const passing = historicalContextFixture({ programId: "prior-program-a-overlap", taskId: "shared-task" });
+  const failing = historicalContextFixture({ programId: "prior-program-b-overlap", taskId: "shared-task" });
+  const beforePassing = snapshotDir(passing.root);
+  const beforeFailing = snapshotDir(failing.root);
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    // The live snapshot carries A's completed task + passed gate; B is recomputed against the SAME
+    // rows, so B fails marker/canonical checks while still resolving the shared physical task.
+    taskList: { id: "x", ok: true, result: { tasks: [passing.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [passing.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(passing.contextPath, fake, {
+      priorProgramContexts: [passing.contextPath, failing.contextPath],
+    });
+    assert.equal(error && error.reasonCode, "AMBIGUOUS_GLOBAL_STATE");
+    assert.equal(error.exitCode, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    assert.equal(result.admitted, false);
+    // The exit-35 path nulls the post-filter counts (no classifiable blocking counts are reported).
+    assert.deepEqual(result.existing_state, { tasks: null, gates: null });
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+    assert.deepEqual(snapshotDir(passing.root), beforePassing, "the ambiguous overlap path must not mutate any input file");
+    assert.deepEqual(snapshotDir(failing.root), beforeFailing, "the ambiguous overlap path must not mutate any input file");
+  } finally {
+    fake.restore();
+    fs.rmSync(passing.root, { recursive: true, force: true });
+    fs.rmSync(failing.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 R5 finding 1: two FAILED prior contexts that claim the SAME physical task are AMBIGUOUS (exit 35), zero mutation", () => {
+  // Neither proof passes (both lost their canonical gate), so neither grants an exemption — but
+  // both recomputed proofs still CLAIM the same physical `shared-task-2` row. Two unproven programs
+  // contending for one live row is unclassifiable, so admission fails closed AMBIGUOUS_GLOBAL_STATE
+  // (exit 35) with zero mutation, never silently reported as exit-34 residue.
+  const first = historicalContextFixture({ programId: "prior-program-c-overlap", taskId: "shared-task-2" });
+  const second = historicalContextFixture({ programId: "prior-program-d-overlap", taskId: "shared-task-2" });
+  const beforeFirst = snapshotDir(first.root);
+  const beforeSecond = snapshotDir(second.root);
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    // The live task is present (so both proofs resolve and CLAIM the shared physical row) but the
+    // gate is gone, so BOTH proofs fail PROOF_GATE_MISSING — neither can grant an exemption.
+    taskList: { id: "x", ok: true, result: { tasks: [first.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [], count: 0 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(first.contextPath, fake, {
+      priorProgramContexts: [first.contextPath, second.contextPath],
+    });
+    assert.equal(error && error.reasonCode, "AMBIGUOUS_GLOBAL_STATE");
+    assert.equal(error.exitCode, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    assert.equal(result.admitted, false);
+    assert.deepEqual(result.existing_state, { tasks: null, gates: null });
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+    assert.deepEqual(snapshotDir(first.root), beforeFirst, "the ambiguous overlap path must not mutate any input file");
+    assert.deepEqual(snapshotDir(second.root), beforeSecond, "the ambiguous overlap path must not mutate any input file");
+  } finally {
+    fake.restore();
+    fs.rmSync(first.root, { recursive: true, force: true });
+    fs.rmSync(second.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 R5 finding 2: the historical reject message is bounded before it is surfaced", () => {
+  // The AMBIGUOUS overlap message embeds a subprocess-derived physical id. An adversarial or wedged
+  // CLI could inflate that id without bound; admission must render `history.message` through
+  // boundedExcerpt like every other reject call site, so a blocking message can never be inflated
+  // or line-injected past the D8 bound (EXCERPT_LIMIT = 256).
+  const longTaskId = "s".repeat(400);
+  const passing = historicalContextFixture({ programId: "prior-program-a-bounded", taskId: longTaskId });
+  const failing = historicalContextFixture({ programId: "prior-program-b-bounded", taskId: longTaskId });
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: { id: "x", ok: true, result: { tasks: [passing.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [passing.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(passing.contextPath, fake, {
+      priorProgramContexts: [passing.contextPath, failing.contextPath],
+    });
+    assert.equal(error && error.reasonCode, "AMBIGUOUS_GLOBAL_STATE");
+    assert.equal(result.admitted, false);
+    // The raw id is >256 chars; the surfaced message must be truncated to the bounded excerpt and
+    // must never carry the full unbounded id.
+    assert.ok(error.message.length <= 256, `reject message must be bounded, got length ${error.message.length}`);
+    assert.ok(!error.message.includes(longTaskId), "the full unbounded id must not appear in the surfaced message");
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(passing.root, { recursive: true, force: true });
+    fs.rmSync(failing.root, { recursive: true, force: true });
   }
 });
 

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -31,6 +31,8 @@ const {
 const { probe } = require(PROBE_JS);
 const { programSegment, resolveRepoContext } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "receipt-io.js"));
 const { RECEIPT_NOTE } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "receipt.js"));
+const { canonicalIntegrationQuestion } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "integration-lifecycle.js"));
+const { verificationBinding, sha256 } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "integration-evidence.js"));
 
 const READ_ONLY_SUBCOMMANDS = new Set(["status", "task-list", "gate-list"]);
 const FORBIDDEN_DEFAULT = ["task-create", "task-update", "dispatch", "run", "reset"];
@@ -87,10 +89,18 @@ function historicalContextFixture({ programId = "prior-program-1", taskId = "pri
   const repo = resolveRepoContext({ repoRootOverride: REPO_ROOT });
   const outcomeId = "integration";
   const marker = `relay-orca: ${programSegment(programId)}/${outcomeId}`;
+  const checkRef = "full-suite";
+  const verification = verificationBinding({
+    input_sha256: sha256("prior-input"),
+    result_sha256: sha256("prior-result"),
+    passed: true,
+  });
   const program = {
     id: programId,
     runtime_id: DEFAULT_RUNTIME_ID,
-    exit_gates: ["budget:tasks_created <= 5"],
+    exit_gates: [`integration:${checkRef}`],
+    integration_evidence_version: 1,
+    integration_evidence: [{ check_ref: checkRef, program_id: programId, runtime_id: DEFAULT_RUNTIME_ID, verification }],
     outcomes: [{ id: outcomeId, task_kind: "integration_gate", accepted_outcomes: ["passed"] }],
   };
   const task = {
@@ -122,16 +132,32 @@ function historicalContextFixture({ programId = "prior-program-1", taskId = "pri
       integration: { passed: true },
     },
   };
+  const generic = {
+    [checkRef]: {
+      schema: 1,
+      program_id: programId,
+      runtime_id: DEFAULT_RUNTIME_ID,
+      check_ref: checkRef,
+      verification,
+      evidence: "prior integration evidence",
+    },
+  };
   const context = {
     schema: 1,
+    // Deliberately false: the probe must ignore this claim and recompute Leaf 1.
+    success: false,
     repo_root: REPO_ROOT,
     accepted_program: { path: path.join(root, "accepted-program.json") },
     canonical_receipt: { path: path.join(root, "receipt.json") },
-    trusted_evidence: { durable_outcomes: { path: path.join(root, "durable.json") } },
+    trusted_evidence: {
+      durable_outcomes: { path: path.join(root, "durable.json") },
+      generic_integration: { path: path.join(root, "generic.json") },
+    },
   };
   fs.writeFileSync(path.join(root, "accepted-program.json"), JSON.stringify(program), "utf8");
   fs.writeFileSync(path.join(root, "receipt.json"), JSON.stringify(receipt), "utf8");
   fs.writeFileSync(path.join(root, "durable.json"), JSON.stringify(durable), "utf8");
+  fs.writeFileSync(path.join(root, "generic.json"), JSON.stringify(generic), "utf8");
   fs.writeFileSync(path.join(root, "context.json"), JSON.stringify(context), "utf8");
   return {
     root,
@@ -142,7 +168,7 @@ function historicalContextFixture({ programId = "prior-program-1", taskId = "pri
     gate: {
       id: `gate-${taskId}`,
       task_id: taskId,
-      question: `Integration evidence for ${marker} passed?`,
+      question: canonicalIntegrationQuestion(programId, outcomeId, programSegment),
       options: ["passed", "failed"],
       status: "passed",
       resolution: "passed",
@@ -644,6 +670,37 @@ test("#1021 verified prior-program context admits its completed task and passed 
   }
 });
 
+test("#1021 probe CLI accepts repeatable context paths and recomputes proof", () => {
+  const history = historicalContextFixture({ programId: "prior-program-cli" });
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: { id: "x", ok: true, result: { tasks: [history.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [history.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const result = runProbe([
+      "--json",
+      "--orca-bin",
+      fake.orcaPath,
+      "--repo-root",
+      REPO_ROOT,
+      "--prior-program-context",
+      history.contextPath,
+      "--prior-program-context",
+      history.contextPath,
+    ]);
+    assert.equal(result.status, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    const body = parseJson(result.stdout);
+    assertExactKeys(body);
+    assert.equal(body.admitted, false);
+    assert.match(body.blocking_reasons[0].message, /duplicated/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
 test("#1021 prior-program contexts never let a foreign terminal row hide behind a verified proof", () => {
   const history = historicalContextFixture({ programId: "prior-program-foreign" });
   const foreign = { id: "foreign-terminal", task_title: "foreign", display_name: "foreign", status: "completed" };
@@ -668,6 +725,89 @@ test("#1021 prior-program contexts never let a foreign terminal row hide behind 
     assert.equal(result.admitted, false);
     assert.match(error.message, /active_tasks=1/);
     assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 failed, missing-id, and duplicate rows are never historical exemptions", () => {
+  const scenarios = [
+    {
+      label: "failed",
+      task: (history) => ({ ...history.task, status: "failed" }),
+      expected: "EXISTING_ORCHESTRATION_STATE",
+    },
+    {
+      label: "missing id",
+      task: (history) => ({ ...history.task, id: "" }),
+      expected: "AMBIGUOUS_GLOBAL_STATE",
+    },
+    {
+      label: "duplicate",
+      task: (history) => [history.task, { ...history.task }],
+      expected: "AMBIGUOUS_GLOBAL_STATE",
+    },
+  ];
+  for (const scenario of scenarios) {
+    const history = historicalContextFixture({ programId: `prior-program-${scenario.label.replace(/ /g, "-")}` });
+    const tasks = scenario.task(history);
+    const rows = Array.isArray(tasks) ? tasks : [tasks];
+    const fake = installFakeOrca({
+      poisonMutations: true,
+      taskList: {
+        id: "x",
+        ok: true,
+        result: { tasks: rows, count: rows.length },
+        _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+      },
+      gateList: {
+        id: "x",
+        ok: true,
+        result: { gates: [history.gate], count: 1 },
+        _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+      },
+    });
+    try {
+      const { result, error } = runProbeWithPriorContext(history.contextPath, fake);
+      assert.equal(error && error.reasonCode, scenario.expected, scenario.label);
+      assert.equal(result.admitted, false, scenario.label);
+      assertNoPoison(fake);
+    } finally {
+      fake.restore();
+      fs.rmSync(history.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("#1021 missing, duplicate, and malformed contexts fail closed before any mutation", () => {
+  const history = historicalContextFixture({ programId: "prior-program-context-errors" });
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: { id: "x", ok: true, result: { tasks: [history.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [history.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  const malformedPath = path.join(history.root, "malformed.json");
+  const crossRepoPath = path.join(history.root, "cross-repo.json");
+  fs.writeFileSync(malformedPath, JSON.stringify({ schema: 1 }), "utf8");
+  fs.writeFileSync(crossRepoPath, JSON.stringify({
+    ...JSON.parse(fs.readFileSync(history.contextPath, "utf8")),
+    repo_root: "/Users/sjlee/gstack",
+  }), "utf8");
+  try {
+    for (const inputs of [
+      [path.join(history.root, "missing.json")],
+      [history.contextPath, history.contextPath],
+      [malformedPath],
+      [crossRepoPath],
+    ]) {
+      const { result, error } = runProbeWithPriorContext(inputs[0], fake, {
+        priorProgramContexts: inputs,
+      });
+      assert.equal(error && error.reasonCode, "AMBIGUOUS_GLOBAL_STATE");
+      assert.equal(result.admitted, false);
+      assertNoPoison(fake);
+    }
   } finally {
     fake.restore();
     fs.rmSync(history.root, { recursive: true, force: true });

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -194,6 +194,57 @@ function runProbeWithPriorContext(contextPath, fake, overrides = {}) {
   return { result, error };
 }
 
+// AC8 (DC #8): mutation / foreign-adoption / worktree / terminal tokens the strictly
+// read-only historical-admission path must NEVER emit. Kept in lock-step with the fixture's
+// poisonMutations surface so a test proves the whole matrix, not a subset.
+const FORBIDDEN_ADMISSION_TOKENS = [
+  "reset",
+  "task-create",
+  "task-update",
+  "task-delete",
+  "gate-create",
+  "gate-resolve",
+  "gate-delete",
+  "dispatch",
+  "worktree",
+  "terminal",
+  "adopt",
+];
+
+// Content-hash every file in a directory so a before/after comparison proves the read-only
+// admission path made ZERO filesystem writes (input byte identity, DC #8).
+function snapshotDir(dir) {
+  const map = {};
+  for (const name of fs.readdirSync(dir).sort()) {
+    const full = path.join(dir, name);
+    if (fs.statSync(full).isFile()) map[name] = sha256(fs.readFileSync(full, "utf8"));
+  }
+  return map;
+}
+
+// Tripwire `gh` and `orca` on PATH: admission is given the fake via --orca-bin and never
+// shells out to GitHub, so IF it ever fell through to a real binary the marker file proves
+// it. Neither marker may exist after a read-only admission (DC #8: never invoke real orca/gh).
+function installRealBinaryPoison() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-real-bin-poison-"));
+  for (const name of ["gh", "orca"]) {
+    const marker = path.join(dir, `${name}.invoked`);
+    fs.writeFileSync(
+      path.join(dir, name),
+      `#!/bin/sh\necho REAL_${name}_INVOKED > ${JSON.stringify(marker)}\nexit 97\n`,
+      "utf8",
+    );
+    fs.chmodSync(path.join(dir, name), 0o755);
+  }
+  return {
+    dir,
+    ghInvoked: () => fs.existsSync(path.join(dir, "gh.invoked")),
+    orcaInvoked: () => fs.existsSync(path.join(dir, "orca.invoked")),
+    pathWith: () => `${dir}${path.delimiter}${process.env.PATH || ""}`,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // D3 binary resolution
 // ---------------------------------------------------------------------------
@@ -810,6 +861,140 @@ test("#1021 missing, duplicate, and malformed contexts fail closed before any mu
     }
   } finally {
     fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 a verified completed task whose live canonical gate is MISSING classifies as EXISTING_ORCHESTRATION_STATE (34), not AMBIGUOUS (35)", () => {
+  // The mapped completed task is still present, but its canonical gate has vanished from the
+  // live gate-list. Leaf 1 recomputes PROOF_GATE_MISSING — a KNOWN blocking lifecycle residue
+  // (a missing gate is no less blocking than a pending/failed one). Admission must therefore
+  // classify the now-unproven completed row through exit 34 with post-filter counts, never
+  // throw PriorProgramContextError → AMBIGUOUS_GLOBAL_STATE (35) with existing_state {null,null}.
+  const history = historicalContextFixture({ programId: "prior-program-gate-missing" });
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: { id: "x", ok: true, result: { tasks: [history.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [], count: 0 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(history.contextPath, fake);
+    assert.equal(error && error.reasonCode, "EXISTING_ORCHESTRATION_STATE");
+    assert.equal(error.exitCode, REASONS.EXISTING_ORCHESTRATION_STATE);
+    assert.equal(result.admitted, false);
+    assert.match(error.message, /active_tasks=1/);
+    // Post-filter counts are reported, NOT nulled out as they are on the exit-35 path.
+    assert.deepEqual(result.existing_state, { tasks: 1, gates: 0 });
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 AC8: task-delete and foreign adoption (adopt) are poisoned on the read-only admission fixture", () => {
+  const fake = installFakeOrca({ poisonMutations: true });
+  try {
+    for (const argv of [
+      ["orchestration", "task-delete", "--id", "t1", "--json"],
+      ["orchestration", "adopt", "--run", "r1", "--json"],
+    ]) {
+      fs.rmSync(fake.poisonPath, { force: true });
+      let status = 0;
+      try {
+        execFileSync(fake.orcaPath, argv, { stdio: "pipe" });
+      } catch (error) {
+        status = error.status;
+      }
+      assert.equal(status, 98, `${argv.join(" ")} must hard-fail the read-only fixture`);
+      assert.match(fake.readPoison(), /MUTATION_INVOKED/);
+    }
+  } finally {
+    fake.restore();
+  }
+});
+
+test("#1021 AC8: read-only admission touches no mutating/adoption subcommand, no real gh/orca, and writes nothing", () => {
+  const realPoison = installRealBinaryPoison();
+  const history = historicalContextFixture({ programId: "prior-program-ac8-readonly" });
+  const fake = installFakeOrca(
+    {
+      poisonMutations: true,
+      taskList: { id: "x", ok: true, result: { tasks: [history.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+      gateList: { id: "x", ok: true, result: { gates: [history.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    },
+    { prependPath: false },
+  );
+  const before = snapshotDir(history.root);
+  try {
+    const result = runProbe(
+      ["--json", "--orca-bin", fake.orcaPath, "--repo-root", REPO_ROOT, "--prior-program-context", history.contextPath],
+      { PATH: realPoison.pathWith() },
+    );
+    assert.equal(result.status, 0);
+    const body = parseJson(result.stdout);
+    assert.equal(body.admitted, true);
+    assert.deepEqual(body.existing_state, { tasks: 0, gates: 0 });
+    // Neither the real `gh` nor a PATH `orca` was shelled out (only the injected fake ran).
+    assert.equal(realPoison.ghInvoked(), false, "real gh must never be invoked by admission");
+    assert.equal(realPoison.orcaInvoked(), false, "real/PATH orca must never be invoked when --orca-bin is injected");
+    // Only read-only subcommands ran; no mutation/adoption/worktree/terminal token appears.
+    assertReadOnlyLog(fake.readLog());
+    const tokens = fake.readLog().join(" ");
+    FORBIDDEN_ADMISSION_TOKENS.forEach((forbidden) =>
+      assert.equal(tokens.includes(forbidden), false, `read-only admission emitted ${forbidden}`),
+    );
+    assertNoPoison(fake);
+    // Zero filesystem writes: every explicit input file is byte-identical and none were added.
+    assert.deepEqual(snapshotDir(history.root), before, "read-only admission must not mutate its input files");
+  } finally {
+    fake.restore();
+    realPoison.cleanup();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 AC8: a rejected admission leaves every explicit context input byte-identical (zero mutation)", () => {
+  const realPoison = installRealBinaryPoison();
+  const history = historicalContextFixture({ programId: "prior-program-ac8-identity" });
+  // A foreign completed terminal row cannot hide behind the verified proof, so admission
+  // rejects with EXISTING_ORCHESTRATION_STATE. Even on this failure path every read input
+  // stays byte-identical — the admission surface never writes.
+  const foreign = { id: "foreign-terminal", task_title: "foreign", display_name: "foreign", status: "completed" };
+  const fake = installFakeOrca(
+    {
+      poisonMutations: true,
+      taskList: { id: "x", ok: true, result: { tasks: [history.task, foreign], count: 2 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+      gateList: { id: "x", ok: true, result: { gates: [history.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    },
+    { prependPath: false },
+  );
+  const before = snapshotDir(history.root);
+  try {
+    const result = runProbe(
+      ["--json", "--orca-bin", fake.orcaPath, "--repo-root", REPO_ROOT, "--prior-program-context", history.contextPath],
+      { PATH: realPoison.pathWith() },
+    );
+    assert.equal(result.status, REASONS.EXISTING_ORCHESTRATION_STATE);
+    const body = parseJson(result.stdout);
+    assert.equal(body.admitted, false);
+    assert.equal(body.blocking_reasons[0].reason_code, "EXISTING_ORCHESTRATION_STATE");
+    assert.match(body.blocking_reasons[0].message, /active_tasks=1/);
+    // Input byte identity: every explicit context/receipt/evidence file is unchanged.
+    assert.deepEqual(snapshotDir(history.root), before, "failed admission must not mutate any input file");
+    // No mutation/adoption, no real gh/orca, no poison marker even on the reject path.
+    assertReadOnlyLog(fake.readLog());
+    const tokens = fake.readLog().join(" ");
+    FORBIDDEN_ADMISSION_TOKENS.forEach((forbidden) =>
+      assert.equal(tokens.includes(forbidden), false, `rejected admission emitted ${forbidden}`),
+    );
+    assert.equal(realPoison.ghInvoked(), false);
+    assert.equal(realPoison.orcaInvoked(), false);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    realPoison.cleanup();
     fs.rmSync(history.root, { recursive: true, force: true });
   }
 });

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -893,6 +893,69 @@ test("#1021 a verified completed task whose live canonical gate is MISSING class
   }
 });
 
+test("#1021 R3 finding 1: a mixed-failure proof (blocking + unclassifiable co-failure) is ambiguous → exit 35, never kept as exit-34 residue", () => {
+  // The retained runtime lost BOTH the mapped task and its canonical gate: Leaf 1 recomputes
+  // a proof whose failures MIX a known blocking residue (PROOF_GATE_MISSING) with an
+  // unclassifiable co-failure (PROOF_TASK_MISSING). Ambiguity must dominate — the whole
+  // context is unclassifiable — so admission throws AMBIGUOUS_GLOBAL_STATE (exit 35) with the
+  // counts nulled, NEVER retaining it as exit-34 classifiable blocking on the strength of the
+  // primary reason code (PROOF_GATE_MISSING) alone. Every explicit input stays byte-identical.
+  const history = historicalContextFixture({ programId: "prior-program-mixed-failure" });
+  const before = snapshotDir(history.root);
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: { id: "x", ok: true, result: { tasks: [], count: 0 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [], count: 0 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(history.contextPath, fake);
+    assert.equal(error && error.reasonCode, "AMBIGUOUS_GLOBAL_STATE");
+    assert.equal(error.exitCode, REASONS.AMBIGUOUS_GLOBAL_STATE);
+    assert.equal(result.admitted, false);
+    // The exit-35 path nulls the post-filter counts (it never reports classifiable blocking counts).
+    assert.deepEqual(result.existing_state, { tasks: null, gates: null });
+    // Zero mutation + byte-identity of every explicit input on the ambiguous failure path.
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+    assert.deepEqual(snapshotDir(history.root), before, "the ambiguous failure path must not mutate any input file");
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 R3 finding 1 boundary: an all-blocking multi-failure proof is STILL retained as exit-34 classifiable residue", () => {
+  // Two blocking residues co-occur — the mapped task is active (PROOF_TASK_ACTIVE) AND its
+  // canonical gate has vanished (PROOF_GATE_MISSING). EVERY failure code is a known blocking
+  // lifecycle code, so the fix must NOT over-throw: the context stays classifiable and
+  // admission reports it through exit 34 (EXISTING_ORCHESTRATION_STATE) with post-filter
+  // counts, not the ambiguous exit-35 path.
+  const history = historicalContextFixture({ programId: "prior-program-all-blocking" });
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [{ ...history.task, status: "dispatched" }], count: 1 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+    gateList: { id: "x", ok: true, result: { gates: [], count: 0 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(history.contextPath, fake);
+    assert.equal(error && error.reasonCode, "EXISTING_ORCHESTRATION_STATE");
+    assert.equal(error.exitCode, REASONS.EXISTING_ORCHESTRATION_STATE);
+    assert.equal(result.admitted, false);
+    assert.match(error.message, /active_tasks=1/);
+    assert.deepEqual(result.existing_state, { tasks: 1, gates: 0 });
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
 test("#1021 AC8: task-delete and foreign adoption (adopt) are poisoned on the read-only admission fixture", () => {
   const fake = installFakeOrca({ poisonMutations: true });
   try {

--- a/tests/relay-orca/scripts/probe-orca.test.js
+++ b/tests/relay-orca/scripts/probe-orca.test.js
@@ -13,6 +13,7 @@ const {
   resolveOrcaBin,
   isRunnableFile,
   runMain,
+  emptyResult,
   MACOS_BUNDLE_FALLBACK,
   JSON_KEYS,
   SMOKE_TITLE_MARKER,
@@ -27,6 +28,9 @@ const {
   DEFAULT_LIVE_AGENT_HANDLE,
   VALID_TASK_STATUSES,
 } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+const { probe } = require(PROBE_JS);
+const { programSegment, resolveRepoContext } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "receipt-io.js"));
+const { RECEIPT_NOTE } = require(path.join(REPO_ROOT, "skills", "relay-orca", "scripts", "lib", "receipt.js"));
 
 const READ_ONLY_SUBCOMMANDS = new Set(["status", "task-list", "gate-list"]);
 const FORBIDDEN_DEFAULT = ["task-create", "task-update", "dispatch", "run", "reset"];
@@ -76,6 +80,92 @@ function assertReadOnlyLog(logLines) {
     if (parts[0] === "orchestration" && READ_ONLY_SUBCOMMANDS.has(parts[1])) continue;
     assert.fail(`unexpected default-mode invocation: ${line}`);
   }
+}
+
+function historicalContextFixture({ programId = "prior-program-1", taskId = "prior-task-1" } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-prior-context-"));
+  const repo = resolveRepoContext({ repoRootOverride: REPO_ROOT });
+  const outcomeId = "integration";
+  const marker = `relay-orca: ${programSegment(programId)}/${outcomeId}`;
+  const program = {
+    id: programId,
+    runtime_id: DEFAULT_RUNTIME_ID,
+    exit_gates: ["budget:tasks_created <= 5"],
+    outcomes: [{ id: outcomeId, task_kind: "integration_gate", accepted_outcomes: ["passed"] }],
+  };
+  const task = {
+    outcome_id: outcomeId,
+    task_id: `plan-${outcomeId}`,
+    kind: "integration_gate",
+    wave: 1,
+    orca_task_id: taskId,
+    dispatch_id: `dispatch-${taskId}`,
+    assignee: DEFAULT_LIVE_AGENT_HANDLE,
+    relay_ids: { request: null, run: null, fleet: null },
+  };
+  const receipt = {
+    schema: 1,
+    program_id: programId,
+    source: path.join(root, "accepted-program.json"),
+    repo: { slug: repo.slug, root: repo.root },
+    runtime_id: DEFAULT_RUNTIME_ID,
+    tasks: [task],
+    terminals_created: [],
+    created_at: "2026-07-21T00:00:00.000Z",
+    updated_at: "2026-07-21T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+  const durable = {
+    [outcomeId]: {
+      outcome_id: outcomeId,
+      runtime_id: DEFAULT_RUNTIME_ID,
+      integration: { passed: true },
+    },
+  };
+  const context = {
+    schema: 1,
+    repo_root: REPO_ROOT,
+    accepted_program: { path: path.join(root, "accepted-program.json") },
+    canonical_receipt: { path: path.join(root, "receipt.json") },
+    trusted_evidence: { durable_outcomes: { path: path.join(root, "durable.json") } },
+  };
+  fs.writeFileSync(path.join(root, "accepted-program.json"), JSON.stringify(program), "utf8");
+  fs.writeFileSync(path.join(root, "receipt.json"), JSON.stringify(receipt), "utf8");
+  fs.writeFileSync(path.join(root, "durable.json"), JSON.stringify(durable), "utf8");
+  fs.writeFileSync(path.join(root, "context.json"), JSON.stringify(context), "utf8");
+  return {
+    root,
+    contextPath: path.join(root, "context.json"),
+    program,
+    receipt,
+    task: { id: taskId, task_title: marker, display_name: marker, status: "completed" },
+    gate: {
+      id: `gate-${taskId}`,
+      task_id: taskId,
+      question: `Integration evidence for ${marker} passed?`,
+      options: ["passed", "failed"],
+      status: "passed",
+      resolution: "passed",
+    },
+  };
+}
+
+function runProbeWithPriorContext(contextPath, fake, overrides = {}) {
+  const result = emptyResult(false);
+  let error = null;
+  try {
+    probe({
+      orcaBin: fake.orcaPath,
+      isRunnableFile: () => true,
+      priorProgramContexts: [contextPath],
+      repoRoot: REPO_ROOT,
+      ...overrides,
+      _result: result,
+    });
+  } catch (caught) {
+    error = caught;
+  }
+  return { result, error };
 }
 
 // ---------------------------------------------------------------------------
@@ -517,6 +607,70 @@ test("D6: gates count > 0 → EXISTING_ORCHESTRATION_STATE exit 34", () => {
     assertNoPoison(fake);
   } finally {
     fake.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1021 reset-free historical admission (red before the admission filter)
+// ---------------------------------------------------------------------------
+
+test("#1021 verified prior-program context admits its completed task and passed gate", () => {
+  const history = historicalContextFixture();
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [history.task], count: 1 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+    gateList: {
+      id: "x",
+      ok: true,
+      result: { gates: [history.gate], count: 1 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(history.contextPath, fake);
+    assert.equal(error, null, "a valid locator must be recomputed and admitted");
+    assert.equal(result.admitted, true);
+    assert.deepEqual(result.existing_state, { tasks: 0, gates: 0 });
+    assertReadOnlyLog(fake.readLog());
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
+  }
+});
+
+test("#1021 prior-program contexts never let a foreign terminal row hide behind a verified proof", () => {
+  const history = historicalContextFixture({ programId: "prior-program-foreign" });
+  const foreign = { id: "foreign-terminal", task_title: "foreign", display_name: "foreign", status: "completed" };
+  const fake = installFakeOrca({
+    poisonMutations: true,
+    taskList: {
+      id: "x",
+      ok: true,
+      result: { tasks: [history.task, foreign], count: 2 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+    gateList: {
+      id: "x",
+      ok: true,
+      result: { gates: [history.gate], count: 1 },
+      _meta: { runtimeId: DEFAULT_RUNTIME_ID },
+    },
+  });
+  try {
+    const { result, error } = runProbeWithPriorContext(history.contextPath, fake);
+    assert.equal(error && error.reasonCode, "EXISTING_ORCHESTRATION_STATE");
+    assert.equal(result.admitted, false);
+    assert.match(error.message, /active_tasks=1/);
+    assertNoPoison(fake);
+  } finally {
+    fake.restore();
+    fs.rmSync(history.root, { recursive: true, force: true });
   }
 });
 

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -499,6 +499,60 @@ test("#1021 D7: probe admits a retained closed-program runtime, then the next ru
   }
 });
 
+test("#1021 R3 finding 2: a prior-program context whose accepted program id equals the launching program is self-referential → rejected, zero receipt overwrite", () => {
+  const world = makeReceiptWorld();
+  // The prior-program context claims the SAME accepted program id as the program being
+  // launched ("epic-run-two"). A context is a record of a DIFFERENT closed program; one that
+  // vouches for the very program it launches is self-referential and must fail closed at
+  // admission (AMBIGUOUS_GLOBAL_STATE → ADMISSION_REJECTED) BEFORE any materialization.
+  const history = priorProgramRunContext(world, { programId: "epic-run-two" });
+  // Pre-seed a sentinel receipt at the launched program's canonical path. A rejected run must
+  // leave it byte-identical — zero overwrite, zero mutation.
+  const receiptPath = receiptPathForWorld(world, "epic-run-two");
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true });
+  const sentinel = `${JSON.stringify({ schema: 1, sentinel: "unchanged" })}\n`;
+  fs.writeFileSync(receiptPath, sentinel, "utf8");
+  const fake = installFakeOrcaRun({
+    taskList: { id: "x", ok: true, result: { tasks: [history.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [history.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  });
+  try {
+    const r = runRun(
+      [
+        "--json",
+        "--orca-bin",
+        fake.orcaPath,
+        "--repo-root",
+        world.repoRoot,
+        "--program-file",
+        fixture("run-two-wave1.json"),
+        "--operator-handle",
+        "h1",
+        "--operator-handle",
+        "h2",
+        "--prior-program-context",
+        history.contextPath,
+      ],
+      { RELAY_ORCA_PROGRAMS_ROOT: world.programsRoot },
+    );
+    assert.equal(r.status, REASONS.ADMISSION_REJECTED);
+    const body = JSON.parse(r.stdout);
+    assert.equal(body.ok, false);
+    assert.equal(body.admission.admitted, false);
+    assert.match(body.blocking_reasons[0].message, /self-referential/);
+    // Zero receipt overwrite: the pre-existing receipt is byte-identical after the rejected run.
+    assert.equal(fs.readFileSync(receiptPath, "utf8"), sentinel, "a rejected self-referential run must not overwrite the receipt");
+    // Zero mutation: no task-create/dispatch/terminal/task-update, no reset/worktree poison marker.
+    assertNoMutations(fake);
+    assertNoPoison(fake);
+    assert.equal(fake.readLog().join(" ").includes("reset"), false, "a rejected self-referential run must not reset the runtime");
+  } finally {
+    fake.cleanup();
+    history.cleanup();
+    fs.rmSync(world.base, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // D11.3 Undelivered injection — exit 42, escalated, no further dispatch
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -305,6 +305,33 @@ test("D11.2: probe rejects admission → ADMISSION_REJECTED exit 40, zero mutati
   }
 });
 
+test("#1021 run forwards every explicit prior-program context to admission", () => {
+  const contextRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-run-context-"));
+  const contextPath = path.join(contextRoot, "context.json");
+  fs.writeFileSync(contextPath, JSON.stringify({}), "utf8");
+  const r = runProgram(
+    "run-two-wave1.json",
+    ["--operator-handle", "h1", "--prior-program-context", contextPath],
+    {
+      gateList: {
+        id: "x",
+        ok: true,
+        result: { gates: [{ id: "g1", task_id: "foreign-task" }], count: 1 },
+        _meta: { runtimeId: "00000000-0000-4000-8000-000000000001" },
+      },
+    },
+  );
+  try {
+    assert.equal(r.status, REASONS.ADMISSION_REJECTED);
+    assert.match(r.body.blocking_reasons[0].message, /prior-program context/);
+    assertNoMutations(r.fake);
+    assertNoPoison(r.fake);
+  } finally {
+    r.fake.cleanup();
+    fs.rmSync(contextRoot, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // D11.3 Undelivered injection — exit 42, escalated, no further dispatch
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -27,9 +27,13 @@ const {
 } = require(path.join(SCRIPTS, "lib", "operator-prompt.js"));
 const { showDispatch } = require(path.join(SCRIPTS, "lib", "run-orca.js"));
 const { provenanceMismatch } = require(path.join(SCRIPTS, "lib", "run-orchestrator.js"));
+const { canonicalIntegrationQuestion } = require(path.join(SCRIPTS, "lib", "integration-lifecycle.js"));
+const { verificationBinding, sha256 } = require(path.join(SCRIPTS, "lib", "integration-evidence.js"));
 const { installFakeOrcaRun } = require(path.join(__dirname, "..", "fixtures", "fake-orca-run.js"));
-const { readyStatus } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
+const { readyStatus, DEFAULT_RUNTIME_ID, DEFAULT_LIVE_AGENT_HANDLE } = require(path.join(__dirname, "..", "fixtures", "fake-orca.js"));
 const { assertReceiptEngineAgnostic } = require("./receipt-hygiene.js");
+
+const PROBE_JS = path.join(SCRIPTS, "probe-orca.js");
 
 // Plan-library codes re-raised verbatim by run (D1/D9).
 const PLAN_CODES = { UNPREPARED_FLEET_LEAF: 12, CONCURRENCY_EXCEEDED: 16, NESTED_RELAY_ORCA: 20 };
@@ -130,6 +134,106 @@ function makeGitWorktreeReceiptWorld() {
     primarySlug: computeRepoSlug(primaryRoot),
     worktreeSlug: computeRepoSlug(fs.realpathSync(worktree)),
   };
+}
+
+// #1021 DC #7: build a retained closed-program context (accepted program + canonical receipt
+// + trusted durable/generic evidence) scoped to the run's temp git repo `world`, plus the
+// live task/gate rows a retained runtime still lists. verifyClosedProgram recomputes clean
+// over these on the next probe, so the completed task + passed gate are exempt and the next
+// run admits WITHOUT reset. Modeled on probe-orca.test.js's historicalContextFixture, but
+// its repo identity is the caller's world (not REPO_ROOT) so the context matches --repo-root.
+function priorProgramRunContext(world, { programId = "prior-program-run", taskId = "prior-task-1" } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "relay-orca-run-prior-context-"));
+  const repo = { slug: world.slug, root: fs.realpathSync(world.repoRoot) };
+  const outcomeId = "integration";
+  const marker = `relay-orca: ${programSegment(programId)}/${outcomeId}`;
+  const checkRef = "full-suite";
+  const verification = verificationBinding({
+    input_sha256: sha256("prior-input"),
+    result_sha256: sha256("prior-result"),
+    passed: true,
+  });
+  const program = {
+    id: programId,
+    runtime_id: DEFAULT_RUNTIME_ID,
+    exit_gates: [`integration:${checkRef}`],
+    integration_evidence_version: 1,
+    integration_evidence: [{ check_ref: checkRef, program_id: programId, runtime_id: DEFAULT_RUNTIME_ID, verification }],
+    outcomes: [{ id: outcomeId, task_kind: "integration_gate", accepted_outcomes: ["passed"] }],
+  };
+  const task = {
+    outcome_id: outcomeId,
+    task_id: `plan-${outcomeId}`,
+    kind: "integration_gate",
+    wave: 1,
+    orca_task_id: taskId,
+    dispatch_id: `dispatch-${taskId}`,
+    assignee: DEFAULT_LIVE_AGENT_HANDLE,
+    relay_ids: { request: null, run: null, fleet: null },
+  };
+  const receipt = {
+    schema: 1,
+    program_id: programId,
+    source: path.join(root, "accepted-program.json"),
+    repo: { slug: repo.slug, root: repo.root },
+    runtime_id: DEFAULT_RUNTIME_ID,
+    tasks: [task],
+    terminals_created: [],
+    created_at: "2026-07-21T00:00:00.000Z",
+    updated_at: "2026-07-21T00:00:00.000Z",
+    note: RECEIPT_NOTE,
+  };
+  const durable = { [outcomeId]: { outcome_id: outcomeId, runtime_id: DEFAULT_RUNTIME_ID, integration: { passed: true } } };
+  const generic = { [checkRef]: { schema: 1, program_id: programId, runtime_id: DEFAULT_RUNTIME_ID, check_ref: checkRef, verification, evidence: "prior integration evidence" } };
+  const context = {
+    schema: 1,
+    // Deliberately false: the probe must ignore this claim and recompute Leaf 1 afresh.
+    success: false,
+    repo_root: world.repoRoot,
+    accepted_program: { path: path.join(root, "accepted-program.json") },
+    canonical_receipt: { path: path.join(root, "receipt.json") },
+    trusted_evidence: {
+      durable_outcomes: { path: path.join(root, "durable.json") },
+      generic_integration: { path: path.join(root, "generic.json") },
+    },
+  };
+  fs.writeFileSync(path.join(root, "accepted-program.json"), JSON.stringify(program), "utf8");
+  fs.writeFileSync(path.join(root, "receipt.json"), JSON.stringify(receipt), "utf8");
+  fs.writeFileSync(path.join(root, "durable.json"), JSON.stringify(durable), "utf8");
+  fs.writeFileSync(path.join(root, "generic.json"), JSON.stringify(generic), "utf8");
+  fs.writeFileSync(path.join(root, "context.json"), JSON.stringify(context), "utf8");
+  return {
+    root,
+    contextPath: path.join(root, "context.json"),
+    task: { id: taskId, task_title: marker, display_name: marker, status: "completed" },
+    gate: {
+      id: `gate-${taskId}`,
+      task_id: taskId,
+      question: canonicalIntegrationQuestion(programId, outcomeId, programSegment),
+      options: ["passed", "failed"],
+      status: "passed",
+      resolution: "passed",
+    },
+    cleanup() {
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function runProbeCli(args, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [PROBE_JS, ...args], {
+      encoding: "utf-8",
+      env: { ...process.env, ...env },
+      stdio: "pipe",
+    });
+    return { status: 0, body: JSON.parse(stdout) };
+  } catch (error) {
+    return {
+      status: error.status,
+      body: error.stdout ? JSON.parse(String(error.stdout)) : null,
+    };
+  }
 }
 
 function runProgram(fixtureName, extraArgs, scenario, options = {}) {
@@ -329,6 +433,69 @@ test("#1021 run forwards every explicit prior-program context to admission", () 
   } finally {
     r.fake.cleanup();
     fs.rmSync(contextRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1021 DC #7 — retained-runtime admission chain: probe admits the closed program's
+// residue, then the SAME context lets the next run pass admission without reset.
+// ---------------------------------------------------------------------------
+
+test("#1021 D7: probe admits a retained closed-program runtime, then the next run forwards the same context and dispatches without reset", () => {
+  const world = makeReceiptWorld();
+  const history = priorProgramRunContext(world, { programId: "prior-program-run" });
+  // The retained runtime still lists the prior program's completed integration task and its
+  // passed canonical gate. Both are covered by the recomputed proof, so admission exempts them.
+  const scenario = {
+    taskList: { id: "x", ok: true, result: { tasks: [history.task], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+    gateList: { id: "x", ok: true, result: { gates: [history.gate], count: 1 }, _meta: { runtimeId: DEFAULT_RUNTIME_ID } },
+  };
+  const fake = installFakeOrcaRun(scenario);
+  try {
+    // (1) A probe on the retained runtime with the same context returns exit 0 / admitted:true
+    // and reports zero post-filter blocking residue (the completed task + passed gate exempt).
+    const probe = runProbeCli(
+      ["--json", "--orca-bin", fake.orcaPath, "--repo-root", world.repoRoot, "--prior-program-context", history.contextPath],
+    );
+    assert.equal(probe.status, 0, "probe admits the retained runtime with the prior-program context");
+    assert.equal(probe.body.admitted, true);
+    assert.deepEqual(probe.body.existing_state, { tasks: 0, gates: 0 });
+
+    // (2) The next run forwards the SAME explicit context, passes admission, and dispatches —
+    // no reset --tasks, no manual receipt/dispatch intervention.
+    const r = runRun(
+      [
+        "--json",
+        "--orca-bin",
+        fake.orcaPath,
+        "--repo-root",
+        world.repoRoot,
+        "--program-file",
+        fixture("run-two-wave1.json"),
+        "--operator-handle",
+        "h1",
+        "--operator-handle",
+        "h2",
+        "--prior-program-context",
+        history.contextPath,
+      ],
+      { RELAY_ORCA_PROGRAMS_ROOT: world.programsRoot },
+    );
+    assert.equal(r.status, 0);
+    const body = JSON.parse(r.stdout);
+    assert.equal(body.ok, true);
+    assert.equal(body.admission.admitted, true, "the retained runtime is admitted, not reset");
+    assert.equal(body.admission.runtime_id, DEFAULT_RUNTIME_ID);
+    for (const outcome of ["alpha", "bravo"]) {
+      assert.equal(taskByOutcome(body, outcome).status, "dispatched");
+    }
+    // Admission adopted the retained runtime WITHOUT clearing it: no reset of any kind ran.
+    assert.equal(fake.readLog().join(" ").includes("reset"), false, "admission must not reset the retained runtime");
+    assert.equal(fake.readPoison(), null, "reset/worktree poison marker must never be written");
+  } finally {
+    fake.cleanup();
+    history.cleanup();
+    fs.rmSync(world.base, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Dispatch Summary

```text
The full serialized suite is still running (waiter task `bsvd0rt09` will notify me when it finishes). Both targeted suites already passed individually:
- `probe-orca.test.js`: 51/51 (4 new tests for Issues 2 & 3)
- `run.test.js`: 37/37 (1 new test for Issue 1)

I'll report the final full-suite result once the background run completes.
```

## Dispatch Metadata

- Run: issue-1021-20260721145439815-b094a7e7
- Executor: codex
- Branch: issue-1021-historical-admission-filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * `probe` 및 `run` 명령에 `--prior-program-context`와 `--repo-root` 옵션을 추가해, 이전 프로그램 컨텍스트를 바탕으로 닫힌 프로그램의 완료 상태와 증명을 재검증할 수 있습니다.
  * 검증된 완료 작업/통과 게이트는 후속 실행에서 불필요한 초기화 없이 재사용됩니다.
* **버그 수정**
  * 중복·모호·교차 저장소·증명 불일치 등 경우를 더 정교하게 분류하고 안전하게 거부하며, 실패 시 입력 컨텍스트를 변경하지 않습니다.
* **문서**
  * 새 옵션 의미와 거부 사유(Reason code) 설명을 더 구체적으로 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->