### PR TITLE
fix(dispatch): refresh head_sha on recovery commits; salvage respects publish policy

### DIFF
--- a/skills/relay-dispatch/scripts/reconcile-run.js
+++ b/skills/relay-dispatch/scripts/reconcile-run.js
@@ -557,15 +557,22 @@ async function trySalvageEscalatedTimeout(
 
   const runDir = getRunDir(repoRoot, runId);
   const executor = data.roles?.executor || "executor";
-  const pushTarget = `origin/${branch}`;
+  const pushTarget = `${resolveBranchRemote(worktreePath, branch)}/${branch}`;
   const evidencePlan = planSalvageEvidence(runDir, testResultFile);
   const reason = salvageAuditReason(runId);
 
-  // Validate escalated→review_pending invariants before any side effect (push,
+  // Salvage must respect the run's publish policy, exactly as row 4 does (#1085).
+  // A delayed-publication run has not had its internal review yet, so salvage may
+  // not force-push it or advance it to public review — publication stays owned by
+  // publish-run.js after the internal review passes.
+  const salvageTarget = dispatchCompletionTarget(data);
+  const shouldPublish = salvageTarget.state === STATES.REVIEW_PENDING;
+
+  // Validate the target transition's invariants before any side effect (push,
   // lease removal, evidence stamp). Mirrors reviewer-swap.js validate-first
   // ordering so a max-1-swap rejection cannot leave a pushed-but-stuck run.
   try {
-    validateTransitionInvariants(data, data.state, STATES.REVIEW_PENDING);
+    validateTransitionInvariants(data, data.state, salvageTarget.state);
   } catch (err) {
     outputResult(salvageResult({
       status: "invariant_blocked",
@@ -597,14 +604,14 @@ async function trySalvageEscalatedTimeout(
         forceWithLease: true,
         evidenceAction: evidencePlan.action,
         evidenceVerified: evidencePlan.verified,
-        targetState: STATES.REVIEW_PENDING,
+        targetState: salvageTarget.state,
         plannedActions: [
-          `push_force_with_lease:${pushTarget}`,
-          "remove_lease_if_present",
+          ...(shouldPublish ? [`push_force_with_lease:${pushTarget}`] : []),
           evidencePlan.verified
             ? "stamp_operator_execution_evidence"
             : "write_replaceable_placeholder_evidence",
-          "force_transition_escalated_to_review_pending",
+          `force_transition_${data.state}_to_${salvageTarget.state}`,
+          "remove_lease_if_present",
         ],
       },
     }), jsonOut);
@@ -612,27 +619,28 @@ async function trySalvageEscalatedTimeout(
   }
 
   // Push before any state mutation: a rejected lease leaves the run untouched.
-  const pushResult = pushSalvageForceWithLease(worktreePath, branch);
-  if (!pushResult.ok) {
-    outputResult(salvageResult({
-      status: "push_rejected",
-      manifestPath,
-      runId,
-      data,
-      dryRun,
-      nextAction: "manual_reconcile_remote",
-      extra: {
-        branch,
-        pushTarget,
-        unpushedCommits: inspection.unpushedCommits,
-        forceWithLeaseRejected: true,
-        pushError: pushResult.detail,
-      },
-    }), jsonOut);
-    return true;
+  // Delayed-publication runs are not pushed here at all — see shouldPublish above.
+  if (shouldPublish) {
+    const pushResult = pushSalvageForceWithLease(worktreePath, branch);
+    if (!pushResult.ok) {
+      outputResult(salvageResult({
+        status: "push_rejected",
+        manifestPath,
+        runId,
+        data,
+        dryRun,
+        nextAction: "manual_reconcile_remote",
+        extra: {
+          branch,
+          pushTarget,
+          unpushedCommits: inspection.unpushedCommits,
+          forceWithLeaseRejected: true,
+          pushError: pushResult.detail,
+        },
+      }), jsonOut);
+      return true;
+    }
   }
-
-  removeRunLease(repoRoot, runId);
 
   const salvageHead = inspection.currentHead || data.git?.head_sha || null;
   const executionEvidence = stampSalvageEvidence({
@@ -649,7 +657,7 @@ async function trySalvageEscalatedTimeout(
   }
 
   const updated = {
-    ...forceUpdateManifestState(data, STATES.REVIEW_PENDING, "run_review", { reason }),
+    ...forceUpdateManifestState(data, salvageTarget.state, salvageTarget.nextAction, { reason }),
     git: {
       ...(data.git || {}),
       head_sha: salvageHead || data.git?.head_sha || null,
@@ -657,6 +665,12 @@ async function trySalvageEscalatedTimeout(
   };
   writeManifest(manifestPath, updated, body);
   appendStateRecovery(repoRoot, data, updated, reason);
+
+  // Release the lease only after the manifest and journal are durable (#1085).
+  // Dropping it earlier advertises the run as unowned while it is still
+  // mid-finalization, so a concurrent reconcile or recover-commit — whose
+  // dispatched guard consults lease liveness — can act on a half-finalized run.
+  removeRunLease(repoRoot, runId);
 
   outputResult(salvageResult({
     status: "salvaged",
@@ -668,9 +682,8 @@ async function trySalvageEscalatedTimeout(
     extra: {
       state: updated.state,
       branch,
-      pushTarget,
+      ...(shouldPublish ? { pushTarget, forceWithLease: true } : { published: false }),
       unpushedCommits: inspection.unpushedCommits,
-      forceWithLease: true,
       executionEvidence,
     },
   }), jsonOut);

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -719,11 +719,19 @@ function main() {
     }
   }
 
+  // git.head_sha must follow any commit we just created, independent of whether a
+  // pr_number stamp is also due (#1084). Previously a run that was already
+  // review_pending with pr_number set took neither stamping branch, so no manifest
+  // write happened at all and head_sha stayed at the pre-commit SHA while the
+  // evidence artifact had already been rebound to the new commit.
+  const prNumberUnset = data.git?.pr_number === undefined || data.git?.pr_number === null;
   let stampedRecord = manifestRecord;
-  if (recoveringFromDispatched) {
+  if (recoveringFromDispatched || prNumberUnset || commitCreated) {
     stampedRecord = stampPrNumberUnderLock(manifestRecord, prNumber, {
       expectedRepoRoot: validatedPaths.repoRoot,
-      caller: "recover-commit dispatched PR stamping",
+      caller: recoveringFromDispatched
+        ? "recover-commit dispatched PR stamping"
+        : "recover-commit PR stamping",
       reason: `Stamped git.pr_number=${prNumber} during recover-commit`,
       updateFreshData(freshData) {
         let updatedData = freshData;
@@ -733,7 +741,7 @@ function main() {
           updatedData = updateManifestState(updatedData, target.state, target.nextAction);
           shouldUpdateHead = true;
         } else if ([STATES.INTERNAL_REVIEW_PENDING, STATES.REVIEW_PENDING].includes(updatedData.state)) {
-          shouldUpdateHead = true;
+          shouldUpdateHead = recoveringFromDispatched || commitCreated;
         }
         if (!shouldUpdateHead) {
           return updatedData;
@@ -746,12 +754,6 @@ function main() {
           },
         };
       },
-    });
-  } else if (data.git?.pr_number === undefined || data.git?.pr_number === null) {
-    stampedRecord = stampPrNumberUnderLock(manifestRecord, prNumber, {
-      expectedRepoRoot: validatedPaths.repoRoot,
-      caller: "recover-commit PR stamping",
-      reason: `Stamped git.pr_number=${prNumber} during recover-commit`,
     });
   }
 

--- a/tests/relay-dispatch/scripts/reconcile-run.test.js
+++ b/tests/relay-dispatch/scripts/reconcile-run.test.js
@@ -972,16 +972,47 @@ test("reconcile dry-run prints the salvage plan without mutating", () => {
   assert.equal(result.forceWithLease, true);
   assert.equal(result.targetState, STATES.REVIEW_PENDING);
   assert.equal(result.evidenceVerified, false);
+  // Order mirrors actual execution: the lease is released LAST, only after the
+  // manifest and journal are durable (#1085).
   assert.deepEqual(result.plannedActions, [
     `push_force_with_lease:origin/${fixture.branch}`,
-    "remove_lease_if_present",
     "write_replaceable_placeholder_evidence",
     "force_transition_escalated_to_review_pending",
+    "remove_lease_if_present",
   ]);
   // No push, no state change, no evidence write.
   assert.equal(remoteBranchSha(fixture), null);
   assert.equal(readManifest(fixture.manifestPath).data.state, STATES.ESCALATED);
   assert.equal(fs.readFileSync(evidencePath, "utf-8"), evidenceBefore);
+});
+
+test("reconcile row 6 salvage preserves delayed-publication policy", () => {
+  // #1085: row-6 salvage used to hardcode review_pending, so a delayed-publication
+  // run was force-pushed AND advanced to public review — bypassing the internal
+  // review gate that publish-run.js exists to enforce. Row 4 already respects the
+  // policy; row 6 must match.
+  const fixture = setupRepo({
+    manifestState: STATES.ESCALATED,
+    committedWork: true,
+    publishPolicy: "after-internal-review",
+    dispatchResultFailureClass: "total_timeout",
+  });
+
+  const result = parseJsonResult(runReconcile(fixture));
+
+  assert.equal(result.row, 6);
+  assert.equal(result.status, "salvaged");
+  assert.equal(result.state, STATES.INTERNAL_REVIEW_PENDING);
+  assert.equal(result.nextAction, "run_internal_review");
+  assert.equal(result.published, false);
+
+  const manifest = readManifest(fixture.manifestPath).data;
+  assert.equal(manifest.state, STATES.INTERNAL_REVIEW_PENDING);
+  assert.equal(manifest.next_action, "run_internal_review");
+  assert.equal(manifest.git.pr_number, null);
+
+  // The defining assertion: the branch must NOT have been published.
+  assert.equal(remoteBranchSha(fixture), null, "delayed-publication salvage must not push");
 });
 
 test("reconcile surfaces an escalated-timeout salvage when the remote moved beyond the lease", () => {

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -1118,3 +1118,35 @@ test("idempotent re-run reuses existing PR without restamping or creating a seco
   assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 1);
   assert.equal(readManifest(fixture.manifestPath).data.git.pr_number, 281);
 });
+
+test("re-run that commits new work refreshes git.head_sha even when pr_number is already stamped", () => {
+  // #1084: the run is already review_pending with pr_number set, so neither stamping
+  // branch used to fire and no manifest write happened at all — leaving git.head_sha
+  // at the pre-commit SHA while the evidence artifact was rebound to the new commit.
+  const fixture = setupRepo({ dirty: true });
+  const first = runRecover(fixture, ["--reason", "first recovery", "--json"]);
+  assert.equal(first.status, 0, first.stderr);
+  const firstManifest = readManifest(fixture.manifestPath).data;
+  assert.equal(firstManifest.state, STATES.REVIEW_PENDING);
+  assert.equal(firstManifest.git.pr_number, 281);
+
+  fs.writeFileSync(path.join(fixture.worktreePath, "late.txt"), "more uncommitted work\n", "utf-8");
+  const second = runRecover(fixture, ["--reason", "second recovery with new work", "--json"]);
+  assert.equal(second.status, 0, second.stderr);
+
+  const secondParsed = JSON.parse(second.stdout);
+  assert.equal(secondParsed.commitCreated, true);
+  assert.notEqual(secondParsed.commitSha, firstManifest.git.head_sha);
+
+  const manifest = readManifest(fixture.manifestPath).data;
+  assert.equal(manifest.git.head_sha, secondParsed.commitSha);
+  assert.equal(manifest.git.pr_number, 281, "pr_number must not be restamped");
+  assert.equal(manifest.state, STATES.REVIEW_PENDING);
+
+  const worktreeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+  assert.equal(manifest.git.head_sha, worktreeHead, "manifest head must track the worktree HEAD");
+
+  const events = readRunEvents(fixture.repoRoot, fixture.runId);
+  assert.equal(events.filter((entry) => entry.event === "pr_number_stamped").length, 1);
+  assert.equal(readJsonLines(fixture.ghLogPath).filter((argv) => argv[0] === "pr" && argv[1] === "create").length, 1);
+});


### PR DESCRIPTION
Closes #1084, closes #1085. Both were surfaced by the independent multi-model review recorded in `docs/relay-run-finalization-consolidation.md` (#1087), and both are recovery-path correctness bugs fixed on their own merits — no refactor.

## #1084 — `recover-commit` left `git.head_sha` stale

Three separate stamping branches decided whether the manifest got written at all. A run already `review_pending` with `git.pr_number` set took **neither**, so no manifest write happened and `head_sha` kept pointing at the pre-commit SHA — while the evidence artifact had **already** been rebound to the new commit (`recover-commit.js:566`), desynchronizing manifest from evidence. The `pr_number`-only branch had the same gap: it stamped without an `updateFreshData`, so `head_sha` was never refreshed either.

`git.head_sha` is what review preflight and the hardened merge gate anchor against, so a stale value can mask that new work landed.

Unified into a single `stampPrNumberUnderLock` call whose `updateFreshData` refreshes `head_sha` whenever a commit was created. The helper already writes when `updateFreshData` is supplied even if `pr_number` is set (`pr-number-stamp.js:133-134`), so the lock, the fresh re-read, and the terminal-state guard are **reused** rather than reimplemented.

## #1085 — `reconcile-run` row-6 salvage ignored publish policy and released the lease early

**1. Publish policy.** Row-6 hardcoded `STATES.REVIEW_PENDING`, so a delayed-publication run was force-pushed **and** advanced to public review — bypassing the internal-review gate that `publish-run.js` exists to enforce. Row 4 already respects the policy (pinned by its own test, `reconcile-run.test.js:614`), so **row 6 was the inconsistent one**. Now derives the target via `dispatchCompletionTarget(data)` and, for `after-internal-review` runs, does not push at all.

> ⚠️ **Behavior change:** salvaging an escalated `after-internal-review` run no longer publishes its branch. It lands in `internal_review_pending` with the work committed locally — matching `recover-commit`'s internal-review mode (`recover-commit.js:461`, `:624`). Publication stays owned by `publish-run` after the internal review passes.

**2. Lease ordering.** `removeRunLease` ran *before* the evidence stamp, manifest write, and journal append — advertising the run as unowned while still mid-finalization. That is exactly the window a concurrent `reconcile-run`, or a `recover-commit` (whose `dispatched` guard consults lease liveness at `:449-457`), can act in. Moved to after the journal append.

Also: the dry-run plan now mirrors real execution order (lease released last) so the preview does not misreport what will happen, and `pushTarget` reports the resolved remote instead of a hardcoded `origin/`.

## Verification

**Both regression tests were confirmed to FAIL against the unfixed sources** (verified by stashing each fix and re-running) and pass with the fix — neither is vacuous:

- `re-run that commits new work refreshes git.head_sha even when pr_number is already stamped`
- `reconcile row 6 salvage preserves delayed-publication policy` — its defining assertion is that the branch was **not** pushed

Suites: `recover-commit` 43/43, `reconcile-run` 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WSvwd4K8m5fmdKxYUt5G9