### PR TITLE
chore: freeze/supersede relay-orca

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Orchestrator-agnostic relay system for plan → dispatch → review workflows with explicit merge. Any supported agent can serve as orchestrator, worker, or reviewer — roles are bound per-run via the relay manifest, not hardcoded.
 
+> ⛔ **`relay-orca` is FROZEN / SUPERSEDED as of 2026-07-24.** Do not use, invoke, or extend it. It was a learning spike (program-altitude coordinator, epic #941) retired in favor of a lighter *decompose-deep/execute-flat* successor still in design. See [skills/relay-orca/SUPERSEDED.md](skills/relay-orca/SUPERSEDED.md) and [skills/SUPERSEDED.md](skills/SUPERSEDED.md). The active relay skillset is unaffected.
+
 ## Architecture
 
 Relay runs are stateful, manifest-backed lifecycle contracts stored in `~/.relay/runs/<repo-slug>/<run-id>.md`. Each manifest records immutable role bindings (`roles.orchestrator`, `roles.executor`, `roles.reviewer`), policy fields, and review anchors. Review-time overrides are tracked separately under `review.last_reviewer` and review events rather than mutating those bindings. The state machine governs all transitions:

--- a/references/operator-surface.md
+++ b/references/operator-surface.md
@@ -9,7 +9,7 @@ dev-relay is a bundle-installed relay runtime exposed through thin skill command
 | Public operator surface | `relay-config`, `relay`, `relay-merge` | Normal day-to-day commands. These should read as stable product entrypoints and hide most phase internals. |
 | Internal phase surface | `relay-ready`, `relay-plan`, `relay-dispatch`, `relay-review` | Direct controls for advanced operation, debugging, recovery, and explicit manual phase work. They stay callable, but they are not the primary product surface. |
 | Optional/advanced surface | `relay-fleet` | Specialized fan-out for already-planned independent leaves. It should point to narrow references rather than expanding the core command surface. |
-| Optional/advanced surface | `relay-orca` | EXPERIMENTAL, opt-in, explicit-only program-altitude coordinator over relay/relay-fleet operators. Not part of ordinary relay use and never implicitly invoked; keep it thin and reference-heavy. |
+| Superseded / frozen | `relay-orca` | ⛔ FROZEN 2026-07-24, do not use or invoke. Retired learning-spike program-altitude coordinator; superseded by a decompose-deep/execute-flat successor (in design). Tombstone: [../skills/relay-orca/SUPERSEDED.md](../skills/relay-orca/SUPERSEDED.md); index: [../skills/SUPERSEDED.md](../skills/SUPERSEDED.md). |
 
 ## Placement Rules
 

--- a/skills/SUPERSEDED.md
+++ b/skills/SUPERSEDED.md
@@ -1,0 +1,11 @@
+# Superseded / frozen skills
+
+Skills listed here are **frozen**: kept in the tree for reference but no longer maintained,
+not to be invoked, and not to be extended. New work must not build on them.
+
+| Skill | Frozen | Superseded by | Tombstone |
+| --- | --- | --- | --- |
+| `relay-orca` | 2026-07-24 | decompose-deep/execute-flat successor (in design) | [relay-orca/SUPERSEDED.md](relay-orca/SUPERSEDED.md) |
+
+The active relay skillset (`relay`, `relay-ready`, `relay-plan`, `relay-dispatch`, `relay-review`,
+`relay-merge`, `relay-fleet`, `relay-config`) is unaffected.

--- a/skills/relay-orca/SKILL.md
+++ b/skills/relay-orca/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: relay-orca
-description: EXPERIMENTAL, explicit-only program-altitude coordinator. On explicit operator request, compile an already-accepted program/epic contract into bounded, read-only Orca wave plans supervising relay and relay-fleet operators. NOT for ordinary relay, relay-fleet, delegation, implementation, or planning requests.
+description: SUPERSEDED — FROZEN 2026-07-24, DO NOT USE OR INVOKE (see SUPERSEDED.md). Learning-spike program-altitude coordinator; retired in favor of a lighter decompose-deep/execute-flat successor. Not maintained; kept only as a reference tombstone.
 compatibility: Requires Node.js 18+. Runtime modes (run/status/resume/stop) additionally require the experimental Orca orchestration surface and are gated on the capability probe.
 argument-hint: plan --program-file <accepted-program.json>
 metadata:
@@ -19,7 +19,7 @@ metadata:
 
 # relay-orca
 
-> EXPERIMENTAL and opt-in. relay-orca is a supervised program controller pilot, not an autonomous software factory, and not an implicit dependency of ordinary relay use. See [references/experimental-status.md](references/experimental-status.md) and the opt-in install + operator guide [references/install-and-operate.md](references/install-and-operate.md).
+> ⛔ **SUPERSEDED — FROZEN 2026-07-24. DO NOT USE.** relay-orca was a learning spike that proved what program-altitude orchestration costs; it is retired in favor of a lighter decompose-deep/execute-flat successor. It is no longer maintained and must not be invoked. Rationale, salvaged principles, and successor pointer: [SUPERSEDED.md](SUPERSEDED.md). Everything below is preserved as-is for reference only.
 
 ## Use when
 

--- a/skills/relay-orca/SUPERSEDED.md
+++ b/skills/relay-orca/SUPERSEDED.md
@@ -1,0 +1,49 @@
+# relay-orca — SUPERSEDED / FROZEN
+
+**Status:** frozen 2026-07-24. Not maintained. Do not use, invoke, or extend.
+**Why kept:** reference tombstone. The code and tests still pass and are left in place so the
+principles it proved (and the machinery it disproved) stay readable. New work goes to the
+successor, not here.
+
+## What it was
+
+An experimental, explicit-only **program-altitude coordinator**: it compiled an already-accepted
+epic/program contract into bounded Orca "waves" that supervised ordinary `relay` / `relay-fleet`
+operators, with integration gates and evidence-backed completion. Milestone #12, epic #941.
+
+## Why it was retired
+
+It worked, but it was the wrong shape for where this project is going:
+
+- **Heavy for its added value.** ~10k lines of JS + 345 tests — comparable to `relay-review`, 3× `relay-fleet` — to add three things over `relay-fleet`: cross-wave persistent supervision, integration gates, and a human-intervention message channel.
+- **Single-layer by design; the opposite of the goal.** The contract explicitly forbids nested relay-orca and raw-intent decomposition (epic #941 invariants). The direction this project actually wants is *deep decomposition* — which relay-orca structurally cannot do.
+- **Coupled supervision to orchestration.** That coupling is what made it heavy: a runtime-session-bound receipt, a coordinator-provenance contract, a live supervision loop.
+- **Only just reached end-to-end against the real CLI.** The 2026-07-22 closure re-pilot never declared completion reset-free (two Orca app restarts stranded the receipt — #1063), and the #1019 gate lifecycle did not run against real Orca until #1067. Both were fixed 2026-07-23, and that clean-close is exactly why it can be frozen now rather than left ambiguous.
+
+## Principles it PROVED — carry these into the successor (non-negotiable)
+
+1. **Evidence over signals.** Never trust `worker_done` / task status; declare completion only from durable truth (relay manifests, merged PRs, closed issues). This is what survived two runtime restarts.
+2. **Frozen anchors are the review contract.** An immutable Done-Criteria anchor per unit of work is what let reviews converge instead of drift.
+3. **Fail closed on ambiguity.** When state is unclear, stop — never advance.
+4. **Audited state transitions.** Every state change carries a reason; no silent edits.
+
+## Machinery it DISPROVED — do NOT reuse
+
+- A bespoke supervised control plane that reimplements orchestration on top of a runtime.
+- Binding durable identity to a runtime/session id (see #1063).
+- A one-layer supervision ceiling with nesting forbidden.
+- A coordinator-provenance contract inferred from CLI payloads (see #1067).
+
+## Successor direction (see project CLAUDE.md / memory)
+
+**Decompose deep, execute flat.** A cheap decomposition tree with no per-node lifecycle; ordinary
+`relay` runs only at the leaves; parents are a recursive *evidence fold* ("done = all children
+done-with-durable-evidence"), not a state machine. No new runtime, no session coupling. The human
+(or a thin planning pass) stays the decomposer for now; raw-intent autonomous decomposition is
+deferred. Successor skill: to be created.
+
+## Shipped history (for archaeology)
+
+Children #942–#948 shipped; closure arc #1016/#1018/#1019/#1020/#1021; Batch-5 re-pilot verdict
+ITERATE (epic #941 closed 2026-07-23); iteration set #1063/#1064/#1066/#1067 merged. Full journal:
+`~/.relay/closure-941-20260722/pilot-journal.md`.

--- a/tests/relay-orca/scripts/plan.test.js
+++ b/tests/relay-orca/scripts/plan.test.js
@@ -261,12 +261,14 @@ test("D5: agents/openai.yaml disables implicit invocation", () => {
   assert.match(yaml, /allow_implicit_invocation:\s*false/, "relay-orca must be explicit-only from the OpenAI agent surface");
 });
 
-test("D5: SKILL.md routing text is explicit-only and disclaims ordinary relay triggers", () => {
+test("D5: SKILL.md is FROZEN and warns against use/invocation (supersedes the old explicit-only disclaimer)", () => {
   const skill = fs.readFileSync(path.join(SKILL_DIR, "SKILL.md"), "utf-8");
   const front = skill.split(/\n---\n/)[0];
-  assert.match(front, /explicit-only/i, "description must declare explicit-only routing");
-  assert.match(front, /NOT for ordinary relay, relay-fleet, delegation, implementation, or planning/i);
-  // keywords must be relay-orca-specific, never bare generic triggers.
+  // relay-orca is superseded/frozen (2026-07-24). A do-not-invoke description is a strictly
+  // stronger guard against auto-triggering on ordinary relay work than the old explicit-only prose.
+  assert.match(front, /SUPERSEDED|FROZEN/i, "frozen skill description must mark it superseded/frozen");
+  assert.match(front, /DO NOT USE|DO NOT INVOKE/i, "frozen skill description must warn against use/invocation");
+  // keywords must still be relay-orca-specific, never bare generic triggers.
   const keywords = (front.match(/keywords:\s*(.*)/) || [])[1] || "";
   for (const bare of ["dispatch", "implement", "delegate", "review"]) {
     assert.ok(!keywords.split(/[\s,]+/).includes(bare), `keyword "${bare}" would auto-trigger on ordinary requests`);

--- a/tests/skills-lint/scripts/skills-lint.test.js
+++ b/tests/skills-lint/scripts/skills-lint.test.js
@@ -26,6 +26,7 @@ const SURFACE_TIERS = {
   "public operator surface": ["relay-config", "relay", "relay-merge"],
   "internal phase surface": ["relay-ready", "relay-plan", "relay-dispatch", "relay-review"],
   "optional/advanced surface": ["relay-fleet"],
+  "superseded / frozen": ["relay-orca"],
 };
 
 function splitLines(text) {


### PR DESCRIPTION
Marks `relay-orca` unmistakably **FROZEN / SUPERSEDED** (2026-07-24) without churning code paths.

## Why
relay-orca was a learning spike — a program-altitude coordinator (epic #941) that proved what that costs. It is retired in favor of a lighter *decompose-deep/execute-flat* successor (in design): a cheap decomposition tree with no per-node lifecycle, ordinary `relay` runs only at the leaves, and parents as a recursive evidence fold. Rationale in [skills/relay-orca/SUPERSEDED.md](../blob/chore/freeze-relay-orca/skills/relay-orca/SUPERSEDED.md).

## What this does (visible freeze, no code churn)
- **SKILL.md**: frontmatter `description` + top banner now read `SUPERSEDED — FROZEN, DO NOT USE OR INVOKE`.
- **skills/relay-orca/SUPERSEDED.md**: tombstone — why retired, the 4 principles to carry into the successor, the machinery not to reuse, successor pointer.
- **skills/SUPERSEDED.md**: skills-root index, visible in `ls skills/`.
- **references/operator-surface.md**: new `Superseded / frozen` tier; skills-lint learns the tier and still classifies every installed skill exactly once.
- **plan.test.js D5**: now asserts the frozen do-not-invoke posture (a strictly stronger guard against auto-triggering than the old explicit-only disclaimer).
- **CLAUDE.md**: frozen banner so future sessions see it immediately.

## What this does NOT do
- No file is deleted; the directory is **not** relocated (that would break test requires + 16 path refs and force a full re-gate on a retired skill). Code and tests stay in place and still pass.
- The active relay skillset (`relay`, `relay-ready`, `relay-plan`, `relay-dispatch`, `relay-review`, `relay-merge`, `relay-fleet`, `relay-config`) is untouched.

Local: skills-lint + relay-plan (160/160), relay-orca (353/353), plan.test.js (32/32). CI runs the full serialized suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * `relay-orca`가 2026-07-24 기준 동결·대체된 기능임을 명확히 안내합니다.
  * 해당 기능의 사용·호출·확장을 금지하고, 후속 설계 및 관련 참고 문서로 안내합니다.
  * 현재 활성 릴레이 스킬셋에는 영향이 없음을 명시했습니다.

* **테스트**
  * 동결 상태와 사용 금지 안내가 올바르게 표시되는지 검증을 강화했습니다.
  * 운영자 표면 분류에 ‘대체됨/동결됨’ 상태를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->