### PR TITLE
feat(relay-dispatch): add audited review-policy extension command (Fixes #1053)

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -236,7 +236,7 @@ Semantics:
 
 ## Event Journal
 
-Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `pr_number`, `bootstrap_exempt`, `model`, `executor_network`, `failure_class`, `before`, `after`, `profile`, `status`, `artifact_path`, `raw_response_path`, `elapsed_ms`, `critical_path_wait_ms`, `consumed_by_phase`, `phase_decision_waited`, `frontier_step_replaced`, `failure_reason`, override audit fields):
+Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/events.jsonl`. Records are emitted by `appendRunEvent()` in `skills/relay-dispatch/scripts/relay-events.js` and share a common envelope (`ts`, `event`, `actor`, `run_id`, `state_from`, `state_to`, `head_sha`, `round`, `reason`) plus optional fields (`reviewer`, `rubric_status`, `last_reviewed_sha`, `pr_number`, `bootstrap_exempt`, `model`, `executor_network`, `failure_class`, `before`, `after`, `profile`, `status`, `artifact_path`, `raw_response_path`, `elapsed_ms`, `critical_path_wait_ms`, `consumed_by_phase`, `phase_decision_waited`, `frontier_step_replaced`, `failure_reason`, `state`, `old_max_rounds`, `new_max_rounds`, override audit fields):
 
 ```jsonl
 {"ts":"2026-04-18T12:00:00.000Z","event":"dispatch_start","actor":"codex","run_id":"issue-42-20260418120000000","state_from":"draft","state_to":"dispatched","head_sha":"abc123","round":null,"reason":"new_dispatch","model":null,"executor_network":{"access":"enabled","mechanism":"sandbox_workspace_write.network_access","domains":null},"policy_decision":{"allowed":true,"reason":"managed_cli","phase":"dispatch","actor":"codex","model":null}}
@@ -259,6 +259,7 @@ Each run keeps an append-only event log at `~/.relay/runs/<repo-slug>/<run-id>/e
 | `recover_commit`, `recover_commit_failed`, `execution_evidence_rebranded` | `relay-dispatch/scripts/recover-commit.js`, `rebrand-evidence.js` |
 | `iteration_score`, `rubric_quality`, `safety_boundary_violation` | `relay-dispatch/scripts/relay-events.js` (helpers) |
 | `close`, `cleanup_result` | `relay-dispatch/scripts/close-run.js`, `cleanup-worktrees.js` |
+| `policy_updated` | `relay-dispatch/scripts/extend-review-policy.js` |
 | `state_recovery` | `relay-dispatch/scripts/recover-state.js`; `reconcile-run.js` emits it for `dispatched -> review_pending` dead-work recovery |
 | `review_invoke` | `relay-review/scripts/review-runner/reviewer-invoke.js` |
 | `advisory_review` | `relay-review/scripts/review-runner/advisory.js` |

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -109,6 +109,7 @@ Risk-aware task profiles derive compact/standard/hardened from task properties, 
 - Crash-only settlement after signal/reboot/OOM or from another shell → `references/recovery-playbook.md` (`reconcile-run.js`).
 - Executor finished but did not commit / push / open the PR → `references/recovery-playbook.md` (`recover-commit.js`).
 - Manifest state needs adjustment after an external event (direct push, hung dispatch, escalation) → `references/recovery-playbook.md` (`recover-state.js`, includes the whitelist transition table).
+- A run needs an exceptional monotonic `review.max_rounds` increase → `references/review-policy-extension.md` (`extend-review-policy.js`; cap extension is not convergence evidence).
 - Standalone worktree creation, cleanup, run-close, reliability report → `references/operator-utilities.md`.
 
 ## Caveats

--- a/skills/relay-dispatch/references/cli-schema.md
+++ b/skills/relay-dispatch/references/cli-schema.md
@@ -57,6 +57,9 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--done-criteria-file` | `verbatim` | Operator-supplied anchor path; keep the literal argv token. |
 | `--dry-run` | `parsed` | Presence flag; no value is consumed. |
 | `--executor, -e` | `parsed` | Closed selector; flag-like following tokens should mean the value is missing. |
+| `--expected-head` | `parsed` | Optimistic policy-update guard; flag-like following tokens should mean the value is missing. |
+| `--expected-round` | `parsed` | Optimistic policy-update guard; flag-like following tokens should mean the value is missing. |
+| `--expected-state` | `parsed` | Optimistic policy-update guard; flag-like following tokens should mean the value is missing. |
 | `--force` | `parsed` | Presence flag; no value is consumed. |
 | `--force-finalize-nonready` | `parsed` | Presence flag; no value is consumed. |
 | `--head-sha` | `parsed` | Structured SHA field; flag-like following tokens should mean the value is missing. |
