### PR TITLE
fix(tests): deflake advisory lock-wait test (#1072)

### DIFF
--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -623,6 +623,24 @@ function waitForFileText(filePath, expectedText, { timeoutMs = 2000 } = {}) {
   return false;
 }
 
+function waitForFile(filePath, { timeoutMs = 2000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return true;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+  }
+  return false;
+}
+
+function waitForAbsent(filePath, { timeoutMs = 2000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!fs.existsSync(filePath)) return true;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+  }
+  return false;
+}
+
 test("executeAdvisoryRequest forwards advisory profile to reviewer argv", () => {
   const { logPath, result } = executeProfileRequest({
     profile: "adversarial",
@@ -638,57 +656,84 @@ test("advisory worker does not publish success while its audit event waits on th
   const { repoRoot, manifestPath, runDir, runId } = setupRepo();
   const manifest = readManifest(manifestPath).data;
   const logPath = path.join(runDir, "blocked-advisory-writer.log");
+  const rawResponsePath = path.join(runDir, "review-round-1-advisory-opencode-raw-response.txt");
   const reviewerScript = writeFakeOpencode(repoRoot, { logPath });
-  const lock = acquireManifestLock(manifestPath);
-  let advisoryRun;
+
+  // The audited append blocks on the manifest lock we hold below. Keep the
+  // worker patient so it waits for the release and then publishes, instead of
+  // timing out its lock acquisition under host load (the default is 5000ms and
+  // a contended host can hold the lock longer). Test-local override only; no
+  // production default changes.
+  const previousLockTimeout = process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS;
+  process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS = "60000";
 
   try {
-    advisoryRun = startAdvisoryReview({
-      headSha: manifest.git.head_sha,
-      laneIndex: 1,
-      profile: "blindspot",
-      promptText: "Wait for the audit event before publishing the result.",
-      reviewerModel: "example/opencode-model-fast",
-      reviewerName: "opencode",
-      reviewerScript,
-      reviewRepoPath: repoRoot,
-      round: 1,
-      runDir,
+    const lock = acquireManifestLock(manifestPath);
+    let advisoryRun;
+    try {
+      advisoryRun = startAdvisoryReview({
+        headSha: manifest.git.head_sha,
+        laneIndex: 1,
+        profile: "blindspot",
+        promptText: "Wait for the audit event before publishing the result.",
+        reviewerModel: "example/opencode-model-fast",
+        reviewerName: "opencode",
+        reviewerScript,
+        reviewRepoPath: repoRoot,
+        round: 1,
+        runDir,
+        runId,
+        runRepoPath: repoRoot,
+        state: STATES.REVIEW_PENDING,
+        // Generous reviewer budget so the fake reviewer cannot time out under
+        // host load — a timeout would intentionally leave the lane lease and
+        // publish a timeout-status event, both of which the assertions below
+        // reject. The reviewer completes near-instantly at rest.
+        timeoutSeconds: 120,
+        trigger: "every_round",
+      });
+
+      // Synchronize on observable state, not a fixed sleep: the worker writes
+      // its raw-response artifact right before entering the audited publish
+      // path, so once it exists the worker is committed to the lock-guarded
+      // append. Because we still hold the lock and the worker cannot steal it
+      // (this owner process is alive), reading the result now must observe a
+      // deferral regardless of host load.
+      assert.equal(waitForFile(rawResponsePath, { timeoutMs: 10000 }), true);
+      const consumedBeforeEvent = await finishAdvisoryReview({
+        advisoryRun,
+        waitMs: 0,
+      });
+      assert.equal(consumedBeforeEvent.status, "deferred");
+      assert.equal(
+        readRunEvents(repoRoot, runId).some((record) => record.event === EVENTS.ADVISORY_REVIEW),
+        false,
+      );
+    } finally {
+      releaseManifestLock(lock);
+    }
+
+    // After release the worker acquires the lock, appends the audit event, and
+    // republishes the result. Post-release publish + advisory worktree cleanup
+    // can be slow under load, so these observation windows are generous.
+    const event = waitForEvent(
+      repoRoot,
       runId,
-      runRepoPath: repoRoot,
-      state: STATES.REVIEW_PENDING,
-      timeoutSeconds: 5,
-      trigger: "every_round",
-    });
-
-    assert.equal(waitForFileText(logPath, "advisory-end", { timeoutMs: 3000 }), true);
-    // The old writer publishes resultPath before trying to acquire this lock.
-    // Give it time to reach the blocked append, then exercise the real reader.
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
-    const consumedBeforeEvent = await finishAdvisoryReview({
-      advisoryRun,
-      waitMs: 0,
-    });
-    assert.equal(consumedBeforeEvent.status, "deferred");
-    assert.equal(
-      readRunEvents(repoRoot, runId).some((record) => record.event === EVENTS.ADVISORY_REVIEW),
-      false,
+      (record) => record.event === EVENTS.ADVISORY_REVIEW,
+      { timeoutMs: 15000 },
     );
+    assert.ok(event);
+    assert.equal(event.status, "success");
+    assert.equal(waitForFileText(advisoryRun.resultPath, '"status": "success"', { timeoutMs: 10000 }), true);
+    assert.equal(JSON.parse(fs.readFileSync(advisoryRun.resultPath, "utf-8")).status, "success");
+    // The worker clears its lane lease only after appending the audit event and
+    // returning from executeAdvisoryRequest, so the cleanup lags the event we
+    // waited on above. Wait for the lease to disappear rather than racing it.
+    assert.equal(waitForAbsent(advisoryRun.laneLeasePath, { timeoutMs: 10000 }), true);
   } finally {
-    releaseManifestLock(lock);
+    if (previousLockTimeout === undefined) delete process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS;
+    else process.env.RELAY_MANIFEST_LOCK_TIMEOUT_MS = previousLockTimeout;
   }
-
-  const event = waitForEvent(
-    repoRoot,
-    runId,
-    (record) => record.event === EVENTS.ADVISORY_REVIEW,
-    { timeoutMs: 5000 },
-  );
-  assert.ok(event);
-  assert.equal(event.status, "success");
-  assert.equal(waitForFileText(advisoryRun.resultPath, '"status": "success"', { timeoutMs: 2000 }), true);
-  assert.equal(JSON.parse(fs.readFileSync(advisoryRun.resultPath, "utf-8")).status, "success");
-  assert.equal(fs.existsSync(advisoryRun.laneLeasePath), false);
 });
 
 test("executeAdvisoryRequest publishes a failed result when the advisory event append fails", () => {


### PR DESCRIPTION
Fixes #1072.

The advisory lock-wait test (`review-runner-advisory.test.js` → *"advisory worker does not publish success while its audit event waits on the shared manifest lock"*) synchronized on wall-clock delays and checked cleanup state immediately, so it failed intermittently under host load while passing in isolation.

## Root cause (reproduced)

Starving the **detached** advisory worker with CPU hogs reproduced the flake (the old test failed ~3/5 under 24 CPU hogs). Two concrete failure modes:

1. **Lane-lease cleanup race.** The lease was asserted with an immediate `fs.existsSync(...laneLeasePath) === false`. The worker clears its lease only *after* appending the audit event and returning from `executeAdvisoryRequest`, so the main thread's check — which fires the moment `waitForEvent` sees the event — raced the worker's still-pending cleanup and saw the lease present.
2. **Reviewer timeout under load.** `timeoutSeconds: 5` let the fake reviewer time out when the worker was descheduled; a timeout intentionally leaves the lane lease and publishes a `timeout`-status event, which the success/lease assertions reject.

The fixed `500ms` sleep and the `3000/5000/2000ms` windows were load-coupled guesses for a worker that can be starved.

## Fix (test-only; no production defaults change)

- Replace the fixed sleep with a wait on **observable state** — poll for the worker's raw-response artifact, written right before the audited publish path (the marker the worker emits before attempting the lock).
- Wait for the lane lease to disappear (`waitForAbsent`) instead of racing its cleanup — same assertion strength.
- Raise advisory `timeoutSeconds` to `120` so the near-instant fake reviewer cannot time out under load.
- Keep the worker patient via a **test-local** `RELAY_MANIFEST_LOCK_TIMEOUT_MS` so its audited append waits for the held lock rather than timing out.
- Widen the post-release event/result observation windows.

## Verification

- Reproduced the old flake under CPU starvation (old: ~3/5 fail at 24 hogs).
- Fixed test: **15/15** under 24- and 32-CPU-hog starvation (loadavg 186–200, 2–3x harsher than the reproduction).
- Full advisory suite: **84/84**.

Acceptance criteria (all met): observable-state sync for the blocked-append step; deferral/success/lease assertions unchanged in strength; passes ≥10/10 under induced load; no production timeout defaults changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 어드바이저리 리뷰 처리 중 동시 작업이 발생하는 상황에 대한 검증을 강화했습니다.
  - 감사 기록이 완료되기 전 성공 결과가 공개되지 않으며, 작업 완료 후에만 최종 결과와 상태가 반영되는지 안정적으로 확인합니다.
  - 대기 및 완료 상태 검증을 개선해 간헐적인 테스트 실패 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->