### PR TITLE
feat(relay-orca): prove runtime rebind on resume

### DIFF
--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -119,7 +119,6 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
 Exit gates come ONLY from the program's `exit_gates`; generic `integration:<check>` evidence is accepted only through the version-1 accepted-program identity/freshness contract (exact program/runtime/raw-ref plus immutable verification binding); a failing integration gate is never masked by task completion. Follow-up proposals are advisory (accepted by the operator as a new later wave). Gate kinds, ordering/masking, follow-up lifecycle, decision/budget/authorization records, the completion rule, stop conditions, and fail-closed codes 70–72: [references/gates-and-completion.md](references/gates-and-completion.md).
 
 Crash-safe resume (reconcile first, then reuse/re-dispatch only what is safe; fail closed on ambiguity):
-
 ```bash
 node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
   --program-id epic-941 \
@@ -127,8 +126,8 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/resume.js" \
   --gate-evidence-dir /tmp/relay-orca-integration-gates \
   --json
 ```
-
-`resume` loads the receipt, runs the SAME reconciliation as `status` **before any mutation**, reuses valid mappings, reacquires lost operator terminals, and re-dispatches ONLY outcomes whose Orca dispatch is verifiably absent AND whose relay side is clean — through the verified path. For integration tasks it re-generates all coordinator/dispatch/assignee/report provenance from fresh reads, adopts or resolves only the canonical gate, sends a fresh explicit `worker_done` instruction after resolution, and requires a task-list re-read of `completed`; it never retries or falls back to `task-update`. It never resets Orca, deletes a task/worktree/branch/PR, or force-closes a relay run. Running it twice is idempotent. Fail-closed decision codes 60–63 and recovery steps: [references/commands.md](references/commands.md) and [references/recovery.md](references/recovery.md).
+`resume` reconciles before mutation; on a mismatch it performs a flagless receipt rebind only after complete exact task-marker/spec proof. The atomic write changes `runtime_id` and appends one `runtime_rebound` event, never lifecycle state or handles. Incomplete/foreign/partial/ambiguous proofs retain exit 60 with zero mutation; normal safe reuse/re-dispatch then proceeds. It never resets Orca, deletes work, or force-closes relay state. Details and fail-closed codes 60–63:
+[references/commands.md](references/commands.md) and [references/recovery.md](references/recovery.md).
 
 Coordinator-only stop (records a bounded stop record; never cancels outcomes):
 

--- a/skills/relay-orca/references/commands.md
+++ b/skills/relay-orca/references/commands.md
@@ -227,6 +227,10 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/status.js" \
 **live** to derive a normalized program view. It is strictly **READ-ONLY**: no GitHub write,
 no relay manifest write, no Orca mutating subcommand or `reset`/`worktree`, and no receipt
 write. Durable truth outranks runtime signals and `worker_done` is never completion evidence.
+When `runtime` is `mismatch`, status also checks the fresh live task inventory and materialized
+fingerprints. A complete proof adds a read-only `repair_candidates` entry of kind
+`runtime_rebind` naming `old_runtime_id`, `new_runtime_id`, and `verified_rows`; status never
+writes the receipt. An incomplete proof retains the ordinary `RUNTIME_MISMATCH` diagnostic.
 
 ### Status report (`--json`)
 
@@ -347,7 +351,7 @@ force-close (see [recovery.md](recovery.md)).
 
 | reason_code | exit | Trigger |
 | --- | --- | --- |
-| `RESUME_RUNTIME_CHANGED` | 60 | Live runtime id differs from the receipt `runtime_id`. |
+| `RESUME_RUNTIME_CHANGED` | 60 | Live runtime id differs and the fresh exact task-marker/spec proof is incomplete or ambiguous; a complete proof rebinds flaglessly before normal reconciliation. |
 | `RESUME_AMBIGUOUS_STATE` | 61 | Runtime foreign/unreachable, or an outcome cannot be classified for resumption (e.g. a stale-`worker_done` inconsistency). |
 | `RESUME_CONFLICTING_MAPPING` | 62 | Duplicate or contradictory (changed) mappings. |
 | `RESUME_MISSING_PROVENANCE` | 63 | A live dispatch exists but the recorded dispatch context/assignee is missing. |

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -88,7 +88,7 @@ when it rewrites the receipt.
 
 ### Optional additive record fields (#947)
 
-Four more top-level keys MAY be appended — each written ONLY at a pinned write point, each
+Five more top-level keys MAY be appended — each written ONLY at a pinned write point, each
 **not** part of the canonical `RECEIPT_KEYS`, so a receipt that never carried them serializes
 **byte-identically** to a pre-#947 receipt and still loads for `status`/`resume` (validation
 ignores extra keys):
@@ -105,6 +105,9 @@ ignores extra keys):
   `tasks_created` / `dispatches_performed` / `waves_dispatched` from the receipt mapping
   itself (a recorded `orca_task_id` = created, a recorded `dispatch_id` = dispatched), so no
   new write point is required. These are the counters the #944/#946 write points already imply.
+- `events` — append-only coordination audit events. A proof-based runtime rebind appends exactly
+  one `runtime_rebound` event with the old/new runtime ids and every verified task row; it never
+  records lifecycle completion or fabricates dispatch/terminal state.
 
 `run` carries these forward across its receipt rewrite; the additive fields are coordination
 metadata, not a second lifecycle state machine. See [gates-and-completion.md](gates-and-completion.md).

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -41,7 +41,10 @@ On a runtime-id mismatch, `resume` takes fresh `status`, task-list, and gate-lis
 same reconciliation pass. It rebinds the receipt automatically, with no new flag, only when the
 proof is complete: the live task inventory is an exact match for every receipt-recorded
 `orca_task_id`, each `task_title` is the exact `relay-orca: <program-segment>/<outcome-id>` marker,
-and each materialized spec carries the exact program segment and outcome id. A successful rebind
+and each materialized spec carries the exact outcome id plus exact program identity — the exact
+program segment when the spec records one, otherwise the exact program id, which is what specs
+materialized before the segment was serialized carry (a spec with neither field never qualifies).
+A successful rebind
 changes only the receipt `runtime_id` and appends one `runtime_rebound` event containing the old
 and new ids plus every verified `{ orca_task_id, outcome_id }` row; it never repairs dispatches,
 terminals, task state, gates, or lifecycle signals. The normal reconciliation then continues.

