### PR TITLE
fix(dispatch): stage tracked runtime-root changes

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -3211,7 +3211,7 @@ async function main() {
   const supersededBeforeCommit = readManifest(manifestPath).data.state !== STATES.DISPATCHED;
   if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted" && !supersededBeforeCommit) {
     try {
-      execGit(wtPath, gitAddReviewableArgs(rawUncommitted));
+      execGit(wtPath, gitAddReviewableArgs(rawUncommitted, wtPath));
       if (dirt.hasReviewableDirt && !execGit(wtPath, ["diff", "--cached", "--name-only"])) {
         throw new Error(formatEmptyReviewableIndexError(rawUncommitted));
       }

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -165,7 +165,12 @@ const {
 } = require("./route-failure-hints");
 const { loadRelayPolicy } = require("./relay-policy");
 const { loadProjectRoutes, resolveRouteIntent, resolveRoutingDecision } = require("./relay-routing");
-const { classifyRepositoryDirt, formatRuntimeMetadataDirt, gitAddReviewableArgs } = require("./runtime-dirt");
+const {
+  classifyRepositoryDirt,
+  formatEmptyReviewableIndexError,
+  formatRuntimeMetadataDirt,
+  gitAddReviewableArgs,
+} = require("./runtime-dirt");
 const {
   dispatchManifestPathFields,
   getRunArtifactPaths,
@@ -3207,6 +3212,9 @@ async function main() {
   if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted" && !supersededBeforeCommit) {
     try {
       execGit(wtPath, gitAddReviewableArgs(rawUncommitted));
+      if (dirt.hasReviewableDirt && !execGit(wtPath, ["diff", "--cached", "--name-only"])) {
+        throw new Error(formatEmptyReviewableIndexError(rawUncommitted));
+      }
       execGit(wtPath, [
         "commit",
         "-m", `Relay run ${runId}`,

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -562,7 +562,7 @@ function main() {
   let commitCreated = false;
   if (hasUncommittedChanges) {
     try {
-      execGit(worktreePath, gitAddReviewableArgs(statusText));
+      execGit(worktreePath, gitAddReviewableArgs(statusText, worktreePath));
       if (dirt.hasReviewableDirt && !execGit(worktreePath, ["diff", "--cached", "--name-only"])) {
         throw new Error(formatEmptyReviewableIndexError(statusText));
       }

--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -31,6 +31,7 @@ const {
 const { execGit, execGh, resolveBranchRemote } = require("./exec");
 const {
   classifyRepositoryDirt,
+  formatEmptyReviewableIndexError,
   formatRuntimeMetadataDirt,
   gitAddReviewableArgs,
 } = require("./runtime-dirt");
@@ -562,6 +563,9 @@ function main() {
   if (hasUncommittedChanges) {
     try {
       execGit(worktreePath, gitAddReviewableArgs(statusText));
+      if (dirt.hasReviewableDirt && !execGit(worktreePath, ["diff", "--cached", "--name-only"])) {
+        throw new Error(formatEmptyReviewableIndexError(statusText));
+      }
       execGit(worktreePath, ["commit", "-m", commitTitle, "-m", commitBody]);
       commitSha = execGit(worktreePath, ["rev-parse", "HEAD"]);
       commitCreated = true;

--- a/skills/relay-dispatch/scripts/runtime-dirt.js
+++ b/skills/relay-dispatch/scripts/runtime-dirt.js
@@ -147,7 +147,8 @@ function statusPathspecs(repoPath, line) {
 
 function isRuntimeMetadataStatusLine(line) {
   if (typeof line !== "string" || line.slice(0, 2) !== "??") return false;
-  const filePath = statusPath(line).replace(/\/+$/, "");
+  const [statusFilePath = ""] = statusPaths(line);
+  const filePath = statusFilePath.replace(/\/+$/, "");
   return RUNTIME_METADATA_ROOTS.some((root) => filePath === root || filePath.startsWith(`${root}/`));
 }
 
@@ -220,7 +221,10 @@ function gitAddReviewableArgs(statusText, repoPath = process.cwd()) {
 
   /*
    * Invariant: anything classifyRepositoryDirt reports reviewable is stageable
-   * by the argv returned here for the same status text.
+   * by the argv returned here for the same status text. Runtime classification
+   * and allowlist generation both compare the decoded paths returned by
+   * statusPaths, so a quoted porcelain path cannot be classified under one
+   * representation and staged under another.
    *
    * A reviewable-path allowlist preserves tracked changes beneath runtime roots
    * while excluding untracked runtime metadata. It also deliberately excludes
@@ -231,7 +235,7 @@ function gitAddReviewableArgs(statusText, repoPath = process.cwd()) {
    */
   const reviewablePaths = reviewableStatusPathspecs(statusText, repoPath);
   if (reviewablePaths.length > 0) {
-    return ["add", "-A", "--", ...reviewablePaths];
+    return ["add", "-A", "--", ...reviewablePaths.map((filePath) => `:(literal)${filePath}`)];
   }
   return ["add", "-A", "--", ".", ...runtimeMetadataRootExclusions()];
 }

--- a/skills/relay-dispatch/scripts/runtime-dirt.js
+++ b/skills/relay-dispatch/scripts/runtime-dirt.js
@@ -106,6 +106,23 @@ function statusPaths(line) {
   ];
 }
 
+function statusPathspecs(line) {
+  const paths = statusPaths(line);
+  /*
+   * A staged rename/copy has R/C in the index column. A rename source is
+   * already absent from the index, so passing it to git add as an allowlist
+   * pathspec aborts the entire add. The destination alone is sufficient for
+   * both shapes to retain the staged index entry (and to pick up any later
+   * destination edits).
+   *
+   * line[2] distinguishes an intact "R  old -> new" / "RM old -> new" entry
+   * from an unstaged first entry whose leading space execGit trimmed to
+   * "R old -> new". The latter must keep both paths.
+   */
+  const hasStagedRenameOrCopy = line[2] === " " && /[RC]/.test(line[0]);
+  return hasStagedRenameOrCopy && paths.length > 1 ? paths.slice(-1) : paths;
+}
+
 function isRuntimeMetadataStatusLine(line) {
   if (typeof line !== "string" || line.slice(0, 2) !== "??") return false;
   const filePath = statusPath(line).replace(/\/+$/, "");
@@ -147,6 +164,13 @@ function reviewableStatusPaths(statusText) {
   )];
 }
 
+function reviewableStatusPathspecs(statusText) {
+  const classified = classifyRepositoryDirt(statusText);
+  return [...new Set(
+    splitStatusLines(classified.reviewableStatus).flatMap((line) => statusPathspecs(line))
+  )];
+}
+
 function formatEmptyReviewableIndexError(statusText) {
   const paths = reviewableStatusPaths(statusText);
   const detail = paths.length
@@ -183,7 +207,7 @@ function gitAddReviewableArgs(statusText) {
    * Both the allowlist and runtime classification derive from
    * RUNTIME_METADATA_ROOTS through classifyRepositoryDirt.
    */
-  const reviewablePaths = reviewableStatusPaths(statusText);
+  const reviewablePaths = reviewableStatusPathspecs(statusText);
   if (reviewablePaths.length > 0) {
     return ["add", "-A", "--", ...reviewablePaths];
   }

--- a/skills/relay-dispatch/scripts/runtime-dirt.js
+++ b/skills/relay-dispatch/scripts/runtime-dirt.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const fs = require("node:fs");
+const path = require("node:path");
+
 const RUNTIME_METADATA_ROOTS = Object.freeze([
   ".antigravitycli",
 ]);
@@ -106,21 +109,40 @@ function statusPaths(line) {
   ];
 }
 
-function statusPathspecs(line) {
+function worktreeStatusCode(line) {
+  if (typeof line !== "string") return " ";
+  if (line[2] === " ") return line[1] || " ";
+  // execGit trims the leading index-column space from the first unstaged line.
+  if (line[1] === " ") return line[0] || " ";
+  return " ";
+}
+
+function isPresentOnDisk(repoPath, filePath) {
+  try {
+    fs.lstatSync(path.resolve(repoPath, filePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function statusPathspecs(repoPath, line) {
   const paths = statusPaths(line);
+  const worktreePath = paths.at(-1);
   /*
-   * A staged rename/copy has R/C in the index column. A rename source is
-   * already absent from the index, so passing it to git add as an allowlist
-   * pathspec aborts the entire add. The destination alone is sufficient for
-   * both shapes to retain the staged index entry (and to pick up any later
-   * destination edits).
+   * General pathspec predicate: emit a path only when git add can have work
+   * to do for it — the path is present on disk, or it is the current worktree
+   * path and porcelain column 2 reports an unstaged change. This omits any
+   * fully staged path that is absent from disk, regardless of its status code,
+   * while retaining absent paths for AD and unstaged deletions.
    *
-   * line[2] distinguishes an intact "R  old -> new" / "RM old -> new" entry
-   * from an unstaged first entry whose leading space execGit trimmed to
-   * "R old -> new". The latter must keep both paths.
+   * Rename/copy porcelain lists a historical source before the current path;
+   * column 2 describes the current path only.
    */
-  const hasStagedRenameOrCopy = line[2] === " " && /[RC]/.test(line[0]);
-  return hasStagedRenameOrCopy && paths.length > 1 ? paths.slice(-1) : paths;
+  return paths.filter((filePath) => (
+    isPresentOnDisk(repoPath, filePath) ||
+    (filePath === worktreePath && worktreeStatusCode(line) !== " ")
+  ));
 }
 
 function isRuntimeMetadataStatusLine(line) {
@@ -164,10 +186,10 @@ function reviewableStatusPaths(statusText) {
   )];
 }
 
-function reviewableStatusPathspecs(statusText) {
+function reviewableStatusPathspecs(statusText, repoPath) {
   const classified = classifyRepositoryDirt(statusText);
   return [...new Set(
-    splitStatusLines(classified.reviewableStatus).flatMap((line) => statusPathspecs(line))
+    splitStatusLines(classified.reviewableStatus).flatMap((line) => statusPathspecs(repoPath, line))
   )];
 }
 
@@ -190,7 +212,7 @@ function runtimeMetadataRootExclusions() {
   ]);
 }
 
-function gitAddReviewableArgs(statusText) {
+function gitAddReviewableArgs(statusText, repoPath = process.cwd()) {
   const classified = classifyRepositoryDirt(statusText);
   if (!classified.hasRuntimeMetadataDirt) {
     return ["add", "-A"];
@@ -207,7 +229,7 @@ function gitAddReviewableArgs(statusText) {
    * Both the allowlist and runtime classification derive from
    * RUNTIME_METADATA_ROOTS through classifyRepositoryDirt.
    */
-  const reviewablePaths = reviewableStatusPathspecs(statusText);
+  const reviewablePaths = reviewableStatusPathspecs(statusText, repoPath);
   if (reviewablePaths.length > 0) {
     return ["add", "-A", "--", ...reviewablePaths];
   }

--- a/skills/relay-dispatch/scripts/runtime-dirt.js
+++ b/skills/relay-dispatch/scripts/runtime-dirt.js
@@ -12,8 +12,98 @@ function splitStatusLines(statusText) {
 }
 
 function statusPath(line) {
-  if (typeof line !== "string" || line.length < 4) return "";
-  return line.slice(3).trim();
+  if (typeof line !== "string" || line.length < 3) return "";
+  if (line[2] === " ") return line.slice(3).trim();
+  // execGit trims command output, so an unstaged first line can arrive as
+  // "M path" rather than the porcelain form " M path".
+  if (line[1] === " ") return line.slice(2).trim();
+  return "";
+}
+
+function decodeQuotedStatusPath(filePath) {
+  if (!filePath.startsWith("\"") || !filePath.endsWith("\"")) return filePath;
+
+  const chunks = [];
+  let literal = "";
+  const flushLiteral = () => {
+    if (!literal) return;
+    chunks.push(Buffer.from(literal, "utf-8"));
+    literal = "";
+  };
+  const escapes = {
+    a: "\x07",
+    b: "\b",
+    f: "\f",
+    n: "\n",
+    r: "\r",
+    t: "\t",
+    v: "\x0b",
+    "\\": "\\",
+    "\"": "\"",
+  };
+
+  for (let index = 1; index < filePath.length - 1; index += 1) {
+    const char = filePath[index];
+    if (char !== "\\") {
+      literal += char;
+      continue;
+    }
+
+    flushLiteral();
+    const escaped = filePath[index + 1];
+    if (/[0-7]/.test(escaped || "")) {
+      let octal = escaped;
+      while (octal.length < 3 && /[0-7]/.test(filePath[index + 1 + octal.length] || "")) {
+        octal += filePath[index + 1 + octal.length];
+      }
+      chunks.push(Buffer.from([Number.parseInt(octal, 8)]));
+      index += octal.length;
+      continue;
+    }
+
+    chunks.push(Buffer.from(escapes[escaped] ?? escaped ?? "\\", "utf-8"));
+    index += 1;
+  }
+
+  flushLiteral();
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function renameSeparatorIndex(filePath) {
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index <= filePath.length - 4; index += 1) {
+    const char = filePath[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quoted) {
+      escaped = true;
+      continue;
+    }
+    if (char === "\"") {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && filePath.slice(index, index + 4) === " -> ") return index;
+  }
+  return -1;
+}
+
+function statusPaths(line) {
+  const filePath = statusPath(line);
+  if (!filePath) return [];
+  if (!/[RC]/.test(line.slice(0, 2))) {
+    return [decodeQuotedStatusPath(filePath)];
+  }
+
+  const separatorIndex = renameSeparatorIndex(filePath);
+  if (separatorIndex === -1) return [decodeQuotedStatusPath(filePath)];
+  return [
+    decodeQuotedStatusPath(filePath.slice(0, separatorIndex)),
+    decodeQuotedStatusPath(filePath.slice(separatorIndex + 4)),
+  ];
 }
 
 function isRuntimeMetadataStatusLine(line) {
@@ -47,7 +137,33 @@ function classifyRepositoryDirt(statusText) {
 
 function formatRuntimeMetadataDirt(statusText) {
   const classified = classifyRepositoryDirt(statusText);
-  return classified.runtimeMetadataStatus || ".antigravitycli/";
+  return classified.runtimeMetadataStatus || `${RUNTIME_METADATA_ROOTS[0]}/`;
+}
+
+function reviewableStatusPaths(statusText) {
+  const classified = classifyRepositoryDirt(statusText);
+  return [...new Set(
+    splitStatusLines(classified.reviewableStatus).flatMap((line) => statusPaths(line))
+  )];
+}
+
+function formatEmptyReviewableIndexError(statusText) {
+  const paths = reviewableStatusPaths(statusText);
+  const detail = paths.length
+    ? paths.map((filePath) => JSON.stringify(filePath)).join(", ")
+    : JSON.stringify(classifyRepositoryDirt(statusText).reviewableStatus);
+  return (
+    "reviewable staging contradiction: classifyRepositoryDirt reported reviewable dirt, " +
+    "but gitAddReviewableArgs left the index empty; reviewable paths that failed to stage: " +
+    detail
+  );
+}
+
+function runtimeMetadataRootExclusions() {
+  return RUNTIME_METADATA_ROOTS.flatMap((root) => [
+    `:(exclude)${root}`,
+    `:(exclude)${root}/**`,
+  ]);
 }
 
 function gitAddReviewableArgs(statusText) {
@@ -55,17 +171,31 @@ function gitAddReviewableArgs(statusText) {
   if (!classified.hasRuntimeMetadataDirt) {
     return ["add", "-A"];
   }
-  return [
-    "add", "-A", "--", ".",
-    ":(exclude).antigravitycli",
-    ":(exclude).antigravitycli/**",
-  ];
+
+  /*
+   * Invariant: anything classifyRepositoryDirt reports reviewable is stageable
+   * by the argv returned here for the same status text.
+   *
+   * A reviewable-path allowlist preserves tracked changes beneath runtime roots
+   * while excluding untracked runtime metadata. It also deliberately excludes
+   * runtime files created after the status snapshot; enumerating only the
+   * runtime paths seen above would race with a still-running metadata writer.
+   * Both the allowlist and runtime classification derive from
+   * RUNTIME_METADATA_ROOTS through classifyRepositoryDirt.
+   */
+  const reviewablePaths = reviewableStatusPaths(statusText);
+  if (reviewablePaths.length > 0) {
+    return ["add", "-A", "--", ...reviewablePaths];
+  }
+  return ["add", "-A", "--", ".", ...runtimeMetadataRootExclusions()];
 }
 
 module.exports = {
   RUNTIME_METADATA_ROOTS,
   classifyRepositoryDirt,
+  formatEmptyReviewableIndexError,
   formatRuntimeMetadataDirt,
   gitAddReviewableArgs,
   isRuntimeMetadataStatusLine,
+  reviewableStatusPaths,
 };

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -838,10 +838,14 @@ childProcess.execFileSync = function patchedExecFileSync(command, args, options)
   const isPush = command === "git" && argv.includes("push");
   const isGh = command === "gh";
   const isRecoverCommit = command === process.execPath && String(argv[0] || "").endsWith("recover-commit.js");
+  const isGitAdd = command === "git" && argv[0] === "-C" && argv[2] === "add";
   if (process.env.RELAY_TEST_FAIL_RECOVER_COMMIT === "1" && isRecoverCommit) {
     const error = new Error("simulated recover-commit failure");
     error.stderr = Buffer.from("simulated recover-commit failure\\n");
     throw error;
+  }
+  if (process.env.RELAY_TEST_SKIP_GIT_ADD === "1" && isGitAdd) {
+    return "";
   }
   // Fail only the orchestrator-owned commit (message "Relay run <id>"), not
   // recover-commit's own commit (message "Recover relay run <id>"), so a test can
@@ -7266,6 +7270,36 @@ test("dispatch escalates delayed internal review when orchestrator commit and re
   assert.equal(manifest.git.pr_number, null);
   assert.deepEqual(readJsonLines(ghLogPath), []);
   assert.equal(Number(fs.readFileSync(pushPrCountPath, "utf-8")), 0);
+});
+
+test("dispatch names reviewable paths when staging leaves an empty index", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    codexMode: "uncommitted",
+  });
+
+  const proc = spawnSync("node", [SCRIPT, repoRoot, ...withRequiredRubric([
+    "-b", "issue-1082-empty-index-diagnosis",
+    "--prompt", "leave a tracked reviewable change uncommitted",
+    "--publish-policy", "after-internal-review",
+    "--json",
+  ])], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...env,
+      RELAY_TEST_SKIP_GIT_ADD: "1",
+    },
+  });
+
+  assert.notEqual(proc.status, 0);
+  const result = JSON.parse(proc.stdout);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.match(result.error, /reviewable staging contradiction/);
+  assert.match(result.error, /README\.md/);
+  assert.match(proc.stderr, /reviewable paths that failed to stage: "README\.md"/);
 });
 
 test("dispatch skips orchestrator commit and publish when the run is superseded mid-dispatch", () => {

--- a/tests/relay-dispatch/scripts/runtime-dirt.test.js
+++ b/tests/relay-dispatch/scripts/runtime-dirt.test.js
@@ -1,0 +1,152 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  RUNTIME_METADATA_ROOTS,
+  classifyRepositoryDirt,
+  gitAddReviewableArgs,
+  reviewableStatusPaths,
+} = require("../../../skills/relay-dispatch/scripts/runtime-dirt");
+const { execGit } = require("../../../skills/relay-dispatch/scripts/exec");
+
+const RUNTIME_DIR = RUNTIME_METADATA_ROOTS[0];
+const TRACKED_RUNTIME_PATH = `${RUNTIME_DIR}/tracked-config`;
+
+function git(repoPath, args) {
+  return execFileSync("git", args, {
+    cwd: repoPath,
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trimEnd();
+}
+
+function writeFile(repoPath, relativePath, contents) {
+  const absolutePath = path.join(repoPath, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf-8");
+}
+
+function createRepository(t) {
+  const repoPath = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-runtime-dirt-")));
+  t.after(() => fs.rmSync(repoPath, { recursive: true, force: true }));
+
+  git(repoPath, ["init", "-b", "main"]);
+  git(repoPath, ["config", "user.name", "Runtime Dirt Test"]);
+  git(repoPath, ["config", "user.email", "runtime-dirt@example.com"]);
+  writeFile(repoPath, TRACKED_RUNTIME_PATH, "base runtime config\n");
+  writeFile(repoPath, "README.md", "base readme\n");
+  git(repoPath, ["add", "-A"]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  return repoPath;
+}
+
+function stagedPaths(repoPath) {
+  const output = git(repoPath, ["diff", "--cached", "--name-only"]);
+  return output ? output.split("\n") : [];
+}
+
+test("stages a modified tracked runtime file while excluding untracked runtime metadata", (t) => {
+  const repoPath = createRepository(t);
+  writeFile(repoPath, TRACKED_RUNTIME_PATH, "modified runtime config\n");
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  const dirt = classifyRepositoryDirt(statusText);
+  assert.equal(dirt.hasReviewableDirt, true);
+  assert.match(dirt.reviewableStatus, new RegExp(TRACKED_RUNTIME_PATH.replace(".", "\\.")));
+  assert.match(dirt.runtimeMetadataStatus, /runtime-file/);
+
+  git(repoPath, gitAddReviewableArgs(statusText));
+
+  assert.deepEqual(stagedPaths(repoPath), [TRACKED_RUNTIME_PATH]);
+  assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("stages every path classified as reviewable in a mixed status", (t) => {
+  const repoPath = createRepository(t);
+  writeFile(repoPath, TRACKED_RUNTIME_PATH, "modified runtime config\n");
+  writeFile(repoPath, "README.md", "modified readme\n");
+  writeFile(repoPath, "new reviewable.txt", "new source\n");
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = git(repoPath, ["status", "--porcelain"]);
+  const dirt = classifyRepositoryDirt(statusText);
+  const classifiedReviewablePaths = reviewableStatusPaths(statusText);
+  assert.equal(dirt.reviewableStatus.split("\n").filter(Boolean).length, 3);
+
+  git(repoPath, gitAddReviewableArgs(statusText));
+
+  const staged = new Set(stagedPaths(repoPath));
+  assert.deepEqual(
+    [...staged].sort(),
+    [TRACKED_RUNTIME_PATH, "README.md", "new reviewable.txt"].sort(),
+  );
+  for (const reviewablePath of classifiedReviewablePaths) {
+    assert.equal(staged.has(reviewablePath), true, `${reviewablePath} must be stageable`);
+  }
+});
+
+test("excludes an untracked runtime file created after the status snapshot", (t) => {
+  const repoPath = createRepository(t);
+  writeFile(repoPath, TRACKED_RUNTIME_PATH, "modified runtime config\n");
+  writeFile(repoPath, "README.md", "modified readme\n");
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-seen`, "seen metadata\n");
+
+  const statusSnapshot = git(repoPath, ["status", "--porcelain"]);
+  const addArgs = gitAddReviewableArgs(statusSnapshot);
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-created-later`, "late metadata\n");
+
+  git(repoPath, addArgs);
+
+  assert.deepEqual(stagedPaths(repoPath).sort(), [TRACKED_RUNTIME_PATH, "README.md"].sort());
+  const remainingStatus = git(repoPath, ["status", "--porcelain"]);
+  assert.match(remainingStatus, /runtime-seen/);
+  assert.match(remainingStatus, /runtime-created-later/);
+});
+
+test("returns plain git add arguments when there is no runtime metadata dirt", () => {
+  const statusText = " M README.md\n?? new-reviewable.txt";
+  assert.deepEqual(gitAddReviewableArgs(statusText), ["add", "-A"]);
+});
+
+test("classifies runtime-only dirt without reporting reviewable dirt", () => {
+  const statusText = [
+    `?? ${RUNTIME_DIR}/runtime-file`,
+    `?? ${RUNTIME_DIR}/cache/`,
+  ].join("\n");
+
+  assert.deepEqual(classifyRepositoryDirt(statusText), {
+    hasDirt: true,
+    hasRuntimeMetadataDirt: true,
+    hasOnlyRuntimeMetadataDirt: true,
+    hasReviewableDirt: false,
+    runtimeMetadataStatus: statusText,
+    reviewableStatus: "",
+  });
+  assert.deepEqual(gitAddReviewableArgs(statusText), [
+    "add",
+    "-A",
+    "--",
+    ".",
+    `:(exclude)${RUNTIME_DIR}`,
+    `:(exclude)${RUNTIME_DIR}/**`,
+  ]);
+});
+
+test("keeps runtime metadata roots as the only source of the runtime root literal", () => {
+  assert.deepEqual(RUNTIME_METADATA_ROOTS, [".antigravitycli"]);
+  assert.equal(Object.isFrozen(RUNTIME_METADATA_ROOTS), true);
+
+  const sourcePath = path.join(
+    __dirname,
+    "../../../skills/relay-dispatch/scripts/runtime-dirt.js",
+  );
+  const source = fs.readFileSync(sourcePath, "utf-8");
+  assert.equal(source.match(/\.antigravitycli/g)?.length, 1);
+});

--- a/tests/relay-dispatch/scripts/runtime-dirt.test.js
+++ b/tests/relay-dispatch/scripts/runtime-dirt.test.js
@@ -150,3 +150,72 @@ test("keeps runtime metadata roots as the only source of the runtime root litera
   const source = fs.readFileSync(sourcePath, "utf-8");
   assert.equal(source.match(/\.antigravitycli/g)?.length, 1);
 });
+
+test("stages a staged rename with runtime dirt and preserves it as a rename", (t) => {
+  const repoPath = createRepository(t);
+  const destination = "RENAMED.md";
+  git(repoPath, ["mv", "README.md", destination]);
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  const addArgs = gitAddReviewableArgs(statusText);
+  assert.deepEqual(addArgs, ["add", "-A", "--", destination]);
+
+  git(repoPath, addArgs);
+
+  assert.equal(
+    git(repoPath, ["diff", "--cached", "--name-status"]),
+    `R100\tREADME.md\t${destination}`,
+  );
+  git(repoPath, ["commit", "-m", "staged rename"]);
+  assert.equal(
+    git(repoPath, ["show", "--format=", "--name-status", "HEAD"]),
+    `R100\tREADME.md\t${destination}`,
+  );
+  assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("stages an unstaged rename with runtime dirt", (t) => {
+  const repoPath = createRepository(t);
+  const destination = "RENAMED.md";
+  fs.renameSync(path.join(repoPath, "README.md"), path.join(repoPath, destination));
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  const addArgs = gitAddReviewableArgs(statusText);
+  assert.deepEqual(
+    new Set(addArgs.slice(3)),
+    new Set(["README.md", destination]),
+  );
+
+  git(repoPath, addArgs);
+
+  assert.equal(
+    git(repoPath, ["diff", "--cached", "--name-status"]),
+    `R100\tREADME.md\t${destination}`,
+  );
+  git(repoPath, ["commit", "-m", "unstaged rename"]);
+  assert.equal(
+    git(repoPath, ["show", "--format=", "--name-status", "HEAD"]),
+    `R100\tREADME.md\t${destination}`,
+  );
+  assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("stages a plain deletion with runtime dirt", (t) => {
+  const repoPath = createRepository(t);
+  fs.unlinkSync(path.join(repoPath, "README.md"));
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  const addArgs = gitAddReviewableArgs(statusText);
+  assert.deepEqual(addArgs, ["add", "-A", "--", "README.md"]);
+
+  git(repoPath, addArgs);
+
+  assert.equal(
+    git(repoPath, ["diff", "--cached", "--name-status"]),
+    "D\tREADME.md",
+  );
+  assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});

--- a/tests/relay-dispatch/scripts/runtime-dirt.test.js
+++ b/tests/relay-dispatch/scripts/runtime-dirt.test.js
@@ -41,6 +41,8 @@ function createRepository(t) {
   git(repoPath, ["config", "user.email", "runtime-dirt@example.com"]);
   writeFile(repoPath, TRACKED_RUNTIME_PATH, "base runtime config\n");
   writeFile(repoPath, "README.md", "base readme\n");
+  writeFile(repoPath, "a.txt", "a\n");
+  writeFile(repoPath, "keep.txt", "keep\n");
   git(repoPath, ["add", "-A"]);
   git(repoPath, ["commit", "-m", "initial"]);
   return repoPath;
@@ -62,7 +64,7 @@ test("stages a modified tracked runtime file while excluding untracked runtime m
   assert.match(dirt.reviewableStatus, new RegExp(TRACKED_RUNTIME_PATH.replace(".", "\\.")));
   assert.match(dirt.runtimeMetadataStatus, /runtime-file/);
 
-  git(repoPath, gitAddReviewableArgs(statusText));
+  git(repoPath, gitAddReviewableArgs(statusText, repoPath));
 
   assert.deepEqual(stagedPaths(repoPath), [TRACKED_RUNTIME_PATH]);
   assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
@@ -80,7 +82,7 @@ test("stages every path classified as reviewable in a mixed status", (t) => {
   const classifiedReviewablePaths = reviewableStatusPaths(statusText);
   assert.equal(dirt.reviewableStatus.split("\n").filter(Boolean).length, 3);
 
-  git(repoPath, gitAddReviewableArgs(statusText));
+  git(repoPath, gitAddReviewableArgs(statusText, repoPath));
 
   const staged = new Set(stagedPaths(repoPath));
   assert.deepEqual(
@@ -99,7 +101,7 @@ test("excludes an untracked runtime file created after the status snapshot", (t)
   writeFile(repoPath, `${RUNTIME_DIR}/runtime-seen`, "seen metadata\n");
 
   const statusSnapshot = git(repoPath, ["status", "--porcelain"]);
-  const addArgs = gitAddReviewableArgs(statusSnapshot);
+  const addArgs = gitAddReviewableArgs(statusSnapshot, repoPath);
   writeFile(repoPath, `${RUNTIME_DIR}/runtime-created-later`, "late metadata\n");
 
   git(repoPath, addArgs);
@@ -158,7 +160,7 @@ test("stages a staged rename with runtime dirt and preserves it as a rename", (t
   writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
 
   const statusText = execGit(repoPath, ["status", "--porcelain"]);
-  const addArgs = gitAddReviewableArgs(statusText);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
   assert.deepEqual(addArgs, ["add", "-A", "--", destination]);
 
   git(repoPath, addArgs);
@@ -182,7 +184,7 @@ test("stages an unstaged rename with runtime dirt", (t) => {
   writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
 
   const statusText = execGit(repoPath, ["status", "--porcelain"]);
-  const addArgs = gitAddReviewableArgs(statusText);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
   assert.deepEqual(
     new Set(addArgs.slice(3)),
     new Set(["README.md", destination]),
@@ -208,7 +210,7 @@ test("stages a plain deletion with runtime dirt", (t) => {
   writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
 
   const statusText = execGit(repoPath, ["status", "--porcelain"]);
-  const addArgs = gitAddReviewableArgs(statusText);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
   assert.deepEqual(addArgs, ["add", "-A", "--", "README.md"]);
 
   git(repoPath, addArgs);
@@ -218,4 +220,70 @@ test("stages a plain deletion with runtime dirt", (t) => {
     "D\tREADME.md",
   );
   assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("stages a modified sibling without naming an already staged deletion", (t) => {
+  const repoPath = createRepository(t);
+  git(repoPath, ["rm", "a.txt"]);
+  writeFile(repoPath, "keep.txt", "modified keep\n");
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  assert.match(statusText, /^D  a\.txt/m);
+  assert.match(statusText, /^ M keep\.txt/m);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
+  assert.deepEqual(addArgs, ["add", "-A", "--", "keep.txt"]);
+
+  git(repoPath, addArgs);
+
+  assert.deepEqual(
+    git(repoPath, ["diff", "--cached", "--name-status"]).split("\n"),
+    ["D\ta.txt", "M\tkeep.txt"],
+  );
+  assert.equal(stagedPaths(repoPath).includes("keep.txt"), true);
+  assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("stages a staged rename alongside an already staged deletion", (t) => {
+  const repoPath = createRepository(t);
+  const destination = "RENAMED.md";
+  git(repoPath, ["mv", "README.md", destination]);
+  git(repoPath, ["rm", "a.txt"]);
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  assert.match(statusText, /^D  a\.txt/m);
+  assert.match(statusText, /^R  README\.md -> RENAMED\.md/m);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
+  assert.deepEqual(addArgs, ["add", "-A", "--", destination]);
+
+  git(repoPath, addArgs);
+
+  assert.deepEqual(
+    git(repoPath, ["diff", "--cached", "--name-status"]).split("\n"),
+    ["R100\tREADME.md\tRENAMED.md", "D\ta.txt"],
+  );
+  assert.match(git(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("emits an AD path that is absent from disk so git add records the deletion", (t) => {
+  const repoPath = createRepository(t);
+  const addedThenDeleted = "added-then-deleted.txt";
+  writeFile(repoPath, addedThenDeleted, "temporary\n");
+  git(repoPath, ["add", "--", addedThenDeleted]);
+  fs.unlinkSync(path.join(repoPath, addedThenDeleted));
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  assert.match(statusText, /^AD added-then-deleted\.txt/m);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
+  assert.deepEqual(addArgs, ["add", "-A", "--", addedThenDeleted]);
+
+  git(repoPath, addArgs);
+
+  assert.deepEqual(stagedPaths(repoPath), []);
+  assert.equal(
+    git(repoPath, ["status", "--porcelain"]),
+    `?? ${RUNTIME_DIR}/runtime-file`,
+  );
 });

--- a/tests/relay-dispatch/scripts/runtime-dirt.test.js
+++ b/tests/relay-dispatch/scripts/runtime-dirt.test.js
@@ -161,7 +161,7 @@ test("stages a staged rename with runtime dirt and preserves it as a rename", (t
 
   const statusText = execGit(repoPath, ["status", "--porcelain"]);
   const addArgs = gitAddReviewableArgs(statusText, repoPath);
-  assert.deepEqual(addArgs, ["add", "-A", "--", destination]);
+  assert.deepEqual(addArgs, ["add", "-A", "--", `:(literal)${destination}`]);
 
   git(repoPath, addArgs);
 
@@ -187,7 +187,7 @@ test("stages an unstaged rename with runtime dirt", (t) => {
   const addArgs = gitAddReviewableArgs(statusText, repoPath);
   assert.deepEqual(
     new Set(addArgs.slice(3)),
-    new Set(["README.md", destination]),
+    new Set([":(literal)README.md", `:(literal)${destination}`]),
   );
 
   git(repoPath, addArgs);
@@ -211,7 +211,7 @@ test("stages a plain deletion with runtime dirt", (t) => {
 
   const statusText = execGit(repoPath, ["status", "--porcelain"]);
   const addArgs = gitAddReviewableArgs(statusText, repoPath);
-  assert.deepEqual(addArgs, ["add", "-A", "--", "README.md"]);
+  assert.deepEqual(addArgs, ["add", "-A", "--", ":(literal)README.md"]);
 
   git(repoPath, addArgs);
 
@@ -232,7 +232,7 @@ test("stages a modified sibling without naming an already staged deletion", (t) 
   assert.match(statusText, /^D  a\.txt/m);
   assert.match(statusText, /^ M keep\.txt/m);
   const addArgs = gitAddReviewableArgs(statusText, repoPath);
-  assert.deepEqual(addArgs, ["add", "-A", "--", "keep.txt"]);
+  assert.deepEqual(addArgs, ["add", "-A", "--", ":(literal)keep.txt"]);
 
   git(repoPath, addArgs);
 
@@ -255,7 +255,7 @@ test("stages a staged rename alongside an already staged deletion", (t) => {
   assert.match(statusText, /^D  a\.txt/m);
   assert.match(statusText, /^R  README\.md -> RENAMED\.md/m);
   const addArgs = gitAddReviewableArgs(statusText, repoPath);
-  assert.deepEqual(addArgs, ["add", "-A", "--", destination]);
+  assert.deepEqual(addArgs, ["add", "-A", "--", `:(literal)${destination}`]);
 
   git(repoPath, addArgs);
 
@@ -277,7 +277,7 @@ test("emits an AD path that is absent from disk so git add records the deletion"
   const statusText = execGit(repoPath, ["status", "--porcelain"]);
   assert.match(statusText, /^AD added-then-deleted\.txt/m);
   const addArgs = gitAddReviewableArgs(statusText, repoPath);
-  assert.deepEqual(addArgs, ["add", "-A", "--", addedThenDeleted]);
+  assert.deepEqual(addArgs, ["add", "-A", "--", `:(literal)${addedThenDeleted}`]);
 
   git(repoPath, addArgs);
 
@@ -286,4 +286,75 @@ test("emits an AD path that is absent from disk so git add records the deletion"
     git(repoPath, ["status", "--porcelain"]),
     `?? ${RUNTIME_DIR}/runtime-file`,
   );
+});
+
+test("excludes quoted non-ASCII runtime metadata while staging a reviewable sibling", (t) => {
+  const repoPath = createRepository(t);
+  const nonAsciiRuntimePath = `${RUNTIME_DIR}/한글.txt`;
+  writeFile(repoPath, `${RUNTIME_DIR}/ascii-runtime`, "ascii metadata\n");
+  writeFile(repoPath, nonAsciiRuntimePath, "non-ascii metadata\n");
+  writeFile(repoPath, "keep.txt", "modified keep\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  assert.match(statusText, new RegExp(`^\\?\\? ${RUNTIME_DIR}/ascii-runtime$`, "m"));
+  assert.match(statusText, new RegExp(`^\\?\\? "${RUNTIME_DIR.replace(".", "\\.")}/\\\\[0-7]`, "m"));
+
+  const dirt = classifyRepositoryDirt(statusText);
+  assert.equal(dirt.hasRuntimeMetadataDirt, true);
+  assert.equal(dirt.hasReviewableDirt, true);
+  assert.match(dirt.runtimeMetadataStatus, /ascii-runtime/);
+  assert.match(dirt.runtimeMetadataStatus, /\\[0-7]{3}/);
+  assert.equal(dirt.reviewableStatus, "M keep.txt");
+
+  git(repoPath, gitAddReviewableArgs(statusText, repoPath));
+
+  assert.deepEqual(stagedPaths(repoPath), ["keep.txt"]);
+  const remainingStatus = execGit(repoPath, ["status", "--porcelain"]);
+  assert.match(remainingStatus, /ascii-runtime/);
+  assert.match(remainingStatus, /\\[0-7]{3}/);
+});
+
+test("stages a quoted non-ASCII reviewable filename", (t) => {
+  const repoPath = createRepository(t);
+  const reviewablePath = "검토.txt";
+  writeFile(repoPath, reviewablePath, "reviewable\n");
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  assert.match(statusText, /^\?\? "/m);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
+  assert.deepEqual(addArgs, ["add", "-A", "--", `:(literal)${reviewablePath}`]);
+
+  git(repoPath, addArgs);
+
+  assert.equal(
+    git(repoPath, ["-c", "core.quotePath=false", "diff", "--cached", "--name-only"]),
+    reviewablePath,
+  );
+  assert.match(execGit(repoPath, ["status", "--porcelain"]), /runtime-file/);
+});
+
+test("stages every reviewable filename as a literal pathspec", (t) => {
+  const repoPath = createRepository(t);
+  const magicPaths = [":foo", "star*file", "!bang"];
+  for (const filePath of magicPaths) {
+    writeFile(repoPath, filePath, `${filePath}\n`);
+  }
+  writeFile(repoPath, "keep.txt", "modified keep\n");
+  writeFile(repoPath, `${RUNTIME_DIR}/runtime-file`, "runtime metadata\n");
+
+  const statusText = execGit(repoPath, ["status", "--porcelain"]);
+  const addArgs = gitAddReviewableArgs(statusText, repoPath);
+  assert.deepEqual(
+    new Set(addArgs.slice(3)),
+    new Set([...magicPaths, "keep.txt"].map((filePath) => `:(literal)${filePath}`)),
+  );
+
+  git(repoPath, addArgs);
+
+  assert.deepEqual(
+    stagedPaths(repoPath).sort(),
+    [...magicPaths, "keep.txt"].sort(),
+  );
+  assert.match(execGit(repoPath, ["status", "--porcelain"]), /runtime-file/);
 });


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋 완료했습니다.

- tracked runtime-root 변경은 stage되고, untracked runtime metadata는 status 이후 생성된 파일까지 제외됩니다.
- `RUNTIME_METADATA_ROOTS`를 단일 소스로 사용합니다.
- reviewable dirt인데 index가 비면 누락 경로를 포함한 오류를 출력합니다.
- 실 Git 저장소 기반 전용 테스트 6개와 빈-index 통합 테스트를 추가했습니다.
- 커밋: `7f95a3e fix(dispatch): stage tracked runtime-root changes`
- 작업트리 깨끗함, PR 생성/수정 없음.

검증:

- 전용 runtime-dirt: `# tests 6`, `# fail 0`
- recover-commit: `# tests 44`, `# fail 0`
- 최종 9-suite 직렬 게이트: `# tests 2482`, `# fail 9`

실패 9개는 모두 예고된 mac
```

## Dispatch Metadata

- Run: issue-1082-20260728064743930-e824e846
- Executor: codex
- Branch: issue-1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 리뷰 가능 변경이 존재하지만 스테이징 인덱스가 비어 모순된 경우 커밋을 중단하고, 문제가 된 파일 경로가 포함된 오류를 표시하도록 개선했습니다.
  * 리뷰 가능 경로를 더 엄격히 판별·스테이징하여 런타임 메타데이터와 리뷰 대상 파일이 섞여 커밋되는 문제를 줄였습니다.
* **품질 개선**
  * Git 상태 출력 변형(따옴표/리네임 등)에도 경로 처리가 더 견고해졌습니다.
  * 런타임 메타데이터 제외 규칙과 staging 대상 계산을 보강했습니다.
  * 관련 시나리오를 실제 Git 기반 테스트로 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->