### PR TITLE
fix(review): degrade oversized generated diffs

### DIFF
--- a/skills/relay-dispatch/scripts/exec.js
+++ b/skills/relay-dispatch/scripts/exec.js
@@ -2,6 +2,8 @@
 
 const { execFileSync } = require("child_process");
 
+const DEFAULT_EXEC_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+
 function outputOrRaw(output, raw) {
   return raw ? output : output.trim();
 }
@@ -10,6 +12,7 @@ function execGit(repoPath, args, opts = {}) {
   const { raw = false, cwd, encoding, stdio, ...execOpts } = opts;
   const gitBin = process.env.RELAY_GIT_BIN || "git";
   const output = execFileSync(gitBin, ["-C", repoPath, ...args], {
+    maxBuffer: DEFAULT_EXEC_MAX_BUFFER_BYTES,
     ...execOpts,
     encoding: "utf-8",
     stdio: "pipe",
@@ -21,6 +24,7 @@ function execGh(repoPath, args, opts = {}) {
   const { raw = false, cwd, encoding, stdio, ...execOpts } = opts;
   const ghBin = process.env.RELAY_GH_BIN || "gh";
   const options = {
+    maxBuffer: DEFAULT_EXEC_MAX_BUFFER_BYTES,
     ...execOpts,
     encoding: "utf-8",
     stdio: "pipe",
@@ -47,6 +51,7 @@ function resolveBranchRemote(worktreePath, branch) {
 }
 
 module.exports = {
+  DEFAULT_EXEC_MAX_BUFFER_BYTES,
   execGit,
   execGh,
   resolveBranchRemote,

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -33,6 +33,15 @@ Prepared or invoked rounds write artifacts under `~/.relay/runs/<repo-slug>/<run
 - `review-round-N-policy-violation.txt` if the reviewer changed files
 - `review-round-N-redispatch.md` when changes are requested
 
+Generated internal and post-publication diffs are read with the shared 16 MiB
+`DEFAULT_EXEC_MAX_BUFFER_BYTES` ceiling. The review degradation threshold is
+derived from that ceiling (`GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES`, currently
+512 KiB), so the subprocess can always return a diff before the guard runs.
+Generated diffs above the threshold are replaced by a `--stat` summary and the
+list of files whose patches were omitted. The marker, observed byte size, and
+threshold are persisted in `review-round-N-diff.patch`. Operator-supplied
+`--diff-file` content remains an unguarded, verbatim escape hatch.
+
 The runner reviews the retained checkout recorded in `paths.worktree`, not the repo root. It records `review.last_reviewed_sha` and enforces `review.max_rounds`: compact defaults to `1`, standard to `2`, and hardened to `3`. A still-higher persisted value is an explicit experimental policy; repeated-issue and flip-flop escalation still apply within that budget.
 
 ## Audit Trail

--- a/skills/relay-review/scripts/review-runner/common.js
+++ b/skills/relay-review/scripts/review-runner/common.js
@@ -11,7 +11,13 @@ const gh = (repoPath, ...ghArgs) => {
   return execGh(repoPath, ghArgs, options);
 };
 
-const git = (repoPath, ...gitArgs) => execGit(repoPath, gitArgs);
+const git = (repoPath, ...gitArgs) => {
+  const lastArg = gitArgs.at(-1);
+  const options = lastArg && typeof lastArg === "object" && !Array.isArray(lastArg)
+    ? gitArgs.pop()
+    : {};
+  return execGit(repoPath, gitArgs, options);
+};
 
 function readText(filePath) {
   return fs.readFileSync(filePath, "utf-8");

--- a/skills/relay-review/scripts/review-runner/context.js
+++ b/skills/relay-review/scripts/review-runner/context.js
@@ -10,7 +10,15 @@ const {
 } = require("../../../relay-dispatch/scripts/manifest/paths");
 const { STATES } = require("../../../relay-dispatch/scripts/manifest/lifecycle");
 const { resolveManifestRecord } = require("../../../relay-dispatch/scripts/relay-resolver");
+const {
+  DEFAULT_EXEC_MAX_BUFFER_BYTES,
+} = require("../../../relay-dispatch/scripts/exec");
 const { gh, git, readText } = require("./common");
+
+// Keep the generated-diff guard strictly below the subprocess read ceiling by
+// deriving it from that ceiling. This leaves enough headroom to read a large
+// diff before replacing it with a bounded review representation.
+const GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES = DEFAULT_EXEC_MAX_BUFFER_BYTES / 32;
 
 // DNS hostname validation — conservative label allowlist. Rejects leading
 // dashes (which could be interpreted as flags by some CLI tools), whitespace,
@@ -453,15 +461,130 @@ function loadRetainedWorktreeDiff(reviewRepoPath, manifestData) {
   );
 }
 
+function isMaxBufferError(error) {
+  return error?.code === "ENOBUFS" || /\bENOBUFS\b/.test(String(error?.message || error));
+}
+
+function observedOutputBytes(error) {
+  const output = error?.stdout ?? error?.output?.[1] ?? "";
+  if (Buffer.isBuffer(output)) return output.length;
+  return Buffer.byteLength(String(output), "utf-8");
+}
+
+function wrapGeneratedDiffReadError(error, source) {
+  if (!isMaxBufferError(error)) throw error;
+  const observedBytes = Math.max(
+    observedOutputBytes(error),
+    DEFAULT_EXEC_MAX_BUFFER_BYTES + 1
+  );
+  const wrapped = new Error(
+    `Generated review diff read failed for ${source}: ` +
+    `observed_size>=${observedBytes} bytes, ` +
+    `maxBuffer_limit=${DEFAULT_EXEC_MAX_BUFFER_BYTES} bytes. ` +
+    "Provide a curated --diff-file to review this change."
+  );
+  wrapped.cause = error;
+  return wrapped;
+}
+
+function parseNumstatPaths(numstat) {
+  return String(numstat)
+    .split("\0")
+    .filter(Boolean)
+    .map((record) => record.split("\t").at(-1))
+    .filter(Boolean);
+}
+
+function fallbackPatchSummary(diffText) {
+  const sections = String(diffText).split(/(?=^diff --git )/m).filter(Boolean);
+  const rows = [];
+  const paths = [];
+  for (const section of sections) {
+    const pathMatch = section.match(/^diff --git .* b\/(.+)$/m);
+    if (!pathMatch) continue;
+    const filePath = pathMatch[1];
+    let additions = 0;
+    let deletions = 0;
+    let inHunk = false;
+    for (const line of section.split("\n")) {
+      if (line.startsWith("@@")) {
+        inHunk = true;
+      } else if (inHunk && line.startsWith("+") && !line.startsWith("+++")) {
+        additions += 1;
+      } else if (inHunk && line.startsWith("-") && !line.startsWith("---")) {
+        deletions += 1;
+      }
+    }
+    rows.push(` ${filePath} | ${additions + deletions} (+${additions} -${deletions})`);
+    paths.push(filePath);
+  }
+  return {
+    paths,
+    stat: rows.length
+      ? `${rows.join("\n")}\n ${rows.length} file${rows.length === 1 ? "" : "s"} changed`
+      : " (unable to parse per-file statistics from generated diff)",
+  };
+}
+
+function buildDegradedDiff(repoPath, diffText, source) {
+  const observedBytes = Buffer.byteLength(diffText, "utf-8");
+  let stat;
+  let paths;
+  try {
+    stat = git(repoPath, "apply", "--stat", "-", {
+      input: diffText,
+    }).trim();
+    const numstat = git(repoPath, "apply", "--numstat", "-z", "-", {
+      input: diffText,
+      raw: true,
+    });
+    paths = parseNumstatPaths(numstat);
+  } catch {
+    ({ stat, paths } = fallbackPatchSummary(diffText));
+  }
+  const uniquePaths = [...new Set(paths)];
+  const omittedFiles = uniquePaths.length
+    ? uniquePaths.map((filePath) => `- ${filePath}`).join("\n")
+    : "- (file names unavailable)";
+
+  return [
+    `# ...generated diff degraded: observed ${observedBytes} bytes; ` +
+      `threshold ${GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES} bytes; source ${source}`,
+    "",
+    "# --stat summary (full patches omitted)",
+    stat,
+    "",
+    "# Files with omitted patches",
+    omittedFiles,
+  ].join("\n");
+}
+
+function guardGeneratedDiff(repoPath, diffText, source) {
+  if (Buffer.byteLength(diffText, "utf-8") <= GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES) {
+    return diffText;
+  }
+  return buildDegradedDiff(repoPath, diffText, source);
+}
+
 function loadDiff(repoPath, prNumber, diffFile, options = {}) {
   if (diffFile) return readText(diffFile).trim();
   if (options.internalReview) {
-    return loadRetainedWorktreeDiff(options.reviewRepoPath, options.manifestData);
+    try {
+      const diffText = loadRetainedWorktreeDiff(options.reviewRepoPath, options.manifestData);
+      return guardGeneratedDiff(options.reviewRepoPath, diffText, "internal git diff");
+    } catch (error) {
+      throw wrapGeneratedDiffReadError(error, "internal git diff");
+    }
   }
   if (!prNumber) {
     throw new Error("PR number is required to fetch a diff. Provide --diff-file for fixture-based runs.");
   }
-  return gh(repoPath, "pr", "diff", String(prNumber)).trim();
+  try {
+    const diffText = gh(repoPath, "pr", "diff", String(prNumber)).trim();
+    return guardGeneratedDiff(repoPath, diffText, `gh pr diff #${prNumber}`);
+  } catch (error) {
+    throw wrapGeneratedDiffReadError(error, `gh pr diff #${prNumber}`);
+  }
 }
 
 function summarizeStatusCheck(check) {
@@ -636,6 +759,7 @@ function formatPriorRoundContext(runDir, round) {
 }
 
 module.exports = {
+  GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES,
   applyReviewerIdentity,
   formatPriorRoundContext,
   getExpectedManifestRepoRoot,

--- a/tests/relay-dispatch/scripts/exec.test.js
+++ b/tests/relay-dispatch/scripts/exec.test.js
@@ -8,7 +8,12 @@ const test = require("node:test");
 
 const { execFileSync } = require("child_process");
 
-const { execGit, execGh, resolveBranchRemote } = require("../../../skills/relay-dispatch/scripts/exec");
+const {
+  DEFAULT_EXEC_MAX_BUFFER_BYTES,
+  execGit,
+  execGh,
+  resolveBranchRemote,
+} = require("../../../skills/relay-dispatch/scripts/exec");
 
 function withEnv(name, value, fn) {
   const previous = process.env[name];
@@ -38,6 +43,20 @@ function writeStub(dir, sentinel) {
   return stubPath;
 }
 
+function writeSizedStub(dir, size) {
+  const stubPath = path.join(dir, `sized-${size}-stub.js`);
+  fs.writeFileSync(
+    stubPath,
+    [
+      "#!/usr/bin/env node",
+      `process.stdout.write("x".repeat(${size}));`,
+    ].join("\n"),
+    "utf-8"
+  );
+  fs.chmodSync(stubPath, 0o755);
+  return stubPath;
+}
+
 test("execGit honors RELAY_GIT_BIN override", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-exec-git-"));
   const stub = writeStub(dir, "git-sentinel");
@@ -54,6 +73,31 @@ test("execGh honors RELAY_GH_BIN override", () => {
   const output = withEnv("RELAY_GH_BIN", stub, () => execGh(dir, ["status"]));
 
   assert.strictEqual(output, "gh-sentinel");
+});
+
+test("execGit and execGh use the shared maxBuffer default and preserve caller overrides", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-exec-buffer-"));
+  const payloadBytes = 1024 * 1024 + 1024;
+  const stub = writeSizedStub(dir, payloadBytes);
+  assert.ok(DEFAULT_EXEC_MAX_BUFFER_BYTES > payloadBytes);
+
+  for (const [label, envName, run] of [
+    ["git", "RELAY_GIT_BIN", () => execGit(dir, ["status"], { raw: true })],
+    ["gh", "RELAY_GH_BIN", () => execGh(dir, ["status"], { raw: true })],
+  ]) {
+    await t.test(label, () => {
+      const output = withEnv(envName, stub, run);
+      assert.equal(Buffer.byteLength(output, "utf-8"), payloadBytes);
+      assert.throws(
+        () => withEnv(envName, stub, () => (
+          label === "git"
+            ? execGit(dir, ["status"], { maxBuffer: 1024 })
+            : execGh(dir, ["status"], { maxBuffer: 1024 })
+        )),
+        (error) => error?.code === "ENOBUFS"
+      );
+    });
+  }
 });
 
 // #1083: recovery and correction scripts used to hardcode "origin", so a repo whose

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -138,6 +138,19 @@ function writeJson(value) {
   process.stdout.write(JSON.stringify(value));
 }
 
+function writeAllStdout(value) {
+  const buffer = Buffer.from(String(value));
+  let offset = 0;
+  while (offset < buffer.length) {
+    try {
+      offset += fs.writeSync(process.stdout.fd, buffer, offset, buffer.length - offset);
+    } catch (error) {
+      if (error.code !== "EAGAIN") throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1);
+    }
+  }
+}
+
 function loadState() {
   if (statePath && fs.existsSync(statePath)) {
     return JSON.parse(fs.readFileSync(statePath, "utf-8"));
@@ -209,6 +222,11 @@ if (args[0] === "pr" && args[1] === "view") {
 
   // Some tests only need gh pr view to succeed; unsupported data stays empty.
   writeJson({});
+  process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "diff") {
+  writeAllStdout(fixture.diff || "");
   process.exit(0);
 }
 

--- a/tests/relay-review/scripts/review-runner-context.test.js
+++ b/tests/relay-review/scripts/review-runner-context.test.js
@@ -11,6 +11,8 @@ const {
   DEFAULT_ENFORCEMENT_RUBRIC,
 } = require("../../relay-dispatch/scripts/test-support");
 const {
+  GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES,
+  loadDiff,
   loadPrReviewSignals,
   loadProjectConventions,
   loadRetainedWorktreeDiff,
@@ -18,9 +20,15 @@ const {
   resolveIssueNumber,
 } = require("../../../skills/relay-review/scripts/review-runner/context");
 const {
+  DEFAULT_EXEC_MAX_BUFFER_BYTES,
+} = require("../../../skills/relay-dispatch/scripts/exec");
+const {
   loadRubricFromRunDir,
 } = require("../../../skills/relay-dispatch/scripts/manifest/rubric");
 const { buildPrompt } = require("../../../skills/relay-review/scripts/review-runner/prompt");
+const {
+  writeRoundArtifacts,
+} = require("../../../skills/relay-review/scripts/review-runner/round-artifacts");
 const { withFakeGh } = require("../fixtures/fake-gh");
 
 function createRunFixture() {
@@ -35,6 +43,74 @@ function createRunFixture() {
   const runId = "issue-189-20260418010101010";
   const { runDir } = ensureRunLayout(repoRoot, runId);
   return { repoRoot, runDir, runId };
+}
+
+function buildLargePatch(filePath, minimumBytes) {
+  const header = [
+    `diff --git a/${filePath} b/${filePath}`,
+    "new file mode 100644",
+    "index 0000000..1111111",
+    "--- /dev/null",
+    `+++ b/${filePath}`,
+  ];
+  const line = `+${"x".repeat(79)}\n`;
+  const lineCount = Math.ceil((minimumBytes - header.join("\n").length - 64) / line.length);
+  return [
+    ...header,
+    `@@ -0,0 +1,${lineCount} @@`,
+    line.repeat(lineCount).trimEnd(),
+  ].join("\n");
+}
+
+function withEnv(name, value, fn) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
+
+function writeOverflowStub(dir, name, gitAware = false) {
+  const stubPath = path.join(dir, name);
+  fs.writeFileSync(
+    stubPath,
+    [
+      "#!/usr/bin/env node",
+      gitAware
+        ? 'if (process.argv.includes("merge-base")) process.stdout.write("a".repeat(40));'
+        : "",
+      gitAware
+        ? 'else process.stdout.write("x".repeat(' + (DEFAULT_EXEC_MAX_BUFFER_BYTES + 1024) + "));"
+        : 'process.stdout.write("x".repeat(' + (DEFAULT_EXEC_MAX_BUFFER_BYTES + 1024) + "));",
+    ].filter(Boolean).join("\n"),
+    "utf-8"
+  );
+  fs.chmodSync(stubPath, 0o755);
+  return stubPath;
+}
+
+function initLargeDiffRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-large-diff-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Relay Review"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "relay-review@example.com"], { cwd: repoRoot, stdio: "pipe" });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["checkout", "-b", "issue-1091"], { cwd: repoRoot, stdio: "pipe" });
+  const largeText = `${"generated review diff payload\n".repeat(
+    Math.ceil((GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES + 4096) / 30)
+  )}`;
+  fs.writeFileSync(path.join(repoRoot, "large.txt"), largeText, "utf-8");
+  execFileSync("git", ["add", "large.txt"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "large change"], { cwd: repoRoot, stdio: "pipe" });
+  return repoRoot;
 }
 
 test("context/resolveIssueNumber prefers manifest issue before GitHub fallbacks", () => {
@@ -352,6 +428,112 @@ test("context/loadRetainedWorktreeDiff builds an internal diff from retained wor
 
   const diff = loadRetainedWorktreeDiff(repoRoot, { git: { base_branch: "main" } });
   assert.match(diff, /\+changed/);
+});
+
+test("context/generated diff threshold stays strictly below the shared read ceiling", () => {
+  assert.ok(DEFAULT_EXEC_MAX_BUFFER_BYTES > GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES);
+});
+
+test("context/loadDiff persists a degraded internal git diff as the round diff artifact", () => {
+  const repoRoot = initLargeDiffRepo();
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-large-round-"));
+  const doneCriteriaFile = path.join(runDir, "done-criteria.md");
+  fs.writeFileSync(doneCriteriaFile, "# Done Criteria\n\n- Review the large change.\n", "utf-8");
+
+  const artifacts = writeRoundArtifacts({
+    branch: "issue-1091",
+    data: {
+      git: { base_branch: "main" },
+      run_id: "issue-1091-large-diff",
+    },
+    diffFile: null,
+    doneCriteriaFile,
+    internalReview: true,
+    issueNumber: 1091,
+    prNumber: null,
+    reviewRepoPath: repoRoot,
+    round: 1,
+    runDir,
+    runRepoPath: repoRoot,
+  });
+
+  assert.match(artifacts.diffText, /generated diff degraded: observed \d+ bytes/);
+  assert.match(artifacts.diffText, new RegExp(`threshold ${GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES} bytes`));
+  assert.match(artifacts.diffText, /# --stat summary \(full patches omitted\)/);
+  assert.match(artifacts.diffText, /large\.txt/);
+  assert.match(artifacts.diffText, /# Files with omitted patches\n- large\.txt/);
+  assert.doesNotMatch(artifacts.diffText, /generated review diff payload/);
+  assert.equal(
+    fs.readFileSync(artifacts.diffPath, "utf-8"),
+    `${artifacts.diffText}\n`
+  );
+});
+
+test("context/loadDiff degrades an oversized gh pr diff", () => {
+  const largePatch = buildLargePatch(
+    "public-large.txt",
+    GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES + 1
+  );
+  assert.ok(Buffer.byteLength(largePatch, "utf-8") > GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES);
+
+  withFakeGh({ diff: largePatch }, (repoRoot) => {
+    const diff = loadDiff(repoRoot, 1091, null);
+    assert.match(diff, /generated diff degraded: observed \d+ bytes/);
+    assert.match(diff, /source gh pr diff #1091/);
+    assert.match(diff, /public-large\.txt/);
+    assert.match(diff, /# Files with omitted patches\n- public-large\.txt/);
+    assert.doesNotMatch(diff, new RegExp(`\\+${"x".repeat(79)}`));
+  });
+});
+
+test("context/loadDiff passes a generated diff just under the threshold byte-identical", () => {
+  const expected = "x".repeat(GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES - 1);
+  withFakeGh({ diff: expected }, (repoRoot) => {
+    assert.equal(loadDiff(repoRoot, 1091, null), expected);
+  });
+});
+
+test("context/loadDiff leaves an oversized --diff-file unguarded", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-diff-file-"));
+  const diffPath = path.join(repoRoot, "curated.patch");
+  const expected = "z".repeat(GENERATED_DIFF_DEGRADE_THRESHOLD_BYTES + 1);
+  fs.writeFileSync(diffPath, expected, "utf-8");
+
+  assert.equal(
+    loadDiff(repoRoot, null, diffPath, {
+      internalReview: true,
+      manifestData: {},
+      reviewRepoPath: null,
+    }),
+    expected
+  );
+});
+
+test("context/loadDiff replaces generated ENOBUFS errors with actionable size context", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-overflow-"));
+  const ghStub = writeOverflowStub(dir, "gh-overflow.js");
+  const gitStub = writeOverflowStub(dir, "git-overflow.js", true);
+  const expectedMessage = new RegExp(
+    `observed_size>=\\d+ bytes, maxBuffer_limit=${DEFAULT_EXEC_MAX_BUFFER_BYTES} bytes\\..*--diff-file`
+  );
+
+  await t.test("gh pr diff", () => {
+    assert.throws(
+      () => withEnv("RELAY_GH_BIN", ghStub, () => loadDiff(dir, 1091, null)),
+      (error) => expectedMessage.test(error.message) && !/^Error: spawnSync gh ENOBUFS$/.test(error.message)
+    );
+  });
+
+  await t.test("internal git diff", () => {
+    assert.throws(
+      () => withEnv("RELAY_GIT_BIN", gitStub, () => loadDiff(dir, null, null, {
+        internalReview: true,
+        manifestData: { git: { base_branch: "main" } },
+        reviewRepoPath: dir,
+      })),
+      (error) => expectedMessage.test(error.message) && !/^Error: spawnSync git ENOBUFS$/.test(error.message)
+    );
+  });
 });
 
 test("context/parseRemoteHost preserves the origin parsing matrix", async (t) => {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋 완료했습니다.

- 공용 `execGit`/`execGh` 기본 버퍼를 16 MiB로 확장하고 caller override를 유지했습니다: [exec.js](/Users/sjlee/.relay/worktrees/10fb0718/dev-relay/skills/relay-dispatch/scripts/exec.js:5)
- 내부 git diff와 공개 `gh pr diff` 모두 512 KiB 초과 시 `--stat`과 omitted-file 목록으로 대체합니다.
- degradation marker와 실제 크기/임계값이 `review-round-N-diff.patch`에 영구 저장됩니다.
- `--diff-file` 경로는 기존 순서와 동작을 유지했습니다.
- 버퍼 초과 시 크기·한도·`--diff-file` 복구 안내가 있는 오류를 제공합니다.

검증:

- exec helper: 7/7 통과
- review context: 49/49 통과
- 최종 직렬 9-suite
```

## Dispatch Metadata

- Run: issue-1091-20260727001244331-b6ac5bcc
- Executor: codex
- Branch: issue-1091