### PR TITLE
Sunset deprecated relay-fleet entry points (#861)

### DIFF
--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -78,7 +78,7 @@ Omit `--fleet-id` to list every fleet for the current repository without modifyi
 node "${RELAY_SKILL_ROOT:-skills}/relay-fleet/scripts/relay-fleet.js" --repo . --status
 ```
 
-Deprecated primary entry points, to be sunset within one release: `relay-fleet.js --resume` is accepted as an alias for re-running the default drive; `relay-fleet.js --review` and `merge-queue.js` remain internal re-entry/debug paths but should not be the operator loop.
+The operator-entry sunset is complete: `relay-fleet.js --resume` is removed and hard-errors with guidance to rerun the idempotent default drive, which resumes in place. `relay-fleet.js --review` and `merge-queue.js` are internal/debug-only re-entry paths, not documented operator entry points.
 
 Dry-run validates the leaf file and invokes child `dispatch.js --dry-run` for each leaf without writing a fleet manifest:
 

--- a/skills/relay-fleet/scripts/merge-queue.js
+++ b/skills/relay-fleet/scripts/merge-queue.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
+// Internal/debug-only re-entry script; relay-fleet.js default drive is the operator entry point.
+
 const { spawn } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -70,7 +70,7 @@ const DEFAULT_PUBLISH_SCRIPT = path.join(__dirname, "..", "..", "relay-dispatch"
 const DEFAULT_REVIEW_SCRIPT = path.join(__dirname, "..", "..", "relay-review", "scripts", "review-runner.js");
 const DEFAULT_FINALIZE_SCRIPT = path.join(__dirname, "..", "..", "relay-merge", "scripts", "finalize-run.js");
 const KNOWN_FLAGS = [
-  "--repo", "--fleet-id", "--leaves-file", "--resume", "--status", "--review", "--parallel",
+  "--repo", "--fleet-id", "--leaves-file", "--status", "--review", "--parallel",
   "--dispatch-script", "--publish-script", "--review-script", "--executor", "--model", "--model-hints", "--sandbox",
   "--network-access", "--timeout", "--reasoning", "--copy", "--test-command", "--publish-policy",
   "--register", "--reviewer", "--reviewer-model", "--finalize-script", "--merge-method",
@@ -113,7 +113,6 @@ function dispatchFailureLastError({ error = null, stderr = null, fallback = null
 function usage() {
   return [
     "Usage: relay-fleet.js --repo <path> --fleet-id <id> [--leaves-file <path>] [options]",
-    "       relay-fleet.js --repo <path> --fleet-id <id> --review [options]",
     "       relay-fleet.js --repo <path> --fleet-id <id> --status [--json]",
     "       relay-fleet.js --repo <path> --status [--json]",
     "",
@@ -121,8 +120,6 @@ function usage() {
     `  --repo <path>          ${modeLabel("--repo")} Repository root (default: current directory)`,
     `  --fleet-id <id>       ${modeLabel("--fleet-id")} Fleet manifest id (required except repo-wide --status)`,
     `  --leaves-file <path>  ${MODE_VERBATIM_LABEL} JSON file with already-planned leaf contracts`,
-    `  --resume             ${MODE_PARSED_LABEL} Deprecated alias for the default drive command`,
-    `  --review             ${MODE_PARSED_LABEL} Deprecated review-only re-entry point`,
     `  --status             ${MODE_PARSED_LABEL} Print derived fleet summary without writing`,
     `  --parallel <n>       ${MODE_PARSED_LABEL} Maximum concurrent child dispatches (default: ${DEFAULT_PARALLEL})`,
     `  --dispatch-script <path>  ${MODE_VERBATIM_LABEL} Dispatch entrypoint (default: relay-dispatch/scripts/dispatch.js)`,
@@ -150,6 +147,12 @@ function usage() {
 }
 
 function parseArgs(argv) {
+  if (argv.includes("--resume")) {
+    throw new FleetInputError(
+      "--resume is no longer supported; use the default drive command without --resume. " +
+      "The default drive is idempotent and resumes in place."
+    );
+  }
   const unknown = findUnknownFlags(argv, KNOWN_FLAGS);
   if (unknown.length) {
     throw new FleetInputError(`unknown flags: ${unknown.join(", ")}`);
@@ -168,7 +171,6 @@ function parseArgs(argv) {
     repo,
     fleetId: getArg("--fleet-id"),
     leavesFile: getArg("--leaves-file"),
-    resume: hasFlag("--resume"),
     review: hasFlag("--review"),
     status: hasFlag("--status"),
     parallel,
@@ -3031,7 +3033,6 @@ function buildDriveResult({
   dispatchResult = null,
   reviewResult = null,
   mergeResult = null,
-  deprecatedAliases = [],
   replacedChildren = [],
 }) {
   closeFleetIfTerminal(repoRoot, fleetId);
@@ -3046,7 +3047,6 @@ function buildDriveResult({
     interrupted,
     fleet_id: fleetId,
     fleetManifestPath,
-    deprecated_aliases: deprecatedAliases,
     replaced_children: replacedChildren,
     children: dispatchResult?.children || [],
     dispatch_children: dispatchResult?.children || [],
@@ -3151,7 +3151,6 @@ async function runFleet(options) {
   }
 
   try {
-    const deprecatedAliases = options.resume ? ["--resume"] : [];
     const dispatchResult = await dispatchFleetPhase({
       repoRoot,
       fleetId,
@@ -3167,7 +3166,6 @@ async function runFleet(options) {
         ok: false,
         interrupted,
         fleetManifestPath: manifestPath,
-        deprecated_aliases: deprecatedAliases,
         replaced_children: replacedChildren,
       };
     }
@@ -3191,7 +3189,6 @@ async function runFleet(options) {
           interrupted,
           dispatchResult,
           reviewResult,
-          deprecatedAliases,
           replacedChildren,
         });
       }
@@ -3206,7 +3203,6 @@ async function runFleet(options) {
       dispatchResult,
       reviewResult,
       mergeResult,
-      deprecatedAliases,
       replacedChildren,
     });
   } finally {
@@ -3228,11 +3224,11 @@ async function main(argv = process.argv.slice(2)) {
     if (!options.fleetId && !options.status) {
       throw new FleetInputError("--fleet-id is required");
     }
-    if (options.status && (options.resume || options.leavesFile || options.dryRun)) {
-      throw new FleetInputError("--status is read-only and cannot be combined with --resume, --leaves-file, or --dry-run");
+    if (options.status && (options.leavesFile || options.dryRun)) {
+      throw new FleetInputError("--status is read-only and cannot be combined with --leaves-file or --dry-run");
     }
-    if (options.review && (options.resume || options.leavesFile || options.dryRun || options.status)) {
-      throw new FleetInputError("--review cannot be combined with --resume, --leaves-file, --dry-run, or --status");
+    if (options.review && (options.leavesFile || options.dryRun || options.status)) {
+      throw new FleetInputError("--review cannot be combined with --leaves-file, --dry-run, or --status");
     }
     const result = await runFleet({ ...options, installSignalHandlers: true });
     writeReplacementNotes(result);

--- a/tests/relay-fleet/scripts/relay-fleet.test.js
+++ b/tests/relay-fleet/scripts/relay-fleet.test.js
@@ -1183,7 +1183,6 @@ test("relay-fleet rejects child manifest ownership drift without rewriting it", 
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", fleetId,
-    "--resume",
     "--json",
   ], { relayHome });
 
@@ -1220,7 +1219,6 @@ test("relay-fleet keeps terminal missing-owner legacy inspection allowed without
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", fleetId,
-    "--resume",
     "--json",
   ], { relayHome });
 
@@ -1254,7 +1252,6 @@ test("relay-fleet rejects terminal existing-owner drift against the persisted le
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", fleetId,
-    "--resume",
     "--json",
   ], { relayHome });
 
@@ -1295,7 +1292,6 @@ test("relay-fleet requires explicit ownership to migrate an active legacy child,
   const blocked = runFleet([
     "--repo", repoRoot,
     "--fleet-id", fleetId,
-    "--resume",
     "--json",
   ], { relayHome });
 
@@ -2665,35 +2661,31 @@ test("relay-fleet with only fleet-id and no manifest fails closed with nothing t
   assert.match(result.stderr, /nothing to continue/);
 });
 
-test("relay-fleet --resume is accepted as a deprecated alias of the default drive", () => {
-  const { relayHome, repoRoot } = setupRepo("relay-fleet-drive-resume-alias-");
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-drive-resume-alias-fake-"));
-  const finalizeScript = writeFakeFinalizeScript(tmpDir);
-  const runId = writeChildRun(repoRoot, {
-    runId: "issue-567-20260516010101000-a1b2c3d4",
-    branch: "issue-567-leaf-a",
-    issueNumber: 567,
-    leafId: "leaf-a",
-    fleetId: "fleet-resume-alias",
-    state: RUN_STATES.READY_TO_MERGE,
-  });
-  createFleetManifest(repoRoot, {
-    fleetId: "fleet-resume-alias",
-    children: [{ leaf_ref: "leaf-a", run_id: runId, dispatch_status: DISPATCH_STATUS.DISPATCHED }],
-  });
-  advanceFleetManifestState(repoRoot, "fleet-resume-alias", FLEET_STATES.REVIEWING);
-
+test("relay-fleet --resume is removed with migration guidance", () => {
   const result = runFleet([
-    "--repo", repoRoot,
-    "--fleet-id", "fleet-resume-alias",
+    "--repo", ".",
+    "--fleet-id", "fleet-resume-removed",
     "--resume",
-    "--finalize-script", finalizeScript,
     "--json",
-  ], { relayHome });
+  ], { relayHome: fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")) });
 
-  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-  assert.equal(JSON.parse(result.stdout).summary.fleet_state, FLEET_STATES.CLOSED);
-  assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.MERGED);
+  assert.notEqual(result.status, 0);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /--resume is no longer supported/);
+  assert.match(result.stderr, /default drive command without --resume/);
+  assert.match(result.stderr, /idempotent and resumes in place/);
+  assert.doesNotMatch(result.stderr, /unknown flags/);
+});
+
+test("relay-fleet help omits removed and debug-only entry flags", () => {
+  const result = runFleet(["--help"], {
+    relayHome: fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-")),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, "");
+  assert.doesNotMatch(result.stdout, /(?:^|\s)--resume(?=\s|$)/m);
+  assert.doesNotMatch(result.stdout, /(?:^|\s)--review(?=\s|$)/m);
 });
 
 test("relay-fleet closes with nonzero attention when one child escalates and the rest merge", () => {
@@ -2941,7 +2933,6 @@ test("relay-fleet records and resumes a child dispatch that fails before manifes
   const resumed = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-premanifest",
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--review-script", reviewScript,
     "--finalize-script", finalizeScript,
@@ -3253,7 +3244,6 @@ test("relay-fleet never row-4 reconciles a live unexpired lease, including at po
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", fleetId,
-    "--resume",
     "--json",
   ], {
     relayHome,
@@ -3323,7 +3313,7 @@ test("relay-fleet treats detached terminal child states as failed dispatch outco
   ]);
 });
 
-test("relay-fleet --resume polls existing dispatching detached child runs before returning ok", () => {
+test("relay-fleet default drive polls existing dispatching detached child runs before returning ok", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-resume-detached-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-resume-detached-fake-"));
   const dispatchScript = writeFakeDispatchScript(tmpDir);
@@ -3355,7 +3345,6 @@ test("relay-fleet --resume polls existing dispatching detached child runs before
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", fleetId,
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--review-script", reviewScript,
     "--finalize-script", finalizeScript,
@@ -3478,7 +3467,7 @@ test("relay-fleet continues ready siblings after an initial partial fan-out fail
   );
 });
 
-test("relay-fleet resume re-adopts orphan child via fleet_id back-pointer", () => {
+test("relay-fleet default drive re-adopts orphan child via fleet_id back-pointer", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-orphan-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-fake-"));
   const dispatchScript = writeFakeDispatchScript(tmpDir);
@@ -3500,7 +3489,6 @@ test("relay-fleet resume re-adopts orphan child via fleet_id back-pointer", () =
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-orphan",
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--finalize-script", finalizeScript,
     "--json",
@@ -3636,7 +3624,6 @@ test("SIGINT during fan-out leaves a consistent fleet manifest and resume recove
   const resumed = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-sigint",
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--review-script", reviewScript,
     "--finalize-script", finalizeScript,
@@ -3691,7 +3678,6 @@ test("resume while a child subprocess is still running does not double-dispatch"
   const resumed = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-running",
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--review-script", reviewScript,
     "--finalize-script", finalizeScript,
@@ -3958,7 +3944,7 @@ test("relay-fleet --review redispatches a child absent from persisted leaves wit
   assert.equal(readManifest(getManifestPath(repoRoot, runId)).data.state, RUN_STATES.READY_TO_MERGE);
 });
 
-test("relay-fleet --resume re-enters the review loop for changes_requested children", () => {
+test("relay-fleet default drive re-enters the review loop for changes_requested children", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-review-resume-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-resume-fake-"));
   const dispatchScript = writeFakeDispatchScript(tmpDir);
@@ -3991,7 +3977,6 @@ test("relay-fleet --resume re-enters the review loop for changes_requested child
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-review-resume",
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--review-script", reviewScript,
     "--finalize-script", finalizeScript,
@@ -4117,7 +4102,7 @@ test("relay-fleet redispatch pairs immutable ownership with fleet ID for real di
   assert.equal(fs.existsSync(path.join(initialPayload.worktree, "resume.txt")), true);
 });
 
-test("relay-fleet --resume keeps pre-manifest dispatch failures visible during review resume", () => {
+test("relay-fleet default drive keeps pre-manifest dispatch failures visible during review resume", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-review-resume-failure-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-resume-failure-fake-"));
   const dispatchScript = writeFakeDispatchScript(tmpDir);
@@ -4147,7 +4132,6 @@ test("relay-fleet --resume keeps pre-manifest dispatch failures visible during r
   const result = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-review-resume-failure",
-    "--resume",
     "--dispatch-script", dispatchScript,
     "--review-script", reviewScript,
     "--json",
@@ -4162,7 +4146,7 @@ test("relay-fleet --resume keeps pre-manifest dispatch failures visible during r
   assert.equal(payload.operator_attention.some((item) => item.leaf_ref === "leaf-b"), true);
 });
 
-test("relay-fleet --resume skips a still-running review subprocess", async () => {
+test("relay-fleet default drive skips a still-running review subprocess", async () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-review-running-");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-review-running-fake-"));
   const reviewScript = writeFakeReviewScript(tmpDir);
@@ -4227,7 +4211,6 @@ test("relay-fleet --resume skips a still-running review subprocess", async () =>
   const resumed = runFleet([
     "--repo", repoRoot,
     "--fleet-id", "fleet-review-running",
-    "--resume",
     "--review-script", reviewScript,
     "--json",
   ], {
@@ -4621,7 +4604,7 @@ test("relay-fleet --status without --fleet-id returns clean empty text and JSON 
 
 test("relay-fleet non-status modes without --fleet-id preserve the missing-argument error", () => {
   const { relayHome, repoRoot } = setupRepo("relay-fleet-list-required-");
-  for (const modeArgs of [[], ["--resume"], ["--review"], ["--dry-run"]]) {
+  for (const modeArgs of [[], ["--review"], ["--dry-run"]]) {
     const result = runFleet(["--repo", repoRoot, ...modeArgs], { relayHome });
     assert.equal(result.status, 1, `mode ${modeArgs.join(" ")} unexpectedly succeeded`);
     assert.equal(result.stdout, "");


### PR DESCRIPTION
## Dispatch Summary

```text
구현과 로컬 커밋은 완료했습니다. 다만 네트워크·인증 제한으로 푸시와 PR 생성은 완료하지 못했습니다.

- 커밋: `a658238 Sunset deprecated relay-fleet entry points (#861)`
- 브랜치: `issue-861`, `origin/main`보다 1커밋 앞섬
- 작업 트리: clean
- 변경 범위: [relay-fleet.js](/Users/sjlee/.relay/worktrees/fc58cabe/dev-relay/skills/relay-fleet/scripts/relay-fleet.js), [merge-queue.js](/Users/sjlee/.relay/worktrees/fc58cabe/dev-relay/skills/relay-fleet/scripts/merge-queue.js), [SKILL.md](/Users/sjlee/.relay/worktrees/fc58cabe/dev-relay/skills/relay-fleet/SKILL.md)
```

## Dispatch Metadata

- Run: issue-861-20260725005242125-d98b339d
- Executor: codex
- Branch: issue-861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * `--resume` 옵션이 제거되어 사용 시 즉시 오류가 발생합니다.
  * 작업 재개는 동일한 `--fleet-id`로 기본 명령을 다시 실행하는 방식으로 지원됩니다.
  * `--status` 및 `--review`와 다른 옵션의 조합 제한과 오류 안내가 명확해졌습니다.
  * 도움말에서 제거된 옵션과 내부 디버그용 재진입 경로가 노출되지 않습니다.

* **문서**
  * 운영자용 실행 안내를 새 옵션 동작에 맞게 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->