@@ -129,6 +132,9 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--done-criteria-file` | `verbatim` | Operator-supplied anchor path; keep the literal argv token. |
 | `--dry-run` | `parsed` | Presence flag; no value is consumed. |
 | `--executor, -e` | `parsed` | Closed selector; flag-like following tokens should mean the value is missing. |
+| `--expected-head` | `parsed` | Optimistic policy-update guard; flag-like following tokens should mean the value is missing. |
+| `--expected-round` | `parsed` | Optimistic policy-update guard; flag-like following tokens should mean the value is missing. |
+| `--expected-state` | `parsed` | Optimistic policy-update guard; flag-like following tokens should mean the value is missing. |
 | `--force` | `parsed` | Presence flag; no value is consumed. |
 | `--force-finalize-nonready` | `parsed` | Presence flag; no value is consumed. |
 | `--head-sha` | `parsed` | Structured SHA field; flag-like following tokens should mean the value is missing. |

--- a/skills/relay-dispatch/references/review-policy-extension.md
+++ b/skills/relay-dispatch/references/review-policy-extension.md
@@ -1,0 +1,47 @@
+# Exceptional Review Policy Extension
+
+`extend-review-policy.js` is the only supported operator path for raising an existing run's
+persisted `review.max_rounds`. It is deliberately narrow: the command can only increase that
+one policy field, refresh `timestamps.updated_at`, and append one dedicated `policy_updated`
+audit event. It cannot decrease the cap, edit lifecycle state, bypass escalation, or change
+review convergence rules.
+
+## Policy boundary
+
+An increased cap is an operator judgment that another independent review round is worth the
+cost. It is **not evidence of convergence**. A longer review budget does not erase prior
+findings, satisfy Done Criteria, or justify a merge. Repeated-issue, flip-flop, escalation,
+publication, and explicit-merge gates continue to apply. Automatic cap extension is forbidden.
+
+The manifest lock used by `withManifestTransaction` is the trust root. Guard values printed by
+a dry run are only a preview; the mutating call re-reads the manifest and enforces state, round,
+HEAD, terminal-state, event-sink, and monotonicity checks while that lock is held. A warning
+printed outside the lock would not be an enforcement mechanism.
+
+## Operator flow
+
+First derive a coherent guard snapshot without changing the manifest or event journal:
+
+```bash
+node skills/relay-dispatch/scripts/extend-review-policy.js \
+  --repo . --run-id <run-id> --max-rounds 8 \
+  --reason "Corrective redispatch needs one additional independent review" \
+  --dry-run --json
+```
+
+Then copy the returned `guards.expected_state`, `guards.expected_round`, and
+`guards.expected_head` values into the mutating call:
+
+```bash
+node skills/relay-dispatch/scripts/extend-review-policy.js \
+  --repo . --run-id <run-id> --max-rounds 8 \
+  --reason "Corrective redispatch needs one additional independent review" \
+  --expected-state changes_requested --expected-round 7 \
+  --expected-head <sha> --json
+```
+
+If the run moves between those calls, the stale guards are refused. Terminal or unknown states,
+a missing manifest HEAD, a non-positive or non-integer persisted cap, a missing/unwritable
+`events.jsonl`, lock contention, and write failures also fail closed. Successful events record
+the locked snapshot's `state`, `round`, `head_sha`, `old_max_rounds`, and `new_max_rounds`, plus
+the operator reason, actor, origin, and timestamp; they never reuse `state_recovery`.

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -43,6 +43,9 @@ const FLAGS = [
   { flag: "--dry-run", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--effective", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--executor", aliases: ["-e"], kind: VALUE, mode: MODE_PARSED, valueName: "<name>", rationale: "Closed selector; flag-like following tokens should mean the value is missing." },
+  { flag: "--expected-head", kind: VALUE, mode: MODE_PARSED, valueName: "<sha>", rationale: "Optimistic policy-update guard; flag-like following tokens should mean the value is missing." },
+  { flag: "--expected-round", kind: VALUE, mode: MODE_PARSED, valueName: "<n>", rationale: "Optimistic policy-update guard; flag-like following tokens should mean the value is missing." },
+  { flag: "--expected-state", kind: VALUE, mode: MODE_PARSED, valueName: "<state>", rationale: "Optimistic policy-update guard; flag-like following tokens should mean the value is missing." },
   { flag: "--fallback", kind: VALUE, mode: MODE_PARSED, valueName: "<mode>", allowedValues: ["catalog"], rationale: "Explicit model-resolution fallback selector; flag-like following tokens should mean the value is missing." },
   { flag: "--file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied input file path; keep the literal argv token." },
   { flag: "--fleet-id", kind: VALUE, mode: MODE_PARSED, valueName: "<id>", rationale: "Structured relay fleet identifier; flag-like following tokens should mean the value is missing." },
@@ -157,6 +160,10 @@ const COMMAND_FLAGS = {
     "--test-command", "--coordination-marker", "--rubric-grandfathered", "--request-id", "--leaf-id",
     "--fleet-id", "--ownership-json", "--done-criteria-file", "--publish-policy", "--review-assurance", "--register", "--auto-recover-commit", "--no-auto-recover-commit",
     "--tags", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help",
+  ],
+  "extend-review-policy": [
+    "--repo", "--run-id", "--manifest", "--max-rounds", "--reason",
+    "--expected-state", "--expected-round", "--expected-head", "--dry-run", "--json", "--help",
   ],
   "finalize-run": [
     "--repo", "--run-id", "--manifest", "--branch", "--pr", "--merge-method",

--- a/skills/relay-dispatch/scripts/extend-review-policy.js
+++ b/skills/relay-dispatch/scripts/extend-review-policy.js
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+"use strict";
+
+// Exceptional operator command for monotonically extending review.max_rounds.
+//
+// Trust root: the manifest lock acquired by withManifestTransaction is the
+// enforcement layer. Any guard display or validation before that lock is only
+// advisory. The mutating path re-reads the manifest, validates every guard, and
+// performs the manifest/event pair while the same per-run lock remains held.
+
+const fs = require("fs");
+const path = require("path");
+
+const { bindCliArgs, findUnknownFlags, modeLabel } = require("./cli-args");
+const { STATES, isTerminalState } = require("./manifest/lifecycle");
+const { nowIso } = require("./manifest/paths");
+const {
+  parseFrontmatter,
+  withManifestTransaction,
+  writeManifestUnlocked,
+} = require("./manifest/store");
+const { resolveManifestRecord } = require("./relay-resolver");
+const { appendRunEvent, EVENTS } = require("./relay-events");
+
+const COMMAND_NAME = "extend-review-policy";
+const CLI_ARG_OPTIONS = { commandName: COMMAND_NAME, reservedFlags: ["-h"] };
+const ACTIVE_STATES = new Set(Object.values(STATES).filter((state) => !isTerminalState(state)));
+
+class PolicyUpdateRefusal extends Error {
+  constructor(result) {
+    super(result.message);
+    this.name = "PolicyUpdateRefusal";
+    this.result = result;
+  }
+}
+
+function refuse(errorCode, message, details = {}) {
+  throw new PolicyUpdateRefusal({
+    status: "refused",
+    error_code: errorCode,
+    message,
+    ...details,
+  });
+}
+
+function parsePositiveInteger(value, label) {
+  const text = value === undefined || value === null ? "" : String(value);
+  if (!/^[1-9]\d*$/.test(text)) {
+    refuse("invalid_max_rounds", `${label} must be an explicitly supplied positive integer`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) {
+    refuse("invalid_max_rounds", `${label} must be a safe positive integer`);
+  }
+  return parsed;
+}
+
+function parseExpectedRound(value) {
+  const text = value === undefined || value === null ? "" : String(value);
+  if (!/^(?:0|[1-9]\d*)$/.test(text)) {
+    refuse("invalid_expected_round", "--expected-round must be a non-negative integer");
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) {
+    refuse("invalid_expected_round", "--expected-round must be a safe non-negative integer");
+  }
+  return parsed;
+}
+
+function requireReason(reason) {
+  if (typeof reason !== "string" || !reason.trim()) {
+    refuse("missing_reason", "--reason must be non-empty");
+  }
+  return reason;
+}
+
+function requireMutationGuards({ expectedState, expectedRound, expectedHead }) {
+  const missing = [];
+  if (typeof expectedState !== "string" || !expectedState.trim()) missing.push("--expected-state");
+  if (expectedRound === undefined || expectedRound === null || expectedRound === "") missing.push("--expected-round");
+  if (typeof expectedHead !== "string" || !expectedHead.trim()) missing.push("--expected-head");
+  if (missing.length) {
+    refuse(
+      "missing_guards",
+      `Mutating calls require explicit optimistic guards: ${missing.join(", ")}. Run with --dry-run to derive them.`
+    );
+  }
+}
+
+function validateManifestSnapshot(data) {
+  if (!ACTIVE_STATES.has(data?.state)) {
+    const code = isTerminalState(data?.state) ? "terminal_state" : "invalid_state";
+    refuse(code, `Review policy cannot be extended while the run state is '${String(data?.state)}'`, {
+      actual_state: data?.state ?? null,
+    });
+  }
+
+  const round = data?.review?.rounds;
+  if (!Number.isInteger(round) || round < 0) {
+    refuse("invalid_manifest_round", "Persisted review.rounds must be a non-negative integer", {
+      actual_round: round ?? null,
+    });
+  }
+
+  const head = data?.git?.head_sha;
+  if (typeof head !== "string" || !head.trim()) {
+    refuse("missing_manifest_head", "Persisted git.head_sha must be non-empty before review policy can be extended", {
+      actual_head: head ?? null,
+    });
+  }
+
+  const oldMaxRounds = data?.review?.max_rounds;
+  if (!Number.isInteger(oldMaxRounds) || oldMaxRounds <= 0) {
+    refuse("invalid_persisted_policy", "Persisted review.max_rounds must be a positive integer", {
+      actual_max_rounds: oldMaxRounds ?? null,
+    });
+  }
+
+  return { state: data.state, round, head, oldMaxRounds };
+}
+
+function validateGuards(snapshot, guards) {
+  const mismatches = [];
+  if (guards.expectedState !== snapshot.state) {
+    mismatches.push({ guard: "expected_state", expected: guards.expectedState, actual: snapshot.state });
+  }
+  if (guards.expectedRound !== snapshot.round) {
+    mismatches.push({ guard: "expected_round", expected: guards.expectedRound, actual: snapshot.round });
+  }
+  if (guards.expectedHead !== snapshot.head) {
+    mismatches.push({ guard: "expected_head", expected: guards.expectedHead, actual: snapshot.head });
+  }
+  if (mismatches.length) {
+    refuse("concurrent_manifest_drift", "Manifest state, round, or HEAD no longer matches the supplied guards", {
+      mismatches,
+      guards: {
+        expected_state: guards.expectedState,
+        expected_round: guards.expectedRound,
+        expected_head: guards.expectedHead,
+      },
+      actual: {
+        state: snapshot.state,
+        round: snapshot.round,
+        head: snapshot.head,
+      },
+    });
+  }
+}
+
+function getEventsPathForManifest(manifestPath, runId) {
+  return path.join(path.dirname(manifestPath), runId, "events.jsonl");
+}
+
+function inspectEventSink(eventsPath, fsApi = fs) {
+  let stat;
+  try {
+    stat = fsApi.lstatSync(eventsPath);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      refuse("missing_event_sink", `Required event sink does not exist: ${eventsPath}`, { events_path: eventsPath });
+    }
+    refuse("unwritable_event_sink", `Cannot inspect event sink ${eventsPath}: ${error.message}`, { events_path: eventsPath });
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    refuse("unwritable_event_sink", `Event sink must be an existing regular file: ${eventsPath}`, { events_path: eventsPath });
+  }
+  if ((stat.mode & 0o222) === 0) {
+    refuse("unwritable_event_sink", `Event sink has no writable permission bits: ${eventsPath}`, { events_path: eventsPath });
+  }
+  try {
+    fsApi.accessSync(eventsPath, fs.constants.W_OK);
+    return { bytes: fsApi.readFileSync(eventsPath), stat };
+  } catch (error) {
+    refuse("unwritable_event_sink", `Event sink is not writable: ${eventsPath}: ${error.message}`, {
+      events_path: eventsPath,
+    });
+  }
+}
+
+function restoreFileBytes(filePath, bytes, stat, fsApi = fs) {
+  const tmpPath = `${filePath}.rollback.${process.pid}.${Date.now()}`;
+  try {
+    fsApi.writeFileSync(tmpPath, bytes, { mode: stat.mode & 0o777 });
+    fsApi.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try { fsApi.unlinkSync(tmpPath); } catch {}
+    throw error;
+  }
+}
+
+function normalizeOptions(options) {
+  const dryRun = options.dryRun === true;
+  const maxRounds = parsePositiveInteger(options.maxRounds, "--max-rounds");
+  const reason = requireReason(options.reason);
+  if (!options.runId && !options.manifestPath) {
+    refuse("missing_target", "Provide --run-id or --manifest");
+  }
+  if (!dryRun) requireMutationGuards(options);
+
+  return {
+    ...options,
+    repoRoot: path.resolve(options.repoRoot || "."),
+    maxRounds,
+    reason,
+    dryRun,
+    expectedRound: options.expectedRound === undefined || options.expectedRound === null || options.expectedRound === ""
+      ? undefined
+      : parseExpectedRound(options.expectedRound),
+  };
+}
+
+function extendReviewPolicy(options, dependencies = {}) {
+  const runtime = {
+    appendRunEvent,
+    fs,
+    nowIso,
+    parseFrontmatter,
+    resolveManifestRecord,
+    withManifestTransaction,
+    writeManifestUnlocked,
+    ...dependencies,
+  };
+  const normalized = normalizeOptions(options);
+
+  let resolved;
+  try {
+    resolved = runtime.resolveManifestRecord({
+      repoRoot: normalized.repoRoot,
+      runId: normalized.runId,
+      manifestPath: normalized.manifestPath,
+    });
+  } catch (error) {
+    if (error instanceof PolicyUpdateRefusal) throw error;
+    refuse("run_resolution_failed", `Cannot resolve relay run: ${error.message}`);
+  }
+
+  try {
+    return runtime.withManifestTransaction(resolved.manifestPath, () => {
+      let current;
+      let originalManifestBytes;
+      let originalManifestStat;
+      try {
+        originalManifestBytes = runtime.fs.readFileSync(resolved.manifestPath);
+        originalManifestStat = runtime.fs.lstatSync(resolved.manifestPath);
+        current = runtime.parseFrontmatter(originalManifestBytes.toString("utf-8"));
+      } catch (error) {
+        refuse("manifest_read_failed", `Cannot read locked manifest snapshot: ${error.message}`, {
+          manifest_path: resolved.manifestPath,
+        });
+      }
+
+      if (current.data?.run_id !== resolved.data?.run_id) {
+        refuse("concurrent_manifest_drift", "Manifest run_id changed after resolution", {
+          expected_run_id: resolved.data?.run_id ?? null,
+          actual_run_id: current.data?.run_id ?? null,
+        });
+      }
+
+      const snapshot = validateManifestSnapshot(current.data);
+      const effectiveGuards = {
+        expectedState: normalized.expectedState ?? snapshot.state,
+        expectedRound: normalized.expectedRound ?? snapshot.round,
+        expectedHead: normalized.expectedHead ?? snapshot.head,
+      };
+
+      // Mutating calls always supplied all three guards. Dry-runs may derive
+      // omitted guards, but any explicitly supplied guard is still checked.
+      validateGuards(snapshot, effectiveGuards);
+
+      if (normalized.maxRounds <= snapshot.oldMaxRounds) {
+        refuse(
+          "non_monotonic_max_rounds",
+          `--max-rounds must be strictly greater than persisted review.max_rounds=${snapshot.oldMaxRounds}`,
+          { current_max_rounds: snapshot.oldMaxRounds, requested_max_rounds: normalized.maxRounds }
+        );
+      }
+
+      const eventsPath = getEventsPathForManifest(resolved.manifestPath, current.data.run_id);
+      const eventSinkSnapshot = inspectEventSink(eventsPath, runtime.fs);
+      const resultBase = {
+        status: normalized.dryRun ? "dry_run" : "updated",
+        manifestPath: resolved.manifestPath,
+        runId: current.data.run_id,
+        dryRun: normalized.dryRun,
+        reason: normalized.reason,
+        guards: {
+          expected_state: snapshot.state,
+          expected_round: snapshot.round,
+          expected_head: snapshot.head,
+        },
+        delta: {
+          current_max_rounds: snapshot.oldMaxRounds,
+          requested_max_rounds: normalized.maxRounds,
+          increase: normalized.maxRounds - snapshot.oldMaxRounds,
+        },
+      };
+
+      if (normalized.dryRun) return resultBase;
+
+      const updated = {
+        ...current.data,
+        review: {
+          ...(current.data.review || {}),
+          max_rounds: normalized.maxRounds,
+        },
+        timestamps: {
+          ...(current.data.timestamps || {}),
+          updated_at: runtime.nowIso(),
+        },
+      };
+
+      try {
+        runtime.writeManifestUnlocked(resolved.manifestPath, updated, current.body);
+      } catch (error) {
+        refuse("manifest_write_failed", `Manifest policy write failed: ${error.message}`, {
+          manifest_path: resolved.manifestPath,
+        });
+      }
+
+      let event;
+      try {
+        // Event values come only from the locked manifest snapshot and the
+        // manifest object just written, never from raw CLI guard values.
+        event = runtime.appendRunEvent(
+          current.data.paths?.repo_root || normalized.repoRoot,
+          current.data.run_id,
+          {
+            event: EVENTS.POLICY_UPDATED,
+            state: snapshot.state,
+            state_from: snapshot.state,
+            state_to: snapshot.state,
+            round: snapshot.round,
+            head_sha: snapshot.head,
+            old_max_rounds: snapshot.oldMaxRounds,
+            new_max_rounds: updated.review.max_rounds,
+            reason: normalized.reason,
+            origin: "operator",
+          },
+          { eventsPath, lockHeld: true }
+        );
+      } catch (error) {
+        const rollbackErrors = [];
+        try {
+          restoreFileBytes(resolved.manifestPath, originalManifestBytes, originalManifestStat, runtime.fs);
+        } catch (rollbackError) {
+          rollbackErrors.push(`manifest: ${rollbackError.message}`);
+        }
+        try {
+          restoreFileBytes(eventsPath, eventSinkSnapshot.bytes, eventSinkSnapshot.stat, runtime.fs);
+        } catch (rollbackError) {
+          rollbackErrors.push(`events: ${rollbackError.message}`);
+        }
+        refuse(
+          rollbackErrors.length ? "policy_update_rollback_failed" : "event_append_failed",
+          `Policy event append failed: ${error.message}` +
+            (rollbackErrors.length ? `; rollback also failed (${rollbackErrors.join("; ")})` : "; manifest and event bytes were restored"),
+          { manifest_path: resolved.manifestPath, events_path: eventsPath, rollback_errors: rollbackErrors }
+        );
+      }
+
+      return { ...resultBase, event };
+    });
+  } catch (error) {
+    if (error instanceof PolicyUpdateRefusal) throw error;
+    if (error?.code === "MANIFEST_LOCK_TIMEOUT") {
+      refuse("lock_contention", `Could not acquire the manifest lock: ${error.message}`, {
+        manifest_path: resolved.manifestPath,
+        lock_path: error.lockPath || null,
+      });
+    }
+    refuse("policy_update_failed", `Review policy update failed: ${error.message}`, {
+      manifest_path: resolved.manifestPath,
+    });
+  }
+}
+
+function printUsage(stream = console.log) {
+  stream(
+    "Usage: extend-review-policy.js (--repo <path> --run-id <id> | --manifest <path>) --max-rounds <n> --reason <text> " +
+    "[--expected-state <state> --expected-round <n> --expected-head <sha>] [--dry-run] [--json]\n\n" +
+    "Options:\n" +
+    `  --repo <path>          ${modeLabel("--repo")} Repository root\n` +
+    `  --run-id <id>          ${modeLabel("--run-id")} Relay run identifier\n` +
+    `  --manifest <path>      ${modeLabel("--manifest")} Explicit manifest path\n` +
+    `  --max-rounds <n>       ${modeLabel("--max-rounds")} Strictly higher review round cap\n` +
+    `  --reason <text>        ${modeLabel("--reason")} Non-empty operator audit reason\n` +
+    `  --expected-state <s>   ${modeLabel("--expected-state")} Locked manifest state guard\n` +
+    `  --expected-round <n>   ${modeLabel("--expected-round")} Locked review round guard\n` +
+    `  --expected-head <sha>  ${modeLabel("--expected-head")} Locked manifest HEAD guard\n` +
+    `  --dry-run              ${modeLabel("--dry-run")} Derive guards and report the delta without mutation\n` +
+    `  --json                 ${modeLabel("--json")} Output structured JSON\n` +
+    `  --help                 ${modeLabel("--help")} Show this help`
+  );
+}
+
+function printResult(result, jsonOut) {
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(result.dryRun ? "Review policy extension dry-run:" : "Review policy extended:");
+  console.log(`  Run:        ${result.runId}`);
+  console.log(`  Max rounds: ${result.delta.current_max_rounds} -> ${result.delta.requested_max_rounds}`);
+  console.log(`  State:      ${result.guards.expected_state}`);
+  console.log(`  Round:      ${result.guards.expected_round}`);
+  console.log(`  HEAD:       ${result.guards.expected_head}`);
+  console.log(`  Reason:     ${result.reason}`);
+  if (result.dryRun) console.log("  dry-run:    no manifest or event changes written");
+}
+
+function printRefusal(result, jsonOut) {
+  if (jsonOut) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.error(`Refused review-policy extension [${result.error_code}]: ${result.message}`);
+  if (result.mismatches) {
+    for (const mismatch of result.mismatches) {
+      console.error(`  ${mismatch.guard}: expected ${String(mismatch.expected)}, actual ${String(mismatch.actual)}`);
+    }
+  }
+}
+
+function main(argv = process.argv.slice(2)) {
+  const cli = bindCliArgs(argv, CLI_ARG_OPTIONS);
+  if (cli.hasFlag(["--help", "-h"])) {
+    printUsage();
+    return 0;
+  }
+  const jsonOut = cli.hasFlag("--json");
+  try {
+    const unknownFlags = findUnknownFlags(argv, COMMAND_NAME);
+    if (unknownFlags.length) {
+      refuse("unknown_flags", `unknown flags: ${unknownFlags.join(", ")}`);
+    }
+    const result = extendReviewPolicy({
+      repoRoot: cli.getArg("--repo", "."),
+      runId: cli.getArg("--run-id", undefined),
+      manifestPath: cli.getArg("--manifest", undefined),
+      maxRounds: cli.getArg("--max-rounds", undefined),
+      reason: cli.getArg("--reason", undefined),
+      expectedState: cli.getArg("--expected-state", undefined),
+      expectedRound: cli.getArg("--expected-round", undefined),
+      expectedHead: cli.getArg("--expected-head", undefined),
+      dryRun: cli.hasFlag("--dry-run"),
+    });
+    printResult(result, jsonOut);
+    return 0;
+  } catch (error) {
+    const result = error instanceof PolicyUpdateRefusal
+      ? error.result
+      : { status: "refused", error_code: "invalid_arguments", message: error.message };
+    printRefusal(result, jsonOut);
+    return 2;
+  }
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  PolicyUpdateRefusal,
+  extendReviewPolicy,
+  main,
+};

--- a/skills/relay-dispatch/scripts/extend-review-policy.js
+++ b/skills/relay-dispatch/scripts/extend-review-policy.js
@@ -312,9 +312,21 @@ function extendReviewPolicy(options, dependencies = {}) {
       try {
         runtime.writeManifestUnlocked(resolved.manifestPath, updated, current.body);
       } catch (error) {
-        refuse("manifest_write_failed", `Manifest policy write failed: ${error.message}`, {
-          manifest_path: resolved.manifestPath,
-        });
+        const rollbackErrors = [];
+        try {
+          restoreFileBytes(resolved.manifestPath, originalManifestBytes, originalManifestStat, runtime.fs);
+        } catch (rollbackError) {
+          rollbackErrors.push(`manifest: ${rollbackError.message}`);
+        }
+        refuse(
+          rollbackErrors.length ? "policy_update_rollback_failed" : "manifest_write_failed",
+          `Manifest policy write failed: ${error.message}` +
+            (rollbackErrors.length ? `; rollback also failed (${rollbackErrors.join("; ")})` : "; original manifest bytes were restored"),
+          {
+            manifest_path: resolved.manifestPath,
+            rollback_errors: rollbackErrors,
+          }
+        );
       }
 
       let event;

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -45,6 +45,7 @@ const EVENTS = Object.freeze({
   MERGE_FINALIZE: "merge_finalize",
   MODEL_HINTS_UPDATED: "model_hints_updated",
   OPERATOR_EXECUTION_EVIDENCE: "operator_execution_evidence",
+  POLICY_UPDATED: "policy_updated",
   PUBLISH_RESULT: "publish_result",
   PR_BODY_SNAPSHOT_FAILED: "pr_body_snapshot_failed",
   PR_NUMBER_STAMPED: "pr_number_stamped",
@@ -159,6 +160,15 @@ function appendRunEventUnlocked(repoRoot, runId, eventData, { eventsPath = null 
       : {}),
     ...(eventData.origin !== undefined
       ? { origin: normalizeEventValue(eventData.origin) }
+      : {}),
+    ...(eventData.state !== undefined
+      ? { state: normalizeEventValue(eventData.state) }
+      : {}),
+    ...(eventData.old_max_rounds !== undefined
+      ? { old_max_rounds: normalizeEventValue(eventData.old_max_rounds) }
+      : {}),
+    ...(eventData.new_max_rounds !== undefined
+      ? { new_max_rounds: normalizeEventValue(eventData.new_max_rounds) }
       : {}),
     ...(eventData.override_class !== undefined
       ? { override_class: normalizeEventValue(eventData.override_class) }

--- a/skills/relay-review/scripts/review-runner/round-cap.js
+++ b/skills/relay-review/scripts/review-runner/round-cap.js
@@ -7,10 +7,14 @@ const { summarizeLineage } = require("./redispatch");
 const DEFAULT_MAX_REVIEW_ROUNDS = 2;
 
 function getMaxReviewRounds(data) {
-  const configured = Number(data?.review?.max_rounds);
-  return Number.isInteger(configured) && configured > 0
-    ? configured
-    : DEFAULT_MAX_REVIEW_ROUNDS;
+  const configured = data?.review?.max_rounds;
+  if (configured === undefined || configured === null) {
+    return DEFAULT_MAX_REVIEW_ROUNDS;
+  }
+  if (!Number.isInteger(configured) || configured <= 0) {
+    throw new Error("Persisted review.max_rounds must be a positive integer");
+  }
+  return configured;
 }
 
 function shouldEscalateRepairCycle({ data, round, blocking }) {

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -176,6 +176,7 @@ const HELP_COMMANDS = [
   ["close-run", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "close-run.js")],
   ["create-worktree", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "create-worktree.js")],
   ["dispatch", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "dispatch.js")],
+  ["extend-review-policy", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "extend-review-policy.js")],
   ["finalize-run", path.join(__dirname, "..", "..", "..", "skills", "relay-merge", "scripts", "finalize-run.js")],
   ["gate-check", path.join(__dirname, "..", "..", "..", "skills", "relay-merge", "scripts", "gate-check.js")],
   ["invoke-reviewer-antigravity", path.join(__dirname, "..", "..", "..", "skills", "relay-review", "scripts", "invoke-reviewer-antigravity.js")],

--- a/tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
+++ b/tests/relay-dispatch/scripts/cli-unknown-flag-wiring.test.js
@@ -28,6 +28,9 @@ const CLI_TARGETS = [
   ["relay-dispatch", "skills/relay-dispatch/scripts/recover-state.js",
     ["--repo", ".", "--run-id", "fake", "--to", "review_pending",
      "--reason", "test", "--no-merge"], "--no-merge"],
+  ["relay-dispatch", "skills/relay-dispatch/scripts/extend-review-policy.js",
+    ["--repo", ".", "--run-id", "fake", "--max-rounds", "3",
+     "--reason", "test", "--no-merge"], "--no-merge"],
   ["relay-review", "skills/relay-review/scripts/review-runner.js",
     ["--repo", ".", "--run-id", "fake", "--no-merge"], "--no-merge"],
 ];

--- a/tests/relay-dispatch/scripts/extend-review-policy.test.js
+++ b/tests/relay-dispatch/scripts/extend-review-policy.test.js
@@ -1,0 +1,333 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  acquireManifestLock,
+  createManifestSkeleton,
+  readManifest,
+  releaseManifestLock,
+  writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/manifest/store");
+const {
+  ensureRunLayout,
+  getEventsPath,
+} = require("../../../skills/relay-dispatch/scripts/manifest/paths");
+const {
+  PolicyUpdateRefusal,
+  extendReviewPolicy,
+} = require("../../../skills/relay-dispatch/scripts/extend-review-policy");
+
+const SCRIPT = path.join(
+  __dirname,
+  "..", "..", "..",
+  "skills", "relay-dispatch", "scripts", "extend-review-policy.js"
+);
+const RUN_ID = "issue-1053-20260722113152000-a1b2c3d4";
+const HEAD_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+function initGitRepo(repoRoot) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Review Policy Operator"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "operator@example.com"], { cwd: repoRoot, stdio: "pipe" });
+}
+
+function setupFixture(overrides = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-policy-repo-"));
+  const relayHome = fs.mkdtempSync(path.join(os.tmpdir(), "relay-policy-home-"));
+  initGitRepo(repoRoot);
+  process.env.RELAY_HOME = relayHome;
+
+  const layout = ensureRunLayout(repoRoot, RUN_ID);
+  const manifest = createManifestSkeleton({
+    repoRoot,
+    runId: RUN_ID,
+    branch: "issue-1053",
+    baseBranch: "main",
+    issueNumber: 1053,
+    worktreePath: repoRoot,
+    orchestrator: "codex",
+    executor: "codex",
+    reviewer: "codex",
+  });
+  manifest.state = overrides.state || "changes_requested";
+  manifest.next_action = "await_redispatch";
+  manifest.git.head_sha = overrides.headSha === undefined ? HEAD_SHA : overrides.headSha;
+  manifest.review.rounds = overrides.rounds === undefined ? 7 : overrides.rounds;
+  manifest.review.max_rounds = overrides.maxRounds === undefined ? 7 : overrides.maxRounds;
+  manifest.timestamps.updated_at = "2026-07-19T16:49:07.992Z";
+  writeManifest(layout.manifestPath, manifest, "# Notes\n\n## Review History\n");
+
+  const eventsPath = getEventsPath(repoRoot, RUN_ID);
+  fs.writeFileSync(eventsPath, overrides.eventsContent || "", "utf-8");
+  return { repoRoot, relayHome, manifestPath: layout.manifestPath, eventsPath };
+}
+
+function runCommand(fixture, extraArgs, env = {}) {
+  return spawnSync(process.execPath, [
+    SCRIPT,
+    "--repo", fixture.repoRoot,
+    "--run-id", RUN_ID,
+    ...extraArgs,
+  ], {
+    encoding: "utf-8",
+    env: { ...process.env, RELAY_HOME: fixture.relayHome, ...env },
+  });
+}
+
+function mutationArgs(maxRounds = "8", guards = {}) {
+  return [
+    "--max-rounds", maxRounds,
+    "--reason", "Corrective redispatch requires public R8",
+    "--expected-state", guards.state || "changes_requested",
+    "--expected-round", String(guards.round ?? 7),
+    "--expected-head", guards.head || HEAD_SHA,
+    "--json",
+  ];
+}
+
+function bytes(fixture) {
+  return {
+    manifest: fs.readFileSync(fixture.manifestPath),
+    events: fs.existsSync(fixture.eventsPath) ? fs.readFileSync(fixture.eventsPath) : null,
+  };
+}
+
+function assertBytesEqual(actual, expected) {
+  assert.deepEqual(actual.manifest, expected.manifest, "manifest bytes must remain unchanged");
+  assert.deepEqual(actual.events, expected.events, "event bytes must remain unchanged");
+}
+
+test("success monotonically updates the cap and appends one snapshot-consistent policy_updated event", () => {
+  const fixture = setupFixture();
+  const before = readManifest(fixture.manifestPath).data;
+  const result = runCommand(fixture, mutationArgs());
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.status, "updated");
+  assert.deepEqual(output.delta, { current_max_rounds: 7, requested_max_rounds: 8, increase: 1 });
+
+  const after = readManifest(fixture.manifestPath).data;
+  assert.equal(after.review.max_rounds, 8);
+  assert.notEqual(after.timestamps.updated_at, before.timestamps.updated_at);
+  const normalizedAfter = structuredClone(after);
+  normalizedAfter.review.max_rounds = before.review.max_rounds;
+  normalizedAfter.timestamps.updated_at = before.timestamps.updated_at;
+  assert.deepEqual(normalizedAfter, before, "only max_rounds and updated_at may change");
+
+  const eventLines = fs.readFileSync(fixture.eventsPath, "utf-8").trim().split("\n").filter(Boolean);
+  assert.equal(eventLines.length, 1);
+  const event = JSON.parse(eventLines[0]);
+  assert.equal(event.event, "policy_updated");
+  assert.equal(event.state, "changes_requested");
+  assert.equal(event.state_from, "changes_requested");
+  assert.equal(event.state_to, "changes_requested");
+  assert.equal(event.round, 7);
+  assert.equal(event.head_sha, HEAD_SHA);
+  assert.equal(event.old_max_rounds, 7);
+  assert.equal(event.new_max_rounds, 8);
+  assert.equal(event.reason, "Corrective redispatch requires public R8");
+  assert.equal(event.actor, "Review Policy Operator");
+  assert.equal(event.origin, "operator");
+  assert.match(event.ts, /^\d{4}-\d{2}-\d{2}T/);
+  assert.notEqual(event.event, "state_recovery");
+});
+
+test("dry-run derives guards and reports the delta with zero mutation", () => {
+  const fixture = setupFixture({ eventsContent: '{"event":"dispatch_result"}\n' });
+  const before = bytes(fixture);
+  const result = runCommand(fixture, [
+    "--max-rounds", "8",
+    "--reason", "Preview one more review",
+    "--dry-run",
+    "--json",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.status, "dry_run");
+  assert.deepEqual(output.guards, {
+    expected_state: "changes_requested",
+    expected_round: 7,
+    expected_head: HEAD_SHA,
+  });
+  assert.deepEqual(output.delta, { current_max_rounds: 7, requested_max_rounds: 8, increase: 1 });
+  assertBytesEqual(bytes(fixture), before);
+});
+
+test("equal and decreased caps are refused idempotently with structured exit 2", () => {
+  for (const requested of ["7", "6"]) {
+    const fixture = setupFixture();
+    const before = bytes(fixture);
+    const result = runCommand(fixture, mutationArgs(requested));
+    assert.equal(result.status, 2, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.status, "refused");
+    assert.equal(output.error_code, "non_monotonic_max_rounds");
+    assertBytesEqual(bytes(fixture), before);
+  }
+});
+
+test("malformed or omitted max-rounds and blank reason fail closed", () => {
+  for (const args of [
+    mutationArgs("0"),
+    mutationArgs("2.5"),
+    mutationArgs("bogus"),
+    ["--reason", "valid", "--json"],
+    ["--max-rounds", "8", "--reason", "", "--json"],
+  ]) {
+    const fixture = setupFixture();
+    const before = bytes(fixture);
+    const result = runCommand(fixture, args);
+    assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
+    assert.equal(JSON.parse(result.stdout).status, "refused");
+    assertBytesEqual(bytes(fixture), before);
+  }
+});
+
+test("mutating call requires all explicit guards", () => {
+  const fixture = setupFixture();
+  const before = bytes(fixture);
+  const result = runCommand(fixture, [
+    "--max-rounds", "8",
+    "--reason", "No implicit guard snapshot",
+    "--json",
+  ]);
+  assert.equal(result.status, 2);
+  assert.equal(JSON.parse(result.stdout).error_code, "missing_guards");
+  assertBytesEqual(bytes(fixture), before);
+});
+
+test("dry-run guards reject concurrent manifest drift and stale HEAD without mutation", () => {
+  const fixture = setupFixture();
+  const preview = runCommand(fixture, [
+    "--max-rounds", "8", "--reason", "Preview", "--dry-run", "--json",
+  ]);
+  assert.equal(preview.status, 0, preview.stderr);
+  const guards = JSON.parse(preview.stdout).guards;
+
+  const record = readManifest(fixture.manifestPath);
+  record.data.review.rounds = 8;
+  record.data.git.head_sha = "fedcba9876543210fedcba9876543210fedcba98";
+  writeManifest(fixture.manifestPath, record.data, record.body);
+  const afterDrift = bytes(fixture);
+
+  const result = runCommand(fixture, mutationArgs("9", {
+    state: guards.expected_state,
+    round: guards.expected_round,
+    head: guards.expected_head,
+  }));
+  assert.equal(result.status, 2, result.stderr);
+  const refusal = JSON.parse(result.stdout);
+  assert.equal(refusal.error_code, "concurrent_manifest_drift");
+  assert.deepEqual(refusal.mismatches.map((item) => item.guard).sort(), ["expected_head", "expected_round"]);
+  assertBytesEqual(bytes(fixture), afterDrift);
+});
+
+test("invalid/terminal states and a missing event sink are real refusals", () => {
+  for (const scenario of ["invalid", "terminal", "missing_events"]) {
+    const fixture = setupFixture({
+      state: scenario === "invalid" ? "forged_state" : scenario === "terminal" ? "merged" : "changes_requested",
+    });
+    if (scenario === "missing_events") fs.unlinkSync(fixture.eventsPath);
+    const before = bytes(fixture);
+    const result = runCommand(fixture, mutationArgs());
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(
+      JSON.parse(result.stdout).error_code,
+      scenario === "invalid"
+        ? "invalid_state"
+        : scenario === "terminal" ? "terminal_state" : "missing_event_sink"
+    );
+    assertBytesEqual(bytes(fixture), before);
+  }
+});
+
+test("an unwritable event sink blocks the mutation instead of acting as a warning", () => {
+  const fixture = setupFixture({ eventsContent: '{"event":"dispatch_start"}\n' });
+  const before = bytes(fixture);
+  fs.chmodSync(fixture.eventsPath, 0o444);
+  try {
+    const result = runCommand(fixture, mutationArgs());
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(JSON.parse(result.stdout).error_code, "unwritable_event_sink");
+    assertBytesEqual(bytes(fixture), before);
+  } finally {
+    fs.chmodSync(fixture.eventsPath, 0o644);
+  }
+});
+
+test("simulated manifest write failure rolls back with zero event mutation", () => {
+  const fixture = setupFixture({ eventsContent: '{"event":"dispatch_start"}\n' });
+  const before = bytes(fixture);
+  process.env.RELAY_HOME = fixture.relayHome;
+
+  assert.throws(
+    () => extendReviewPolicy({
+      repoRoot: fixture.repoRoot,
+      runId: RUN_ID,
+      maxRounds: "8",
+      reason: "Simulate storage failure",
+      expectedState: "changes_requested",
+      expectedRound: "7",
+      expectedHead: HEAD_SHA,
+    }, {
+      writeManifestUnlocked() {
+        const error = new Error("simulated write failure");
+        error.code = "EIO";
+        throw error;
+      },
+    }),
+    (error) => error instanceof PolicyUpdateRefusal && error.result.error_code === "manifest_write_failed"
+  );
+  assertBytesEqual(bytes(fixture), before);
+});
+
+test("manifest lock contention exits 2 and leaves manifest and event bytes untouched", () => {
+  const fixture = setupFixture();
+  const before = bytes(fixture);
+  const lock = acquireManifestLock(fixture.manifestPath);
+  try {
+    const result = runCommand(fixture, mutationArgs(), {
+      RELAY_MANIFEST_LOCK_TIMEOUT_MS: "20",
+      RELAY_MANIFEST_LOCK_POLL_MS: "5",
+      RELAY_MANIFEST_LOCK_STALE_MS: "60000",
+    });
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(JSON.parse(result.stdout).error_code, "lock_contention");
+    assertBytesEqual(bytes(fixture), before);
+  } finally {
+    releaseManifestLock(lock);
+  }
+});
+
+test("event append failure restores both files to their exact pre-transaction bytes", () => {
+  const fixture = setupFixture({ eventsContent: '{"event":"dispatch_start"}\n' });
+  const before = bytes(fixture);
+  process.env.RELAY_HOME = fixture.relayHome;
+
+  assert.throws(
+    () => extendReviewPolicy({
+      repoRoot: fixture.repoRoot,
+      runId: RUN_ID,
+      maxRounds: "8",
+      reason: "Exercise paired rollback",
+      expectedState: "changes_requested",
+      expectedRound: "7",
+      expectedHead: HEAD_SHA,
+    }, {
+      appendRunEvent(_repoRoot, _runId, _event, options) {
+        fs.appendFileSync(options.eventsPath, "partial-event\n", "utf-8");
+        throw new Error("simulated event failure");
+      },
+    }),
+    (error) => error instanceof PolicyUpdateRefusal && error.result.error_code === "event_append_failed"
+  );
+  assertBytesEqual(bytes(fixture), before);
+});

--- a/tests/relay-dispatch/scripts/extend-review-policy.test.js
+++ b/tests/relay-dispatch/scripts/extend-review-policy.test.js
@@ -13,6 +13,7 @@ const {
   readManifest,
   releaseManifestLock,
   writeManifest,
+  writeManifestUnlocked,
 } = require("../../../skills/relay-dispatch/scripts/manifest/store");
 const {
   ensureRunLayout,
@@ -263,7 +264,7 @@ test("an unwritable event sink blocks the mutation instead of acting as a warnin
   }
 });
 
-test("simulated manifest write failure rolls back with zero event mutation", () => {
+test("simulated post-write manifest failure restores exact bytes with zero event mutation", () => {
   const fixture = setupFixture({ eventsContent: '{"event":"dispatch_start"}\n' });
   const before = bytes(fixture);
   process.env.RELAY_HOME = fixture.relayHome;
@@ -278,7 +279,8 @@ test("simulated manifest write failure rolls back with zero event mutation", () 
       expectedRound: "7",
       expectedHead: HEAD_SHA,
     }, {
-      writeManifestUnlocked() {
+      writeManifestUnlocked(manifestPath, data, body) {
+        writeManifestUnlocked(manifestPath, data, body);
         const error = new Error("simulated write failure");
         error.code = "EIO";
         throw error;

--- a/tests/relay-review/scripts/review-round-policy.test.js
+++ b/tests/relay-review/scripts/review-round-policy.test.js
@@ -25,6 +25,15 @@ test("an explicit extended policy preserves additional review rounds", () => {
   assert.equal(shouldEscalateRepairCycle({ data, round: 5, blocking: true }), true);
 });
 
+test("persisted max_rounds must be a plain positive integer and is never coerced", () => {
+  for (const maxRounds of ["5", 0, -1, 2.5, Number.NaN]) {
+    assert.throws(
+      () => getMaxReviewRounds({ review: { max_rounds: maxRounds } }),
+      /must be a positive integer/
+    );
+  }
+});
+
 test("assurance-derived caps bound compact and hardened repair depth", () => {
   const compact = { review: { max_rounds: 1 } };
   const hardened = { review: { max_rounds: 3 } };


### PR DESCRIPTION
Fixes #1053

Adds a narrow, audited `extend-review-policy` command that lets an operator monotonically raise a run's persisted `review.max_rounds` under explicit guards, atomically, recording a dedicated `policy_updated` event -- replacing the ad hoc manifest-editing workaround used during #1019.

- `skills/relay-dispatch/scripts/extend-review-policy.js`: resolves runs via the canonical resolver, supports `--dry-run`/`--json`, requires a strictly-greater `--max-rounds` and non-empty `--reason` plus state/round/HEAD guards, mutates atomically under the manifest lock, and rolls back byte-for-byte on any write/event failure.
- `skills/relay-dispatch/scripts/relay-events.js`: adds `EVENTS.POLICY_UPDATED` with old/new cap, reason, state, round, HEAD, actor/origin, timestamp -- never overloads `STATE_RECOVERY`.
- `skills/relay-review/scripts/review-runner/round-cap.js`: `getMaxReviewRounds` now throws on a malformed/non-positive persisted `max_rounds` instead of silently falling back to the default, so the cap is always enforced explicitly.
- `skills/relay-dispatch/references/review-policy-extension.md`: documents the exceptional policy boundary and warns that a cap increase is not evidence of review convergence.
- `tests/relay-dispatch/scripts/extend-review-policy.test.js`: fixture-only coverage for success, dry-run, idempotence rejection, rollback, lock contention, concurrent drift, and event/manifest consistency.

---

## Dispatch Summary

```text
구현 완료했고 작업 트리는 깨끗합니다.

