### PR TITLE
fix(relay-orca): verify integration coordinator liveness

### DIFF
--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -122,10 +122,21 @@ PROPOSED follow-up: `{ "id", "source_gate" | "source_outcome", "description",
 
 `integration_gate` is a coordinator-owned terminal boundary. The read-only integration
 operator writes deterministic live evidence; it never creates or resolves an Orca gate.
-The coordinator must supply an explicit current `--coordinator-handle` and revalidate it
-from live runtime/dispatch reads on every run, resume, redispatch, and restart. A receipt,
-history entry, prior completion message, or stale assignee is never a source for coordinator
-identity.
+The coordinator must supply an explicit current `--coordinator-handle` and verify that it is
+present in the live terminal set from a read-only `orca terminal list --json` query on every run,
+resume, redispatch, and restart. A failed/unparseable query or absent handle fails closed with
+`INTEGRATION_COORDINATOR_PROVENANCE_MISSING` before any lifecycle mutation. A recognized
+structured coordinator field, when present in a payload, remains an optional feature-detection
+check; a mismatch still fails closed as `INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH`, while
+absence is not a failure. A receipt, history entry, prior completion message, or stale assignee is
+never a source for coordinator identity.
+
+The payload shapes targeted here were observed with `ORCA_APP_VERSION=1.4.148`: `status --json`
+has `result.app`, `result.runtime`, and `result.graph` without coordinator identity; a
+`dispatch-show --preamble --from <assignee> --json` dispatch row carries `id`, `task_id`,
+`assignee_handle`, status/failure/timestamp fields, and `preamble` is a plain string. The preamble
+is never parsed as a coordinator object or used as sole authority; text that names the assignee or
+contradicts the live handle cannot override liveness.
 
 The physical gate id is not caller-selectable in the installed Orca CLI, so the stable
 logical identity is exactly:
@@ -149,7 +160,7 @@ verified dispatch
   -> operator writes <outcome-id>.json with {"passed":true,"evidence":"...",
        "runtime_id":"<live>","task_id":"<this task>","dispatch_id":"<this dispatch>",
        "assignee":"<this pane>"}
-  -> fresh runtime/coordinator/task/dispatch/assignee/report revalidation
+  -> fresh runtime/coordinator-terminal/task/dispatch/assignee/report revalidation
        (the report's runtime_id/task_id/dispatch_id/assignee MUST match the live dispatch;
         a reused or prior-run artifact fails closed and never resolves the gate)
   -> coordinator resolves that physical gate to passed

--- a/skills/relay-orca/references/operator-dispatch.md
+++ b/skills/relay-orca/references/operator-dispatch.md
@@ -68,6 +68,20 @@ An unverified task is never reported `dispatched`. A step 1–2 failure records 
 `escalated`, dispatches no further pending task, and leaves already-verified running operators
 untouched (stop semantics are #946).
 
+### Integration coordinator verification on Orca 1.4.148
+
+The integration lifecycle targets payloads observed with `ORCA_APP_VERSION=1.4.148`. Coordinator
+identity is verified by the read-only `orca terminal list --json` live terminal set: the explicitly
+supplied `--coordinator-handle` must be present before any gate mutation. A failed, unparseable, or
+missing handle fails closed as `INTEGRATION_COORDINATOR_PROVENANCE_MISSING`.
+
+In this build, `orca status --json` returns `result.app`, `result.runtime`, and `result.graph` but
+no coordinator field. `dispatch-show --preamble --from <assignee> --json` returns a dispatch row
+with `id`, `task_id`, `assignee_handle`, status/failure/timestamp fields, and a plain-string
+`preamble`; the string can name the assignee and is never coordinator authority. If a payload does
+carry a recognized structured coordinator field, it is optional feature detection: a mismatch with
+the live handle still fails closed as `INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH`.
+
 ## Integration-gate completion contract (#1019)
 
 An integration operator must write the live report at the exact path supplied in the prompt,
@@ -87,7 +101,7 @@ the exact question and the exact options `["passed","failed"]`; it lists, create
 and re-lists under a bounded lock. Lost create responses are recovered by re-list/adopt, while
 duplicates, noncanonical gates, missing physical ids, and conflicting results stop the flow.
 
-After fresh runtime, coordinator, task, dispatch, assignee, and report validation, the
+After fresh runtime, live coordinator-terminal, task, dispatch, assignee, and report validation, the
 coordinator resolves the adopted physical gate to the canonical `passed` resolution and sends
 a fresh instruction. That instruction includes one copy-paste command in the real CLI shape:
 

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -31,26 +31,31 @@ function unwrap(value) {
   return value && typeof value === "object" ? value : {};
 }
 
-function parseEnvelope(proc, command) {
+function parseEnvelope(proc, command, failureReasonCode = "INTEGRATION_CAPABILITY_GAP") {
   let parsed = null;
   try {
     parsed = JSON.parse(String(proc && proc.stdout ? proc.stdout : ""));
   } catch (error) {
-    fail("INTEGRATION_CAPABILITY_GAP", `${command} returned non-JSON output: ${error.message}`);
+    fail(failureReasonCode, `${command} returned non-JSON output: ${error.message}`);
   }
   if (!proc || proc.status !== 0 || !parsed || parsed.ok !== true) {
     const detail = proc && proc.stderr ? `: ${boundedExcerpt(proc.stderr)}` : "";
-    fail("INTEGRATION_CAPABILITY_GAP", `${command} is unavailable or rejected by the installed Orca contract${detail}`);
+    fail(failureReasonCode, `${command} is unavailable or rejected by the installed Orca contract${detail}`);
   }
   return parsed;
 }
 
-function runJson(ctx, args, label) {
+function runJson(ctx, args, label, failureReasonCode = "INTEGRATION_CAPABILITY_GAP") {
   if (!ctx || typeof ctx.run !== "function" || !nonEmpty(ctx.orcaBin)) {
-    fail("INTEGRATION_CAPABILITY_GAP", `${label} cannot run: injected Orca runner is missing`);
+    fail(failureReasonCode, `${label} cannot run: injected Orca runner is missing`);
   }
-  const proc = ctx.run(ctx.orcaBin, args, {});
-  return parseEnvelope(proc, label);
+  let proc;
+  try {
+    proc = ctx.run(ctx.orcaBin, args, {});
+  } catch (error) {
+    fail(failureReasonCode, `${label} failed through the injected Orca runner: ${error.message}`);
+  }
+  return parseEnvelope(proc, label, failureReasonCode);
 }
 
 function resultOf(payload) {
@@ -79,6 +84,46 @@ function coordinatorFrom(payload) {
     preamble.coordinator_handle,
     preamble.coordinatorHandle,
   ].find(nonEmpty) || null;
+}
+
+function terminalRows(payload) {
+  const result = payload && payload.result;
+  if (Array.isArray(result)) return result;
+  if (!result || typeof result !== "object") return null;
+  return [result.terminals, result.terminal_rows, result.rows, result.items, result.terminal]
+    .find(Array.isArray) || null;
+}
+
+function terminalHandle(row) {
+  if (typeof row === "string") return row;
+  if (!row || typeof row !== "object") return null;
+  return [row.handle, row.id, row.terminal_handle, row.terminalHandle].find(nonEmpty) || null;
+}
+
+// The coordinator handle is routing metadata, not lifecycle authority. The live terminal set
+// is the only identity check that remains valid when Orca reissues terminal handles. This read is
+// intentionally performed through the injected runner so scripts/lib stays subprocess-free.
+function verifyCoordinatorLiveness(ctx) {
+  if (!nonEmpty(ctx && ctx.coordinatorHandle)) {
+    fail("INTEGRATION_COORDINATOR_PROVENANCE_MISSING", "an explicit coordinator handle is required for live terminal verification");
+  }
+  const payload = runJson(
+    ctx,
+    ["terminal", "list", "--json"],
+    "orca terminal list",
+    "INTEGRATION_COORDINATOR_PROVENANCE_MISSING",
+  );
+  const terminals = terminalRows(payload);
+  if (!terminals) {
+    fail("INTEGRATION_COORDINATOR_PROVENANCE_MISSING", "orca terminal list returned no parseable live terminal set");
+  }
+  if (!terminals.some((terminal) => terminalHandle(terminal) === ctx.coordinatorHandle)) {
+    fail(
+      "INTEGRATION_COORDINATOR_PROVENANCE_MISSING",
+      `coordinator handle ${ctx.coordinatorHandle} is absent from the current live terminal set`,
+    );
+  }
+  return ctx.coordinatorHandle;
 }
 
 function taskRows(payload) {
@@ -253,6 +298,7 @@ function currentProvenance(ctx) {
   const currentRuntime = runtimeId(statusPayload);
   if (!nonEmpty(currentRuntime)) fail("INTEGRATION_RUNTIME_PROVENANCE_MISSING", "live Orca runtime id is unavailable; coordinator mutation is unsafe");
   if (ctx.runtimeId && currentRuntime !== ctx.runtimeId) fail("INTEGRATION_RUNTIME_PROVENANCE_MISMATCH", `live Orca runtime ${currentRuntime} does not match verified runtime ${ctx.runtimeId}`);
+  const liveCoordinator = verifyCoordinatorLiveness(ctx);
   const currentCoordinator = coordinatorFrom(statusPayload);
   if (nonEmpty(currentCoordinator) && currentCoordinator !== ctx.coordinatorHandle) {
     fail("INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", `coordinator handle ${ctx.coordinatorHandle} is stale; live coordinator is ${currentCoordinator}`);
@@ -271,15 +317,13 @@ function currentProvenance(ctx) {
   const liveDispatch = dispatch.id || dispatch.dispatch_id || dispatch.dispatchId;
   const liveAssignee = dispatch.assignee_handle || dispatch.assignee || dispatch.to;
   const dispatchCoordinator = coordinatorFrom(dispatchPayload);
-  const verifiedCoordinator = dispatchCoordinator || currentCoordinator;
-  if (!nonEmpty(verifiedCoordinator)) fail("INTEGRATION_COORDINATOR_PROVENANCE_MISSING", "live/current coordinator handle is unavailable; never infer it from stale receipt or history");
-  if (verifiedCoordinator !== ctx.coordinatorHandle) {
-    fail("INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", `coordinator handle ${ctx.coordinatorHandle} is stale; live coordinator is ${verifiedCoordinator}`);
+  if (nonEmpty(dispatchCoordinator) && dispatchCoordinator !== ctx.coordinatorHandle) {
+    fail("INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", `coordinator handle ${ctx.coordinatorHandle} is stale; live dispatch metadata names ${dispatchCoordinator}`);
   }
   if (liveTask !== ctx.taskId || liveDispatch !== ctx.dispatchId || liveAssignee !== ctx.assignee || dispatch.terminal_present === false || result.terminal_present === false) {
     fail("INTEGRATION_DISPATCH_PROVENANCE_MISMATCH", `fresh dispatch provenance mismatch (task=${liveTask || "missing"}, dispatch=${liveDispatch || "missing"}, assignee=${liveAssignee || "missing"})`);
   }
-  return { runtimeId: currentRuntime, coordinator: verifiedCoordinator, task, tasks, dispatch };
+  return { runtimeId: currentRuntime, coordinator: liveCoordinator, task, tasks, dispatch };
 }
 
 // The evidence artifact lives at a DETERMINISTIC path derived from the program/outcome alone,

--- a/tests/relay-orca/fixtures/fake-orca-integration-lifecycle.js
+++ b/tests/relay-orca/fixtures/fake-orca-integration-lifecycle.js
@@ -13,6 +13,11 @@ function defaultScenario(overrides = {}) {
   return {
     runtimeId: overrides.runtimeId || DEFAULT_RUNTIME_ID,
     coordinator: overrides.coordinator || "coord-current",
+    liveTerminals: overrides.liveTerminals !== undefined ? overrides.liveTerminals : [overrides.coordinator || "coord-current"],
+    terminalListOk: overrides.terminalListOk !== undefined ? overrides.terminalListOk : true,
+    terminalListMalformed: overrides.terminalListMalformed === true,
+    structuredCoordinator: overrides.structuredCoordinator,
+    preamble: overrides.preamble,
     tasks: overrides.tasks || [],
     dispatch: overrides.dispatch || {},
     gates: overrides.gates || [],
@@ -38,7 +43,11 @@ function log() { fs.appendFileSync(logPath, JSON.stringify(args) + "\\n", "utf8"
 function poison(reason) { fs.writeFileSync(poisonPath, reason + ":" + args.join(" "), "utf8"); process.exit(99); }
 function value(flag) { const index = args.indexOf(flag); return index >= 0 ? args[index + 1] : null; }
 function has(flag) { return args.includes(flag); }
-function emit(body, code = 0) { if (body !== null) process.stdout.write(JSON.stringify(body)); process.exit(code); }
+function emit(body, code = 0) {
+  if (body !== null && body && typeof body === "object" && !body._meta) body._meta = { runtimeId: readState().runtimeId };
+  if (body !== null) process.stdout.write(JSON.stringify(body));
+  process.exit(code);
+}
 function envelope(result) { return { ok: true, result, _meta: { runtimeId: readState().runtimeId } }; }
 function taskFor(state, taskId) {
   return state.tasks.find((task) => task.id === taskId) || null;
@@ -68,7 +77,17 @@ if (has("task-update")) poison("TASK_UPDATE_INVOKED");
 const state = readState();
 
 if (args[0] === "status" && args[1] === "--json") {
-  emit(envelope({ runtime: { runtimeId: state.runtimeId }, coordinator: { handle: state.coordinator } }));
+  const result = { app: { running: true, pid: 1 }, runtime: { runtimeId: state.runtimeId }, graph: { state: "ready" } };
+  if (state.structuredCoordinator !== undefined) result.coordinator_handle = state.structuredCoordinator;
+  emit(envelope(result));
+}
+if (args[0] === "terminal" && args[1] === "list" && has("--json")) {
+  if (!state.terminalListOk) emit({ ok: false, error: "terminal list failed" }, 1);
+  if (state.terminalListMalformed) emit(envelope({ count: 0 }));
+  const terminals = (Array.isArray(state.liveTerminals) ? state.liveTerminals : []).map((terminal) => (
+    typeof terminal === "string" ? { handle: terminal, id: terminal, status: "running" } : terminal
+  ));
+  emit(envelope({ terminals, count: terminals.length }));
 }
 if (args[0] === "orchestration" && args[1] === "task-list") {
   emit(envelope({ tasks: state.tasks }));
@@ -78,7 +97,28 @@ if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   const taskId = value("--task");
   const dispatch = state.dispatch[taskId] || {};
   if (has("--from") && value("--from") !== dispatch.assignee) emit({ ok: false, error: "dispatch-show stale --from" }, 3);
-  emit(envelope({ dispatch: { task_id: taskId, id: dispatch.dispatch_id, assignee_handle: dispatch.assignee, terminal_present: dispatch.terminal_present !== false }, preamble: { coordinator_handle: state.coordinator } }));
+  const dispatchRow = {
+    id: dispatch.dispatch_id,
+    task_id: taskId,
+    assignee_handle: dispatch.assignee,
+    status: dispatch.status || "dispatched",
+    failure_count: dispatch.failure_count || 0,
+    last_failure: dispatch.last_failure || null,
+    dispatched_at: dispatch.dispatched_at || null,
+    completed_at: dispatch.completed_at || null,
+    created_at: dispatch.created_at || null,
+    last_heartbeat_at: dispatch.last_heartbeat_at || null,
+    assignee_pane_key: dispatch.assignee_pane_key || dispatch.assignee,
+  };
+  const result = {
+    dispatch: dispatchRow,
+    // Real Orca injects the assignee into this text when dispatch-show is called with --from
+    // <assignee>. It is deliberately not coordinator identity authority.
+    preamble: state.preamble !== undefined ? String(state.preamble) : "Coordinator: " + value("--from"),
+  };
+  if (dispatch.terminal_present !== undefined) result.terminal_present = dispatch.terminal_present;
+  if (state.structuredCoordinator !== undefined) result.coordinator_handle = state.structuredCoordinator;
+  emit(envelope(result));
 }
 if (args[0] === "orchestration" && args[1] === "gate-list") {
   if (!has("--task") || !has("--json")) emit({ ok: false, error: "gate-list requires --task and --json" }, 2);

--- a/tests/relay-orca/fixtures/fake-orca-resume.js
+++ b/tests/relay-orca/fixtures/fake-orca-resume.js
@@ -41,6 +41,13 @@ function defaultResumeScenario(overrides = {}) {
     // Per-task dispatch-show seed (pre-resume state): { terminal_present, assignee,
     // dispatch_id, runtimeId }. A real dispatch supersedes it for that task.
     dispatch: overrides.dispatch || {},
+    liveTerminals: overrides.liveTerminals !== undefined
+      ? overrides.liveTerminals
+      : (overrides.coordinator !== undefined ? [overrides.coordinator] : []),
+    terminalListOk: overrides.terminalListOk !== undefined ? overrides.terminalListOk : true,
+    terminalListMalformed: overrides.terminalListMalformed === true,
+    structuredCoordinator: overrides.structuredCoordinator,
+    preamble: overrides.preamble,
     // Execution knobs (fail-closed / optional): an orca task id whose `dispatch --inject`
     // returns ok:false, and terminal-create failure modes.
     dispatchFailFor: overrides.dispatchFailFor || null,
@@ -50,11 +57,8 @@ function defaultResumeScenario(overrides = {}) {
     terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
     terminalCreateEmptyHandle: overrides.terminalCreateEmptyHandle || false,
     terminalSendOkFalse: overrides.terminalSendOkFalse || false,
-    // #1019: the live coordinator handle. UNDEFINED by default, which keeps `status` and
-    // `dispatch-show` byte-identical for every pre-#1019 scenario (the integration lifecycle
-    // then fails closed on missing coordinator provenance, as it should). Setting it opts a
-    // scenario into a runtime that can actually complete the integration-gate lifecycle, so
-    // an over-broad advancement filter really does create/resolve gates and get caught.
+    // #1019: the coordinator handle is verified by the live terminal list. UNDEFINED by
+    // default keeps non-integration scenarios free of coordinator-specific fixture state.
     coordinator: overrides.coordinator,
   };
 }
@@ -73,17 +77,27 @@ const stateDir = ${JSON.stringify(stateDir)};
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
 appendLog(args.join(" "));
 // The real dispatch-show payload nests provenance under result.dispatch (D4.3/D5.2).
-function nestDispatch(flat, coordinator) {
-  const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
+function nestDispatch(flat, structuredCoordinator, preamble) {
+  const dispatch = {
+    id: flat.dispatch_id,
+    task_id: flat.task_id,
+    assignee_handle: flat.assignee,
+    status: flat.status || "dispatched",
+    failure_count: flat.failure_count || 0,
+    last_failure: flat.last_failure || null,
+    dispatched_at: flat.dispatched_at || null,
+    completed_at: flat.completed_at || null,
+    created_at: flat.created_at || null,
+    last_heartbeat_at: flat.last_heartbeat_at || null,
+    assignee_pane_key: flat.assignee_pane_key || flat.assignee,
+  };
   const result = { dispatch: dispatch };
   if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
-  // #1019: the real --preamble read is a string. Keep the normalized coordinator object
-  // alongside it for the existing lifecycle fixture contract; the dispatch row itself has
-  // only the real assignee_handle provenance field and no coordinator field.
-  if (coordinator !== undefined) {
-    result.preamble = String(coordinator);
-    result.coordinator = { handle: coordinator };
-  }
+  // The real --preamble read is a string and, with --from <assignee>, can name the assignee
+  // as coordinator. It is corroboration only; structuredCoordinator is the optional feature
+  // detection variant used by dedicated lifecycle tests.
+  result.preamble = preamble !== undefined ? String(preamble) : "Coordinator: " + flat.assignee;
+  if (structuredCoordinator !== undefined) result.coordinator_handle = structuredCoordinator;
   return result;
 }
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }
@@ -113,8 +127,16 @@ if (args[0] === "status") {
   if (!scenario.omitRuntimeId) runtime.runtimeId = scenario.runtimeId;
   const statusMeta = scenario.omitRuntimeId ? {} : meta;
   const statusResult = { app: { running: true, pid: 1 }, runtime, graph: { state: "ready" } };
-  if (scenario.coordinator !== undefined) statusResult.coordinator = { handle: scenario.coordinator };
+  if (scenario.structuredCoordinator !== undefined) statusResult.coordinator_handle = scenario.structuredCoordinator;
   emit({ id: "status-1", ok: true, result: statusResult, _meta: statusMeta }, 0);
+}
+if (args[0] === "terminal" && args[1] === "list") {
+  if (!scenario.terminalListOk) { process.stderr.write("orca terminal list unreachable\\n"); process.exit(1); }
+  if (scenario.terminalListMalformed) emit({ id: "terminal-list-1", ok: true, result: { count: 0 }, _meta: meta }, 0);
+  const terminals = (Array.isArray(scenario.liveTerminals) ? scenario.liveTerminals : []).map((terminal) => (
+    typeof terminal === "string" ? { handle: terminal, id: terminal, status: "running" } : terminal
+  ));
+  emit({ id: "terminal-list-1", ok: true, result: { terminals, count: terminals.length }, _meta: meta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "task-list") {
   if (scenario.taskListOk === false) { process.stderr.write("orca task-list unreachable\\n"); process.exit(1); }
@@ -182,7 +204,7 @@ if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   Object.keys(seed).forEach((k) => { if (k === "runtimeId") seedRuntime = seed[k]; else result[k] = seed[k]; });
   try { Object.assign(result, JSON.parse(fs.readFileSync(stateFile(task), "utf-8"))); } catch (e) { /* no real dispatch yet */ }
   const dispatchMeta = seedRuntime !== undefined ? { runtimeId: seedRuntime } : meta;
-  emit({ id: "ds-" + task, ok: true, result: nestDispatch(result, scenario.coordinator), _meta: dispatchMeta }, 0);
+  emit({ id: "ds-" + task, ok: true, result: nestDispatch(result, scenario.structuredCoordinator, scenario.preamble), _meta: dispatchMeta }, 0);
 }
 if (args[0] === "orchestration" && args[1] === "dispatch") {
   const task = argValue("--task");

--- a/tests/relay-orca/fixtures/fake-orca-run.js
+++ b/tests/relay-orca/fixtures/fake-orca-run.js
@@ -48,6 +48,14 @@ function defaultRunScenario(overrides = {}) {
     injectNonAgentHandles: Array.isArray(overrides.injectNonAgentHandles) ? overrides.injectNonAgentHandles : [],
     provenanceOverride: overrides.provenanceOverride || null, // merged over dispatch-show result
     provenanceOverrideFor: overrides.provenanceOverrideFor || null, // limit override to one orca task id
+    coordinator: overrides.coordinator,
+    liveTerminals: overrides.liveTerminals !== undefined
+      ? overrides.liveTerminals
+      : (overrides.coordinator !== undefined ? [overrides.coordinator] : []),
+    terminalListOk: overrides.terminalListOk !== undefined ? overrides.terminalListOk : true,
+    terminalListMalformed: overrides.terminalListMalformed === true,
+    structuredCoordinator: overrides.structuredCoordinator,
+    preamble: overrides.preamble,
     terminalCreateOkFalse: overrides.terminalCreateOkFalse || false,
     terminalCreateEmptyHandle: overrides.terminalCreateEmptyHandle || false,
     terminalSendOkFalse: overrides.terminalSendOkFalse || false,
@@ -69,10 +77,24 @@ const sendsPath = ${JSON.stringify(sendsPath)};
 function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n", "utf-8"); }
 appendLog(args.join(" "));
 // The real dispatch-show payload nests provenance under result.dispatch (D2/D5.2).
-function nestDispatch(flat) {
-  const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
+function nestDispatch(flat, scenario) {
+  const dispatch = {
+    id: flat.dispatch_id,
+    task_id: flat.task_id,
+    assignee_handle: flat.assignee,
+    status: flat.status || "dispatched",
+    failure_count: flat.failure_count || 0,
+    last_failure: flat.last_failure || null,
+    dispatched_at: flat.dispatched_at || null,
+    completed_at: flat.completed_at || null,
+    created_at: flat.created_at || null,
+    last_heartbeat_at: flat.last_heartbeat_at || null,
+    assignee_pane_key: flat.assignee_pane_key || flat.assignee,
+  };
   const result = { dispatch: dispatch };
   if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
+  result.preamble = scenario.preamble !== undefined ? String(scenario.preamble) : "Coordinator: " + flat.assignee;
+  if (scenario.structuredCoordinator !== undefined) result.coordinator_handle = scenario.structuredCoordinator;
   return result;
 }
 
@@ -101,9 +123,22 @@ if (args.includes("worktree")) {
 
 const scenario = loadScenario();
 
-if (args[0] === "status") emit(scenario.status, scenario.statusExit, scenario.statusStdout);
+if (args[0] === "status") {
+  const status = scenario.status && typeof scenario.status === "object" ? JSON.parse(JSON.stringify(scenario.status)) : scenario.status;
+  if (scenario.structuredCoordinator !== undefined && status && status.result) status.result.coordinator_handle = scenario.structuredCoordinator;
+  emit(status, scenario.statusExit, scenario.statusStdout);
+}
 if (args[0] === "orchestration" && args[1] === "task-list") emit(scenario.taskList, scenario.taskListExit);
 if (args[0] === "orchestration" && args[1] === "gate-list") emit(scenario.gateList, scenario.gateListExit);
+
+if (args[0] === "terminal" && args[1] === "list") {
+  if (!scenario.terminalListOk) emit({ ok: false, error: "terminal list failed", _meta: { runtimeId: scenario.runtimeId } }, 1);
+  if (scenario.terminalListMalformed) emit({ ok: true, result: { count: 0 }, _meta: { runtimeId: scenario.runtimeId } }, 0);
+  const terminals = (Array.isArray(scenario.liveTerminals) ? scenario.liveTerminals : []).map((terminal) => (
+    typeof terminal === "string" ? { handle: terminal, id: terminal, status: "running" } : terminal
+  ));
+  emit({ ok: true, result: { terminals, count: terminals.length }, _meta: { runtimeId: scenario.runtimeId } }, 0);
+}
 
 if (args[0] === "orchestration" && args[1] === "task-create") {
   const title = argValue("--task-title") || "";
@@ -142,7 +177,7 @@ if (args[0] === "orchestration" && args[1] === "dispatch-show") {
   if (scenario.provenanceOverride && (!scenario.provenanceOverrideFor || scenario.provenanceOverrideFor === task)) {
     Object.assign(base, scenario.provenanceOverride);
   }
-  emit({ id: "ds-" + task, ok: true, result: nestDispatch(base), _meta: { runtimeId: scenario.runtimeId } }, 0);
+  emit({ id: "ds-" + task, ok: true, result: nestDispatch(base, scenario), _meta: { runtimeId: scenario.runtimeId } }, 0);
 }
 
 if (args[0] === "terminal" && args[1] === "create") {

--- a/tests/relay-orca/fixtures/fake-orca-status.js
+++ b/tests/relay-orca/fixtures/fake-orca-status.js
@@ -60,9 +60,22 @@ function appendLog(line) { if (logPath) fs.appendFileSync(logPath, line + "\\n",
 appendLog(args.join(" "));
 // The real dispatch-show payload nests provenance under result.dispatch (D4.3/D5.2).
 function nestDispatch(flat) {
-  const dispatch = { id: flat.dispatch_id, task_id: flat.task_id, assignee_handle: flat.assignee, status: flat.status || "dispatched" };
+  const dispatch = {
+    id: flat.dispatch_id,
+    task_id: flat.task_id,
+    assignee_handle: flat.assignee,
+    status: flat.status || "dispatched",
+    failure_count: flat.failure_count || 0,
+    last_failure: flat.last_failure || null,
+    dispatched_at: flat.dispatched_at || null,
+    completed_at: flat.completed_at || null,
+    created_at: flat.created_at || null,
+    last_heartbeat_at: flat.last_heartbeat_at || null,
+    assignee_pane_key: flat.assignee_pane_key || flat.assignee,
+  };
   const result = { dispatch: dispatch };
   if (flat.terminal_present !== undefined) result.terminal_present = flat.terminal_present;
+  result.preamble = "Coordinator: " + flat.assignee;
   return result;
 }
 function loadScenario() { return JSON.parse(fs.readFileSync(scenarioPath, "utf-8")); }

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -86,6 +86,10 @@ function initialState(extra = {}) {
   };
 }
 
+function lifecycleMutations(fake) {
+  return fake.readLog().filter((argv) => ["gate-create", "gate-resolve", "send"].includes(argv[1]));
+}
+
 test("#1019 happy path is gate-create, evidence, resolve, fresh instruction, worker_done, completed re-read", () => {
   const fake = installFakeOrcaIntegrationLifecycle(initialState());
   const report = reportFile();
@@ -101,12 +105,95 @@ test("#1019 happy path is gate-create, evidence, resolve, fresh instruction, wor
     const completed = advanceIntegrationGate(context(fake, report.reportPath));
     assert.equal(completed.ok, true);
     const log = fake.readLog().map((argv) => argv.slice(0, 2).join(" "));
+    assert.ok(log.includes("terminal list"), "coordinator liveness must be checked through the live terminal query");
     assert.ok(log.includes("orchestration gate-create"));
     assert.ok(log.includes("orchestration gate-resolve"));
     assert.ok(log.includes("orchestration send"));
     assert.equal(fake.readSends().filter((argv) => argv.includes("worker_done")).length, 1);
     assert.equal(fake.readState().tasks[0].status, "completed");
     assert.equal(fake.readPoison(), null);
+  } finally {
+    fake.cleanup();
+    fs.rmSync(report.dir, { recursive: true, force: true });
+  }
+});
+
+test("#1067 coordinator liveness matrix is fail-closed and structured metadata remains optional", () => {
+  const cases = [
+    { label: "handle absent from live terminal set", state: initialState({ liveTerminals: [] }) },
+    { label: "terminal query failed", state: initialState({ terminalListOk: false }) },
+    { label: "terminal query is unparseable", state: initialState({ terminalListMalformed: true }) },
+  ];
+  for (const scenario of cases) {
+    const fake = installFakeOrcaIntegrationLifecycle(scenario.state);
+    const report = reportFile();
+    try {
+      assert.throws(() => prepareIntegrationGate(context(fake, report.reportPath)), (error) => {
+        assert.ok(error instanceof IntegrationLifecycleError, scenario.label);
+        assert.equal(error.reasonCode, "INTEGRATION_COORDINATOR_PROVENANCE_MISSING", scenario.label);
+        return true;
+      }, scenario.label);
+      assert.deepEqual(lifecycleMutations(fake), [], `${scenario.label} must not mutate the lifecycle`);
+      assert.equal(fake.readPoison(), null);
+    } finally {
+      fake.cleanup();
+      fs.rmSync(report.dir, { recursive: true, force: true });
+    }
+  }
+
+  const matching = installFakeOrcaIntegrationLifecycle(initialState({ structuredCoordinator: COORDINATOR }));
+  const matchingReport = reportFile();
+  try {
+    const prepared = prepareIntegrationGate(context(matching, matchingReport.reportPath));
+    assert.equal(prepared.ok, true, "a matching structured coordinator field remains compatible");
+    assert.equal(matching.readState().gates.length, 1);
+  } finally {
+    matching.cleanup();
+    fs.rmSync(matchingReport.dir, { recursive: true, force: true });
+  }
+
+  const mismatching = installFakeOrcaIntegrationLifecycle(initialState({
+    structuredCoordinator: "coord-stale",
+    liveTerminals: [COORDINATOR],
+  }));
+  const mismatchingReport = reportFile();
+  try {
+    assert.throws(() => prepareIntegrationGate(context(mismatching, mismatchingReport.reportPath)), (error) => {
+      assert.equal(error.reasonCode, "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH");
+      return true;
+    });
+    assert.deepEqual(lifecycleMutations(mismatching), [], "a structured mismatch must not mutate the lifecycle");
+  } finally {
+    mismatching.cleanup();
+    fs.rmSync(mismatchingReport.dir, { recursive: true, force: true });
+  }
+});
+
+test("#1067 string preambles are inert corroboration, including contradictory text", () => {
+  const fake = installFakeOrcaIntegrationLifecycle(initialState({ preamble: "Coordinator: coord-stale" }));
+  const report = reportFile();
+  try {
+    const status = JSON.parse(fake.run(["status", "--json"]).stdout);
+    assert.deepEqual(Object.keys(status.result).sort(), ["app", "graph", "runtime"]);
+    assert.equal("coordinator" in status.result, false);
+    assert.equal(status._meta.runtimeId, DEFAULT_RUNTIME_ID);
+    const dispatch = JSON.parse(fake.run([
+      "orchestration", "dispatch-show", "--task", TASK_ID, "--preamble", "--from", ASSIGNEE, "--json",
+    ]).stdout);
+    assert.equal(typeof dispatch.result.preamble, "string");
+    assert.match(dispatch.result.preamble, /coord-stale/);
+    assert.equal(dispatch.result.dispatch.assignee_handle, ASSIGNEE);
+    assert.equal("coordinator_handle" in dispatch.result.dispatch, false);
+    assert.equal("from" in dispatch.result.dispatch, false);
+    assert.equal(dispatch._meta.runtimeId, DEFAULT_RUNTIME_ID);
+
+    // The contradictory text cannot replace the criterion-1 liveness proof or cause a
+    // coordinator mismatch. The canonical gate mutation is authorized by the verified live
+    // handle and the remaining dispatch/runtime bindings, never by preamble text.
+    const prepared = prepareIntegrationGate(context(fake, report.reportPath));
+    assert.equal(prepared.ok, true);
+    assert.equal(fake.readState().gates.length, 1);
+    assert.equal(lifecycleMutations(fake).filter((argv) => argv[1] === "gate-create").length, 1);
   } finally {
     fake.cleanup();
     fs.rmSync(report.dir, { recursive: true, force: true });
@@ -262,7 +349,7 @@ test("#1019 duplicate or noncanonical gates fail closed before further mutation"
 
 test("#1019 stale coordinator, dispatch, assignee, and report provenance fail closed", () => {
   const cases = [
-    { label: "coordinator", reasonCode: "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", state: initialState({ coordinator: "coord-stale" }) },
+    { label: "coordinator", reasonCode: "INTEGRATION_COORDINATOR_PROVENANCE_MISMATCH", state: initialState({ structuredCoordinator: "coord-stale", liveTerminals: [COORDINATOR] }) },
     { label: "dispatch", reasonCode: "INTEGRATION_DISPATCH_PROVENANCE_MISMATCH", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: "dispatch-other", assignee: ASSIGNEE } } }) },
     // A stale --from is rejected at the dispatch-show CLI boundary, surfacing as a capability gap.
     { label: "assignee", reasonCode: "INTEGRATION_CAPABILITY_GAP", state: initialState({ dispatch: { [TASK_ID]: { dispatch_id: DISPATCH_ID, assignee: "term-other" } } }) },


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료 및 커밋했습니다.

- coordinator 검증을 `orca terminal list --json` 기반 liveness로 변경
- 구조화 coordinator mismatch 검증 유지, string preamble 비권위 처리
- 실제 Orca `1.4.148` payload fixture와 회귀 테스트 추가
- 문서 및 fixture 갱신
- Worktree clean

검증:

- `relay-orca`: 348/348 통과
- 최종 status fixture: 70/70 통과
- skills lint: 33/33 통과
- 전체 직렬 게이트: 2,780 통과, 기존 advisory-lane reap 타이밍 테스트 9건 실패

커밋: `b853983 fix(relay-orca): verify integration coordinator liveness`
```

## Dispatch Metadata

- Run: issue-1067-20260723114823798-216d6ec8
- Executor: codex
- Branch: issue-1067