### PR TITLE
fix(dispatch): preserve rubric and flag assurance authority

### DIFF
--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -104,7 +104,7 @@ const FLAGS = [
   { flag: "--require-checks-green", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Require a same-HEAD pending-checks marker plus all-green live checks for same-HEAD recovery; no value is consumed." },
   { flag: "--require-pr-body-change", kind: BOOLEAN, mode: MODE_PARSED, rationale: "Require audited PR body evidence for same-HEAD recovery; no value is consumed." },
   { flag: "--review-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied verdict path; keep the literal argv token." },
-  { flag: "--review-assurance", kind: VALUE, mode: MODE_PARSED, valueName: "<level>", allowedValues: ["compact", "standard", "hardened"], rationale: "Run-level review assurance policy; closed selector independent of agent identity." },
+  { flag: "--review-assurance", kind: VALUE, mode: MODE_PARSED, valueName: "<level>", allowedValues: ["compact", "standard", "hardened"], rationale: "Default run-level review assurance when the rubric omits task_profile.review_assurance; a rubric value is authoritative." },
   { flag: "--review", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--advisory-review", kind: VALUE, mode: MODE_PARSED, valueName: "<actor[:provider/model]>", rationale: "Run route preview selector; flag-like following tokens should mean the value is missing." },
   { flag: "--route-intent-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied run route intent JSON path; keep the literal argv token." },

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -89,11 +89,9 @@ const {
 const { parseModelHints } = require("./model-hints");
 const { resolveExecutorDefaultModel } = require("./executor-model-config");
 const {
-  REVIEW_ASSURANCE: REVIEW_ASSURANCE_LEVEL,
   extractReviewAssuranceFromRubric,
   normalizeReviewAssurance,
   resolveReviewAssurance,
-  reviewAssuranceRank,
 } = require("./manifest/review-assurance");
 const {
   createRunId,
@@ -376,7 +374,6 @@ const DONE_CRITERIA_FILE = readArg(args, "--done-criteria-file", undefined, CLI_
 const REVIEW_ASSURANCE_RAW = readArg(args, "--review-assurance", undefined, CLI_ARG_OPTIONS);
 const ROUTING_TAGS = readArg(args, "--tags", "", CLI_ARG_OPTIONS);
 let REVIEW_ASSURANCE;
-let REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RAW ? "cli" : null;
 let REVIEW_ASSURANCE_RESOLUTION = null;
 try {
   REVIEW_ASSURANCE = normalizeReviewAssurance(REVIEW_ASSURANCE_RAW || "standard");
@@ -395,30 +392,6 @@ let AUTO_RECOVER_COMMIT = null;
 
 function resolveDispatchRuntime(repoRoot) {
   const routeResolution = loadInitialRoutePlan(repoRoot);
-  // Route-derived review assurance is a preset-feature behavior. No-preset
-  // dispatches must stay byte-identical (DC6): a route-intent file must not
-  // change policy.review_assurance when no --route-preset was requested; those
-  // runs fall through to prompt-derived assurance extraction as before.
-  if (!REVIEW_ASSURANCE_RAW && ROUTE_PRESET) {
-    const intentReviewAssurance = nonEmptyString(routeResolution.routeIntent?.review_assurance);
-    const presetReviewAssurance = nonEmptyString(routeResolution.routePlan?.route_preset?.review_assurance);
-    const routeReviewAssurance = intentReviewAssurance || presetReviewAssurance;
-    if (routeReviewAssurance) {
-      try {
-        REVIEW_ASSURANCE = normalizeReviewAssurance(routeReviewAssurance);
-        REVIEW_ASSURANCE_SOURCE = intentReviewAssurance
-          ? "route_intent"
-          : routeResolution.routePlan.route_preset.source;
-      } catch (error) {
-        failEarly(error.message, {
-          error_code: "invalid_review_assurance",
-          review_assurance_source: intentReviewAssurance
-            ? "route_intent"
-            : routeResolution.routePlan?.route_preset?.source || null,
-        });
-      }
-    }
-  }
   const executor = EXECUTOR_ARG || routeResolution.routePlan.phases.dispatch?.executor || "codex";
   let resolvedAdapter;
   let resolvedAdapterDescriptor;
@@ -2343,7 +2316,6 @@ async function main() {
         };
       }
       REVIEW_ASSURANCE = REVIEW_ASSURANCE_RESOLUTION.level;
-      REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RESOLUTION.source;
       manifest = {
         ...manifest,
         policy: {
@@ -2359,14 +2331,13 @@ async function main() {
       console.error(`Error: ${error.message}`);
       process.exit(1);
     }
-  } else if (rubricReviewAssurance) {
+  } else {
     REVIEW_ASSURANCE_RESOLUTION = resolveReviewAssurance({
       rubricReviewAssurance,
       flagReviewAssurance: REVIEW_ASSURANCE,
       flagWasExplicit: REVIEW_ASSURANCE_RAW !== undefined,
     });
     REVIEW_ASSURANCE = REVIEW_ASSURANCE_RESOLUTION.level;
-    REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RESOLUTION.source;
   }
   let routePlanSnapshot = null;
 
@@ -2397,36 +2368,6 @@ async function main() {
   if (!RESUME_MODE) {
     try {
       const promptTaskProfile = extractTaskProfileSummaryFromPrompt(taskPrompt);
-      const promptReviewAssurance = promptTaskProfile?.review_assurance || null;
-      if (
-        promptReviewAssurance
-        && REVIEW_ASSURANCE_SOURCE !== "rubric"
-        && REVIEW_ASSURANCE_RAW === undefined
-        && REVIEW_ASSURANCE_SOURCE === null
-      ) {
-        REVIEW_ASSURANCE = promptReviewAssurance;
-      } else if (
-        promptReviewAssurance
-        && REVIEW_ASSURANCE_SOURCE !== "rubric"
-        && reviewAssuranceRank(REVIEW_ASSURANCE)
-          < reviewAssuranceRank(promptReviewAssurance)
-      ) {
-        throw new Error(
-          `review_assurance=${REVIEW_ASSURANCE} is below the `
-          + `${promptReviewAssurance} risk floor from task_profile`
-        );
-      }
-      const minimumReviewAssurance = promptTaskProfile?.minimum_review_assurance
-        || REVIEW_ASSURANCE_LEVEL.STANDARD;
-      if (
-        reviewAssuranceRank(REVIEW_ASSURANCE)
-        < reviewAssuranceRank(minimumReviewAssurance)
-      ) {
-        throw new Error(
-          `review_assurance=${REVIEW_ASSURANCE} requires a complete risk-aware `
-          + "task_profile before selecting below the standard fail-closed floor"
-        );
-      }
       if (promptTaskProfile?.publish_policy === "after-internal-review") {
         if (
           PUBLISH_POLICY_ARG !== undefined
@@ -2443,12 +2384,6 @@ async function main() {
         error_code: "task_profile_parse_failed",
       });
     }
-  }
-  if (!REVIEW_ASSURANCE_RESOLUTION) {
-    REVIEW_ASSURANCE_RESOLUTION = resolveReviewAssurance({
-      flagReviewAssurance: REVIEW_ASSURANCE,
-      flagWasExplicit: REVIEW_ASSURANCE_RAW !== undefined,
-    });
   }
   if (taskPromptResult.source === "auto-discovered-redispatch" && !JSON_OUT) {
     console.log(`Auto-discovered redispatch prompt (round ${taskPromptResult.round}): ${taskPromptResult.path}`);

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -90,7 +90,9 @@ const { parseModelHints } = require("./model-hints");
 const { resolveExecutorDefaultModel } = require("./executor-model-config");
 const {
   REVIEW_ASSURANCE: REVIEW_ASSURANCE_LEVEL,
+  extractReviewAssuranceFromRubric,
   normalizeReviewAssurance,
+  resolveReviewAssurance,
   reviewAssuranceRank,
 } = require("./manifest/review-assurance");
 const {
@@ -323,9 +325,9 @@ function loadInitialRoutePlan(repoRoot) {
     executor: EXECUTOR_ARG,
     model: MODEL,
   });
-  // An explicit CLI --review-assurance wins when it meets the task-derived risk
-  // floor. Seed it before preset expansion so a preset cannot record itself as
-  // having filled a field the CLI overrode (keeps attribution honest).
+  // Seed an explicit CLI --review-assurance before preset expansion so the
+  // preset cannot claim it filled the value. The persisted rubric is resolved
+  // later and remains authoritative over this dispatch default.
   if (REVIEW_ASSURANCE_RAW && !nonEmptyString(routeIntent.review_assurance)) {
     routeIntent.review_assurance = normalizeReviewAssurance(REVIEW_ASSURANCE_RAW);
   }
@@ -375,6 +377,7 @@ const REVIEW_ASSURANCE_RAW = readArg(args, "--review-assurance", undefined, CLI_
 const ROUTING_TAGS = readArg(args, "--tags", "", CLI_ARG_OPTIONS);
 let REVIEW_ASSURANCE;
 let REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RAW ? "cli" : null;
+let REVIEW_ASSURANCE_RESOLUTION = null;
 try {
   REVIEW_ASSURANCE = normalizeReviewAssurance(REVIEW_ASSURANCE_RAW || "standard");
 } catch (error) {
@@ -811,7 +814,15 @@ function ensureEmptyFile(filePath) {
   fs.closeSync(fd);
 }
 
-function writeDetachReceiptIfRequested({ repoRoot, runId, manifestPath, runDir, stdoutLog, stderrLog }) {
+function writeDetachReceiptIfRequested({
+  repoRoot,
+  runId,
+  manifestPath,
+  runDir,
+  stdoutLog,
+  stderrLog,
+  reviewAssuranceResolution = null,
+}) {
   if (detachReceiptWritten) return;
   const receiptPath = process.env[DETACH_RECEIPT_ENV];
   if (!receiptPath) return;
@@ -825,6 +836,13 @@ function writeDetachReceiptIfRequested({ repoRoot, runId, manifestPath, runDir, 
     stdoutLog,
     stderrLog,
     reconcileCommand: reconcileCommandForReceipt(repoRoot, runId),
+    ...(reviewAssuranceResolution
+      ? {
+          reviewAssurance: reviewAssuranceResolution.level,
+          reviewAssuranceSource: reviewAssuranceResolution.source,
+          reviewAssuranceOverridden: reviewAssuranceResolution.overridden,
+        }
+      : {}),
   });
   detachReceiptWritten = true;
   delete process.env[DETACH_RECEIPT_ENV];
@@ -974,6 +992,15 @@ async function launchDetachedAndExit() {
     console.log(`  Stdout log: ${output.stdoutLog}`);
     console.log(`  Stderr log: ${output.stderrLog}`);
     console.log(`  Reconcile:  ${output.reconcileCommand}`);
+    if (output.reviewAssurance) {
+      const assuranceOverride = output.reviewAssuranceOverridden
+        ? `; overridden flag=${output.reviewAssuranceOverridden}`
+        : "";
+      console.log(
+        `  Assurance: ${output.reviewAssurance} ` +
+        `(source=${output.reviewAssuranceSource})${assuranceOverride}`
+      );
+    }
     if (output.note) console.log(`  Note:       ${output.note}`);
   }
 }
@@ -2264,11 +2291,6 @@ async function main() {
         fleetId: FLEET_ID,
         doneCriteriaPath: resumeDoneCriteriaPath,
       });
-      if (REVIEW_ASSURANCE_RAW !== undefined) {
-        validateResumeReviewAssurance(manifest, REVIEW_ASSURANCE);
-      } else {
-        REVIEW_ASSURANCE = normalizeReviewAssurance(manifest?.policy?.review_assurance);
-      }
     } catch (error) {
       console.error(`Error: ${error.message}`);
       process.exit(1);
@@ -2277,6 +2299,75 @@ async function main() {
 
   const manifestRunDir = getRunDir(repoRoot, runId);
   enforceRubricPersistence(manifest, manifestRunDir);
+  const rubricText = resolveRoutingRubricText({
+    rubricFile: RUBRIC_FILE,
+    manifest,
+    runDir: manifestRunDir,
+  });
+  let rubricReviewAssurance = null;
+  try {
+    rubricReviewAssurance = extractReviewAssuranceFromRubric(rubricText);
+  } catch (error) {
+    failEarly(`Invalid task_profile.review_assurance in rubric: ${error.message}`, {
+      error_code: "rubric_review_assurance_invalid",
+      rubric_file: RUBRIC_FILE || manifest?.anchor?.rubric_path || null,
+    });
+  }
+
+  if (RESUME_MODE) {
+    try {
+      const existingReviewAssurance = normalizeReviewAssurance(manifest?.policy?.review_assurance);
+      if (rubricReviewAssurance) {
+        if (existingReviewAssurance !== rubricReviewAssurance) {
+          throw new Error(
+            "same-run resume found policy.review_assurance inconsistent with the fixed rubric " +
+            `(existing: ${existingReviewAssurance}, rubric: ${rubricReviewAssurance})`
+          );
+        }
+        REVIEW_ASSURANCE_RESOLUTION = resolveReviewAssurance({
+          rubricReviewAssurance,
+          flagReviewAssurance: REVIEW_ASSURANCE,
+          flagWasExplicit: REVIEW_ASSURANCE_RAW !== undefined,
+        });
+        REVIEW_ASSURANCE_RESOLUTION.overridden = REVIEW_ASSURANCE_RESOLUTION.overridden
+          || manifest?.policy?.review_assurance_overridden
+          || null;
+      } else {
+        if (REVIEW_ASSURANCE_RAW !== undefined) {
+          validateResumeReviewAssurance(manifest, REVIEW_ASSURANCE);
+        }
+        REVIEW_ASSURANCE_RESOLUTION = {
+          level: existingReviewAssurance,
+          source: manifest?.policy?.review_assurance_source || "flag",
+          overridden: manifest?.policy?.review_assurance_overridden || null,
+        };
+      }
+      REVIEW_ASSURANCE = REVIEW_ASSURANCE_RESOLUTION.level;
+      REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RESOLUTION.source;
+      manifest = {
+        ...manifest,
+        policy: {
+          ...(manifest.policy || {}),
+          review_assurance: REVIEW_ASSURANCE_RESOLUTION.level,
+          review_assurance_source: REVIEW_ASSURANCE_RESOLUTION.source,
+          ...(REVIEW_ASSURANCE_RESOLUTION.overridden
+            ? { review_assurance_overridden: REVIEW_ASSURANCE_RESOLUTION.overridden }
+            : {}),
+        },
+      };
+    } catch (error) {
+      console.error(`Error: ${error.message}`);
+      process.exit(1);
+    }
+  } else if (rubricReviewAssurance) {
+    REVIEW_ASSURANCE_RESOLUTION = resolveReviewAssurance({
+      rubricReviewAssurance,
+      flagReviewAssurance: REVIEW_ASSURANCE,
+      flagWasExplicit: REVIEW_ASSURANCE_RAW !== undefined,
+    });
+    REVIEW_ASSURANCE = REVIEW_ASSURANCE_RESOLUTION.level;
+    REVIEW_ASSURANCE_SOURCE = REVIEW_ASSURANCE_RESOLUTION.source;
+  }
   let routePlanSnapshot = null;
 
   // A resumed run may carry a Done Criteria amendment: the operator edits the
@@ -2309,12 +2400,14 @@ async function main() {
       const promptReviewAssurance = promptTaskProfile?.review_assurance || null;
       if (
         promptReviewAssurance
+        && REVIEW_ASSURANCE_SOURCE !== "rubric"
         && REVIEW_ASSURANCE_RAW === undefined
         && REVIEW_ASSURANCE_SOURCE === null
       ) {
         REVIEW_ASSURANCE = promptReviewAssurance;
       } else if (
         promptReviewAssurance
+        && REVIEW_ASSURANCE_SOURCE !== "rubric"
         && reviewAssuranceRank(REVIEW_ASSURANCE)
           < reviewAssuranceRank(promptReviewAssurance)
       ) {
@@ -2350,6 +2443,12 @@ async function main() {
         error_code: "task_profile_parse_failed",
       });
     }
+  }
+  if (!REVIEW_ASSURANCE_RESOLUTION) {
+    REVIEW_ASSURANCE_RESOLUTION = resolveReviewAssurance({
+      flagReviewAssurance: REVIEW_ASSURANCE,
+      flagWasExplicit: REVIEW_ASSURANCE_RAW !== undefined,
+    });
   }
   if (taskPromptResult.source === "auto-discovered-redispatch" && !JSON_OUT) {
     console.log(`Auto-discovered redispatch prompt (round ${taskPromptResult.round}): ${taskPromptResult.path}`);
@@ -2503,6 +2602,8 @@ async function main() {
       leafId: LEAF_ID || manifest?.source?.leaf_id || null,
       doneCriteriaFile: resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null,
       reviewAssurance: REVIEW_ASSURANCE,
+      reviewAssuranceSource: REVIEW_ASSURANCE_RESOLUTION.source,
+      reviewAssuranceOverridden: REVIEW_ASSURANCE_RESOLUTION.overridden,
       publishPolicy: PUBLISH_POLICY,
       environment: RESUME_MODE ? (manifest?.environment || null) : "collected-at-dispatch",
       runState: manifest?.state || null,
@@ -2557,6 +2658,8 @@ async function main() {
         fleetId: planFleetId,
         doneCriteriaFile: resolvedDoneCriteriaPath || manifest?.anchor?.done_criteria_path || null,
         reviewAssurance: REVIEW_ASSURANCE,
+        reviewAssuranceSource: REVIEW_ASSURANCE_RESOLUTION.source,
+        reviewAssuranceOverridden: REVIEW_ASSURANCE_RESOLUTION.overridden,
         policyDecision,
         routingDecision,
         worktreePlan,
@@ -2595,6 +2698,8 @@ async function main() {
       doneCriteriaPath: resolvedDoneCriteriaPath,
       doneCriteriaSource,
       reviewAssurance: REVIEW_ASSURANCE,
+      reviewAssuranceSource: REVIEW_ASSURANCE_RESOLUTION.source,
+      reviewAssuranceOverridden: REVIEW_ASSURANCE_RESOLUTION.overridden,
       modelHints: MODEL_HINTS,
       fleetId: FLEET_ID,
       ownership: OWNERSHIP || undefined,
@@ -2917,6 +3022,7 @@ async function main() {
     runDir: runArtifactPaths.runDir,
     stdoutLog,
     stderrLog,
+    reviewAssuranceResolution: REVIEW_ASSURANCE_RESOLUTION,
   });
   await maybePauseBeforeExecutorSpawnForTest();
 
@@ -2955,6 +3061,7 @@ async function main() {
       runDir: runArtifactPaths.runDir,
       stdoutLog,
       stderrLog,
+      reviewAssuranceResolution: REVIEW_ASSURANCE_RESOLUTION,
     });
   }
 
@@ -3425,6 +3532,9 @@ async function main() {
     executorNetwork: executorNetworkPolicy,
     executorPolicy,
     publishPolicy: PUBLISH_POLICY,
+    reviewAssurance: manifest.policy.review_assurance,
+    reviewAssuranceSource: manifest.policy.review_assurance_source,
+    reviewAssuranceOverridden: manifest.policy.review_assurance_overridden || null,
     policyDecision,
     routePlanPath: routePlanSnapshot?.path || null,
     routePlan: routePlanSnapshot?.snapshot || null,
@@ -3466,6 +3576,13 @@ async function main() {
     if (error) console.log(`  Error: ${error}`);
     console.log(`  Run state: ${result.runState}`);
     console.log(`  Commit mode: ${result.commitMode}`);
+    const assuranceOverride = result.reviewAssuranceOverridden
+      ? `; overridden flag=${result.reviewAssuranceOverridden}`
+      : "";
+    console.log(
+      `  Assurance: ${result.reviewAssurance} ` +
+      `(source=${result.reviewAssuranceSource})${assuranceOverride}`
+    );
     if (prNumber !== null) {
       console.log(`  PR:        #${prNumber}${prCreatedByUs === true ? " (created by orchestrator)" : prCreatedByUs === false ? " (existing)" : ""}`);
     }

--- a/skills/relay-dispatch/scripts/manifest/review-assurance.js
+++ b/skills/relay-dispatch/scripts/manifest/review-assurance.js
@@ -6,6 +6,7 @@ const REVIEW_ASSURANCE = Object.freeze({
 
 const REVIEW_ASSURANCE_LEVELS = Object.freeze(Object.values(REVIEW_ASSURANCE));
 const DEFAULT_REVIEW_ASSURANCE = REVIEW_ASSURANCE.STANDARD;
+const REVIEW_ASSURANCE_SOURCES = Object.freeze(["rubric", "flag"]);
 
 function normalizeReviewAssurance(value, { fallback = DEFAULT_REVIEW_ASSURANCE } = {}) {
   const text = typeof value === "string" ? value.trim().toLowerCase() : "";
@@ -14,6 +15,80 @@ function normalizeReviewAssurance(value, { fallback = DEFAULT_REVIEW_ASSURANCE }
   throw new Error(
     `invalid review assurance '${value}'; expected one of: ${REVIEW_ASSURANCE_LEVELS.join(", ")}`
   );
+}
+
+function normalizeReviewAssuranceSource(value, { fallback = "flag" } = {}) {
+  const text = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (!text) return fallback;
+  if (REVIEW_ASSURANCE_SOURCES.includes(text)) return text;
+  throw new Error(
+    `invalid review assurance source '${value}'; expected one of: ${REVIEW_ASSURANCE_SOURCES.join(", ")}`
+  );
+}
+
+function stripYamlScalar(value) {
+  let text = String(value || "").trim();
+  if (!text) return "";
+  text = text.replace(/\s+#.*$/, "").trim();
+  if (text.startsWith("\"") && text.endsWith("\"")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text.slice(1, -1);
+    }
+  }
+  if (text.startsWith("'") && text.endsWith("'")) {
+    return text.slice(1, -1).replace(/''/g, "'");
+  }
+  return text;
+}
+
+function extractReviewAssuranceFromRubric(rubricText) {
+  const lines = String(rubricText || "").replace(/\r\n/g, "\n").split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const taskProfile = /^(\s*)task_profile:\s*(?:#.*)?$/.exec(lines[index]);
+    if (!taskProfile) continue;
+
+    const profileIndent = taskProfile[1].length;
+    let childIndent = null;
+    for (let childIndex = index + 1; childIndex < lines.length; childIndex += 1) {
+      const line = lines[childIndex];
+      if (/^\s*(?:#.*)?$/.test(line)) continue;
+      const indent = line.match(/^\s*/)[0].length;
+      if (indent <= profileIndent) break;
+
+      const keyValue = /^(\s*)([A-Za-z0-9_]+):(?:\s*(.*))?$/.exec(line);
+      if (!keyValue) continue;
+      if (childIndent === null) childIndent = keyValue[1].length;
+      if (keyValue[1].length !== childIndent || keyValue[2] !== "review_assurance") continue;
+
+      const value = stripYamlScalar(keyValue[3]);
+      return value ? normalizeReviewAssurance(value) : null;
+    }
+  }
+  return null;
+}
+
+function resolveReviewAssurance({
+  rubricReviewAssurance = null,
+  flagReviewAssurance = DEFAULT_REVIEW_ASSURANCE,
+  flagWasExplicit = false,
+} = {}) {
+  const flag = normalizeReviewAssurance(flagReviewAssurance);
+  if (!rubricReviewAssurance) {
+    return {
+      level: flag,
+      source: "flag",
+      overridden: null,
+    };
+  }
+
+  const rubric = normalizeReviewAssurance(rubricReviewAssurance);
+  return {
+    level: rubric,
+    source: "rubric",
+    overridden: flagWasExplicit && flag !== rubric ? flag : null,
+  };
 }
 
 function getReviewAssurance(data) {
@@ -39,9 +114,13 @@ module.exports = {
   DEFAULT_REVIEW_ASSURANCE,
   REVIEW_ASSURANCE,
   REVIEW_ASSURANCE_LEVELS,
+  REVIEW_ASSURANCE_SOURCES,
+  extractReviewAssuranceFromRubric,
   getReviewAssurance,
   isHardenedReviewAssurance,
   normalizeReviewAssurance,
+  normalizeReviewAssuranceSource,
+  resolveReviewAssurance,
   reviewAssuranceRank,
   reviewRoundLimitForAssurance,
 };

--- a/skills/relay-dispatch/scripts/manifest/store.js
+++ b/skills/relay-dispatch/scripts/manifest/store.js
@@ -13,6 +13,7 @@ const {
 } = require("./paths");
 const {
   normalizeReviewAssurance,
+  normalizeReviewAssuranceSource,
   reviewRoundLimitForAssurance,
 } = require("./review-assurance");
 const { normalizeOwnership } = require("../ownership");
@@ -341,6 +342,8 @@ function createManifestSkeleton({
   cleanupPolicy = "on_close",
   reviewerWritePolicy = "forbid",
   reviewAssurance = "standard",
+  reviewAssuranceSource = "flag",
+  reviewAssuranceOverridden = null,
   environment = null,
   requestId = null,
   leafId = null,
@@ -356,6 +359,10 @@ function createManifestSkeleton({
   const createdAt = nowIso();
   const normalizedRunId = requireValidRunId(runId);
   const normalizedReviewAssurance = normalizeReviewAssurance(reviewAssurance);
+  const normalizedReviewAssuranceSource = normalizeReviewAssuranceSource(reviewAssuranceSource);
+  const normalizedReviewAssuranceOverridden = reviewAssuranceOverridden
+    ? normalizeReviewAssurance(reviewAssuranceOverridden)
+    : null;
 
   const manifest = {
     relay_version: RELAY_VERSION,
@@ -389,6 +396,10 @@ function createManifestSkeleton({
       cleanup: cleanupPolicy,
       reviewer_write: reviewerWritePolicy,
       review_assurance: normalizedReviewAssurance,
+      review_assurance_source: normalizedReviewAssuranceSource,
+      ...(normalizedReviewAssuranceOverridden
+        ? { review_assurance_overridden: normalizedReviewAssuranceOverridden }
+        : {}),
     },
     anchor: {
       done_criteria_source: doneCriteriaSource || (issueNumber ? "issue" : "unknown"),

--- a/skills/relay-dispatch/scripts/worktree-runtime.js
+++ b/skills/relay-dispatch/scripts/worktree-runtime.js
@@ -55,6 +55,8 @@ function formatDispatchDryRun({
   fleetId = null,
   doneCriteriaFile = null,
   reviewAssurance = null,
+  reviewAssuranceSource = null,
+  reviewAssuranceOverridden = null,
   policyDecision = null,
   routingDecision = null,
   worktreePlan,
@@ -93,7 +95,11 @@ function formatDispatchDryRun({
     lines.push(`  Done AC:  ${doneCriteriaFile}`);
   }
   if (reviewAssurance) {
-    lines.push(`  Assurance: ${reviewAssurance}`);
+    const source = reviewAssuranceSource ? ` (source=${reviewAssuranceSource})` : "";
+    const overridden = reviewAssuranceOverridden
+      ? `; overridden flag=${reviewAssuranceOverridden}`
+      : "";
+    lines.push(`  Assurance: ${reviewAssurance}${source}${overridden}`);
   }
   if (policyDecision) {
     const actorField = policyDecision.actor_field || "actor";

--- a/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.json
+++ b/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.json
@@ -20,6 +20,8 @@
   "leafId": null,
   "doneCriteriaFile": null,
   "reviewAssurance": "standard",
+  "reviewAssuranceSource": "flag",
+  "reviewAssuranceOverridden": null,
   "publishPolicy": "immediate",
   "environment": "collected-at-dispatch",
   "runState": null,

--- a/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.txt
+++ b/tests/relay-dispatch/fixtures/worktree-runtime/dispatch-dry-run.txt
@@ -15,7 +15,7 @@ Dry run:
   Cleanup:  on_close
   Timeout:  2400s
   Rubric:   /tmp/issue187-fixtures/rubric.yaml
-  Assurance: standard
+  Assurance: standard (source=flag)
   Policy:   allowed phase=dispatch executor=codex model=(none) reason=managed_cli
   Routing: no match (no_routing_rule_matched)
   Tags:    effective=(none)

--- a/tests/relay-dispatch/scripts/dispatch-risk-assurance.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-risk-assurance.test.js
@@ -90,10 +90,11 @@ function previewPrompt(name, prompt, extra = []) {
   return JSON.parse(stdout);
 }
 
-test("real dispatch surface selects compact without weakening durable runtime boundaries", () => {
+test("real dispatch surface keeps the default when prompt risk metadata suggests compact", () => {
   const result = preview("compact");
 
-  assert.equal(result.reviewAssurance, "compact");
+  assert.equal(result.reviewAssurance, "standard");
+  assert.equal(result.reviewAssuranceSource, "flag");
   assert.equal(result.publishPolicy, "immediate");
   assert.equal(result.sandbox, "workspace-write");
   assert.equal(result.networkAccess, "disabled");
@@ -102,40 +103,34 @@ test("real dispatch surface selects compact without weakening durable runtime bo
   assert.equal(fs.existsSync(result.worktree), false);
 });
 
-test("real dispatch surface accepts an explicit compact tier at the derived floor", () => {
+test("real dispatch surface accepts an explicit compact tier when the rubric omits assurance", () => {
   const result = preview("compact", ["--review-assurance", "compact"]);
 
   assert.equal(result.reviewAssurance, "compact");
   assert.equal(result.publishPolicy, "immediate");
 });
 
-test("real dispatch surface rejects compact without a task-derived risk floor", () => {
+test("real dispatch surface accepts the assurance flag without a prompt risk floor", () => {
   const defaultResult = previewPrompt(
     "missing-risk-default",
     "Update a repository file according to the issue."
   );
   assert.equal(defaultResult.reviewAssurance, "standard");
 
-  assert.throws(
-    () => previewPrompt(
-      "missing-risk-compact",
-      "Update a repository file according to the issue.",
-      ["--review-assurance", "compact"]
-    ),
-    (error) => {
-      assert.match(
-        `${String(error.stdout)}\n${String(error.stderr)}`,
-        /compact.*complete risk-aware task_profile|task-derived risk floor/i
-      );
-      return true;
-    }
+  const compactResult = previewPrompt(
+    "missing-risk-compact",
+    "Update a repository file according to the issue.",
+    ["--review-assurance", "compact"]
   );
+  assert.equal(compactResult.reviewAssurance, "compact");
+  assert.equal(compactResult.reviewAssuranceSource, "flag");
 });
 
-test("real dispatch surface selects hardened on the existing delayed-publication path", () => {
+test("real dispatch surface keeps default assurance on the existing delayed-publication path", () => {
   const result = preview("hardened");
 
-  assert.equal(result.reviewAssurance, "hardened");
+  assert.equal(result.reviewAssurance, "standard");
+  assert.equal(result.reviewAssuranceSource, "flag");
   assert.equal(result.publishPolicy, "after-internal-review");
   assert.equal(result.sandbox, "workspace-write");
   assert.equal(result.networkAccess, "disabled");
@@ -158,20 +153,15 @@ test("real dispatch surface refuses immediate publication below a high-risk path
   );
 });
 
-test("real dispatch surface rejects an explicit tier below the task-derived floor", () => {
-  assert.throws(
-    () => preview("hardened", [
-      "--review-assurance",
-      "standard",
-      "--publish-policy",
-      "after-internal-review",
-    ]),
-    (error) => {
-      assert.match(
-        `${String(error.stdout)}\n${String(error.stderr)}`,
-        /below.*hardened.*risk floor/i
-      );
-      return true;
-    }
-  );
+test("real dispatch surface accepts a flag below prompt-derived assurance metadata", () => {
+  const result = preview("hardened", [
+    "--review-assurance",
+    "standard",
+    "--publish-policy",
+    "after-internal-review",
+  ]);
+
+  assert.equal(result.reviewAssurance, "standard");
+  assert.equal(result.reviewAssuranceSource, "flag");
+  assert.equal(result.publishPolicy, "after-internal-review");
 });

--- a/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
+++ b/tests/relay-dispatch/scripts/dispatch-route-plan.test.js
@@ -220,7 +220,7 @@ test("dispatch unknown route preset fails before creating run side effects inclu
   assert.equal(fs.existsSync(sprintStateLog), false);
 });
 
-test("dispatch route preset review_assurance maps to existing review assurance path", () => {
+test("dispatch route preset review_assurance does not replace the rubric-omission default", () => {
   const { repoRoot, relayHome, rubricFile } = setupRepo();
   writeJson(path.join(relayHome, "routes.json"), {
     version: 2,
@@ -251,10 +251,11 @@ test("dispatch route preset review_assurance maps to existing review assurance p
 
   assert.equal(proc.status, 0, proc.stderr);
   const output = JSON.parse(proc.stdout);
-  assert.equal(output.reviewAssurance, "hardened");
+  assert.equal(output.reviewAssurance, "standard");
+  assert.equal(output.reviewAssuranceSource, "flag");
 });
 
-test("dispatch persists review assurance route preset source metadata in route-plan snapshot", () => {
+test("dispatch records route preset assurance metadata without changing the fixed assurance cap", () => {
   const { repoRoot, relayHome, rubricFile } = setupRepo();
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-route-preset-hardened-bin-"));
   writeFakeCodex(binDir);
@@ -293,7 +294,8 @@ test("dispatch persists review assurance route preset source metadata in route-p
   assert.equal(snapshot.route_preset.review_assurance, "hardened");
   assert.deepEqual(snapshot.route_preset.filled, [{ field: "review_assurance" }]);
   const manifest = readManifest(output.manifestPath).data;
-  assert.equal(manifest.policy.review_assurance, "hardened");
+  assert.equal(manifest.policy.review_assurance, "standard");
+  assert.equal(manifest.policy.review_assurance_source, "flag");
 });
 
 test("dispatch keeps explicit --review-assurance over a preset in the route-plan snapshot", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -958,6 +958,32 @@ function runDispatch(repoRoot, args, env) {
   });
 }
 
+function writeAssuranceRubric(reviewAssurance = null) {
+  const rubricFile = path.join(
+    os.tmpdir(),
+    `relay-dispatch-assurance-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`
+  );
+  fs.writeFileSync(rubricFile, [
+    "evaluation:",
+    "  schema_version: 2",
+    "  outcome_contract:",
+    "    source: done_criteria",
+    "    path: done-criteria.md",
+    "  verification:",
+    "    checks:",
+    "      - name: focused test",
+    "        type: command",
+    "        command: node --test tests/focused.test.js",
+    "        target: exit 0",
+    "  earned_rubric:",
+    "    factors: []",
+    "  task_profile:",
+    "    size: M",
+    ...(reviewAssurance ? [`    review_assurance: ${reviewAssurance}`] : []),
+  ].join("\n"), "utf-8");
+  return rubricFile;
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -1322,6 +1348,9 @@ test("dispatch --detach returns a launch receipt while detached supervisor compl
   assert.equal(receipt.status, "detached");
   assert.match(receipt.runId, /^issue-802-/);
   assert.equal(receipt.manifestPath, getManifestPath(repoRoot, receipt.runId));
+  assert.equal(receipt.reviewAssurance, "standard");
+  assert.equal(receipt.reviewAssuranceSource, "flag");
+  assert.equal(receipt.reviewAssuranceOverridden, null);
   assert.equal(Number.isInteger(receipt.supervisorPid), true);
   assert.ok(receipt.supervisorPid > 0);
   assert.equal(receipt.stdoutLog, path.join(getRunDir(repoRoot, receipt.runId), "dispatch-stdout.log"));
@@ -6050,6 +6079,91 @@ test("dispatch derives review assurance from task_profile when CLI policy is uns
   const manifest = readManifest(result.manifestPath).data;
   assert.equal(manifest.policy.review_assurance, "hardened");
   assert.equal(manifest.advisory.guidance.task_profile_summary.review_assurance, "hardened");
+});
+
+test("dispatch uses rubric-only review assurance and persists its resolved cap and source", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-rubric-assurance-bin-"));
+  writeFakeCodex(binDir);
+  const rubricFile = writeAssuranceRubric("hardened");
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-rubric-assurance-only",
+    "--prompt", "honour the fixed rubric assurance",
+    "--rubric-file", rubricFile,
+    "--json",
+  ], env));
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(result.reviewAssurance, "hardened");
+  assert.equal(result.reviewAssuranceSource, "rubric");
+  assert.equal(result.reviewAssuranceOverridden, null);
+  assert.equal(manifest.policy.review_assurance, "hardened");
+  assert.equal(manifest.policy.review_assurance_source, "rubric");
+  assert.equal(manifest.policy.review_assurance_overridden, undefined);
+  assert.equal(manifest.review.max_rounds, 3);
+});
+
+test("dispatch uses the review assurance flag when the rubric omits the field", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-flag-assurance-bin-"));
+  writeFakeCodex(binDir);
+  const rubricFile = writeAssuranceRubric();
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-flag-assurance-only",
+    "--prompt", "use the dispatch assurance flag",
+    "--rubric-file", rubricFile,
+    "--review-assurance", "hardened",
+    "--json",
+  ], env));
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(result.reviewAssurance, "hardened");
+  assert.equal(result.reviewAssuranceSource, "flag");
+  assert.equal(result.reviewAssuranceOverridden, null);
+  assert.equal(manifest.policy.review_assurance, "hardened");
+  assert.equal(manifest.policy.review_assurance_source, "flag");
+  assert.equal(manifest.review.max_rounds, 3);
+});
+
+test("dispatch records a disagreeing assurance flag while the rubric wins", () => {
+  const { repoRoot, relayHome } = setupRepo();
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-assurance-conflict-bin-"));
+  writeFakeCodex(binDir);
+  const rubricFile = writeAssuranceRubric("hardened");
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    RELAY_HOME: relayHome,
+  };
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-assurance-conflict",
+    "--prompt", "record the assurance conflict",
+    "--rubric-file", rubricFile,
+    "--review-assurance", "standard",
+    "--json",
+  ], env));
+
+  const manifest = readManifest(result.manifestPath).data;
+  assert.equal(result.reviewAssurance, "hardened");
+  assert.equal(result.reviewAssuranceSource, "rubric");
+  assert.equal(result.reviewAssuranceOverridden, "standard");
+  assert.equal(manifest.policy.review_assurance, "hardened");
+  assert.equal(manifest.policy.review_assurance_source, "rubric");
+  assert.equal(manifest.policy.review_assurance_overridden, "standard");
+  assert.equal(manifest.review.max_rounds, 3);
 });
 
 test("dispatch resume preserves guidance metadata without injecting stale Working Guidance blocks", () => {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -6062,30 +6062,48 @@ test("dispatch persists selected guidance metadata in run artifacts and events",
   assert.deepEqual(guidanceEvent.task_profile_summary, artifact.task_profile_summary);
 });
 
-test("dispatch derives review assurance from task_profile when CLI policy is unset", () => {
+test("dispatch keeps rubric-omission default and flag over prompt task_profile assurance", () => {
   const { repoRoot, relayHome } = setupRepo();
   process.env.RELAY_HOME = relayHome;
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-codex-bin-"));
   writeFakeCodex(binDir);
   const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
 
-  const result = JSON.parse(runDispatch(repoRoot, [
+  const defaultResult = JSON.parse(runDispatch(repoRoot, [
     "-b", "issue-profile-assurance",
     "--prompt", guidancePrompt({ reviewAssurance: "hardened" }),
     "--json",
   ], env));
 
-  assert.equal(result.status, "completed");
-  const manifest = readManifest(result.manifestPath).data;
-  assert.equal(manifest.policy.review_assurance, "hardened");
-  assert.equal(manifest.advisory.guidance.task_profile_summary.review_assurance, "hardened");
+  assert.equal(defaultResult.status, "completed");
+  const defaultManifest = readManifest(defaultResult.manifestPath).data;
+  assert.equal(defaultResult.reviewAssurance, "standard");
+  assert.equal(defaultResult.reviewAssuranceSource, "flag");
+  assert.equal(defaultManifest.policy.review_assurance, "standard");
+  assert.equal(defaultManifest.policy.review_assurance_source, "flag");
+  assert.equal(defaultManifest.advisory.guidance.task_profile_summary.review_assurance, "hardened");
+
+  const flagResult = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-profile-assurance-flag",
+    "--prompt", guidancePrompt({ reviewAssurance: "hardened" }),
+    "--review-assurance", "standard",
+    "--json",
+  ], env));
+
+  assert.equal(flagResult.status, "completed");
+  const flagManifest = readManifest(flagResult.manifestPath).data;
+  assert.equal(flagResult.reviewAssurance, "standard");
+  assert.equal(flagResult.reviewAssuranceSource, "flag");
+  assert.equal(flagManifest.policy.review_assurance, "standard");
+  assert.equal(flagManifest.policy.review_assurance_source, "flag");
+  assert.equal(flagManifest.advisory.guidance.task_profile_summary.review_assurance, "hardened");
 });
 
-test("dispatch uses rubric-only review assurance and persists its resolved cap and source", () => {
+test("dispatch uses rubric assurance over prompt metadata and persists its resolved cap and source", () => {
   const { repoRoot, relayHome } = setupRepo();
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-rubric-assurance-bin-"));
   writeFakeCodex(binDir);
-  const rubricFile = writeAssuranceRubric("hardened");
+  const rubricFile = writeAssuranceRubric("compact");
   const env = {
     ...process.env,
     PATH: `${binDir}:${process.env.PATH}`,
@@ -6094,19 +6112,20 @@ test("dispatch uses rubric-only review assurance and persists its resolved cap a
 
   const result = JSON.parse(runDispatch(repoRoot, [
     "-b", "issue-rubric-assurance-only",
-    "--prompt", "honour the fixed rubric assurance",
+    "--prompt", guidancePrompt({ reviewAssurance: "hardened" }),
     "--rubric-file", rubricFile,
     "--json",
   ], env));
 
   const manifest = readManifest(result.manifestPath).data;
-  assert.equal(result.reviewAssurance, "hardened");
+  assert.equal(result.reviewAssurance, "compact");
   assert.equal(result.reviewAssuranceSource, "rubric");
   assert.equal(result.reviewAssuranceOverridden, null);
-  assert.equal(manifest.policy.review_assurance, "hardened");
+  assert.equal(manifest.policy.review_assurance, "compact");
   assert.equal(manifest.policy.review_assurance_source, "rubric");
   assert.equal(manifest.policy.review_assurance_overridden, undefined);
-  assert.equal(manifest.review.max_rounds, 3);
+  assert.equal(manifest.advisory.guidance.task_profile_summary.review_assurance, "hardened");
+  assert.equal(manifest.review.max_rounds, 1);
 });
 
 test("dispatch uses the review assurance flag when the rubric omits the field", () => {

--- a/tests/relay-dispatch/scripts/relay-manifest.test.js
+++ b/tests/relay-dispatch/scripts/relay-manifest.test.js
@@ -33,6 +33,10 @@ const {
   writeManifest,
 } = require("../../../skills/relay-dispatch/scripts/relay-manifest");
 const {
+  extractReviewAssuranceFromRubric,
+  resolveReviewAssurance,
+} = require("../../../skills/relay-dispatch/scripts/manifest/review-assurance");
+const {
   createGrandfatheredRubricAnchor,
 } = require("./test-support");
 
@@ -132,6 +136,8 @@ test("createManifestSkeleton defaults and validates review assurance policy", ()
     worktreePath: path.join(repoRoot, "wt"),
   });
   assert.equal(standard.policy.review_assurance, DEFAULT_REVIEW_ASSURANCE);
+  assert.equal(standard.policy.review_assurance_source, "flag");
+  assert.equal(standard.policy.review_assurance_overridden, undefined);
   assert.equal(standard.review.max_rounds, 2);
 
   const compact = createManifestSkeleton({
@@ -174,6 +180,36 @@ test("createManifestSkeleton defaults and validates review assurance policy", ()
     }),
     /invalid review assurance/
   );
+});
+
+test("rubric review assurance extraction and resolution preserve authoritative provenance", () => {
+  const nestedRubric = [
+    "evaluation:",
+    "  schema_version: 2",
+    "  task_profile:",
+    "    size: L",
+    "    review_assurance: 'hardened' # fixed review anchor",
+  ].join("\n");
+  assert.equal(extractReviewAssuranceFromRubric(nestedRubric), "hardened");
+  assert.equal(extractReviewAssuranceFromRubric("rubric:\n  factors: []\n"), null);
+
+  assert.deepEqual(resolveReviewAssurance({
+    rubricReviewAssurance: "hardened",
+    flagReviewAssurance: "standard",
+    flagWasExplicit: true,
+  }), {
+    level: "hardened",
+    source: "rubric",
+    overridden: "standard",
+  });
+  assert.deepEqual(resolveReviewAssurance({
+    flagReviewAssurance: "compact",
+    flagWasExplicit: true,
+  }), {
+    level: "compact",
+    source: "flag",
+    overridden: null,
+  });
 });
 
 test("createRunId is branch-stable and filesystem-safe", () => {

--- a/tests/relay-dispatch/scripts/worktree-runtime.test.js
+++ b/tests/relay-dispatch/scripts/worktree-runtime.test.js
@@ -72,6 +72,7 @@ test("formatDispatchDryRun matches the frozen dispatch text fixture", () => {
     timeout: 2400,
     rubricFile: "/tmp/issue187-fixtures/rubric.yaml",
     reviewAssurance: "standard",
+    reviewAssuranceSource: "flag",
     policyDecision: frozenJson.policy_decision,
     routingDecision: frozenJson.routing_decision,
     worktreePlan: {


### PR DESCRIPTION
## Dispatch Summary

```text
수정 완료 후 같은 브랜치에 푸시했습니다.

- 커밋: `70c10e5 fix(dispatch): preserve rubric and flag assurance authority`
- 브랜치: `issue-1098` → `origin/issue-1098`
- rubric 누락 시 prompt/route가 아닌 flag 또는 기본 `standard`만 적용
- manifest source를 실제 provenance인 `flag`/`rubric`으로 기록
- 관련 테스트 83개 통과
- 전체 스위트: 1,149 통과, 비관련 process-group 테스트 5개 실패(단독 재현), 2개 skip
- 작업 트리 clean, 로컬/원격 SHA 일치

GitHub 조회상 해당 브랜치에 연결된 PR은 아직 없었습니다. 요청 범위에 따라 PR 생성은 하지 않았습니다.
```

## Dispatch Metadata

- Run: issue-1098-20260728084425650-2d249fb3
- Executor: codex
- Branch: issue-1098