### PR TITLE
fix(dispatch): explicit PR base in recovery + finish #229 remote resolution

### DIFF
--- a/skills/relay-dispatch/scripts/exec.js
+++ b/skills/relay-dispatch/scripts/exec.js
@@ -32,7 +32,22 @@ function execGh(repoPath, args, opts = {}) {
   return outputOrRaw(output, raw);
 }
 
+// Resolve the remote a branch actually tracks, falling back to "origin".
+// Mirrors dispatch-publish.js's resolveBranchRemote (#229) for the recovery and
+// correction scripts, which drive git through execGit rather than an injected
+// execFile. Without this they hardcode "origin" and target the wrong remote in a
+// repo whose branch remote is named otherwise (#1083).
+function resolveBranchRemote(worktreePath, branch) {
+  if (!branch) return "origin";
+  try {
+    return execGit(worktreePath, ["config", "--get", `branch.${branch}.remote`]) || "origin";
+  } catch {
+    return "origin";
+  }
+}
+
 module.exports = {
   execGit,
   execGh,
+  resolveBranchRemote,
 };

--- a/skills/relay-dispatch/scripts/rebrand-evidence.js
+++ b/skills/relay-dispatch/scripts/rebrand-evidence.js
@@ -25,7 +25,7 @@ const {
   readArg,
   schemaHasFlag,
 } = require("./cli-args");
-const { execGit } = require("./exec");
+const { execGit, resolveBranchRemote } = require("./exec");
 
 const args = process.argv.slice(2);
 const CLI_ARG_OPTIONS = { commandName: "rebrand-evidence", reservedFlags: ["-h"] };
@@ -183,7 +183,7 @@ function rebaseOntoBaseAndPush({ worktreePath, baseBranch, branch }) {
   }
 
   const newHeadSha = execGit(worktreePath, ["rev-parse", "HEAD"]);
-  execGit(worktreePath, ["push", "--force-with-lease", "origin", branch]);
+  execGit(worktreePath, ["push", "--force-with-lease", resolveBranchRemote(worktreePath, branch), branch]);
   return { oldHeadSha, newHeadSha, base: originBase };
 }
 

--- a/skills/relay-dispatch/scripts/reconcile-run.js
+++ b/skills/relay-dispatch/scripts/reconcile-run.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const path = require("path");
 
 const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
