### PR TITLE
fix: resolve three R5 verification-evidence gaps (#1116)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -3229,6 +3229,7 @@ async function main() {
   // the prior behavior: the downstream recover-commit path is itself
   // supersede-guarded and correctly no-ops.
   let orchestratorCommitted = false;
+  let verificationTreeMismatch = null;
   const supersededBeforeCommit = readManifest(manifestPath).data.state !== STATES.DISPATCHED;
   if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted" && !supersededBeforeCommit) {
     try {
@@ -3236,19 +3237,39 @@ async function main() {
       if (dirt.hasReviewableDirt && !execGit(wtPath, ["diff", "--cached", "--name-only"])) {
         throw new Error(formatEmptyReviewableIndexError(rawUncommitted));
       }
+      // Verification gates ran against the executor's completed working tree.
+      // Staging snapshots that tree into the index; a hook must not change the
+      // commit tree before the executor-confirmed results are SHA-bound below.
+      const verifiedTree = verificationGates.length > 0
+        ? execGit(wtPath, ["write-tree"])
+        : null;
       execGit(wtPath, [
         "commit",
         "-m", `Relay run ${runId}`,
         "-m", `Executor reviewable changes committed by the relay orchestrator (run ${runId}).`,
       ]);
       currentHead = execGit(wtPath, ["rev-parse", "HEAD"]);
+      const committedTree = execGit(wtPath, ["rev-parse", "HEAD^{tree}"]);
+      if (verifiedTree && verifiedTree !== committedTree) {
+        verificationTreeMismatch = { verifiedTree, committedTree };
+      }
       if (startHead && currentHead !== startHead) {
         gitLog = execGit(wtPath, ["log", "--oneline", `${startHead}..HEAD`]);
       }
       uncommitted = classifyRepositoryDirt(execGit(wtPath, ["status", "--porcelain"])).reviewableStatus;
       if (!uncommitted) uncommittedDiff = "";
-      status = "completed";
       orchestratorCommitted = true;
+      if (verificationTreeMismatch) {
+        status = "failed";
+        exitCode = exitCode || 1;
+        error = (
+          "verification_tree_mismatch: the orchestrator commit changed the tree after executor " +
+          `verification (${verificationTreeMismatch.verifiedTree} -> ` +
+          `${verificationTreeMismatch.committedTree}); re-run the executor verification gates at the committed HEAD`
+        );
+      } else {
+        status = "completed";
+      }
     } catch (orchestratorCommitError) {
       // Leave status as completed-uncommitted; the auto-recover-commit fallback runs
       // below. Surface the git failure reason — this is now the primary commit path,

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -10,6 +10,79 @@ const VERIFICATION_REQUEST_END = "RELAY_VERIFICATION_REQUEST_END";
 const VERIFICATION_RESULT_BEGIN = "RELAY_VERIFICATION_RESULT_BEGIN";
 const VERIFICATION_RESULT_END = "RELAY_VERIFICATION_RESULT_END";
 const MAX_VERIFICATION_OUTPUT_BYTES = 1024 * 1024;
+const SHA40_PATTERN = /^[0-9a-f]{40}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+const VERIFICATION_HASH_FIELDS = ["output_hash", "stdout_hash", "stderr_hash"];
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function verificationRunsMalformation(verificationRuns) {
+  if (!Array.isArray(verificationRuns)) {
+    const valueType = verificationRuns === null ? "null" : typeof verificationRuns;
+    return `verification_runs must be an array when present; found ${valueType}`;
+  }
+  if (verificationRuns.length === 0) {
+    return "verification_runs must not be empty when present";
+  }
+
+  for (let index = 0; index < verificationRuns.length; index += 1) {
+    const run = verificationRuns[index];
+    if (!run || typeof run !== "object" || Array.isArray(run)) {
+      return `verification_runs[${index}] must be a JSON object`;
+    }
+    if (!isNonEmptyString(run.command)) {
+      return `verification_runs[${index}].command must be a non-empty string`;
+    }
+    if (!isNonEmptyString(run.cwd)) {
+      return `verification_runs[${index}].cwd must be a non-empty string`;
+    }
+    if (!isNonEmptyString(run.head_sha) || !SHA40_PATTERN.test(run.head_sha)) {
+      return `verification_runs[${index}].head_sha must be a 40-character hex SHA`;
+    }
+    if (!Number.isInteger(run.exit_code) || run.exit_code < 0) {
+      return `verification_runs[${index}].exit_code must be a non-negative integer`;
+    }
+    if (!isNonEmptyString(run.recorded_by)) {
+      return `verification_runs[${index}].recorded_by must be a non-empty string`;
+    }
+    if (!isNonEmptyString(run.recorded_at) || Number.isNaN(Date.parse(run.recorded_at))) {
+      return `verification_runs[${index}].recorded_at must be a valid ISO timestamp`;
+    }
+    for (const fieldName of VERIFICATION_HASH_FIELDS) {
+      const value = run[fieldName];
+      if (value !== undefined && (!isNonEmptyString(value) || !SHA256_PATTERN.test(value))) {
+        return `verification_runs[${index}].${fieldName} must be a sha256 hex digest when present`;
+      }
+    }
+    if (run.output_path !== undefined && !isNonEmptyString(run.output_path)) {
+      return `verification_runs[${index}].output_path must be a non-empty string when present`;
+    }
+    if (!VERIFICATION_HASH_FIELDS.some((fieldName) => isNonEmptyString(run[fieldName]))) {
+      return (
+        `verification_runs[${index}] requires at least one of ` +
+        VERIFICATION_HASH_FIELDS.join(", ")
+      );
+    }
+  }
+
+  return null;
+}
+
+function verificationRunsValueType(verificationRuns) {
+  if (verificationRuns === null) return "null";
+  if (Array.isArray(verificationRuns)) return "array";
+  return typeof verificationRuns;
+}
+
+function verificationRunHeadShas(verificationRuns) {
+  if (!Array.isArray(verificationRuns)) return [];
+  return [...new Set(verificationRuns
+    .filter((run) => run && typeof run === "object" && !Array.isArray(run))
+    .map((run) => run.head_sha)
+    .filter(isNonEmptyString))];
+}
 
 function yamlKeyMatch(line) {
   return String(line || "").match(/^(\s*)(?:-\s*)?([A-Za-z_][\w.-]*):\s*(.*?)\s*$/);
@@ -360,35 +433,62 @@ function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebr
   }
 
   const previousSha = existing.head_sha;
-  const previousVerificationRuns = Array.isArray(existing.verification_runs)
-    ? existing.verification_runs
+  const verificationRunsPresent = Object.prototype.hasOwnProperty.call(existing, "verification_runs");
+  const previousVerificationRuns = existing.verification_runs;
+  const verificationRunsMalformed = verificationRunsPresent
+    ? verificationRunsMalformation(previousVerificationRuns)
     : null;
   const {
     verification_runs: _staleVerificationRuns,
     ...rebrandedEvidence
   } = existing;
-  const verificationRunsAudit = previousVerificationRuns
+  const verificationRunsAudit = !verificationRunsPresent
+    ? {}
+    : verificationRunsMalformed
       ? {
           verification_runs: {
-            policy: "removed_stale_after_rebrand",
-            removed_count: previousVerificationRuns.length,
-            previous_head_shas: [...new Set(previousVerificationRuns.map((run) => run.head_sha))],
-            removed_runs: previousVerificationRuns,
+            policy: "removed_malformed_after_rebrand",
+            removed_value_type: verificationRunsValueType(previousVerificationRuns),
+            malformation_reason: verificationRunsMalformed,
+            removed_value: previousVerificationRuns,
+            previous_head_shas: verificationRunHeadShas(previousVerificationRuns),
             next_action: "re-verify at the new HEAD or record audited operator evidence",
           },
         }
-      : {};
+      : {
+          verification_runs: {
+            policy: "removed_stale_after_rebrand",
+            removed_count: previousVerificationRuns.length,
+            previous_head_shas: verificationRunHeadShas(previousVerificationRuns),
+            removed_runs: previousVerificationRuns,
+            next_action: "re-verify at the new HEAD or record audited operator evidence",
+          },
+        };
+  const previousRebrandHistory = Array.isArray(existing.rebrand_history)
+    ? existing.rebrand_history
+    : [];
+  const previousRebrand = existing.rebrand
+    && typeof existing.rebrand === "object"
+    && !Array.isArray(existing.rebrand)
+    ? existing.rebrand
+    : null;
+  const rebrandHistory = previousRebrand
+    ? [...previousRebrandHistory, previousRebrand]
+    : previousRebrandHistory;
+  const rebrand = {
+    previous_head_sha: previousSha,
+    new_head_sha: newHeadSha,
+    previous_recorded_by: existing.recorded_by,
+    reason,
+    recorded_at: new Date().toISOString(),
+    ...verificationRunsAudit,
+  };
   writeExecutionEvidence(runDir, {
     ...rebrandedEvidence,
     head_sha: newHeadSha,
     recorded_by: recordedBy,
-    rebrand: {
-      previous_head_sha: previousSha,
-      previous_recorded_by: existing.recorded_by,
-      reason,
-      recorded_at: new Date().toISOString(),
-      ...verificationRunsAudit,
-    },
+    ...(rebrandHistory.length ? { rebrand_history: rebrandHistory } : {}),
+    rebrand,
   });
 
   return {
@@ -397,10 +497,17 @@ function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebr
     newHeadSha,
     evidencePath,
     evidenceHash: hashFileSha256(evidencePath),
-    ...(previousVerificationRuns
+    ...(verificationRunsPresent
       ? {
-          verificationRunsPolicy: "removed_stale_after_rebrand",
-          removedVerificationRuns: previousVerificationRuns.length,
+          verificationRunsPolicy: verificationRunsMalformed
+            ? "removed_malformed_after_rebrand"
+            : "removed_stale_after_rebrand",
+          ...(Array.isArray(previousVerificationRuns)
+            ? { removedVerificationRuns: previousVerificationRuns.length }
+            : {}),
+          ...(verificationRunsMalformed
+            ? { verificationRunsMalformation: verificationRunsMalformed }
+            : {}),
         }
       : {}),
   };

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -360,8 +360,26 @@ function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebr
   }
 
   const previousSha = existing.head_sha;
+  const previousVerificationRuns = Array.isArray(existing.verification_runs)
+    ? existing.verification_runs
+    : null;
+  const {
+    verification_runs: _staleVerificationRuns,
+    ...rebrandedEvidence
+  } = existing;
+  const verificationRunsAudit = previousVerificationRuns
+      ? {
+          verification_runs: {
+            policy: "removed_stale_after_rebrand",
+            removed_count: previousVerificationRuns.length,
+            previous_head_shas: [...new Set(previousVerificationRuns.map((run) => run.head_sha))],
+            removed_runs: previousVerificationRuns,
+            next_action: "re-verify at the new HEAD or record audited operator evidence",
+          },
+        }
+      : {};
   writeExecutionEvidence(runDir, {
-    ...existing,
+    ...rebrandedEvidence,
     head_sha: newHeadSha,
     recorded_by: recordedBy,
     rebrand: {
@@ -369,6 +387,7 @@ function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebr
       previous_recorded_by: existing.recorded_by,
       reason,
       recorded_at: new Date().toISOString(),
+      ...verificationRunsAudit,
     },
   });
 
@@ -378,6 +397,12 @@ function rebrandEvidence(runDir, { newHeadSha, recordedBy = "recover-commit-rebr
     newHeadSha,
     evidencePath,
     evidenceHash: hashFileSha256(evidencePath),
+    ...(previousVerificationRuns
+      ? {
+          verificationRunsPolicy: "removed_stale_after_rebrand",
+          removedVerificationRuns: previousVerificationRuns.length,
+        }
+      : {}),
   };
 }
 

--- a/skills/relay-merge/scripts/review-gate.js
+++ b/skills/relay-merge/scripts/review-gate.js
@@ -578,6 +578,7 @@ function buildReviewAssuranceGateFailure({ prNumber, manifestData, runDir }) {
     runDir,
     reviewedHead,
     strict: true,
+    manifestData,
   });
   if (executionStatus.status !== "pass") {
     return {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -207,7 +207,12 @@ async function run() {
   if (rubricLoad.state === "loaded") {
     validateReviewerScoresForArtifact(rubricLoad, verdict.rubric_scores);
   }
-  const executionStatus = computeQualityExecutionStatus({ runDir, reviewedHead: reviewedHeadSha, strict: hardenedAssurance });
+  const executionStatus = computeQualityExecutionStatus({
+    runDir,
+    reviewedHead: reviewedHeadSha,
+    strict: hardenedAssurance,
+    manifestData: data,
+  });
   verdict = applyQualityExecutionStatus(verdict, executionStatus);
   const gateSettlement = await settleAdvisoryGatesForRound({
     advisoryConfig,

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -4,6 +4,9 @@ const {
   extractVerificationGates,
   hashFileSha256,
 } = require("../../../relay-dispatch/scripts/execution-evidence");
+const {
+  getRubricAnchorStatus,
+} = require("../../../relay-dispatch/scripts/manifest/rubric");
 
 const EXECUTION_EVIDENCE_FILENAME = "execution-evidence.json";
 const REQUIRED_EXECUTION_EVIDENCE_FIELDS = [
@@ -32,13 +35,36 @@ function buildMissingExecutionEvidenceReason() {
   return `execution-evidence.json missing; if this is a pre-261 run, use ${FORCE_FINALIZE_GUIDANCE}`;
 }
 
-function strictMissingTestCommandReason(runDir) {
+function resolveVerificationRubricContent(runDir, manifestData) {
+  const rubricPath = typeof manifestData?.anchor?.rubric_path === "string"
+    ? manifestData.anchor.rubric_path.trim()
+    : "";
+  if (!rubricPath) {
+    const fallbackPath = path.join(runDir, "rubric.yaml");
+    return fs.existsSync(fallbackPath)
+      ? fs.readFileSync(fallbackPath, "utf-8")
+      : null;
+  }
+
+  const rubricAnchor = getRubricAnchorStatus(manifestData, {
+    runDir,
+    includeContent: true,
+  });
+  if (!rubricAnchor.satisfied) {
+    throw new Error(
+      `rubric anchor ${rubricAnchor.status}: ${rubricAnchor.error || "anchor validation failed"}`
+    );
+  }
+  return rubricAnchor.content;
+}
+
+function strictMissingTestCommandReason(runDir, manifestData) {
   try {
-    const rubricPath = path.join(runDir, "rubric.yaml");
-    if (!fs.existsSync(rubricPath)) {
+    const rubricContent = resolveVerificationRubricContent(runDir, manifestData);
+    if (rubricContent === null) {
       return "strict execution evidence requires a non-empty test_command";
     }
-    const gates = extractVerificationGates(fs.readFileSync(rubricPath, "utf-8"));
+    const gates = extractVerificationGates(rubricContent);
     if (!gates.length) {
       return "strict execution evidence requires a non-empty test_command";
     }
@@ -52,16 +78,28 @@ function strictMissingTestCommandReason(runDir) {
   }
 }
 
-function expectedVerificationGates(runDir) {
-  const rubricPath = path.join(runDir, "rubric.yaml");
-  if (!fs.existsSync(rubricPath)) return [];
-  return extractVerificationGates(fs.readFileSync(rubricPath, "utf-8"));
+function expectedVerificationGates(runDir, manifestData) {
+  const rubricContent = resolveVerificationRubricContent(runDir, manifestData);
+  return rubricContent === null ? [] : extractVerificationGates(rubricContent);
 }
 
 function missingVerificationGateReason(gates) {
   return (
     `strict execution evidence verification ${gates.length === 1 ? "gate" : "gates"} ` +
     `went unrecorded: ${gates.map((gate) => `'${gate.name}'`).join(", ")}`
+  );
+}
+
+function rebrandVerificationGateReason(artifact, gates) {
+  const audit = artifact.rebrand?.verification_runs;
+  if (audit?.policy !== "removed_stale_after_rebrand") return null;
+  return (
+    `strict execution evidence rebrand removed ${audit.removed_count} stale ` +
+    `${audit.removed_count === 1 ? "verification_run" : "verification_runs"} after HEAD changed ` +
+    `from ${artifact.rebrand.previous_head_sha} to ${artifact.head_sha}; ` +
+    "re-verify at the new HEAD or record audited operator evidence. " +
+    `Required verification ${gates.length === 1 ? "gate" : "gates"}: ` +
+    gates.map((gate) => `'${gate.name}'`).join(", ")
   );
 }
 
@@ -356,7 +394,7 @@ function readExecutionEvidenceArtifact(runDir) {
   }
 }
 
-function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false }) {
+function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false, manifestData = null }) {
   const artifactLoad = readExecutionEvidenceArtifact(runDir);
   if (artifactLoad.state === "missing") {
     return {
@@ -385,7 +423,7 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false })
   if (strict) {
     let verificationGates;
     try {
-      verificationGates = expectedVerificationGates(runDir);
+      verificationGates = expectedVerificationGates(runDir, manifestData);
     } catch (error) {
       return {
         status: "fail",
@@ -396,7 +434,8 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false })
       if (artifactLoad.artifact.verification_runs === undefined) {
         return {
           status: "fail",
-          reason: missingVerificationGateReason(verificationGates),
+          reason: rebrandVerificationGateReason(artifactLoad.artifact, verificationGates)
+            || missingVerificationGateReason(verificationGates),
         };
       }
       const missingGates = findMissingVerificationGates(
@@ -433,7 +472,7 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false })
     if (!isNonEmptyString(artifactLoad.artifact.test_command) || artifactLoad.artifact.test_command === "unspecified") {
       return {
         status: "fail",
-        reason: strictMissingTestCommandReason(runDir),
+        reason: strictMissingTestCommandReason(runDir, manifestData),
       };
     }
     if (artifactLoad.artifact.test_result_hash === "unspecified") {
@@ -461,9 +500,14 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false })
   };
 }
 
-function buildExecutionEvidencePreflight({ runDir, reviewedHead, strict = false }) {
+function buildExecutionEvidencePreflight({ runDir, reviewedHead, strict = false, manifestData = null }) {
   const artifactLoad = readExecutionEvidenceArtifact(runDir);
-  const executionStatus = computeQualityExecutionStatus({ runDir, reviewedHead, strict });
+  const executionStatus = computeQualityExecutionStatus({
+    runDir,
+    reviewedHead,
+    strict,
+    manifestData,
+  });
   const status = executionStatus.status === "pass" ? "pass" : "blocked";
   return {
     status,

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -91,15 +91,42 @@ function missingVerificationGateReason(gates) {
 }
 
 function rebrandVerificationGateReason(artifact, gates) {
-  const audit = artifact.rebrand?.verification_runs;
-  if (audit?.policy !== "removed_stale_after_rebrand") return null;
+  const rebrands = [
+    artifact.rebrand,
+    ...(Array.isArray(artifact.rebrand_history)
+      ? [...artifact.rebrand_history].reverse()
+      : []),
+  ].filter(isObject);
+  const rebrand = rebrands.find((entry) => (
+    entry.verification_runs?.policy === "removed_stale_after_rebrand"
+    || entry.verification_runs?.policy === "removed_malformed_after_rebrand"
+  ));
+  if (!rebrand) return null;
+
+  const audit = rebrand.verification_runs;
+  const rebrandHead = rebrand.new_head_sha || artifact.head_sha;
+  const laterRebrand = rebrandHead !== artifact.head_sha
+    ? `; evidence is now at ${artifact.head_sha}`
+    : "";
+  const requiredGates = (
+    `Required verification ${gates.length === 1 ? "gate" : "gates"}: ` +
+    gates.map((gate) => `'${gate.name}'`).join(", ")
+  );
+  if (audit.policy === "removed_malformed_after_rebrand") {
+    return (
+      "strict execution evidence rebrand removed malformed verification_runs after HEAD changed " +
+      `from ${rebrand.previous_head_sha} to ${rebrandHead}${laterRebrand}; ` +
+      `${audit.malformation_reason}. ` +
+      "Re-verify at the new HEAD or record audited operator evidence. " +
+      requiredGates
+    );
+  }
   return (
     `strict execution evidence rebrand removed ${audit.removed_count} stale ` +
     `${audit.removed_count === 1 ? "verification_run" : "verification_runs"} after HEAD changed ` +
-    `from ${artifact.rebrand.previous_head_sha} to ${artifact.head_sha}; ` +
+    `from ${rebrand.previous_head_sha} to ${rebrandHead}${laterRebrand}; ` +
     "re-verify at the new HEAD or record audited operator evidence. " +
-    `Required verification ${gates.length === 1 ? "gate" : "gates"}: ` +
-    gates.map((gate) => `'${gate.name}'`).join(", ")
+    requiredGates
   );
 }
 

--- a/skills/relay-review/scripts/review-runner/preflight.js
+++ b/skills/relay-review/scripts/review-runner/preflight.js
@@ -106,6 +106,7 @@ function maybeBlockForExecutionEvidencePreflight({
     runDir,
     reviewedHead: reviewedHeadSha,
     strict,
+    manifestData: data,
   });
   if (reviewFile || result.executionEvidencePreflight.status === "pass") {
     return false;

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -26,6 +26,9 @@ const {
   VERIFICATION_OUTPUT_FILENAME,
   hashFileSha256,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
+const {
+  buildExecutionEvidencePreflight,
+} = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 const { parseModelHints } = require("../../../skills/relay-dispatch/scripts/model-hints");
 const {
   extractRubricSize,
@@ -545,6 +548,7 @@ function writeUncommittedCodex(binDir) {
   fs.writeFileSync(codexPath, `#!/usr/bin/env node
 const fs = require("fs");
 const args = process.argv.slice(2);
+${fakeExecutorVerificationSupportSource()}
 if (args[0] === "--version") {
   process.stdout.write("codex-fake\\n");
   process.exit(0);
@@ -564,7 +568,7 @@ if (process.env.RELAY_TEST_EXTERNAL_ADVANCE === "1") {
   fs.writeFileSync(manifestPath, manifest, "utf-8");
 }
 fs.appendFileSync(cwd + "/README.md", "dirty\\n", "utf-8");
-fs.writeFileSync(output, "work completed without commit\\n", "utf-8");
+fs.writeFileSync(output, withVerificationEvidence("work completed without commit\\n"), "utf-8");
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
@@ -7097,6 +7101,66 @@ test("dispatch orchestrator-commits uncommitted codex runs by default", () => {
     result.headSha,
     "execution evidence binds to the orchestrator commit SHA, not the pre-commit HEAD",
   );
+});
+
+test("dispatch fails closed when a commit hook changes the tree after executor verification", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    codexMode: "uncommitted",
+  });
+  const hookPath = path.join(repoRoot, ".git", "hooks", "pre-commit");
+  fs.writeFileSync(hookPath, [
+    "#!/bin/sh",
+    "printf 'mutated by pre-commit hook\\n' >> README.md",
+    "git add README.md",
+    "",
+  ].join("\n"), "utf-8");
+  fs.chmodSync(hookPath, 0o755);
+  const rubricFile = writeAssuranceRubric("hardened");
+
+  const dispatched = spawnSync(process.execPath, [
+    SCRIPT,
+    repoRoot,
+    "-b", "issue-1116-tree-mutating-hook",
+    "--prompt", "verify uncommitted work before orchestrator commit",
+    "--rubric-file", rubricFile,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+  const result = JSON.parse(dispatched.stdout);
+  const evidence = readExecutionEvidence(result.runDir);
+  const manifestData = readManifest(result.manifestPath).data;
+  const preflight = buildExecutionEvidencePreflight({
+    runDir: result.runDir,
+    reviewedHead: result.headSha,
+    strict: true,
+    manifestData,
+  });
+
+  assert.equal(dispatched.status, 1, dispatched.stderr);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.equal(result.commitMode, "orchestrator-committed");
+  assert.match(result.error, /verification_tree_mismatch/);
+  assert.match(result.error, /re-run the executor verification gates at the committed HEAD/);
+  assert.equal(evidence.head_sha, result.headSha);
+  assert.equal(evidence.verification_runs, undefined);
+  assert.equal(evidence.test_exit_code, 1);
+  assert.match(
+    execFileSync("git", ["show", `${result.headSha}:README.md`], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }),
+    /mutated by pre-commit hook/
+  );
+  assert.equal(preflight.status, "blocked");
+  assert.equal(preflight.qualityExecutionStatus, "fail");
+  assert.match(preflight.reason, /verification gate went unrecorded: 'focused test'/);
 });
 
 test("dispatch Claude resume orchestrator-commits completed-uncommitted work by default", () => {

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -387,6 +387,139 @@ test("rebrandEvidence removes stale verification_runs and strict preflight names
   assert.match(preflight.reason, /re-verify at the new HEAD or record audited operator evidence/);
 });
 
+test("rebrandEvidence safely audits malformed verification_runs and strict preflight names the rebrand", () => {
+  const malformedValues = [{
+    name: "object",
+    value: { command: "node --test required.test.js" },
+    reason: /must be an array when present; found object/,
+  }, {
+    name: "null",
+    value: null,
+    reason: /must be an array when present; found null/,
+  }, {
+    name: "array with invalid entry",
+    value: [null],
+    reason: /verification_runs\[0\] must be a JSON object/,
+  }];
+
+  for (const entry of malformedValues) {
+    const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-rebrand-malformed-"));
+    fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+      "evaluation:",
+      "  verification:",
+      "    checks:",
+      "      - name: required after malformed rebrand",
+      "        type: command",
+      "        command: node --test required.test.js",
+    ].join("\n"), "utf-8");
+    const evidencePath = writeExecutionEvidence(runDir, {
+      schema_version: 1,
+      head_sha: "a".repeat(40),
+      test_command: "unspecified",
+      test_result_hash: "unspecified",
+      test_result_summary: "malformed verification evidence",
+      verification_runs: entry.value,
+      recorded_at: "2026-04-22T00:00:00.000Z",
+      recorded_by: "dispatch-orchestrator-v1",
+    });
+
+    const rebrand = rebrandEvidence(runDir, {
+      newHeadSha: "b".repeat(40),
+      reason: `recover malformed ${entry.name}`,
+    });
+    const written = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+    const preflight = buildExecutionEvidencePreflight({
+      runDir,
+      reviewedHead: "b".repeat(40),
+      strict: true,
+    });
+
+    assert.equal(rebrand.rewritten, true, entry.name);
+    assert.equal(rebrand.verificationRunsPolicy, "removed_malformed_after_rebrand", entry.name);
+    assert.match(rebrand.verificationRunsMalformation, entry.reason, entry.name);
+    assert.equal(written.verification_runs, undefined, entry.name);
+    assert.equal(
+      written.rebrand.verification_runs.policy,
+      "removed_malformed_after_rebrand",
+      entry.name
+    );
+    assert.deepEqual(written.rebrand.verification_runs.removed_value, entry.value, entry.name);
+    assert.match(written.rebrand.verification_runs.malformation_reason, entry.reason, entry.name);
+    assert.equal(preflight.status, "blocked", entry.name);
+    assert.equal(preflight.qualityExecutionStatus, "fail", entry.name);
+    assert.match(preflight.reason, /rebrand removed malformed verification_runs/, entry.name);
+    assert.match(preflight.reason, entry.reason, entry.name);
+    assert.match(
+      preflight.reason,
+      /Re-verify at the new HEAD or record audited operator evidence/,
+      entry.name
+    );
+  }
+});
+
+test("rebrandEvidence retains verification removal provenance across repeated rebrands", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-double-rebrand-"));
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+    "evaluation:",
+    "  verification:",
+    "    checks:",
+    "      - name: required after repeated rebrand",
+    "        type: command",
+    "        command: node --test required.test.js",
+  ].join("\n"), "utf-8");
+  const evidencePath = writeExecutionEvidence(runDir, {
+    schema_version: 1,
+    head_sha: "a".repeat(40),
+    test_command: "unspecified",
+    test_result_hash: "unspecified",
+    test_result_summary: "verified before repeated rebrand",
+    verification_runs: [{
+      name: "required after repeated rebrand",
+      command: "node --test required.test.js",
+      cwd: "/repo",
+      head_sha: "a".repeat(40),
+      exit_code: 0,
+      output_hash: "c".repeat(64),
+      recorded_by: "codex-confirmed-verification-v1",
+      recorded_at: "2026-04-22T00:00:00.000Z",
+    }],
+    recorded_at: "2026-04-22T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  });
+
+  rebrandEvidence(runDir, {
+    newHeadSha: "b".repeat(40),
+    reason: "first recovery commit",
+  });
+  rebrandEvidence(runDir, {
+    newHeadSha: "c".repeat(40),
+    reason: "second recovery commit",
+  });
+
+  const written = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  const preflight = buildExecutionEvidencePreflight({
+    runDir,
+    reviewedHead: "c".repeat(40),
+    strict: true,
+  });
+
+  assert.equal(written.rebrand.previous_head_sha, "b".repeat(40));
+  assert.equal(written.rebrand.new_head_sha, "c".repeat(40));
+  assert.equal(written.rebrand.verification_runs, undefined);
+  assert.equal(written.rebrand_history.length, 1);
+  assert.equal(written.rebrand_history[0].previous_head_sha, "a".repeat(40));
+  assert.equal(written.rebrand_history[0].new_head_sha, "b".repeat(40));
+  assert.equal(
+    written.rebrand_history[0].verification_runs.policy,
+    "removed_stale_after_rebrand"
+  );
+  assert.equal(preflight.status, "blocked");
+  assert.equal(preflight.qualityExecutionStatus, "fail");
+  assert.match(preflight.reason, /rebrand removed 1 stale verification_run/);
+  assert.match(preflight.reason, /from a{40} to b{40}; evidence is now at c{40}/);
+  assert.match(preflight.reason, /re-verify at the new HEAD or record audited operator evidence/);
+});
+
 test("rebrandEvidence skips when execution evidence is absent", () => {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-no-evidence-"));
 

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -16,6 +16,9 @@ const {
   resolveExecutionEvidenceTestCommand,
   writeExecutionEvidence,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
+const {
+  buildExecutionEvidencePreflight,
+} = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 
 test("verification gates seed the evidence command and identify malformed command gates", () => {
   const rubric = [
@@ -316,6 +319,72 @@ test("rebrandEvidence rewrites existing evidence to the new head and preserves a
   assert.equal(written.rebrand.previous_recorded_by, "dispatch-orchestrator-v1");
   assert.equal(written.rebrand.reason, "recover-commit added new commit");
   assert.match(written.rebrand.recorded_at, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("rebrandEvidence removes stale verification_runs and strict preflight names the rebrand", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-rebrand-runs-"));
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+    "evaluation:",
+    "  verification:",
+    "    checks:",
+    "      - name: required after rebrand",
+    "        type: command",
+    "        command: node --test required.test.js",
+  ].join("\n"), "utf-8");
+  const evidencePath = writeExecutionEvidence(runDir, {
+    schema_version: 1,
+    head_sha: "a".repeat(40),
+    test_command: "unspecified",
+    test_result_hash: "unspecified",
+    test_result_summary: "verified before rebrand",
+    verification_runs: [{
+      name: "required after rebrand",
+      command: "node --test required.test.js",
+      cwd: "/repo",
+      head_sha: "a".repeat(40),
+      exit_code: 0,
+      output_hash: "c".repeat(64),
+      recorded_by: "codex-confirmed-verification-v1",
+      recorded_at: "2026-04-22T00:00:00.000Z",
+    }],
+    recorded_at: "2026-04-22T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  });
+
+  const rebrand = rebrandEvidence(runDir, {
+    newHeadSha: "b".repeat(40),
+    reason: "recover-commit added new commit",
+  });
+  const written = JSON.parse(fs.readFileSync(evidencePath, "utf-8"));
+  const preflight = buildExecutionEvidencePreflight({
+    runDir,
+    reviewedHead: "b".repeat(40),
+    strict: true,
+  });
+
+  assert.equal(rebrand.verificationRunsPolicy, "removed_stale_after_rebrand");
+  assert.equal(rebrand.removedVerificationRuns, 1);
+  assert.equal(written.verification_runs, undefined);
+  assert.deepEqual(written.rebrand.verification_runs, {
+    policy: "removed_stale_after_rebrand",
+    removed_count: 1,
+    previous_head_shas: ["a".repeat(40)],
+    removed_runs: [{
+      name: "required after rebrand",
+      command: "node --test required.test.js",
+      cwd: "/repo",
+      head_sha: "a".repeat(40),
+      exit_code: 0,
+      output_hash: "c".repeat(64),
+      recorded_by: "codex-confirmed-verification-v1",
+      recorded_at: "2026-04-22T00:00:00.000Z",
+    }],
+    next_action: "re-verify at the new HEAD or record audited operator evidence",
+  });
+  assert.equal(preflight.status, "blocked");
+  assert.equal(preflight.qualityExecutionStatus, "fail");
+  assert.match(preflight.reason, /rebrand removed 1 stale verification_run/);
+  assert.match(preflight.reason, /re-verify at the new HEAD or record audited operator evidence/);
 });
 
 test("rebrandEvidence skips when execution evidence is absent", () => {

--- a/tests/relay-merge/scripts/review-gate.test.js
+++ b/tests/relay-merge/scripts/review-gate.test.js
@@ -840,6 +840,43 @@ test("evaluateReviewGate accepts hardened PASS with verification_runs evidence",
   assert.equal(result.readyToMerge, true);
 });
 
+test("evaluateReviewGate resolves hardened verification gates from a non-default rubric anchor", () => {
+  const { headSha, runDir, manifestData } = createHardenedGateFixture({ verificationRuns: true });
+  const retainedRubricPath = path.join(runDir, "retained", "rubric-r5.yaml");
+  fs.mkdirSync(path.dirname(retainedRubricPath), { recursive: true });
+  fs.writeFileSync(retainedRubricPath, [
+    "evaluation:",
+    "  verification:",
+    "    checks:",
+    "      - name: retained merge gate",
+    "        type: command",
+    "        command: node --test retained-merge.test.js",
+  ].join("\n"), "utf-8");
+  manifestData.anchor.rubric_path = "retained/rubric-r5.yaml";
+
+  const result = evaluateReviewGate({
+    prNumber: 40,
+    comments: [
+      {
+        body: "<!-- relay-review -->\n## Relay Review\nVerdict: PASS\nRounds: 1",
+        createdAt: "2026-04-03T08:00:00Z",
+      },
+    ],
+    commits: [
+      {
+        oid: headSha,
+        committedDate: "2026-04-03T07:00:00Z",
+      },
+    ],
+    manifestData,
+    runDir,
+  });
+
+  assert.equal(result.status, "hardened_execution_evidence_failed");
+  assert.equal(result.readyToMerge, false);
+  assert.match(result.reason, /verification gate went unrecorded: 'retained merge gate'/);
+});
+
 test("evaluateReviewGate rejects the legacy grandfather field matrix", async (t) => {
   const cases = [
     { label: "undefined", state: "loaded", expectedStatus: "lgtm", expectedRubricStatus: "satisfied", readyToMerge: true },

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -176,6 +176,75 @@ test("execution-evidence strict mode prefers verification_runs when present", ()
   );
 });
 
+test("execution-evidence strict mode resolves retained non-default rubric anchors", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-execution-anchor-"));
+  const rubricPath = path.join(runDir, "retained", "rubric-r5.yaml");
+  fs.mkdirSync(path.dirname(rubricPath), { recursive: true });
+  fs.writeFileSync(rubricPath, [
+    "evaluation:",
+    "  verification:",
+    "    checks:",
+    "      - name: retained mandatory gate",
+    "        type: command",
+    "        command: node --test retained.test.js",
+  ].join("\n"), "utf-8");
+  writeArtifact(runDir, makeArtifact("a".repeat(40), {
+    verification_runs: [{
+      command: "node --test other.test.js",
+      cwd: "/repo",
+      head_sha: "a".repeat(40),
+      exit_code: 0,
+      output_hash: "b".repeat(64),
+      recorded_by: "orchestrator",
+      recorded_at: "2026-04-22T00:00:00.000Z",
+    }],
+  }));
+  const manifestData = {
+    run_id: "issue-1116-retained-run",
+    anchor: { rubric_path: "retained/rubric-r5.yaml" },
+  };
+
+  const result = computeQualityExecutionStatus({
+    runDir,
+    reviewedHead: "a".repeat(40),
+    strict: true,
+    manifestData,
+  });
+
+  assert.equal(result.status, "fail");
+  assert.match(result.reason, /verification gate went unrecorded: 'retained mandatory gate'/);
+});
+
+test("execution-evidence strict mode fails closed for an invalid present rubric anchor", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-execution-anchor-invalid-"));
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+    "evaluation:",
+    "  verification:",
+    "    checks:",
+    "      - name: fallback must not be used",
+    "        type: command",
+    "        command: node --test fallback.test.js",
+  ].join("\n"), "utf-8");
+  writeArtifact(runDir, makeArtifact("a".repeat(40), {
+    test_result_hash: "b".repeat(64),
+    test_exit_code: 0,
+  }));
+
+  const result = computeQualityExecutionStatus({
+    runDir,
+    reviewedHead: "a".repeat(40),
+    strict: true,
+    manifestData: {
+      run_id: "issue-1116-invalid-anchor",
+      anchor: { rubric_path: "../outside.yaml" },
+    },
+  });
+
+  assert.equal(result.status, "fail");
+  assert.match(result.reason, /rubric anchor outside_run_dir/);
+  assert.match(result.reason, /anchor\.rubric_path/);
+});
+
 test("execution-evidence strict verification_runs fail on nonzero exit and stale head", () => {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-execution-runs-fail-"));
   writeArtifact(runDir, makeArtifact("a".repeat(40), {


### PR DESCRIPTION
## Recovery Summary

Opened by `relay-recover-commit` after the executor completed but did not publish a PR.

- Run ID: issue-1116-20260728125259469-47b55ef2
- Branch: issue-1116
- Reason: Executor total_timeout at 5400s left DC-complete work uncommitted; orchestrator verified full nine-suite gate 2503 tests / 0 fail (exit 0) on this exact tree. Timeout placeholder evidence moved aside as execution-evidence.placeholder.bak due to detector gap #1119.
- Provenance: manifest /Users/sjlee/.relay/runs/dev-relay-778886da/issue-1116-20260728125259469-47b55ef2.md; orchestrator=unknown; executor=codex
- Recovered at (UTC): 2026-07-28T15:58:37.965Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 검증 후 커밋 훅 등으로 작업 트리가 변경되면 불일치를 감지해 실패 처리하고 재검증을 요구합니다.
  - 리브랜딩 시 오래된/손상된 검증 기록을 제거하고, 제거 내역을 감사 정보로 남깁니다.
  - 지정된 루브릭 경로(앵커)와 검증 게이트 기준으로 실행 품질 판정을 더 정확히 합니다.
  - 잘못된 루브릭 경로는 안전하게 실패 처리합니다.
- **테스트**
  - 커밋 후 트리 변경, 리브랜딩 검증 기록 처리, 사용자 지정 루브릭/경로 실패 케이스를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->