--- a/skills/relay-orca/references/recovery.md
+++ b/skills/relay-orca/references/recovery.md
@@ -2,7 +2,9 @@
 
 `resume` is **reconcile-first and fail-closed for runtime restoration**: it loads the
 reconstructible receipt, runs the SAME live reconciliation as `status` before restoring an Orca
-dispatch, and only then restores what is safe (reuse valid mappings, reacquire a lost operator
+dispatch, and on a runtime-id mismatch may perform a flagless proof-based receipt rebind only
+when every receipt-recorded task is present in the fresh live task-list with an exact coordination
+marker and materialized spec identity. It then restores what is safe (reuse valid mappings, reacquire a lost operator
 terminal, re-dispatch a verifiably-absent, relay-clean wave-1 outcome, or advance an equivalent
 later-wave outcome after every earlier wave is `complete_with_evidence`, through the same verified
 path — always to an explicitly provided `--operator-handle`, never a self-created terminal). The
@@ -35,15 +37,25 @@ reference — never a destructive action. Resolve the decision by hand, then re-
 
 ### `RESUME_RUNTIME_CHANGED` (exit 60) — live runtime id ≠ receipt
 
-The Orca runtime was restarted (or replaced): the live `runtime_id` no longer matches the
-receipt, so every recorded `orca_task_id`/`dispatch_id`/terminal belongs to a runtime that is
-gone. Bounded steps:
+On a runtime-id mismatch, `resume` takes fresh `status`, task-list, and gate-list reads in the
+same reconciliation pass. It rebinds the receipt automatically, with no new flag, only when the
+proof is complete: the live task inventory is an exact match for every receipt-recorded
+`orca_task_id`, each `task_title` is the exact `relay-orca: <program-segment>/<outcome-id>` marker,
+and each materialized spec carries the exact program segment and outcome id. A successful rebind
+changes only the receipt `runtime_id` and appends one `runtime_rebound` event containing the old
+and new ids plus every verified `{ orca_task_id, outcome_id }` row; it never repairs dispatches,
+terminals, task state, gates, or lifecycle signals. The normal reconciliation then continues.
 
-1. Inspect the live view: `node scripts/status.js --program-id <id> --json`.
-2. Confirm — from live relay manifests, PRs, and issues — which outcomes already have durable
-   work, so a fresh run cannot duplicate it.
-3. Only then, against the new runtime, re-run `node scripts/run.js --program-file <program>` for
-   the outcomes that are genuinely unstarted. Leave in-flight relay runs alone.
+`status` performs the same proof read-only and reports a `repair_candidates` entry with the old and
+new runtime ids when the proof is complete; it never writes the receipt.
+
+Any incomplete or ambiguous proof remains fail-closed as `RESUME_RUNTIME_CHANGED` (exit 60) with
+zero mutation: a missing receipt row, a foreign or extra live row, a marker mismatch, a spec
+identity mismatch, a partial match, a failed/malformed/ambiguous live read, or any other inventory
+ambiguity. The existing no-context rejection path is unchanged for these shapes. Inspect with
+`node scripts/status.js --program-id <id> --json`, then confirm durable relay/GitHub truth and use
+the normal run/reconciliation path for genuinely unstarted work; never salvage `worker_done` or
+manually mutate Orca state.
 
 ### `RESUME_AMBIGUOUS_STATE` (exit 61) — foreign/unreachable runtime or an unclassifiable outcome
 

--- a/skills/relay-orca/scripts/lib/operator-records.js
+++ b/skills/relay-orca/scripts/lib/operator-records.js
@@ -8,7 +8,7 @@
 // (run/resume never fabricate one automatically).
 const { buildDecisionRecord, buildAuthorizationRecord } = require("./decision-records");
 
-const CARRY_FORWARD_KEYS = Object.freeze(["follow_ups", "decisions", "authorizations", "counters"]);
+const CARRY_FORWARD_KEYS = Object.freeze(["follow_ups", "decisions", "authorizations", "counters", "events"]);
 
 // Upsert a record into an array field by `id` (replace same-id, else append). Preserves
 // order for a stable, reproducible serialization.

--- a/skills/relay-orca/scripts/lib/orca-reads.js
+++ b/skills/relay-orca/scripts/lib/orca-reads.js
@@ -37,8 +37,9 @@ function orcaTaskList(run, orcaBin, options = {}) {
   const { ok, value } = envelope(proc);
   if (!ok) return { ok: false, reachable: false, tasks: [], runtimeId: null, proc };
   const result = value.result || {};
-  const tasks = Array.isArray(result.tasks) ? result.tasks : [];
-  return { ok: true, reachable: true, tasks, runtimeId: metaRuntimeId(value), proc };
+  const wellFormed = Array.isArray(result.tasks);
+  const tasks = wellFormed ? result.tasks : [];
+  return { ok: true, reachable: true, wellFormed, tasks, runtimeId: metaRuntimeId(value), proc };
 }
 
 function orcaGateList(run, orcaBin, options = {}) {
@@ -46,10 +47,11 @@ function orcaGateList(run, orcaBin, options = {}) {
   const { ok, value } = envelope(proc);
   if (!ok) return { ok: false, reachable: false, gates: [], runtimeId: null, proc };
   const result = value.result || {};
-  const gates = Array.isArray(result.gates) ? result.gates : [];
+  const wellFormed = Array.isArray(result.gates);
+  const gates = wellFormed ? result.gates : [];
   // A17: expose the read's `_meta.runtimeId` so the caller can prove this whole-runtime
   // read came from the SAME runtime the status read established before adopting its data.
-  return { ok: true, reachable: true, gates, runtimeId: metaRuntimeId(value), proc };
+  return { ok: true, reachable: true, wellFormed, gates, runtimeId: metaRuntimeId(value), proc };
 }
 
 // First non-empty string among the candidates, else null. Candidates are drawn from a

--- a/skills/relay-orca/scripts/lib/receipt.js
+++ b/skills/relay-orca/scripts/lib/receipt.js
@@ -61,7 +61,8 @@ const STOP_REASON_MAX = 256;
 //   - decisions      : decision records, written ONLY via the run/resume --resolve-decision flag
 //   - authorizations : authorization records, written ONLY via the run/resume --record-authorization flag
 //   - counters       : optional explicit budget counters (otherwise derived from the mapping)
-const ADDITIVE_RECORD_KEYS = Object.freeze(["follow_ups", "decisions", "authorizations", "counters"]);
+//   - events         : bounded coordination events, including runtime_rebound
+const ADDITIVE_RECORD_KEYS = Object.freeze(["follow_ups", "decisions", "authorizations", "counters", "events"]);
 
 // An additive record field is "present" (worth serializing) when it is a non-empty array
 // or a non-empty object. Absent/empty → skipped, preserving byte-identity with a receipt

--- a/skills/relay-orca/scripts/lib/run-orchestrator.js
+++ b/skills/relay-orca/scripts/lib/run-orchestrator.js
@@ -81,17 +81,19 @@ function taskTitle(program, task, programSegment) {
   return coordinationMarkerFor(program.id, task.outcome_id, programSegment);
 }
 
-function taskSpec(program, task) {
+function taskSpec(program, task, programSegment) {
   // Machine-readable task metadata embedded in --spec (D4). No operator prompt is
   // embedded here: the prompt is delivered only AFTER provenance verification (D6).
-  return JSON.stringify({
+  const spec = {
     marker: "relay-orca",
     program_id: program.id,
+    ...(typeof programSegment === "function" ? { program_segment: programSegment(program.id) } : {}),
     outcome_id: task.outcome_id,
     task_kind: task.kind,
     wave: task.wave,
     depends_on: task.depends_on,
-  });
+  };
+  return JSON.stringify(spec);
 }
 
 // D4 materialization. Waves are ordered and dependencies resolve to strictly
@@ -107,7 +109,7 @@ function materialize(plan, program, report, orcaBin, options) {
       const deps = task.depends_on.map((dep) => orcaIdByPlanId.get(dep));
       const res = createTask(options.runOrca, orcaBin, {
         title: taskTitle(program, task, options.programSegment),
-        spec: taskSpec(program, task),
+        spec: taskSpec(program, task, options.programSegment),
         deps,
       });
       if (!res.ok) {

--- a/skills/relay-orca/scripts/lib/runtime-rebind-proof.js
+++ b/skills/relay-orca/scripts/lib/runtime-rebind-proof.js
@@ -1,0 +1,94 @@
+"use strict";
+
+// Pure proof for a runtime-id rebind. The caller supplies the fresh live reads;
+// this module never reads, writes, or invokes a subprocess. A proof is complete
+// only when the live task inventory is exactly the receipt inventory and every row
+// carries both the exact coordination marker and materialized spec identity.
+const { coordinationMarkerFor } = require("./coordination-marker");
+const { programSegment: defaultProgramSegment } = require("./program-segment");
+
+const SPEC_FIELDS = Object.freeze(["spec", "task_spec", "specification"]);
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function failure(reason) {
+  return { complete: false, reason, verified_rows: [] };
+}
+
+function parseSpec(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  if (!nonEmpty(value)) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function specCandidates(task) {
+  return SPEC_FIELDS
+    .filter((field) => Object.prototype.hasOwnProperty.call(task, field))
+    .map((field) => parseSpec(task[field]));
+}
+
+function exactSpecIdentity(task, expectedSegment, expectedOutcome, expectedProgramId) {
+  const specs = specCandidates(task);
+  if (specs.length === 0 || specs.some((spec) => !spec)) return false;
+  return specs.every((spec) => {
+    if (spec.marker !== "relay-orca" || spec.outcome_id !== expectedOutcome) return false;
+    const segment = spec.program_segment ?? spec.programSegment;
+    const programId = spec.program_id ?? spec.programId;
+    if (segment !== expectedSegment) return false;
+    if (programId !== undefined && programId !== expectedProgramId) return false;
+    return true;
+  });
+}
+
+function proveRuntimeRebind({ receipt, programId, liveRuntimeId, tasks, programSegment = defaultProgramSegment }) {
+  if (!receipt || typeof receipt !== "object" || !nonEmpty(programId)) return failure("receipt or program identity is unavailable");
+  if (!nonEmpty(receipt.runtime_id) || !nonEmpty(liveRuntimeId) || receipt.runtime_id === liveRuntimeId) {
+    return failure("runtime ids do not describe a rebind");
+  }
+  if (!Array.isArray(tasks)) return failure("live task-list is ambiguous");
+  if (typeof programSegment !== "function") return failure("program segment encoder is unavailable");
+
+  const expected = (receipt.tasks || []).filter((task) => task && nonEmpty(task.orca_task_id));
+  if (expected.length === 0) return failure("receipt has no recorded Orca task ids");
+  const expectedById = new Map();
+  for (const task of expected) {
+    if (!nonEmpty(task.outcome_id) || expectedById.has(task.orca_task_id)) return failure("receipt task inventory is ambiguous");
+    expectedById.set(task.orca_task_id, task);
+  }
+
+  const liveById = new Map();
+  for (const task of tasks) {
+    if (!task || typeof task !== "object" || !nonEmpty(task.id) || liveById.has(task.id)) {
+      return failure("live task-list is ambiguous");
+    }
+    liveById.set(task.id, task);
+  }
+  if (liveById.size !== expectedById.size) return failure("live task inventory is not an exact match");
+
+  const segment = programSegment(programId);
+  const verifiedRows = [];
+  for (const [orcaTaskId, receiptTask] of expectedById) {
+    const liveTask = liveById.get(orcaTaskId);
+    if (!liveTask) return failure("a receipt-recorded Orca task is missing from the live task-list");
+    const marker = coordinationMarkerFor(programId, receiptTask.outcome_id, programSegment);
+    if (liveTask.task_title !== marker) return failure("live task coordination marker does not match");
+    if (!exactSpecIdentity(liveTask, segment, receiptTask.outcome_id, programId)) return failure("live task spec identity does not match");
+    verifiedRows.push({ orca_task_id: orcaTaskId, outcome_id: receiptTask.outcome_id });
+  }
+
+  return {
+    complete: true,
+    old_runtime_id: receipt.runtime_id,
+    new_runtime_id: liveRuntimeId,
+    verified_rows: verifiedRows,
+  };
+}
+
+module.exports = { proveRuntimeRebind, parseSpec, exactSpecIdentity };

--- a/skills/relay-orca/scripts/lib/runtime-rebind-proof.js
+++ b/skills/relay-orca/scripts/lib/runtime-rebind-proof.js
@@ -41,6 +41,12 @@ function exactSpecIdentity(task, expectedSegment, expectedOutcome, expectedProgr
     if (spec.marker !== "relay-orca" || spec.outcome_id !== expectedOutcome) return false;
     const segment = spec.program_segment ?? spec.programSegment;
     const programId = spec.program_id ?? spec.programId;
+    // Specs materialized before the segment was serialized carry only the program id.
+    // The segment is derived from that id by the shared encoder, so an exact program-id
+    // match is identity of equal strength (the task-title coordination marker, checked
+    // for every row, already binds `<segment>/<outcome-id>` exactly). A spec carrying
+    // NEITHER field is not identity — the marker alone never qualifies.
+    if (segment === undefined) return programId !== undefined && programId === expectedProgramId;
     if (segment !== expectedSegment) return false;
     if (programId !== undefined && programId !== expectedProgramId) return false;
     return true;

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -17,6 +17,7 @@ const { classifyOutcome, deriveProgramState, requiredEvidenceFor } = require("./
 const { isTerminalManifestState, isEscalatedManifestState } = require("./manifest-parse");
 const { orderReport } = require("./status-report");
 const { canonicalIntegrationQuestion, inspectCanonicalGates } = require("./integration-lifecycle");
+const { proveRuntimeRebind } = require("./runtime-rebind-proof");
 
 // A17: two runtime ids attribute to the SAME runtime only when both are non-empty
 // strings AND identical. Used to prove every adopted read (task-list, gate-list, and
@@ -64,7 +65,7 @@ function taskDisplayString(task) {
 
 // Attribute the live runtime (D6). Orca facts are trusted ONLY when the live runtime
 // id matches the receipt AND every live orchestration task is marked for this program.
-function attributeRuntime({ receipt, programId, orca, programSegment }) {
+function attributeRuntime({ receipt, programId, orca, programSegment, acceptCompleteRuntimeRebind = false, runtimeRebindProofSink }) {
   const unreachable = { runtime: "unreachable", orcaTrusted: false, tasks: [], gates: [], diagnostic: null };
   if (!orca) return unreachable;
   const status = orcaStatus(orca, null, {});
@@ -82,25 +83,59 @@ function attributeRuntime({ receipt, programId, orca, programSegment }) {
   // MISSING_TASK against a receipt whose task simply could not be listed. On unreachable,
   // Orca-derived facts are withheld and each outcome's Orca facts degrade per D5/D6.
   const taskList = orcaTaskList(orca, null, {});
-  if (!taskList.ok) return unreachable;
+  const liveRuntime = boundedExcerpt(status.runtimeId);
+  const runtimeMismatch = Boolean(receipt.runtime_id && status.runtimeId && status.runtimeId !== receipt.runtime_id);
+  const mismatchResult = (rebindProof) => ({
+    runtime: "mismatch",
+    orcaTrusted: false,
+    tasks: [],
+    gates: [],
+    rebindProof,
+    diagnostic: diag("RUNTIME_MISMATCH", null, "live Orca runtime id does not match the receipt; runtime signals are not adopted", { receipt_runtime: receipt.runtime_id, live_runtime: liveRuntime }),
+  });
+  if (!taskList.ok) {
+    if (runtimeMismatch) return mismatchResult({ complete: false, reason: "live task-list is unreachable", verified_rows: [] });
+    return unreachable;
+  }
   const gateList = orcaGateList(orca, null, {});
-  if (!gateList.ok) return unreachable;
+  if (!gateList.ok) {
+    if (runtimeMismatch) return mismatchResult({ complete: false, reason: "live gate-list is unreachable", verified_rows: [] });
+    return unreachable;
+  }
   const tasks = taskList.tasks;
   const gates = gateList.gates;
+  if (runtimeMismatch) {
+    let rebindProof = { complete: false, reason: "live reads are not attributable", verified_rows: [] };
+    if (
+      taskList.wellFormed === true
+      && gateList.wellFormed === true
+      && runtimeIdMatches(taskList.runtimeId, status.runtimeId)
+      && runtimeIdMatches(gateList.runtimeId, status.runtimeId)
+    ) {
+      rebindProof = proveRuntimeRebind({
+        receipt,
+        programId,
+        liveRuntimeId: status.runtimeId,
+        tasks,
+        programSegment,
+      });
+    }
+    if (runtimeRebindProofSink && typeof runtimeRebindProofSink === "object") runtimeRebindProofSink.proof = rebindProof;
+    if (acceptCompleteRuntimeRebind && rebindProof.complete) {
+      return {
+        runtime: "ok",
+        orcaTrusted: true,
+        tasks,
+        gates,
+        runtimeId: status.runtimeId,
+        diagnostic: null,
+        rebindProof,
+      };
+    }
+    return mismatchResult(rebindProof);
+  }
   const marker = programMarker(programId, programSegment);
   const foreignTasks = tasks.filter((task) => !taskDisplayString(task).includes(marker));
-  // The live runtime id is subprocess-derived, so it is bounded (≤256 chars, marker
-  // included) before it enters a diagnostic — the same rule the probe uses (D7).
-  const liveRuntime = boundedExcerpt(status.runtimeId);
-  if (receipt.runtime_id && status.runtimeId && status.runtimeId !== receipt.runtime_id) {
-    return {
-      runtime: "mismatch",
-      orcaTrusted: false,
-      tasks: [],
-      gates: [],
-      diagnostic: diag("RUNTIME_MISMATCH", null, "live Orca runtime id does not match the receipt; runtime signals are not adopted", { receipt_runtime: receipt.runtime_id, live_runtime: liveRuntime }),
-    };
-  }
   if (foreignTasks.length > 0) {
     return {
       runtime: "foreign_state",
@@ -382,11 +417,11 @@ function summarizeLiveDispatch(runtime, facts) {
 // from the SEPARATE fleets root (#945 A8), keyed by fleet id. `liveDispatchSink` is an
 // OPTIONAL Map that, when provided (only `resume` passes it), is populated per outcome
 // with the reconciliation's live dispatch fact — it never changes the returned report.
-function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment, liveDispatchSink, strictIntegration = false }) {
+function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetManifests = [], orca, gh, urlFor, programSegment, liveDispatchSink, strictIntegration = false, acceptCompleteRuntimeRebind = false, runtimeRebindProofSink }) {
   const resolvedUrlFor = typeof urlFor === "function" ? urlFor : () => null;
   const manifestByRunId = new Map(manifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
   const fleetManifestById = new Map(fleetManifests.filter((entry) => entry.run_id).map((entry) => [entry.run_id, entry.parsed]));
-  const runtime = attributeRuntime({ receipt, programId, orca, programSegment });
+  const runtime = attributeRuntime({ receipt, programId, orca, programSegment, acceptCompleteRuntimeRebind, runtimeRebindProofSink });
   const { diagnostics: duplicateDiagnostics, duplicateOutcomeIds } = detectDuplicateMappings(receipt.tasks);
 
   const entries = receipt.tasks.map((task) => {
@@ -403,6 +438,15 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
   duplicateDiagnostics.forEach((duplicateDiag) => diagnostics.push(duplicateDiag));
 
   const repairCandidates = [];
+  if (runtime.rebindProof && runtime.rebindProof.complete) {
+    repairCandidates.push({
+      kind: "runtime_rebind",
+      old_runtime_id: runtime.rebindProof.old_runtime_id,
+      new_runtime_id: runtime.rebindProof.new_runtime_id,
+      verified_rows: runtime.rebindProof.verified_rows,
+      proposal: boundedExcerpt(`receipt runtime ${runtime.rebindProof.old_runtime_id} can be rebound to live runtime ${runtime.rebindProof.new_runtime_id} from a complete task fingerprint proof; status performed no mutation`),
+    });
+  }
   entries.forEach((entry) => repairForOutcome(entry).forEach((repair) => repairCandidates.push(repair)));
   discoverBackPointers({ manifests, tasks: receipt.tasks, programId, programSegment }).forEach((candidate) => repairCandidates.push(candidate));
   discoverFleetBackPointers({ fleetManifests, tasks: receipt.tasks, programId, programSegment }).forEach((candidate) => repairCandidates.push(candidate));

--- a/skills/relay-orca/scripts/resume.js
+++ b/skills/relay-orca/scripts/resume.js
@@ -57,6 +57,7 @@ const READ_TIMEOUT_MS = 15000;
 const READ_MAX_BUFFER = 4 * 1024 * 1024;
 const DEFAULT_RUN_TIMEOUT_MS = 30000;
 const RUN_MAX_BUFFER = 4 * 1024 * 1024;
+const RUNTIME_REBOUND_EVENT = "runtime_rebound";
 
 function usageError(message) {
   process.stderr.write(`relay-orca resume: ${message}\n`);
@@ -229,6 +230,7 @@ function reconcile({ receipt, opts, repo, receiptPath }) {
   const manifests = listManifestFiles(repo.slug).map((entry) => ({ run_id: entry.run_id, text: entry.text, parsed: parseManifest(entry.text) }));
   const fleetManifests = listFleetManifestFiles(repo.slug).map((entry) => ({ run_id: entry.run_id, text: entry.text, parsed: parseManifest(entry.text) }));
   const liveDispatch = new Map();
+  const runtimeRebindProof = { proof: null };
   const report = deriveStatusReport({
     receipt,
     programId: opts.programId,
@@ -241,8 +243,10 @@ function reconcile({ receipt, opts, repo, receiptPath }) {
     programSegment,
     liveDispatchSink: liveDispatch,
     strictIntegration: true,
+    acceptCompleteRuntimeRebind: true,
+    runtimeRebindProofSink: runtimeRebindProof,
   });
-  return { report, liveDispatch };
+  return { report, liveDispatch, runtimeRebindProof: runtimeRebindProof.proof };
 }
 
 function makeIntegrationReportPathResolver(opts, receiptPath) {
@@ -275,6 +279,27 @@ function makeReceiptPersistor(receipt, receiptPath) {
     writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
     return receiptPath;
   };
+}
+
+// A complete proof grants exactly one receipt mutation at the subprocess boundary:
+// replace runtime_id and append the dedicated audit event in one atomic write. No
+// timestamp, mapping, terminal handle, or lifecycle field is synthesized here.
+function applyRuntimeRebind(receipt, receiptPath, proof) {
+  if (!proof || proof.complete !== true) return false;
+  if (receipt.runtime_id !== proof.old_runtime_id || receipt.runtime_id === proof.new_runtime_id) return false;
+  const event = {
+    event: RUNTIME_REBOUND_EVENT,
+    old_runtime_id: proof.old_runtime_id,
+    new_runtime_id: proof.new_runtime_id,
+    verified_rows: proof.verified_rows.map((row) => ({
+      orca_task_id: row.orca_task_id,
+      outcome_id: row.outcome_id,
+    })),
+  };
+  receipt.runtime_id = proof.new_runtime_id;
+  receipt.events = Array.isArray(receipt.events) ? receipt.events.concat([event]) : [event];
+  writeReceiptAtomic(receiptPath, serializeReceiptWithRecords(receipt));
+  return true;
 }
 
 // Source a decision-gate definition (question/options/downstream_wave provenance) from an
@@ -601,6 +626,7 @@ function main() {
   let receiptPath;
   let report;
   let liveDispatch;
+  let runtimeRebindProof;
   try {
     repo = resolveRepoContext({ repoRootOverride: opts.repoRoot });
     receiptPath = receiptPathFor(repo.slug, opts.programId);
@@ -618,7 +644,7 @@ function main() {
     // #947: an explicit --resolve-decision / --record-authorization writes its record to the
     // receipt up front, so the decision persists regardless of the reconciliation verdict.
     recordOperatorDecisions(receipt, receiptPath, opts);
-    ({ report, liveDispatch } = reconcile({ receipt, opts, repo, receiptPath }));
+    ({ report, liveDispatch, runtimeRebindProof } = reconcile({ receipt, opts, repo, receiptPath }));
   } catch (error) {
     if (error instanceof StatusError || error instanceof CanonicalizationError) failReceipt(error, opts.json);
     if (error instanceof IntegrationLifecycleError) {
@@ -631,8 +657,11 @@ function main() {
     throw error;
   }
 
-  // Reconciliation is complete; the plan is pure. A program-level decision performs ZERO
+  // Reconciliation is complete. A complete fresh fingerprint proof permits the one
+  // flagless receipt rebind before the normal plan; an incomplete proof leaves the
+  // existing fail-closed plan untouched. A program-level decision performs ZERO
   // mutation and exits 60-63; otherwise the safe actions execute through the verified path.
+  applyRuntimeRebind(receipt, receiptPath, runtimeRebindProof);
   const plan = planResume({ receipt, report, liveDispatch, hasOperatorHandle: opts.operatorHandles.length > 0 });
   let terminalsCreated = [];
   let blockingReasons = plan.blockingReasons.slice();
@@ -657,4 +686,4 @@ function main() {
 // without triggering a real resume run.
 if (require.main === module) main();
 
-module.exports = { syntheticTask, reportActions, integrationBlockingEntry, integrationGateAdvanceable, integrationTasksToAdvance, advanceIntegrationTasks };
+module.exports = { syntheticTask, reportActions, integrationBlockingEntry, integrationGateAdvanceable, integrationTasksToAdvance, advanceIntegrationTasks, applyRuntimeRebind };

--- a/tests/relay-orca/fixtures/fake-orca-resume.js
+++ b/tests/relay-orca/fixtures/fake-orca-resume.js
@@ -31,6 +31,7 @@ function defaultResumeScenario(overrides = {}) {
     runtimeId,
     statusOk: overrides.statusOk !== undefined ? overrides.statusOk : true,
     taskListOk: overrides.taskListOk !== undefined ? overrides.taskListOk : true,
+    taskListMalformed: overrides.taskListMalformed === true,
     gateListOk: overrides.gateListOk !== undefined ? overrides.gateListOk : true,
     omitRuntimeId: overrides.omitRuntimeId === true,
     taskListRuntimeId: overrides.taskListRuntimeId,
@@ -76,9 +77,13 @@ function nestDispatch(flat, coordinator) {
   const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
   const result = { dispatch: dispatch };
   if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
-  // #1019: the real --preamble read carries the live coordinator handle. Emitted only when
-  // the scenario defines one, so pre-#1019 scenarios keep their exact previous payload.
-  if (coordinator !== undefined) result.preamble = { coordinator_handle: coordinator };
+  // #1019: the real --preamble read is a string. Keep the normalized coordinator object
+  // alongside it for the existing lifecycle fixture contract; the dispatch row itself has
+  // only the real assignee_handle provenance field and no coordinator field.
+  if (coordinator !== undefined) {
+    result.preamble = String(coordinator);
+    result.coordinator = { handle: coordinator };
+  }
   return result;
 }
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
@@ -115,7 +120,8 @@ if (args[0] === "orchestration" && args[1] === "task-list") {
   if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }
   const tasks = Array.isArray(scenario.tasks) ? scenario.tasks : [];
   const taskMeta = scenario.taskListRuntimeId !== undefined ? { runtimeId: scenario.taskListRuntimeId } : meta;
-  emit({ id: "task-list-1", ok: true, result: { tasks, count: tasks.length }, _meta: taskMeta }, 0);
+  const taskResult = scenario.taskListMalformed ? { count: tasks.length } : { tasks, count: tasks.length };
+  emit({ id: "task-list-1", ok: true, result: taskResult, _meta: taskMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "gate-list") {
   if (scenario.gateListOk === false) { process.stderr.write("orca gate-list unreachable\\n"); process.exit(1); }
@@ -223,7 +229,7 @@ if (args[0] === "terminal" && args[1] === "send") {
     }
   }
   if (scenario.terminalSendOkFalse) emit({ ok: false, error: "terminal send failed" }, 1);
-  emit({ ok: true, result: { delivered: true } }, 0);
+  emit({ ok: true, result: { delivered: true }, _meta: meta }, 0);
 }
 
 process.stderr.write("Unsupported fake orca (resume) invocation: " + args.join(" ") + "\\n");

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -107,6 +107,23 @@ function fingerprintedOrcaTask(programId, outcome, extra = {}) {
   };
 }
 
+// Pre-upgrade fingerprint rows: Orca tasks materialized BEFORE `program_segment` was
+// serialized into the spec (real 2026-07-15 pilot rows have exactly this shape). Identity
+// rests on `program_id`, from which the segment is derived. `specOverrides` values set to
+// undefined drop the key entirely, so callers can model a spec missing the program id too.
+function preUpgradeOrcaTask(programId, outcome, specOverrides = {}) {
+  const spec = {
+    marker: "relay-orca",
+    program_id: programId,
+    outcome_id: outcome,
+    task_kind: "relay_run",
+    wave: 1,
+    depends_on: [],
+    ...specOverrides,
+  };
+  return { ...orcaTask(programId, outcome), spec: JSON.stringify(spec) };
+}
+
 // A task-list entry NOT marked for this program — makes the runtime foreign_state.
 function foreignTask(id) {
   return { id, task_title: `relay-orca: other-program/${id}`, status: "dispatched", worker_done: false };
@@ -372,6 +389,74 @@ test("#1063 complete fingerprint proof → resume rebinds once and continues nor
       verified_rows: [{ orca_task_id: "orca-live-a", outcome_id: "a" }],
     }]);
     assert.deepEqual({ ...persisted, runtime_id: before.runtime_id, events: undefined }, { ...before, events: undefined });
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 pre-upgrade spec (no program_segment, matching program_id) → resume still rebinds once", () => {
+  const programId = "epic-runtime-rebind-pre-upgrade";
+  const { world, oldRuntime, newRuntime } = rebindWorld({
+    programId,
+    liveTasks: [preUpgradeOrcaTask(programId, "a")],
+  });
+  const before = parseReceipt(world.receiptOnDisk()).receipt;
+  try {
+    const result = world.run();
+    assert.equal(result.status, 0);
+    assert.equal(result.body.runtime, "ok");
+    assert.deepEqual(result.body.decision_required, []);
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "rebind does not mutate an Orca task or dispatch");
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    assert.equal(persisted.runtime_id, newRuntime);
+    assert.deepEqual(persisted.events, [{
+      event: "runtime_rebound",
+      old_runtime_id: oldRuntime,
+      new_runtime_id: newRuntime,
+      verified_rows: [{ orca_task_id: "orca-live-a", outcome_id: "a" }],
+    }]);
+    assert.deepEqual({ ...persisted, runtime_id: before.runtime_id, events: undefined }, { ...before, events: undefined });
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 pre-upgrade spec with mismatching program_id → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-pre-upgrade-wrong-id";
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [preUpgradeOrcaTask(programId, "a", { program_id: "epic-some-other-program" })],
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.ok(result.body.decision_required.some((entry) => entry.reason_code === "RESUME_RUNTIME_CHANGED"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 spec carrying neither program_segment nor program_id → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-no-identity";
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [preUpgradeOrcaTask(programId, "a", { program_id: undefined })],
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.ok(result.body.decision_required.some((entry) => entry.reason_code === "RESUME_RUNTIME_CHANGED"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
     assertNoPoison(world);
   } finally {
     world.cleanup();

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -89,6 +89,24 @@ function orcaTask(programId, outcome, extra = {}) {
   };
 }
 
+// Real mid-2026 fingerprint rows: task_title is the exact coordination marker and the
+// materialized spec is a JSON string carrying the same program segment + outcome identity.
+function fingerprintedOrcaTask(programId, outcome, extra = {}) {
+  return {
+    ...orcaTask(programId, outcome),
+    spec: JSON.stringify({
+      marker: "relay-orca",
+      program_id: programId,
+      program_segment: programSegment(programId),
+      outcome_id: outcome,
+      task_kind: "relay_run",
+      wave: 1,
+      depends_on: [],
+    }),
+    ...extra,
+  };
+}
+
 // A task-list entry NOT marked for this program — makes the runtime foreign_state.
 function foreignTask(id) {
   return { id, task_title: `relay-orca: other-program/${id}`, status: "dispatched", worker_done: false };
@@ -303,6 +321,195 @@ test("D9.2: runtime restart (live id != receipt) → RESUME_RUNTIME_CHANGED exit
     assert.ok(r.body.decision_required.some((d) => d.reason_code === "RESUME_RUNTIME_CHANGED"));
     assert.deepEqual(mutationLines(world.orca.readLog()), [], "no mutation on a runtime-changed abort");
     assert.equal(world.receiptOnDisk(), before, "receipt byte-identical on abort");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1063 — proof-based flagless runtime rebind
+// ---------------------------------------------------------------------------
+
+function rebindWorld({ programId, liveTasks, orcaScenario = {}, outcomes = ["a"] }) {
+  const oldRuntime = DEFAULT_RUNTIME_ID;
+  const newRuntime = "99999999-9999-4999-8999-999999999999";
+  const world = buildWorld({
+    programId,
+    runtimeId: oldRuntime,
+    orcaScenario: { runtimeId: newRuntime, tasks: liveTasks, ...orcaScenario },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    runtimeId: oldRuntime,
+    tasks: outcomes.map((outcome) => ({ outcome_id: outcome })),
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  return { world, oldRuntime, newRuntime };
+}
+
+test("#1063 complete fingerprint proof → resume rebinds once and continues normal reconciliation", () => {
+  const programId = "epic-runtime-rebind-clean";
+  const { world, oldRuntime, newRuntime } = rebindWorld({
+    programId,
+    liveTasks: [fingerprintedOrcaTask(programId, "a")],
+  });
+  const before = parseReceipt(world.receiptOnDisk()).receipt;
+  try {
+    const result = world.run();
+    assert.equal(result.status, 0);
+    assert.equal(result.body.runtime, "ok");
+    assert.deepEqual(result.body.decision_required, []);
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "rebind does not mutate an Orca task or dispatch");
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    assert.equal(persisted.runtime_id, newRuntime);
+    assert.deepEqual(persisted.events, [{
+      event: "runtime_rebound",
+      old_runtime_id: oldRuntime,
+      new_runtime_id: newRuntime,
+      verified_rows: [{ orca_task_id: "orca-live-a", outcome_id: "a" }],
+    }]);
+    assert.deepEqual({ ...persisted, runtime_id: before.runtime_id, events: undefined }, { ...before, events: undefined });
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 missing live row → existing runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-missing";
+  const { world } = rebindWorld({ programId, liveTasks: [] });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.ok(result.body.decision_required.some((entry) => entry.reason_code === "RESUME_RUNTIME_CHANGED"));
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 foreign live row → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-foreign";
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [{ id: "foreign-task", task_title: "relay-orca: other-program/outcome", display_name: "relay-orca: other-program/outcome" }],
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 marker mismatch → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-marker";
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [fingerprintedOrcaTask(programId, "a", { task_title: "relay-orca: wrong-segment/a" })],
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 spec identity mismatch → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-spec";
+  const badSpec = JSON.stringify({ marker: "relay-orca", program_id: programId, program_segment: programSegment(programId), outcome_id: "other", task_kind: "relay_run", wave: 1, depends_on: [] });
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [fingerprintedOrcaTask(programId, "a", { spec: badSpec })],
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 partial live match → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-partial";
+  const { world } = rebindWorld({
+    programId,
+    outcomes: ["a", "b"],
+    liveTasks: [fingerprintedOrcaTask(programId, "a")],
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 ambiguous live task-list read → runtime-changed exit 60 with zero mutation", () => {
+  const programId = "epic-runtime-rebind-ambiguous";
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [fingerprintedOrcaTask(programId, "a")],
+    orcaScenario: { taskListMalformed: true },
+  });
+  const before = world.receiptOnDisk();
+  try {
+    const result = world.run();
+    assert.equal(result.status, 60);
+    assert.equal(result.body.runtime, "mismatch");
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assert.equal(world.receiptOnDisk(), before);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 immediate second resume is idempotent after a successful rebind", () => {
+  const programId = "epic-runtime-rebind-idempotent";
+  const { world } = rebindWorld({
+    programId,
+    liveTasks: [fingerprintedOrcaTask(programId, "a")],
+  });
+  try {
+    const first = world.run();
+    assert.equal(first.status, 0);
+    const beforeSecond = world.receiptOnDisk();
+    const logStart = world.orca.readLog().length;
+    const second = world.run();
+    assert.equal(second.status, 0);
+    assert.equal(world.receiptOnDisk(), beforeSecond);
+    assert.deepEqual(mutationLines(world.orca.readLog().slice(logStart)), []);
+    const persisted = parseReceipt(world.receiptOnDisk()).receipt;
+    assert.equal(persisted.events.filter((event) => event.event === "runtime_rebound").length, 1);
     assertNoPoison(world);
   } finally {
     world.cleanup();

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -97,6 +97,25 @@ function orcaTask(programId, outcome, extra = {}) {
   };
 }
 
+// Real mid-2026 fingerprint row used by #1063: exact task_title marker plus the
+// materialized JSON spec identity. Dispatch provenance remains nested under
+// result.dispatch in the fake CLI, with assignee_handle and no coordinator field.
+function fingerprintedOrcaTask(programId, outcome, extra = {}) {
+  return {
+    ...orcaTask(programId, outcome),
+    spec: JSON.stringify({
+      marker: "relay-orca",
+      program_id: programId,
+      program_segment: programSegment(programId),
+      outcome_id: outcome,
+      task_kind: "relay_run",
+      wave: 1,
+      depends_on: [],
+    }),
+    ...extra,
+  };
+}
+
 // A relay-fleet manifest fixture matching the real shape (#945 A3): `fleet_id`,
 // `fleet_state`, and a single-line JSON `children` array of { leaf_ref, run_id, ... }.
 // Detected by buildWorld via the presence of `fleet_state`.
@@ -503,6 +522,46 @@ test("D10.8: runtime restart → runtime mismatch, Orca facts degrade, durable-c
     assert.equal(outcomeById(r.body, "live").state, "stale_missing", "Orca facts degrade to stale_missing");
     // foreign tasks are never attributed to this program's outcomes.
     assert.deepEqual(r.body.outcomes.map((o) => o.outcome_id).sort(), ["done", "live"]);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1063 status: complete proof is a read-only runtime rebind repair candidate", () => {
+  const programId = "epic-status-runtime-rebind";
+  const oldRuntime = DEFAULT_RUNTIME_ID;
+  const newRuntime = "99999999-9999-4999-8999-999999999999";
+  const world = buildWorld({
+    programId,
+    runtimeId: oldRuntime,
+    orcaScenario: {
+      runtimeId: newRuntime,
+      tasks: [fingerprintedOrcaTask(programId, "a")],
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    runtimeId: oldRuntime,
+    tasks: [{ outcome_id: "a" }],
+  });
+  fs.writeFileSync(world.receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf-8");
+  const before = fs.readFileSync(world.receiptPath, "utf-8");
+  try {
+    const result = world.run();
+    assert.equal(result.status, 0);
+    assert.equal(result.body.runtime, "mismatch");
+    const candidate = result.body.repair_candidates.find((entry) => entry.kind === "runtime_rebind");
+    assert.deepEqual(candidate, {
+      kind: "runtime_rebind",
+      old_runtime_id: oldRuntime,
+      new_runtime_id: newRuntime,
+      verified_rows: [{ orca_task_id: "orca-live-a", outcome_id: "a" }],
+      proposal: `receipt runtime ${oldRuntime} can be rebound to live runtime ${newRuntime} from a complete task fingerprint proof; status performed no mutation`,
+    });
+    assert.equal(fs.readFileSync(world.receiptPath, "utf-8"), before, "status never writes the receipt");
+    assert.equal(world.orca.readPoison(), null);
   } finally {
     world.cleanup();
   }


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료 및 커밋했습니다.

커밋: `45460f3 feat(relay-orca): prove runtime rebind on resume`

- 완전한 fingerprint proof 기반 flagless rebind 구현
- 실패 시 exit 60·zero mutation 유지
- `status` read-only repair candidate 추가
- `runtime_rebound` atomic receipt event 및 idempotence 구현
- 실 payload fixture와 전체 #1063 테스트 추가
- 문서 및 lib purity 반영

검증:

- relay-orca: 343 passed
- skills lint: 33 passed
- #1063 집중 테스트: 9 passed
- 전체 serialized gate는 1회 실행했으며, 기존 advisory-lane/cleanup 타이밍 실패 9건과 수정 전 lint 1건으로 최종 green은 아니었습니다. Wo
```

## Dispatch Metadata

- Run: issue-1063-20260723091011208-04e4c9ae
- Executor: codex
- Branch: issue-1063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 런타임 불일치 시 작업 마커와 스펙 증명이 완전히 검증되면 안전하게 런타임을 재연결합니다.
  * 재연결 내역에 `runtime_rebound` 이벤트가 기록됩니다.
  * 상태 확인에서 검증 가능한 런타임 재연결 후보를 제공합니다.

* **버그 수정**
  * 증명이 불완전하거나 모호한 경우 변경 없이 종료하여 잘못된 재연결을 방지합니다.
  * 비정상적인 작업 목록 응답을 안전하게 처리합니다.

* **문서**
  * 런타임 복구, 재개, 상태 확인 및 영수증 이벤트 동작 설명을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->