### PR TITLE
fix(review): normalize unbound advisory failures

### DIFF
--- a/skills/relay-config/references/model-catalog.md
+++ b/skills/relay-config/references/model-catalog.md
@@ -4,6 +4,8 @@ Last checked: 2026-07-06. Treat as stale after 60 days.
 
 Use only when live model-list probes fail or the user asks for a recommendation. Prefer provider CLI model lists from `relay-config doctor` when available. The executable catalog data lives in `skills/relay-dispatch/scripts/model-catalog.js`; this note is operator-facing context, not a runtime allow-list.
 
+Cline routes in this fallback catalog are legacy dispatch values. Advisory review requires the executable relay form `cline-pass/modelType/model`; two-segment catalog routes are rejected during configuration.
+
 | Model | Actor routes | Use when | Cost hint |
 | --- | --- | --- | --- |
 | `glm-5.2` | `cline` -> `cline-pass/glm-5.2`; `opencode` -> `opencode-go/glm-5.2` | Strong default for harder coding and reasoning routes. | premium |

--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -106,5 +106,5 @@ node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --
 
 # ClinePass dispatch and advisory review with an explicit route
 node skills/relay-dispatch/scripts/dispatch.js . --executor cline --model cline-pass/glm-5.2 -b issue-42 -p "..." --rubric-file rubric.yaml
-node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer codex --advisory-reviewer cline --advisory-reviewer-model cline-pass/glm-5.2 --json
+node skills/relay-review/scripts/review-runner.js --repo . --run-id "$RUN_ID" --reviewer codex --advisory-reviewer cline --advisory-reviewer-model cline-pass/z-ai/glm-5.2 --json
 ```

--- a/skills/relay-dispatch/scripts/agent-adapters/cline-model-route.js
+++ b/skills/relay-dispatch/scripts/agent-adapters/cline-model-route.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const CLINE_PROVIDER = "cline-pass";
+const CLINE_MODEL_FORMAT = "modelType/model";
+const CLINE_RELAY_MODEL_FORMAT = `${CLINE_PROVIDER}/${CLINE_MODEL_FORMAT}`;
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function formatError(label, value) {
+  return (
+    `${label} cannot execute: Cline's --model expects ${CLINE_MODEL_FORMAT} after the ` +
+    `${CLINE_PROVIDER}/ relay provider prefix. Expected relay format ` +
+    `${CLINE_RELAY_MODEL_FORMAT} (for example ${CLINE_PROVIDER}/z-ai/glm-5.2); ` +
+    `got ${JSON.stringify(value)}`
+  );
+}
+
+function parseClineRelayModelRoute(value, { label = "Cline advisory model route" } = {}) {
+  const route = nonEmptyString(value);
+  if (!route) return null;
+
+  const segments = route.split("/");
+  if (
+    segments.length !== 3
+    || segments[0] !== CLINE_PROVIDER
+    || segments.slice(1).some((segment) => !segment.trim())
+  ) {
+    throw new Error(formatError(label, value));
+  }
+
+  return {
+    cliModel: segments.slice(1).join("/"),
+    provider: CLINE_PROVIDER,
+    route,
+  };
+}
+
+function isPatternRoute(value) {
+  return /[*?[\]]/.test(String(value || ""));
+}
+
+module.exports = {
+  CLINE_MODEL_FORMAT,
+  CLINE_PROVIDER,
+  CLINE_RELAY_MODEL_FORMAT,
+  isPatternRoute,
+  parseClineRelayModelRoute,
+};