-const { execGit } = require("./exec");
+const { execGit, resolveBranchRemote } = require("./exec");
 const {
   buildExecutionEvidence,
   EXECUTION_EVIDENCE_FILENAME,
@@ -385,7 +385,7 @@ function inspectSalvageWorktree(worktreePath, branch, data) {
 // the lease guards against overwriting a remote that moved past our known point.
 function pushSalvageForceWithLease(worktreePath, branch) {
   try {
-    execGit(worktreePath, ["push", "--force-with-lease", "origin", branch]);
+    execGit(worktreePath, ["push", "--force-with-lease", resolveBranchRemote(worktreePath, branch), branch]);
     return { ok: true };
   } catch (error) {
     const detail = [error.stderr, error.stdout, error.message]

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -28,7 +28,7 @@ const {
   readArg,
   schemaHasFlag,
 } = require("./cli-args");
-const { execGit, execGh } = require("./exec");
+const { execGit, execGh, resolveBranchRemote } = require("./exec");
 const {
   classifyRepositoryDirt,
   formatRuntimeMetadataDirt,
@@ -294,15 +294,15 @@ function countRange(worktreePath, range) {
   return Number.isInteger(count) && count > 0 ? count : 0;
 }
 
-function countUnpushedCommits(worktreePath, branch, baseBranch) {
+function countUnpushedCommits(worktreePath, branch, baseBranch, remoteName = "origin") {
   try {
     const upstream = execGit(worktreePath, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]);
     if (upstream) return countRange(worktreePath, `${upstream}..HEAD`);
   } catch {}
 
   for (const ref of [
-    `refs/remotes/origin/${branch}`,
-    ...(baseBranch ? [`refs/remotes/origin/${baseBranch}`, baseBranch] : []),
+    `refs/remotes/${remoteName}/${branch}`,
+    ...(baseBranch ? [`refs/remotes/${remoteName}/${baseBranch}`, baseBranch] : []),
   ]) {
     try {
       execGit(worktreePath, ["rev-parse", "--verify", ref]);
@@ -474,7 +474,9 @@ function main() {
   const statusText = execGit(worktreePath, ["status", "--porcelain"]);
   const dirt = classifyRepositoryDirt(statusText);
   const hasUncommittedChanges = dirt.hasReviewableDirt;
-  const unpushedCommits = countUnpushedCommits(worktreePath, branch, data.git?.base_branch);
+  const baseBranch = data.git?.base_branch || "main";
+  const remoteName = resolveBranchRemote(worktreePath, branch);
+  const unpushedCommits = countUnpushedCommits(worktreePath, branch, data.git?.base_branch, remoteName);
   const prBody = readPrBodyFile(prBodyFile) || buildPrBody({
     runId: data.run_id,
     reason,
@@ -524,8 +526,14 @@ function main() {
       plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "commit", "-m", commitTitle, "-m", commitBody]));
     }
     if (!internalReview) {
-      plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "push", "-u", "origin", branch]));
-      plannedCommands.push(commandRecord(worktreePath, ["gh", "pr", "create", "--title", prTitleResolution.title, "--body", prBody]));
+      plannedCommands.push(commandRecord(worktreePath, ["git", "-C", worktreePath, "push", "-u", remoteName, branch]));
+      plannedCommands.push(commandRecord(worktreePath, [
+        "gh", "pr", "create",
+        "--base", baseBranch,
+        "--head", branch,
+        "--title", prTitleResolution.title,
+        "--body", prBody,
+      ]));
     }
 
     const result = {
@@ -661,7 +669,7 @@ function main() {
   const shouldPush = prNumber === null || hasUncommittedChanges || unpushedCommits > 0;
   if (shouldPush) {
     try {
-      execGit(worktreePath, ["push", "-u", "origin", branch]);
+      execGit(worktreePath, ["push", "-u", remoteName, branch]);
     } catch (error) {
       const detail = formatExecError(error);
       appendFailureEvent(validatedPaths.repoRoot, data, "push_failed", detail, commitSha, branch);
@@ -686,7 +694,16 @@ function main() {
           runId: data.run_id,
           data,
         });
-        const raw = execGh(worktreePath, ["pr", "create", "--title", prTitleResolution.title, "--body", prBody]);
+        // --base/--head are explicit: without --base, gh falls back to the repository
+      // default branch and silently opens the recovery PR against the wrong target
+      // whenever manifest git.base_branch differs (#1083).
+      const raw = execGh(worktreePath, [
+        "pr", "create",
+        "--base", baseBranch,
+        "--head", branch,
+        "--title", prTitleResolution.title,
+        "--body", prBody,
+      ]);
         prNumber = parsePrNumber(raw);
       } catch (error) {
         const detail = formatExecError(error);

--- a/tests/relay-dispatch/scripts/exec.test.js
+++ b/tests/relay-dispatch/scripts/exec.test.js
@@ -6,7 +6,9 @@ const os = require("os");
 const path = require("path");
 const test = require("node:test");
 
-const { execGit, execGh } = require("../../../skills/relay-dispatch/scripts/exec");
+const { execFileSync } = require("child_process");
+
+const { execGit, execGh, resolveBranchRemote } = require("../../../skills/relay-dispatch/scripts/exec");
 
 function withEnv(name, value, fn) {
   const previous = process.env[name];
@@ -52,4 +54,33 @@ test("execGh honors RELAY_GH_BIN override", () => {
   const output = withEnv("RELAY_GH_BIN", stub, () => execGh(dir, ["status"]));
 
   assert.strictEqual(output, "gh-sentinel");
+});
+
+// #1083: recovery and correction scripts used to hardcode "origin", so a repo whose
+// branch tracks a differently named remote had dispatch publish correctly while every
+// recovery path targeted the wrong remote.
+function initRepoOnBranch(dir, branch) {
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args], { encoding: "utf-8", stdio: "pipe" });
+  git("init", "-b", branch);
+  git("config", "user.name", "Relay Exec Test");
+  git("config", "user.email", "relay-exec@example.com");
+  return git;
+}
+
+test("resolveBranchRemote returns the branch's configured remote", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-exec-remote-"));
+  const git = initRepoOnBranch(dir, "feature");
+  git("config", "branch.feature.remote", "upstream");
+
+  assert.strictEqual(resolveBranchRemote(dir, "feature"), "upstream");
+});
+
+test("resolveBranchRemote falls back to origin when unset, unknown, or branchless", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-exec-remote-default-"));
+  initRepoOnBranch(dir, "feature");
+
+  assert.strictEqual(resolveBranchRemote(dir, "feature"), "origin");
+  assert.strictEqual(resolveBranchRemote(dir, "never-configured"), "origin");
+  assert.strictEqual(resolveBranchRemote(dir, ""), "origin");
+  assert.strictEqual(resolveBranchRemote(dir, null), "origin");
 });

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -380,6 +380,13 @@ test("happy path commits dirty worktree, pushes, opens PR, stamps manifest, and 
   assert.equal(events.filter((entry) => entry.event === "execution_evidence_rebranded").length, 0);
   assert.ok(readJsonLines(fixture.eventLogPath).some((entry) => entry.eventData.event === "recover_commit"));
   assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 1);
+
+  // #1083: without an explicit --base, gh falls back to the repository default
+  // branch and silently opens the recovery PR against the wrong target whenever
+  // the manifest's base_branch differs.
+  const prCreateCall = findGhCall(fixture, "pr", "create");
+  assert.equal(ghArg(prCreateCall, "--base"), manifest.git.base_branch);
+  assert.equal(ghArg(prCreateCall, "--head"), fixture.branch);
 });
 
 test("internal_review_pending recovery commits locally without pushing or opening a PR", () => {


### PR DESCRIPTION
Fixes #1083.

Two live defects where `recover-commit`'s own publish implementation had drifted from the shared `dispatch-publish` path. Both were surfaced by an independent multi-model design review (GPT-5.6 Sol, Grok 4.5, Codex) — see the companion docs PR.

## 1. Recovery PRs opened against the wrong base

`recover-commit.js` created PRs with only `--title`/`--body`, so `gh` fell back to the **repository default branch**, ignoring `manifest.git.base_branch`:

```js
execGh(worktreePath, ["pr", "create", "--title", ..., "--body", ...]);   // before
```

The shared path has always passed both explicitly (`dispatch-publish.js:119-125`). Any run whose base is not the repo default (stacked work, release branches) got a recovery PR opened against the **wrong target** — silently, since creation succeeds. `base_branch` was already read for `countUnpushedCommits`, so the value was right there.

Now passes `--base` (from the manifest) and `--head`. The dry-run plan is updated to match, so the preview stays truthful.

## 2. #229's branch-remote resolution had reached 1 of 5 push sites

`dispatch-publish.js:55-68` resolves `branch.<b>.remote` with an `origin` fallback. Every other site hardcoded `origin`:

| Site | Before |
| --- | --- |
| `dispatch-publish.js:98` | ✅ resolved |
| `recover-commit.js:664` (push) | ❌ `origin` |
| `recover-commit.js:527` (dry-run plan) | ❌ `origin` |
| `recover-commit.js:303-304` (unpushed detection) | ❌ `refs/remotes/origin/...` |
| `reconcile-run.js:388` (salvage force-push) | ❌ `origin` |
| `rebrand-evidence.js:186` (`--rebase-onto-base`) | ❌ `origin` |

So in a repo whose branch tracks another remote, dispatch published correctly while **every recovery and correction path targeted the wrong remote** — making #229 incompletely landed rather than a `recover-commit` quirk.

Adds `resolveBranchRemote` to `exec.js` — the `execGit` seam these scripts already use, which honors `RELAY_GIT_BIN` — and routes all four remaining sites through it. **No hardcoded `origin` push targets remain in `relay-dispatch/scripts`.**

## Deliberately not done here

`dispatch-publish` keeps its own resolver: it drives git through an injectable `execFile` that its tests fixture, and unifying the two seams would force re-fixturing another suite. That is follow-up work tracked in #1083, kept out of a bug-fix PR.

Also untouched: `recover-commit`'s issue-derived PR titles, audit PR body, conditional push, and post-push PR re-probe — all three reviewers independently confirmed these are **intentional** and should be preserved, not collapsed into the shared path.

## Verification

- New: assert `--base`/`--head` on the recovery PR create; cover `resolveBranchRemote`'s configured-remote and fallback (unset / unknown / empty / null) paths.
- `exec` + `recover-commit` + `rebrand-evidence` + `reconcile-run`, serialized: **90/90**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WSvwd4K8m5fmdKxYUt5G9