### PR TITLE
docs(relay-orca): align operator guidance with Orca 1.4.148

### DIFF
--- a/skills/relay-orca/references/gates-and-completion.md
+++ b/skills/relay-orca/references/gates-and-completion.md
@@ -192,9 +192,10 @@ absent owner record are never stolen — that contention still times out fail-cl
 no mtime-lease fallback: an old mtime is not evidence that the owner is gone.
 
 The completion instruction contains a concrete command in the authoritative shape, with
-`--from <fresh-assignee>`, `--to <current-coordinator>`, `--type worker_done`, `--task-id`,
-`--dispatch-id`, `--report-path`, `--phase integration_gate`, and `--json`. It does not use
-raw `--payload` JSON. If gate identity, coordinator/dispatch/report provenance, completion
+`--to <current-coordinator>`, `--type worker_done`, `--task-id`, `--dispatch-id`,
+`--report-path`, `--phase integration_gate`, and `--json`; `orca orchestration send` resolves
+and validates the sender from the invoking terminal, so `--from` is reserved for impersonation
+and omitted. It does not use raw `--payload` JSON. If gate identity, coordinator/dispatch/report provenance, completion
 delivery, or the terminal transition cannot be expressed by the installed contract, the
 coordinator reports the exact missing capability and stops. There is no `task-update`, reset,
 receipt-edit, or manual-dispatch-replay fallback.

--- a/skills/relay-orca/references/install-and-operate.md
+++ b/skills/relay-orca/references/install-and-operate.md
@@ -69,6 +69,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-orca/scripts/stop.js" \
 
 ## Orca version and capability policy
 
+- The command and payload shapes in this guide target the observed `ORCA_APP_VERSION=1.4.148`.
 - The targeted mid-2026 Orca CLI exposes **no version subcommand** (`orca version` →
   "Unknown command"; `orca --version` prints usage). Version is best-effort only and never
   blocks admission.
@@ -98,14 +99,38 @@ coordinator (a terminal session running relay-orca's CLI scripts)
   run manifests**; relay-orca never invokes any `orca worktree` subcommand.
 - Each operator terminal must already be running an agent CLI: `orca orchestration dispatch
   --inject` requires a **live recognized agent**, and a bare/self-created terminal cannot accept
-  an injection. Create one with `orca terminal create` and start the agent in it (empirically,
-  starting the agent via a `terminal send` command is more reliable than `--command` at create
-  time, which can race and exit).
+  an injection. Use the current two-step startup pattern, and wait for the TUI to be idle before
+  any dispatch or prompt delivery:
+
+  ```bash
+  orca terminal create --command "<agent-cli>" --json
+  orca terminal wait --terminal <handle> --for tui-idle --timeout-ms <n> --json
+  ```
+
+  The handle returned by `terminal create` is the handle passed to `terminal wait` and later
+  dispatches.
 - **Explicit `--operator-handle`s are required.** `run` and `resume` dispatch ONLY to handles you
   pass and **never self-create a terminal**. `run` with zero handles fails closed
   (`OPERATOR_DISPATCH_FAILED`, exit 44) before any mutation; `resume` fails closed
   (`RESUME_NO_OPERATOR_HANDLE`, exit 66) with zero mutation. A handle carries at most one active
   task. See [operator-dispatch.md](operator-dispatch.md).
+- Terminal handles are **routing metadata**, not lifecycle authority. An Orca app restart may
+  reissue every handle; a changed handle is normal. Re-resolve live handles with
+  `orca terminal list --json` and route subsequent sends to the new handle. Lifecycle authority
+  remains the payload `taskId` + `dispatchId`, verified against the dispatched pane. The
+  receipt-side, proof-based rebind design is tracked in [#1063](https://github.com/sungjunlee/dev-relay/issues/1063).
+
+## Wait discipline
+
+For Orca-side lifecycle signals, use the sanctioned wait primitive instead of a sleep or polling
+supervision loop:
+
+```bash
+orca orchestration check --wait --types worker_done,escalation,decision_gate --timeout-ms <n>
+```
+
+This waits for `worker_done`, escalations, and decision gates. Durable-truth signals such as relay
+manifests, PRs, and issues are outside Orca's check surface and still need their own watch.
 
 ## One active program per runtime (v0) and reset discipline
 
@@ -158,6 +183,13 @@ run on any path. Manual decision recovery: [recovery.md](recovery.md).
   defaults), resolved at relay dispatch time. It **never** appears in the accepted-program JSON or
   in the operator prompts: the program schema carries no execution engine field, and prompts
   source only an operator name and mode from `recommended_route`.
+- Before each ordinary relay run, read its routing contract and pin the executor/model with
+  `--executor` + `--model` (or `--model-hints dispatch=...`), the reviewer/model with
+  `--reviewer` + `--reviewer-model`, and the review assurance with `--review-assurance`. Do not
+  let policy defaults silently route the reviewer to the executor, self-select `hardened`
+  assurance, or leave the dispatch `route-plan` model null; CLI defaults can change between
+  pilots. The accepted program remains engine-agnostic, but the operator's relay invocation must
+  be explicit and auditable.
 - Because the operator contract is engine-independent, the same program runs across supported
   agent CLIs with no engine-specific skill branch. In the pilot, operator A ran `claude` and
   operator B ran `codex` under an **identical operator contract**; each drove a full ordinary
@@ -171,3 +203,11 @@ factory. It preserves relay's lifecycle truth (durable relay manifests, PRs, and
 evidence — `worker_done` is never completion authority) and adds no new orchestration service to
 operate. Program completion is proven only from live relay/GitHub/gate evidence, and several
 steps above still require a supervised operator in the loop. Treat every run accordingly.