- [`extend-review-policy.js`](/Users/sjlee/.relay/worktrees/622b95fe/dev-relay/skills/relay-dispatch/scripts/extend-review-policy.js:212): canonical resolver, 잠금 내부 guard 재검증, 단조 증가, dry-run/JSON, 실패 롤백
- [`relay-events.js`](/Users/sjlee/.relay/worktrees/622b95fe/dev-relay/skills/relay-dispatch/scripts/relay-events.js:48): 전용 `policy_updated` 이벤트와 감사 필드
- [`round-cap.js`](/Users/sjlee/.relay/worktrees/622b95fe/dev-relay/skills/relay-review/scripts/review-runner/round-cap.js:9): persisted positive integer를 그대로 강제
- [`review-policy-extension.md`](/Users/sjlee/.relay/worktrees/622b95fe/dev-relay/skills/relay-dispatch/references/review-policy-extension.md:1): 예외 정책 경계와 운영 절차
```

## Dispatch Metadata

- Run: issue-1053-20260722144254501-698d8802
- Executor: codex
- Branch: issue-1053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 리뷰 정책의 `max_rounds`를 안전하게 확장하는 운영자 명령을 추가했습니다.
  - 동시성 가드, 미리보기, JSON 결과, 실패 시 롤백을 지원합니다.
  - 정책 변경 내용을 `policy_updated` 이벤트로 기록합니다.

- **버그 수정**
  - 잘못된 `max_rounds` 값은 기본값으로 대체하지 않고 즉시 거부합니다.

- **문서**
  - 정책 확장 절차, 이벤트 형식, CLI 옵션 및 운영 시 주의사항을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
