### PR TITLE
Retire coordination marker dispatch surface

### DIFF
--- a/skills/relay-dispatch/references/cli-schema.md
+++ b/skills/relay-dispatch/references/cli-schema.md
@@ -37,6 +37,8 @@ Pick `parsed` when the value is a structured selector, enum, number, or generate
 
 Defaults belong at the call site, not in the global schema, because the same flag can have different defaults in different tools.
 
+Retired dispatch flag: `--coordination-marker` is no longer supported. The coordination-marker seam was removed and nothing replaces it; passing the flag produces a dedicated sunset error.
+
 ## Current Flag Audit
 
 Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same table is mirrored in the PR body when the schema changes — see PR #276 for the audit snapshot convention.
@@ -52,7 +54,6 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--by-role` | `parsed` | Presence flag; no value is consumed. |
 | `--contract-file` | `verbatim` | Operator-supplied artifact path; keep the literal argv token. |
 | `--copy` | `verbatim` | Operator-supplied file list; keep the literal argv token. |
-| `--coordination-marker` | `verbatim` | Opaque single-line coordination marker persisted in the relay manifest; keep the literal argv token. |
 | `--diff-file` | `verbatim` | Operator-supplied fixture path; keep the literal argv token. |
 | `--done-criteria-file` | `verbatim` | Operator-supplied anchor path; keep the literal argv token. |
 | `--dry-run` | `parsed` | Presence flag; no value is consumed. |
@@ -127,7 +128,6 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--by-role` | `parsed` | Presence flag; no value is consumed. |
 | `--contract-file` | `verbatim` | Operator-supplied artifact path; keep the literal argv token. |
 | `--copy` | `verbatim` | Operator-supplied file list; keep the literal argv token. |
