### PR TITLE
feat(braid): v0 decompose-deep/execute-flat successor to relay-orca

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
             tests/relay-config/scripts/*.test.js
             tests/relay-fleet/scripts/*.test.js
             tests/relay-orca/scripts/*.test.js
+            tests/braid/scripts/*.test.js
             tests/skills-lint/scripts/*.test.js
           )
           count=${#files[@]}
@@ -47,4 +48,5 @@ jobs:
           tests/relay-config/scripts/*.test.js
           tests/relay-fleet/scripts/*.test.js
           tests/relay-orca/scripts/*.test.js
+          tests/braid/scripts/*.test.js
           tests/skills-lint/scripts/*.test.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ node skills/relay-merge/scripts/finalize-run.js --run-id <id> --merge-method squ
 node skills/relay-merge/scripts/finalize-run.js --run-id <id> --force-finalize-nonready --reason "..." --json
 
 # Final gate for broad changes (serialize; fleet condition waits can flake under parallel file execution)
-node --test --test-concurrency=1 tests/relay-ready/scripts/*.test.js tests/relay-plan/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay/scripts/*.test.js tests/relay-config/scripts/*.test.js tests/relay-fleet/scripts/*.test.js tests/relay-orca/scripts/*.test.js tests/skills-lint/scripts/*.test.js
+node --test --test-concurrency=1 tests/relay-ready/scripts/*.test.js tests/relay-plan/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay/scripts/*.test.js tests/relay-config/scripts/*.test.js tests/relay-fleet/scripts/*.test.js tests/relay-orca/scripts/*.test.js tests/braid/scripts/*.test.js tests/skills-lint/scripts/*.test.js
 ```
 
 ## Key Design Decisions

--- a/references/operator-surface.md
+++ b/references/operator-surface.md
@@ -9,6 +9,7 @@ dev-relay is a bundle-installed relay runtime exposed through thin skill command
 | Public operator surface | `relay-config`, `relay`, `relay-merge` | Normal day-to-day commands. These should read as stable product entrypoints and hide most phase internals. |
 | Internal phase surface | `relay-ready`, `relay-plan`, `relay-dispatch`, `relay-review` | Direct controls for advanced operation, debugging, recovery, and explicit manual phase work. They stay callable, but they are not the primary product surface. |
 | Optional/advanced surface | `relay-fleet` | Specialized fan-out for already-planned independent leaves. It should point to narrow references rather than expanding the core command surface. |
+| Optional/advanced surface | `braid` | v0 experimental, read-only. Decompose one goal into a cheap tree of relay-able leaves and fold relay's durable evidence back up; leaves are driven by ordinary relay. A sibling to the relay skillset (not a relay-* skill), successor to the frozen `relay-orca`. Keep it thin and reference-heavy. |
 | Superseded / frozen | `relay-orca` | ⛔ FROZEN 2026-07-24, do not use or invoke. Retired learning-spike program-altitude coordinator; superseded by a decompose-deep/execute-flat successor (in design). Tombstone: [../skills/relay-orca/SUPERSEDED.md](../skills/relay-orca/SUPERSEDED.md); index: [../skills/SUPERSEDED.md](../skills/SUPERSEDED.md). |
 
 ## Placement Rules

--- a/skills/braid/SKILL.md
+++ b/skills/braid/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # braid
 
-> **v0 — experimental, read-only.** braid decomposes work deep and executes it flat. It does **not** dispatch, supervise, or couple to any runtime; ordinary `relay` runs do the work at the leaves and braid folds their durable evidence back up. Design and rationale: [references/design.md](references/design.md).
+> **v0 — experimental, read-only.** braid decomposes work deep and executes it flat. It does **not** dispatch, supervise, or couple to any runtime; ordinary `relay` runs do the work at the leaves and braid folds their durable evidence back up. Resuming braid in a new session? Start with [references/roadmap.md](references/roadmap.md); full rationale in [references/design.md](references/design.md).
 
 ## The idea
 

--- a/skills/braid/SKILL.md
+++ b/skills/braid/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: braid
+description: Decompose one accepted goal into a cheap tree of relay-able leaves, then fold relay's durable evidence back up — a node is done only when every child is done-with-evidence. v0 is read-only (validate/status); leaves are driven by ordinary relay.
+compatibility: Requires Node.js 18+. Reads relay run manifests under ${RELAY_HOME:-~/.relay}/runs/. No Orca, no new runtime.
+argument-hint: status --plan <braid-plan.json> --repo-slug <slug>
+metadata:
+  related-skills: relay, relay-dispatch, relay-review, relay-merge, relay-fleet
+  keywords: braid, decompose, decomposition tree, evidence fold, work breakdown, leaves, deep tree
+---
+
+## Inputs
+- Files: a human-authored **braid plan** (JSON) describing a decomposition tree. Schema: [references/plan-format.md](references/plan-format.md).
+- Env: `RELAY_HOME` (defaults to `~/.relay`) locates relay run manifests; `--repo-slug` (or `BRAID_REPO_SLUG`) selects the repo's runs directory.
+- Script: `${RELAY_SKILL_ROOT:-skills}/braid/scripts/braid.js` (the only I/O boundary; the `lib/` fold and plan modules are pure).
+
+# braid
+
+> **v0 — experimental, read-only.** braid decomposes work deep and executes it flat. It does **not** dispatch, supervise, or couple to any runtime; ordinary `relay` runs do the work at the leaves and braid folds their durable evidence back up. Design and rationale: [references/design.md](references/design.md).
+
+## The idea
+
+**Decompose deep, execute flat.** One accepted goal becomes a *cheap* tree: internal nodes are pure structure with no lifecycle, and every leaf is one relay-able unit. A leaf is `done` only when its relay run reached durable truth (merged PR + closed issue) — never from a `worker_done` signal. A parent is `done` only when **every** child is `done`. That "done = fold of children's durable evidence" is braid's whole thesis; it is a recursive fold, not a state machine.
+
+## Use when
+
+- You have one accepted goal that is too big for a single `relay` run and naturally splits into a tree of smaller relay-able pieces, and you want to track roll-up completion and see what is ready to work next.
+
+## Do not use when
+
+- One tracker-backed outcome fits a single run — use `relay`.
+- A flat set of already-planned independent leaves — use `relay-fleet`.
+- You want autonomous raw-intent decomposition — **not in v0**; you (or a planning pass) author the tree.
+
+## Intents (v0)
+
+| Intent | I/O | Purpose |
+| --- | --- | --- |
+| `validate` | read-only | Check a braid plan's tree shape, unique ids, and acyclic `depends_on`. |
+| `status` | read-only | Fold relay manifests over the tree: per-node status, whether the whole tree is complete, and which leaves are ready to dispatch next. |
+
+braid v0 performs **no** mutation: no dispatch, no manifest/receipt write, no Orca, no `gh` write.
+
+## Commands
+
+```bash
+# validate a decomposition tree
+node "${RELAY_SKILL_ROOT:-skills}/braid/scripts/braid.js" validate --plan /tmp/goal.braid.json
+
+# fold relay's durable evidence over the tree (read-only)
+node "${RELAY_SKILL_ROOT:-skills}/braid/scripts/braid.js" status --plan /tmp/goal.braid.json --repo-slug <repo-slug> --json
+```
+
+## How leaves get done
+
+braid never dispatches. For each leaf that `status` reports `ready`, drive it through ordinary `relay` (readiness → plan → dispatch → review → merge). Once merged, record the run id in the leaf's `run_id` so the next `status` folds it as `done`. When the root folds to `done`, the goal is complete on durable evidence.
+
+## Status meanings
+
+- `not_started` — no relay run mapped yet (leaf), or all children untouched (internal).
+- `running` — a relay run is in flight, or children are mixed.
+- `done` — leaf reached merged + closed; internal node has every child `done`.
+- `blocked` — fail-closed: a leaf's relay run went terminal without merged+closed (abandoned/superseded), or any descendant is blocked. Needs a human.
+
+## v0 boundaries (deliberately deferred)
+
+No autonomous decomposition, no live coordinator loop, no runtime coupling, no depth-triggered gates. These come only after the base-case heuristic and the fold are proven. See [references/design.md](references/design.md).

--- a/skills/braid/references/design.md
+++ b/skills/braid/references/design.md
@@ -1,0 +1,66 @@
+# braid — design and rationale
+
+braid is the successor to the frozen `relay-orca` ([../../relay-orca/SUPERSEDED.md](../../relay-orca/SUPERSEDED.md)).
+It keeps the principles relay-orca proved and drops the machinery it disproved.
+
+## Thesis: decompose deep, execute flat
+
+The goal is a lightweight way to take one accepted piece of work and split it recursively into a
+tree of smaller pieces, do the small pieces, and reassemble — without losing control the way a
+deep supervised control plane does.
+
+The insight from relay-orca: **supervision and orchestration should not be one thing.** relay-orca
+coupled them and got heavy (~10k LOC, a runtime-bound receipt, a coordinator-provenance contract,
+a one-layer ceiling). braid separates them:
+
+- **Decomposition is deep and cheap.** Internal tree nodes are pure structure — no lifecycle, no
+  manifest, no runtime state. Just "this work = these sub-works".
+- **Execution accountability is flat.** Ordinary `relay` runs, already trustworthy and
+  evidence-gated, do the work at the **leaves** and nowhere else.
+- **Aggregation is a fold, not a state machine.** A parent is `done` iff every child is
+  `done-with-durable-evidence`. `braid status` reads relay manifests and folds — it never runs a
+  live coordinator loop and never couples to a session/runtime id.
+
+Good human orgs work this way: plan deep, keep execution accountability flat.
+
+## Principles carried from relay-orca (non-negotiable)
+
+1. **Evidence over signals** — `done` comes only from durable truth (merged PR + closed issue),
+   never from `worker_done` or task status.
+2. **Fail closed on ambiguity** — a leaf that went terminal without merged+closed is `blocked`,
+   and `blocked` dominates a parent's fold; nothing advances on unclear state.
+3. **Frozen anchors** — each leaf is an ordinary relay run with its own frozen Done Criteria; braid
+   adds no second review contract.
+4. **No runtime coupling** — durable state lives in relay manifests + git, not in any braid- or
+   session-owned lifecycle.
+
+## What v0 proves (and only this)
+
+- **The fold is reliable from durable evidence alone.** Verified against real merged runs: braid
+  folded the actual #1063/#1067/#1066 iteration tree to `complete` purely from relay manifests.
+- **Dependency ordering is pure data.** `ready` leaves fall out of the same fold, no live loop.
+- **The base case is human-marked.** You declare a leaf when it is small enough for one relay run;
+  v0 exists partly to exercise that judgment before any heuristic automates it.
+
+## v0 acceptance: `state: merged` is trusted as the merge+close record
+
+braid's headline is "done only on merged PR + closed issue." In v0 the CLI reads that from the
+relay manifest's `state` field alone: it trusts `state: merged` to mean both, because relay's
+finalize-run sets `merged` only after a squash-merge whose `Fixes #N` closes the issue. This is a
+**deliberate v0 acceptance**, not an oversight — its consequence is that the fold's
+"merged PR but the issue is somehow still open → `blocked`" branch is unreachable through the
+default path (only a `closed`/abandoned run reaches `blocked` end-to-end). The branch stays in the
+code, unit-tested, and becomes reachable the moment live issue re-verification is wired: the
+`durableFacts(manifest, overrides)` seam accepts a live `gh issue view` result as `issue_closed`.
+Given this repo's own history of merged-PR-but-open-issue cases, wiring that live check is the
+first thing a v1 should add.
+
+## Deliberately deferred (until the fold + base-case earn it)
+
+- Autonomous raw-intent decomposition (the human/planning pass owns the tree in v0).
+- Any live coordinator loop or dispatch from braid itself (leaves are driven by ordinary relay).
+- Depth-triggered integration gates and cross-tree wave materialization.
+- Auto-mapping a leaf to its relay run (v0 uses an explicit `run_id`).
+
+If braid ever grows past a few hundred lines of real logic for these, that is the signal to stop
+and reconsider — lightness is the whole point.

--- a/skills/braid/references/plan-format.md
+++ b/skills/braid/references/plan-format.md
@@ -1,0 +1,48 @@
+# braid plan format (v0)
+
+A braid plan is a human-authored JSON decomposition tree. v0 has no autonomous decomposition —
+you (or a thin planning pass) write the tree; braid validates it and folds relay's evidence over it.
+
+## Shape
+
+```jsonc
+{
+  "braid": {
+    "id": "some-goal",              // REQUIRED — stable program id
+    "root": {                        // REQUIRED — the root node
+      "id": "root",                  // REQUIRED — unique, non-empty
+      "children": [                  // internal node: non-empty children, NO `leaf`
+        {
+          "id": "leaf-a",
+          "leaf": { "issue": 1063, "run_id": "issue-1063-..." }   // leaf: has `leaf`, NO children
+        },
+        {
+          "id": "wave-2",
+          "depends_on": ["leaf-a"],  // optional — ids that must be `done` first
+          "children": [
+            { "id": "leaf-b", "leaf": { "task": "free-text task when there is no issue yet" } }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+The root may be `{ "braid": {...} }` or the bare plan object.
+
+## Rules
+
+- A node is a **leaf** iff it has `leaf` and no `children`; **internal** iff it has a non-empty
+  `children` array and no `leaf`. A node that is both, or neither, is rejected.
+- `leaf` must carry an integer `issue` **or** a non-empty `task`. Optional `run_id` maps the leaf
+  to its relay run manifest; without a `run_id` the leaf reads as `not_started`.
+- `id`s are unique across the whole tree.
+- `depends_on` lists ids that must be `done` before this node (and its leaves) become `ready`.
+  Unknown references, self-references, and cycles are rejected.
+
+## The base case (v0)
+
+You mark the base case by hand: a node is a leaf when it is small enough to be **one** relay run.
+Getting that judgment right is the thing v0 exists to exercise — see [design.md](design.md). Later
+versions may suggest a base-case heuristic, but braid will never split below a leaf you declared.

--- a/skills/braid/references/roadmap.md
+++ b/skills/braid/references/roadmap.md
@@ -1,0 +1,79 @@
+# braid — status and roadmap (start here for a new session)
+
+This is the pick-up doc. If you are resuming braid in a fresh session, read this first, then
+[design.md](design.md) for the full rationale and [plan-format.md](plan-format.md) for the input
+shape. braid is the successor to the frozen `relay-orca` ([../../relay-orca/SUPERSEDED.md](../../relay-orca/SUPERSEDED.md)).
+
+## Where braid is (v0, shipped)
+
+- **Thesis:** decompose deep, execute flat. A cheap decomposition tree (internal nodes are pure
+  structure, no lifecycle); ordinary `relay` runs only at the leaves; a parent is `done` only when
+  every child is done-with-durable-evidence. That recursive **evidence fold** is the whole product.
+- **Shipped surface (read-only):** `validate` and `status`. No dispatch, no supervision, no runtime
+  coupling. Leaves are driven by ordinary `relay`.
+- **Code:** `scripts/lib/fold.js` (~100 lines, the heart), `scripts/lib/plan.js` (tree validator),
+  `scripts/lib/manifest.js` (tiny relay-manifest reader), `scripts/braid.js` (the only I/O boundary).
+  The `lib/` modules are pure; all I/O is in the CLI.
+- **Tests:** `tests/braid/scripts/{fold,plan,manifest}.test.js` (42 tests). Independent code review
+  verified the fold/dependency/validator logic correct.
+- **Live-verified:** braid folded the real merged #1063/#1067/#1066 iteration tree to `COMPLETE`
+  purely from relay manifests, and surfaced `ready` leaves + dep-gating on a partial tree.
+
+## Run it
+
+```bash
+node skills/braid/scripts/braid.js validate --plan <plan.json>
+node skills/braid/scripts/braid.js status  --plan <plan.json> --repo-slug <slug> --json
+node --test tests/braid/scripts/*.test.js
+```
+
+A worked plan lives inline in [plan-format.md](plan-format.md); the status output shows per-node
+status, whole-tree `complete`, and `ready_leaves` (what to drive through relay next).
+
+## What v0 proved (and only this)
+
+1. The fold is reliable from durable evidence alone (never a signal).
+2. Dependency ordering falls out of the same fold as pure data — no live loop.
+3. The base case is human-marked: you declare a node a leaf when it is small enough for one relay run.
+
+## Next candidates (prioritized)
+
+1. **Live issue-close verification (v1's first job).** Today `status: merged` is trusted as the
+   merge+close record, so the fold's "merged PR but issue still open → `blocked`" branch is
+   unreachable end-to-end (see the v0 acceptance in design.md). The `durableFacts(manifest, overrides)`
+   seam already accepts a live result — wire an optional `gh issue view` per merged leaf so that
+   branch becomes real. Keep it opt-in / graceful when `gh` is absent.
+2. **Dogfood a real goal.** Decompose one genuine multi-part goal into a braid tree and drive it
+   end-to-end through relay. This is the cheapest way to pressure-test the two open unknowns: is the
+   human base-case judgment stable, and does the fold read cleanly in practice? Do this BEFORE
+   building any heuristic — let the pain point the next feature.
+3. **A `next` convenience.** Print each `ready` leaf as a copy-paste `relay` invocation (issue/task +
+   suggested route), so the operator loop is: `braid status` → run the printed `relay` commands →
+   record `run_id`s → repeat until `complete`.
+4. **Auto-map leaf → relay run** (drop the explicit `run_id`): discover a leaf's run by matching its
+   `issue` against `~/.relay/runs/<slug>/` manifests. Convenience; low priority; keep the exact,
+   no-guessing default available.
+5. **Base-case heuristic** (suggest when a node is "one relay run" sized). Only after dogfood shows
+   the manual judgment is the real friction. Never auto-split below a human-declared leaf.
+
+## Deliberately deferred (do not build until the above earn it)
+
+Autonomous raw-intent decomposition; any live coordinator loop or dispatch from braid; runtime
+coupling (durable state stays relay manifests + git); depth-triggered integration gates and
+cross-tree wave materialization. These are exactly the machinery that made relay-orca heavy.
+
+## Open design questions (decide when a real case forces them)
+
+- Should a `blocked` subtree halt dispatch of *independent* siblings? v0 says no — `readyLeaves` is
+  `depends_on`-only, so an unrelated ready leaf still surfaces even while another subtree is blocked
+  (tested). Revisit only if a real program wants "stop the world on any block."
+- How does a leaf that is itself a **fan-out** interact with `relay-fleet`? v0 treats every leaf as
+  one `relay` run; a fleet-shaped leaf is out of scope until a real case appears.
+- How deep is actually useful? v0 imposes no depth limit; watch whether real trees stay shallow.
+
+## Hard guardrail
+
+Lightness is the point. The new logic that matters is the fold; leaves reuse relay. If braid grows
+past a few hundred lines of real logic for the "next candidates," stop and reconsider — that growth
+is the relay-orca failure mode returning. Keep the human as the decomposer until a real case proves
+a heuristic is safe.

--- a/skills/braid/scripts/braid.js
+++ b/skills/braid/scripts/braid.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+"use strict";
+
+// braid v0 — decompose deep, execute flat. This CLI is the ONLY I/O boundary; the fold/plan
+// libs stay pure. Two read-only intents in v0:
+//   validate --plan <file>   → check a human-authored decomposition tree
+//   status   --plan <file>   → fold relay's durable truth over the tree, print rolled-up
+//                              status + which leaves are ready to dispatch next
+// braid never dispatches, supervises, or couples to any runtime. Leaves are driven by ordinary
+// `relay`; braid only tells you what is ready and whether the whole tree is done.
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { validatePlan, BraidPlanError } = require("./lib/plan");
+const { foldPlan, readyLeaves, STATUS } = require("./lib/fold");
+const { durableFacts } = require("./lib/manifest");
+
+function fail(message, code = 1) {
+  process.stderr.write(`braid: ${message}\n`);
+  process.exit(code);
+}
+
+function readArg(argv, name) {
+  const index = argv.indexOf(name);
+  return index >= 0 && index + 1 < argv.length ? argv[index + 1] : null;
+}
+
+function loadPlan(planPath) {
+  if (!planPath) fail("--plan <file> is required");
+  let raw;
+  try {
+    raw = fs.readFileSync(planPath, "utf8");
+  } catch (error) {
+    fail(`cannot read plan ${planPath}: ${error.message}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    fail(`plan ${planPath} is not valid JSON: ${error.message}`);
+  }
+  try {
+    return validatePlan(parsed);
+  } catch (error) {
+    if (error instanceof BraidPlanError) fail(error.message, 2);
+    throw error;
+  }
+}
+
+// Resolve a leaf's durable facts by reading its mapped relay manifest. v0 maps ONLY via an
+// explicit `leaf.run_id` (no guessing); a leaf without a run_id is "not started". The runs
+// root honors RELAY_HOME. Returns null when unmapped or unreadable (→ NOT_STARTED, fail-open
+// to "not started" is safe here because an unmapped leaf genuinely has no evidence yet).
+function makeLeafFacts(repoSlug) {
+  const relayHome = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
+  const runsRoot = path.join(relayHome, "runs", repoSlug);
+  return (node) => {
+    const runId = node.leaf && node.leaf.run_id;
+    if (!runId) return null;
+    const manifestPath = path.join(runsRoot, `${runId}.md`);
+    let text;
+    try {
+      text = fs.readFileSync(manifestPath, "utf8");
+    } catch {
+      return null;
+    }
+    return durableFacts(text);
+  };
+}
+
+function printStatus(planPath, repoSlug, json) {
+  const plan = loadPlan(planPath);
+  const folded = foldPlan(plan, makeLeafFacts(repoSlug));
+  const ready = readyLeaves(plan, folded);
+  const report = { ok: true, program_id: folded.program_id, complete: folded.complete, status: folded.root.status, ready_leaves: ready, tree: folded.root };
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`braid ${folded.program_id}: ${folded.root.status}${folded.complete ? " (COMPLETE)" : ""}\n`);
+  const lines = [];
+  (function render(node, depth) {
+    lines.push(`${"  ".repeat(depth)}- ${node.id} [${node.status}]${node.kind === "leaf" && node.run_id ? ` ← ${node.run_id}` : ""}`);
+    if (node.children) node.children.forEach((child) => render(child, depth + 1));
+  })(folded.root, 0);
+  process.stdout.write(`${lines.join("\n")}\n`);
+  process.stdout.write(`ready to dispatch next: ${ready.length ? ready.join(", ") : "(none)"}\n`);
+}
+
+function main(argv) {
+  const intent = argv[0];
+  const json = argv.includes("--json");
+  const planPath = readArg(argv, "--plan");
+  const repoSlug = readArg(argv, "--repo-slug") || process.env.BRAID_REPO_SLUG || "";
+  if (intent === "validate") {
+    loadPlan(planPath);
+    process.stdout.write(json ? `${JSON.stringify({ ok: true }, null, 2)}\n` : "braid: plan is valid\n");
+    return;
+  }
+  if (intent === "status") {
+    if (!repoSlug) fail("status requires --repo-slug <slug> (or BRAID_REPO_SLUG) to locate relay manifests");
+    printStatus(planPath, repoSlug, json);
+    return;
+  }
+  fail("usage: braid <validate|status> --plan <file> [--repo-slug <slug>] [--json]", 64);
+}
+
+if (require.main === module) main(process.argv.slice(2));
+module.exports = { main };

--- a/skills/braid/scripts/lib/fold.js
+++ b/skills/braid/scripts/lib/fold.js
@@ -1,0 +1,102 @@
+"use strict";
+
+// The heart of braid: a PURE recursive evidence fold over a decomposition tree.
+//
+// braid's thesis is "decompose deep, execute flat": the tree is cheap structure with no
+// per-node lifecycle; ordinary `relay` runs only at the leaves; a parent is DONE only when
+// every child is DONE-with-durable-evidence. This module is that fold. It performs NO I/O —
+// the caller injects `leafFacts(node)` returning the durable truth already read from relay
+// manifests (or null when a leaf has no mapped run yet). Completion is NEVER inferred from a
+// signal (no worker_done, no task status); a leaf is DONE only on merged PR + closed issue.
+
+const STATUS = Object.freeze({
+  NOT_STARTED: "not_started",
+  RUNNING: "running",
+  DONE: "done",
+  BLOCKED: "blocked",
+});
+
+// A leaf's durable status, derived ONLY from relay's durable truth. `facts` is either null
+// (no relay run mapped → not started) or { state, pr_merged, issue_closed } read from the
+// leaf's relay manifest. Fail closed: a terminal manifest that did NOT reach merged+closed is
+// an abandoned/superseded attempt that needs a human, so it is BLOCKED, never silently done.
+function leafStatus(facts) {
+  if (!facts) return STATUS.NOT_STARTED;
+  if (facts.state === "merged" && facts.pr_merged === true && facts.issue_closed === true) {
+    return STATUS.DONE;
+  }
+  if (facts.state === "merged" || facts.state === "closed") return STATUS.BLOCKED;
+  return STATUS.RUNNING;
+}
+
+// Fold N child statuses into a parent status. Precedence is fail-closed: BLOCKED dominates;
+// then all-DONE is DONE; then any progress makes it RUNNING; only all-untouched is NOT_STARTED.
+function combine(childStatuses) {
+  if (childStatuses.length === 0) return STATUS.NOT_STARTED;
+  if (childStatuses.some((s) => s === STATUS.BLOCKED)) return STATUS.BLOCKED;
+  if (childStatuses.every((s) => s === STATUS.DONE)) return STATUS.DONE;
+  if (childStatuses.every((s) => s === STATUS.NOT_STARTED)) return STATUS.NOT_STARTED;
+  return STATUS.RUNNING;
+}
+
+function isLeaf(node) {
+  return !Array.isArray(node.children) || node.children.length === 0;
+}
+
+// Recursively fold a node into { id, kind, status, run_id?, children? }. Leaf status comes
+// from injected facts; internal status is the combine() of its children's statuses.
+function foldNode(node, leafFacts) {
+  if (isLeaf(node)) {
+    const facts = leafFacts(node) || null;
+    return {
+      id: node.id,
+      kind: "leaf",
+      status: leafStatus(facts),
+      run_id: (node.leaf && node.leaf.run_id) || null,
+    };
+  }
+  const children = node.children.map((child) => foldNode(child, leafFacts));
+  return {
+    id: node.id,
+    kind: "internal",
+    status: combine(children.map((c) => c.status)),
+    children,
+  };
+}
+
+// Fold a whole braid plan. Returns { program_id, root, complete }. `complete` is true only
+// when the root folds to DONE — i.e. every leaf reached merged+closed durable evidence.
+function foldPlan(plan, leafFacts) {
+  const root = foldNode(plan.root, leafFacts);
+  return { program_id: plan.id, root, complete: root.status === STATUS.DONE };
+}
+
+// Which leaves are ready to dispatch next: NOT_STARTED leaves whose own depends_on and every
+// ancestor's depends_on are all DONE. Dependency ordering is thus pure data computed from the
+// same fold — no live coordinator loop. `depends_on` ids resolve against the folded status map.
+function readyLeaves(plan, folded) {
+  const statusById = new Map();
+  (function index(node) {
+    statusById.set(node.id, node.status);
+    if (node.children) node.children.forEach(index);
+  })(folded.root);
+
+  const depsSatisfied = (node) =>
+    (node.depends_on || []).every((dep) => statusById.get(dep) === STATUS.DONE);
+
+  const ready = [];
+  (function walk(planNode, ancestorsEligible) {
+    const eligible = ancestorsEligible && depsSatisfied(planNode);
+    if (isLeaf(planNode)) {
+      if (eligible && statusById.get(planNode.id) === STATUS.NOT_STARTED) {
+        ready.push(planNode.id);
+      }
+      return;
+    }
+    planNode.children.forEach((child) => walk(child, eligible));
+  })(plan.root, true);
+
+  return ready;
+}
+
+module.exports = { STATUS, leafStatus, combine, foldNode, foldPlan, readyLeaves };

--- a/skills/braid/scripts/lib/manifest.js
+++ b/skills/braid/scripts/lib/manifest.js
@@ -1,0 +1,71 @@
+"use strict";
+
+// Minimal relay-manifest reader — braid needs ONLY the three durable-truth fields the fold
+// judges completion on: the lifecycle `state`, the git `pr_number`, and the tracker
+// `issue.number`. Relay manifests are YAML-frontmatter `.md` files under
+// `~/.relay/runs/<repo-slug>/<run-id>.md`. This is a deliberately tiny frontmatter scanner
+// (not a general YAML engine, not a require into the relay skillset) so braid stays a
+// standalone sibling. The caller owns the read boundary; parseManifest takes bytes.
+
+function parseScalar(raw) {
+  let value = raw.trim();
+  if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))) {
+    value = value.slice(1, -1);
+  }
+  return value;
+}
+
+// Walk the leading `---`…`---` frontmatter, capturing top-level scalars and one level of
+// nesting (enough for `git:`/`issue:` maps). Returns a flat lookup keyed by dotted path.
+function parseManifest(text) {
+  const lines = String(text || "").split(/\r?\n/);
+  if (lines[0] !== "---") return {};
+  const out = {};
+  let parent = null;
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line === "---") break;
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    const indented = /^\s+/.test(line);
+    const match = line.match(/^\s*([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (!match) continue;
+    const key = match[1];
+    const rest = match[2];
+    if (!indented) {
+      if (rest === "") {
+        parent = key;
+      } else {
+        parent = null;
+        out[key] = parseScalar(rest);
+      }
+    } else if (parent && rest !== "") {
+      out[`${parent}.${key}`] = parseScalar(rest);
+    }
+  }
+  return out;
+}
+
+// Derive the three durable facts the fold consumes.
+//
+// v0 ACCEPTANCE (deliberate, not an oversight): braid trusts a relay manifest in state `merged`
+// as the atomic merge+close record. This is sound for relay's contract — `state: merged` is set
+// by relay finalize-run ONLY after a squash-merge whose body carries `Fixes #N`, which closes the
+// tracker issue. So `pr_merged`/`issue_closed` are DERIVED from `state === "merged"` here. The
+// consequence the reviewer must see: the fold's "merged PR but issue still open → blocked" branch
+// is unreachable through the default CLI path (only a `closed`/abandoned run reaches `blocked`).
+// `overrides` is the seam a future version uses to make that branch reachable by passing a live
+// `gh issue view` result as `issue_closed`. Until then, live issue re-verification is deferred
+// (see references/design.md). Kept explicit and minimal.
+function durableFacts(manifestText, overrides = {}) {
+  const fm = parseManifest(manifestText);
+  const state = fm.state || null;
+  return {
+    state,
+    pr_number: fm["git.pr_number"] ? Number(fm["git.pr_number"]) : null,
+    issue_number: fm["issue.number"] ? Number(fm["issue.number"]) : null,
+    pr_merged: overrides.pr_merged !== undefined ? overrides.pr_merged : state === "merged",
+    issue_closed: overrides.issue_closed !== undefined ? overrides.issue_closed : state === "merged",
+  };
+}
+
+module.exports = { parseManifest, durableFacts };

--- a/skills/braid/scripts/lib/plan.js
+++ b/skills/braid/scripts/lib/plan.js
@@ -1,0 +1,99 @@
+"use strict";
+
+// Pure validator/parser for a braid plan — a human-authored decomposition tree (v0: no auto
+// decomposition). A node is a LEAF (a relay-able unit) iff it has `leaf` and no children; it is
+// INTERNAL iff it has a non-empty `children` array and no `leaf`. The validator enforces the
+// tree shape, unique ids, and acyclic sibling-scoped `depends_on`; it reads no filesystem.
+
+class BraidPlanError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "BraidPlanError";
+  }
+}
+
+function isObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+// Validate one node; collect ids and depends_on edges for the global cycle/ref check.
+function validateNode(node, ids, edges, path) {
+  if (!isObject(node)) throw new BraidPlanError(`${path} must be an object`);
+  if (!nonEmptyString(node.id)) throw new BraidPlanError(`${path} must have a non-empty string id`);
+  if (ids.has(node.id)) throw new BraidPlanError(`duplicate node id "${node.id}"`);
+  ids.add(node.id);
+
+  const hasLeaf = node.leaf !== undefined;
+  const hasChildren = Array.isArray(node.children) && node.children.length > 0;
+  if (hasLeaf && hasChildren) {
+    throw new BraidPlanError(`node "${node.id}" is both a leaf and an internal node`);
+  }
+  if (!hasLeaf && !hasChildren) {
+    throw new BraidPlanError(`node "${node.id}" is neither a leaf (needs \`leaf\`) nor internal (needs \`children\`)`);
+  }
+
+  if (node.depends_on !== undefined) {
+    if (!Array.isArray(node.depends_on)) throw new BraidPlanError(`node "${node.id}" depends_on must be an array`);
+    for (const dep of node.depends_on) {
+      if (!nonEmptyString(dep)) throw new BraidPlanError(`node "${node.id}" has an empty depends_on entry`);
+      if (dep === node.id) throw new BraidPlanError(`node "${node.id}" depends on itself`);
+      edges.push([node.id, dep]);
+    }
+  }
+
+  if (hasLeaf) {
+    if (!isObject(node.leaf)) throw new BraidPlanError(`node "${node.id}" leaf must be an object`);
+    const hasIssue = Number.isInteger(node.leaf.issue);
+    const hasTask = nonEmptyString(node.leaf.task);
+    if (!hasIssue && !hasTask) {
+      throw new BraidPlanError(`leaf "${node.id}" must carry an integer \`issue\` or a non-empty \`task\``);
+    }
+    if (node.leaf.run_id !== undefined && !nonEmptyString(node.leaf.run_id)) {
+      throw new BraidPlanError(`leaf "${node.id}" run_id must be a non-empty string when present`);
+    }
+    return;
+  }
+
+  node.children.forEach((child, index) => validateNode(child, ids, edges, `${path}.children[${index}]`));
+}
+
+// Every depends_on id must reference a known node, and the dependency graph must be acyclic.
+function assertResolvableAcyclic(ids, edges) {
+  for (const [from, dep] of edges) {
+    if (!ids.has(dep)) throw new BraidPlanError(`node "${from}" depends on unknown id "${dep}"`);
+  }
+  const adjacency = new Map();
+  for (const [from, dep] of edges) {
+    if (!adjacency.has(from)) adjacency.set(from, []);
+    adjacency.get(from).push(dep);
+  }
+  const state = new Map(); // id -> 0 visiting, 1 done
+  const visit = (id) => {
+    if (state.get(id) === 1) return;
+    if (state.get(id) === 0) throw new BraidPlanError(`dependency cycle involving "${id}"`);
+    state.set(id, 0);
+    for (const dep of adjacency.get(id) || []) visit(dep);
+    state.set(id, 1);
+  };
+  for (const id of adjacency.keys()) visit(id);
+}
+
+// Accept `{ braid: {...} }` or the bare plan object. Returns the validated plan `{ id, root }`.
+function validatePlan(input) {
+  const plan = isObject(input) && isObject(input.braid) ? input.braid : input;
+  if (!isObject(plan)) throw new BraidPlanError("braid plan must be an object");
+  if (!nonEmptyString(plan.id)) throw new BraidPlanError("braid plan must have a non-empty id");
+  if (!isObject(plan.root)) throw new BraidPlanError("braid plan must have a root node");
+
+  const ids = new Set();
+  const edges = [];
+  validateNode(plan.root, ids, edges, "root");
+  assertResolvableAcyclic(ids, edges);
+  return { id: plan.id, root: plan.root };
+}
+
+module.exports = { validatePlan, BraidPlanError };

--- a/tests/braid/scripts/fold.test.js
+++ b/tests/braid/scripts/fold.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { STATUS, leafStatus, combine, foldPlan, readyLeaves } = require("../../../skills/braid/scripts/lib/fold");
+
+// --- leafStatus: completion is durable-evidence only, never a signal ---
+
+test("leaf with no mapped run is not_started", () => {
+  assert.equal(leafStatus(null), STATUS.NOT_STARTED);
+});
+
+test("leaf is DONE only on merged + pr_merged + issue_closed", () => {
+  assert.equal(leafStatus({ state: "merged", pr_merged: true, issue_closed: true }), STATUS.DONE);
+});
+
+test("merged manifest without closed issue is NOT done (fail closed → blocked)", () => {
+  assert.equal(leafStatus({ state: "merged", pr_merged: true, issue_closed: false }), STATUS.BLOCKED);
+});
+
+test("a closed-but-not-merged relay run is an abandoned attempt → blocked", () => {
+  assert.equal(leafStatus({ state: "closed", pr_merged: false, issue_closed: false }), STATUS.BLOCKED);
+});
+
+test("a non-terminal manifest is running", () => {
+  for (const state of ["dispatched", "review_pending", "ready_to_merge", "changes_requested"]) {
+    assert.equal(leafStatus({ state, pr_merged: false, issue_closed: false }), STATUS.RUNNING);
+  }
+});
+
+// --- combine: fail-closed precedence (BLOCKED dominates) ---
+
+test("combine: all done → done", () => {
+  assert.equal(combine([STATUS.DONE, STATUS.DONE]), STATUS.DONE);
+});
+
+test("combine: any blocked dominates even amid dones", () => {
+  assert.equal(combine([STATUS.DONE, STATUS.BLOCKED, STATUS.DONE]), STATUS.BLOCKED);
+});
+
+test("combine: mixed progress is running", () => {
+  assert.equal(combine([STATUS.DONE, STATUS.NOT_STARTED]), STATUS.RUNNING);
+  assert.equal(combine([STATUS.RUNNING, STATUS.NOT_STARTED]), STATUS.RUNNING);
+});
+
+test("combine: all untouched is not_started", () => {
+  assert.equal(combine([STATUS.NOT_STARTED, STATUS.NOT_STARTED]), STATUS.NOT_STARTED);
+});
+
+// --- foldPlan: a parent is DONE only when every leaf reached durable evidence ---
+
+const doneFacts = { state: "merged", pr_merged: true, issue_closed: true };
+
+function factsByRun(map) {
+  return (node) => {
+    const runId = node.leaf && node.leaf.run_id;
+    return runId && map[runId] ? map[runId] : null;
+  };
+}
+
+const twoLevelPlan = {
+  id: "goal-1",
+  root: {
+    id: "root",
+    children: [
+      { id: "a", leaf: { issue: 1, run_id: "run-a" } },
+      { id: "b", leaf: { issue: 2, run_id: "run-b" } },
+    ],
+  },
+};
+
+test("root is not complete until BOTH leaves are done", () => {
+  const partial = foldPlan(twoLevelPlan, factsByRun({ "run-a": doneFacts }));
+  assert.equal(partial.complete, false);
+  assert.equal(partial.root.status, STATUS.RUNNING);
+
+  const full = foldPlan(twoLevelPlan, factsByRun({ "run-a": doneFacts, "run-b": doneFacts }));
+  assert.equal(full.complete, true);
+  assert.equal(full.root.status, STATUS.DONE);
+});
+
+test("a blocked leaf blocks the whole tree (worker_done can never override durable truth)", () => {
+  const folded = foldPlan(twoLevelPlan, factsByRun({ "run-a": doneFacts, "run-b": { state: "closed" } }));
+  assert.equal(folded.root.status, STATUS.BLOCKED);
+  assert.equal(folded.complete, false);
+});
+
+test("deep tree folds recursively", () => {
+  const deep = {
+    id: "goal-deep",
+    root: {
+      id: "root",
+      children: [
+        { id: "g1", children: [{ id: "l1", leaf: { run_id: "r1" } }, { id: "l2", leaf: { run_id: "r2" } }] },
+        { id: "l3", leaf: { run_id: "r3" } },
+      ],
+    },
+  };
+  const facts = factsByRun({ r1: doneFacts, r2: doneFacts, r3: doneFacts });
+  assert.equal(foldPlan(deep, facts).complete, true);
+  const partial = factsByRun({ r1: doneFacts, r2: doneFacts });
+  const f = foldPlan(deep, partial);
+  assert.equal(f.root.status, STATUS.RUNNING);
+  // the fully-done subtree g1 is DONE while its sibling leaf l3 is not_started
+  const g1 = f.root.children.find((c) => c.id === "g1");
+  assert.equal(g1.status, STATUS.DONE);
+});
+
+// --- readyLeaves: dependency ordering as pure data ---
+
+const depPlan = {
+  id: "goal-dep",
+  root: {
+    id: "root",
+    children: [
+      { id: "a", leaf: { run_id: "run-a" } },
+      { id: "b", leaf: { run_id: "run-b" }, depends_on: ["a"] },
+    ],
+  },
+};
+
+test("only dependency-satisfied not_started leaves are ready", () => {
+  const none = foldPlan(depPlan, factsByRun({}));
+  assert.deepEqual(readyLeaves(depPlan, none), ["a"]); // b waits on a
+
+  const aDone = foldPlan(depPlan, factsByRun({ "run-a": doneFacts }));
+  assert.deepEqual(readyLeaves(depPlan, aDone), ["b"]); // a done → b now ready
+
+  const bothDone = foldPlan(depPlan, factsByRun({ "run-a": doneFacts, "run-b": doneFacts }));
+  assert.deepEqual(readyLeaves(depPlan, bothDone), []); // nothing left
+});
+
+test("a blocked leaf nested DEEP under internal nodes still blocks the root (fail-closed at any depth)", () => {
+  const deep = {
+    id: "goal-deep-blocked",
+    root: {
+      id: "root",
+      children: [
+        { id: "mid", children: [{ id: "inner", children: [{ id: "bad", leaf: { run_id: "r-bad" } }] }] },
+        { id: "ok", leaf: { run_id: "r-ok" } },
+      ],
+    },
+  };
+  const folded = foldPlan(deep, factsByRun({ "r-ok": doneFacts, "r-bad": { state: "closed" } }));
+  assert.equal(folded.root.status, STATUS.BLOCKED);
+  const mid = folded.root.children.find((c) => c.id === "mid");
+  assert.equal(mid.status, STATUS.BLOCKED); // propagated up through two internal levels
+});
+
+test("a blocked leaf does NOT gate an INDEPENDENT not_started sibling (readyLeaves is depends_on-only)", () => {
+  const plan = {
+    id: "goal-indep",
+    root: {
+      id: "root",
+      children: [
+        { id: "blocked", leaf: { run_id: "r-blocked" } },
+        { id: "free", leaf: { run_id: "r-free" } },
+      ],
+    },
+  };
+  const folded = foldPlan(plan, factsByRun({ "r-blocked": { state: "closed" } }));
+  // the free sibling has no depends_on on the blocked one, so it remains ready
+  assert.deepEqual(readyLeaves(plan, folded), ["free"]);
+  assert.equal(folded.root.status, STATUS.BLOCKED); // but the whole tree is still blocked
+});
+
+test("readyLeaves resolves a dependency on an INTERNAL node (whole subtree must be done)", () => {
+  const plan = {
+    id: "goal-dep-internal",
+    root: {
+      id: "root",
+      children: [
+        { id: "phase1", children: [{ id: "p1a", leaf: { run_id: "r-p1a" } }, { id: "p1b", leaf: { run_id: "r-p1b" } }] },
+        { id: "phase2", depends_on: ["phase1"], leaf: { run_id: "r-p2" } },
+      ],
+    },
+  };
+  const partial = foldPlan(plan, factsByRun({ "r-p1a": doneFacts })); // phase1 not fully done
+  assert.deepEqual(readyLeaves(plan, partial), ["p1b"]); // phase2 gated by internal phase1
+  const phase1Done = foldPlan(plan, factsByRun({ "r-p1a": doneFacts, "r-p1b": doneFacts }));
+  assert.deepEqual(readyLeaves(plan, phase1Done), ["phase2"]); // phase1 subtree done → phase2 ready
+});
+
+test("a leaf under an internal node with an unmet dependency is not ready", () => {
+  const gated = {
+    id: "goal-gated",
+    root: {
+      id: "root",
+      children: [
+        { id: "pre", leaf: { run_id: "run-pre" } },
+        { id: "wave2", depends_on: ["pre"], children: [{ id: "w2a", leaf: { run_id: "run-w2a" } }] },
+      ],
+    },
+  };
+  const before = foldPlan(gated, factsByRun({}));
+  assert.deepEqual(readyLeaves(gated, before), ["pre"]); // w2a gated by its parent's dep
+  const after = foldPlan(gated, factsByRun({ "run-pre": doneFacts }));
+  assert.deepEqual(readyLeaves(gated, after), ["w2a"]);
+});

--- a/tests/braid/scripts/manifest.test.js
+++ b/tests/braid/scripts/manifest.test.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { parseManifest, durableFacts } = require("../../../skills/braid/scripts/lib/manifest");
+
+// A representative relay manifest head (frontmatter only is read).
+const MANIFEST = [
+  "---",
+  "relay_version: 2",
+  "run_id: 'issue-1-abc'",
+  "state: 'merged'",
+  "# a comment line",
+  "",
+  "git:",
+  "  base_branch: 'main'",
+  "  pr_number: 1069",
+  "issue:",
+  "  number: 1063",
+  "  source: 'github'",
+  "policy:",
+  "  merge: 'manual_after_lgtm'",
+  "---",
+  "",
+  "# Body starts here (must be ignored)",
+  "state: not-this-one",
+].join("\n");
+
+test("parseManifest reads top-level scalars and one level of nesting", () => {
+  const fm = parseManifest(MANIFEST);
+  assert.equal(fm.state, "merged");
+  assert.equal(fm["git.pr_number"], "1069");
+  assert.equal(fm["issue.number"], "1063");
+  assert.equal(fm["policy.merge"], "manual_after_lgtm");
+});
+
+test("parseManifest strips quotes, skips comments/blanks, and stops at the closing ---", () => {
+  const fm = parseManifest(MANIFEST);
+  assert.equal(fm.run_id, "issue-1-abc"); // single-quoted stripped
+  assert.ok(!("source" in fm)); // nested key exposed only as issue.source
+  assert.equal(fm["issue.source"], "github");
+  // a body line after the closing --- must not leak in
+  assert.equal(fm.state, "merged");
+});
+
+test("parseManifest returns {} when the text has no leading frontmatter", () => {
+  assert.deepEqual(parseManifest("no frontmatter here\nstate: merged"), {});
+  assert.deepEqual(parseManifest(""), {});
+  assert.deepEqual(parseManifest(null), {});
+});
+
+test("durableFacts derives done-shaped facts from a merged manifest", () => {
+  const facts = durableFacts(MANIFEST);
+  assert.equal(facts.state, "merged");
+  assert.equal(facts.pr_number, 1069);
+  assert.equal(facts.issue_number, 1063);
+  // v0 acceptance: state==='merged' is trusted as the merge+close record.
+  assert.equal(facts.pr_merged, true);
+  assert.equal(facts.issue_closed, true);
+});
+
+test("durableFacts on a non-terminal manifest yields not-merged facts", () => {
+  const running = MANIFEST.replace("state: 'merged'", "state: 'review_pending'");
+  const facts = durableFacts(running);
+  assert.equal(facts.state, "review_pending");
+  assert.equal(facts.pr_merged, false);
+  assert.equal(facts.issue_closed, false);
+});
+
+test("durableFacts overrides take precedence over the state-derived defaults", () => {
+  // this is the path a future live-gh read uses to make the fail-closed branch reachable
+  const facts = durableFacts(MANIFEST, { issue_closed: false });
+  assert.equal(facts.pr_merged, true); // still derived from merged
+  assert.equal(facts.issue_closed, false); // override wins
+});
+
+test("durableFacts on a manifest with no state is null-safe", () => {
+  const facts = durableFacts("---\nrun_id: 'x'\n---");
+  assert.equal(facts.state, null);
+  assert.equal(facts.pr_merged, false);
+  assert.equal(facts.issue_closed, false);
+  assert.equal(facts.pr_number, null);
+});

--- a/tests/braid/scripts/plan.test.js
+++ b/tests/braid/scripts/plan.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { validatePlan, BraidPlanError } = require("../../../skills/braid/scripts/lib/plan");
+
+const valid = {
+  braid: {
+    id: "goal-1",
+    root: {
+      id: "root",
+      children: [
+        { id: "a", leaf: { issue: 1 } },
+        { id: "b", leaf: { task: "do the thing", run_id: "run-b" }, depends_on: ["a"] },
+      ],
+    },
+  },
+};
+
+test("accepts a well-formed plan (wrapped or bare)", () => {
+  assert.equal(validatePlan(valid).id, "goal-1");
+  assert.equal(validatePlan(valid.braid).id, "goal-1");
+});
+
+test("rejects a node that is both leaf and internal", () => {
+  const bad = { id: "g", root: { id: "root", leaf: { issue: 1 }, children: [{ id: "c", leaf: { issue: 2 } }] } };
+  assert.throws(() => validatePlan(bad), /both a leaf and an internal/);
+});
+
+test("rejects a node that is neither leaf nor internal", () => {
+  const bad = { id: "g", root: { id: "root" } };
+  assert.throws(() => validatePlan(bad), /neither a leaf .* nor internal/);
+});
+
+test("rejects duplicate ids", () => {
+  const bad = { id: "g", root: { id: "root", children: [{ id: "x", leaf: { issue: 1 } }, { id: "x", leaf: { issue: 2 } }] } };
+  assert.throws(() => validatePlan(bad), /duplicate node id "x"/);
+});
+
+test("rejects a leaf without issue or task", () => {
+  const bad = { id: "g", root: { id: "root", children: [{ id: "a", leaf: {} }] } };
+  assert.throws(() => validatePlan(bad), /must carry an integer `issue` or a non-empty `task`/);
+});
+
+test("rejects depends_on referencing an unknown id", () => {
+  const bad = { id: "g", root: { id: "root", children: [{ id: "a", leaf: { issue: 1 }, depends_on: ["ghost"] }] } };
+  assert.throws(() => validatePlan(bad), /depends on unknown id "ghost"/);
+});
+
+test("rejects a dependency cycle", () => {
+  const bad = {
+    id: "g",
+    root: {
+      id: "root",
+      children: [
+        { id: "a", leaf: { issue: 1 }, depends_on: ["b"] },
+        { id: "b", leaf: { issue: 2 }, depends_on: ["a"] },
+      ],
+    },
+  };
+  assert.throws(() => validatePlan(bad), /dependency cycle/);
+});
+
+test("accepts a valid diamond/shared dependency (not a cycle)", () => {
+  const diamond = {
+    id: "g",
+    root: {
+      id: "root",
+      children: [
+        { id: "base", leaf: { issue: 1 } },
+        { id: "left", leaf: { issue: 2 }, depends_on: ["base"] },
+        { id: "right", leaf: { issue: 3 }, depends_on: ["base"] },
+        { id: "join", leaf: { issue: 4 }, depends_on: ["left", "right"] },
+      ],
+    },
+  };
+  assert.equal(validatePlan(diamond).id, "g"); // shared 'base' dep must not read as a cycle
+});
+
+test("rejects self-dependency", () => {
+  const bad = { id: "g", root: { id: "root", children: [{ id: "a", leaf: { issue: 1 }, depends_on: ["a"] }] } };
+  assert.throws(() => validatePlan(bad), /depends on itself/);
+});
+
+test("error type is BraidPlanError", () => {
+  try {
+    validatePlan({});
+    assert.fail("expected throw");
+  } catch (error) {
+    assert.ok(error instanceof BraidPlanError);
+  }
+});


### PR DESCRIPTION
New **sibling** skill `braid` — the successor to the frozen `relay-orca`. Not a `relay-*` skill.

## Thesis: decompose deep, execute flat
One accepted goal becomes a *cheap* tree — internal nodes are pure structure with no lifecycle; every leaf is one relay-able unit. Ordinary `relay` runs do the work at the leaves and nowhere else. A parent is `done` only when **every** child is done-with-durable-evidence. That recursive **evidence fold** — not a state machine, not a live coordinator, not a runtime coupling — is braid's whole contribution.

This keeps the principles relay-orca proved (evidence over signals, fail-closed on ambiguity, frozen anchors, no runtime coupling) and drops the machinery it disproved (bespoke control plane, runtime-bound receipt, one-layer ceiling). Rationale: [skills/braid/references/design.md](../blob/feat/braid-v0/skills/braid/references/design.md).

## What v0 is
- Read-only: `validate` (check a tree) + `status` (fold relay manifests over the tree → per-node status, whole-tree completeness, and which leaves are ready next).
- `scripts/lib/fold.js` (~100 lines) is the heart; `plan.js` validates the tree; `manifest.js` is a tiny relay-manifest reader. The CLI is the only I/O boundary; the libs are pure.
- **Live-verified**: braid folded the real merged #1063/#1067/#1066 iteration tree to `COMPLETE` purely from relay manifests, and surfaced `ready` leaves + dep-gating on a partial tree.

## What v0 is NOT (deliberately deferred)
Autonomous decomposition, any dispatch/supervision from braid, live coordinator loop, runtime coupling, depth-triggered gates, auto-mapping leaves to runs. These come only after the fold + base-case earn them. If braid grows past a few hundred lines of real logic, that's the signal to stop — lightness is the point.

## Review
Independent code review verified the fold/dependency/validator logic correct (no fail-closed, durability, dependency-ordering, or validation bug). Review-driven additions: full `manifest.js` test coverage, deep blocked-propagation / independent-sibling / DAG-acceptance / dep-on-internal tests, and an explicit **v0 acceptance** note — `state: merged` is trusted as relay's atomic merge+close record, so the "merged PR but open issue → blocked" fold branch is reachable via the `durableFacts` override seam when live `gh` verification is wired in v1.

42 braid tests + skills-lint green locally. relay-orca stays frozen; the active relay skillset is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 실험용 읽기 전용 braid 기능이 추가되었습니다.
  * JSON 기반 작업 계획을 검증하고, 릴레이 실행 증거를 바탕으로 전체 진행 상태와 완료 여부를 확인할 수 있습니다.
  * 다음 실행 가능한 작업을 의존성에 따라 식별할 수 있습니다.
  * `validate` 및 `status` 명령과 JSON 출력 형식을 제공합니다.

* **문서**
  * 계획 형식, 상태 판정 기준, 설계 원칙, 사용 방법 및 향후 로드맵을 추가했습니다.

* **테스트**
  * 계획 검증, 상태 집계, 매니페스트 처리 테스트가 CI에 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->