### PR TITLE
fix: close verification-evidence integrity gaps

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -3229,7 +3229,6 @@ async function main() {
   // the prior behavior: the downstream recover-commit path is itself
   // supersede-guarded and correctly no-ops.
   let orchestratorCommitted = false;
-  let verificationTreeMismatch = null;
   const supersededBeforeCommit = readManifest(manifestPath).data.state !== STATES.DISPATCHED;
   if (!DRY_RUN && AUTO_RECOVER_COMMIT && status === "completed-uncommitted" && !supersededBeforeCommit) {
     try {
@@ -3237,39 +3236,19 @@ async function main() {
       if (dirt.hasReviewableDirt && !execGit(wtPath, ["diff", "--cached", "--name-only"])) {
         throw new Error(formatEmptyReviewableIndexError(rawUncommitted));
       }
-      // Verification gates ran against the executor's completed working tree.
-      // Staging snapshots that tree into the index; a hook must not change the
-      // commit tree before the executor-confirmed results are SHA-bound below.
-      const verifiedTree = verificationGates.length > 0
-        ? execGit(wtPath, ["write-tree"])
-        : null;
       execGit(wtPath, [
         "commit",
         "-m", `Relay run ${runId}`,
         "-m", `Executor reviewable changes committed by the relay orchestrator (run ${runId}).`,
       ]);
       currentHead = execGit(wtPath, ["rev-parse", "HEAD"]);
-      const committedTree = execGit(wtPath, ["rev-parse", "HEAD^{tree}"]);
-      if (verifiedTree && verifiedTree !== committedTree) {
-        verificationTreeMismatch = { verifiedTree, committedTree };
-      }
       if (startHead && currentHead !== startHead) {
         gitLog = execGit(wtPath, ["log", "--oneline", `${startHead}..HEAD`]);
       }
       uncommitted = classifyRepositoryDirt(execGit(wtPath, ["status", "--porcelain"])).reviewableStatus;
       if (!uncommitted) uncommittedDiff = "";
       orchestratorCommitted = true;
-      if (verificationTreeMismatch) {
-        status = "failed";
-        exitCode = exitCode || 1;
-        error = (
-          "verification_tree_mismatch: the orchestrator commit changed the tree after executor " +
-          `verification (${verificationTreeMismatch.verifiedTree} -> ` +
-          `${verificationTreeMismatch.committedTree}); re-run the executor verification gates at the committed HEAD`
-        );
-      } else {
-        status = "completed";
-      }
+      status = "completed";
     } catch (orchestratorCommitError) {
       // Leave status as completed-uncommitted; the auto-recover-commit fallback runs
       // below. Surface the git failure reason — this is now the primary commit path,
@@ -3309,6 +3288,7 @@ async function main() {
         gates: verificationGates,
         cwd: wtPath,
         headSha: currentHead || startHead,
+        finalTreeSha: execGit(wtPath, ["rev-parse", "HEAD^{tree}"]),
         runDir: getRunDir(repoRoot, runId),
         resultText,
         executor: EXECUTOR,
@@ -3328,6 +3308,7 @@ async function main() {
       error = `verification_gate_evidence_invalid: ${String(
         verificationError.message || verificationError
       ).split("\n")[0]}`;
+      verificationEvidence = { runs: [], outputPath: null, exitCode: undefined };
     }
   }
 

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -260,20 +260,31 @@ function verificationTreeProofStagedRuntimeAdditionsGitDiffArgs() {
   /*
    * A path added under a runtime root exists only in the repository's real
    * index, so `git add -u` cannot discover it from the HEAD-seeded proof
-   * index. Export only staged additions as a binary/full-index patch. Applying
-   * that patch to the proof index preserves the staged blob and mode without
-   * reading later unstaged worktree content or adjacent untracked metadata.
+   * index. Use the real index only to identify those intentionally staged
+   * paths. The proof index must read their gate-time content, mode, or deletion
+   * from the worktree instead of trusting a possibly stale staged blob.
    */
   return [
     "diff",
     "--cached",
-    "--binary",
-    "--full-index",
+    "--name-only",
+    "-z",
+    "--no-renames",
     "--no-ext-diff",
     "--diff-filter=A",
     "--",
     ...RUNTIME_METADATA_ROOTS,
   ];
+}
+
+function verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs() {
+  /*
+   * `update-index --stdin -z` consumes literal NUL-delimited repository paths,
+   * stages current worktree content and executable mode, and removes a listed
+   * path that disappeared after it was staged. That makes the proof describe
+   * what the gates observed while the real index remains read-only.
+   */
+  return ["update-index", "--add", "--remove", "-z", "--stdin"];
 }
 
 function shellQuote(value) {
@@ -300,7 +311,13 @@ function buildExecutorVerificationInstructions(gates) {
     'GIT_INDEX_FILE="$verification_real_index"',
     "git",
     ...verificationTreeProofStagedRuntimeAdditionsGitDiffArgs().map(shellQuote),
-    '> "$verification_runtime_patch"',
+    '> "$verification_runtime_paths"',
+  ].join(" ");
+  const stageGateTimeRuntimeAdditionsCommand = [
+    'GIT_INDEX_FILE="$verification_index"',
+    "git",
+    ...verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs().map(shellQuote),
+    '< "$verification_runtime_paths"',
   ].join(" ");
   return [
     "## Required executor-side verification",
@@ -310,19 +327,19 @@ function buildExecutorVerificationInstructions(gates) {
     "Do not delegate them back to the relay orchestrator and do not expose credentials or secret environment values.",
     "After all required gates finish, capture the exact reviewable repository state with the temporary Git index commands below.",
     "Use the repository's real index only as a read-only source for intentionally staged runtime-root additions; untracked, unstaged executor runtime metadata must stay excluded, while tracked runtime-root modifications and deletions remain reviewable.",
-    "The staged-addition overlay preserves the exact staged blob and mode instead of later unstaged working-tree content.",
+    "The staged-addition allowlist is refreshed from the gate-time worktree, so later content, mode, and deletion state are proven instead of a stale staged blob.",
     "",
     'verification_real_index="$(git rev-parse --git-path index)"',
     'verification_index="$(mktemp)"',
-    'verification_runtime_patch="$(mktemp)"',
+    'verification_runtime_paths="$(mktemp)"',
     'rm -f "$verification_index"',
     'GIT_INDEX_FILE="$verification_index" git read-tree HEAD',
     reviewableGitAddCommand,
     trackedGitAddCommand,
     stagedRuntimeAdditionsCommand,
-    'if test -s "$verification_runtime_patch"; then GIT_INDEX_FILE="$verification_index" git apply --cached --whitespace=nowarn "$verification_runtime_patch"; fi',
+    `if test -s "$verification_runtime_paths"; then ${stageGateTimeRuntimeAdditionsCommand} || { rm -f "$verification_runtime_paths" "$verification_index"; echo "failed to refresh staged runtime additions from the gate-time worktree" >&2; exit 1; }; fi`,
     'verification_tree_sha="$(GIT_INDEX_FILE="$verification_index" git write-tree)"',
-    'rm -f "$verification_runtime_patch" "$verification_index"',
+    'rm -f "$verification_runtime_paths" "$verification_index"',
     "",
     "Capture this proof before any later commit or commit hook can mutate the tree, then report it as verification_tree_sha.",
     "",
@@ -647,6 +664,7 @@ module.exports = {
   resolveExecutionEvidenceTestCommand,
   verificationTreeProofGitAddArgs,
   verificationTreeProofStagedRuntimeAdditionsGitDiffArgs,
+  verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs,
   verificationTreeProofTrackedGitAddArgs,
   writeExecutionEvidence,
 };

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -246,6 +246,16 @@ function verificationTreeProofGitAddArgs() {
   ];
 }
 
+function verificationTreeProofTrackedGitAddArgs() {
+  /*
+   * The first proof add deliberately excludes runtime roots so untracked
+   * executor metadata cannot enter the verification tree. Overlay every
+   * tracked worktree update afterward: `git add -u` records modifications and
+   * deletions beneath those roots without adding their untracked neighbors.
+   */
+  return ["add", "-u", "--", "."];
+}
+
 function shellQuote(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
@@ -261,6 +271,11 @@ function buildExecutorVerificationInstructions(gates) {
     "git",
     ...verificationTreeProofGitAddArgs().map(shellQuote),
   ].join(" ");
+  const trackedGitAddCommand = [
+    'GIT_INDEX_FILE="$verification_index"',
+    "git",
+    ...verificationTreeProofTrackedGitAddArgs().map(shellQuote),
+  ].join(" ");
   return [
     "## Required executor-side verification",
     "",
@@ -268,12 +283,13 @@ function buildExecutorVerificationInstructions(gates) {
     "The commands must remain subject to the executor's current sandbox and network policy.",
     "Do not delegate them back to the relay orchestrator and do not expose credentials or secret environment values.",
     "After all required gates finish, capture the exact reviewable repository state with the temporary Git index commands below.",
-    "Do not use the repository's real index for this proof; executor runtime metadata roots must stay excluded even if they are already staged there.",
+    "Do not use the repository's real index for this proof; untracked executor runtime metadata must stay excluded even if it is already staged there, while tracked runtime-root modifications and deletions remain reviewable.",
     "",
     'verification_index="$(mktemp)"',
     'rm -f "$verification_index"',
     'GIT_INDEX_FILE="$verification_index" git read-tree HEAD',
     reviewableGitAddCommand,
+    trackedGitAddCommand,
     'verification_tree_sha="$(GIT_INDEX_FILE="$verification_index" git write-tree)"',
     'rm -f "$verification_index"',
     "",
@@ -599,5 +615,6 @@ module.exports = {
   rebrandEvidence,
   resolveExecutionEvidenceTestCommand,
   verificationTreeProofGitAddArgs,
+  verificationTreeProofTrackedGitAddArgs,
   writeExecutionEvidence,
 };

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -41,6 +41,13 @@ function verificationRunsMalformation(verificationRuns) {
     if (!isNonEmptyString(run.head_sha) || !SHA40_PATTERN.test(run.head_sha)) {
       return `verification_runs[${index}].head_sha must be a 40-character hex SHA`;
     }
+    if (
+      run.verification_tree_sha !== undefined
+      && (!isNonEmptyString(run.verification_tree_sha)
+        || !SHA40_PATTERN.test(run.verification_tree_sha))
+    ) {
+      return `verification_runs[${index}].verification_tree_sha must be a 40-character hex Git tree SHA when present`;
+    }
     if (!Number.isInteger(run.exit_code) || run.exit_code < 0) {
       return `verification_runs[${index}].exit_code must be a non-negative integer`;
     }
@@ -235,6 +242,8 @@ function buildExecutorVerificationInstructions(gates) {
     "After completing the task, run every command below inside this same executor session.",
     "The commands must remain subject to the executor's current sandbox and network policy.",
     "Do not delegate them back to the relay orchestrator and do not expose credentials or secret environment values.",
+    "After all required gates finish, stage the exact verified repository state and capture its Git tree with `git write-tree`.",
+    "Capture this proof before any later commit or commit hook can mutate the tree, then report it as verification_tree_sha.",
     "",
     VERIFICATION_REQUEST_BEGIN,
     JSON.stringify(request),
@@ -242,7 +251,7 @@ function buildExecutorVerificationInstructions(gates) {
     "",
     "At the end of your final response, append exactly one result envelope using this shape:",
     VERIFICATION_RESULT_BEGIN,
-    '{"schema_version":1,"runs":[{"command":"exact command from request","exit_code":0,"output":"captured stdout/stderr"}]}',
+    '{"schema_version":1,"verification_tree_sha":"40-hex Git tree SHA captured after all gates and before commit","runs":[{"command":"exact command from request","exit_code":0,"output":"captured stdout/stderr"}]}',
     VERIFICATION_RESULT_END,
     "Preserve each command verbatim, keep request order, and report a nonzero exit_code when policy blocks a command.",
   ].join("\n");
@@ -289,10 +298,35 @@ function parseExecutorVerificationResult(resultText) {
   return result;
 }
 
+function validateVerificationTreeProof(verificationTreeSha, finalTreeSha) {
+  if (!isNonEmptyString(verificationTreeSha) || !SHA40_PATTERN.test(verificationTreeSha)) {
+    throw new Error(
+      "verification_tree_proof_invalid: executor verification result verification_tree_sha " +
+      "must be an exact 40-character hex Git tree SHA captured after all required gates and " +
+      "before any later commit or hook; re-run the executor verification gates at the committed HEAD"
+    );
+  }
+  if (!isNonEmptyString(finalTreeSha) || !SHA40_PATTERN.test(finalTreeSha)) {
+    throw new Error(
+      "verification_tree_proof_invalid: final HEAD^{tree} did not resolve to an exact " +
+      "40-character hex Git tree SHA; repair the commit and re-run the executor verification gates"
+    );
+  }
+  if (verificationTreeSha.toLowerCase() !== finalTreeSha.toLowerCase()) {
+    throw new Error(
+      "verification_tree_mismatch: executor verification ran against tree " +
+      `${verificationTreeSha}, but final HEAD^{tree} is ${finalTreeSha}; ` +
+      "re-run the executor verification gates at the committed HEAD and report a new tree proof"
+    );
+  }
+  return verificationTreeSha.toLowerCase();
+}
+
 function collectExecutorVerificationEvidence({
   gates,
   cwd,
   headSha,
+  finalTreeSha,
   runDir,
   resultText,
   executor,
@@ -301,11 +335,15 @@ function collectExecutorVerificationEvidence({
   if (!Array.isArray(gates) || gates.length === 0) {
     return { runs: [], outputPath: null, exitCode: undefined };
   }
-  if (!cwd || !headSha || !runDir) {
-    throw new Error("executor verification evidence requires cwd, headSha, and runDir");
+  if (!cwd || !headSha || !finalTreeSha || !runDir) {
+    throw new Error("executor verification evidence requires cwd, headSha, finalTreeSha, and runDir");
   }
 
   const result = parseExecutorVerificationResult(resultText);
+  const verificationTreeSha = validateVerificationTreeProof(
+    result.verification_tree_sha,
+    finalTreeSha
+  );
   if (result.runs.length !== gates.length) {
     throw new Error(
       `executor verification result recorded ${result.runs.length} runs for ${gates.length} required gates`
@@ -356,6 +394,7 @@ function collectExecutorVerificationEvidence({
       command: gate.command,
       cwd,
       head_sha: headSha,
+      verification_tree_sha: verificationTreeSha,
       exit_code: confirmed.exit_code,
       output_path: outputName,
       output_hash: hashFileSha256(outputPath),
@@ -370,6 +409,7 @@ function collectExecutorVerificationEvidence({
     runs,
     outputPath: aggregateOutputPath,
     exitCode: failedRun ? failedRun.exit_code : 0,
+    verificationTreeSha,
   };
 }
 

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -1,6 +1,9 @@
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
+const {
+  RUNTIME_METADATA_ROOTS,
+} = require("./runtime-dirt");
 
 const EXECUTION_EVIDENCE_FILENAME = "execution-evidence.json";
 const EXECUTION_EVIDENCE_SCHEMA_VERSION = 1;
@@ -230,19 +233,50 @@ function hashFileSha256(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
+function verificationTreeProofGitAddArgs() {
+  return [
+    "add",
+    "-A",
+    "--",
+    ".",
+    ...RUNTIME_METADATA_ROOTS.flatMap((root) => [
+      `:(exclude)${root}`,
+      `:(exclude)${root}/**`,
+    ]),
+  ];
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
 function buildExecutorVerificationInstructions(gates) {
   if (!Array.isArray(gates) || gates.length === 0) return "";
   const request = {
     schema_version: 1,
     gates: gates.map(({ name, command }) => ({ name, command })),
   };
+  const reviewableGitAddCommand = [
+    'GIT_INDEX_FILE="$verification_index"',
+    "git",
+    ...verificationTreeProofGitAddArgs().map(shellQuote),
+  ].join(" ");
   return [
     "## Required executor-side verification",
     "",
     "After completing the task, run every command below inside this same executor session.",
     "The commands must remain subject to the executor's current sandbox and network policy.",
     "Do not delegate them back to the relay orchestrator and do not expose credentials or secret environment values.",
-    "After all required gates finish, stage the exact verified repository state and capture its Git tree with `git write-tree`.",
+    "After all required gates finish, capture the exact reviewable repository state with the temporary Git index commands below.",
+    "Do not use the repository's real index for this proof; executor runtime metadata roots must stay excluded even if they are already staged there.",
+    "",
+    'verification_index="$(mktemp)"',
+    'rm -f "$verification_index"',
+    'GIT_INDEX_FILE="$verification_index" git read-tree HEAD',
+    reviewableGitAddCommand,
+    'verification_tree_sha="$(GIT_INDEX_FILE="$verification_index" git write-tree)"',
+    'rm -f "$verification_index"',
+    "",
     "Capture this proof before any later commit or commit hook can mutate the tree, then report it as verification_tree_sha.",
     "",
     VERIFICATION_REQUEST_BEGIN,
@@ -564,5 +598,6 @@ module.exports = {
   hashFileSha256,
   rebrandEvidence,
   resolveExecutionEvidenceTestCommand,
+  verificationTreeProofGitAddArgs,
   writeExecutionEvidence,
 };

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -256,6 +256,26 @@ function verificationTreeProofTrackedGitAddArgs() {
   return ["add", "-u", "--", "."];
 }
 
+function verificationTreeProofStagedRuntimeAdditionsGitDiffArgs() {
+  /*
+   * A path added under a runtime root exists only in the repository's real
+   * index, so `git add -u` cannot discover it from the HEAD-seeded proof
+   * index. Export only staged additions as a binary/full-index patch. Applying
+   * that patch to the proof index preserves the staged blob and mode without
+   * reading later unstaged worktree content or adjacent untracked metadata.
+   */
+  return [
+    "diff",
+    "--cached",
+    "--binary",
+    "--full-index",
+    "--no-ext-diff",
+    "--diff-filter=A",
+    "--",
+    ...RUNTIME_METADATA_ROOTS,
+  ];
+}
+
 function shellQuote(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
@@ -276,6 +296,12 @@ function buildExecutorVerificationInstructions(gates) {
     "git",
     ...verificationTreeProofTrackedGitAddArgs().map(shellQuote),
   ].join(" ");
+  const stagedRuntimeAdditionsCommand = [
+    'GIT_INDEX_FILE="$verification_real_index"',
+    "git",
+    ...verificationTreeProofStagedRuntimeAdditionsGitDiffArgs().map(shellQuote),
+    '> "$verification_runtime_patch"',
+  ].join(" ");
   return [
     "## Required executor-side verification",
     "",
@@ -283,15 +309,20 @@ function buildExecutorVerificationInstructions(gates) {
     "The commands must remain subject to the executor's current sandbox and network policy.",
     "Do not delegate them back to the relay orchestrator and do not expose credentials or secret environment values.",
     "After all required gates finish, capture the exact reviewable repository state with the temporary Git index commands below.",
-    "Do not use the repository's real index for this proof; untracked executor runtime metadata must stay excluded even if it is already staged there, while tracked runtime-root modifications and deletions remain reviewable.",
+    "Use the repository's real index only as a read-only source for intentionally staged runtime-root additions; untracked, unstaged executor runtime metadata must stay excluded, while tracked runtime-root modifications and deletions remain reviewable.",
+    "The staged-addition overlay preserves the exact staged blob and mode instead of later unstaged working-tree content.",
     "",
+    'verification_real_index="$(git rev-parse --git-path index)"',
     'verification_index="$(mktemp)"',
+    'verification_runtime_patch="$(mktemp)"',
     'rm -f "$verification_index"',
     'GIT_INDEX_FILE="$verification_index" git read-tree HEAD',
     reviewableGitAddCommand,
     trackedGitAddCommand,
+    stagedRuntimeAdditionsCommand,
+    'if test -s "$verification_runtime_patch"; then GIT_INDEX_FILE="$verification_index" git apply --cached --whitespace=nowarn "$verification_runtime_patch"; fi',
     'verification_tree_sha="$(GIT_INDEX_FILE="$verification_index" git write-tree)"',
-    'rm -f "$verification_index"',
+    'rm -f "$verification_runtime_patch" "$verification_index"',
     "",
     "Capture this proof before any later commit or commit hook can mutate the tree, then report it as verification_tree_sha.",
     "",
@@ -615,6 +646,7 @@ module.exports = {
   rebrandEvidence,
   resolveExecutionEvidenceTestCommand,
   verificationTreeProofGitAddArgs,
+  verificationTreeProofStagedRuntimeAdditionsGitDiffArgs,
   verificationTreeProofTrackedGitAddArgs,
   writeExecutionEvidence,
 };

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -267,6 +267,7 @@ function verificationTreeProofStagedRuntimeAdditionsGitDiffArgs() {
   return [
     "diff",
     "--cached",
+    "--ita-visible-in-index",
     "--name-only",
     "-z",
     "--no-renames",

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -7,6 +7,7 @@ const {
 const {
   getRubricAnchorStatus,
 } = require("../../../relay-dispatch/scripts/manifest/rubric");
+const { git } = require("./common");
 
 const EXECUTION_EVIDENCE_FILENAME = "execution-evidence.json";
 const REQUIRED_EXECUTION_EVIDENCE_FIELDS = [
@@ -22,6 +23,7 @@ const SHA40_PATTERN = /^[0-9a-f]{40}$/i;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
 const FORCE_FINALIZE_GUIDANCE = 'finalize-run --force-finalize-nonready --reason "pre-261 run, no artifact"';
 const VERIFICATION_HASH_FIELDS = ["output_hash", "stdout_hash", "stderr_hash"];
+const CONFIRMED_VERIFICATION_RECORDED_BY_SUFFIX = "-confirmed-verification-v1";
 
 function isNonEmptyString(value) {
   return typeof value === "string" && value.trim() !== "";
@@ -140,6 +142,66 @@ function findMissingVerificationGates(gates, verificationRuns) {
     unmatchedRuns.splice(matchIndex, 1);
     return false;
   });
+}
+
+function isConfirmedVerificationRun(run) {
+  return run.recorded_by.endsWith(CONFIRMED_VERIFICATION_RECORDED_BY_SUFFIX);
+}
+
+function resolveReviewedTreeSha(artifact, reviewedHead, manifestData) {
+  const repoPaths = [
+    manifestData?.paths?.worktree,
+    ...artifact.verification_runs.filter(isConfirmedVerificationRun).map((run) => run.cwd),
+  ].filter(isNonEmptyString);
+  let lastError = null;
+
+  for (const repoPath of [...new Set(repoPaths)]) {
+    try {
+      const treeSha = git(repoPath, "rev-parse", `${reviewedHead}^{tree}`).trim();
+      if (SHA40_PATTERN.test(treeSha)) return treeSha.toLowerCase();
+      lastError = `git returned invalid tree SHA '${treeSha || "(empty)"}'`;
+    } catch (error) {
+      lastError = error.message;
+    }
+  }
+
+  throw new Error(
+    "strict confirmed verification evidence could not resolve the reviewed HEAD^{tree}" +
+    `${lastError ? `: ${lastError}` : ""}; restore the reviewed checkout and re-run verification`
+  );
+}
+
+function confirmedVerificationTreeReason(artifact, reviewedHead, manifestData) {
+  const confirmedRuns = artifact.verification_runs
+    .map((run, index) => ({ run, index }))
+    .filter(({ run }) => isConfirmedVerificationRun(run));
+  if (confirmedRuns.length === 0) return null;
+
+  const missingProof = confirmedRuns.find(({ run }) => run.verification_tree_sha === undefined);
+  if (missingProof) {
+    return (
+      `strict execution evidence verification_runs[${missingProof.index}] recorded by ` +
+      `'${missingProof.run.recorded_by}' requires verification_tree_sha; ` +
+      "re-run the executor verification gates at the reviewed HEAD"
+    );
+  }
+
+  let reviewedTreeSha;
+  try {
+    reviewedTreeSha = resolveReviewedTreeSha(artifact, reviewedHead, manifestData);
+  } catch (error) {
+    return error.message;
+  }
+  const mismatch = confirmedRuns.find(({ run }) => (
+    run.verification_tree_sha.toLowerCase() !== reviewedTreeSha
+  ));
+  if (!mismatch) return null;
+
+  return (
+    `strict execution evidence verification_runs[${mismatch.index}].verification_tree_sha ` +
+    `${mismatch.run.verification_tree_sha} does not match reviewed HEAD ${reviewedHead}^{tree} ` +
+    `${reviewedTreeSha}; re-run the executor verification gates at the reviewed HEAD`
+  );
 }
 
 function validateVerificationHash(value, fieldName) {
@@ -504,6 +566,17 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false, m
         return {
           status: "fail",
           reason: `strict verification_runs evidence is stale: recorded at ${staleRun.head_sha}, reviewed at ${reviewedHead}`,
+        };
+      }
+      const verificationTreeReason = confirmedVerificationTreeReason(
+        artifactLoad.artifact,
+        reviewedHead,
+        manifestData
+      );
+      if (verificationTreeReason) {
+        return {
+          status: "fail",
+          reason: verificationTreeReason,
         };
       }
       const failedRun = artifactLoad.artifact.verification_runs.find((run) => run.exit_code !== 0);

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -145,7 +145,10 @@ function findMissingVerificationGates(gates, verificationRuns) {
 }
 
 function isConfirmedVerificationRun(run) {
-  return run.recorded_by.endsWith(CONFIRMED_VERIFICATION_RECORDED_BY_SUFFIX);
+  return (
+    typeof run.recorded_by === "string"
+    && run.recorded_by.endsWith(CONFIRMED_VERIFICATION_RECORDED_BY_SUFFIX)
+  );
 }
 
 function resolveReviewedTreeSha(artifact, reviewedHead, manifestData) {
@@ -172,6 +175,12 @@ function resolveReviewedTreeSha(artifact, reviewedHead, manifestData) {
 }
 
 function confirmedVerificationTreeReason(artifact, reviewedHead, manifestData) {
+  try {
+    artifact.verification_runs.forEach(validateVerificationRun);
+  } catch (error) {
+    return error.message;
+  }
+
   const confirmedRuns = artifact.verification_runs
     .map((run, index) => ({ run, index }))
     .filter(({ run }) => isConfirmedVerificationRun(run));

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -90,17 +90,17 @@ function missingVerificationGateReason(gates) {
   );
 }
 
-function rebrandVerificationGateReason(artifact, gates) {
+function rebrandVerificationGateReason(artifact, gates, policies = [
+  "removed_stale_after_rebrand",
+  "removed_malformed_after_rebrand",
+]) {
   const rebrands = [
     artifact.rebrand,
     ...(Array.isArray(artifact.rebrand_history)
       ? [...artifact.rebrand_history].reverse()
       : []),
   ].filter(isObject);
-  const rebrand = rebrands.find((entry) => (
-    entry.verification_runs?.policy === "removed_stale_after_rebrand"
-    || entry.verification_runs?.policy === "removed_malformed_after_rebrand"
-  ));
+  const rebrand = rebrands.find((entry) => policies.includes(entry.verification_runs?.policy));
   if (!rebrand) return null;
 
   const audit = rebrand.verification_runs;
@@ -108,16 +108,18 @@ function rebrandVerificationGateReason(artifact, gates) {
   const laterRebrand = rebrandHead !== artifact.head_sha
     ? `; evidence is now at ${artifact.head_sha}`
     : "";
-  const requiredGates = (
-    `Required verification ${gates.length === 1 ? "gate" : "gates"}: ` +
-    gates.map((gate) => `'${gate.name}'`).join(", ")
-  );
+  const requiredGates = gates.length > 0
+    ? (
+        ` Required verification ${gates.length === 1 ? "gate" : "gates"}: ` +
+        gates.map((gate) => `'${gate.name}'`).join(", ")
+      )
+    : "";
   if (audit.policy === "removed_malformed_after_rebrand") {
     return (
       "strict execution evidence rebrand removed malformed verification_runs after HEAD changed " +
       `from ${rebrand.previous_head_sha} to ${rebrandHead}${laterRebrand}; ` +
       `${audit.malformation_reason}. ` +
-      "Re-verify at the new HEAD or record audited operator evidence. " +
+      "Re-verify at the new HEAD or record audited operator evidence." +
       requiredGates
     );
   }
@@ -125,7 +127,7 @@ function rebrandVerificationGateReason(artifact, gates) {
     `strict execution evidence rebrand removed ${audit.removed_count} stale ` +
     `${audit.removed_count === 1 ? "verification_run" : "verification_runs"} after HEAD changed ` +
     `from ${rebrand.previous_head_sha} to ${rebrandHead}${laterRebrand}; ` +
-    "re-verify at the new HEAD or record audited operator evidence. " +
+    "re-verify at the new HEAD or record audited operator evidence." +
     requiredGates
   );
 }
@@ -158,6 +160,15 @@ function validateVerificationRun(run, index) {
   }
   if (!isNonEmptyString(run.head_sha) || !SHA40_PATTERN.test(run.head_sha)) {
     throw new Error(`execution evidence verification_runs[${index}].head_sha must be a 40-character hex SHA`);
+  }
+  if (
+    run.verification_tree_sha !== undefined
+    && (!isNonEmptyString(run.verification_tree_sha)
+      || !SHA40_PATTERN.test(run.verification_tree_sha))
+  ) {
+    throw new Error(
+      `execution evidence verification_runs[${index}].verification_tree_sha must be a 40-character hex Git tree SHA when present`
+    );
   }
   if (!Number.isInteger(run.exit_code) || run.exit_code < 0) {
     throw new Error(`execution evidence verification_runs[${index}].exit_code must be a non-negative integer`);
@@ -455,6 +466,17 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false, m
       return {
         status: "fail",
         reason: `strict execution evidence could not resolve verification gates: ${error.message}`,
+      };
+    }
+    const malformedRebrandReason = rebrandVerificationGateReason(
+      artifactLoad.artifact,
+      verificationGates,
+      ["removed_malformed_after_rebrand"]
+    );
+    if (malformedRebrandReason) {
+      return {
+        status: "fail",
+        reason: malformedRebrandReason,
       };
     }
     if (verificationGates.length > 0) {

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -7607,10 +7607,10 @@ for (const scenario of [
       encoding: "utf-8",
       env,
     });
+    assert.equal(dispatched.status, 1, dispatched.stderr);
     const result = JSON.parse(dispatched.stdout);
     const evidence = readExecutionEvidence(result.runDir);
 
-    assert.equal(dispatched.status, 1, dispatched.stderr);
     assert.equal(result.status, "failed");
     assert.equal(result.runState, STATES.ESCALATED);
     assert.equal(result.commitMode, "committed in-sandbox");

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -639,6 +639,58 @@ fs.writeFileSync(
   return codexPath;
 }
 
+function writeStagedRuntimeRootAdditionCodex(binDir, { directCommit = false } = {}) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+${fakeExecutorVerificationSupportSource()}
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+const runtimeDir = path.join(cwd, ".antigravitycli");
+const stagedAddition = path.join(runtimeDir, "reviewable-runtime-config");
+fs.mkdirSync(runtimeDir, { recursive: true });
+fs.writeFileSync(stagedAddition, "intentionally staged runtime config\\n", "utf-8");
+fs.chmodSync(stagedAddition, 0o755);
+execFileSync(
+  "git",
+  ["-C", cwd, "add", ".antigravitycli/reviewable-runtime-config"],
+  { stdio: "pipe" }
+);
+fs.writeFileSync(
+  path.join(runtimeDir, "runtime-state.json"),
+  '{"session":"unstaged-runtime-metadata"}\\n',
+  "utf-8"
+);
+const verificationTreeSha = captureVerificationTree(cwd);
+if (${JSON.stringify(directCommit)}) {
+  execFileSync(
+    "git",
+    ["-C", cwd, "commit", "-m", "add staged runtime config"],
+    { stdio: "pipe" }
+  );
+}
+fs.writeFileSync(
+  output,
+  withVerificationEvidence("staged runtime-root addition completed\\n", verificationTreeSha),
+  "utf-8"
+);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
 function writeUncommittedClaude(binDir) {
   ensureDefaultFakeGh(binDir);
   const claudePath = path.join(binDir, "claude");
@@ -902,6 +954,10 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
     writeSilentCodex(binDir);
   } else if (codexMode === "commit-no-result") {
     writeCommittedNoResultCodex(binDir);
+  } else if (codexMode === "runtime-root-staged-addition-direct") {
+    writeStagedRuntimeRootAdditionCodex(binDir, { directCommit: true });
+  } else if (codexMode === "runtime-root-staged-addition-uncommitted") {
+    writeStagedRuntimeRootAdditionCodex(binDir);
   } else if (codexMode === "runtime-root-uncommitted") {
     writeUncommittedRuntimeRootCodex(binDir);
   } else if (codexMode === "uncommitted") {
@@ -7271,6 +7327,85 @@ test("dispatch commit keeps tracked runtime-root changes but excludes adjacent m
     revParse(repoRoot, `${result.headSha}^{tree}`)
   );
 });
+
+for (const scenario of [
+  {
+    name: "orchestrator commit",
+    codexMode: "runtime-root-staged-addition-uncommitted",
+    branch: "issue-1121-staged-runtime-addition-orchestrator",
+    commitMode: "orchestrator-committed",
+  },
+  {
+    name: "executor-direct commit",
+    codexMode: "runtime-root-staged-addition-direct",
+    branch: "issue-1121-staged-runtime-addition-direct",
+    commitMode: "committed in-sandbox",
+  },
+]) {
+  test(`dispatch ${scenario.name} preserves a staged runtime-root addition beside unstaged metadata`, () => {
+    const { repoRoot, relayHome } = setupRepoWithOrigin();
+    process.env.RELAY_HOME = relayHome;
+    const { env } = createPushPrTestEnv({
+      relayHome,
+      ghState: {
+        prCreateUrl: "https://github.com/acme/dev-relay/pull/1121",
+      },
+      codexMode: scenario.codexMode,
+    });
+    const rubricFile = writeAssuranceRubric("hardened");
+
+    const result = JSON.parse(runDispatch(repoRoot, [
+      "-b", scenario.branch,
+      "--prompt", "stage a reviewable runtime-root addition beside executor metadata",
+      "--rubric-file", rubricFile,
+      "--json",
+    ], env));
+    const stagedPath = ".antigravitycli/reviewable-runtime-config";
+    const metadataPath = ".antigravitycli/runtime-state.json";
+
+    assert.equal(result.status, "completed");
+    assert.equal(result.commitMode, scenario.commitMode);
+    assert.equal(
+      execFileSync("git", ["show", `${result.headSha}:${stagedPath}`], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }),
+      "intentionally staged runtime config\n"
+    );
+    assert.match(
+      execFileSync("git", ["ls-tree", result.headSha, stagedPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }),
+      /^100755 blob /
+    );
+    assert.notEqual(
+      spawnSync("git", ["cat-file", "-e", `${result.headSha}:${metadataPath}`], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }).status,
+      0
+    );
+    assert.match(
+      execFileSync("git", ["status", "--porcelain"], {
+        cwd: result.worktree,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }),
+      /^\?\? \.antigravitycli\/runtime-state\.json$/m
+    );
+
+    const evidence = readExecutionEvidence(result.runDir);
+    assert.equal(evidence.verification_runs.length, 1);
+    assert.equal(
+      evidence.verification_runs[0].verification_tree_sha,
+      revParse(repoRoot, `${result.headSha}^{tree}`)
+    );
+  });
+}
 
 test("dispatch fails closed when an orchestrator-owned commit hook changes the verified tree", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -199,7 +199,14 @@ process.stdout.write("ok\\n");
 
 function fakeExecutorVerificationSupportSource() {
   return `
-function withVerificationEvidence(summary) {
+function captureVerificationTree(cwd) {
+  return require("child_process").execFileSync(
+    "git",
+    ["-C", cwd, "write-tree"],
+    { encoding: "utf-8", stdio: "pipe" }
+  ).trim();
+}
+function withVerificationEvidence(summary, verificationTreeSha) {
   const prompt = String(args[args.length - 1] || "");
   const requestBegin = "RELAY_VERIFICATION_REQUEST_BEGIN";
   const requestEnd = "RELAY_VERIFICATION_REQUEST_END";
@@ -229,7 +236,11 @@ function withVerificationEvidence(summary) {
   return [
     String(summary || "").trimEnd(),
     resultBegin,
-    JSON.stringify({ schema_version: 1, runs }),
+    JSON.stringify({
+      schema_version: 1,
+      verification_tree_sha: verificationTreeSha,
+      runs,
+    }),
     resultEnd,
     "",
   ].join("\\n");
@@ -258,8 +269,9 @@ const output = args[args.indexOf("-o") + 1];
 const fileName = fs.existsSync(cwd + "/first.txt") ? "resume.txt" : "first.txt";
 fs.writeFileSync(cwd + "/" + fileName, fileName + "\\n", "utf-8");
 execFileSync("git", ["-C", cwd, "add", fileName], { stdio: "pipe" });
+const verificationTreeSha = captureVerificationTree(cwd);
 execFileSync("git", ["-C", cwd, "commit", "-m", "fake " + fileName], { stdio: "pipe" });
-fs.writeFileSync(output, withVerificationEvidence("ok\\n"), "utf-8");
+fs.writeFileSync(output, withVerificationEvidence("ok\\n", verificationTreeSha), "utf-8");
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
@@ -472,8 +484,13 @@ if (args[0] !== "exec") {
   process.stderr.write("unsupported fake codex invocation");
   process.exit(1);
 }
+const cwd = args[args.indexOf("-C") + 1];
 const output = args[args.indexOf("-o") + 1];
-fs.writeFileSync(output, withVerificationEvidence("already applied\\n"), "utf-8");
+fs.writeFileSync(
+  output,
+  withVerificationEvidence("already applied\\n", captureVerificationTree(cwd)),
+  "utf-8"
+);
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
@@ -547,6 +564,7 @@ function writeUncommittedCodex(binDir) {
   const codexPath = path.join(binDir, "codex");
   fs.writeFileSync(codexPath, `#!/usr/bin/env node
 const fs = require("fs");
+const { execFileSync } = require("child_process");
 const args = process.argv.slice(2);
 ${fakeExecutorVerificationSupportSource()}
 if (args[0] === "--version") {
@@ -568,7 +586,13 @@ if (process.env.RELAY_TEST_EXTERNAL_ADVANCE === "1") {
   fs.writeFileSync(manifestPath, manifest, "utf-8");
 }
 fs.appendFileSync(cwd + "/README.md", "dirty\\n", "utf-8");
-fs.writeFileSync(output, withVerificationEvidence("work completed without commit\\n"), "utf-8");
+execFileSync("git", ["-C", cwd, "add", "README.md"], { stdio: "pipe" });
+const verificationTreeSha = captureVerificationTree(cwd);
+fs.writeFileSync(
+  output,
+  withVerificationEvidence("work completed without commit\\n", verificationTreeSha),
+  "utf-8"
+);
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
@@ -7060,10 +7084,12 @@ test("dispatch orchestrator-commits uncommitted codex runs by default", () => {
     },
     codexMode: "uncommitted",
   });
+  const rubricFile = writeAssuranceRubric("hardened");
 
   const result = JSON.parse(runDispatch(repoRoot, [
     "-b", "issue-508-codex-default-auto-recover",
     "--prompt", "work without commit",
+    "--rubric-file", rubricFile,
     "--json",
   ], env));
 
@@ -7101,9 +7127,14 @@ test("dispatch orchestrator-commits uncommitted codex runs by default", () => {
     result.headSha,
     "execution evidence binds to the orchestrator commit SHA, not the pre-commit HEAD",
   );
+  assert.equal(evidence.verification_runs.length, 1);
+  assert.equal(
+    evidence.verification_runs[0].verification_tree_sha,
+    revParse(repoRoot, `${result.headSha}^{tree}`)
+  );
 });
 
-test("dispatch fails closed when a commit hook changes the tree after executor verification", () => {
+test("dispatch fails closed when an orchestrator-owned commit hook changes the verified tree", () => {
   const { repoRoot, relayHome } = setupRepoWithOrigin();
   const { env } = createPushPrTestEnv({
     relayHome,
@@ -7157,6 +7188,67 @@ test("dispatch fails closed when a commit hook changes the tree after executor v
       stdio: "pipe",
     }),
     /mutated by pre-commit hook/
+  );
+  assert.equal(preflight.status, "blocked");
+  assert.equal(preflight.qualityExecutionStatus, "fail");
+  assert.match(preflight.reason, /verification gate went unrecorded: 'focused test'/);
+});
+
+test("dispatch fails closed when an executor-direct commit hook changes the verified tree", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    codexMode: "commit",
+  });
+  const hookPath = path.join(repoRoot, ".git", "hooks", "pre-commit");
+  fs.writeFileSync(hookPath, [
+    "#!/bin/sh",
+    "printf 'mutated in executor-direct pre-commit hook\\n' >> README.md",
+    "git add README.md",
+    "",
+  ].join("\n"), "utf-8");
+  fs.chmodSync(hookPath, 0o755);
+  const rubricFile = writeAssuranceRubric("hardened");
+
+  const dispatched = spawnSync(process.execPath, [
+    SCRIPT,
+    repoRoot,
+    "-b", "issue-1121-executor-tree-mutating-hook",
+    "--prompt", "verify work before the executor commits it",
+    "--rubric-file", rubricFile,
+    "--json",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env,
+  });
+  const result = JSON.parse(dispatched.stdout);
+  const evidence = readExecutionEvidence(result.runDir);
+  const manifestData = readManifest(result.manifestPath).data;
+  const preflight = buildExecutionEvidencePreflight({
+    runDir: result.runDir,
+    reviewedHead: result.headSha,
+    strict: true,
+    manifestData,
+  });
+
+  assert.equal(dispatched.status, 1, dispatched.stderr);
+  assert.equal(result.status, "failed");
+  assert.equal(result.runState, STATES.ESCALATED);
+  assert.equal(result.commitMode, "committed in-sandbox");
+  assert.match(result.error, /verification_tree_mismatch/);
+  assert.match(result.error, /final HEAD\^\{tree\}/);
+  assert.match(result.error, /re-run the executor verification gates at the committed HEAD/);
+  assert.equal(evidence.head_sha, result.headSha);
+  assert.equal(evidence.verification_runs, undefined);
+  assert.equal(evidence.test_exit_code, 1);
+  assert.match(
+    execFileSync("git", ["show", `${result.headSha}:README.md`], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }),
+    /mutated in executor-direct pre-commit hook/
   );
   assert.equal(preflight.status, "blocked");
   assert.equal(preflight.qualityExecutionStatus, "fail");
@@ -7782,6 +7874,10 @@ test("dispatch seeds execution evidence test_command from structured verificatio
   assert.equal(evidence.verification_runs.length, 1);
   assert.equal(evidence.verification_runs[0].command, "node --version");
   assert.equal(evidence.verification_runs[0].head_sha, result.headSha);
+  assert.equal(
+    evidence.verification_runs[0].verification_tree_sha,
+    revParse(fixture.repoRoot, `${result.headSha}^{tree}`)
+  );
   assert.equal(evidence.verification_runs[0].exit_code, 0);
   assert.equal(
     evidence.verification_runs[0].recorded_by,

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -25,6 +25,10 @@ const {
   EXECUTION_EVIDENCE_FILENAME,
   VERIFICATION_OUTPUT_FILENAME,
   hashFileSha256,
+  verificationTreeProofGitAddArgs,
+  verificationTreeProofStagedRuntimeAdditionsGitDiffArgs,
+  verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs,
+  verificationTreeProofTrackedGitAddArgs,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
 const {
   buildExecutionEvidencePreflight,
@@ -198,6 +202,14 @@ process.stdout.write("ok\\n");
 }
 
 function fakeExecutorVerificationSupportSource() {
+  const proofGitAddArgs = JSON.stringify(verificationTreeProofGitAddArgs());
+  const proofTrackedGitAddArgs = JSON.stringify(verificationTreeProofTrackedGitAddArgs());
+  const stagedRuntimePathArgs = JSON.stringify(
+    verificationTreeProofStagedRuntimeAdditionsGitDiffArgs()
+  );
+  const stageGateTimeRuntimeArgs = JSON.stringify(
+    verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs()
+  );
   return `
 function captureVerificationTree(cwd) {
   return require("child_process").execFileSync(
@@ -205,6 +217,57 @@ function captureVerificationTree(cwd) {
     ["-C", cwd, "write-tree"],
     { encoding: "utf-8", stdio: "pipe" }
   ).trim();
+}
+function captureGateTimeVerificationTree(cwd) {
+  const childProcess = require("child_process");
+  const fs = require("fs");
+  const os = require("os");
+  const path = require("path");
+  const proofDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-gate-time-proof-"));
+  const proofIndex = path.join(proofDir, "index");
+  const realIndex = childProcess.execFileSync(
+    "git",
+    ["-C", cwd, "rev-parse", "--git-path", "index"],
+    { encoding: "utf-8", stdio: "pipe" }
+  ).trim();
+  const proofEnv = { ...process.env, GIT_INDEX_FILE: proofIndex };
+  const realIndexEnv = { ...process.env, GIT_INDEX_FILE: realIndex };
+  try {
+    childProcess.execFileSync(
+      "git",
+      ["-C", cwd, "read-tree", "HEAD"],
+      { env: proofEnv, stdio: "pipe" }
+    );
+    childProcess.execFileSync(
+      "git",
+      ["-C", cwd, ...${proofGitAddArgs}],
+      { env: proofEnv, stdio: "pipe" }
+    );
+    childProcess.execFileSync(
+      "git",
+      ["-C", cwd, ...${proofTrackedGitAddArgs}],
+      { env: proofEnv, stdio: "pipe" }
+    );
+    const stagedRuntimePaths = childProcess.execFileSync(
+      "git",
+      ["-C", cwd, ...${stagedRuntimePathArgs}],
+      { env: realIndexEnv, stdio: "pipe" }
+    );
+    if (stagedRuntimePaths.length > 0) {
+      childProcess.execFileSync(
+        "git",
+        ["-C", cwd, ...${stageGateTimeRuntimeArgs}],
+        { env: proofEnv, input: stagedRuntimePaths, stdio: ["pipe", "pipe", "pipe"] }
+      );
+    }
+    return childProcess.execFileSync(
+      "git",
+      ["-C", cwd, "write-tree"],
+      { env: proofEnv, encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } finally {
+    fs.rmSync(proofDir, { recursive: true, force: true });
+  }
 }
 function withVerificationEvidence(summary, verificationTreeSha) {
   const prompt = String(args[args.length - 1] || "");
@@ -639,7 +702,10 @@ fs.writeFileSync(
   return codexPath;
 }
 
-function writeStagedRuntimeRootAdditionCodex(binDir, { directCommit = false } = {}) {
+function writeStagedRuntimeRootAdditionCodex(
+  binDir,
+  { directCommit = false, postStageMutation = "none" } = {}
+) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
   fs.writeFileSync(codexPath, `#!/usr/bin/env node
@@ -673,7 +739,16 @@ fs.writeFileSync(
   '{"session":"unstaged-runtime-metadata"}\\n',
   "utf-8"
 );
-const verificationTreeSha = captureVerificationTree(cwd);
+if (${JSON.stringify(postStageMutation)} === "content-mode") {
+  fs.writeFileSync(stagedAddition, "gate-time runtime config\\n", "utf-8");
+  fs.chmodSync(stagedAddition, 0o644);
+} else if (${JSON.stringify(postStageMutation)} === "delete") {
+  fs.unlinkSync(stagedAddition);
+  fs.appendFileSync(path.join(cwd, "README.md"), "gate-time sibling change\\n", "utf-8");
+}
+const verificationTreeSha = ${JSON.stringify(postStageMutation)} === "none"
+  ? captureVerificationTree(cwd)
+  : captureGateTimeVerificationTree(cwd);
 if (${JSON.stringify(directCommit)}) {
   execFileSync(
     "git",
@@ -958,6 +1033,24 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
     writeStagedRuntimeRootAdditionCodex(binDir, { directCommit: true });
   } else if (codexMode === "runtime-root-staged-addition-uncommitted") {
     writeStagedRuntimeRootAdditionCodex(binDir);
+  } else if (codexMode === "runtime-root-staged-addition-mutated-direct") {
+    writeStagedRuntimeRootAdditionCodex(binDir, {
+      directCommit: true,
+      postStageMutation: "content-mode",
+    });
+  } else if (codexMode === "runtime-root-staged-addition-mutated-uncommitted") {
+    writeStagedRuntimeRootAdditionCodex(binDir, {
+      postStageMutation: "content-mode",
+    });
+  } else if (codexMode === "runtime-root-staged-addition-deleted-direct") {
+    writeStagedRuntimeRootAdditionCodex(binDir, {
+      directCommit: true,
+      postStageMutation: "delete",
+    });
+  } else if (codexMode === "runtime-root-staged-addition-deleted-uncommitted") {
+    writeStagedRuntimeRootAdditionCodex(binDir, {
+      postStageMutation: "delete",
+    });
   } else if (codexMode === "runtime-root-uncommitted") {
     writeUncommittedRuntimeRootCodex(binDir);
   } else if (codexMode === "uncommitted") {
@@ -7404,6 +7497,126 @@ for (const scenario of [
       evidence.verification_runs[0].verification_tree_sha,
       revParse(repoRoot, `${result.headSha}^{tree}`)
     );
+  });
+}
+
+for (const scenario of [
+  {
+    name: "content and mode mutation",
+    codexMode: "runtime-root-staged-addition-mutated-uncommitted",
+    branch: "issue-1121-staged-runtime-mutated-orchestrator",
+    expectedContent: "gate-time runtime config\n",
+    expectedMode: /^100644 blob /,
+  },
+  {
+    name: "deletion",
+    codexMode: "runtime-root-staged-addition-deleted-uncommitted",
+    branch: "issue-1121-staged-runtime-deleted-orchestrator",
+    expectedContent: null,
+    expectedMode: null,
+  },
+]) {
+  test(`dispatch orchestrator commit proves staged runtime-root ${scenario.name} from the gate-time worktree`, () => {
+    const { repoRoot, relayHome } = setupRepoWithOrigin();
+    process.env.RELAY_HOME = relayHome;
+    const { env } = createPushPrTestEnv({
+      relayHome,
+      ghState: {
+        prCreateUrl: "https://github.com/acme/dev-relay/pull/1121",
+      },
+      codexMode: scenario.codexMode,
+    });
+    const rubricFile = writeAssuranceRubric("hardened");
+
+    const result = JSON.parse(runDispatch(repoRoot, [
+      "-b", scenario.branch,
+      "--prompt", "prove the gate-time runtime-root state",
+      "--rubric-file", rubricFile,
+      "--json",
+    ], env));
+    const stagedPath = ".antigravitycli/reviewable-runtime-config";
+
+    assert.equal(result.status, "completed");
+    assert.equal(result.commitMode, "orchestrator-committed");
+    if (scenario.expectedContent === null) {
+      assert.notEqual(
+        spawnSync("git", ["cat-file", "-e", `${result.headSha}:${stagedPath}`], {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          stdio: "pipe",
+        }).status,
+        0
+      );
+    } else {
+      assert.equal(
+        execFileSync("git", ["show", `${result.headSha}:${stagedPath}`], {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          stdio: "pipe",
+        }),
+        scenario.expectedContent
+      );
+      assert.match(
+        execFileSync("git", ["ls-tree", result.headSha, stagedPath], {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          stdio: "pipe",
+        }),
+        scenario.expectedMode
+      );
+    }
+
+    const evidence = readExecutionEvidence(result.runDir);
+    assert.equal(evidence.verification_runs.length, 1);
+    assert.equal(
+      evidence.verification_runs[0].verification_tree_sha,
+      revParse(repoRoot, `${result.headSha}^{tree}`)
+    );
+  });
+}
+
+for (const scenario of [
+  {
+    name: "content and mode mutation",
+    codexMode: "runtime-root-staged-addition-mutated-direct",
+    branch: "issue-1121-staged-runtime-mutated-direct",
+  },
+  {
+    name: "deletion",
+    codexMode: "runtime-root-staged-addition-deleted-direct",
+    branch: "issue-1121-staged-runtime-deleted-direct",
+  },
+]) {
+  test(`dispatch fails closed when an executor-direct commit ignores staged runtime-root ${scenario.name}`, () => {
+    const { repoRoot, relayHome } = setupRepoWithOrigin();
+    const { env } = createPushPrTestEnv({
+      relayHome,
+      codexMode: scenario.codexMode,
+    });
+    const rubricFile = writeAssuranceRubric("hardened");
+
+    const dispatched = spawnSync(process.execPath, [
+      SCRIPT,
+      repoRoot,
+      "-b", scenario.branch,
+      "--prompt", "prove the gate-time runtime-root state before a stale direct commit",
+      "--rubric-file", rubricFile,
+      "--json",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env,
+    });
+    const result = JSON.parse(dispatched.stdout);
+    const evidence = readExecutionEvidence(result.runDir);
+
+    assert.equal(dispatched.status, 1, dispatched.stderr);
+    assert.equal(result.status, "failed");
+    assert.equal(result.runState, STATES.ESCALATED);
+    assert.equal(result.commitMode, "committed in-sandbox");
+    assert.match(result.error, /verification_tree_mismatch/);
+    assert.equal(evidence.verification_runs, undefined);
+    assert.equal(evidence.test_exit_code, 1);
   });
 }
 

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -704,7 +704,7 @@ fs.writeFileSync(
 
 function writeStagedRuntimeRootAdditionCodex(
   binDir,
-  { directCommit = false, postStageMutation = "none" } = {}
+  { directCommit = false, intentToAdd = false, postStageMutation = "none" } = {}
 ) {
   ensureDefaultFakeGh(binDir);
   const codexPath = path.join(binDir, "codex");
@@ -731,7 +731,7 @@ fs.writeFileSync(stagedAddition, "intentionally staged runtime config\\n", "utf-
 fs.chmodSync(stagedAddition, 0o755);
 execFileSync(
   "git",
-  ["-C", cwd, "add", ".antigravitycli/reviewable-runtime-config"],
+  ["-C", cwd, "add", ${JSON.stringify(intentToAdd ? "-N" : null)}, ".antigravitycli/reviewable-runtime-config"].filter(Boolean),
   { stdio: "pipe" }
 );
 fs.writeFileSync(
@@ -746,13 +746,16 @@ if (${JSON.stringify(postStageMutation)} === "content-mode") {
   fs.unlinkSync(stagedAddition);
   fs.appendFileSync(path.join(cwd, "README.md"), "gate-time sibling change\\n", "utf-8");
 }
-const verificationTreeSha = ${JSON.stringify(postStageMutation)} === "none"
+const verificationTreeSha = (
+  ${JSON.stringify(postStageMutation)} === "none"
+  && !${JSON.stringify(intentToAdd)}
+)
   ? captureVerificationTree(cwd)
   : captureGateTimeVerificationTree(cwd);
 if (${JSON.stringify(directCommit)}) {
   execFileSync(
     "git",
-    ["-C", cwd, "commit", "-m", "add staged runtime config"],
+    ["-C", cwd, "commit", ${JSON.stringify(intentToAdd ? "-a" : null)}, "-m", "add staged runtime config"].filter(Boolean),
     { stdio: "pipe" }
   );
 }
@@ -1050,6 +1053,15 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
   } else if (codexMode === "runtime-root-staged-addition-deleted-uncommitted") {
     writeStagedRuntimeRootAdditionCodex(binDir, {
       postStageMutation: "delete",
+    });
+  } else if (codexMode === "runtime-root-intent-to-add-direct") {
+    writeStagedRuntimeRootAdditionCodex(binDir, {
+      directCommit: true,
+      intentToAdd: true,
+    });
+  } else if (codexMode === "runtime-root-intent-to-add-uncommitted") {
+    writeStagedRuntimeRootAdditionCodex(binDir, {
+      intentToAdd: true,
     });
   } else if (codexMode === "runtime-root-uncommitted") {
     writeUncommittedRuntimeRootCodex(binDir);
@@ -7491,6 +7503,68 @@ for (const scenario of [
       /^\?\? \.antigravitycli\/runtime-state\.json$/m
     );
 
+    const evidence = readExecutionEvidence(result.runDir);
+    assert.equal(evidence.verification_runs.length, 1);
+    assert.equal(
+      evidence.verification_runs[0].verification_tree_sha,
+      revParse(repoRoot, `${result.headSha}^{tree}`)
+    );
+  });
+}
+
+for (const scenario of [
+  {
+    name: "orchestrator commit",
+    codexMode: "runtime-root-intent-to-add-uncommitted",
+    branch: "issue-1121-runtime-intent-orchestrator",
+    commitMode: "orchestrator-committed",
+  },
+  {
+    name: "executor-direct commit -a",
+    codexMode: "runtime-root-intent-to-add-direct",
+    branch: "issue-1121-runtime-intent-direct",
+    commitMode: "committed in-sandbox",
+  },
+]) {
+  test(`dispatch ${scenario.name} proves an intent-to-add runtime-root path from the gate-time worktree`, () => {
+    const { repoRoot, relayHome } = setupRepoWithOrigin();
+    process.env.RELAY_HOME = relayHome;
+    const { env } = createPushPrTestEnv({
+      relayHome,
+      ghState: {
+        prCreateUrl: "https://github.com/acme/dev-relay/pull/1121",
+      },
+      codexMode: scenario.codexMode,
+    });
+    const rubricFile = writeAssuranceRubric("hardened");
+
+    const result = JSON.parse(runDispatch(repoRoot, [
+      "-b", scenario.branch,
+      "--prompt", "prove an intent-to-add runtime-root path beside executor metadata",
+      "--rubric-file", rubricFile,
+      "--json",
+    ], env));
+    const stagedPath = ".antigravitycli/reviewable-runtime-config";
+    const metadataPath = ".antigravitycli/runtime-state.json";
+
+    assert.equal(result.status, "completed");
+    assert.equal(result.commitMode, scenario.commitMode);
+    assert.equal(
+      execFileSync("git", ["show", `${result.headSha}:${stagedPath}`], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }),
+      "intentionally staged runtime config\n"
+    );
+    assert.notEqual(
+      spawnSync("git", ["cat-file", "-e", `${result.headSha}:${metadataPath}`], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }).status,
+      0
+    );
     const evidence = readExecutionEvidence(result.runDir);
     assert.equal(evidence.verification_runs.length, 1);
     assert.equal(

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -1375,6 +1375,55 @@ finishWhenReady();
   return codexPath;
 }
 
+function writeMarkedProcessInventoryCommands(binDir) {
+  const pgrepPath = path.join(binDir, "pgrep");
+  fs.writeFileSync(pgrepPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+let marker;
+try {
+  marker = JSON.parse(fs.readFileSync(process.env.RELAY_TEST_EXECUTOR_MARKER, "utf-8"));
+} catch {
+  process.exit(1);
+}
+if (
+  args.length === 2 &&
+  args[0] === "-g" &&
+  Number(args[1]) === Number(marker.pgid) &&
+  Number.isFinite(Number(marker.childPid))
+) {
+  process.stdout.write(String(marker.childPid) + "\\n");
+  process.exit(0);
+}
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(pgrepPath, 0o755);
+
+  const psPath = path.join(binDir, "ps");
+  fs.writeFileSync(psPath, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+let marker;
+try {
+  marker = JSON.parse(fs.readFileSync(process.env.RELAY_TEST_EXECUTOR_MARKER, "utf-8"));
+} catch {
+  process.exit(1);
+}
+if (
+  args.length === 4 &&
+  args[0] === "-p" &&
+  Number(args[1]) === Number(marker.childPid) &&
+  args[2] === "-o" &&
+  args[3] === "comm="
+) {
+  process.stdout.write("relay-lingering-child\\n");
+  process.exit(0);
+}
+process.exit(1);
+`, "utf-8");
+  fs.chmodSync(psPath, 0o755);
+}
+
 async function waitForDispatchExit(proc) {
   let stdout = "";
   let stderr = "";
@@ -5953,6 +6002,7 @@ test("dispatch completes normally when clean leader exit leaves a lingering proc
     paths: () => [binDir, markerPath, `${markerPath}.child-ready`],
   });
   writeLeaderExitBackgroundCodex(binDir);
+  writeMarkedProcessInventoryCommands(binDir);
   const env = {
     ...process.env,
     PATH: `${binDir}:${process.env.PATH}`,

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -598,6 +598,47 @@ fs.writeFileSync(
   return codexPath;
 }
 
+function writeUncommittedRuntimeRootCodex(binDir) {
+  ensureDefaultFakeGh(binDir);
+  const codexPath = path.join(binDir, "codex");
+  fs.writeFileSync(codexPath, `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const args = process.argv.slice(2);
+${fakeExecutorVerificationSupportSource()}
+if (args[0] === "--version") {
+  process.stdout.write("codex-fake\\n");
+  process.exit(0);
+}
+if (args[0] !== "exec") {
+  process.stderr.write("unsupported fake codex invocation");
+  process.exit(1);
+}
+const cwd = args[args.indexOf("-C") + 1];
+const output = args[args.indexOf("-o") + 1];
+const runtimeDir = path.join(cwd, ".antigravitycli");
+fs.appendFileSync(path.join(runtimeDir, "tracked-config"), "tracked after\\n", "utf-8");
+fs.rmSync(path.join(runtimeDir, "tracked-obsolete"));
+fs.writeFileSync(
+  path.join(runtimeDir, "runtime-state.json"),
+  '{"session":"runtime-only"}\\n',
+  "utf-8"
+);
+execFileSync("git", ["-C", cwd, "add", "-u", "--", ".antigravitycli"], {
+  stdio: "pipe",
+});
+const verificationTreeSha = captureVerificationTree(cwd);
+fs.writeFileSync(
+  output,
+  withVerificationEvidence("runtime-root work completed without commit\\n", verificationTreeSha),
+  "utf-8"
+);
+`, "utf-8");
+  fs.chmodSync(codexPath, 0o755);
+  return codexPath;
+}
+
 function writeUncommittedClaude(binDir) {
   ensureDefaultFakeGh(binDir);
   const claudePath = path.join(binDir, "claude");
@@ -861,6 +902,8 @@ function createPushPrTestEnv({ relayHome, ghState = {}, failGitPush = false, cod
     writeSilentCodex(binDir);
   } else if (codexMode === "commit-no-result") {
     writeCommittedNoResultCodex(binDir);
+  } else if (codexMode === "runtime-root-uncommitted") {
+    writeUncommittedRuntimeRootCodex(binDir);
   } else if (codexMode === "uncommitted") {
     writeUncommittedCodex(binDir);
   } else if (codexMode === "partial-no-result") {
@@ -1373,55 +1416,6 @@ finishWhenReady();
 `, "utf-8");
   fs.chmodSync(codexPath, 0o755);
   return codexPath;
-}
-
-function writeMarkedProcessInventoryCommands(binDir) {
-  const pgrepPath = path.join(binDir, "pgrep");
-  fs.writeFileSync(pgrepPath, `#!/usr/bin/env node
-const fs = require("fs");
-const args = process.argv.slice(2);
-let marker;
-try {
-  marker = JSON.parse(fs.readFileSync(process.env.RELAY_TEST_EXECUTOR_MARKER, "utf-8"));
-} catch {
-  process.exit(1);
-}
-if (
-  args.length === 2 &&
-  args[0] === "-g" &&
-  Number(args[1]) === Number(marker.pgid) &&
-  Number.isFinite(Number(marker.childPid))
-) {
-  process.stdout.write(String(marker.childPid) + "\\n");
-  process.exit(0);
-}
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(pgrepPath, 0o755);
-
-  const psPath = path.join(binDir, "ps");
-  fs.writeFileSync(psPath, `#!/usr/bin/env node
-const fs = require("fs");
-const args = process.argv.slice(2);
-let marker;
-try {
-  marker = JSON.parse(fs.readFileSync(process.env.RELAY_TEST_EXECUTOR_MARKER, "utf-8"));
-} catch {
-  process.exit(1);
-}
-if (
-  args.length === 4 &&
-  args[0] === "-p" &&
-  Number(args[1]) === Number(marker.childPid) &&
-  args[2] === "-o" &&
-  args[3] === "comm="
-) {
-  process.stdout.write("relay-lingering-child\\n");
-  process.exit(0);
-}
-process.exit(1);
-`, "utf-8");
-  fs.chmodSync(psPath, 0o755);
 }
 
 async function waitForDispatchExit(proc) {
@@ -6002,7 +5996,6 @@ test("dispatch completes normally when clean leader exit leaves a lingering proc
     paths: () => [binDir, markerPath, `${markerPath}.child-ready`],
   });
   writeLeaderExitBackgroundCodex(binDir);
-  writeMarkedProcessInventoryCommands(binDir);
   const env = {
     ...process.env,
     PATH: `${binDir}:${process.env.PATH}`,
@@ -7177,6 +7170,101 @@ test("dispatch orchestrator-commits uncommitted codex runs by default", () => {
     result.headSha,
     "execution evidence binds to the orchestrator commit SHA, not the pre-commit HEAD",
   );
+  assert.equal(evidence.verification_runs.length, 1);
+  assert.equal(
+    evidence.verification_runs[0].verification_tree_sha,
+    revParse(repoRoot, `${result.headSha}^{tree}`)
+  );
+});
+
+test("dispatch commit keeps tracked runtime-root changes but excludes adjacent metadata", () => {
+  const { repoRoot, relayHome } = setupRepoWithOrigin();
+  process.env.RELAY_HOME = relayHome;
+  const runtimeDir = path.join(repoRoot, ".antigravitycli");
+  const trackedRuntimePath = ".antigravitycli/tracked-config";
+  const deletedRuntimePath = ".antigravitycli/tracked-obsolete";
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(repoRoot, trackedRuntimePath),
+    "tracked before\n",
+    "utf-8"
+  );
+  fs.writeFileSync(
+    path.join(repoRoot, deletedRuntimePath),
+    "remove during dispatch\n",
+    "utf-8"
+  );
+  execFileSync("git", ["add", trackedRuntimePath, deletedRuntimePath], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  execFileSync("git", ["commit", "-m", "track runtime config"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  execFileSync("git", ["push", "origin", "main"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  const { env } = createPushPrTestEnv({
+    relayHome,
+    ghState: {
+      prCreateUrl: "https://github.com/acme/dev-relay/pull/1121",
+    },
+    codexMode: "runtime-root-uncommitted",
+  });
+  const rubricFile = writeAssuranceRubric("hardened");
+
+  const result = JSON.parse(runDispatch(repoRoot, [
+    "-b", "issue-1121-runtime-root-reviewable",
+    "--prompt", "change tracked runtime config beside executor metadata",
+    "--rubric-file", rubricFile,
+    "--json",
+  ], env));
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.commitMode, "orchestrator-committed");
+  assert.equal(
+    execFileSync("git", ["show", `${result.headSha}:${trackedRuntimePath}`], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }),
+    "tracked before\ntracked after\n"
+  );
+  assert.notEqual(
+    spawnSync("git", [
+      "cat-file",
+      "-e",
+      `${result.headSha}:.antigravitycli/runtime-state.json`,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).status,
+    0
+  );
+  assert.notEqual(
+    spawnSync("git", ["cat-file", "-e", `${result.headSha}:${deletedRuntimePath}`], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).status,
+    0
+  );
+  const worktreeStatus = execFileSync("git", ["status", "--porcelain"], {
+    cwd: result.worktree,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  assert.match(worktreeStatus, /^\?\? \.antigravitycli\/runtime-state\.json$/m);
+  assert.doesNotMatch(worktreeStatus, /tracked-config/);
+
+  const evidence = readExecutionEvidence(result.runDir);
   assert.equal(evidence.verification_runs.length, 1);
   assert.equal(
     evidence.verification_runs[0].verification_tree_sha,

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -16,6 +16,7 @@ const {
   rebrandEvidence,
   resolveExecutionEvidenceTestCommand,
   verificationTreeProofGitAddArgs,
+  verificationTreeProofTrackedGitAddArgs,
   writeExecutionEvidence,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
 const {
@@ -129,12 +130,13 @@ test("executor verification instructions keep gate execution inside the dispatch
   assert.match(instructions, /GIT_INDEX_FILE/);
   assert.match(instructions, /git write-tree/);
   assert.match(instructions, /:\(exclude\)\.antigravitycli/);
+  assert.match(instructions, /tracked runtime-root modifications and deletions remain reviewable/);
   assert.match(instructions, /before any later commit or commit hook can mutate the tree/);
   assert.match(instructions, /verification_tree_sha/);
   assert.match(instructions, /"command":"node --test focused\.test\.js"/);
 });
 
-test("verification tree proof excludes staged Antigravity runtime metadata", (t) => {
+test("verification tree proof keeps tracked runtime changes and excludes adjacent metadata", (t) => {
   const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-verification-tree-"));
   const verificationIndex = path.join(
     os.tmpdir(),
@@ -146,11 +148,33 @@ test("verification tree proof excludes staged Antigravity runtime metadata", (t)
   git(repoPath, "config", "user.name", "Relay Test");
   git(repoPath, "config", "user.email", "relay@example.com");
   fs.writeFileSync(path.join(repoPath, "reviewable.txt"), "before\n", "utf-8");
-  git(repoPath, "add", "reviewable.txt");
+  fs.mkdirSync(path.join(repoPath, ".antigravitycli"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoPath, ".antigravitycli", "tracked-config"),
+    "tracked before\n",
+    "utf-8"
+  );
+  fs.writeFileSync(
+    path.join(repoPath, ".antigravitycli", "tracked-obsolete"),
+    "remove after verification\n",
+    "utf-8"
+  );
+  git(
+    repoPath,
+    "add",
+    "reviewable.txt",
+    ".antigravitycli/tracked-config",
+    ".antigravitycli/tracked-obsolete"
+  );
   git(repoPath, "commit", "-m", "base");
 
   fs.writeFileSync(path.join(repoPath, "reviewable.txt"), "after\n", "utf-8");
-  fs.mkdirSync(path.join(repoPath, ".antigravitycli"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoPath, ".antigravitycli", "tracked-config"),
+    "tracked after\n",
+    "utf-8"
+  );
+  fs.unlinkSync(path.join(repoPath, ".antigravitycli", "tracked-obsolete"));
   fs.writeFileSync(
     path.join(repoPath, ".antigravitycli", "runtime-state.json"),
     '{"session":"runtime-only"}\n',
@@ -172,6 +196,11 @@ test("verification tree proof excludes staged Antigravity runtime metadata", (t)
     env: proofEnv,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  execFileSync("git", verificationTreeProofTrackedGitAddArgs(), {
+    cwd: repoPath,
+    env: proofEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
   const verificationTreeSha = execFileSync("git", ["write-tree"], {
     cwd: repoPath,
     env: proofEnv,
@@ -182,11 +211,23 @@ test("verification tree proof excludes staged Antigravity runtime metadata", (t)
 
   assert.deepEqual(
     git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha).split("\n"),
-    ["reviewable.txt"]
+    [".antigravitycli/tracked-config", "reviewable.txt"]
+  );
+  assert.equal(
+    git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/tracked-config`),
+    "tracked after"
   );
   assert.match(
     git(repoPath, "ls-tree", "-r", "--name-only", realIndexTreeSha),
     /\.antigravitycli\/runtime-state\.json/
+  );
+  assert.match(
+    git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha),
+    /\.antigravitycli\/tracked-config/
+  );
+  assert.doesNotMatch(
+    git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha),
+    /\.antigravitycli\/(?:runtime-state\.json|tracked-obsolete)/
   );
   assert.notEqual(verificationTreeSha, realIndexTreeSha);
 });

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -17,6 +17,7 @@ const {
   resolveExecutionEvidenceTestCommand,
   verificationTreeProofGitAddArgs,
   verificationTreeProofStagedRuntimeAdditionsGitDiffArgs,
+  verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs,
   verificationTreeProofTrackedGitAddArgs,
   writeExecutionEvidence,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
@@ -133,7 +134,9 @@ test("executor verification instructions keep gate execution inside the dispatch
   assert.match(instructions, /:\(exclude\)\.antigravitycli/);
   assert.match(instructions, /intentionally staged runtime-root additions/);
   assert.match(instructions, /tracked runtime-root modifications and deletions remain reviewable/);
-  assert.match(instructions, /exact staged blob and mode/);
+  assert.match(instructions, /gate-time worktree/);
+  assert.match(instructions, /update-index/);
+  assert.match(instructions, /--remove/);
   assert.match(instructions, /before any later commit or commit hook can mutate the tree/);
   assert.match(instructions, /verification_tree_sha/);
   assert.match(instructions, /"command":"node --test focused\.test\.js"/);
@@ -191,8 +194,16 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   fs.writeFileSync(stagedAdditionPath, "staged addition\n", "utf-8");
   fs.chmodSync(stagedAdditionPath, 0o755);
   git(repoPath, "add", ".antigravitycli/staged-tool");
+  const stagedDeletedPath = path.join(
+    repoPath,
+    ".antigravitycli",
+    "staged-deleted"
+  );
+  fs.writeFileSync(stagedDeletedPath, "deleted after staging\n", "utf-8");
+  git(repoPath, "add", ".antigravitycli/staged-deleted");
   fs.writeFileSync(stagedAdditionPath, "later unstaged content\n", "utf-8");
   fs.chmodSync(stagedAdditionPath, 0o644);
+  fs.unlinkSync(stagedDeletedPath);
 
   const proofEnv = {
     ...process.env,
@@ -213,13 +224,13 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
     env: proofEnv,
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const stagedRuntimePatch = path.join(
+  const stagedRuntimePaths = path.join(
     os.tmpdir(),
-    `relay-verification-runtime-additions-${process.pid}-${Date.now()}.patch`
+    `relay-verification-runtime-additions-${process.pid}-${Date.now()}.paths`
   );
-  t.after(() => fs.rmSync(stagedRuntimePatch, { force: true }));
+  t.after(() => fs.rmSync(stagedRuntimePaths, { force: true }));
   const realIndexPath = git(repoPath, "rev-parse", "--git-path", "index");
-  const stagedRuntimeDiff = execFileSync(
+  const stagedRuntimePathList = execFileSync(
     "git",
     verificationTreeProofStagedRuntimeAdditionsGitDiffArgs(),
     {
@@ -231,14 +242,15 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
       stdio: ["ignore", "pipe", "pipe"],
     }
   );
-  fs.writeFileSync(stagedRuntimePatch, stagedRuntimeDiff);
+  fs.writeFileSync(stagedRuntimePaths, stagedRuntimePathList);
   execFileSync(
     "git",
-    ["apply", "--cached", "--whitespace=nowarn", stagedRuntimePatch],
+    verificationTreeProofStagedRuntimeAdditionsGitUpdateIndexArgs(),
     {
       cwd: repoPath,
       env: proofEnv,
-      stdio: ["ignore", "pipe", "pipe"],
+      input: stagedRuntimePathList,
+      stdio: ["pipe", "pipe", "pipe"],
     }
   );
   const verificationTreeSha = execFileSync("git", ["write-tree"], {
@@ -263,11 +275,11 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   );
   assert.equal(
     git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/staged-tool`),
-    "staged addition"
+    "later unstaged content"
   );
   assert.match(
     git(repoPath, "ls-tree", verificationTreeSha, ".antigravitycli/staged-tool"),
-    /^100755 blob /
+    /^100644 blob /
   );
   assert.match(
     git(repoPath, "ls-tree", "-r", "--name-only", realIndexTreeSha),
@@ -279,11 +291,11 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   );
   assert.doesNotMatch(
     git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha),
-    /\.antigravitycli\/(?:runtime-state\.json|tracked-obsolete)/
+    /\.antigravitycli\/(?:runtime-state\.json|staged-deleted|tracked-obsolete)/
   );
   assert.doesNotMatch(
     git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/staged-tool`),
-    /later unstaged content/
+    /staged addition/
   );
   assert.notEqual(verificationTreeSha, realIndexTreeSha);
 });

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -114,6 +114,10 @@ test("executor verification instructions keep gate execution inside the dispatch
   assert.match(instructions, /inside this same executor session/);
   assert.match(instructions, /current sandbox and network policy/);
   assert.match(instructions, /Do not delegate them back to the relay orchestrator/);
+  assert.match(instructions, /After all required gates finish/);
+  assert.match(instructions, /git write-tree/);
+  assert.match(instructions, /before any later commit or commit hook can mutate the tree/);
+  assert.match(instructions, /verification_tree_sha/);
   assert.match(instructions, /"command":"node --test focused\.test\.js"/);
 });
 
@@ -128,6 +132,7 @@ test("executor-confirmed verification results persist SHA-bound output evidence 
     "RELAY_VERIFICATION_RESULT_BEGIN",
     JSON.stringify({
       schema_version: 1,
+      verification_tree_sha: "c".repeat(40),
       runs: [{
         command,
         exit_code: 1,
@@ -141,6 +146,7 @@ test("executor-confirmed verification results persist SHA-bound output evidence 
     gates: [{ name: "focused gate", type: "command", command }],
     cwd,
     headSha,
+    finalTreeSha: "c".repeat(40),
     runDir,
     resultText,
     executor: "codex",
@@ -153,6 +159,7 @@ test("executor-confirmed verification results persist SHA-bound output evidence 
   assert.equal(result.runs[0].command, command);
   assert.equal(result.runs[0].cwd, cwd);
   assert.equal(result.runs[0].head_sha, headSha);
+  assert.equal(result.runs[0].verification_tree_sha, "c".repeat(40));
   assert.equal(result.runs[0].exit_code, 1);
   assert.equal(result.runs[0].recorded_by, "codex-confirmed-verification-v1");
   assert.equal(result.runs[0].recorded_at, "2026-07-28T00:00:00.000Z");
@@ -161,6 +168,7 @@ test("executor-confirmed verification results persist SHA-bound output evidence 
     hashFileSha256(path.join(runDir, result.runs[0].output_path))
   );
   assert.equal(path.basename(result.outputPath), VERIFICATION_OUTPUT_FILENAME);
+  assert.equal(result.verificationTreeSha, "c".repeat(40));
   assert.match(fs.readFileSync(result.outputPath, "utf-8"), /sandbox policy denied write/);
   assert.equal(fs.existsSync(sentinelPath), false);
 });
@@ -170,6 +178,7 @@ test("executor verification evidence fails closed on missing or mismatched confi
     gates: [{ name: "focused gate", command: "node --test focused.test.js" }],
     cwd: "/repo",
     headSha: "b".repeat(40),
+    finalTreeSha: "c".repeat(40),
     runDir: fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-verification-invalid-")),
     executor: "codex",
   };
@@ -183,11 +192,54 @@ test("executor verification evidence fails closed on missing or mismatched confi
       ...options,
       resultText: [
         "RELAY_VERIFICATION_RESULT_BEGIN",
-        '{"schema_version":1,"runs":[{"command":"npm test","exit_code":0,"output":"ok"}]}',
+        `{"schema_version":1,"verification_tree_sha":"${"c".repeat(40)}","runs":[{"command":"npm test","exit_code":0,"output":"ok"}]}`,
         "RELAY_VERIFICATION_RESULT_END",
       ].join("\n"),
     }),
     /did not match required gate/
+  );
+
+  for (const verificationTreeSha of [undefined, "not-a-tree", "a".repeat(39)]) {
+    const envelope = {
+      schema_version: 1,
+      ...(verificationTreeSha === undefined ? {} : { verification_tree_sha: verificationTreeSha }),
+      runs: [{
+        command: "node --test focused.test.js",
+        exit_code: 0,
+        output: "ok",
+      }],
+    };
+    assert.throws(
+      () => collectExecutorVerificationEvidence({
+        ...options,
+        resultText: [
+          "RELAY_VERIFICATION_RESULT_BEGIN",
+          JSON.stringify(envelope),
+          "RELAY_VERIFICATION_RESULT_END",
+        ].join("\n"),
+      }),
+      /verification_tree_proof_invalid.*40-character hex Git tree SHA.*re-run the executor verification gates/
+    );
+  }
+
+  assert.throws(
+    () => collectExecutorVerificationEvidence({
+      ...options,
+      resultText: [
+        "RELAY_VERIFICATION_RESULT_BEGIN",
+        JSON.stringify({
+          schema_version: 1,
+          verification_tree_sha: "d".repeat(40),
+          runs: [{
+            command: "node --test focused.test.js",
+            exit_code: 0,
+            output: "ok",
+          }],
+        }),
+        "RELAY_VERIFICATION_RESULT_END",
+      ].join("\n"),
+    }),
+    /verification_tree_mismatch.*final HEAD\^\{tree\}.*re-run the executor verification gates/
   );
 });
 
@@ -455,6 +507,74 @@ test("rebrandEvidence safely audits malformed verification_runs and strict prefl
       entry.name
     );
   }
+});
+
+test("strict preflight blocks a malformed verification rebrand audit with zero command gates", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-rebrand-gateless-"));
+  const rubric = [
+    "evaluation:",
+    "  verification:",
+    "    checks:",
+    "      - name: inspect artifact",
+    "        type: observation",
+  ].join("\n");
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), rubric, "utf-8");
+  const legacyFields = {
+    schema_version: 1,
+    test_command: "node --test legacy.test.js",
+    test_result_hash: "c".repeat(64),
+    test_result_summary: "legacy gate passed",
+    test_exit_code: 0,
+    recorded_at: "2026-04-22T00:00:00.000Z",
+    recorded_by: "dispatch-orchestrator-v1",
+  };
+  writeExecutionEvidence(runDir, {
+    ...legacyFields,
+    head_sha: "a".repeat(40),
+    verification_runs: { command: "node --test malformed.test.js" },
+  });
+
+  rebrandEvidence(runDir, {
+    newHeadSha: "b".repeat(40),
+    reason: "recover malformed gateless evidence",
+  });
+  const blocked = buildExecutionEvidencePreflight({
+    runDir,
+    reviewedHead: "b".repeat(40),
+    strict: true,
+  });
+
+  assert.equal(blocked.status, "blocked");
+  assert.equal(blocked.qualityExecutionStatus, "fail");
+  assert.match(blocked.reason, /removed malformed verification_runs/);
+  assert.match(blocked.reason, /must be an array when present; found object/);
+  assert.match(blocked.reason, new RegExp(`from ${"a".repeat(40)} to ${"b".repeat(40)}`));
+  assert.match(blocked.reason, /Re-verify at the new HEAD or record audited operator evidence/);
+  assert.doesNotMatch(blocked.reason, /Required verification gates?:/);
+
+  const cleanRunDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-clean-gateless-"));
+  fs.writeFileSync(path.join(cleanRunDir, "rubric.yaml"), rubric, "utf-8");
+  writeExecutionEvidence(cleanRunDir, {
+    ...legacyFields,
+    head_sha: "b".repeat(40),
+  });
+  assert.deepEqual(
+    buildExecutionEvidencePreflight({
+      runDir: cleanRunDir,
+      reviewedHead: "b".repeat(40),
+      strict: true,
+    }),
+    {
+      status: "pass",
+      qualityExecutionStatus: "pass",
+      reason: null,
+      reviewedHeadSha: "b".repeat(40),
+      evidenceHeadSha: "b".repeat(40),
+      artifactPath: path.join(cleanRunDir, EXECUTION_EVIDENCE_FILENAME),
+      browserEvidence: { present: false },
+      nextAction: "invoke_primary_reviewer",
+    }
+  );
 });
 
 test("rebrandEvidence retains verification removal provenance across repeated rebrands", () => {

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -16,6 +16,7 @@ const {
   rebrandEvidence,
   resolveExecutionEvidenceTestCommand,
   verificationTreeProofGitAddArgs,
+  verificationTreeProofStagedRuntimeAdditionsGitDiffArgs,
   verificationTreeProofTrackedGitAddArgs,
   writeExecutionEvidence,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
@@ -130,7 +131,9 @@ test("executor verification instructions keep gate execution inside the dispatch
   assert.match(instructions, /GIT_INDEX_FILE/);
   assert.match(instructions, /git write-tree/);
   assert.match(instructions, /:\(exclude\)\.antigravitycli/);
+  assert.match(instructions, /intentionally staged runtime-root additions/);
   assert.match(instructions, /tracked runtime-root modifications and deletions remain reviewable/);
+  assert.match(instructions, /exact staged blob and mode/);
   assert.match(instructions, /before any later commit or commit hook can mutate the tree/);
   assert.match(instructions, /verification_tree_sha/);
   assert.match(instructions, /"command":"node --test focused\.test\.js"/);
@@ -180,7 +183,16 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
     '{"session":"runtime-only"}\n',
     "utf-8"
   );
-  git(repoPath, "add", "-A");
+  const stagedAdditionPath = path.join(
+    repoPath,
+    ".antigravitycli",
+    "staged-tool"
+  );
+  fs.writeFileSync(stagedAdditionPath, "staged addition\n", "utf-8");
+  fs.chmodSync(stagedAdditionPath, 0o755);
+  git(repoPath, "add", ".antigravitycli/staged-tool");
+  fs.writeFileSync(stagedAdditionPath, "later unstaged content\n", "utf-8");
+  fs.chmodSync(stagedAdditionPath, 0o644);
 
   const proofEnv = {
     ...process.env,
@@ -201,6 +213,34 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
     env: proofEnv,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  const stagedRuntimePatch = path.join(
+    os.tmpdir(),
+    `relay-verification-runtime-additions-${process.pid}-${Date.now()}.patch`
+  );
+  t.after(() => fs.rmSync(stagedRuntimePatch, { force: true }));
+  const realIndexPath = git(repoPath, "rev-parse", "--git-path", "index");
+  const stagedRuntimeDiff = execFileSync(
+    "git",
+    verificationTreeProofStagedRuntimeAdditionsGitDiffArgs(),
+    {
+      cwd: repoPath,
+      env: {
+        ...process.env,
+        GIT_INDEX_FILE: realIndexPath,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  );
+  fs.writeFileSync(stagedRuntimePatch, stagedRuntimeDiff);
+  execFileSync(
+    "git",
+    ["apply", "--cached", "--whitespace=nowarn", stagedRuntimePatch],
+    {
+      cwd: repoPath,
+      env: proofEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  );
   const verificationTreeSha = execFileSync("git", ["write-tree"], {
     cwd: repoPath,
     env: proofEnv,
@@ -211,15 +251,27 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
 
   assert.deepEqual(
     git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha).split("\n"),
-    [".antigravitycli/tracked-config", "reviewable.txt"]
+    [
+      ".antigravitycli/staged-tool",
+      ".antigravitycli/tracked-config",
+      "reviewable.txt",
+    ]
   );
   assert.equal(
     git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/tracked-config`),
     "tracked after"
   );
+  assert.equal(
+    git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/staged-tool`),
+    "staged addition"
+  );
+  assert.match(
+    git(repoPath, "ls-tree", verificationTreeSha, ".antigravitycli/staged-tool"),
+    /^100755 blob /
+  );
   assert.match(
     git(repoPath, "ls-tree", "-r", "--name-only", realIndexTreeSha),
-    /\.antigravitycli\/runtime-state\.json/
+    /\.antigravitycli\/staged-tool/
   );
   assert.match(
     git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha),
@@ -228,6 +280,10 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   assert.doesNotMatch(
     git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha),
     /\.antigravitycli\/(?:runtime-state\.json|tracked-obsolete)/
+  );
+  assert.doesNotMatch(
+    git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/staged-tool`),
+    /later unstaged content/
   );
   assert.notEqual(verificationTreeSha, realIndexTreeSha);
 });

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -14,11 +15,20 @@ const {
   hashFileSha256,
   rebrandEvidence,
   resolveExecutionEvidenceTestCommand,
+  verificationTreeProofGitAddArgs,
   writeExecutionEvidence,
 } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
 const {
   buildExecutionEvidencePreflight,
 } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+
+function git(repoPath, ...args) {
+  return execFileSync("git", args, {
+    cwd: repoPath,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
 
 test("verification gates seed the evidence command and identify malformed command gates", () => {
   const rubric = [
@@ -115,10 +125,70 @@ test("executor verification instructions keep gate execution inside the dispatch
   assert.match(instructions, /current sandbox and network policy/);
   assert.match(instructions, /Do not delegate them back to the relay orchestrator/);
   assert.match(instructions, /After all required gates finish/);
+  assert.match(instructions, /temporary Git index/);
+  assert.match(instructions, /GIT_INDEX_FILE/);
   assert.match(instructions, /git write-tree/);
+  assert.match(instructions, /:\(exclude\)\.antigravitycli/);
   assert.match(instructions, /before any later commit or commit hook can mutate the tree/);
   assert.match(instructions, /verification_tree_sha/);
   assert.match(instructions, /"command":"node --test focused\.test\.js"/);
+});
+
+test("verification tree proof excludes staged Antigravity runtime metadata", (t) => {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-verification-tree-"));
+  const verificationIndex = path.join(
+    os.tmpdir(),
+    `relay-verification-index-${process.pid}-${Date.now()}`
+  );
+  t.after(() => fs.rmSync(verificationIndex, { force: true }));
+
+  git(repoPath, "init");
+  git(repoPath, "config", "user.name", "Relay Test");
+  git(repoPath, "config", "user.email", "relay@example.com");
+  fs.writeFileSync(path.join(repoPath, "reviewable.txt"), "before\n", "utf-8");
+  git(repoPath, "add", "reviewable.txt");
+  git(repoPath, "commit", "-m", "base");
+
+  fs.writeFileSync(path.join(repoPath, "reviewable.txt"), "after\n", "utf-8");
+  fs.mkdirSync(path.join(repoPath, ".antigravitycli"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoPath, ".antigravitycli", "runtime-state.json"),
+    '{"session":"runtime-only"}\n',
+    "utf-8"
+  );
+  git(repoPath, "add", "-A");
+
+  const proofEnv = {
+    ...process.env,
+    GIT_INDEX_FILE: verificationIndex,
+  };
+  execFileSync("git", ["read-tree", "HEAD"], {
+    cwd: repoPath,
+    env: proofEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  execFileSync("git", verificationTreeProofGitAddArgs(), {
+    cwd: repoPath,
+    env: proofEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const verificationTreeSha = execFileSync("git", ["write-tree"], {
+    cwd: repoPath,
+    env: proofEnv,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  const realIndexTreeSha = git(repoPath, "write-tree");
+
+  assert.deepEqual(
+    git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha).split("\n"),
+    ["reviewable.txt"]
+  );
+  assert.match(
+    git(repoPath, "ls-tree", "-r", "--name-only", realIndexTreeSha),
+    /\.antigravitycli\/runtime-state\.json/
+  );
+  assert.notEqual(verificationTreeSha, realIndexTreeSha);
 });
 
 test("executor-confirmed verification results persist SHA-bound output evidence without executing commands", () => {

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -201,6 +201,13 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   );
   fs.writeFileSync(stagedDeletedPath, "deleted after staging\n", "utf-8");
   git(repoPath, "add", ".antigravitycli/staged-deleted");
+  const intentToAddPath = path.join(
+    repoPath,
+    ".antigravitycli",
+    "intent-to-add"
+  );
+  fs.writeFileSync(intentToAddPath, "intent-to-add content\n", "utf-8");
+  git(repoPath, "add", "-N", ".antigravitycli/intent-to-add");
   fs.writeFileSync(stagedAdditionPath, "later unstaged content\n", "utf-8");
   fs.chmodSync(stagedAdditionPath, 0o644);
   fs.unlinkSync(stagedDeletedPath);
@@ -264,6 +271,7 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   assert.deepEqual(
     git(repoPath, "ls-tree", "-r", "--name-only", verificationTreeSha).split("\n"),
     [
+      ".antigravitycli/intent-to-add",
       ".antigravitycli/staged-tool",
       ".antigravitycli/tracked-config",
       "reviewable.txt",
@@ -276,6 +284,10 @@ test("verification tree proof keeps tracked runtime changes and excludes adjacen
   assert.equal(
     git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/staged-tool`),
     "later unstaged content"
+  );
+  assert.equal(
+    git(repoPath, "show", `${verificationTreeSha}:.antigravitycli/intent-to-add`),
+    "intent-to-add content"
   );
   assert.match(
     git(repoPath, "ls-tree", verificationTreeSha, ".antigravitycli/staged-tool"),

--- a/tests/relay-review/scripts/review-runner-advisory.test.js
+++ b/tests/relay-review/scripts/review-runner-advisory.test.js
@@ -353,6 +353,7 @@ function writeNoOpCodex(binDir) {
   const codexPath = path.join(binDir, "codex");
   fs.writeFileSync(codexPath, `#!/usr/bin/env node
 const fs = require("fs");
+const { execFileSync } = require("child_process");
 const args = process.argv.slice(2);
 if (args[0] === "--version") {
   process.stdout.write("codex-fake\\n");
@@ -362,6 +363,7 @@ if (args[0] !== "exec") {
   process.stderr.write("unsupported fake codex invocation");
   process.exit(1);
 }
+const cwd = args[args.indexOf("-C") + 1];
 const output = args[args.indexOf("-o") + 1];
 const prompt = String(args[args.length - 1] || "");
 const requestBegin = "RELAY_VERIFICATION_REQUEST_BEGIN";
@@ -377,6 +379,11 @@ if (requestStart !== -1) {
     "RELAY_VERIFICATION_RESULT_BEGIN",
     JSON.stringify({
       schema_version: 1,
+      verification_tree_sha: execFileSync(
+        "git",
+        ["-C", cwd, "write-tree"],
+        { encoding: "utf-8", stdio: "pipe" }
+      ).trim(),
       runs: request.gates.map((gate) => ({
         command: gate.command,
         exit_code: 0,

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -221,6 +221,40 @@ test("execution-evidence strict preflight binds confirmed verification proof to 
   writeArtifact(runDir, makeArtifact(reviewedHead, {
     verification_runs: [{
       ...confirmedRun,
+      recorded_by: 42,
+    }],
+  }));
+  let malformedRecorder;
+  assert.doesNotThrow(() => {
+    malformedRecorder = strictPreflight();
+  });
+  assert.equal(malformedRecorder.status, "blocked");
+  assert.match(
+    malformedRecorder.reason,
+    /verification_runs\[0\]\.recorded_by must be a non-empty string/
+  );
+
+  for (const malformedProof of [null, "", "not-a-tree-sha", 42, {}, []]) {
+    writeArtifact(runDir, makeArtifact(reviewedHead, {
+      verification_runs: [{
+        ...confirmedRun,
+        verification_tree_sha: malformedProof,
+      }],
+    }));
+    let malformedResult;
+    assert.doesNotThrow(() => {
+      malformedResult = strictPreflight();
+    });
+    assert.equal(malformedResult.status, "blocked");
+    assert.match(
+      malformedResult.reason,
+      /verification_runs\[0\]\.verification_tree_sha must be a 40-character hex Git tree SHA when present/
+    );
+  }
+
+  writeArtifact(runDir, makeArtifact(reviewedHead, {
+    verification_runs: [{
+      ...confirmedRun,
       verification_tree_sha: "f".repeat(40),
     }],
   }));

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -14,6 +15,14 @@ const {
   parseExecutionEvidenceArtifact,
   readExecutionEvidenceArtifact,
 } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
+
+function git(repoPath, ...args) {
+  return execFileSync("git", args, {
+    cwd: repoPath,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
 
 function makeArtifact(headSha, overrides = {}) {
   return {
@@ -174,6 +183,68 @@ test("execution-evidence strict mode prefers verification_runs when present", ()
     computeQualityExecutionStatus({ runDir, reviewedHead: "a".repeat(40), strict: true }),
     { status: "pass", reason: null }
   );
+});
+
+test("execution-evidence strict preflight binds confirmed verification proof to reviewed HEAD tree", () => {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-confirmed-tree-"));
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-confirmed-tree-run-"));
+  git(repoPath, "init", "--object-format=sha1");
+  git(repoPath, "config", "user.name", "Relay Test");
+  git(repoPath, "config", "user.email", "relay@example.com");
+  fs.writeFileSync(path.join(repoPath, "reviewed.txt"), "reviewed tree\n", "utf-8");
+  git(repoPath, "add", "reviewed.txt");
+  git(repoPath, "commit", "-m", "reviewed head");
+  const reviewedHead = git(repoPath, "rev-parse", "HEAD");
+  const reviewedTree = git(repoPath, "rev-parse", "HEAD^{tree}");
+  const confirmedRun = {
+    command: "node --test confirmed.test.js",
+    cwd: repoPath,
+    head_sha: reviewedHead,
+    exit_code: 0,
+    output_hash: "b".repeat(64),
+    recorded_by: "antigravity-confirmed-verification-v1",
+    recorded_at: "2026-07-30T00:00:00.000Z",
+  };
+  const strictPreflight = () => buildExecutionEvidencePreflight({
+    runDir,
+    reviewedHead,
+    strict: true,
+  });
+
+  writeArtifact(runDir, makeArtifact(reviewedHead, {
+    verification_runs: [confirmedRun],
+  }));
+  const missingProof = strictPreflight();
+  assert.equal(missingProof.status, "blocked");
+  assert.match(missingProof.reason, /confirmed-verification-v1.*requires verification_tree_sha/);
+
+  writeArtifact(runDir, makeArtifact(reviewedHead, {
+    verification_runs: [{
+      ...confirmedRun,
+      verification_tree_sha: "f".repeat(40),
+    }],
+  }));
+  const mismatchedProof = strictPreflight();
+  assert.equal(mismatchedProof.status, "blocked");
+  assert.match(mismatchedProof.reason, /verification_tree_sha/);
+  assert.match(mismatchedProof.reason, new RegExp(`reviewed HEAD ${reviewedHead}\\^\\{tree\\} ${reviewedTree}`));
+
+  writeArtifact(runDir, makeArtifact(reviewedHead, {
+    verification_runs: [{
+      ...confirmedRun,
+      verification_tree_sha: reviewedTree,
+    }],
+  }));
+  assert.equal(strictPreflight().status, "pass");
+
+  writeArtifact(runDir, makeArtifact(reviewedHead, {
+    verification_runs: [{
+      ...confirmedRun,
+      recorded_by: "legacy-orchestrator-v1",
+      verification_tree_sha: undefined,
+    }],
+  }));
+  assert.equal(strictPreflight().status, "pass");
 });
 
 test("execution-evidence strict mode resolves retained non-default rubric anchors", () => {


### PR DESCRIPTION
## Summary

- block malformed verification rebrand audits even when a strict rubric has no command gates
- bind executor verification results to a validated Git tree and compare it with the final commit tree on both commit paths
- fail closed without successful `verification_runs` when the tree proof is missing, malformed, or mismatched
- make the lingering process-group inventory fixture hermetic under restricted executor sandboxes

## Verification

- `node --test tests/relay-review/scripts/review-runner-execution-evidence.test.js tests/relay-dispatch/scripts/execution-evidence.test.js` — 44/44 passed
- `node --test tests/relay-dispatch/scripts/dispatch.test.js` — 212/212 passed

Closes #1121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 실행/검증 증거에 검증 트리 SHA(40자 Git tree 형식)를 기록하고, 누락·형식 오류·불일치 시 엄격 사전점검에서 차단합니다.
  - 커밋 자동 복구 흐름을 단순화하고, 증거 수집 시 최종 트리 SHA 전달/검증을 강화합니다.
  - 리뷰 기준 트리 바인딩을 엄격히 적용해 confirmed 검증 결과의 트리 일치 여부를 판정합니다.
- **테스트**
  - 검증 트리 생성·증거 주입, 리뷰드 HEAD 트리 바인딩, 누락/불일치 fail-closed 및 엄격/레거시 경계 케이스를 확장 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->