### PR TITLE
chore: gitignore .relay-operator/ (local operator scratch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ node_modules/
 # Relay runtime metadata
 .relay/
 
+# Local operator scratch (durable DC anchors + dispatch prompts; stays out of the repo)
+.relay-operator/
+
 # Local agent memory should stay outside the repo
 memory/
 


### PR DESCRIPTION
`.relay-operator/` holds durable operator scratch — DC anchors (`dc-<id>.md`) and dispatch prompts (`dispatch-<id>.md`) persisted across reboots so relay runs don't lose their `/tmp`-based anchors. It is local-only working state, the same category as the already-ignored `.relay/`, and should never enter the repo.

Ignoring it stops it from surfacing as untracked in every `git status`. No code touched; docs/tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로컬 작업용 디렉터리가 저장소에 실수로 포함되지 않도록 제외 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->