+
+## Closeout hygiene
+
+After a program's outcomes are durably complete, the coordinator closes **only** operator
+terminals it created. For each such handle, verify that it is idle with `orca terminal read` or
+`orca terminal show`, then run `orca terminal close --terminal <handle>`. User-owned panes are
+never closed. Auto-closing inside `stop.js` remains a non-goal; its only mutation remains
+`orca orchestration run-stop`.

--- a/skills/relay-orca/references/operator-dispatch.md
+++ b/skills/relay-orca/references/operator-dispatch.md
@@ -35,6 +35,10 @@ appears in a prompt — engine selection is `relay-config`, resolved at relay di
 `integration_gate` and `advisory_review` prompts always contain the literal token `read-only`
 and never instruct file edits.
 
+Every operator prompt states the heartbeat cadence: send a heartbeat on phase change or after
+roughly 15 minutes of silence, not every few minutes; escalations, blockers, and the final
+`worker_done` remain immediate.
+
 ## Completion payload contract
 
 Every operator prompt embeds the completion payload contract — the operator returns ALL of:
@@ -107,15 +111,17 @@ a fresh instruction. That instruction includes one copy-paste command in the rea
 
 ```bash
 orca orchestration send \
-  --from <fresh-assignee> --to <current-coordinator> \
+  --to <current-coordinator> \
   --subject '<marker>' --body '<completion text>' \
   --type worker_done --task-id <task-id> --dispatch-id <dispatch-id> \
   --report-path <deterministic-report> --phase integration_gate --json
 ```
 
-The operator runs it exactly once from the current dispatched pane. The coordinator then
-re-reads `task-list` and accepts completion only when that task is `completed`. The command
-never uses raw `--payload` JSON. A stale runtime/coordinator/task/dispatch/assignee/report,
+The operator runs it exactly once from the current dispatched pane. `orca orchestration send`
+auto-resolves the sender from the invoking terminal and validates that pane; `--from` is reserved
+for deliberate impersonation and is omitted here. The coordinator then re-reads `task-list` and
+accepts completion only when that task is `completed`. The command never uses raw `--payload` JSON.
+A stale runtime/coordinator/task/dispatch/assignee/report,
 unavailable gate identity, completion-delivery gap, or missing terminal transition fails closed
 with the exact capability gap. No `task-update`, reset, receipt edit, or manual dispatch replay
 is a repair path. Redispatch and restart regenerate every provenance field and the completion

