### PR TITLE
fix(merge): auto-ready draft PRs before finalize (Fixes #1057)

### DIFF
--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -32,6 +32,7 @@ const EVENTS = Object.freeze({
   DISPATCH_INTERRUPTED: "dispatch_interrupted",
   DISPATCH_RESULT: "dispatch_result",
   DISPATCH_START: "dispatch_start",
+  DRAFT_PR_AUTO_READY: "draft_pr_auto_ready",
   ENVIRONMENT_DRIFT: "environment_drift",
   ESCALATION_DECISION: "escalation_decision",
   EXECUTION_EVIDENCE_REBRANDED: "execution_evidence_rebranded",

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -192,6 +192,18 @@ class MergeFreshnessRefusal extends Error {
   }
 }
 
+class DraftPrRefusal extends Error {
+  constructor(prNumber) {
+    super(`Draft PR #${prNumber} could not be marked ready for review`);
+    this.name = "DraftPrRefusal";
+    this.result = {
+      status: "refused_draft_pr",
+      next_action: "mark_ready_and_rerun",
+      pr_number: prNumber,
+    };
+  }
+}
+
 function splitLines(value) {
   return String(value || "").split(/\r?\n/).filter(Boolean);
 }
@@ -269,7 +281,7 @@ function fetchReviewContext(repoPath, prNumber) {
 
 function fetchPreMergeContext(repoPath, prNumber) {
   const raw = execGh(repoPath, ["pr", "view", String(prNumber),
-    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title"]);
+    "--json", "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,isDraft,title"]);
   const parsed = JSON.parse(raw);
   const checks = parsed.statusCheckRollup || [];
   return {
@@ -278,6 +290,7 @@ function fetchPreMergeContext(repoPath, prNumber) {
     commits: parsed.commits || [],
     mergeable: parsed.mergeable || null,
     headRefOid: parsed.headRefOid || null,
+    isDraft: parsed.isDraft === true,
     title: typeof parsed.title === "string" && parsed.title ? parsed.title : null,
     checks,
     unsafeChecks: checks.filter(isUnsafeStatusCheck),
@@ -506,6 +519,34 @@ function assertStackedBaseGuard(guard, prNumber) {
     `(default: '${guard.defaultBranchName || "unknown"}')${basePrText}. ` +
     "Merge the base PR first or rerun with --allow-stacked-base-hazard <reason>."
   );
+}
+
+function buildDraftPrGuard(preMerge, prNumber) {
+  return {
+    status: preMerge?.isDraft ? "draft" : "clear",
+    prNumber,
+  };
+}
+
+function assertDraftPrGuard(repoPath, safeData, guard, { currentHeadSha, dryRun }) {
+  if (!guard || guard.status !== "draft") return guard;
+  if (dryRun) return { ...guard, status: "would_auto_ready" };
+
+  try {
+    execGh(repoPath, ["pr", "ready", String(guard.prNumber)]);
+  } catch {
+    throw new DraftPrRefusal(guard.prNumber);
+  }
+
+  appendRunEvent(repoPath, safeData.run_id, {
+    event: EVENTS.DRAFT_PR_AUTO_READY,
+    state_from: STATES.READY_TO_MERGE,
+    state_to: STATES.READY_TO_MERGE,
+    head_sha: currentHeadSha,
+    round: safeData.review?.rounds || null,
+    pr_number: guard.prNumber,
+  });
+  return { ...guard, status: "auto_readied" };
 }
 
 function assertPreMergeSafety(preMerge, prNumber) {
@@ -1396,6 +1437,7 @@ function main() {
   let issueCloseWarning = null;
   let reviewGate = null;
   let stackedBaseGuard = { status: "not_checked", reason: null };
+  let preMergeContext = null;
   let freshness = null;
   let freshnessOverrideRequired = false;
   let currentHeadSha = safeData.git?.head_sha || null;
@@ -1515,12 +1557,12 @@ function main() {
       }
     } else if (skipReviewReason) {
       assertSkipReviewGate(repoPath, safeData, { prNumber, currentHeadSha, dryRun, skipReviewRubricAudit });
-      const preMerge = fetchPreMergeContext(repoPath, prNumber);
-      prTitle = preMerge.title;
+      preMergeContext = fetchPreMergeContext(repoPath, prNumber);
+      prTitle = preMergeContext.title;
       stackedBaseGuard = buildStackedBaseGuard(
         repoPath,
         prNumber,
-        preMerge.baseRefName,
+        preMergeContext.baseRefName,
         stackedBaseOverrideReason
       );
       if (stackedBaseGuard.status === "blocked" && !dryRun) {
@@ -1538,16 +1580,16 @@ function main() {
         prNumber, currentHeadSha, dryRun, skipReviewReason, skipReviewRubricStatus, skipReviewRubricAudit,
       });
     } else if (safeData.state === STATES.READY_TO_MERGE) {
-      const preMerge = fetchPreMergeContext(repoPath, prNumber);
-      prTitle = preMerge.title;
+      preMergeContext = fetchPreMergeContext(repoPath, prNumber);
+      prTitle = preMergeContext.title;
       reviewGate = evaluateReviewGate({
         prNumber,
-        comments: preMerge.comments,
-        commits: preMerge.commits,
+        comments: preMergeContext.comments,
+        commits: preMergeContext.commits,
         manifestData: safeData,
         expectedReviewerLogin: safeData.review?.reviewer_login || null,
         runDir: getRunDir(validatedPaths.repoRoot, safeData.run_id),
-        headRefOid: preMerge.headRefOid,
+        headRefOid: preMergeContext.headRefOid,
       });
       if (!reviewGate.readyToMerge) {
         if (!dryRun) {
@@ -1565,7 +1607,7 @@ function main() {
       stackedBaseGuard = buildStackedBaseGuard(
         repoPath,
         prNumber,
-        preMerge.baseRefName,
+        preMergeContext.baseRefName,
         stackedBaseOverrideReason
       );
       if (stackedBaseGuard.status === "blocked" && !dryRun) {
@@ -1579,14 +1621,14 @@ function main() {
         });
       }
       assertStackedBaseGuard(stackedBaseGuard, prNumber);
-      assertPreMergeSafety(preMerge, prNumber);
+      assertPreMergeSafety(preMergeContext, prNumber);
     } else if (forceFinalizeNonready) {
-      const preMerge = fetchPreMergeContext(repoPath, prNumber);
-      prTitle = preMerge.title;
+      preMergeContext = fetchPreMergeContext(repoPath, prNumber);
+      prTitle = preMergeContext.title;
       stackedBaseGuard = buildStackedBaseGuard(
         repoPath,
         prNumber,
-        preMerge.baseRefName,
+        preMergeContext.baseRefName,
         stackedBaseOverrideReason
       );
       if (stackedBaseGuard.status === "blocked" && !dryRun) {
@@ -1600,11 +1642,15 @@ function main() {
         });
       }
       assertStackedBaseGuard(stackedBaseGuard, prNumber);
-      assertPreMergeSafety(preMerge, prNumber);
+      assertPreMergeSafety(preMergeContext, prNumber);
     }
   }
 
   if (mergeAllowed) {
+    if (!alreadyMerged) {
+      const draftPrGuard = buildDraftPrGuard(preMergeContext, prNumber);
+      assertDraftPrGuard(repoPath, safeData, draftPrGuard, { currentHeadSha, dryRun });
+    }
     if (freshnessOverrideRequired && !dryRun) {
       appendBehindMainOverrideEvent(repoPath, safeData, {
         prNumber,
@@ -1874,6 +1920,15 @@ if (require.main === module) {
   try {
     main();
   } catch (error) {
+    if (error instanceof DraftPrRefusal) {
+      if (args.includes("--json")) {
+        console.log(JSON.stringify(error.result, null, 2));
+      } else {
+        console.log(`Merge refused: PR #${error.result.pr_number} is still a draft and could not be marked ready.`);
+        console.log(`  Next action: ${error.result.next_action}`);
+      }
+      process.exit(2);
+    }
     if (error instanceof MergeFreshnessRefusal) {
       if (args.includes("--json")) {
         console.log(JSON.stringify(error.result, null, 2));

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -540,8 +540,8 @@ function assertDraftPrGuard(repoPath, safeData, guard, { currentHeadSha, dryRun 
 
   appendRunEvent(repoPath, safeData.run_id, {
     event: EVENTS.DRAFT_PR_AUTO_READY,
-    state_from: STATES.READY_TO_MERGE,
-    state_to: STATES.READY_TO_MERGE,
+    state_from: safeData.state,
+    state_to: safeData.state,
     head_sha: currentHeadSha,
     round: safeData.review?.rounds || null,
     pr_number: guard.prNumber,

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -277,6 +277,9 @@ function writeFakeGh(logPath, {
   statusCheckRollup = [],
   stateAfterMerge = "MERGED",
   mergeCommitAfterMerge = { oid: "merged-sha" },
+  isDraft = false,
+  prReadyExitCode = 0,
+  prReadyStderr = "",
   prMergeExitCode = 0,
   prMergeStderr = "",
   title = "fix(relay): finalize test PR",
@@ -296,6 +299,9 @@ function writeFakeGh(logPath, {
     statusCheckRollup,
     stateAfterMerge,
     mergeCommitAfterMerge,
+    isDraft,
+    prReadyExitCode,
+    prReadyStderr,
     prMergeExitCode,
     prMergeStderr,
     title,
@@ -311,6 +317,16 @@ function saveState(next) {
   fs.writeFileSync(statePath, JSON.stringify(next), "utf-8");
 }
 fs.appendFileSync(${JSON.stringify(logPath)}, args.join(" ") + "\\n", "utf-8");
+if (args[0] === "pr" && args[1] === "ready") {
+  const state = loadState();
+  if (state.prReadyExitCode) {
+    process.stderr.write(state.prReadyStderr || "ready failed");
+    process.exit(state.prReadyExitCode);
+  }
+  state.isDraft = false;
+  saveState(state);
+  process.exit(0);
+}
 if (args[0] === "pr" && args[1] === "merge") {
   const state = loadState();
   state.state = state.stateAfterMerge;
@@ -333,6 +349,7 @@ if (args[0] === "pr" && args[1] === "view") {
     commits: state.commits,
     mergeable: state.mergeable,
     statusCheckRollup: state.statusCheckRollup,
+    isDraft: state.isDraft,
     title: state.title
   }));
 }
@@ -512,11 +529,12 @@ function advanceOriginMain(fixture, commits) {
   });
 }
 
-function spawnFreshnessFinalize(fixture, { extraArgs = [] } = {}) {
+function spawnFreshnessFinalize(fixture, { extraArgs = [], ghOptions = {} } = {}) {
   const logPath = path.join(fixture.repoRoot, "gh.log");
   const fakeGh = writeFakeGh(logPath, {
     comments: [DEFAULT_REVIEW_COMMENT],
     commits: [{ oid: fixture.headSha, committedDate: DEFAULT_COMMIT_DATE }],
+    ...ghOptions,
   });
   const result = spawnSync("node", [
     SCRIPT,
@@ -573,6 +591,73 @@ test("finalize-run freshness gate passes an up-to-date head without informationa
   assert.equal(finalized.result.state, STATES.MERGED);
   assert.equal(finalized.result.mergePerformed, true);
   assert.equal("freshness" in finalized.result, false);
+});
+
+test("finalize-run marks a draft PR ready once before merging", () => {
+  const fixture = setupRepo();
+  const finalized = execFinalize(fixture, {
+    ghOptions: {
+      comments: [DEFAULT_REVIEW_COMMENT],
+      isDraft: true,
+    },
+  });
+
+  assert.equal(finalized.result.state, STATES.MERGED);
+  assert.equal(finalized.result.mergePerformed, true);
+  const ghLog = fs.readFileSync(finalized.logPath, "utf-8");
+  assert.equal((ghLog.match(/^pr ready 123$/gm) || []).length, 1);
+  assert.equal((ghLog.match(/^pr merge 123 /gm) || []).length, 1);
+  assert.ok(ghLog.indexOf("pr ready 123") < ghLog.indexOf("pr merge 123 "));
+
+  const draftEvents = finalized.events.filter((entry) => entry.event === "draft_pr_auto_ready");
+  assert.equal(draftEvents.length, 1);
+  assert.equal(draftEvents[0].state_from, STATES.READY_TO_MERGE);
+  assert.equal(draftEvents[0].state_to, STATES.READY_TO_MERGE);
+  assert.equal(draftEvents[0].pr_number, 123);
+});
+
+test("finalize-run refuses a draft PR when marking it ready fails", () => {
+  const fixture = setupRepo();
+  const rawGraphqlError = "GraphQL: Pull Request is still a draft (markPullRequestReadyForReview)";
+  const { result, logPath } = spawnFreshnessFinalize(fixture, {
+    ghOptions: {
+      isDraft: true,
+      prReadyExitCode: 1,
+      prReadyStderr: rawGraphqlError,
+    },
+  });
+
+  assert.equal(result.status, 2, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    status: "refused_draft_pr",
+    next_action: "mark_ready_and_rerun",
+    pr_number: 123,
+  });
+  assert.doesNotMatch(result.stdout, /GraphQL|still a draft/);
+  assert.doesNotMatch(result.stderr, /GraphQL|still a draft/);
+  const ghLog = fs.readFileSync(logPath, "utf-8");
+  assert.equal((ghLog.match(/^pr ready 123$/gm) || []).length, 1);
+  assert.doesNotMatch(ghLog, /^pr merge 123 /m);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.deepEqual(readRunEvents(fixture.repoRoot, fixture.runId), []);
+});
+
+test("finalize-run dry-run does not mark a draft PR ready", () => {
+  const fixture = setupRepo();
+  const finalized = execFinalize(fixture, {
+    extraArgs: ["--dry-run"],
+    ghOptions: {
+      comments: [DEFAULT_REVIEW_COMMENT],
+      isDraft: true,
+    },
+  });
+
+  assert.equal(finalized.result.dryRun, true);
+  assert.equal(readManifest(fixture.manifestPath).data.state, STATES.READY_TO_MERGE);
+  assert.deepEqual(finalized.events, []);
+  const ghLog = fs.readFileSync(finalized.logPath, "utf-8");
+  assert.doesNotMatch(ghLog, /^pr ready 123$/m);
+  assert.doesNotMatch(ghLog, /^pr merge 123 /m);
 });
 
 test("finalize-run freshness gate skips when remote PR head is unresolvable", () => {

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -616,6 +616,19 @@ test("finalize-run marks a draft PR ready once before merging", () => {
   assert.equal(draftEvents[0].pr_number, 123);
 });
 
+test("finalize-run records the actual non-ready state when force-finalize marks a draft PR ready", () => {
+  const fixture = setupRepo({ manifestState: STATES.ESCALATED });
+  const finalized = execFinalize(fixture, {
+    extraArgs: ["--force-finalize-nonready", "--reason", "manual draft PR recovery"],
+    ghOptions: { isDraft: true },
+  });
+
+  const draftEvents = finalized.events.filter((entry) => entry.event === "draft_pr_auto_ready");
+  assert.equal(draftEvents.length, 1);
+  assert.equal(draftEvents[0].state_from, STATES.ESCALATED);
+  assert.equal(draftEvents[0].state_to, STATES.ESCALATED);
+});
+
 test("finalize-run refuses a draft PR when marking it ready fails", () => {
   const fixture = setupRepo();
   const rawGraphqlError = "GraphQL: Pull Request is still a draft (markPullRequestReadyForReview)";

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -51,6 +51,10 @@ const PR_VIEW_JSON_REGISTRY = Object.freeze({
   "baseRefName,comments,commits,mergeable,statusCheckRollup": mergeGateResponse,
   "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid": mergeGateResponse,
   "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title": mergeGateResponse,
+  "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,isDraft,title": (fixture) => ({
+    ...mergeGateResponse(fixture),
+    isDraft: fixture.isDraft || false,
+  }),
   "comments,commits,headRefOid": mergeGateResponse,
   "comments,commits,headRefName,headRefOid": (fixture) => ({
     comments: fixture.comments || [],
@@ -121,6 +125,7 @@ function saveChecksIndex(next) {
     fs.writeFileSync(checksStatePath, JSON.stringify({ index: next }), "utf-8");
   }
 }
+const mergeGateResponse = ${mergeGateResponse.toString()};
 const prViewJsonRegistry = {
 ${serializedPrViewRegistry}
 };

--- a/tests/skills-lint/scripts/pr-view-json-contract.test.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.test.js
@@ -79,7 +79,7 @@ test("enumerates pr view fields from an argv variable assembled separately", () 
 });
 
 test("#894 regression: missing title-bearing merge fields names finalize-run", () => {
-  const titleBearingFields = "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,title";
+  const titleBearingFields = "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid,isDraft,title";
   const registryWithoutTitleBearingFields = Object.fromEntries(
     Object.entries(PR_VIEW_JSON_REGISTRY).filter(([fields]) => fields !== titleBearingFields),
   );


### PR DESCRIPTION
## Dispatch Summary

```text
이슈 #1057 구현 및 커밋을 완료했습니다.

- draft PR을 공통 merge 진입점에서 한 번만 `gh pr ready` 처리하고, 실패 시 구조화된 `refused_draft_pr`를 반환합니다: [finalize-run.js](/Users/sjlee/.relay/worktrees/09a465d7/dev-relay/skills/relay-merge/scripts/finalize-run.js:195)
- `draft_pr_auto_ready` 이벤트를 추가했습니다: [relay-events.js](/Users/sjlee/.relay/worktrees/09a465d7/dev-relay/skills/relay-dispatch/scripts/relay-events.js:35)
- 성공·실패·dry-run fixture 테스트를 추가했습니다: [finalize-run.test.js](/Users/sjlee/.relay/worktrees/09a465d7/dev-relay/tests/
```

## Dispatch Metadata

- Run: issue-1057-20260722085934229-6776d21c
- Executor: codex
- Branch: issue-1057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 드래프트 PR을 병합하기 전에 자동으로 준비 완료 상태로 전환합니다.
  * 드래프트 PR 자동 전환 이벤트가 기록됩니다.
* **버그 수정**
  * 준비 완료 전환 실패 시 병합을 중단하고 명확한 거부 상태를 보고합니다.
  * 강제 완료 및 미리보기 실행에서도 PR 상태가 정확히 반영됩니다.
* **테스트**
  * 자동 전환 성공·실패, 이벤트 중복 방지, 병합 순서 및 미리보기 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->