### PR TITLE
fix(relay-orca): ignore superseded marked runs on resume

### DIFF
--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -346,6 +346,7 @@ Each diagnostic is `{ code, outcome_id | null, message, ids }` with `code` one o
 | `PR_CHANGED` | the PR head moved or its state regressed relative to durable evidence |
 | `ISSUE_REOPENED` | the issue is open though the outcome's evidence contract requires closure |
 | `STALE_WORKER_DONE` | an Orca task reports done but durable evidence is incomplete |
+| `SUPERSEDED_MARKED_RUN` | a closed marked relay run is residue for the same outcome whose mapped relay run is currently `complete_with_evidence`; `ids` carries `superseded_run_id` and `superseding_run_id` |
 
 Diagnostics carry stable IDs (task/dispatch/run/PR numbers) and remediation hints but NEVER
 terminal output, secrets, or env values. **Every** subprocess-derived value that reaches a

--- a/skills/relay-orca/references/receipt-and-status.md
+++ b/skills/relay-orca/references/receipt-and-status.md
@@ -348,6 +348,14 @@ Each diagnostic is `{ code, outcome_id | null, message, ids }` with `code` one o
 | `STALE_WORKER_DONE` | an Orca task reports done but durable evidence is incomplete |
 | `SUPERSEDED_MARKED_RUN` | a closed marked relay run is residue for the same outcome whose mapped relay run is currently `complete_with_evidence`; `ids` carries `superseded_run_id` and `superseding_run_id` |
 
+`SUPERSEDED_MARKED_RUN` is the ONE discovery path that removes a block instead of adding one,
+so its attribution is exact by construction, never by terminator heuristics: outcome ids are
+not charset-restricted, so the marked id is read up to the real terminator relay's manifest
+store emits (a quoted frontmatter scalar closes on its quote; any other form runs to the end
+of its line) and must EQUAL a receipt outcome id. Any residual ambiguity — an unresolvable
+marker, several marked ids, an id absent from the receipt, or a duplicated receipt outcome —
+keeps the manifest an `adopt_relay_run` candidate that still blocks re-dispatch.
+
 Diagnostics carry stable IDs (task/dispatch/run/PR numbers) and remediation hints but NEVER
 terminal output, secrets, or env values. **Every** subprocess-derived value that reaches a
 diagnostic is bounded to ≤ 256 chars (marker included), the same rule the probe uses — and

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -49,6 +49,59 @@ function referencesProgram(text, programId, programSegment) {
   return body.includes("relay-orca") && (body.includes(programId) || (segment && body.includes(segment)));
 }
 
