### PR TITLE
fix: recognize gate-seeded recovery placeholders

### DIFF
--- a/skills/relay-dispatch/scripts/recover-commit.js
+++ b/skills/relay-dispatch/scripts/recover-commit.js
@@ -422,7 +422,8 @@ function main() {
     } catch {}
     const isPlaceholder = (
       existingEvidence?.recorded_by === "dispatch-orchestrator-v1" &&
-      existingEvidence?.test_command === "unspecified"
+      existingEvidence?.test_result_hash === "unspecified" &&
+      existingEvidence?.test_result_summary === "unspecified"
     );
     if (replacePlaceholderEvidence && isPlaceholder) {
       replacedEvidence = {

--- a/tests/relay-dispatch/scripts/recover-commit.test.js
+++ b/tests/relay-dispatch/scripts/recover-commit.test.js
@@ -692,7 +692,11 @@ test("missing execution evidence without operator test flags preserves recovery 
 });
 
 test("operator test flags refuse to overwrite existing execution evidence", () => {
-  const fixture = setupRepo({ dirty: true, evidence: true });
+  const fixture = setupRepo({
+    dirty: true,
+    evidence: true,
+    evidenceOverrides: { test_result_hash: "a".repeat(64) },
+  });
   const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
   fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
   const beforeHead = execFileSync("git", ["-C", fixture.worktreePath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
@@ -750,7 +754,7 @@ test("placeholder evidence without replacement flag is refused with the flag hin
   const fixture = setupRepo({
     dirty: true,
     evidence: true,
-    evidenceOverrides: { test_command: "unspecified" },
+    evidenceOverrides: { test_exit_code: 1 },
   });
   const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
   fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
@@ -776,7 +780,7 @@ test("replacement flag without operator evidence flags is rejected before recove
   const fixture = setupRepo({
     dirty: true,
     evidence: true,
-    evidenceOverrides: { test_command: "unspecified", test_exit_code: 1 },
+    evidenceOverrides: { test_exit_code: 1 },
   });
   const evidencePath = path.join(fixture.runDir, EXECUTION_EVIDENCE_FILENAME);
   const beforeEvidence = fs.readFileSync(evidencePath, "utf-8");
@@ -799,11 +803,11 @@ test("replacement flag without operator evidence flags is rejected before recove
   assert.equal(readRunEvents(fixture.repoRoot, fixture.runId).length, 0);
 });
 
-test("replacement flag replaces exact placeholder and journals replaced fields on operator evidence event", () => {
+test("replacement flag replaces gate-seeded placeholder and journals replaced fields on operator evidence event", () => {
   const fixture = setupRepo({
     dirty: true,
     evidence: true,
-    evidenceOverrides: { test_command: "unspecified", test_exit_code: 1 },
+    evidenceOverrides: { test_exit_code: 1 },
   });
   const resultFile = path.join(fixture.runDir, "operator-test-result.txt");
   fs.writeFileSync(resultFile, "node --test passed\n", "utf-8");
@@ -837,9 +841,9 @@ test("replacement flag replaces exact placeholder and journals replaced fields o
 });
 
 [
-  { name: "recorded_by differs", overrides: { test_command: "unspecified", recorded_by: "recover-commit-operator-v1" } },
-  { name: "test_command differs", overrides: { test_command: "node --test", recorded_by: "dispatch-orchestrator-v1" } },
-  { name: "both fields differ", overrides: { test_command: "node --test", recorded_by: "codex-executor-v1" } },
+  { name: "recorded_by differs", overrides: { recorded_by: "recover-commit-operator-v1" } },
+  { name: "test_result_hash differs", overrides: { test_result_hash: "a".repeat(64) } },
+  { name: "test_result_summary differs", overrides: { test_result_summary: "executor result.txt hashed" } },
 ].forEach(({ name, overrides }) => {
   test(`replacement flag refuses non-placeholder evidence when ${name}`, () => {
     const fixture = setupRepo({ dirty: true, evidence: true, evidenceOverrides: overrides });


### PR DESCRIPTION
## Dispatch Summary

```text
구현 및 커밋 완료했습니다.

- 분류 조건을 provenance + 두 result sentinel의 엄격한 AND로 변경
- gate-seeded `test_command` 회귀 및 provenance/hash/summary near-miss 테스트 추가
- 커밋: `9aa042f fix: recognize gate-seeded recovery placeholders`
- 검증: `44/44` 통과, exit code `0`
- worktree clean (`issue-1119`, 1 commit ahead)

RELAY_VERIFICATION_RESULT_BEGIN
{"schema_version":1,"runs":[{"command":"node --test tests/relay-dispatch/scripts/recover-commit.test.js","exit_code":0,"output":"ℹ tests 44\nℹ suites 0\nℹ pass 44\nℹ fail 0\nℹ c
```

## Dispatch Metadata

- Run: issue-1119-20260730045449248-a4c7e91b
- Executor: codex
- Branch: issue-1119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실행 증거의 타임아웃 placeholder 판별 기준을 실제 결과 해시와 요약 필드에 맞게 조정했습니다.
  * `--replace-placeholder-evidence`가 placeholder 증거만 교체하고, 유효한 증거는 계속 보호하도록 동작을 보완했습니다.

* **테스트**
  * 증거 교체 플래그 및 비-placeholder 증거 보호 시나리오를 새로운 판별 기준에 맞게 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->