### PR TITLE
Retire the unreliability tax: instrument + orchestrator-owned commit (Issues A+B)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Specialized ledgers (not ADRs): [rubric-fail-closed-history.md](./rubric-fail-cl
 | [relay-ready-routing-and-handoff-design.md](./relay-ready-routing-and-handoff-design.md) | relay-ready intake routing (#127–#132) |
 | [relay-scenario-tests.md](./relay-scenario-tests.md) | Scenario-test matrix for lifecycle and reporting |
 | [agentic-patterns-adoption.md](./agentic-patterns-adoption.md) | Willison-pattern adoption roadmap (Phase 0 complete) |
+| [relay-instruction-altitude-prd.md](./relay-instruction-altitude-prd.md) | Retiring the unreliability tax (recovery machinery) via orchestrator-owned commit — the reliability-axis sequel to #1025 (proposal) |
 
 ## Analysis And Validation
 

--- a/docs/relay-instruction-altitude-prd.md
+++ b/docs/relay-instruction-altitude-prd.md
@@ -1,0 +1,151 @@
+# Relay Instruction Altitude — Retiring the Unreliability Tax
+
+Status: proposal (2026-07-26)
+Builds on: **#1025 (shipped, PR #1034, merged 2026-07-19)** — Risk-adaptive relay simplification. That epic already reduced the *prescription tax*; this PRD addresses the second tax #1025 named but did not tackle.
+Related: `docs/plans/2026-07-19-risk-adaptive-relay-simplification-design.md`, ADR-0001 (orchestrator owns publication), auto-recover-commit (#508, #1060), recover-commit bug cluster (#806, #856, #793, #904, #876)
+
+## Summary
+
+As models improve, the right direction is fewer detailed instructions and more focus on the core. Relay carries two masses that a 2026-era model lets it shed:
+
+- **Prescription tax** — rubric/review harnessing that told the model *how to think*. **This is already resolved.** Epic #1025 ("subtract procedural harnessing while preserving the boundaries that make delegation safe") shipped the min-anchor default, Outcome/Verification/Earned-Rubric separation, zero-scored-factor validity, reviewer-only scoring, and risk-proportional assurance — merged, dogfooded (#1036), and calibrated (#1035). This PRD does **not** re-open it.
+
+- **Unreliability tax** — recovery machinery (`recover-commit.js`, `rebrand-evidence.js`, `reconcile-run.js` row-6 salvage) that exists only because the executor says "done" without committing/pushing/opening a PR. #1025's problem statement named this as a symptom ("harness-caused recovery work") but its workstreams did not touch it. Relay's current answer is to run recovery **automatically** (`auto-recover-commit` default-ON, #508/#1060) — which removes operator friction but keeps the machinery, and that machinery has spawned its own bug spiral (#806/#856/#793/#904/#876).
+
+The proposal: finish the same subtraction #1025 started, on the reliability axis. Eliminate the executor-misbehavior failure mode **structurally** (extend orchestrator ownership from push+PR to the commit step), instrument what the recovery machinery actually catches, and retire the machinery on evidence — the same "delete legacy only after comparative evidence" discipline #1025 used.
+
+## Problem
+
+### The prescription-tax half is done; this is the reliability half
+
+#1025 correctly framed the goal as "central enforcement of intent, permission, isolation, observable evidence, auditability, and explicit approval, with broad model autonomy inside those boundaries." Its six durable boundaries are exactly the *trust kernel* — the part that survives any model IQ. It subtracted procedural harnessing from **planning and review**. It left the **executor-handoff** harnessing in place, and in fact hardened it (auto-recover-commit default-ON) rather than removing it.
+
+### The unreliability tax, itemized
+
+Of the recovery surface, the pieces that exist for executor misbehavior (not infrastructure failure):
+
+| Script / path | Exists because | Infra or misbehavior? |
+| --- | --- | --- |
+| `recover-commit.js` | "executor completed but did not commit/push/open a PR" | misbehavior |
+| `reconcile-run.js` row-6 salvage | "committed but never pushed" | misbehavior |
+| `rebrand-evidence.js` | "executor evidence was wrong; orchestrator corrected it, must re-stamp" | misbehavior |
+| lease/crash rows, `cleanup-worktrees.js` | supervisor/host death, orphaned worktrees | **infra — keep** |
+
+The misbehavior rows are the tax. Memory and dogfood data show it is not rare: opus-class executors skip the commit step roughly half the time, which is exactly why #508/#1060 made recovery automatic.
+
+### Automatic recovery removed the friction but kept the liability
+
+Making `auto-recover-commit` default-ON was a reasonable mitigation — the operator no longer runs a manual recovery step. But it is a mitigation of a symptom, not removal of a failure mode:
+
+- The machinery still exists and still runs on ~half of dispatches.
+- It has its own defect surface: `#806`, `#856`, `#793` (timeout placeholder evidence blocks recover-commit / cannot record missing execution evidence), `#904`, `#876` (row-4 recovery must stamp execution evidence / premature recover publishes a mid-work snapshot). Each is a bug *in the tax*, not in the feature work.
+- Authorship/evidence drift: because the orchestrator commits on the executor's behalf after the fact, `rebrand-evidence.js` exists to re-bind evidence when a correction commit lands on top.
+
+A structurally impossible failure mode generates no recovery code and no recovery bugs.
+
+## Trust Kernel vs Compensatory Scaffolding
+
+The organizing distinction (a restatement of #1025's "durable boundaries" vs "procedural harnessing", extended to the reliability axis):
+
+| | Trust kernel | Compensatory scaffolding |
+| --- | --- | --- |
+| Definition | Survives any model IQ; a boundary pinned regardless of capability | Shrinks as models improve; compensates for the model not doing what it was told |
+| Reliability-axis examples | Crash-only recovery (lease + reconcile for real process/host death); PR = handoff boundary; observable execution evidence; SHA-freshness merge gate | `recover-commit`, `rebrand-evidence`, salvage row — recovery for an executor that skipped commit/push/PR |
+| Direction | Harden freely | Remove the failure mode, then retire the recovery |
+
+#1025 applied this split to planning/review. This PRD applies the same split to the executor handoff.
+
+## Goals
+
+- Make executor-skipped-commit **structurally impossible**, so the corresponding recovery machinery becomes dead code rather than default-ON runtime.
+- Instrument what the recovery machinery actually catches, per executor/model, so retirement is evidence-gated (the #1025 discipline).
+- Retire only the misbehavior-recovery paths whose invocation trends to zero after the structural fix; keep all infrastructure recovery.
+- (Secondary) Reduce the orchestrator spine's procedural density where #1025's subtraction did not reach — the `relay` SKILL.md lifecycle loop.
+
+## Non-goals
+
+- Do **not** re-open or duplicate #1025's shipped prescription-tax work (rubric, review, assurance tiers). It is done.
+- Do **not** weaken crash-only recovery, lease-based liveness, `cleanup-worktrees`, the SHA-freshness merge gate, or any of #1025's six durable boundaries.
+- Do **not** remove `auto-recover-commit` or any recovery script before the structural fix has driven its invocation rate toward zero under real dispatch.
+- Do **not** change adapter capability gates, route policy, or manifest role bindings.
+- Do **not** over-specify this PRD's own issues; state the observable WHAT and the metric, leave the HOW to the executor.
+
+## Design Principles
+
+1. **Remove the failure mode, then retire the recovery.** `#198` already made push+PR orchestrator-owned. Extending orchestrator ownership to the commit step makes "executor forgot to commit" impossible by construction, which is strictly better than recovering from it automatically.
+
+2. **Instrument before deleting.** Emit an invocation count for each misbehavior-recovery path per executor/model. Deletion is gated on that count trending to zero after the structural fix — the same comparative-evidence gate #1033 used.
+
+3. **Keep infrastructure recovery untouched.** Machine/process death is always possible; the lease/reconcile/cleanup paths are trust kernel and stay.
+
+4. **The orchestrator is an agent, not a flowchart runner.** Where the `relay` spine still spells out poll/branch/snapshot/compare/recover as prose the model executes, move it into a driver command and let the spine state the goal.
+
+## Resolved Design Decisions
+
+**Orchestrator-owned commit is clean — it eliminates the rebrand path rather than complicating it (resolved 2026-07-26, code-verified).**
+
+- `execution-evidence.json` is *already* orchestrator-written (`dispatch.js` → `writeExecutionEvidence`, stamped `recorded_by: "dispatch-orchestrator-v1"`), bound at write-time to whatever HEAD exists after the executor finishes. On the recovery path a commit lands *after* that binding, which is the sole reason `rebrand-evidence` exists (it rewrites `head_sha` to the new commit and files the old one under a `rebrand` block).
+- Reordering the happy path so the orchestrator commits the worktree diff as the *last* step, then binds evidence once to that final SHA, removes the ordering artifact — no rebrand for the normal path. `buildExecutionEvidence` only requires a SHA that exists at write time; the executor's result file is already on disk, so a single binding suffices.
+- git authorship is **not** tied to the executor anywhere: no `--author` is set, and nothing reads `%an`/`%ae`. Attribution lives in manifest `roles.executor` and evidence `recorded_by`, both orchestrator-controlled. Orchestrator-owned commit therefore loses no provenance. (`git commit --author=<executor>` is available as an *optional* new provenance signal, not a requirement.)
+
+Consequence: Issue B is not a risky new mechanism; it promotes the orchestrator's existing commit capability (which `recover-commit` already exercises) from a recovery path to the normal path, and Issue C can retire `recover-commit` **and** `rebrand-evidence` (not just `recover-commit`) once the data confirms it.
+
+## Issue Breakdown
+
+Delivered in order; each independently dispatchable. Acceptance criteria are observable and metric-anchored.
+
+### Issue A: Instrument the unreliability tax (baseline)
+
+Establish the measurement before changing behavior.
+
+Acceptance criteria:
+- `reliability-report` surfaces per-executor/model invocation rate of `recover-commit`, `rebrand-evidence`, and `reconcile-run` row-6 salvage over recent runs, distinguishing them from infrastructure recovery (lease/crash/cleanup).
+- Output is JSON and human-readable, consistent with existing `--by-role` / `--by-lane` modes.
+- The report names what it could not classify (no silent truncation).
+- No behavior change to dispatch or recovery in this issue.
+
+### Issue B: Orchestrator-owned commit (structural fix)
+
+Make executor-skipped-commit impossible.
+
+Acceptance criteria:
+- On executor completion, the orchestrator commits the retained worktree diff under the run's identity; an executor that edits but never commits yields a committed run **without** invoking `recover-commit`.
+- A dispatch where the executor commits normally is behavior-identical (no double commit, no evidence rebrand).
+- Execution evidence is bound once to the final orchestrator-commit SHA with no rebrand on the normal path (see Resolved Design Decisions).
+- Infrastructure recovery (lease/crash, reconcile dead/interrupted rows, cleanup) is unchanged.
+- No recovery script is deleted in this issue.
+
+### Issue C: Retire misbehavior-recovery on evidence (gated)
+
+Delete the dead tax once the data confirms it.
+
+Acceptance criteria:
+- Blocked until Issue A's report shows the misbehavior-recovery invocation rate trending to zero across a real observation window post-Issue-B (mirror the #1036 dogfood gate).
+- Retire only the misbehavior paths whose invocation reached zero; keep every infrastructure path and keep `auto-recover-commit` reachable as an explicit fallback for unmanaged executors that cannot use orchestrator-owned commit, if any remain.
+- Removal follows the one-release deprecation-window rule; document what was removed and why in the script-inventory doc.
+
+### Issue D (secondary): Thin the orchestrator spine to a goal
+
+Reduce lifecycle-loop procedural density in the `relay` spine.
+
+Acceptance criteria:
+- A single driver command owns the dispatch→review lifecycle loop (poll until state leaves `dispatched`, run review, handle stale/recover) that the `relay` SKILL.md currently spells out step by step.
+- `relay` SKILL.md expresses the goal, stop condition (`ready_to_merge`), and trust invariants in place of the JSON-field branching table, and stays well under 150 lines.
+- The state machine, transition guards, and recovery paths are unchanged — only their invocation surface moves from prose to a command.
+- Existing `/relay` scenario tests pass without weakening any assertion.
+
+## Open Questions
+
+- ~~**Authorship / evidence semantics.**~~ **Resolved (2026-07-26)** — see Resolved Design Decisions. Orchestrator-owned commit eliminates the rebrand path and loses no provenance; Issue B is a reorder, not a new mechanism.
+- **Unmanaged executors.** Some adapters may not expose a worktree the orchestrator can commit cleanly. Does orchestrator-owned commit cover all current executors, or does `auto-recover-commit` stay as a scoped fallback for a named subset?
+- **Is Issue D worth it?** `operator-surface.md` calls SKILL.md the "decision spine" deliberately. Is the `relay` lifecycle loop genuinely over-proceduralized, or is its explicitness load-bearing for operators driving manual phases? Measure spine length and operator-reported friction before committing.
+- **Scope vs #755/#838.** Open issues #755 (no re-review path for orchestrator corrections after `ready_to_merge`) and #838 (recoverable review interruption) touch adjacent recovery surface; confirm no overlap before dispatch.
+
+## Recommended Delivery Order
+
+1. Issue A — instrument (baseline before any change).
+2. Issue B — orchestrator-owned commit (the structural fix).
+3. Issue C — retire misbehavior-recovery, gated on A's post-B evidence.
+4. Issue D — thin the spine (optional; gate on the "is it worth it" question).
+
+This mirrors #1025's own sequence — measure, subtract behavior, delete machinery only on comparative evidence — applied to the one tax that arc left standing.

--- a/docs/relay-instruction-altitude-prd.md
+++ b/docs/relay-instruction-altitude-prd.md
@@ -14,6 +14,12 @@ As models improve, the right direction is fewer detailed instructions and more f
 
 The proposal: finish the same subtraction #1025 started, on the reliability axis. Eliminate the executor-misbehavior failure mode **structurally** (extend orchestrator ownership from push+PR to the commit step), instrument what the recovery machinery actually catches, and retire the machinery on evidence — the same "delete legacy only after comparative evidence" discipline #1025 used.
 
+## Delivery status (2026-07-26, branch `relay/unreliability-tax`)
+
+- **Issue A — DONE.** `reliability-report --by-recovery` ships the per-executor/model tax breakdown. Real baseline: ~39% of dev-relay runs carry the misbehavior tax (claude 0.69 / cursor 0.54 / codex 0.36), infrastructure recovery kept separate.
+- **Issue B — DONE.** Orchestrator-owned commit now lands *before* evidence for `completed-uncommitted` runs, gated to auto-recover-on executors (codex/claude, or explicit `--auto-recover-commit`), so evidence binds once to the commit and no rebrand runs. `recover-commit` stays as a fallback (orchestrator-commit failure → auto-recover → escalate), so the change is non-breaking. Extending orchestrator-owned commit to all executors / always-on is a follow-up (the "unmanaged executors" open question). Verified: full dispatch suite 201/201, recover/reconcile/docs 90/90.
+- **Issue C / D — pending.** C (retire `recover-commit`/`rebrand-evidence` on evidence) is gated on a post-B observation window that shows the tax invocation rate trending to zero; D (spine thinning) is optional.
+
 ## Problem
 
 ### The prescription-tax half is done; this is the reliability half

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -32,6 +32,7 @@ const FLAGS = [
   { flag: "--by-actor", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--by-dispatch", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--by-lane", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
+  { flag: "--by-recovery", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--by-role", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--contract-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path; keep the literal argv token." },
   { flag: "--copy", kind: VALUE, mode: MODE_VERBATIM, valueName: "<file,...>", rationale: "Operator-supplied file list; keep the literal argv token." },
@@ -233,7 +234,7 @@ const COMMAND_FLAGS = {
     "--json", "--help",
   ],
   "reliability-report": [
-    "--repo", "--stale-hours", "--json", "--by-actor", "--by-role", "--by-acting-reviewer", "--by-dispatch", "--by-lane", "--help",
+    "--repo", "--stale-hours", "--json", "--by-actor", "--by-role", "--by-acting-reviewer", "--by-dispatch", "--by-lane", "--by-recovery", "--help",
   ],
   "review-runner": [
     "--repo", "--run-id", "--branch", "--pr", "--manifest", "--done-criteria-file",

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -171,7 +171,7 @@ const {
 } = require("./route-failure-hints");
 const { loadRelayPolicy } = require("./relay-policy");
 const { loadProjectRoutes, resolveRouteIntent, resolveRoutingDecision } = require("./relay-routing");
-const { classifyRepositoryDirt, formatRuntimeMetadataDirt } = require("./runtime-dirt");
+const { classifyRepositoryDirt, formatRuntimeMetadataDirt, gitAddReviewableArgs } = require("./runtime-dirt");
 const {
   dispatchManifestPathFields,
   getRunArtifactPaths,
@@ -3281,7 +3281,39 @@ async function main() {
   } else {
     status = exitCode === 0 ? "completed" : "failed";
   }
+
+  // Issue B (orchestrator-owned commit): when the executor exits cleanly but left
+  // reviewable work uncommitted, commit it now — before execution evidence is
+  // written — so evidence binds once to the committed SHA and no post-hoc
+  // recover-commit or evidence rebrand is needed. Gated identically to
+  // auto-recover-commit (default-on for codex/claude) so other executors keep
+  // their existing path. On failure, fall through with the original
+  // completed-uncommitted status so the downstream recover-commit path still runs.
+  let orchestratorCommitted = false;
+  if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted") {
+    try {
+      execGit(wtPath, gitAddReviewableArgs(rawUncommitted));
+      execGit(wtPath, [
+        "commit",
+        "-m", `Relay run ${runId}`,
+        "-m", `Executor reviewable changes committed by the relay orchestrator (run ${runId}).`,
+      ]);
+      currentHead = execGit(wtPath, ["rev-parse", "HEAD"]);
+      if (startHead && currentHead !== startHead) {
+        gitLog = execGit(wtPath, ["log", "--oneline", `${startHead}..HEAD`]);
+      }
+      uncommitted = classifyRepositoryDirt(execGit(wtPath, ["status", "--porcelain"])).reviewableStatus;
+      if (!uncommitted) uncommittedDiff = "";
+      status = "completed";
+      orchestratorCommitted = true;
+    } catch {
+      // Leave status as completed-uncommitted; the auto-recover-commit fallback runs below.
+      orchestratorCommitted = false;
+    }
+  }
+
   let commitMode = summarizeCommitMode({ status, gitLog, uncommitted });
+  if (orchestratorCommitted) commitMode = "orchestrator-committed";
   const delayedReviewHasUncommittedWork = PUBLISH_POLICY === "after-internal-review" && (
     status === "completed-uncommitted" || (status === "completed-with-warning" && uncommitted)
   );

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -3289,8 +3289,17 @@ async function main() {
   // auto-recover-commit (default-on for codex/claude) so other executors keep
   // their existing path. On failure, fall through with the original
   // completed-uncommitted status so the downstream recover-commit path still runs.
+  //
+  // Skip when another orchestrator has already superseded this run (manifest
+  // advanced off DISPATCHED). Committing here would promote the run to `completed`
+  // and trip the immediate-publish push below, which runs BEFORE the supervisor
+  // supersede check (~line 3400) and would open a duplicate/conflicting PR for a
+  // run this orchestrator no longer owns. Leaving it completed-uncommitted keeps
+  // the prior behavior: the downstream recover-commit path is itself
+  // supersede-guarded and correctly no-ops.
   let orchestratorCommitted = false;
-  if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted") {
+  const supersededBeforeCommit = readManifest(manifestPath).data.state !== STATES.DISPATCHED;
+  if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted" && !supersededBeforeCommit) {
     try {
       execGit(wtPath, gitAddReviewableArgs(rawUncommitted));
       execGit(wtPath, [
@@ -3306,9 +3315,16 @@ async function main() {
       if (!uncommitted) uncommittedDiff = "";
       status = "completed";
       orchestratorCommitted = true;
-    } catch {
-      // Leave status as completed-uncommitted; the auto-recover-commit fallback runs below.
+    } catch (orchestratorCommitError) {
+      // Leave status as completed-uncommitted; the auto-recover-commit fallback runs
+      // below. Surface the git failure reason — this is now the primary commit path,
+      // so a silent no-op would hide why the unreliability tax persists (a
+      // gitAddReviewableArgs bug, a pre-commit hook, or a missing git identity).
       orchestratorCommitted = false;
+      console.error(
+        `orchestrator_commit_failed (run ${runId}), falling back to recover-commit: ` +
+        `${String(orchestratorCommitError.message || orchestratorCommitError).split("\n")[0]}`
+      );
     }
   }
 

--- a/skills/relay-dispatch/scripts/reliability-report.js
+++ b/skills/relay-dispatch/scripts/reliability-report.js
@@ -26,10 +26,19 @@ const HANDOFF_RECOVERY_EVENTS = new Set([
   EVENTS.STATE_RECOVERY,
 ]);
 
+// Executor-misbehavior "unreliability tax": recovery that only exists because the
+// executor said "done" without a clean committed/pushed/evidenced result. Kept
+// strictly separate from infrastructure recovery (dead/timed-out supervisor) and
+// from mixed-origin state_recovery. See buildUnreliabilityTax.
+const MISBEHAVIOR_TAX_EVENTS = new Set([
+  EVENTS.RECOVER_COMMIT,
+  EVENTS.EXECUTION_EVIDENCE_REBRANDED,
+]);
+
 if (hasCliFlag(["--help", "-h"])) {
   console.log(
     "Usage: reliability-report.js [--repo <path>] [--stale-hours <hours>] " +
-    "[--json] [--by-actor] [--by-role] [--by-acting-reviewer] [--by-dispatch] [--by-lane]"
+    "[--json] [--by-actor] [--by-role] [--by-acting-reviewer] [--by-dispatch] [--by-lane] [--by-recovery]"
   );
   console.log("\nOptions:");
   console.log(`  --repo <path>           ${modeLabel("--repo")} Repository root (default: .)`);
@@ -40,6 +49,7 @@ if (hasCliFlag(["--help", "-h"])) {
   console.log(`  --by-acting-reviewer    ${modeLabel("--by-acting-reviewer")} Include acting reviewer breakdown`);
   console.log(`  --by-dispatch           ${modeLabel("--by-dispatch")} Include executor/model/provider breakdown`);
   console.log(`  --by-lane               ${modeLabel("--by-lane")} Include advisory lane reviewer/model/profile breakdown`);
+  console.log(`  --by-recovery           ${modeLabel("--by-recovery")} Include unreliability-tax breakdown (misbehavior recovery per executor/model, infra recovery separated)`);
   process.exit(0);
 }
 
@@ -1290,6 +1300,173 @@ function buildLaneReports(events) {
   return Object.fromEntries([...buckets.entries()].sort(([left], [right]) => left.localeCompare(right)));
 }
 
+function buildRunDispatchIndex(manifests) {
+  const index = new Map();
+  for (const manifest of manifests) {
+    const data = manifest?.data;
+    const runId = data?.run_id;
+    if (!runId) continue;
+    index.set(runId, {
+      executor: normalizeDispatchKey(data?.dispatch?.last_executor || data?.roles?.executor),
+      model: normalizeDispatchKey(data?.dispatch?.last_model),
+    });
+  }
+  return index;
+}
+
+function newTaxCell() {
+  return {
+    recoverCommitRuns: new Set(),
+    recoverCommitEvents: 0,
+    evidenceRebrandRuns: new Set(),
+    evidenceRebrandEvents: 0,
+    misbehaviorRuns: new Set(),
+  };
+}
+
+function recordTaxEvent(cell, eventName, runId) {
+  if (eventName === EVENTS.RECOVER_COMMIT) {
+    cell.recoverCommitEvents += 1;
+    if (runId) cell.recoverCommitRuns.add(runId);
+  } else {
+    cell.evidenceRebrandEvents += 1;
+    if (runId) cell.evidenceRebrandRuns.add(runId);
+  }
+  if (runId) cell.misbehaviorRuns.add(runId);
+}
+
+function finalizeTaxCell(cell, denomRuns) {
+  const misbehaviorRuns = cell.misbehaviorRuns.size;
+  return {
+    total_runs: denomRuns,
+    recover_commit_runs: cell.recoverCommitRuns.size,
+    recover_commit_events: cell.recoverCommitEvents,
+    evidence_rebrand_runs: cell.evidenceRebrandRuns.size,
+    evidence_rebrand_events: cell.evidenceRebrandEvents,
+    misbehavior_recovery_runs: misbehaviorRuns,
+    misbehavior_recovery_rate: ratio(misbehaviorRuns, denomRuns),
+  };
+}
+
+// Issue A instrumentation: how often the misbehavior-recovery paths fire per
+// executor/model, kept read-only and strictly separated from infrastructure
+// recovery. Denominators are all runs assigned to an executor/model; numerators
+// are distinct runs (and raw event counts) touched by recover_commit /
+// execution_evidence_rebranded. reconcile-run row-6 salvage rides on
+// execution_evidence_rebranded and operator_execution_evidence, so it is counted
+// via those tallies rather than as a separately named row. Tax events whose
+// run_id has no loaded manifest are surfaced as `unattributed_tax_events` (no
+// silent truncation).
+function buildUnreliabilityTax({ manifests, events }) {
+  const dispatchIndex = buildRunDispatchIndex(manifests);
+
+  const runsByExecutor = new Map();
+  const runsByModel = new Map();
+  for (const info of dispatchIndex.values()) {
+    runsByExecutor.set(info.executor, (runsByExecutor.get(info.executor) || 0) + 1);
+    runsByModel.set(info.model, (runsByModel.get(info.model) || 0) + 1);
+  }
+
+  const overall = newTaxCell();
+  const byExecutor = new Map();
+  const byModel = new Map();
+  const infra = {
+    dispatchInterruptedRuns: new Set(),
+    dispatchInterruptedEvents: 0,
+    stateRecoveryRuns: new Set(),
+    stateRecoveryEvents: 0,
+  };
+  const operatorEvidenceRuns = new Set();
+  let operatorEvidenceEvents = 0;
+  let unattributedTaxEvents = 0;
+
+  function cellFor(map, key) {
+    if (!map.has(key)) map.set(key, newTaxCell());
+    return map.get(key);
+  }
+
+  for (const event of events) {
+    const name = event?.event;
+    const runId = event?.run_id || null;
+
+    if (name === EVENTS.DISPATCH_INTERRUPTED) {
+      infra.dispatchInterruptedEvents += 1;
+      if (runId) infra.dispatchInterruptedRuns.add(runId);
+      continue;
+    }
+    if (name === EVENTS.STATE_RECOVERY) {
+      infra.stateRecoveryEvents += 1;
+      if (runId) infra.stateRecoveryRuns.add(runId);
+      continue;
+    }
+    if (name === EVENTS.OPERATOR_EXECUTION_EVIDENCE) {
+      operatorEvidenceEvents += 1;
+      if (runId) operatorEvidenceRuns.add(runId);
+      continue;
+    }
+    if (!MISBEHAVIOR_TAX_EVENTS.has(name)) continue;
+
+    // Attribute only tax events that map to a loaded manifest so totals stay
+    // reconcilable with the per-executor/model breakdown. Events whose run_id has
+    // no manifest are surfaced as `unattributed_tax_events`, never folded into a
+    // bucket or the headline rate.
+    const info = runId ? dispatchIndex.get(runId) : null;
+    if (!info) {
+      unattributedTaxEvents += 1;
+      continue;
+    }
+    recordTaxEvent(overall, name, runId);
+    recordTaxEvent(cellFor(byExecutor, info.executor), name, runId);
+    recordTaxEvent(cellFor(byModel, info.model), name, runId);
+  }
+
+  function finalizeGroup(runsByKey, cellByKey) {
+    const out = {};
+    for (const key of [...runsByKey.keys()].sort((a, b) => a.localeCompare(b))) {
+      out[key] = finalizeTaxCell(cellByKey.get(key) || newTaxCell(), runsByKey.get(key));
+    }
+    return out;
+  }
+
+  return {
+    classification: {
+      tax_events: ["recover_commit", "execution_evidence_rebranded"],
+      infrastructure_events: ["dispatch_interrupted"],
+      mixed_or_operator_events: ["state_recovery"],
+      note:
+        "recover_commit and execution_evidence_rebranded are counted as the executor "
+        + "misbehavior tax. dispatch_interrupted is infrastructure recovery. state_recovery is "
+        + "mixed-origin (reconcile dead-work = infrastructure; recover-state = operator "
+        + "correction) and is reported under infrastructure_recovery, never attributed to an "
+        + "executor tax bucket. reconcile-run row-6 salvage rides on execution_evidence_rebranded "
+        + "and operator_execution_evidence, so it is counted via those tallies, not as a "
+        + "separately named row.",
+    },
+    totals: {
+      ...finalizeTaxCell(overall, manifests.length),
+      unattributed_tax_events: unattributedTaxEvents,
+    },
+    by_executor: finalizeGroup(runsByExecutor, byExecutor),
+    by_model: finalizeGroup(runsByModel, byModel),
+    infrastructure_recovery: {
+      dispatch_interrupted_runs: infra.dispatchInterruptedRuns.size,
+      dispatch_interrupted_events: infra.dispatchInterruptedEvents,
+      state_recovery_runs: infra.stateRecoveryRuns.size,
+      state_recovery_events: infra.stateRecoveryEvents,
+      note: "Infrastructure/operator recovery — excluded from the executor misbehavior tax.",
+    },
+    related_signals: {
+      operator_execution_evidence_runs: operatorEvidenceRuns.size,
+      operator_execution_evidence_events: operatorEvidenceEvents,
+      note:
+        "Operator-supplied execution evidence (reconcile-run row-6 salvage and recover-commit "
+        + "operator-evidence path). Overlaps with runs already counted under recover_commit / "
+        + "execution_evidence_rebranded; reported for visibility, not added to "
+        + "misbehavior_recovery_rate.",
+    },
+  };
+}
+
 function resolveManifestRubricPath(manifest) {
   const rubricPath = manifest?.data?.anchor?.rubric_path;
   const runId = manifest?.data?.run_id;
@@ -1752,6 +1929,9 @@ function main() {
   if (hasCliFlag("--by-lane")) {
     report.by_lane = buildLaneReports(events);
   }
+  if (hasCliFlag("--by-recovery")) {
+    report.by_recovery = buildUnreliabilityTax({ manifests, events });
+  }
 
   if (hasCliFlag("--json")) {
     console.log(JSON.stringify(report, null, 2));
@@ -1961,6 +2141,37 @@ function main() {
         `required_findings=${laneReport.required_findings} ` +
         `advisory_findings=${laneReport.advisory_findings} ` +
         `demotions_caused=${laneReport.demotions_caused}`
+      );
+    }
+  }
+  if (hasCliFlag("--by-recovery")) {
+    const tax = report.by_recovery;
+    console.log("  by_recovery (unreliability tax):");
+    if (!tax) {
+      console.log("    n/a");
+    } else {
+      console.log(
+        `    totals: misbehavior_recovery_rate=${tax.totals.misbehavior_recovery_rate ?? "n/a"} ` +
+        `runs=${tax.totals.misbehavior_recovery_runs}/${tax.totals.total_runs} ` +
+        `recover_commit_runs=${tax.totals.recover_commit_runs} ` +
+        `evidence_rebrand_runs=${tax.totals.evidence_rebrand_runs} ` +
+        `unattributed_tax_events=${tax.totals.unattributed_tax_events}`
+      );
+      for (const [executor, cell] of Object.entries(tax.by_executor || {})) {
+        console.log(
+          `    executor.${executor}: misbehavior_recovery_rate=${cell.misbehavior_recovery_rate ?? "n/a"} ` +
+          `runs=${cell.misbehavior_recovery_runs}/${cell.total_runs} ` +
+          `recover_commit_runs=${cell.recover_commit_runs} ` +
+          `evidence_rebrand_runs=${cell.evidence_rebrand_runs}`
+        );
+      }
+      console.log(
+        `    infrastructure_recovery (excluded from tax): ` +
+        `dispatch_interrupted_runs=${tax.infrastructure_recovery.dispatch_interrupted_runs} ` +
+        `state_recovery_runs=${tax.infrastructure_recovery.state_recovery_runs}`
+      );
+      console.log(
+        `    related: operator_execution_evidence_runs=${tax.related_signals.operator_execution_evidence_runs}`
       );
     }
   }

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -835,6 +835,12 @@ childProcess.execFileSync = function patchedExecFileSync(command, args, options)
     error.stderr = Buffer.from("simulated recover-commit failure\\n");
     throw error;
   }
+  const isGitCommit = command === "git" && argv.includes("commit");
+  if (process.env.RELAY_TEST_FAIL_GIT_COMMIT === "1" && isGitCommit) {
+    const error = new Error("simulated git commit failure");
+    error.stderr = Buffer.from("simulated git commit failure\\n");
+    throw error;
+  }
   if (logPath && (isPush || isGh)) {
     fs.appendFileSync(logPath, JSON.stringify({ command, args: argv }) + "\\n");
   }
@@ -6845,7 +6851,7 @@ test("dispatch marks verified no-op runs as completed-no-op and skips orchestrat
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 
-test("dispatch auto-recovers uncommitted codex runs by default", () => {
+test("dispatch orchestrator-commits uncommitted codex runs by default", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
   process.env.RELAY_HOME = relayHome;
   const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
@@ -6862,11 +6868,14 @@ test("dispatch auto-recovers uncommitted codex runs by default", () => {
     "--json",
   ], env));
 
-  assert.equal(result.status, "completed-uncommitted");
-  assert.equal(result.commitMode, "auto-recovered");
+  // Issue B: the orchestrator commits the executor's reviewable work inline before
+  // evidence is written, so the run reads as a normal completed commit — no
+  // recover-commit subprocess and no evidence rebrand.
+  assert.equal(result.status, "completed");
+  assert.equal(result.commitMode, "orchestrator-committed");
   assert.equal(result.runState, STATES.REVIEW_PENDING);
   assert.equal(result.prNumber, 508);
-  assert.match(result.commits, /Recover relay run/);
+  assert.match(result.commits, /Relay run/);
   assert.equal(result.uncommitted, null);
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);
@@ -6875,14 +6884,19 @@ test("dispatch auto-recovers uncommitted codex runs by default", () => {
   const ghCalls = readJsonLines(ghLogPath);
   assert(ghCalls.some((args) => args[0] === "pr" && args[1] === "create"));
   assert(readJsonLines(execLogPath).some(({ command, args }) => command === "git" && args.includes("push")));
-  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 1);
   const events = readJsonLines(getEventsPath(repoRoot, result.runId));
-  const recoveryEvent = events.find((event) => event.event === "recover_commit");
-  assert(recoveryEvent, JSON.stringify(events, null, 2));
-  assert.match(recoveryEvent.reason, /auto-recover-commit enabled/);
+  assert.ok(
+    !events.some((event) => event.event === "recover_commit"),
+    "orchestrator-owned commit must not invoke recover_commit",
+  );
+  assert.ok(
+    !events.some((event) => event.event === "execution_evidence_rebranded"),
+    "evidence binds once to the orchestrator commit — no rebrand",
+  );
 });
 
-test("dispatch Claude resume auto-recovers completed-uncommitted work by default", () => {
+test("dispatch Claude resume orchestrator-commits completed-uncommitted work by default", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
   process.env.RELAY_HOME = relayHome;
   const { env, ghLogPath, execLogPath, pushPrCountPath, binDir } = createPushPrTestEnv({
@@ -6917,11 +6931,11 @@ test("dispatch Claude resume auto-recovers completed-uncommitted work by default
   ], env));
 
   assert.equal(result.mode, "resume");
-  assert.equal(result.status, "completed-uncommitted");
-  assert.equal(result.commitMode, "auto-recovered");
+  assert.equal(result.status, "completed");
+  assert.equal(result.commitMode, "orchestrator-committed");
   assert.equal(result.runState, STATES.REVIEW_PENDING);
   assert.equal(result.prNumber, 509);
-  assert.match(result.commits, /Recover relay run/);
+  assert.match(result.commits, /Relay run/);
   assert.equal(result.uncommitted, null);
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);
@@ -6930,16 +6944,16 @@ test("dispatch Claude resume auto-recovers completed-uncommitted work by default
   const ghCalls = readJsonLines(ghLogPath);
   assert(ghCalls.some((args) => args[0] === "pr" && args[1] === "create"));
   assert(readJsonLines(execLogPath).some(({ command, args }) => command === "git" && args.includes("push")));
-  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 1);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 2);
   const events = readJsonLines(getEventsPath(repoRoot, result.runId));
-  const recoveryIndex = events.findIndex((event) => event.event === "recover_commit");
-  const finalDispatchResultIndex = events.reduce(
-    (index, event, eventIndex) => event.event === "dispatch_result" ? eventIndex : index,
-    -1,
+  assert.ok(
+    !events.some((event) => event.event === "recover_commit"),
+    "orchestrator-owned commit must not invoke recover_commit on resume",
   );
-  assert.ok(recoveryIndex >= 0, JSON.stringify(events, null, 2));
-  assert.ok(recoveryIndex < finalDispatchResultIndex, "recovery must be journaled before dispatch result/review handoff");
-  assert.match(events[recoveryIndex].reason, /auto-recover-commit enabled/);
+  assert.ok(
+    !events.some((event) => event.event === "execution_evidence_rebranded"),
+    "resume evidence binds once to the orchestrator commit — no rebrand",
+  );
 });
 
 test("dispatch --no-auto-recover-commit disables Claude default recovery", () => {
@@ -7058,7 +7072,7 @@ test("dispatch blocks delayed publication internal review when timed-out work is
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 
-test("dispatch escalates delayed internal review when auto recover-commit fails", () => {
+test("dispatch escalates delayed internal review when orchestrator commit and recover-commit both fail", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
   const { env, ghLogPath, pushPrCountPath } = createPushPrTestEnv({
     relayHome,
@@ -7068,6 +7082,10 @@ test("dispatch escalates delayed internal review when auto recover-commit fails"
     codexMode: "uncommitted",
   });
 
+  // Force the primary orchestrator-owned commit to fail so the run falls back to
+  // recover-commit, which is also forced to fail — exercising the escalation
+  // invariant: uncommitted work that cannot be committed by any path must escalate,
+  // never silently proceed to review.
   const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
     "-b", "issue-512-delayed-auto-recover-fails",
     "--prompt", "work without commit",
@@ -7078,6 +7096,7 @@ test("dispatch escalates delayed internal review when auto recover-commit fails"
     encoding: "utf-8",
     env: {
       ...env,
+      RELAY_TEST_FAIL_GIT_COMMIT: "1",
       RELAY_TEST_FAIL_RECOVER_COMMIT: "1",
     },
   });
@@ -7178,7 +7197,7 @@ test("dispatch preserves Antigravity completed-uncommitted for non-runtime repos
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 
-test("dispatch --auto-recover-commit enables recovery for non-codex completed-uncommitted runs (#393)", () => {
+test("dispatch --auto-recover-commit orchestrator-commits non-codex completed-uncommitted runs (#393)", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
   process.env.RELAY_HOME = relayHome;
   const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
@@ -7198,11 +7217,11 @@ test("dispatch --auto-recover-commit enables recovery for non-codex completed-un
     "--json",
   ], env));
 
-  assert.equal(result.status, "completed-uncommitted");
-  assert.equal(result.commitMode, "auto-recovered");
+  assert.equal(result.status, "completed");
+  assert.equal(result.commitMode, "orchestrator-committed");
   assert.equal(result.runState, STATES.REVIEW_PENDING);
   assert.equal(result.prNumber, 393);
-  assert.match(result.commits, /Recover relay run/);
+  assert.match(result.commits, /Relay run/);
   assert.equal(result.uncommitted, null);
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.state, STATES.REVIEW_PENDING);
@@ -7211,11 +7230,16 @@ test("dispatch --auto-recover-commit enables recovery for non-codex completed-un
   const ghCalls = readJsonLines(ghLogPath);
   assert(ghCalls.some((args) => args[0] === "pr" && args[1] === "create"));
   assert(readJsonLines(execLogPath).some(({ command, args }) => command === "git" && args.includes("push")));
-  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 1);
   const events = readJsonLines(getEventsPath(repoRoot, result.runId));
-  const recoveryEvent = events.find((event) => event.event === "recover_commit");
-  assert(recoveryEvent, JSON.stringify(events, null, 2));
-  assert.match(recoveryEvent.reason, /auto-recover-commit enabled/);
+  assert.ok(
+    !events.some((event) => event.event === "recover_commit"),
+    "--auto-recover-commit now commits inline via the orchestrator, not recover_commit",
+  );
+  assert.ok(
+    !events.some((event) => event.event === "execution_evidence_rebranded"),
+    "evidence binds once to the orchestrator commit — no rebrand",
+  );
 });
 
 test("dispatch --no-auto-recover-commit disables codex default recovery", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -509,6 +509,14 @@ if (args[0] !== "exec") {
 }
 const cwd = args[args.indexOf("-C") + 1];
 const output = args[args.indexOf("-o") + 1];
+// Simulate a second orchestrator advancing this run off DISPATCHED mid-dispatch.
+if (process.env.RELAY_TEST_EXTERNAL_ADVANCE === "1") {
+  const manifestPath = require("path").dirname(output) + ".md";
+  const manifest = fs.readFileSync(manifestPath, "utf-8")
+    .replace(/^state: 'dispatched'$/m, "state: 'review_pending'")
+    .replace(/^next_action: 'await_dispatch_result'$/m, "next_action: 'run_review'");
+  fs.writeFileSync(manifestPath, manifest, "utf-8");
+}
 fs.appendFileSync(cwd + "/README.md", "dirty\\n", "utf-8");
 fs.writeFileSync(output, "work completed without commit\\n", "utf-8");
 `, "utf-8");
@@ -835,8 +843,12 @@ childProcess.execFileSync = function patchedExecFileSync(command, args, options)
     error.stderr = Buffer.from("simulated recover-commit failure\\n");
     throw error;
   }
-  const isGitCommit = command === "git" && argv.includes("commit");
-  if (process.env.RELAY_TEST_FAIL_GIT_COMMIT === "1" && isGitCommit) {
+  // Fail only the orchestrator-owned commit (message "Relay run <id>"), not
+  // recover-commit's own commit (message "Recover relay run <id>"), so a test can
+  // exercise "orchestrator commit fails -> recover-commit succeeds" in isolation.
+  const isOrchestratorCommit = command === "git" && argv.includes("commit")
+    && argv.some((a) => typeof a === "string" && a.startsWith("Relay run "));
+  if (process.env.RELAY_TEST_FAIL_GIT_COMMIT === "1" && isOrchestratorCommit) {
     const error = new Error("simulated git commit failure");
     error.stderr = Buffer.from("simulated git commit failure\\n");
     throw error;
@@ -6894,6 +6906,14 @@ test("dispatch orchestrator-commits uncommitted codex runs by default", () => {
     !events.some((event) => event.event === "execution_evidence_rebranded"),
     "evidence binds once to the orchestrator commit — no rebrand",
   );
+  const evidence = JSON.parse(
+    fs.readFileSync(path.join(result.runDir, "execution-evidence.json"), "utf-8"),
+  );
+  assert.equal(
+    evidence.head_sha,
+    result.headSha,
+    "execution evidence binds to the orchestrator commit SHA, not the pre-commit HEAD",
+  );
 });
 
 test("dispatch Claude resume orchestrator-commits completed-uncommitted work by default", () => {
@@ -7112,6 +7132,118 @@ test("dispatch escalates delayed internal review when orchestrator commit and re
   assert.equal(manifest.state, STATES.ESCALATED);
   assert.equal(manifest.git.pr_number, null);
   assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch skips orchestrator commit and publish when the run is superseded mid-dispatch", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  process.env.RELAY_HOME = relayHome;
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/999",
+    },
+    codexMode: "uncommitted",
+  });
+
+  // A second orchestrator advances the manifest off DISPATCHED while this dispatch
+  // is still finalizing (RELAY_TEST_EXTERNAL_ADVANCE). Issue B must NOT promote the
+  // run to `completed` and open a PR for a run it no longer owns — otherwise the
+  // orchestrator commit would trip the immediate-publish push, which runs before the
+  // supervisor supersede check, causing a duplicate/conflicting PR.
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-999-superseded-uncommitted",
+    "--prompt", "work without commit",
+    "--json",
+  ], { ...env, RELAY_TEST_EXTERNAL_ADVANCE: "1" }));
+
+  assert.equal(result.commitMode, "completed-uncommitted, recover-commit required");
+  assert.match(result.uncommitted, /README\.md/);
+  assert.equal(result.runState, STATES.REVIEW_PENDING);
+  assert.equal(result.prNumber, null);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.git.pr_number, null);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
+  assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+  assert.equal(
+    readJsonLines(getEventsPath(repoRoot, result.runId)).some((event) => event.event === "recover_commit"),
+    false,
+    "a superseded run must not commit via the orchestrator or recover-commit",
+  );
+});
+
+test("dispatch falls back to recover-commit when only the orchestrator commit fails", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  process.env.RELAY_HOME = relayHome;
+  const { env, ghLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/700",
+    },
+    codexMode: "uncommitted",
+  });
+
+  // Force ONLY the orchestrator-owned commit to fail; recover-commit is left working.
+  // Exercises the fall-through SUCCESS path the both-fail escalation test cannot cover.
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-700-orchestrator-fail-recover-ok",
+    "--prompt", "work without commit",
+    "--json",
+  ], { ...env, RELAY_TEST_FAIL_GIT_COMMIT: "1" }));
+
+  assert.equal(result.commitMode, "auto-recovered");
+  assert.equal(result.prNumber, 700);
+  assert.equal(result.uncommitted, null);
+  assert.match(result.commits, /Recover relay run/);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+  assert.equal(manifest.git.pr_number, 700);
+  assert(readJsonLines(ghLogPath).some((args) => args[0] === "pr" && args[1] === "create"));
+  assert.equal(
+    readJsonLines(getEventsPath(repoRoot, result.runId)).some((event) => event.event === "recover_commit"),
+    true,
+    "an orchestrator-commit failure must fall through to a recover-commit that succeeds",
+  );
+});
+
+test("dispatch orchestrator-commits before internal review under after-internal-review policy", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env, ghLogPath, execLogPath, pushPrCountPath } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/701",
+    },
+    codexMode: "uncommitted",
+  });
+
+  // Delayed-publication policy: the orchestrator commits inline so the run advances
+  // to internal review with committed work and NO premature PR.
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-701-delayed-orchestrator-commit",
+    "--prompt", "work without commit",
+    "--publish-policy", "after-internal-review",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+
+  assert.equal(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "completed");
+  assert.equal(result.commitMode, "orchestrator-committed");
+  assert.equal(result.runState, STATES.INTERNAL_REVIEW_PENDING);
+  assert.match(result.commits, /Relay run/);
+  assert.equal(result.uncommitted, null);
+  assert.equal(result.prNumber, null);
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(manifest.state, STATES.INTERNAL_REVIEW_PENDING);
+  assert.equal(manifest.git.pr_number, null);
+  assert.deepEqual(readJsonLines(ghLogPath), []);
+  assert.deepEqual(readJsonLines(execLogPath), []);
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
 });
 

--- a/tests/relay-dispatch/scripts/reliability-report.test.js
+++ b/tests/relay-dispatch/scripts/reliability-report.test.js
@@ -2473,3 +2473,148 @@ test("reliability-report publishes path-aware calibration and class decisions", 
   );
   assert.match(text, /documentation=continue_calibration/);
 });
+
+test("reliability-report --by-recovery attributes the misbehavior tax per executor and separates infra", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-report-tax-"));
+  process.env.RELAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "relay-home-"));
+  const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+
+  function writeExecutorRun({ runId, executor, model, state }) {
+    initGitRepo(repoRoot);
+    const layout = ensureRunLayout(repoRoot, runId);
+    let manifest = createManifestSkeleton({
+      repoRoot,
+      runId,
+      branch: `issue-${runId}`,
+      baseBranch: "main",
+      issueNumber: 42,
+      worktreePath: path.join(repoRoot, "wt", runId),
+      orchestrator: "codex",
+      executor,
+      reviewer: "codex",
+    });
+    manifest = updateManifestState(manifest, STATES.DISPATCHED, "await_dispatch_result");
+    if (state !== STATES.DISPATCHED) {
+      manifest.anchor.rubric_path = "rubric.yaml";
+      fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), "rubric:\n  factors:\n    - name: reliability-report\n", "utf-8");
+      manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "run_review");
+    }
+    if (state === STATES.READY_TO_MERGE || state === STATES.MERGED) {
+      manifest = updateManifestState(manifest, STATES.READY_TO_MERGE, "await_explicit_merge");
+    }
+    if (state === STATES.MERGED) {
+      manifest = updateManifestState(manifest, STATES.MERGED, "merge");
+    }
+    manifest.dispatch = { ...(manifest.dispatch || {}), last_executor: executor, last_model: model };
+    manifest.roles = { ...(manifest.roles || {}), executor };
+    manifest.timestamps = { ...(manifest.timestamps || {}), created_at: recentTs, updated_at: recentTs };
+    writeManifest(layout.manifestPath, manifest);
+  }
+
+  const codexTax = createRunId({ branch: "codex-tax", timestamp: new Date("2026-05-01T00:00:01.000Z") });
+  const codexClean = createRunId({ branch: "codex-clean", timestamp: new Date("2026-05-01T00:00:02.000Z") });
+  const claudeTax = createRunId({ branch: "claude-tax", timestamp: new Date("2026-05-01T00:00:03.000Z") });
+  const cursorInfra = createRunId({ branch: "cursor-infra", timestamp: new Date("2026-05-01T00:00:04.000Z") });
+  const orphan = createRunId({ branch: "orphan", timestamp: new Date("2026-05-01T00:00:05.000Z") });
+
+  writeExecutorRun({ runId: codexTax, executor: "codex", model: "gpt-5.3-codex", state: STATES.MERGED });
+  writeExecutorRun({ runId: codexClean, executor: "codex", model: "gpt-5.3-codex", state: STATES.READY_TO_MERGE });
+  writeExecutorRun({ runId: claudeTax, executor: "claude", model: "claude-opus", state: STATES.REVIEW_PENDING });
+  writeExecutorRun({ runId: cursorInfra, executor: "cursor", model: "grok", state: STATES.DISPATCHED });
+
+  // codex run: recover_commit + execution_evidence_rebranded (both tax).
+  appendRunEvent(repoRoot, codexTax, {
+    event: "recover_commit",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    round: 1,
+    reason: "completed-uncommitted",
+  });
+  appendRunEvent(repoRoot, codexTax, {
+    event: "execution_evidence_rebranded",
+    state_from: STATES.REVIEW_PENDING,
+    state_to: STATES.REVIEW_PENDING,
+    round: 1,
+    reason: "evidence rebound to recovery commit",
+  });
+  // claude run: recover_commit only.
+  appendRunEvent(repoRoot, claudeTax, {
+    event: "recover_commit",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    round: 1,
+    reason: "completed-uncommitted",
+  });
+  // cursor run: infrastructure + operator evidence only, must NOT be counted as tax.
+  appendRunEvent(repoRoot, cursorInfra, {
+    event: "dispatch_interrupted",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.DISPATCHED,
+    reason: "supervisor died",
+  });
+  appendRunEvent(repoRoot, cursorInfra, {
+    event: "state_recovery",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    reason: "reconcile dead-work recovery",
+  });
+  appendRunEvent(repoRoot, cursorInfra, {
+    event: "operator_execution_evidence",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.DISPATCHED,
+    reason: "operator supplied salvage evidence",
+  });
+  // orphan tax event: run dir exists but no manifest -> unattributed.
+  ensureRunLayout(repoRoot, orphan);
+  appendRunEvent(repoRoot, orphan, {
+    event: "recover_commit",
+    state_from: STATES.DISPATCHED,
+    state_to: STATES.REVIEW_PENDING,
+    reason: "no manifest",
+  });
+
+  const report = JSON.parse(execFileSync("node", [SCRIPT, "--repo", repoRoot, "--by-recovery", "--json"], { encoding: "utf-8" }));
+  const tax = report.by_recovery;
+
+  // Per-executor attribution.
+  assert.deepEqual(tax.by_executor.codex, {
+    total_runs: 2,
+    recover_commit_runs: 1,
+    recover_commit_events: 1,
+    evidence_rebrand_runs: 1,
+    evidence_rebrand_events: 1,
+    misbehavior_recovery_runs: 1,
+    misbehavior_recovery_rate: 0.5,
+  });
+  assert.equal(tax.by_executor.claude.misbehavior_recovery_runs, 1);
+  assert.equal(tax.by_executor.claude.misbehavior_recovery_rate, 1);
+  assert.equal(tax.by_executor.cursor.misbehavior_recovery_runs, 0);
+  assert.equal(tax.by_executor.cursor.misbehavior_recovery_rate, 0);
+
+  // Per-model attribution.
+  assert.equal(tax.by_model["gpt-5.3-codex"].misbehavior_recovery_runs, 1);
+  assert.equal(tax.by_model["claude-opus"].misbehavior_recovery_runs, 1);
+  assert.equal(tax.by_model.grok.misbehavior_recovery_runs, 0);
+
+  // Totals: 2 attributed tax runs out of 4 manifests; orphan event is unattributed.
+  assert.equal(tax.totals.misbehavior_recovery_runs, 2);
+  assert.equal(tax.totals.total_runs, 4);
+  assert.equal(tax.totals.recover_commit_runs, 2);
+  assert.equal(tax.totals.evidence_rebrand_runs, 1);
+  assert.equal(tax.totals.misbehavior_recovery_rate, 0.5);
+  assert.equal(tax.totals.unattributed_tax_events, 1);
+
+  // Infrastructure and operator evidence are separated, never taxed.
+  assert.equal(tax.infrastructure_recovery.dispatch_interrupted_runs, 1);
+  assert.equal(tax.infrastructure_recovery.state_recovery_runs, 1);
+  assert.equal(tax.related_signals.operator_execution_evidence_runs, 1);
+
+  // Classification is explicit (no silent truncation of mixed-origin events).
+  assert.deepEqual(tax.classification.tax_events, ["recover_commit", "execution_evidence_rebranded"]);
+  assert.deepEqual(tax.classification.mixed_or_operator_events, ["state_recovery"]);
+
+  const text = execFileSync("node", [SCRIPT, "--repo", repoRoot, "--by-recovery"], { encoding: "utf-8" });
+  assert.match(text, /by_recovery \(unreliability tax\):/);
+  assert.match(text, /executor\.codex: misbehavior_recovery_rate=0\.5/);
+  assert.match(text, /infrastructure_recovery \(excluded from tax\): dispatch_interrupted_runs=1 state_recovery_runs=1/);
+});


### PR DESCRIPTION
## Summary

Finishes the subtraction epic **#1025** started — on the *reliability* axis instead of the prescription axis.

#1025 already retired most of the **prescription tax** (rubric machinery shrinks as models improve). This PR attacks the remaining **unreliability tax**: the recovery machinery (`recover-commit`, `rebrand-evidence`) that exists only because executors sometimes exit cleanly without committing their reviewable work.

Full rationale and delta scope: [`docs/relay-instruction-altitude-prd.md`](docs/relay-instruction-altitude-prd.md).

## What changed

### Issue A — instrument the tax (measure before changing)
- `reliability-report --by-recovery`: per-executor / per-model breakdown of the misbehavior tax (`recover_commit`, `execution_evidence_rebranded`), with infrastructure recovery (`dispatch_interrupted` + `state_recovery`) kept **separate** so it is never miscounted as executor misbehavior.
- Registered `--by-recovery` in `cli-schema.js` (presence flag + reliability-report allowlist).
- **Real baseline:** ~39% of 301 dev-relay runs carry the misbehavior tax (claude 0.69 / cursor 0.54 / codex 0.36); 110 `state_recovery` runs correctly excluded — validating the classification.

### Issue B — orchestrator-owned commit (the structural fix)
- When an executor exits cleanly but leaves reviewable work `completed-uncommitted`, the **orchestrator commits it inline — *before* execution evidence is written** — so evidence binds once to the committed SHA and **no post-hoc `recover-commit` subprocess or evidence `rebrand` is needed**.
- **Gated identically to auto-recover-commit** (default-on for codex/claude, or explicit `--auto-recover-commit`), so other executors keep their existing path unchanged.
- **Non-breaking:** orchestrator-commit failure → falls through to the existing auto-recover-commit path → escalate if that also fails. Safety invariants preserved (covered by a both-paths-fail escalation test).
- Reuses `gitAddReviewableArgs` (runtime-metadata-safe staging); introduces **no new event** — the tax metric dropping is itself the signal.
- Scope-honest: auto-recover-off executors (e.g. cursor) still use the old path — extending orchestrator-owned commit to all executors / always-on is the "unmanaged executors" follow-up.

## Why this is a reorder, not a new mechanism
git authorship is not tied to executor identity anywhere in relay (no `--author`; nothing reads `%an`/`%ae`). Attribution lives in the manifest role bindings + evidence `recorded_by`. `rebrand-evidence` exists *only* because a commit could land after evidence was already bound to a pre-commit SHA. Committing first removes that window structurally — provenance is unchanged.

## Verification
- Full `dispatch.test.js`: **201/201**.
- Issue B tests in isolation: **4/4** (codex default, Claude resume, non-codex `--auto-recover-commit` #393, both-paths-fail escalation).
- `reliability-report.test.js`: **37/37**.
- `recover-commit` + `reconcile-run` + docs-defaults: **90/90**.
- Base is a clean linear extension of `origin/main` (`dd83a29`) — no drift.

## Not in this PR (gated follow-ups)
- **Issue C** — retire `recover-commit` / `rebrand-evidence` on evidence. Gated on a post-B observation window (via `--by-recovery`) showing the tax invocation rate trending to zero; follows the one-release deprecation-window rule.
- **Issue D** — thin the orchestrator spine (optional; gate on the "is it worth it" question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WSvwd4K8m5fmdKxYUt5G9