--- a/skills/relay-orca/scripts/lib/integration-lifecycle.js
+++ b/skills/relay-orca/scripts/lib/integration-lifecycle.js
@@ -387,7 +387,7 @@ function completionCommand(ctx) {
   const body = `Canonical integration gate passed for ${marker}. Send this command exactly once from the current dispatched pane.`;
   const argv = [
     "orchestration", "send", "--to", ctx.coordinatorHandle, "--subject", subject,
-    "--from", ctx.assignee, "--body", body, "--type", "worker_done",
+    "--body", body, "--type", "worker_done",
     "--task-id", ctx.taskId, "--dispatch-id", ctx.dispatchId, "--report-path", ctx.reportPath,
     "--phase", "integration_gate", "--json",
   ];

--- a/skills/relay-orca/scripts/lib/operator-prompt.js
+++ b/skills/relay-orca/scripts/lib/operator-prompt.js
@@ -31,6 +31,8 @@ const RECONCILIATION_SENTENCE =
   "Live reconciliation is still required; this payload is not completion evidence.";
 const LIFECYCLE_NOTE =
   "Orca worker_done and task status are lifecycle signals, never completion authority.";
+const HEARTBEAT_NOTE =
+  "Heartbeat cadence: send a heartbeat on phase change or after roughly 15 minutes of silence, not every few minutes; escalations, blockers, and the final worker_done remain immediate.";
 const OWNERSHIP_NOTE =
   "The coordinator and Orca terminals never edit implementation code directly; relay owns every implementation worktree and durable run manifest.";
 const READ_ONLY_MARKER = "read-only";
@@ -43,6 +45,7 @@ function payloadContractBlock() {
   return [
     "Completion payload contract (return ALL fields):",
     ...PAYLOAD_FIELDS.map((field) => `  - ${field}`),
+    HEARTBEAT_NOTE,
     RECONCILIATION_SENTENCE,
     LIFECYCLE_NOTE,
   ].join("\n");
@@ -152,6 +155,7 @@ module.exports = {
   PAYLOAD_FIELDS,
   RECONCILIATION_SENTENCE,
   LIFECYCLE_NOTE,
+  HEARTBEAT_NOTE,
   OWNERSHIP_NOTE,
   READ_ONLY_MARKER,
   NO_EDIT_CLAUSE,

--- a/tests/relay-orca/fixtures/fake-orca-integration-lifecycle.js
+++ b/tests/relay-orca/fixtures/fake-orca-integration-lifecycle.js
@@ -150,7 +150,7 @@ if (args[0] === "orchestration" && args[1] === "send") {
   if (type === "worker_done") {
     const taskId = value("--task-id");
     const dispatch = state.dispatch[taskId] || {};
-    if (value("--from") !== dispatch.assignee || value("--to") !== state.coordinator) emit({ ok: false, error: "worker_done provenance rejected" }, 3);
+    if (has("--from") || value("--to") !== state.coordinator) emit({ ok: false, error: "worker_done sender must auto-resolve from the invoking terminal" }, 3);
     if (value("--dispatch-id") !== dispatch.dispatch_id) emit({ ok: false, error: "worker_done dispatch rejected" }, 3);
     const task = taskFor(state, taskId);
     if (task) { task.status = state.taskListAfterWorkerDone; task.worker_done = true; }

--- a/tests/relay-orca/scripts/integration-lifecycle.test.js
+++ b/tests/relay-orca/scripts/integration-lifecycle.test.js
@@ -387,14 +387,15 @@ test("#1019 stale coordinator, dispatch, assignee, and report provenance fail cl
   }
 });
 
-test("#1019 completion command is explicit and never raw-payload shaped", () => {
+test("#1019 completion command auto-resolves the sender and is never raw-payload shaped", () => {
   const report = reportFile();
   try {
     const command = completionCommand(context({ dir: "locks" }, report.reportPath));
     assert.deepEqual(command.argv.slice(0, 2), ["orchestration", "send"]);
-    ["--from", ASSIGNEE, "--to", COORDINATOR, "--type", "worker_done", "--task-id", TASK_ID, "--dispatch-id", DISPATCH_ID, "--report-path", report.reportPath, "--phase", "integration_gate", "--json"].forEach((token) => assert.ok(command.argv.includes(token), token));
+    ["--to", COORDINATOR, "--type", "worker_done", "--task-id", TASK_ID, "--dispatch-id", DISPATCH_ID, "--report-path", report.reportPath, "--phase", "integration_gate", "--json"].forEach((token) => assert.ok(command.argv.includes(token), token));
+    assert.equal(command.argv.includes("--from"), false, "sender must auto-resolve from the invoking terminal");
     assert.equal(command.argv.includes("--payload"), false);
-    assert.match(command.copy_paste, /--from/);
+    assert.doesNotMatch(command.copy_paste, /--from/);
     assert.match(command.copy_paste, /--to/);
     assert.match(command.copy_paste, /--report-path/);
   } finally {

--- a/tests/relay-orca/scripts/resume.test.js
+++ b/tests/relay-orca/scripts/resume.test.js
@@ -1822,7 +1822,7 @@ test("#1008 mapping intake enables complete_with_evidence on the next status rec
 // --- #1019 R2: resume surfaces the copy-paste worker_done command while awaiting completion ---
 
 test("#1019 integrationBlockingEntry surfaces the full copy-paste worker_done command while awaiting completion", () => {
-  const copyPaste = "orca orchestration send --to coord-current --subject 'worker_done: relay-orca: seg/out' --from term-fresh --body 'send once' --type worker_done --task-id task_x --dispatch-id disp_x --report-path /runs/out.json --phase integration_gate --json";
+  const copyPaste = "orca orchestration send --to coord-current --subject 'worker_done: relay-orca: seg/out' --body 'send once' --type worker_done --task-id task_x --dispatch-id disp_x --report-path /runs/out.json --phase integration_gate --json";
   const entry = integrationBlockingEntry({
     ok: false,
     state: "awaiting_worker_done",

--- a/tests/relay-orca/scripts/run.test.js
+++ b/tests/relay-orca/scripts/run.test.js
@@ -22,6 +22,7 @@ const {
   PAYLOAD_FIELDS,
   RECONCILIATION_SENTENCE,
   LIFECYCLE_NOTE,
+  HEARTBEAT_NOTE,
   READ_ONLY_MARKER,
   NO_EDIT_CLAUSE,
 } = require(path.join(SCRIPTS, "lib", "operator-prompt.js"));
@@ -786,6 +787,7 @@ test("D11.10: operator prompts carry the pinned literals and never name an engin
     PAYLOAD_FIELDS.forEach((field) => assert.ok(prompt.includes(field), `${task.kind} prompt missing payload field ${field}`));
     assert.ok(prompt.includes(RECONCILIATION_SENTENCE), `${task.kind} prompt missing reconciliation sentence`);
     assert.ok(prompt.includes(LIFECYCLE_NOTE), `${task.kind} prompt missing lifecycle note`);
+    assert.ok(prompt.includes(HEARTBEAT_NOTE), `${task.kind} prompt missing heartbeat cadence`);
     // No executor/reviewer engine or model name anywhere.
     const lowered = prompt.toLowerCase();
     FORBIDDEN_ENGINE_TOKENS.forEach((token) =>


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋 완료했습니다.

- Orca 1.4.148 기준 startup/rebind/wait/closeout 지침 정렬
- completion command에서 `--from` 제거
- heartbeat cadence를 operator prompt에 추가
- 관련 문서·fixture·테스트 동기화
- 타깃 테스트: 386/386 통과
- 전체 직렬 게이트: 2,796개 중 2,784 통과, 기존 advisory/process-group 관련 10건 실패

커밋: `c31c35e`  
워크트리는 clean 상태입니다.
```

## Dispatch Metadata

- Run: issue-1064-20260723151013269-cebbeba2
- Executor: codex
- Branch: issue-1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 완료 보고 전송 시 발신자 정보를 명시하지 않아 호출 터미널 기준으로 안전하게 확인되도록 변경했습니다.
  * 완료 보고가 대상 코디네이터와 작업 정보에 정확히 연결되도록 검증을 강화했습니다.
  * 오퍼레이터 안내에 상태 변화 또는 장시간 유휴 시 하트비트 전송 규칙을 추가했습니다.

* **문서**
  * 터미널 준비, 상태 대기, 라우팅 설정 및 종료 절차를 더욱 구체적으로 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->