--- a/skills/relay-dispatch/scripts/relay-events.js
+++ b/skills/relay-dispatch/scripts/relay-events.js
@@ -445,6 +445,9 @@ function appendRunEventUnlocked(repoRoot, runId, eventData, { eventsPath = null 
     ...(eventData.duplicate_low_confidence_count !== undefined
       ? { duplicate_low_confidence_count: normalizeEventValue(eventData.duplicate_low_confidence_count) }
       : {}),
+    ...(eventData.advisory_outcome !== undefined
+      ? { advisory_outcome: normalizeEventValue(eventData.advisory_outcome) }
+      : {}),
     ...(eventData.confidence_downgrade !== undefined
       ? { confidence_downgrade: eventData.confidence_downgrade === true }
       : {}),

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -514,9 +514,11 @@ function normalizePresets(value, sourceLabel) {
 
 function validatesClineAdvisoryRoute(entry) {
   const phases = entry.phases;
+  const executors = entry.executors;
   const reviewers = entry.reviewers;
   const canSelectAdvisory = phases === undefined || phases.includes("advisory_review");
-  return canSelectAdvisory && reviewers?.includes("cline");
+  const hasActorScope = executors !== undefined || reviewers !== undefined;
+  return canSelectAdvisory && (!hasActorScope || reviewers?.includes("cline"));
 }
 
 function validateClineAdvisoryModel(model, label) {

--- a/skills/relay-dispatch/scripts/relay-routing.js
+++ b/skills/relay-dispatch/scripts/relay-routing.js
@@ -3,6 +3,10 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const {
+  isPatternRoute,
+  parseClineRelayModelRoute,
+} = require("./agent-adapters/cline-model-route");
 const { resolveExecutorDefaultModel } = require("./executor-model-config");
 const { getProjectRoutesPath } = require("./manifest/paths");
 const { buildDefaultRelayPolicy, evaluateRelayRoute } = require("./relay-policy");
@@ -508,6 +512,48 @@ function normalizePresets(value, sourceLabel) {
   return normalized;
 }
 
+function validatesClineAdvisoryRoute(entry) {
+  const phases = entry.phases;
+  const reviewers = entry.reviewers;
+  const canSelectAdvisory = phases === undefined || phases.includes("advisory_review");
+  return canSelectAdvisory && reviewers?.includes("cline");
+}
+
+function validateClineAdvisoryModel(model, label) {
+  if (model === undefined || model === null) return;
+  parseClineRelayModelRoute(model, { label });
+}
+
+function validateExecutableAdvisoryRoutes(routes, sourceLabel) {
+  for (const [index, entry] of (routes.routes || []).entries()) {
+    if (!validatesClineAdvisoryRoute(entry) || isPatternRoute(entry.route)) continue;
+    validateClineAdvisoryModel(
+      entry.route,
+      `invalid routes config at ${sourceLabel}: routes[${index}].route`
+    );
+  }
+
+  const defaults = routes.defaults?.advisory_review;
+  for (const [index, lane] of (Array.isArray(defaults) ? defaults : []).entries()) {
+    if (lane.reviewer !== "cline") continue;
+    validateClineAdvisoryModel(
+      lane.model,
+      `invalid routes config at ${sourceLabel}: defaults.advisory_review[${index}].model`
+    );
+  }
+
+  for (const [presetName, preset] of Object.entries(routes.presets || {})) {
+    const lanes = preset.advisory_review;
+    for (const [index, lane] of (Array.isArray(lanes) ? lanes : []).entries()) {
+      if (lane.reviewer !== "cline") continue;
+      validateClineAdvisoryModel(
+        lane.model,
+        `invalid routes config at ${sourceLabel}: presets.${presetName}.advisory_review[${index}].model`
+      );
+    }
+  }
+}
+
 function validateRouteConfig(routes, sourceLabel = "routes config", { project = false } = {}) {
   if (!isPlainObject(routes)) {
     throw new Error(`invalid routes config at ${sourceLabel}: expected object`);
@@ -535,6 +581,7 @@ function validateRouteConfig(routes, sourceLabel = "routes config", { project = 
   } else {
     normalized.strict = routes.strict === true;
   }
+  validateExecutableAdvisoryRoutes(normalized, sourceLabel);
   return normalized;
 }
 
@@ -694,6 +741,7 @@ function loadRouteConfig({ repoRoot, relayHome, globalPath, projectPath, globalR
     // legacy policy.json/executors.json precedence.
     if (globalConfig && projectConfig) {
       effectiveConfig = mergeRouteConfigs(globalConfig, projectConfig);
+      validateExecutableAdvisoryRoutes(effectiveConfig, "merged global and project routes");
     }
   } catch (error) {
     return { ok: false, status: "error", config: null, errors: [{ source: resolvedProjectPath, message: error.message }], sources };

--- a/skills/relay-review/scripts/advisory-review-schema.js
+++ b/skills/relay-review/scripts/advisory-review-schema.js
@@ -6,6 +6,7 @@ const {
 } = require("./reviewer-helpers");
 
 const ADVISORY_PROFILES = Object.freeze(["blindspot", "adversarial"]);
+const ADVISORY_TERMINAL_STATUSES = new Set(["failed", "policy_violation", "success", "timeout"]);
 const ADVISORY_SEVERITIES = new Set(["P1", "P2", "P3"]);
 const ADVISORY_CATEGORIES = new Set([
   "test-gap",
@@ -127,9 +128,186 @@ function parseAdvisoryReview(text, {
   }
 }
 
+function nonNegativeCount(value) {
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : 0;
+}
+
+function advisoryLaneKey(value) {
+  return [
+    Number(value?.lane_index || value?.laneIndex || 0),
+    value?.reviewer || "unknown-reviewer",
+    value?.trigger || "every_round",
+  ].join(":");
+}
+
+function advisoryOutcomeForStatus(status, counts) {
+  if (status === "success") {
+    return counts.required_count + counts.advisory_count + counts.duplicate_low_confidence_count > 0
+      ? "findings"
+      : "clean";
+  }
+  if (status === "timeout") return "timed_out";
+  if (status === "failed") return "failed";
+  if (status === "policy_violation") return "policy_violation";
+  if (status === "deferred") return "deferred";
+  if (status === "running") return "running";
+  return "not_run";
+}
+
+function toAdvisoryLaneEvidence(value = {}) {
+  const counts = {
+    required_count: nonNegativeCount(value.required_count),
+    advisory_count: nonNegativeCount(value.advisory_count),
+    duplicate_low_confidence_count: nonNegativeCount(value.duplicate_low_confidence_count),
+  };
+  const status = typeof value.status === "string" && value.status.trim()
+    ? value.status.trim()
+    : "not_run";
+  return {
+    lane_index: nonNegativeCount(value.lane_index || value.laneIndex) || 1,
+    reviewer: typeof value.reviewer === "string" && value.reviewer.trim()
+      ? value.reviewer.trim()
+      : "unknown",
+    model: typeof value.model === "string" && value.model.trim() ? value.model.trim() : null,
+    profile: typeof value.profile === "string" && value.profile.trim()
+      ? value.profile.trim()
+      : "blindspot",
+    trigger: typeof value.trigger === "string" && value.trigger.trim()
+      ? value.trigger.trim()
+      : "every_round",
+    gating: value.gating === true,
+    status,
+    outcome: advisoryOutcomeForStatus(status, counts),
+    ran: status === "success",
+    failure_reason: typeof value.failureReason === "string" && value.failureReason.trim()
+      ? value.failureReason.trim()
+      : typeof value.failure_reason === "string" && value.failure_reason.trim()
+        ? value.failure_reason.trim()
+        : null,
+    completed_at: typeof value.completed_at === "string" && value.completed_at.trim()
+      ? value.completed_at.trim()
+      : null,
+    ...counts,
+  };
+}
+
+function overallAdvisoryStatus(configuredCount, outcomes) {
+  if (configuredCount === 0) return "not_configured";
+  if (outcomes.length < configuredCount || outcomes.some((entry) => !ADVISORY_TERMINAL_STATUSES.has(entry.status))) {
+    return "incomplete";
+  }
+  if (outcomes.every((entry) => entry.outcome === "clean")) return "clean";
+  if (outcomes.every((entry) => entry.status === "success")) return "findings";
+  if (outcomes.every((entry) => entry.status === "timeout")) return "timed_out";
+  if (outcomes.every((entry) => entry.status !== "success")) return "failed";
+  return "partial";
+}
+
+function buildAdvisoryRoundEvidence({
+  configuredCount = 0,
+  headSha = null,
+  outcomes = [],
+  round,
+} = {}) {
+  const normalizedOutcomes = (outcomes || []).filter(Boolean).map(toAdvisoryLaneEvidence);
+  const normalizedConfiguredCount = Math.max(
+    nonNegativeCount(configuredCount),
+    normalizedOutcomes.length,
+  );
+  return {
+    round: nonNegativeCount(round),
+    head_sha: typeof headSha === "string" && headSha.trim() ? headSha.trim() : null,
+    configured_count: normalizedConfiguredCount,
+    status: overallAdvisoryStatus(normalizedConfiguredCount, normalizedOutcomes),
+    outcomes: normalizedOutcomes,
+  };
+}
+
+function evidenceRank(outcome) {
+  if (ADVISORY_TERMINAL_STATUSES.has(outcome?.status)) return 3;
+  if (outcome?.status === "deferred") return 2;
+  if (outcome?.status === "running") return 1;
+  return 0;
+}
+
+function preferAdvisoryOutcome(left, right) {
+  if (!left) return right;
+  if (!right) return left;
+  const leftRank = evidenceRank(left);
+  const rightRank = evidenceRank(right);
+  if (rightRank !== leftRank) return rightRank > leftRank ? right : left;
+  if (right.completed_at && (!left.completed_at || right.completed_at >= left.completed_at)) return right;
+  return left;
+}
+
+function mergeAdvisoryRoundEvidence(left, right) {
+  if (!left) return right || null;
+  if (!right) return left;
+  const leftRound = nonNegativeCount(left.round);
+  const rightRound = nonNegativeCount(right.round);
+  if (leftRound !== rightRound) return rightRound > leftRound ? right : left;
+  if (left.head_sha && right.head_sha && left.head_sha !== right.head_sha) return right;
+
+  const merged = new Map();
+  for (const outcome of left.outcomes || []) {
+    const normalized = toAdvisoryLaneEvidence(outcome);
+    merged.set(advisoryLaneKey(normalized), normalized);
+  }
+  for (const outcome of right.outcomes || []) {
+    const normalized = toAdvisoryLaneEvidence(outcome);
+    const key = advisoryLaneKey(normalized);
+    merged.set(key, preferAdvisoryOutcome(merged.get(key), normalized));
+  }
+  return buildAdvisoryRoundEvidence({
+    configuredCount: Math.max(
+      nonNegativeCount(left.configured_count),
+      nonNegativeCount(right.configured_count),
+    ),
+    headSha: right.head_sha || left.head_sha || null,
+    outcomes: Array.from(merged.values()).sort((a, b) => a.lane_index - b.lane_index),
+    round: rightRound || leftRound,
+  });
+}
+
+function formatAdvisoryRoundSummary(evidence) {
+  if (!evidence || evidence.configured_count === 0) {
+    return ["- No advisory reviewer was configured; advisory did not run."];
+  }
+  const lines = (evidence.outcomes || []).map((entry) => {
+    const label = `${entry.reviewer} (lane ${entry.lane_index}, ${entry.trigger})`;
+    if (entry.outcome === "clean") return `- ${label}: advisory ran and found nothing.`;
+    if (entry.outcome === "findings") {
+      return (
+        `- ${label}: advisory ran and reported required=${entry.required_count}, ` +
+        `advisory=${entry.advisory_count}, duplicate/low-confidence=${entry.duplicate_low_confidence_count}.`
+      );
+    }
+    if (entry.outcome === "timed_out") {
+      return `- ${label}: advisory did not run to completion (timed out)${entry.failure_reason ? ` — ${entry.failure_reason}` : "."}`;
+    }
+    if (entry.outcome === "failed" || entry.outcome === "policy_violation") {
+      return `- ${label}: advisory did not run to completion (${entry.outcome})${entry.failure_reason ? ` — ${entry.failure_reason}` : "."}`;
+    }
+    if (entry.outcome === "deferred") {
+      return `- ${label}: advisory did not complete before this round summary (deferred).`;
+    }
+    if (entry.outcome === "running") return `- ${label}: advisory was still running when this round was summarized.`;
+    return `- ${label}: advisory did not run.`;
+  });
+  while (lines.length < evidence.configured_count) {
+    lines.push("- Configured advisory lane had no execution evidence; advisory did not run.");
+  }
+  return lines;
+}
+
 module.exports = {
   ADVISORY_PROFILES,
+  buildAdvisoryRoundEvidence,
+  formatAdvisoryRoundSummary,
+  mergeAdvisoryRoundEvidence,
   normalizeAdvisoryJsonText,
   parseAdvisoryReview,
+  toAdvisoryLaneEvidence,
   validateAdvisoryProfile,
 };

--- a/skills/relay-review/scripts/invoke-reviewer-cline.js
+++ b/skills/relay-review/scripts/invoke-reviewer-cline.js
@@ -13,6 +13,10 @@ const {
   extractClineAdvisoryCandidates,
 } = require("../../relay-dispatch/scripts/agent-adapters/cline-jsonl");
 const {
+  CLINE_PROVIDER,
+  parseClineRelayModelRoute,
+} = require("../../relay-dispatch/scripts/agent-adapters/cline-model-route");
+const {
   summarizeFailure,
 } = require("./reviewer-helpers");
 const { parseAdvisoryReview, validateAdvisoryProfile } = require("./advisory-review-schema");
@@ -36,7 +40,7 @@ if (!args.length || cliArgs.hasFlag(["--help", "-h"])) {
   console.log("\nOptions:");
   console.log(`  --repo <path>        ${modeLabel("--repo")} Repository root`);
   console.log(`  --prompt-file <path> ${modeLabel("--prompt-file")} Prompt bundle path`);
-  console.log(`  --model <route>      ${modeLabel("--model")} Model route, for example cline-pass/glm-5.2`);
+  console.log(`  --model <route>      ${modeLabel("--model")} Model route, for example cline-pass/z-ai/glm-5.2`);
   console.log(`  --phase <name>       ${modeLabel("--phase")} advisory_review only`);
   console.log(`  --profile <name>     ${modeLabel("--profile")} Advisory profile, defaults to blindspot`);
   console.log(`  --json               ${modeLabel("--json")} Output JSON`);
@@ -101,32 +105,19 @@ function isExecTimeout(error) {
   return error?.code === "ETIMEDOUT" || (error?.signal === "SIGKILL" && error?.killed);
 }
 
-function providerForModel(model) {
-  if (typeof model !== "string" || !model.trim()) return "cline-pass";
-  const idx = model.indexOf("/");
-  return idx > 0 ? model.slice(0, idx) : "cline-pass";
-}
-
 function validateModelRoute(model) {
-  if (typeof model !== "string" || !model.trim()) return null;
-  const normalized = model.trim();
-  if (!normalized.includes("/")) {
-    throw new Error(
-      `--model must use the expected modelType/model form, for example cline-pass/glm-5.2; got ${JSON.stringify(model)}`
-    );
-  }
-  return normalized;
+  return parseClineRelayModelRoute(model, { label: "--model" });
 }
 
-function buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout }) {
+function buildTimeoutDiagnosticCommand({ clineBin, modelRoute, reviewTimeout }) {
   const parentTimeoutMs = parseReviewTimeoutMs(reviewTimeout);
   const command = [
     clineBin || "cline",
     "--json",
     "--yolo",
-    "-P", providerForModel(model),
+    "-P", modelRoute?.provider || CLINE_PROVIDER,
   ];
-  if (model) command.push("-m", model);
+  if (modelRoute) command.push("-m", modelRoute.cliModel);
   command.push(
     "--timeout", clineTimeoutSecondsFromParentMs(parentTimeoutMs),
     "'Return exactly {\"ok\":true} and nothing else.'"
@@ -156,7 +147,7 @@ function withRawAdapterOutput(error, rawOutput, rawStderr) {
 function main() {
   const repoPath = path.resolve(cliArgs.getArg("--repo") || ".");
   const promptFile = cliArgs.getArg("--prompt-file");
-  const model = validateModelRoute(cliArgs.getArg("--model"));
+  const modelRoute = validateModelRoute(cliArgs.getArg("--model"));
   const phase = resolvePhase(cliArgs.getArg("--phase", "advisory_review"));
   const advisoryProfile = validateAdvisoryProfile(readAdvisoryProfileArg(args) || "blindspot");
   const clineBin = process.env.RELAY_CLINE_BIN || "cline";
@@ -173,9 +164,9 @@ function main() {
   const execArgs = [
     "--json",
     "--yolo",
-    "-P", providerForModel(model),
+    "-P", modelRoute?.provider || CLINE_PROVIDER,
   ];
-  if (model) execArgs.push("-m", model);
+  if (modelRoute) execArgs.push("-m", modelRoute.cliModel);
   execArgs.push(
     "--cwd", repoPath,
     "--timeout", clineTimeoutSecondsFromParentMs(parentTimeoutMs)
@@ -196,7 +187,7 @@ function main() {
   const rawStderr = String(execResult.stderr || "");
   if (execResult.error || execResult.status !== 0) {
     if (isExecTimeout(execResult.error)) {
-      const diagnosticCommand = buildTimeoutDiagnosticCommand({ clineBin, model, reviewTimeout });
+      const diagnosticCommand = buildTimeoutDiagnosticCommand({ clineBin, modelRoute, reviewTimeout });
       throw new Error(
         `Cline reviewer ${phase} timed out after ${reviewTimeout} (${REVIEW_TIMEOUT_ENV}). ` +
         "The cline --json invocation did not return before the parent-process timeout, so relay cannot treat this as healthy advisory evidence. " +

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -227,6 +227,7 @@ async function run() {
   ({ advisoryResults, advisoryRuns, gateResult, verdict } = gateSettlement);
 
   finalizeRound({
+    advisoryConfig,
     advisoryResults,
     body,
     checkWait,

--- a/skills/relay-review/scripts/review-runner/advisory-orchestration.js
+++ b/skills/relay-review/scripts/review-runner/advisory-orchestration.js
@@ -422,6 +422,8 @@ function startConfiguredAdvisory({
       reviewer: lane.reviewer,
       source: lane.source,
       status: "running",
+      outcome: "running",
+      ran: false,
       trigger: lane.trigger,
       policy_decision: policyDecision,
     });

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -12,10 +12,22 @@ const {
 } = require("../../../relay-dispatch/scripts/agent-adapters/policy");
 const { resolveExecutorDefaultModel } = require("../../../relay-dispatch/scripts/executor-model-config");
 const { hashFileSha256 } = require("../../../relay-dispatch/scripts/execution-evidence");
+const { getManifestPath } = require("../../../relay-dispatch/scripts/manifest/paths");
+const {
+  readManifest,
+  withManifestTransaction,
+  writeManifestUnlocked,
+} = require("../../../relay-dispatch/scripts/manifest/store");
 const { appendRunEvent, appendUnregisteredRouteUsedEvent, EVENTS, readRunEvents } = require("../../../relay-dispatch/scripts/relay-events");
 const { writeAdvisoryLaneLease } = require("../../../relay-dispatch/scripts/run-runtime-state");
 const { reapPriorAdvisoryLaneAttempts } = require("./advisory-lane-reap");
-const { parseAdvisoryReview, validateAdvisoryProfile } = require("../advisory-review-schema");
+const {
+  buildAdvisoryRoundEvidence,
+  mergeAdvisoryRoundEvidence,
+  parseAdvisoryReview,
+  toAdvisoryLaneEvidence,
+  validateAdvisoryProfile,
+} = require("../advisory-review-schema");
 const { captureGitStatus, resolveReviewerScript } = require("./reviewer-invoke");
 const { writeJson, writeText } = require("./common");
 const {
@@ -245,6 +257,8 @@ function startAdvisoryReview({
       reviewer: request.reviewerName,
       source: request.source || null,
       status: "failed",
+      outcome: "failed",
+      ran: false,
       trigger: request.trigger || "every_round",
       advisory_count: 0,
       duplicate_low_confidence_count: 0,
@@ -353,6 +367,8 @@ function buildDeferredResult(advisoryRun, { criticalPathWaitMs = 0, consumedByPh
     reviewer: advisoryRun.reviewerName,
     source: advisoryRun.source || null,
     status: "deferred",
+    outcome: "deferred",
+    ran: false,
     trigger: advisoryRun.trigger || "every_round",
   };
 }
@@ -752,6 +768,9 @@ function executeAdvisoryRequest(request) {
     trigger: request.trigger || "every_round",
     ...counts,
   };
+  const laneEvidence = toAdvisoryLaneEvidence(result);
+  result.outcome = laneEvidence.outcome;
+  result.ran = laneEvidence.ran;
   const timingFields = waitForDecisionTiming(request);
   Object.assign(result, {
     consumedByPhase: timingFields.consumed_by_phase,
@@ -763,7 +782,7 @@ function executeAdvisoryRequest(request) {
   // required audit event has been durably appended under the shared manifest
   // transaction lock, so settlement cannot consume success without provenance.
   try {
-    appendRunEvent(request.runRepoPath, request.runId, {
+    const advisoryEvent = {
       event: EVENTS.ADVISORY_REVIEW,
       state_from: request.state,
       state_to: request.state,
@@ -797,8 +816,35 @@ function executeAdvisoryRequest(request) {
       raw_response_paths: rawResponsePaths.slice(),
       attempt_count: attemptCount,
       failure_reason: failureReason,
+      advisory_outcome: result.outcome,
       ...counts,
       ...timingFields,
+    };
+    const manifestPath = getManifestPath(request.runRepoPath, request.runId);
+    withManifestTransaction(manifestPath, () => {
+      appendRunEvent(request.runRepoPath, request.runId, advisoryEvent, { lockHeld: true });
+      const current = readManifest(manifestPath);
+      const incomingEvidence = buildAdvisoryRoundEvidence({
+        configuredCount: request.advisoryConfigSnapshot?.lanes?.length || 1,
+        headSha: request.headSha,
+        outcomes: [result],
+        round: request.round,
+      });
+      const lastAdvisory = mergeAdvisoryRoundEvidence(
+        current.data.review?.last_advisory || null,
+        incomingEvidence,
+      );
+      writeManifestUnlocked(manifestPath, {
+        ...current.data,
+        review: {
+          ...(current.data.review || {}),
+          last_advisory: lastAdvisory,
+        },
+        timestamps: {
+          ...(current.data.timestamps || {}),
+          updated_at: new Date().toISOString(),
+        },
+      }, current.body);
     });
     appendUnregisteredRouteUsedEvent(request.runRepoPath, request.runId, {
       state: request.state,
@@ -811,6 +857,8 @@ function executeAdvisoryRequest(request) {
     status = "failed";
     result.status = "failed";
     result.failureReason = `advisory event write failed: ${error.message}`;
+    result.outcome = "failed";
+    result.ran = false;
   } finally {
     if (advisoryRepoPath) {
       cleanupAdvisoryWorktree(request.reviewRepoPath, advisoryRepoPath);

--- a/skills/relay-review/scripts/review-runner/advisory.js
+++ b/skills/relay-review/scripts/review-runner/advisory.js
@@ -425,7 +425,9 @@ function buildUnboundSuccessResult(advisoryRun, result, failureReason, {
     criticalPathWaitMs,
     elapsedMs: Date.now() - advisoryRun.startedAt,
     failureReason,
+    outcome: "failed",
     phaseDecisionWaited: criticalPathWaitMs > 0,
+    ran: false,
     status: "failed",
   };
 }

--- a/skills/relay-review/scripts/review-runner/comment.js
+++ b/skills/relay-review/scripts/review-runner/comment.js
@@ -1,4 +1,5 @@
 const { gh } = require("./common");
+const { formatAdvisoryRoundSummary } = require("../advisory-review-schema");
 const { isLowConfidenceAdvisoryPass } = require("./verdict");
 
 const REVIEW_MARKER = "<!-- relay-review -->";
@@ -18,6 +19,15 @@ function appendCommentWarnings(commentBody, warnings = []) {
     "",
     "Advisory review warnings:",
     ...warnings.map((warning) => `- ${warning}`),
+  ].join("\n");
+}
+
+function appendAdvisorySummary(commentBody, advisorySummary) {
+  return [
+    commentBody,
+    "",
+    "Advisory review:",
+    ...formatAdvisoryRoundSummary(advisorySummary),
   ].join("\n");
 }
 
@@ -42,9 +52,9 @@ function formatStatus(value) {
   return String(value || "unknown").toUpperCase();
 }
 
-function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } = {}) {
+function buildCommentBody(verdict, round, { warnings = [], gateFailure = null, advisorySummary = null } = {}) {
   if (gateFailure) {
-    return appendCommentWarnings([
+    return appendCommentWarnings(appendAdvisorySummary([
       REVIEW_ROUND_MARKER,
       `## Relay Review Round ${round}`,
       "Verdict: CHANGES_REQUESTED",
@@ -59,11 +69,11 @@ function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } 
       `Recovery command: ${gateFailure.recoveryCommand}`,
       "Issues:",
       `- Rubric gate failed closed: ${gateFailure.reason}. ${gateFailure.recovery}`,
-    ].join("\n"), warnings);
+    ].join("\n"), advisorySummary), warnings);
   }
 
   if (verdict.verdict === "pass") {
-    return appendCommentWarnings([
+    return appendCommentWarnings(appendAdvisorySummary([
       REVIEW_MARKER,
       "## Relay Review",
       "Verdict: LGTM",
@@ -72,11 +82,11 @@ function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } 
       `Quality Review: ${formatStatus(verdict.quality_review_status)}`,
       `Quality Execution: ${formatStatus(verdict.quality_execution_status)}`,
       `Rounds: ${round}`,
-    ].join("\n"), warnings);
+    ].join("\n"), advisorySummary), warnings);
   }
 
   if (isLowConfidenceAdvisoryPass(verdict)) {
-    return appendCommentWarnings([
+    return appendCommentWarnings(appendAdvisorySummary([
       REVIEW_MARKER,
       "## Relay Review",
       "Verdict: LGTM",
@@ -87,11 +97,11 @@ function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } 
       `Rounds: ${round}`,
       "Low-confidence findings (non-blocking):",
       formatIssueList(verdict.issues, { includeConfidence: true }),
-    ].join("\n"), warnings);
+    ].join("\n"), advisorySummary), warnings);
   }
 
   if (verdict.verdict === "changes_requested") {
-    return appendCommentWarnings([
+    return appendCommentWarnings(appendAdvisorySummary([
       REVIEW_ROUND_MARKER,
       `## Relay Review Round ${round}`,
       "Verdict: CHANGES_REQUESTED",
@@ -101,10 +111,10 @@ function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } 
       `Quality Execution: ${formatStatus(verdict.quality_execution_status)}`,
       "Issues:",
       formatIssueList(verdict.issues),
-    ].join("\n"), warnings);
+    ].join("\n"), advisorySummary), warnings);
   }
 
-  return appendCommentWarnings([
+  return appendCommentWarnings(appendAdvisorySummary([
     REVIEW_MARKER,
     "## Relay Review",
     "Verdict: ESCALATED",
@@ -115,7 +125,7 @@ function buildCommentBody(verdict, round, { warnings = [], gateFailure = null } 
     `Rounds: ${round}`,
     "Issues:",
     formatIssueList(verdict.issues),
-  ].join("\n"), warnings);
+  ].join("\n"), advisorySummary), warnings);
 }
 
 function postComment(repoPath, prNumber, commentBody) {
@@ -127,6 +137,7 @@ function postComment(repoPath, prNumber, commentBody) {
 
 module.exports = {
   appendCommentWarnings,
+  appendAdvisorySummary,
   buildCommentBody,
   formatStatus,
   formatIssueList,

--- a/skills/relay-review/scripts/review-runner/output.js
+++ b/skills/relay-review/scripts/review-runner/output.js
@@ -1,4 +1,5 @@
 const { modeLabel } = require("../../../relay-dispatch/scripts/cli-args");
+const { formatAdvisoryRoundSummary } = require("../advisory-review-schema");
 
 function printUsage() {
   console.log("Usage: review-runner.js --repo <path> (--run-id <id> | --branch <name> | --pr <number>) [options]");
@@ -63,6 +64,10 @@ function printResult({
   console.log(`  State:    ${originalState} -> ${updatedManifest.state}`);
   console.log(`  Prompt:   ${promptPath}`);
   console.log(`  Verdict:  ${verdictPath}`);
+  console.log("  Advisory:");
+  for (const line of formatAdvisoryRoundSummary(result.advisorySummary)) {
+    console.log(`    ${line}`);
+  }
   if (redispatchPath) console.log(`  Re-dispatch: ${redispatchPath}`);
   if (result.commentPosted) console.log(`  PR comment posted to #${prNumber}`);
 }

--- a/skills/relay-review/scripts/review-runner/round-persistence.js
+++ b/skills/relay-review/scripts/review-runner/round-persistence.js
@@ -1,4 +1,8 @@
-const { writeManifest } = require("../../../relay-dispatch/scripts/manifest/store");
+const {
+  readManifest,
+  withManifestTransaction,
+  writeManifestUnlocked,
+} = require("../../../relay-dispatch/scripts/manifest/store");
 const {
   appendIterationScore,
   appendRunEvent,
@@ -9,9 +13,59 @@ const { buildCommentBody, postComment } = require("./comment");
 const { toIterationScoreEventEntry } = require("./score-utils");
 const { applyVerdictToManifest } = require("./manifest-apply");
 const { applyPendingChecksMarker } = require("./check-wait");
+const {
+  buildAdvisoryRoundEvidence,
+  mergeAdvisoryRoundEvidence,
+} = require("../advisory-review-schema");
+
+function advisoryOutcomesForRound(advisoryConfig, advisoryResults) {
+  const lanes = advisoryConfig?.lanes || [];
+  const results = advisoryResults || [];
+  return lanes.map((lane, index) => {
+    const laneIndex = Number(lane.index || index + 1);
+    const matching = results.find((result) => (
+      Number(result?.lane_index || result?.laneIndex || 0) === laneIndex
+      && (result?.trigger || "every_round") === (lane.trigger || "every_round")
+    ));
+    return matching || {
+      advisory_count: 0,
+      duplicate_low_confidence_count: 0,
+      failureReason: null,
+      gating: lane.gating === true,
+      lane_index: laneIndex,
+      model: lane.model || null,
+      profile: lane.profile || "blindspot",
+      required_count: 0,
+      reviewer: lane.reviewer,
+      status: "not_run",
+      trigger: lane.trigger || "every_round",
+    };
+  });
+}
+
+function persistManifestWithAdvisoryEvidence(manifestPath, updatedManifest, body, advisoryEvidence) {
+  let persistedManifest = updatedManifest;
+  withManifestTransaction(manifestPath, () => {
+    const current = readManifest(manifestPath);
+    persistedManifest = {
+      ...updatedManifest,
+      review: {
+        ...(updatedManifest.review || {}),
+        last_advisory: mergeAdvisoryRoundEvidence(
+          current.data.review?.last_advisory || null,
+          advisoryEvidence,
+        ),
+      },
+    };
+    writeManifestUnlocked(manifestPath, persistedManifest, body);
+  });
+  return persistedManifest;
+}
 
 function persistManifestAndEvents(context, analysis, artifacts) {
   const {
+    advisoryConfig,
+    advisoryResults,
     body,
     checkWait,
     data,
@@ -40,7 +94,16 @@ function persistManifestAndEvents(context, analysis, artifacts) {
     rubricGateFailure,
   } = artifacts;
 
+  const advisoryEvidence = buildAdvisoryRoundEvidence({
+    configuredCount: advisoryConfig?.lanes?.length || 0,
+    headSha: reviewedHeadSha,
+    outcomes: advisoryOutcomesForRound(advisoryConfig, advisoryResults),
+    round,
+  });
+  result.advisorySummary = advisoryEvidence;
+
   const commentBody = buildCommentBody(verdict, round, {
+    advisorySummary: advisoryEvidence,
     gateFailure: rubricGateFailure,
     warnings: result.advisoryWarnings || [],
   });
@@ -90,7 +153,12 @@ function persistManifestAndEvents(context, analysis, artifacts) {
     noComment || internalReview,
     runRepoPath
   );
-  writeManifest(manifestPath, updatedManifest, body);
+  updatedManifest = persistManifestWithAdvisoryEvidence(
+    manifestPath,
+    updatedManifest,
+    body,
+    advisoryEvidence,
+  );
   appendRunEvent(runRepoPath, data.run_id, {
     event: EVENTS.ESCALATION_DECISION,
     state_from: data.state,

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -213,6 +213,51 @@ test("doctor stays quiet when primary-review routes use capable adapters", () =>
   );
 });
 
+test("add-route refuses an inexecutable cline advisory model with the expected format", () => {
+  const relayHome = tempDir();
+
+  const result = runConfig([
+    "add-route",
+    "cline-pass/glm-5.2",
+    "--phase",
+    "advisory_review",
+    "--reviewer",
+    "cline",
+    "--json",
+  ], { relayHome });
+
+  assert.notEqual(result.status, 0, result.combined);
+  assert.match(result.combined, /cannot execute/i);
+  assert.match(result.combined, /modelType\/model/);
+  assert.match(result.combined, /cline-pass\/modelType\/model/);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+
+  const extraSegment = runConfig([
+    "add-route",
+    "cline-pass/z-ai/glm/5.2",
+    "--phase",
+    "advisory_review",
+    "--reviewer",
+    "cline",
+    "--json",
+  ], { relayHome });
+  assert.notEqual(extraSegment.status, 0, extraSegment.combined);
+  assert.match(extraSegment.combined, /cline-pass\/modelType\/model/);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+
+  const valid = runConfig([
+    "add-route",
+    "cline-pass/z-ai/glm-5.2",
+    "--phase",
+    "advisory_review",
+    "--reviewer",
+    "cline",
+    "--json",
+  ], { relayHome });
+  assert.equal(valid.status, 0, valid.combined);
+  assert.equal(readRoutes(relayHome).routes[0].route, "cline-pass/z-ai/glm-5.2");
+});
+
 test("preset add resolves compact actor short-model and stores explicit route provenance", () => {
   const relayHome = tempDir();
   const binDir = tempDir("relay-config-preset-model-bin-");
@@ -247,7 +292,7 @@ test("preset add resolves compact actor short-model and stores explicit route pr
   assert.equal(output.preset.model_resolution.dispatch.original_input, "opencode:glm-5.2");
 });
 
-test("preset add resolves cline short model through catalog fallback in open mode", () => {
+test("preset add refuses a catalog fallback that cannot execute as a cline advisory model", () => {
   const relayHome = tempDir();
 
   const result = runConfig([
@@ -261,17 +306,10 @@ test("preset add resolves cline short model through catalog fallback in open mod
     "--json",
   ], { relayHome });
 
-  assert.equal(result.status, 0, result.combined);
-  const routes = readRoutes(relayHome);
-  assert.deepEqual(routes.presets.diverse.advisory_review, {
-    reviewer: "cline",
-    model: "cline-pass/glm-5.2",
-    profile: "blindspot",
-  });
-  const metadata = routes.presets.diverse.model_resolution.advisory_review;
-  assert.equal(metadata.original_input, "cline:glm-5.2");
-  assert.equal(metadata.source, "catalog_fallback");
-  assert.match(metadata.warnings.join("\n"), /catalog fallback/i);
+  assert.notEqual(result.status, 0, result.combined);
+  assert.match(result.combined, /cannot execute/i);
+  assert.match(result.combined, /modelType\/model/);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
 });
 
 test("strict preset add rejects unresolved unregistered compact routes", () => {

--- a/tests/relay-config/scripts/relay-config.test.js
+++ b/tests/relay-config/scripts/relay-config.test.js
@@ -216,6 +216,19 @@ test("doctor stays quiet when primary-review routes use capable adapters", () =>
 test("add-route refuses an inexecutable cline advisory model with the expected format", () => {
   const relayHome = tempDir();
 
+  const actorUnscoped = runConfig([
+    "add-route",
+    "cline-pass/glm-5.2",
+    "--phase",
+    "advisory_review",
+    "--json",
+  ], { relayHome });
+  assert.notEqual(actorUnscoped.status, 0, actorUnscoped.combined);
+  assert.match(actorUnscoped.combined, /cannot execute/i);
+  assert.match(actorUnscoped.combined, /modelType\/model/);
+  assert.match(actorUnscoped.combined, /cline-pass\/modelType\/model/);
+  assert.equal(fs.existsSync(path.join(relayHome, "routes.json")), false);
+
   const result = runConfig([
     "add-route",
     "cline-pass/glm-5.2",

--- a/tests/relay-dispatch/scripts/relay-routing.test.js
+++ b/tests/relay-dispatch/scripts/relay-routing.test.js
@@ -707,6 +707,34 @@ test("partial project advisory default composes with an inherited single global 
   assert.equal(result.phases.advisory_review[0].model, "example/opencode-model-fast");
 });
 
+test("merged project advisory override rejects an inexecutable inherited cline route", () => {
+  const { relayHome, repoRoot } = tempRepo();
+  writeJson(path.join(relayHome, "routes.json"), {
+    version: 2,
+    defaults: {
+      advisory_review: {
+        reviewer: "cline",
+        model: "cline-pass/z-ai/glm-5.2",
+      },
+    },
+    routes: [
+      { route: "cline-pass/*", phases: ["advisory_review"], reviewers: ["cline"] },
+    ],
+  });
+  writeJson(getProjectRoutesPath(repoRoot, { relayHome }), {
+    version: 2,
+    defaults: {
+      advisory_review: { model: "cline-pass/glm-5.2" },
+    },
+  });
+
+  const result = loadRouteConfig({ repoRoot, relayHome });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors[0].message, /modelType\/model/);
+  assert.match(result.errors[0].message, /cannot execute/);
+});
+
 test("partial advisory default over a multi-lane list fails closed", () => {
   assert.throws(() => resolveRouteIntent({
     projectRoutes: {
@@ -902,7 +930,7 @@ test("route preset expansion carries advisory model resolution metadata onto pre
         diverse: {
           advisory_review: {
             reviewer: "cline",
-            model: "cline-pass/glm-5.2",
+            model: "cline-pass/z-ai/glm-5.2",
             profile: "blindspot",
           },
           model_resolution: {
@@ -912,9 +940,9 @@ test("route preset expansion carries advisory model resolution metadata onto pre
               actor_field: "reviewer",
               phase: "advisory_review",
               requested_model: "glm-5.2",
-              resolved_route: "cline-pass/glm-5.2",
+              resolved_route: "cline-pass/z-ai/glm-5.2",
               source: "catalog_fallback",
-              candidates: ["cline-pass/glm-5.2"],
+              candidates: ["cline-pass/z-ai/glm-5.2"],
               warnings: ["catalog fallback"],
             },
           },
@@ -927,7 +955,7 @@ test("route preset expansion carries advisory model resolution metadata onto pre
   });
 
   assert.equal(result.phases.advisory_review[0].reviewer, "cline");
-  assert.equal(result.phases.advisory_review[0].model, "cline-pass/glm-5.2");
+  assert.equal(result.phases.advisory_review[0].model, "cline-pass/z-ai/glm-5.2");
   assert.equal(result.phases.advisory_review[0].model_resolution.original_input, "cline:glm-5.2");
   assert.equal(result.phases.advisory_review[0].model_resolution.source, "catalog_fallback");
 });

--- a/tests/relay-review/scripts/invoke-reviewer.test.js
+++ b/tests/relay-review/scripts/invoke-reviewer.test.js
@@ -103,7 +103,7 @@ process.stdout.write(JSON.stringify(${JSON.stringify(payload)}));
     envKey: "RELAY_CLINE_BIN",
     fakeName: "fake-cline.js",
     extraEnv: { RELAY_CLINE_REVIEW_TIMEOUT: "120s" },
-    extraArgs: ["--model", "cline-pass/glm-5.2"],
+    extraArgs: ["--model", "cline-pass/z-ai/glm-5.2"],
     fakeBody: (payload, markerPath) => `#!/usr/bin/env node
 const fs = require("fs");
 fs.writeFileSync(${JSON.stringify(markerPath)}, "spawned\\n", "utf-8");
@@ -1710,7 +1710,7 @@ process.stdin.on("end", () => {
     CLINE_SCRIPT,
     "--repo", repoRoot,
     "--prompt-file", promptPath,
-    "--model", "cline-pass/glm-5.2",
+    "--model", "cline-pass/z-ai/glm-5.2",
     "--phase", "advisory_review",
     "--json",
   ], {
@@ -1731,7 +1731,7 @@ process.stdin.on("end", () => {
     "--json",
     "--yolo",
     "-P", "cline-pass",
-    "-m", "cline-pass/glm-5.2",
+    "-m", "z-ai/glm-5.2",
     "--cwd", repoRoot,
     "--timeout", "60",
   ]);
@@ -1856,7 +1856,7 @@ fs.writeFileSync(${JSON.stringify(logPath)}, "invoked\\n", "utf-8");
 
   assert.equal(fs.existsSync(logPath), false);
   assert.match(String(error.stderr || ""), /modelType\/model/);
-  assert.match(String(error.stderr || ""), /cline-pass\/glm-5\.2/);
+  assert.match(String(error.stderr || ""), /cline-pass\/modelType\/model/);
 });
 
 test("cline adapter omits -m when model is absent and keeps default provider path", () => {
@@ -2080,7 +2080,7 @@ process.exit(0);
       CLINE_SCRIPT,
       "--repo", repoRoot,
       "--prompt-file", promptPath,
-      "--model", "cline-pass/glm-5.2",
+      "--model", "cline-pass/z-ai/glm-5.2",
       "--json",
     ], {
       cwd: repoRoot,
@@ -2114,7 +2114,7 @@ fs.writeFileSync(${JSON.stringify(logPath)}, "invoked\\n", "utf-8");
       CLINE_SCRIPT,
       "--repo", repoRoot,
       "--prompt-file", promptPath,
-      "--model", "cline-pass/glm-5.2",
+      "--model", "cline-pass/z-ai/glm-5.2",
       "--json",
     ], {
       cwd: repoRoot,

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -2666,6 +2666,8 @@ test("hardened advisory finish does not expose success before event provenance i
     rawResponsePath: null,
     required_count: 0,
     reviewer: "opencode",
+    outcome: "findings",
+    ran: true,
     status: "success",
   };
   fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf-8");
@@ -2687,6 +2689,8 @@ test("hardened advisory finish does not expose success before event provenance i
   });
 
   assert.equal(unbound.status, "failed");
+  assert.equal(unbound.outcome, "failed");
+  assert.equal(unbound.ran, false);
   assert.match(unbound.failureReason, /not bound to a successful advisory_review event/);
 
   appendRunEvent(repoRoot, runId, {
@@ -2713,6 +2717,8 @@ test("hardened advisory finish does not expose success before event provenance i
   });
 
   assert.equal(bound.status, "success");
+  assert.equal(bound.outcome, "findings");
+  assert.equal(bound.ran, true);
 });
 
 test("hardened advisory finish binds cached success when result rewrite lands after deadline", async () => {

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -383,7 +383,7 @@ setTimeout(() => {
   return filePath;
 }
 
-function writeFakeOpencode(repoRoot, { delayMs = 0, logPath = null, invalidJson = false, mutate = false, requiredFinding = false, primaryVerdict = null, profile = "blindspot" } = {}) {
+function writeFakeOpencode(repoRoot, { clean = false, delayMs = 0, logPath = null, invalidJson = false, mutate = false, requiredFinding = false, primaryVerdict = null, profile = "blindspot" } = {}) {
   const filePath = path.join(repoRoot, "fake-opencode.js");
   fs.writeFileSync(filePath, `#!/usr/bin/env node
 const fs = require("fs");
@@ -402,7 +402,7 @@ setTimeout(() => {
       profile: ${JSON.stringify(profile)},
       summary: "One advisory blind spot.",
       required_findings: ${requiredFinding ? `[{ title: "Required hardened fix", body: "Must fix before merge.", file: "README.md", line: 1, severity: "P2", category: "bypass", confidence: 0.9 }]` : "[]"},
-      advisory_findings: [{
+      advisory_findings: ${clean ? "[]" : `[{
         title: "Advisory-only test gap",
         body: "This should be recorded but not merged into primary redispatch.",
         file: "README.md",
@@ -410,7 +410,7 @@ setTimeout(() => {
         severity: "P3",
         category: "test-gap",
         confidence: 0.8
-      }],
+      }]`},
       duplicate_or_low_confidence: []
     }));
   }
@@ -1212,6 +1212,46 @@ test("review-runner records successful opencode advisory review without gating p
   assert.match(event.reviewer_policy.read_only.warnings.join("\n"), /not prevent writes/i);
 });
 
+test("clean advisory is explicit in manifest, JSON evidence, and posted review summary", () => {
+  const { repoRoot, manifestPath, runId, doneCriteriaPath, diffPath } = setupRepo();
+  const commentPath = path.join(repoRoot, "posted-clean-advisory-comment.md");
+  const ghFixture = installFakeGhOnPath({
+    body: "## Test PR\n\nFixture body.\n",
+    headRefOid: "a".repeat(40),
+    headRefName: "issue-429",
+    statusCheckRollup: [{ name: "unit", conclusion: "SUCCESS", status: "COMPLETED" }],
+  }, { prefix: "relay-review-clean-advisory-gh-", capturePath: commentPath });
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
+  const opencodeScript = writeFakeOpencode(repoRoot, { clean: true });
+
+  try {
+    const result = runReview({
+      repoRoot,
+      runId,
+      doneCriteriaPath,
+      diffPath,
+      primaryScript,
+      opencodeScript,
+      noComment: false,
+      extraArgs: ["--advisory-grace", "30"],
+    });
+    const manifest = readManifest(manifestPath).data;
+    const comment = fs.readFileSync(commentPath, "utf-8");
+
+    assert.equal(result.nextState, STATES.READY_TO_MERGE);
+    assert.equal(result.advisoryReview.status, "success");
+    assert.equal(result.advisoryReview.outcome, "clean");
+    assert.equal(result.advisorySummary.status, "clean");
+    assert.equal(manifest.review.last_advisory.status, "clean");
+    assert.equal(manifest.review.last_advisory.outcomes[0].outcome, "clean");
+    assert.equal(manifest.review.last_advisory.outcomes[0].ran, true);
+    assert.match(comment, /advisory ran and found nothing/i);
+    assert.doesNotMatch(comment, /advisory did not run/i);
+  } finally {
+    ghFixture.restore();
+  }
+});
+
 test("advisory lane request uses adversarial profile default timeout of 1800s", () => {
   const { repoRoot, runDir, runId, doneCriteriaPath, diffPath } = setupRepo();
   const primaryScript = writePrimaryReviewer(repoRoot, passVerdict());
@@ -1953,7 +1993,7 @@ test("review-runner accepts cline advisory review when route policy allows the r
     opencodeScript: null,
     clineScript,
     advisoryReviewer: "cline",
-    extraArgs: ["--advisory-reviewer-model", "cline-pass/glm-5.2", "--advisory-grace", "30"],
+    extraArgs: ["--advisory-reviewer-model", "cline-pass/z-ai/glm-5.2", "--advisory-grace", "30"],
   });
   const event = readRunEvents(repoRoot, runId).find((record) => record.event === "advisory_review");
 
@@ -1963,7 +2003,7 @@ test("review-runner accepts cline advisory review when route policy allows the r
   assert.ok(fs.existsSync(path.join(runDir, "review-round-1-advisory-cline.json")));
   assert.equal(event.reviewer, "cline");
   assert.equal(event.policy_decision.allowed, true);
-  assert.equal(event.policy_decision.model, "cline-pass/glm-5.2");
+  assert.equal(event.policy_decision.model, "cline-pass/z-ai/glm-5.2");
   assert.equal(event.reviewer_policy.adapter, "cline");
   assert.equal(event.reviewer_policy.phase, "advisory_review");
   assert.equal(event.reviewer_policy.read_only.enforcement_level, "prompt-only");
@@ -1993,7 +2033,7 @@ process.stderr.write("cline-provider-stderr-887\\n");
     opencodeScript: null,
     clineScript,
     advisoryReviewer: "cline",
-    extraArgs: ["--advisory-reviewer-model", "cline-pass/glm-5.2", "--advisory-grace", "30"],
+    extraArgs: ["--advisory-reviewer-model", "cline-pass/z-ai/glm-5.2", "--advisory-grace", "30"],
   });
 
   assert.equal(result.advisoryReview.status, "failed");
@@ -2189,7 +2229,10 @@ test("on_pass advisory lane gets its own settlement deadline after a slow primar
   // Primary takes longer than the whole advisory settlement grace, so a
   // deadline computed at round start is already exhausted when the on_pass
   // lane spawns. The lane must still be settled from its own fresh deadline.
-  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { delayMs: 3000 });
+  // Keep enough post-spawn room for nested Node startup under loaded CI hosts.
+  // The primary still exceeds timeout+grace, preserving the stale round-start
+  // deadline regression this test is meant to catch.
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { delayMs: 4000 });
   const opencodeScript = writeFakeOpencode(repoRoot, {});
 
   const result = runReview({
@@ -2200,7 +2243,7 @@ test("on_pass advisory lane gets its own settlement deadline after a slow primar
     primaryScript,
     opencodeScript,
     advisoryReviewer: null,
-    extraArgs: ["--advisory-timeout", "1", "--advisory-grace", "1"],
+    extraArgs: ["--advisory-timeout", "1", "--advisory-grace", "2"],
   });
 
   assert.equal(result.nextState, STATES.READY_TO_MERGE);
@@ -2465,6 +2508,10 @@ test("standard review applies the primary verdict after advisory grace and recor
   assert.equal(event.frontier_step_replaced, false);
   assert.ok(event.elapsed_ms >= 3000);
   assert.ok(event.critical_path_wait_ms <= 75);
+  const manifest = readManifest(manifestPath).data;
+  assert.equal(manifest.review.last_advisory.status, "findings");
+  assert.equal(manifest.review.last_advisory.outcomes[0].status, "success");
+  assert.equal(manifest.review.last_advisory.outcomes[0].outcome, "findings");
 });
 
 test("standard review applies the primary verdict when advisory times out during grace", () => {
@@ -2487,7 +2534,12 @@ test("standard review applies the primary verdict when advisory times out during
   assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
   assert.equal(result.advisoryReview.status, "timeout");
   assert.match(result.advisoryReview.failureReason, /reviewer advisory_review timed out after 1s/);
+  assert.equal(result.advisoryReview.outcome, "timed_out");
+  assert.equal(result.advisorySummary.status, "timed_out");
+  assert.equal(readManifest(manifestPath).data.review.last_advisory.status, "timed_out");
+  assert.equal(readManifest(manifestPath).data.review.last_advisory.outcomes[0].outcome, "timed_out");
   assert.equal(event.status, "timeout");
+  assert.equal(event.advisory_outcome, "timed_out");
   assert.equal(event.consumed_by_phase, "review");
 });
 
@@ -2953,7 +3005,12 @@ test("invalid advisory JSON is recorded as advisory failure while primary pass s
   assert.equal(readManifest(manifestPath).data.state, STATES.READY_TO_MERGE);
   assert.equal(result.advisoryReview.status, "failed");
   assert.match(result.advisoryReview.failureReason, /valid JSON|exited with code 1/);
+  assert.equal(result.advisoryReview.outcome, "failed");
+  assert.equal(result.advisorySummary.status, "failed");
+  assert.equal(readManifest(manifestPath).data.review.last_advisory.status, "failed");
+  assert.equal(readManifest(manifestPath).data.review.last_advisory.outcomes[0].outcome, "failed");
   assert.equal(event.status, "failed");
+  assert.equal(event.advisory_outcome, "failed");
 });
 
 test("standard gating lane infrastructure failure is surfaced in JSON, event, and posted comment without demotion", () => {
@@ -3000,6 +3057,7 @@ test("standard gating lane infrastructure failure is surfaced in JSON, event, an
     assert.equal(event.status, "failed");
     assert.equal(event.gating, true);
     assert.match(event.failure_reason, /valid JSON|exited with code 1/);
+    assert.match(comment, /advisory did not run to completion \(failed\)/i);
     assert.match(comment, /Advisory review warning.*opencode/i);
   } finally {
     ghFixture.restore();

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -2229,10 +2229,7 @@ test("on_pass advisory lane gets its own settlement deadline after a slow primar
   // Primary takes longer than the whole advisory settlement grace, so a
   // deadline computed at round start is already exhausted when the on_pass
   // lane spawns. The lane must still be settled from its own fresh deadline.
-  // Keep enough post-spawn room for nested Node startup under loaded CI hosts.
-  // The primary still exceeds timeout+grace, preserving the stale round-start
-  // deadline regression this test is meant to catch.
-  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { delayMs: 4000 });
+  const primaryScript = writePrimaryReviewer(repoRoot, passVerdict(), { delayMs: 3000 });
   const opencodeScript = writeFakeOpencode(repoRoot, {});
 
   const result = runReview({
@@ -2243,7 +2240,7 @@ test("on_pass advisory lane gets its own settlement deadline after a slow primar
     primaryScript,
     opencodeScript,
     advisoryReviewer: null,
-    extraArgs: ["--advisory-timeout", "1", "--advisory-grace", "2"],
+    extraArgs: ["--advisory-timeout", "1", "--advisory-grace", "1"],
   });
 
   assert.equal(result.nextState, STATES.READY_TO_MERGE);


### PR DESCRIPTION
## Dispatch Summary

```text
수정 및 커밋을 완료했습니다.

- 미결합 성공 결과를 `status: failed`, `outcome: failed`, `ran: false`로 일관되게 정규화
- 기존 provenance 테스트에 세 필드의 성공·실패 상태 검증 추가
- 관련 advisory 테스트: 85/85 통과
- relay-config: 16/16 통과
- relay-review 전체: 657/659 통과. 샌드박스의 `ps` 차단으로 기존 lane-reap 테스트 2개만 실패
- 커밋: `1835cd5 fix(review): normalize unbound advisory failures`
- 워크트리 깨끗함
```

## Dispatch Metadata

- Run: issue-1100-20260728084426732-091808ff
- Executor: codex
- Branch: issue-1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 어드바이저리 리뷰 결과에 성공, 발견 사항, 시간 초과, 실패 등의 상태가 명확히 표시됩니다.
  * 리뷰 댓글과 CLI 출력에 어드바이저리 라운드 요약이 추가됩니다.
  * 리뷰 결과와 매니페스트에 어드바이저리 상태 및 실행 여부가 일관되게 기록됩니다.

* **버그 수정**
  * 실행할 수 없는 Cline 어드바이저리 모델 설정을 사전에 감지하고 안내합니다.
  * 병합된 라우팅 설정에서도 잘못된 모델 경로가 조기에 검증됩니다.

* **문서**
  * Cline 모델 경로 형식과 레거시 폴백 사용에 대한 안내를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->