-| `--coordination-marker` | `verbatim` | Opaque single-line coordination marker persisted in the relay manifest; keep the literal argv token. |
 | `--diff-file` | `verbatim` | Operator-supplied fixture path; keep the literal argv token. |
 | `--done-criteria-file` | `verbatim` | Operator-supplied anchor path; keep the literal argv token. |
 | `--dry-run` | `parsed` | Presence flag; no value is consumed. |

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -36,7 +36,6 @@ const FLAGS = [
   { flag: "--by-role", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Presence flag; no value is consumed." },
   { flag: "--contract-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied artifact path; keep the literal argv token." },
   { flag: "--copy", kind: VALUE, mode: MODE_VERBATIM, valueName: "<file,...>", rationale: "Operator-supplied file list; keep the literal argv token." },
-  { flag: "--coordination-marker", kind: VALUE, mode: MODE_VERBATIM, valueName: "<marker>", rationale: "Opaque single-line coordination marker persisted in the relay manifest; keep the literal argv token." },
   { flag: "--diff-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied fixture path; keep the literal argv token." },
   { flag: "--dispatch", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--detach", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Launch the run (dispatch or review round) under a detached supervisor and return a receipt; no value is consumed." },
@@ -158,7 +157,7 @@ const COMMAND_FLAGS = {
   dispatch: [
     "--branch", "--run-id", "--manifest", "--prompt", "--prompt-file", "--executor",
     "--model", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file",
-    "--test-command", "--coordination-marker", "--rubric-grandfathered", "--request-id", "--leaf-id",
+    "--test-command", "--rubric-grandfathered", "--request-id", "--leaf-id",
     "--fleet-id", "--ownership-json", "--done-criteria-file", "--publish-policy", "--review-assurance", "--register", "--auto-recover-commit", "--no-auto-recover-commit",
     "--tags", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help",
   ],

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -28,7 +28,6 @@
  *   --reasoning <level>    Codex reasoning effort override (default by rubric size: S=medium, M=high, L/XL=xhigh)
  *   --rubric-file <path>   REQUIRED: copy rubric YAML to run dir (persists for review)
  *   --test-command <cmd>   Record the executor-side test command in execution evidence
- *   --coordination-marker <marker>  Persist one safe single-line marker in the raw manifest
  *   --publish-policy <mode> immediate | after-internal-review (default: immediate)
  *   --review-assurance <level> compact | standard | hardened (default: standard)
  *   --tags <csv>          Explicit routing tags; override inferred routing tags
@@ -87,11 +86,6 @@ const {
   readManifest,
   writeManifest,
 } = require("./manifest/store");
-const {
-  coordinationMarkerFromManifest,
-  validateCoordinationMarker,
-  withCoordinationMarker,
-} = require("./manifest/coordination");
 const { parseModelHints } = require("./model-hints");
 const { resolveExecutorDefaultModel } = require("./executor-model-config");
 const {
@@ -191,13 +185,32 @@ const args = process.argv.slice(2);
 
 const KNOWN_FLAGS = [
   "--branch", "-b", "--run-id", "--manifest", "--prompt", "-p", "--prompt-file", "--executor", "-e",
-  "--model", "-m", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--coordination-marker", "--rubric-grandfathered",
+  "--model", "-m", "--model-hints", "--route-intent-file", "--route-preset", "--sandbox", "--network-access", "--copy", "--timeout", "--reasoning", "--rubric-file", "--test-command", "--rubric-grandfathered",
   "--request-id", "--leaf-id", "--fleet-id", "--ownership-json", "--done-criteria-file", "--publish-policy", "--review-assurance", "--tags",
   "--register", "--auto-recover-commit", "--no-auto-recover-commit", "--allow-conflicting-run", "--detach", "--dry-run", "--json", "--help", "-h",
 ];
 const CLI_ARG_OPTIONS = { commandName: "dispatch", reservedFlags: KNOWN_FLAGS };
 const hasCliFlag = (flag) => schemaHasFlag(args, flag, CLI_ARG_OPTIONS);
 const JSON_OUT_REQUESTED = hasCliFlag("--json");
+
+function failEarly(message, extra = {}) {
+  if (JSON_OUT_REQUESTED) {
+    console.log(JSON.stringify({
+      status: "failed",
+      error: message,
+      ...extra,
+    }, null, 2));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+  process.exit(1);
+}
+
+if (args.some((arg) => arg === "--coordination-marker" || arg.startsWith("--coordination-marker="))) {
+  failEarly(
+    "--coordination-marker is no longer supported; the coordination-marker seam was removed and nothing replaces it."
+  );
+}
 
 if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log("Usage: dispatch.js <repo-path> --branch <name> --prompt <task> [options]");
@@ -222,7 +235,6 @@ if (!args.length || hasCliFlag(["--help", "-h"])) {
   console.log(`  --reasoning        ${modeLabel("--reasoning")} Codex reasoning effort (default by rubric size: S=medium, M=high, L/XL=xhigh)`);
   console.log(`  --rubric-file      ${modeLabel("--rubric-file")} REQUIRED: copy rubric YAML to run dir (persists for review)`);
   console.log(`  --test-command     ${modeLabel("--test-command")} Record the executor-side test command in execution evidence`);
-  console.log(`  --coordination-marker ${modeLabel("--coordination-marker")} Persist one safe single-line marker in the raw manifest before executor spawn`);
   console.log(`  --publish-policy   ${modeLabel("--publish-policy")} PR publication policy: immediate | after-internal-review (default: immediate)`);
   console.log(`  --review-assurance ${modeLabel("--review-assurance")} Review assurance: compact | standard | hardened (default: standard)`);
   console.log(`  --tags             ${modeLabel("--tags")} Explicit routing tags; override inferred routing tags`);
@@ -261,33 +273,6 @@ const MODEL = readArg(args, ["--model", "-m"], undefined, CLI_ARG_OPTIONS);
 const ROUTE_INTENT_FILE = readArg(args, "--route-intent-file", undefined, CLI_ARG_OPTIONS);
 const ROUTE_PRESET = readArg(args, "--route-preset", undefined, CLI_ARG_OPTIONS);
 const RELAY_HOME_FOR_ROUTES = process.env.RELAY_HOME || path.join(os.homedir(), ".relay");
-
-function failEarly(message, extra = {}) {
-  if (JSON_OUT_REQUESTED) {
-    console.log(JSON.stringify({
-      status: "failed",
-      error: message,
-      ...extra,
-    }, null, 2));
-  } else {
-    console.error(`Error: ${message}`);
-  }
-  process.exit(1);
-}
-
-// Validate this optional integration value before route resolution, worktree creation,
-// run-dir claims, or executor probing. An absent flag preserves ordinary dispatch.
-const COORDINATION_MARKER_FLAG = hasCliFlag("--coordination-marker");
-let COORDINATION_MARKER;
-try {
-  COORDINATION_MARKER = readArg(args, "--coordination-marker", undefined, CLI_ARG_OPTIONS);
-  if (COORDINATION_MARKER_FLAG && COORDINATION_MARKER === undefined) {
-    failEarly("--coordination-marker requires a value", { error_code: "missing_coordination_marker" });
-  }
-  if (COORDINATION_MARKER !== undefined) validateCoordinationMarker(COORDINATION_MARKER);
-} catch (error) {
-  failEarly(error.message, { error_code: "invalid_coordination_marker" });
-}
 
 function readRouteIntentFile(filePath) {
   if (!filePath) return {};
@@ -1934,7 +1919,6 @@ async function main() {
   let handlingSignal = false;
   let runtime = null;
   let runDirClaimPath = null;
-  let provisionalMarkerSetup = false;
 
   function releaseRunDirClaim() {
     if (!runDirClaimPath) return;
@@ -1952,52 +1936,10 @@ async function main() {
     fleetIssueLock = null;
   }
 
-  function cleanupProvisionalMarkerSetup() {
-    const errors = [];
-    const runDir = runId ? getRunDir(repoRoot, runId) : null;
-
-    try { releaseRunDirClaim(); } catch (error) { errors.push(`run-dir claim release failed: ${error.message}`); }
-    try { releaseFleetIssueLock(); } catch (error) { errors.push(`issue lock release failed: ${error.message}`); }
-
-    if (wtPath && fs.existsSync(wtPath)) {
-      try {
-        removeWorktree({ repoRoot, worktreePath: wtPath });
-        if (fs.existsSync(wtPath)) {
-          const relative = path.relative(path.resolve(wtBase), path.resolve(wtPath));
-          if (relative && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) {
-            fs.rmSync(wtPath, { recursive: true, force: true });
-          }
-        }
-      } catch (error) {
-        errors.push(`worktree cleanup failed: ${error.message}`);
-      }
-    }
-    if (wtPath) {
-      try {
-        const worktreeShell = path.dirname(wtPath);
-        if (fs.existsSync(worktreeShell) && fs.readdirSync(worktreeShell).length === 0) {
-          fs.rmdirSync(worktreeShell);
-        }
-      } catch (error) {
-        errors.push(`worktree shell cleanup failed: ${error.message}`);
-      }
-    }
-
-    try {
-      if (manifestPath) fs.rmSync(manifestPath, { force: true });
-      if (runDir) fs.rmSync(runDir, { recursive: true, force: true });
-    } catch (error) {
-      errors.push(`provisional run cleanup failed: ${error.message}`);
-    }
-    return errors;
-  }
-
   function failBeforeAdmission(message, extra = {}) {
-    const cleanupErrors = provisionalMarkerSetup ? cleanupProvisionalMarkerSetup() : [];
     failEarly(message, {
       ...extra,
-      recoverable: cleanupErrors.length === 0,
-      ...(cleanupErrors.length ? { cleanup_error: cleanupErrors.join("; ") } : {}),
+      recoverable: true,
     });
   }
 
@@ -2027,7 +1969,7 @@ async function main() {
     }
   }
 
-  function journalDispatchInterrupted(signal, executorTerminated, { reason = "signal", coordinationMarker = undefined } = {}) {
+  function journalDispatchInterrupted(signal, executorTerminated, { reason = "signal" } = {}) {
     if (!manifest || !runId) return false;
     let runDir;
     try {
@@ -2046,7 +1988,6 @@ async function main() {
         timeout_s: TIMEOUT,
         executor_terminated: executorTerminated,
         worktree: wtPath || null,
-        ...(coordinationMarker !== undefined ? { coordination_marker: coordinationMarker } : {}),
       });
       return true;
     } catch { return false; }
@@ -2138,16 +2079,6 @@ async function main() {
         worktree: validatedPaths.worktree,
       },
     };
-    if (COORDINATION_MARKER !== undefined) {
-      const existingMarker = coordinationMarkerFromManifest(manifest);
-      if (existingMarker !== COORDINATION_MARKER) {
-        console.error(
-          "Error: same-run resume cannot add or replace a coordination marker; " +
-          "close this run with close-run.js, then start a fresh dispatch with the desired --coordination-marker value"
-        );
-        process.exit(1);
-      }
-    }
     const manifestPublishPolicy = manifest.dispatch?.publish_policy || "immediate";
     if (PUBLISH_POLICY_ARG && PUBLISH_POLICY_ARG !== manifestPublishPolicy) {
       console.error(
@@ -2171,16 +2102,6 @@ async function main() {
     const interruptibleResumeState = manifest.state === STATES.DISPATCHED || manifest.state === STATES.DRAFT;
     const latestEvent = interruptibleResumeState ? latestRunEvent(repoRoot, runId) : null;
     const resumesInterruptedDispatch = interruptibleResumeState && latestEvent?.event === EVENTS.DISPATCH_INTERRUPTED;
-    const markerDurabilityRecoveryPending = resumesInterruptedDispatch
-      && latestEvent?.reason === "coordination_marker_not_persisted_before_executor_spawn"
-      && coordinationMarkerFromManifest(manifest) === undefined;
-    if (markerDurabilityRecoveryPending) {
-      console.error(
-        "Error: coordination marker durability recovery is incomplete; " +
-        "close this run with close-run.js, then start a fresh dispatch with the exact --coordination-marker value",
-      );
-      process.exit(1);
-    }
     if (resumesInterruptedDispatch && isProcessGroupAlive(latestEvent.executor_pgid)) {
       console.error(
         `Error: interrupted executor process group is still alive for run '${runId}' ` +
@@ -2678,9 +2599,6 @@ async function main() {
       fleetId: FLEET_ID,
       ownership: OWNERSHIP || undefined,
     });
-    if (COORDINATION_MARKER !== undefined) {
-      manifest = withCoordinationMarker(manifest, COORDINATION_MARKER);
-    }
     ensureRunLayout(repoRoot, runId);
     manifest = persistDoneCriteria(manifest, manifestRunDir, resolvedDoneCriteriaPath, doneCriteriaSource);
     manifest = {
@@ -2704,29 +2622,6 @@ async function main() {
         summary: summarizeRoutePlan(routePlan),
       },
     };
-    // A coordination marker is an admission invariant. Publish and verify the
-    // manifest before creating a relay-owned worktree so a persistence failure
-    // cannot reach any worktree or executor mutation. The later write refreshes
-    // environment/path metadata after worktree creation and preserves the marker
-    // through the shared manifest writer boundary.
-    if (COORDINATION_MARKER !== undefined) {
-      provisionalMarkerSetup = true;
-      try {
-        writeManifest(manifestPath, manifest);
-        const persistedManifest = readManifest(manifestPath).data;
-        if (coordinationMarkerFromManifest(persistedManifest) !== COORDINATION_MARKER) {
-          failEarly(
-            "coordination marker was not durably persisted before worktree creation",
-            { error_code: "coordination_marker_not_persisted" },
-          );
-        }
-      } catch (error) {
-        failBeforeAdmission(
-          `coordination marker persistence failed before worktree creation: ${error.message}`,
-          { error_code: "coordination_marker_persistence_failed" },
-        );
-      }
-    }
     try {
       const created = createWorktree({
         repoRoot,
@@ -2749,7 +2644,7 @@ async function main() {
       });
       copiedFiles = created.copiedFiles;
     } catch (error) {
-      failBeforeAdmission(`worktree creation failed after coordination marker persistence: ${error.message}`, {
+      failBeforeAdmission(`worktree creation failed: ${error.message}`, {
         error_code: "worktree_creation_failed",
       });
     }
@@ -3002,37 +2897,6 @@ async function main() {
     },
   };
   writeManifest(manifestPath, manifest);
-  if (COORDINATION_MARKER !== undefined) {
-    const persistedManifest = readManifest(manifestPath).data;
-    const markerPersisted = process.env.RELAY_TEST_FAIL_FINAL_COORDINATION_MARKER_VERIFY === "1"
-      ? false
-      : coordinationMarkerFromManifest(persistedManifest) === COORDINATION_MARKER;
-    if (!markerPersisted) {
-      const audited = journalDispatchInterrupted(null, false, {
-        reason: "coordination_marker_not_persisted_before_executor_spawn",
-        coordinationMarker: COORDINATION_MARKER,
-      });
-      if (!audited) {
-        failBeforeAdmission(
-          "coordination marker was not durably persisted before executor spawn and interruption audit failed",
-          {
-            error_code: "coordination_marker_not_persisted",
-            interruption_audit: "failed",
-          },
-        );
-      }
-      releaseRunDirClaim();
-      releaseFleetIssueLock();
-      failEarly(
-        "coordination marker was not durably persisted before executor spawn; dispatch was interrupted for recovery",
-        {
-          error_code: "coordination_marker_not_persisted",
-          interruption_audit: "dispatch_interrupted",
-          recovery: "close this run with close-run.js, then start a fresh dispatch with the exact --coordination-marker value",
-        },
-      );
-    }
-  }
   appendRunEvent(repoRoot, runId, {
     event: EVENTS.DISPATCH_START,
     state_from: dispatchFromState,
@@ -3046,7 +2910,6 @@ async function main() {
     executor_policy: executorPolicy,
     policy_decision: policyDecision,
   });
-  provisionalMarkerSetup = false;
   writeDetachReceiptIfRequested({
     repoRoot,
     runId,

--- a/tests/relay-dispatch/scripts/dispatch-marker-recovery.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-marker-recovery.test.js
@@ -10,7 +10,6 @@ const path = require("node:path");
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const DISPATCH_JS = path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "dispatch.js");
 const { getRepoSlug } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "paths.js"));
-const { readManifest } = require(path.join(REPO_ROOT, "skills", "relay-dispatch", "scripts", "manifest", "store.js"));
 
 function setupRepo() {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "relay-marker-recovery-dispatch-"));
@@ -70,7 +69,7 @@ function runDispatch(fixture, extraArgs, envOverrides = {}) {
   return { ...result, body };
 }
 
-function dispatchArgs(fixture, runId) {
+function normalDispatchArgs(fixture, runId) {
   return [
     "--run-id", runId,
     "--branch", "issue-1016-marker-recovery",
@@ -78,40 +77,36 @@ function dispatchArgs(fixture, runId) {
     "--executor", "codex",
     "--rubric-file", fixture.rubricPath,
     "--publish-policy", "after-internal-review",
-    "--coordination-marker", "relay-orca: marker-test/outcome-a",
     "--json",
   ];
 }
 
-function assertNoOwningRun(fixture, runId) {
+function assertNoOwningManifestOrWorktree(fixture, runId) {
   const runRoot = path.join(fixture.relayHome, "runs", getRepoSlug(fixture.repoRoot));
   const manifestPath = path.join(runRoot, `${runId}.md`);
-  assert.equal(fs.existsSync(manifestPath), false, "provisional failure must leave no owning manifest");
-  const runDir = path.join(runRoot, runId);
-  assert.equal(fs.existsSync(runDir), false, "provisional failure must remove the run directory");
+  assert.equal(fs.existsSync(manifestPath), false, "pre-admission failure must leave no owning manifest");
   const worktrees = path.join(fixture.relayHome, "worktrees");
-  assert.equal(fs.existsSync(worktrees) ? fs.readdirSync(worktrees).length : 0, 0, "provisional failure must remove relay worktrees");
+  const retainedCheckouts = fs.existsSync(worktrees)
+    ? fs.readdirSync(worktrees).flatMap((entry) => fs.readdirSync(path.join(worktrees, entry)))
+    : [];
+  assert.deepEqual(retainedCheckouts, [], "pre-admission failure must remove relay worktree checkouts");
 }
 
-function readFixtureEvents(fixture, runId) {
-  const eventsPath = path.join(fixture.relayHome, "runs", getRepoSlug(fixture.repoRoot), runId, "events.jsonl");
-  return fs.readFileSync(eventsPath, "utf-8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
-}
-
-for (const [label, failureEnv] of [
-  ["worktree creation", { RELAY_TEST_FAIL_CREATE_WORKTREE: "1" }],
-  ["base-branch merge", { RELAY_TEST_FAIL_BASE_MERGE: "1" }],
+for (const [label, failureEnv, errorCode] of [
+  ["worktree creation", { RELAY_TEST_FAIL_CREATE_WORKTREE: "1" }, "worktree_creation_failed"],
+  ["base-branch merge", { RELAY_TEST_FAIL_BASE_MERGE: "1" }, "base_branch_merge_failed"],
 ]) {
-  test(`marker ${label} failure rolls back provisional ownership and permits same-run retry`, () => {
+  test(`${label} failure without a coordination flag remains recoverable and permits same-run retry`, () => {
     const fixture = setupRepo();
     const runId = `issue-1016-marker-${label === "worktree creation" ? "create" : "merge"}-20260720120000000-aabbccdd`;
     try {
-      const failed = runDispatch(fixture, dispatchArgs(fixture, runId), failureEnv);
+      const failed = runDispatch(fixture, normalDispatchArgs(fixture, runId), failureEnv);
       assert.notEqual(failed.status, 0, failed.stderr);
+      assert.equal(failed.body.error_code, errorCode);
       assert.equal(failed.body.recoverable, true, JSON.stringify(failed.body));
-      assertNoOwningRun(fixture, runId);
+      assertNoOwningManifestOrWorktree(fixture, runId);
 
-      const retried = runDispatch(fixture, dispatchArgs(fixture, runId));
+      const retried = runDispatch(fixture, normalDispatchArgs(fixture, runId));
       assert.equal(retried.status, 0, `${retried.stderr}\n${retried.stdout}`);
       assert.equal(retried.body.runId, runId);
       assert.equal(retried.body.runState, "internal_review_pending");
@@ -122,38 +117,39 @@ for (const [label, failureEnv] of [
   });
 }
 
-test("final marker durability failure records an interrupted recovery event before executor spawn", () => {
+test("normal dispatch without a coordination flag is unaffected", () => {
   const fixture = setupRepo();
-  const runId = "issue-1016-marker-final-20260720120000000-aabbccdd";
+  const runId = "issue-1016-no-marker-20260720120000000-aabbccdd";
   try {
-    const failed = runDispatch(fixture, dispatchArgs(fixture, runId), {
-      RELAY_TEST_FAIL_FINAL_COORDINATION_MARKER_VERIFY: "1",
-    });
-    assert.notEqual(failed.status, 0, failed.stderr);
-    assert.equal(failed.body.error_code, "coordination_marker_not_persisted");
-    assert.equal(failed.body.interruption_audit, "dispatch_interrupted");
-    assert.equal(fs.existsSync(fixture.env.RELAY_TEST_EXECUTOR_MARKER), false, "durability failure must precede executor spawn");
-
-    const manifestPath = path.join(fixture.relayHome, "runs", getRepoSlug(fixture.repoRoot), `${runId}.md`);
-    const manifest = readManifest(manifestPath).data;
-    assert.equal(manifest.state, "dispatched");
-    assert.equal(fs.existsSync(manifest.paths.worktree), true, "interrupted recovery retains the clean worktree");
-    const interrupted = readFixtureEvents(fixture, runId).at(-1);
-    assert.equal(interrupted.event, "dispatch_interrupted");
-    assert.equal(interrupted.reason, "coordination_marker_not_persisted_before_executor_spawn");
-    assert.equal(interrupted.state_from, "dispatched");
-    assert.equal(interrupted.state_to, "dispatched");
-    assert.equal(interrupted.coordination_marker, "relay-orca: marker-test/outcome-a");
-
-    const resumed = runDispatch(fixture, [
-      "--manifest", manifestPath,
-      "--prompt", "resume after marker durability recovery",
-      "--json",
-    ]);
-    assert.equal(resumed.status, 0, `${resumed.stderr}\n${resumed.stdout}`);
-    assert.equal(resumed.body.runState, "internal_review_pending");
+    const result = runDispatch(fixture, normalDispatchArgs(fixture, runId));
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.equal(result.body.runId, runId);
+    assert.equal(result.body.runState, "internal_review_pending");
     assert.equal(fs.existsSync(fixture.env.RELAY_TEST_EXECUTOR_MARKER), true);
   } finally {
     fs.rmSync(fixture.base, { recursive: true, force: true });
   }
 });
+
+for (const [label, retiredArgs] of [
+  ["with a value", ["--coordination-marker", "relay-orca: retired"]],
+  ["with an equals value", ["--coordination-marker=relay-orca: retired"]],
+  ["without a value", ["--coordination-marker"]],
+]) {
+  test(`--coordination-marker ${label} reports the specific sunset error`, () => {
+    const fixture = setupRepo();
+    try {
+      const result = runDispatch(fixture, [...retiredArgs, "--json"]);
+      assert.notEqual(result.status, 0);
+      assert.equal(
+        result.body.error,
+        "--coordination-marker is no longer supported; the coordination-marker seam was removed and nothing replaces it."
+      );
+      assert.doesNotMatch(result.stdout, /unknown flags/);
+      assert.doesNotMatch(result.stdout, /missing_coordination_marker|invalid_coordination_marker/);
+      assert.equal(fs.existsSync(fixture.env.RELAY_TEST_EXECUTOR_MARKER), false);
+    } finally {
+      fs.rmSync(fixture.base, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/skills-lint/scripts/script-reachability.test.js
+++ b/tests/skills-lint/scripts/script-reachability.test.js
@@ -9,7 +9,8 @@ const SKILLS_DIR = path.join(REPO_ROOT, "skills");
 const ADAPTER_INDEX_PATH = path.join(SKILLS_DIR, "relay-dispatch", "scripts", "agent-adapters", "index.js");
 
 const PACKAGED_SCRIPT_ALLOWLIST = [
-  // Keep empty when possible. Each entry must include a justification comment.
+  // #1090 leaf 1 removes every importer; leaf 2 owns deletion of the safety-critical write path.
+  "skills/relay-dispatch/scripts/manifest/coordination.js",
 ];
 
 function toRepoRelative(filePath, repoRoot) {


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋을 완료했습니다. 커밋: `b103dfe` (`Retire coordination marker dispatch surface`)

주요 결과:

- `--coordination-marker` 값 있음/없음/`=` 형식 모두 전용 sunset 오류를 반환합니다.
- 마커 가드와 전용 오류 코드 4개를 제거했으며, 기존 `error_code` 5개만 유지했습니다.
- CLI 스키마·도움말·문서를 갱신하고 복구 테스트를 정상 디스패치 및 sunset 테스트로 전환했습니다.
- leaf 2 대상 파일 3개는 SHA-256까지 변경 전과 동일합니다.
- worktree는 깨끗하며 PR은 수정하지 않았습니다.

검증:

- 변환 테스트: 6 tests / 0 fail
- reachability 테스트: 6 tests / 0 fail
- relay-dispatch 표적 스위트: 1151 tests / 5 fail
- 직렬 9-suite 게이트는 정확히 한 번 실행:

```text

```

## Dispatch Metadata

- Run: issue-1090-20260727111633439-605eedf7
- Executor: codex
- Branch: issue-1090-leaf1