+// A coordination marker identifies the outcome after the program prefix. Only treat a
+// marker as exact when its value is terminated; otherwise an outcome `a` would also match
+// a marker for outcome `ab`. The terminating characters cover body lines and the quoted
+// frontmatter form written by relay's manifest store.
+function containsExactMarker(text, marker) {
+  const body = String(text || "");
+  let offset = body.indexOf(marker);
+  while (offset >= 0) {
+    const following = body[offset + marker.length];
+    if (following === undefined || /[\s'"`,;:.)\]}]/.test(following)) return true;
+    offset = body.indexOf(marker, offset + marker.length);
+  }
+  return false;
+}
+
+// Resolve a marked manifest to receipt outcome ids without trusting arbitrary text. The
+// segment marker is authoritative; the raw-program form is retained for older manifests
+// because referencesProgram intentionally still discovers those markers. Multiple matches
+// are ambiguous and therefore never license supersession.
+function markedOutcomeIds(text, tasks, programId, programSegment) {
+  const prefixes = [];
+  if (typeof programSegment === "function") prefixes.push(programSegment(programId));
+  if (typeof programId === "string" && programId.length > 0) prefixes.push(programId);
+  const uniquePrefixes = [...new Set(prefixes)];
+  const outcomeIds = new Set();
+  (Array.isArray(tasks) ? tasks : []).forEach((task) => {
+    if (!task || typeof task.outcome_id !== "string") return;
+    const matches = uniquePrefixes.some((prefix) => containsExactMarker(text, `relay-orca: ${prefix}/${task.outcome_id}`));
+    if (matches) outcomeIds.add(task.outcome_id);
+  });
+  return [...outcomeIds];
+}
+
+// A closed marked run is superseded only when its exact marker names one receipt outcome
+// and that same outcome has exactly one mapped relay run whose live reconciler result is
+// complete_with_evidence. Every missing or ambiguous fact falls back to the blocking
+// adopt_relay_run behavior.
+function supersedingRunFor({ entry, tasks, outcomes, programId, programSegment }) {
+  if (!entry || !entry.parsed || entry.parsed.state !== "closed") return null;
+  const outcomeIds = markedOutcomeIds(entry.text, tasks, programId, programSegment);
+  if (outcomeIds.length !== 1) return null;
+  const [outcomeId] = outcomeIds;
+  const classified = (Array.isArray(outcomes) ? outcomes : []).filter(
+    (outcome) => outcome && outcome.outcome_id === outcomeId && outcome.state === "complete_with_evidence",
+  );
+  const mappedRuns = (Array.isArray(tasks) ? tasks : [])
+    .filter((task) => task && task.outcome_id === outcomeId && task.relay_ids && typeof task.relay_ids.run === "string" && task.relay_ids.run.length > 0)
+    .map((task) => task.relay_ids.run);
+  const uniqueMappedRuns = [...new Set(mappedRuns)];
+  if (classified.length !== 1 || mappedRuns.length !== 1 || uniqueMappedRuns.length !== 1) return null;
+  return { outcomeId, supersedingRunId: uniqueMappedRuns[0] };
+}
+
 // D4.1: a live task row's display string is the FIRST non-empty of `task_title`,
 // `display_name`, `title`. The real mid-2026 task-list row carries `task_title`
 // (and `display_name`) and NO `title`; older rows may still carry only `title`.
@@ -346,13 +399,25 @@ function detectDuplicateMappings(tasks) {
 }
 
 // live→receipt back-pointer discovery (D7): a relay manifest referencing this program
-// but absent from the receipt's mappings. Text only; NO mutation is performed.
-function discoverBackPointers({ manifests, tasks, programId, programSegment }) {
+// but absent from the receipt's mappings. Text only; NO mutation is performed. The optional
+// diagnostics sink preserves the historical array return value while allowing status to
+// report proven superseded residue without turning it into repair work.
+function discoverBackPointers({ manifests, tasks, outcomes = [], programId, programSegment }, diagnostics = []) {
   const knownRunIds = new Set(tasks.map((task) => task.relay_ids && task.relay_ids.run).filter(Boolean));
   const candidates = [];
   manifests.forEach((entry) => {
     if (!entry.run_id || knownRunIds.has(entry.run_id)) return;
     if (!referencesProgram(entry.text, programId, programSegment)) return;
+    const superseding = supersedingRunFor({ entry, tasks, outcomes, programId, programSegment });
+    if (superseding) {
+      diagnostics.push(diag(
+        "SUPERSEDED_MARKED_RUN",
+        null,
+        `closed marked relay run ${entry.run_id} is superseded by mapped run ${superseding.supersedingRunId} for outcome ${superseding.outcomeId}; no adoption is required`,
+        { superseded_run_id: entry.run_id, superseding_run_id: superseding.supersedingRunId },
+      ));
+      return;
+    }
     candidates.push({
       kind: "adopt_relay_run",
       outcome_id: null,
@@ -448,7 +513,10 @@ function deriveStatusReport({ receipt, programId, receiptPath, manifests, fleetM
     });
   }
   entries.forEach((entry) => repairForOutcome(entry).forEach((repair) => repairCandidates.push(repair)));
-  discoverBackPointers({ manifests, tasks: receipt.tasks, programId, programSegment }).forEach((candidate) => repairCandidates.push(candidate));
+  const backPointerDiagnostics = [];
+  discoverBackPointers({ manifests, tasks: receipt.tasks, outcomes: entries.map((entry) => entry.outcome), programId, programSegment }, backPointerDiagnostics)
+    .forEach((candidate) => repairCandidates.push(candidate));
+  backPointerDiagnostics.forEach((diagnostic) => diagnostics.push(diagnostic));
   discoverFleetBackPointers({ fleetManifests, tasks: receipt.tasks, programId, programSegment }).forEach((candidate) => repairCandidates.push(candidate));
 
   const report = {

--- a/skills/relay-orca/scripts/lib/status-derive.js
+++ b/skills/relay-orca/scripts/lib/status-derive.js
@@ -49,53 +49,86 @@ function referencesProgram(text, programId, programSegment) {
   return body.includes("relay-orca") && (body.includes(programId) || (segment && body.includes(segment)));
 }
 
-// A coordination marker identifies the outcome after the program prefix. Only treat a
-// marker as exact when its value is terminated; otherwise an outcome `a` would also match
-// a marker for outcome `ab`. The terminating characters cover body lines and the quoted
-// frontmatter form written by relay's manifest store.
-function containsExactMarker(text, marker) {
-  const body = String(text || "");
-  let offset = body.indexOf(marker);
-  while (offset >= 0) {
-    const following = body[offset + marker.length];
-    if (following === undefined || /[\s'"`,;:.)\]}]/.test(following)) return true;
-    offset = body.indexOf(marker, offset + marker.length);
+const MARKER_LABEL = "relay-orca: ";
+
+// The supersession path REMOVES a block, so its attribution must be exact BY CONSTRUCTION.
+// Outcome ids are not charset-restricted (compile-program only requires an id that slugs to
+// a stable task id), so `:`, `.`, `;`, `)` are legal id characters and no terminator charset
+// can bound an id — a `…/a:legacy` marker would "exactly" match outcome `a`. Instead, read
+// the id the marker actually names, up to the real terminator relay's manifest store emits:
+// a quoted frontmatter scalar closes on its quote (single-quoted with `''` doubling, or the
+// JSON form), and every other form runs to the end of its line. Returns the marker-bearing
+// values of one line, or `null` when a marker's terminator cannot be resolved — an
+// unresolvable terminator is ambiguity, and ambiguity must block, never supersede.
+function markerValuesForLine(line) {
+  const trimmedEnd = line.replace(/\s+$/, "");
+  const quoted = trimmedEnd.match(/^\s*[A-Za-z0-9_.-]+:\s*(['"])(.*)$/);
+  if (!quoted) return [trimmedEnd];
+  const [, quote, rest] = quoted;
+  if (quote === "'") {
+    if (!rest.endsWith("'")) return null;
+    return [rest.slice(0, -1).replace(/''/g, "'")];
   }
-  return false;
+  try {
+    return [JSON.parse(`${quote}${rest}`)];
+  } catch {
+    return null;
+  }
 }
 
-// Resolve a marked manifest to receipt outcome ids without trusting arbitrary text. The
-// segment marker is authoritative; the raw-program form is retained for older manifests
-// because referencesProgram intentionally still discovers those markers. Multiple matches
-// are ambiguous and therefore never license supersession.
-function markedOutcomeIds(text, tasks, programId, programSegment) {
+function markerPrefixes(programId, programSegment) {
   const prefixes = [];
   if (typeof programSegment === "function") prefixes.push(programSegment(programId));
   if (typeof programId === "string" && programId.length > 0) prefixes.push(programId);
-  const uniquePrefixes = [...new Set(prefixes)];
+  return [...new Set(prefixes.filter((prefix) => typeof prefix === "string" && prefix.length > 0))];
+}
+
+// Every outcome id this manifest's coordination markers name, extracted exactly. The
+// segment marker is authoritative; the raw-program form is retained for older manifests
+// because referencesProgram intentionally still discovers those markers. Returns `null` on
+// any unresolvable shape (unterminated quote, empty id, two markers inside one value) so
+// the caller falls back to blocking.
+function exactMarkedOutcomeIds(text, prefixes) {
   const outcomeIds = new Set();
-  (Array.isArray(tasks) ? tasks : []).forEach((task) => {
-    if (!task || typeof task.outcome_id !== "string") return;
-    const matches = uniquePrefixes.some((prefix) => containsExactMarker(text, `relay-orca: ${prefix}/${task.outcome_id}`));
-    if (matches) outcomeIds.add(task.outcome_id);
-  });
+  const lines = String(text || "").replace(/\r\n/g, "\n").split("\n");
+  for (const line of lines) {
+    if (!line.includes(MARKER_LABEL)) continue;
+    const values = markerValuesForLine(line);
+    if (values === null) return null;
+    for (const value of values) {
+      for (const prefix of prefixes) {
+        const needle = `${MARKER_LABEL}${prefix}/`;
+        const start = value.indexOf(needle);
+        if (start < 0) continue;
+        if (value.indexOf(needle, start + needle.length) >= 0) return null;
+        const outcomeId = value.slice(start + needle.length);
+        if (!outcomeId) return null;
+        outcomeIds.add(outcomeId);
+      }
+    }
+  }
   return [...outcomeIds];
 }
 
-// A closed marked run is superseded only when its exact marker names one receipt outcome
-// and that same outcome has exactly one mapped relay run whose live reconciler result is
-// complete_with_evidence. Every missing or ambiguous fact falls back to the blocking
-// adopt_relay_run behavior.
+// A closed marked run is superseded only when its marker names — exactly — one id that
+// EQUALS one receipt outcome, and that same outcome has exactly one mapped relay run whose
+// live reconciler result is complete_with_evidence. Every missing or ambiguous fact
+// (unresolvable marker, several marked ids, an id absent from the receipt, a duplicated
+// receipt outcome) falls back to the blocking adopt_relay_run behavior.
 function supersedingRunFor({ entry, tasks, outcomes, programId, programSegment }) {
   if (!entry || !entry.parsed || entry.parsed.state !== "closed") return null;
-  const outcomeIds = markedOutcomeIds(entry.text, tasks, programId, programSegment);
-  if (outcomeIds.length !== 1) return null;
+  const outcomeIds = exactMarkedOutcomeIds(entry.text, markerPrefixes(programId, programSegment));
+  if (!outcomeIds || outcomeIds.length !== 1) return null;
   const [outcomeId] = outcomeIds;
+  const receiptTasks = (Array.isArray(tasks) ? tasks : []).filter(
+    (task) => task && task.outcome_id === outcomeId,
+  );
+  if (receiptTasks.length !== 1) return null;
   const classified = (Array.isArray(outcomes) ? outcomes : []).filter(
     (outcome) => outcome && outcome.outcome_id === outcomeId && outcome.state === "complete_with_evidence",
   );
-  const mappedRuns = (Array.isArray(tasks) ? tasks : [])
-    .filter((task) => task && task.outcome_id === outcomeId && task.relay_ids && typeof task.relay_ids.run === "string" && task.relay_ids.run.length > 0)
+  const mappedRuns = receiptTasks
+    .filter((task) => task.relay_ids && typeof task.relay_ids.run === "string" && task.relay_ids.run.length > 0)
     .map((task) => task.relay_ids.run);
   const uniqueMappedRuns = [...new Set(mappedRuns)];
   if (classified.length !== 1 || mappedRuns.length !== 1 || uniqueMappedRuns.length !== 1) return null;

--- a/skills/relay-orca/scripts/lib/status-report.js
+++ b/skills/relay-orca/scripts/lib/status-report.js
@@ -60,6 +60,7 @@ const DIAGNOSTIC_CODES = Object.freeze([
   "PR_CHANGED",
   "ISSUE_REOPENED",
   "STALE_WORKER_DONE",
+  "SUPERSEDED_MARKED_RUN",
 ]);
 
 function orderOutcome(outcome) {

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -1100,6 +1100,81 @@ test("D3: an absent outcome is NOT re-dispatched while unmapped relay work refer
   }
 });
 
+test("#1066: a closed marked run superseded by the same mapped complete outcome does not block wave advancement", () => {
+  const programId = "epic-resume-superseded-marked-run";
+  const segment = programSegment(programId);
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-superseded", state: "closed", body: `relay-orca: ${segment}/wave-one` },
+      { run_id: "run-superseding", state: "merged", pr_number: 401, issue_number: 4401 },
+    ],
+    orcaScenario: {
+      tasks: [
+        orcaTask(programId, "wave-one", { status: "completed", worker_done: true }),
+        orcaTask(programId, "wave-two", { status: "pending" }),
+      ],
+      dispatch: absentDispatch("wave-two"),
+    },
+    ghScenario: {
+      prs: { 401: { state: "MERGED", mergedAt: "2026-07-22T00:00:00Z" } },
+      issues: { 4401: { state: "CLOSED" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "wave-one", wave: 1, run: "run-superseding" },
+      { outcome_id: "wave-two", wave: 2, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const beforeStatus = world.receiptOnDisk();
+  try {
+    const status = runStatus(world, programId);
+    assert.ok(status.diagnostics.some((diagnostic) => diagnostic.code === "SUPERSEDED_MARKED_RUN"));
+    assert.ok(!status.repair_candidates.some((candidate) => candidate.kind === "adopt_relay_run"));
+    assert.deepEqual(runStatus(world, programId), status, "repeating status is deterministic and read-only");
+    assert.deepEqual(world.receiptOnDisk(), beforeStatus, "status remains read-only");
+
+    const resumed = world.run(["--operator-handle", "h-wave-2"]);
+    assert.equal(resumed.status, 0);
+    assert.equal(actionFor(resumed.body, "wave-two").action, "redispatched");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
+test("#1066: a closed marked run without same-outcome complete evidence still blocks resume", () => {
+  const programId = "epic-resume-closed-marked-blocking";
+  const segment = programSegment(programId);
+  const world = buildWorld({
+    programId,
+    manifests: [{ run_id: "run-closed-unmapped", state: "closed", body: `relay-orca: ${segment}/wave-one` }],
+    orcaScenario: { tasks: [orcaTask(programId, "wave-one")], dispatch: absentDispatch("wave-one") },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [{ outcome_id: "wave-one", dispatch_id: null, assignee: null }],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  try {
+    const resumed = world.run();
+    assert.equal(resumed.status, 0);
+    assert.equal(actionFor(resumed.body, "wave-one").action, "skipped");
+    assert.match(actionFor(resumed.body, "wave-one").reason, /unmapped relay work references this program/);
+    assert.deepEqual(mutationLines(world.orca.readLog()), []);
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
 // A2 (#946 R2, owner amendment A2): an unmapped FLEET manifest under the SEPARATE fleets
 // root blocks re-dispatch of an absent relay_fleet outcome — re-injecting would duplicate
 // the whole fleet (forbidden by the drain invariant), the same no-duplicate-work semantics

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -1148,6 +1148,59 @@ test("#1066: a closed marked run superseded by the same mapped complete outcome 
   }
 });
 
+// #1066 R2: the marked outcome id is `wave-one:legacy` — a legal outcome id that merely
+// starts with the mapped, complete outcome `wave-one`. Attributing it to `wave-one` would
+// let a foreign closed run unblock re-dispatch (fail-open); the residue must stay an
+// adopt_relay_run candidate and keep tripping the no-duplicate-work guard.
+test("#1066 R2: a closed marked run whose id only PREFIXES a complete outcome still blocks resume", () => {
+  const programId = "epic-resume-marked-prefix-blocking";
+  const segment = programSegment(programId);
+  const world = buildWorld({
+    programId,
+    manifests: [
+      { run_id: "run-marked-legacy", state: "closed", body: `relay-orca: ${segment}/wave-one:legacy` },
+      { run_id: "run-superseding", state: "merged", pr_number: 411, issue_number: 4411 },
+    ],
+    orcaScenario: {
+      tasks: [
+        orcaTask(programId, "wave-one", { status: "completed", worker_done: true }),
+        orcaTask(programId, "wave-two", { status: "pending" }),
+      ],
+      dispatch: absentDispatch("wave-two"),
+    },
+    ghScenario: {
+      prs: { 411: { state: "MERGED", mergedAt: "2026-07-22T00:00:00Z" } },
+      issues: { 4411: { state: "CLOSED" } },
+    },
+  });
+  const receipt = makeReceipt({
+    programId,
+    slug: world.slug,
+    root: fs.realpathSync(world.repoRoot),
+    tasks: [
+      { outcome_id: "wave-one", wave: 1, run: "run-superseding" },
+      { outcome_id: "wave-two", wave: 2, dispatch_id: null, assignee: null },
+    ],
+  });
+  fs.writeFileSync(world.receiptPath, serializeReceipt(receipt), "utf-8");
+  const beforeStatus = world.receiptOnDisk();
+  try {
+    const status = runStatus(world, programId);
+    assert.ok(!status.diagnostics.some((diagnostic) => diagnostic.code === "SUPERSEDED_MARKED_RUN"), "a prefix-only marker never proves supersession");
+    assert.ok(status.repair_candidates.some((candidate) => candidate.kind === "adopt_relay_run"), "the adopt_relay_run candidate is retained");
+    assert.deepEqual(world.receiptOnDisk(), beforeStatus, "status remains read-only");
+
+    const resumed = world.run(["--operator-handle", "h-wave-2"]);
+    assert.equal(resumed.status, 0);
+    assert.equal(actionFor(resumed.body, "wave-two").action, "skipped");
+    assert.match(actionFor(resumed.body, "wave-two").reason, /unmapped relay work references this program/);
+    assert.deepEqual(mutationLines(world.orca.readLog()), [], "the no-duplicate-work guard still blocks re-dispatch");
+    assertNoPoison(world);
+  } finally {
+    world.cleanup();
+  }
+});
+
 test("#1066: a closed marked run without same-outcome complete evidence still blocks resume", () => {
   const programId = "epic-resume-closed-marked-blocking";
   const segment = programSegment(programId);

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -14,6 +14,7 @@ const STATUS_JS = path.join(SCRIPTS, "status.js");
 const { REASONS } = require(path.join(SCRIPTS, "lib", "status-reasons.js"));
 const { REPORT_KEYS, OUTCOME_KEYS, DIAGNOSTIC_CODES } = require(path.join(SCRIPTS, "lib", "status-report.js"));
 const { classifyOutcome } = require(path.join(SCRIPTS, "lib", "status-classify.js"));
+const { discoverBackPointers } = require(path.join(SCRIPTS, "lib", "status-derive.js"));
 const { orcaDispatchShow } = require(path.join(SCRIPTS, "lib", "orca-reads.js"));
 const { RECEIPT_NOTE } = require(path.join(SCRIPTS, "lib", "receipt.js"));
 const { computeRepoSlug } = require(path.join(SCRIPTS, "lib", "repo-slug.js"));
@@ -257,7 +258,7 @@ function diagCodes(body, outcomeId) {
 // D9 report shape + verbatim taxonomy sanity
 // ---------------------------------------------------------------------------
 
-test("D7: the nine detector codes exist verbatim in DIAGNOSTIC_CODES", () => {
+test("D7: the detector codes exist verbatim in DIAGNOSTIC_CODES", () => {
   assert.deepEqual(
     [...DIAGNOSTIC_CODES].sort(),
     [
@@ -270,8 +271,58 @@ test("D7: the nine detector codes exist verbatim in DIAGNOSTIC_CODES", () => {
       "PR_CHANGED",
       "RUNTIME_MISMATCH",
       "STALE_WORKER_DONE",
+      "SUPERSEDED_MARKED_RUN",
     ],
   );
+});
+
+test("#1066: marked-run discovery only suppresses a closed exact-outcome residue with mapped complete evidence", () => {
+  const programId = "pilot-1066";
+  const programSegment = () => "pilot-1066-segment";
+  const discover = ({ state, markerOutcome = "a", tasks, outcomes }) => {
+    const diagnostics = [];
+    const candidates = discoverBackPointers({
+      manifests: [{ run_id: `run-${state || "absent"}`, text: `relay-orca: pilot-1066-segment/${markerOutcome}`, parsed: state === undefined ? {} : { state } }],
+      tasks: tasks || [{ outcome_id: "a", relay_ids: { run: null } }],
+      outcomes: outcomes || [],
+      programId,
+      programSegment,
+    }, diagnostics);
+    return { candidates, diagnostics };
+  };
+
+  const superseded = discover({
+    state: "closed",
+    tasks: [{ outcome_id: "a", relay_ids: { run: "run-superseding" } }],
+    outcomes: [{ outcome_id: "a", state: "complete_with_evidence" }],
+  });
+  assert.deepEqual(superseded.candidates, []);
+  assert.equal(superseded.diagnostics[0].code, "SUPERSEDED_MARKED_RUN");
+  assert.deepEqual(superseded.diagnostics[0].ids, {
+    superseded_run_id: "run-closed",
+    superseding_run_id: "run-superseding",
+  });
+
+  const closedWithoutComplete = discover({ state: "closed" });
+  assert.equal(closedWithoutComplete.candidates[0].kind, "adopt_relay_run");
+  assert.deepEqual(closedWithoutComplete.diagnostics, []);
+
+  const differentOutcome = discover({
+    state: "closed",
+    markerOutcome: "b",
+    tasks: [
+      { outcome_id: "a", relay_ids: { run: "run-complete-a" } },
+      { outcome_id: "b", relay_ids: { run: null } },
+    ],
+    outcomes: [{ outcome_id: "a", state: "complete_with_evidence" }],
+  });
+  assert.equal(differentOutcome.candidates[0].kind, "adopt_relay_run");
+
+  for (const state of ["draft", "dispatched", "review_pending", "changes_requested", "ready_to_merge", "escalated", "merged", "unparseable", undefined]) {
+    const result = discover({ state: state === "unparseable" ? "[invalid" : state });
+    assert.equal(result.candidates.length, 1, `state ${String(state)} remains blocking`);
+    assert.deepEqual(result.diagnostics, [], `state ${String(state)} is not classified as superseded`);
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/relay-orca/scripts/status.test.js
+++ b/tests/relay-orca/scripts/status.test.js
@@ -325,6 +325,77 @@ test("#1066: marked-run discovery only suppresses a closed exact-outcome residue
   }
 });
 
+// #1066 R2: supersession is the ONE discovery path that REMOVES a block, so it may never
+// attribute a marker by guessing where the outcome id ends. Outcome ids are not
+// charset-restricted, so `:`/`.`/`;`/`)` are legal id characters: a `…/a:legacy` marker must
+// NOT be read as outcome `a`. The id is taken up to the real terminator relay's manifest
+// store emits (quote for a frontmatter scalar, end-of-line otherwise) and must EQUAL a
+// receipt outcome; every residual ambiguity keeps the blocking adopt_relay_run candidate.
+test("#1066 R2: supersession attributes the marked outcome id exactly; ambiguity keeps blocking", () => {
+  const programId = "pilot-1066";
+  const segment = "pilot-1066-segment";
+  const programSegment = () => segment;
+  const MAPPED_TASKS = [{ outcome_id: "a", relay_ids: { run: "run-superseding" } }];
+  const COMPLETE_OUTCOMES = [{ outcome_id: "a", state: "complete_with_evidence" }];
+  const discover = ({ text, tasks = MAPPED_TASKS, outcomes = COMPLETE_OUTCOMES }) => {
+    const diagnostics = [];
+    const candidates = discoverBackPointers({
+      manifests: [{ run_id: "run-closed", text, parsed: { state: "closed" } }],
+      tasks,
+      outcomes,
+      programId,
+      programSegment,
+    }, diagnostics);
+    return { candidates, diagnostics };
+  };
+  const assertBlocks = (label, options) => {
+    const result = discover(options);
+    assert.equal(result.candidates.length, 1, `${label}: the adopt_relay_run candidate is retained`);
+    assert.equal(result.candidates[0].kind, "adopt_relay_run", `${label}: the retained candidate still blocks`);
+    assert.deepEqual(result.diagnostics, [], `${label}: nothing is reported as superseded`);
+  };
+  const assertSupersedes = (label, options) => {
+    const result = discover(options);
+    assert.deepEqual(result.candidates, [], `${label}: the genuine residue is not proposed for adoption`);
+    assert.equal(result.diagnostics.length, 1, `${label}: exactly one diagnostic`);
+    assert.equal(result.diagnostics[0].code, "SUPERSEDED_MARKED_RUN", `${label}: the superseded diagnostic is emitted`);
+  };
+
+  // The reproduction: a legal `a:legacy` outcome id must not be truncated to outcome `a`.
+  assertBlocks("colon inside the marked id", { text: `relay-orca: ${segment}/a:legacy` });
+  assertBlocks("colon inside the marked id (frontmatter scalar)", { text: `---\ncoordination:\n  marker: 'relay-orca: ${segment}/a:legacy'\n---\n` });
+  // The remaining terminator characters the old heuristic accepted are equally legal id chars.
+  for (const suffix of [".legacy", ";legacy", ")legacy", "]legacy", "}legacy", ",legacy", "'legacy"]) {
+    assertBlocks(`suffix ${suffix} inside the marked id`, { text: `relay-orca: ${segment}/a${suffix}` });
+  }
+
+  // The genuine shapes still unblock: the store's quoted frontmatter scalar (both quote
+  // forms, with `''` doubling), a plain body line, CRLF text, and the legacy raw-id prefix.
+  assertSupersedes("single-quoted frontmatter scalar", { text: `---\ncoordination:\n  marker: 'relay-orca: ${segment}/a'\n---\n# Notes\n` });
+  assertSupersedes("double-quoted frontmatter scalar", { text: `---\ncoordination:\n  marker: "relay-orca: ${segment}/a"\n---\n` });
+  assertSupersedes("body line", { text: `# Notes\nrelay-orca: ${segment}/a\n` });
+  assertSupersedes("CRLF body line", { text: `# Notes\r\nrelay-orca: ${segment}/a\r\n` });
+  assertSupersedes("legacy raw-program-id prefix", { text: `relay-orca: ${programId}/a\n` });
+  assertSupersedes("the same marker repeated on separate lines", { text: `relay-orca: ${segment}/a\nrelay-orca: ${segment}/a\n` });
+
+  // Residual ambiguity shapes — each keeps the blocking candidate.
+  assertBlocks("unterminated quoted scalar", { text: `---\ncoordination:\n  marker: 'relay-orca: ${segment}/a\n---\n` });
+  assertBlocks("unparseable double-quoted scalar", { text: `---\ncoordination:\n  marker: "relay-orca: ${segment}/a\\q"\n---\n` });
+  assertBlocks("trailing prose on the marker line", { text: `relay-orca: ${segment}/a and more notes` });
+  assertBlocks("empty marked outcome id", { text: `relay-orca: ${segment}/` });
+  assertBlocks("two markers inside one value", { text: `note: 'relay-orca: ${segment}/a relay-orca: ${segment}/a'` });
+  assertBlocks("two marked outcome ids", {
+    text: `relay-orca: ${segment}/a\nrelay-orca: ${segment}/b\n`,
+    tasks: [...MAPPED_TASKS, { outcome_id: "b", relay_ids: { run: "run-superseding-b" } }],
+    outcomes: [...COMPLETE_OUTCOMES, { outcome_id: "b", state: "complete_with_evidence" }],
+  });
+  assertBlocks("marked id absent from the receipt", { text: `relay-orca: ${segment}/zzz` });
+  assertBlocks("marked id duplicated across receipt outcomes", {
+    text: `relay-orca: ${segment}/a`,
+    tasks: [...MAPPED_TASKS, { outcome_id: "a", relay_ids: { run: "run-superseding" } }],
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Scenario 1 — clean running program
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋 완료했습니다.

- `closed` + 동일 outcome의 mapped `complete_with_evidence` sibling만 `SUPERSEDED_MARKED_RUN`으로 분류
- `adopt_relay_run` 후보 및 resume guard에서 제외
- 그 외 상태는 기존 blocking 동작 유지
- fixture 테스트·문서·lib purity 반영

검증:
- #1066 타깃 테스트 3개 통과
- relay-orca 전체 관련 테스트 통과
- 전체 게이트: 2783 통과, 기존 환경 의존 advisory/process-group 테스트 9건 실패

커밋: `e2afb1e`
```

## Dispatch Metadata

- Run: issue-1066-20260723130948814-370c9d73
- Executor: codex
- Branch: issue-1066