### PR TITLE
relay-dispatch: record audited verification evidence

### DIFF
--- a/skills/relay-dispatch/references/cli-schema.md
+++ b/skills/relay-dispatch/references/cli-schema.md
@@ -94,6 +94,7 @@ Generated from `formatFlagAuditMarkdown()` in `scripts/cli-schema.js`. The same 
 | `--next-action` | `verbatim` | Operator-supplied manifest text; keep the literal argv token. |
 | `--no-comment` | `parsed` | Presence flag; no value is consumed. |
 | `--no-issue-close` | `parsed` | Presence flag; no value is consumed. |
+| `--observation-result` | `verbatim` | Repeatable operator-supplied observation artifact mapping; preserve the literal token. |
 | `--older-than` | `parsed` | Numeric threshold; flag-like following tokens should mean the value is missing. |
 | `--ownership-json` | `verbatim` | Typed fleet ownership object; preserve the JSON token for strict parsing. |
 | `--pin` | `parsed` | Presence flag; no value is consumed. |

--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -113,6 +113,27 @@ node skills/relay-dispatch/scripts/recover-commit.js --repo . --run-id issue-788
 
 The resulting `execution-evidence.json` is bound to the post-recovery HEAD, preserves the test command verbatim, hashes the result file, records `test_exit_code: 0`, and uses `recorded_by: "recover-commit-operator-v1"`. The next step is the normal `review-runner.js` path. Do not use `finalize-run.js --force-finalize-nonready` when the goal is to supply real execution evidence for review.
 
+## Re-verify an unchanged retained worktree after evidence rebrand
+
+When `rebrand-evidence.js` removes stale `verification_runs`, do not edit the JSON by hand. On an `internal_review_pending` or `review_pending` run, `record-verification-evidence.js` reruns the frozen command gates at the retained worktree's exact HEAD and writes bounded run-directory logs. It only replaces an existing same-HEAD artifact when hardened preflight is currently blocked because gates are missing or unrecorded; dirty worktrees, terminal states, stale artifacts, and already-valid artifacts are rejected.
+
+```bash
+node skills/relay-dispatch/scripts/record-verification-evidence.js --repo . --run-id <id> \
+  --reason "re-verified exact rubric gates after rebase evidence invalidation" --dry-run --json
+node skills/relay-dispatch/scripts/record-verification-evidence.js --repo . --run-id <id> \
+  --reason "re-verified exact rubric gates after rebase evidence invalidation" --json
+```
+
+For every `type: observation` gate, supply a repeatable regular-file artifact. The source is never logged; it is limited to 1 MiB, rejected if it is a symlink, and copied into the run directory before its SHA-256 is recorded:
+
+```bash
+node skills/relay-dispatch/scripts/record-verification-evidence.js --repo . --run-id <id> \
+  --reason "operator inspected release surface" \
+  --observation-result "release-screenshot=/secure/path/screenshot.png"
+```
+
+The command does not publish, commit, or change state. It emits `operator_execution_evidence` with old/new evidence hashes, gate names, reason, and the verified `HEAD^{tree}` binding. Review the copied logs/artifacts before re-running the normal review path because an exit failure remains honest evidence and hardened preflight will block it.
+
 When `--pr-title` is omitted, the PR title defaults to the linked GitHub issue title as `<issue title> (#<N>)`, first from `manifest.issue.number`, then from an unambiguous `issue-N` branch name. If issue lookup fails or no issue is linked, it falls back to `Recover <branch> (<run-id>)`. `--pr-title` always wins exactly.
 
 If a PR already exists for the branch, the command no-ops the create step and stamps `pr_number` from the existing PR — safe to re-run after a partial failure. Use `--dry-run` first when uncertain.

--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -124,7 +124,7 @@ node skills/relay-dispatch/scripts/record-verification-evidence.js --repo . --ru
   --reason "re-verified exact rubric gates after rebase evidence invalidation" --json
 ```
 
-For every `type: observation` gate, supply a repeatable regular-file artifact. The source is never logged; it is limited to 1 MiB, rejected if it is a symlink, and copied into the run directory before its SHA-256 is recorded:
+For every `type: observation` gate with a frozen `command`, supply a repeatable regular-file artifact. That command is an observation instruction and is **not executed** by this CLI; `exit_code: 0` records successful artifact-boundary validation, not command execution. The source is never logged; it is limited to 1 MiB, rejected if it is a symlink, and copied into the run directory before its SHA-256 is recorded:
 
 ```bash
 node skills/relay-dispatch/scripts/record-verification-evidence.js --repo . --run-id <id> \
@@ -132,7 +132,7 @@ node skills/relay-dispatch/scripts/record-verification-evidence.js --repo . --ru
   --observation-result "release-screenshot=/secure/path/screenshot.png"
 ```
 
-The command does not publish, commit, or change state. It emits `operator_execution_evidence` with old/new evidence hashes, gate names, reason, and the verified `HEAD^{tree}` binding. Review the copied logs/artifacts before re-running the normal review path because an exit failure remains honest evidence and hardened preflight will block it.
+The command does not publish, commit, or change state. Every attempt uses nonce-qualified artifact names, so it never overwrites artifacts referenced by prior evidence; a failed attempt's private staging files are removed. It emits `operator_execution_evidence` with old/new evidence hashes, gate names, reason, and the verified `HEAD^{tree}` binding. Review the copied logs/artifacts before re-running the normal review path because an exit failure remains honest evidence and hardened preflight will block it.
 
 When `--pr-title` is omitted, the PR title defaults to the linked GitHub issue title as `<issue title> (#<N>)`, first from `manifest.issue.number`, then from an unambiguous `issue-N` branch name. If issue lookup fails or no issue is linked, it falls back to `Recover <branch> (<run-id>)`. `--pr-title` always wins exactly.
 

--- a/skills/relay-dispatch/scripts/cli-schema.js
+++ b/skills/relay-dispatch/scripts/cli-schema.js
@@ -90,6 +90,7 @@ const FLAGS = [
   { flag: "--prompt-file", kind: VALUE, mode: MODE_VERBATIM, valueName: "<path>", rationale: "Operator-supplied prompt path; keep the literal argv token." },
   { flag: "--publish-policy", kind: VALUE, mode: MODE_PARSED, valueName: "<mode>", allowedValues: ["immediate", "after-internal-review"], rationale: "Closed PR publication policy for dispatch; flag-like following tokens should mean the value is missing." },
   { flag: "--reason", kind: VALUE, mode: MODE_VERBATIM, valueName: "<text>", rationale: "Audit reason text must be recorded exactly and must not be blank." },
+  { flag: "--observation-result", kind: VALUE, mode: MODE_VERBATIM, valueName: "<gate=file>", rationale: "Repeatable operator-supplied observation artifact mapping; preserve the literal token." },
   { flag: "--reasoning", kind: VALUE, mode: MODE_PARSED, valueName: "<level>",
     allowedValues: ["none", "minimal", "low", "medium", "high", "xhigh"],
     rationale: "Codex reasoning_effort override; closed selector over codex CLI levels." },
@@ -214,6 +215,9 @@ const COMMAND_FLAGS = {
     "--repo", "--run-id", "--manifest", "--reason", "--pr-title", "--pr-body-file",
     "--test-command", "--test-result-file", "--test-exit-code", "--replace-placeholder-evidence",
     "--dry-run", "--json", "--help",
+  ],
+  "record-verification-evidence": [
+    "--repo", "--run-id", "--manifest", "--reason", "--observation-result", "--dry-run", "--json", "--help",
   ],
   "reconcile-run": [
     "--repo", "--run-id", "--test-result-file", "--dry-run", "--json", "--help",

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -205,25 +205,39 @@ function scalarFromVerificationCheck(block, key) {
   return "";
 }
 
-function extractVerificationGates(rubricYaml) {
-  return extractVerificationGateDefinitions(rubricYaml).filter((gate) => gate.type === "command");
-}
-
-// Keep this separate from extractVerificationGates(): review's legacy strict
-// matching intentionally consumes command gates only, while an operator tool
-// also needs to resolve explicit observation gates without weakening it.
-function extractVerificationGateDefinitions(rubricYaml) {
+function parseVerificationGateFields(rubricYaml) {
   return verificationCheckBlocks(rubricYaml).map((block, index) => {
     const name = scalarFromVerificationCheck(block, "name") || `verification.checks[${index}]`;
     const type = scalarFromVerificationCheck(block, "type");
     const command = scalarFromVerificationCheck(block, "command");
+    return { name, type, command };
+  });
+}
+
+// Compatibility contract: existing callers treat every check with a command as
+// executable regardless of its rubric type. Only an explicitly command-typed
+// check without a command is malformed; all other commandless checks are ignored.
+function extractVerificationGates(rubricYaml) {
+  return parseVerificationGateFields(rubricYaml).map((gate) => {
+    const { name, type, command } = gate;
     if (type === "command" && !command.trim()) {
       throw new Error(`verification gate '${name}' did not record a command for execution evidence`);
     }
-    if (type !== "command" && type !== "observation") {
-      throw new Error(`verification gate '${name}' has unsupported type '${type || "(missing)"}'`);
+    return gate;
+  }).filter((gate) => gate.command.trim());
+}
+
+// The operator recorder additionally recognizes explicit observations. Legacy
+// non-command types remain command gates when they carry a command, matching
+// extractVerificationGates(), and are otherwise ignored.
+function extractVerificationGateDefinitions(rubricYaml) {
+  return parseVerificationGateFields(rubricYaml).flatMap((gate) => {
+    if (gate.type === "observation") return [{ ...gate, type: "observation" }];
+    if (gate.command.trim()) return [{ ...gate, type: "command" }];
+    if (gate.type === "command") {
+      throw new Error(`verification gate '${gate.name}' did not record a command for execution evidence`);
     }
-    return { name, type, command };
+    return [];
   });
 }
 

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -232,7 +232,9 @@ function extractVerificationGates(rubricYaml) {
 // extractVerificationGates(), and are otherwise ignored.
 function extractVerificationGateDefinitions(rubricYaml) {
   return parseVerificationGateFields(rubricYaml).flatMap((gate) => {
-    if (gate.type === "observation") return [{ ...gate, type: "observation" }];
+    if (gate.type === "observation") return gate.command.trim()
+      ? [{ ...gate, type: "observation" }]
+      : [];
     if (gate.command.trim()) return [{ ...gate, type: "command" }];
     if (gate.type === "command") {
       throw new Error(`verification gate '${gate.name}' did not record a command for execution evidence`);

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -206,6 +206,13 @@ function scalarFromVerificationCheck(block, key) {
 }
 
 function extractVerificationGates(rubricYaml) {
+  return extractVerificationGateDefinitions(rubricYaml).filter((gate) => gate.type === "command");
+}
+
+// Keep this separate from extractVerificationGates(): review's legacy strict
+// matching intentionally consumes command gates only, while an operator tool
+// also needs to resolve explicit observation gates without weakening it.
+function extractVerificationGateDefinitions(rubricYaml) {
   return verificationCheckBlocks(rubricYaml).map((block, index) => {
     const name = scalarFromVerificationCheck(block, "name") || `verification.checks[${index}]`;
     const type = scalarFromVerificationCheck(block, "type");
@@ -213,8 +220,11 @@ function extractVerificationGates(rubricYaml) {
     if (type === "command" && !command.trim()) {
       throw new Error(`verification gate '${name}' did not record a command for execution evidence`);
     }
+    if (type !== "command" && type !== "observation") {
+      throw new Error(`verification gate '${name}' has unsupported type '${type || "(missing)"}'`);
+    }
     return { name, type, command };
-  }).filter((gate) => gate.command.trim());
+  });
 }
 
 function resolveExecutionEvidenceTestCommand({ explicitTestCommand, rubricYaml } = {}) {
@@ -659,6 +669,7 @@ module.exports = {
   buildExecutionEvidence,
   buildExecutorVerificationInstructions,
   collectExecutorVerificationEvidence,
+  extractVerificationGateDefinitions,
   extractVerificationGates,
   hashFileSha256,
   rebrandEvidence,

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -575,7 +575,6 @@ function writeExecutionEvidence(runDir, evidence, options = {}) {
     fs.writeFileSync(tmpPath, `${JSON.stringify(evidence, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
     fs.chmodSync(tmpPath, 0o600);
     fs.renameSync(tmpPath, finalPath);
-    fs.chmodSync(finalPath, 0o600);
   } catch (error) {
     try { fs.unlinkSync(tmpPath); } catch {}
     throw error;

--- a/skills/relay-dispatch/scripts/execution-evidence.js
+++ b/skills/relay-dispatch/scripts/execution-evidence.js
@@ -572,8 +572,10 @@ function writeExecutionEvidence(runDir, evidence, options = {}) {
     `${EXECUTION_EVIDENCE_FILENAME}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
   );
   try {
-    fs.writeFileSync(tmpPath, `${JSON.stringify(evidence, null, 2)}\n`, "utf-8");
+    fs.writeFileSync(tmpPath, `${JSON.stringify(evidence, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+    fs.chmodSync(tmpPath, 0o600);
     fs.renameSync(tmpPath, finalPath);
+    fs.chmodSync(finalPath, 0o600);
   } catch (error) {
     try { fs.unlinkSync(tmpPath); } catch {}
     throw error;

--- a/skills/relay-dispatch/scripts/record-verification-evidence.js
+++ b/skills/relay-dispatch/scripts/record-verification-evidence.js
@@ -114,7 +114,6 @@ function writePrivateFile(destination, data) {
     fd = fs.openSync(temporary, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
     fs.writeFileSync(fd, data); fs.fchmodSync(fd, 0o600); fs.fsyncSync(fd); fs.closeSync(fd); fd = null;
     fs.renameSync(temporary, destination);
-    fs.chmodSync(destination, 0o600);
   } catch (error) {
     if (fd !== undefined && fd !== null) try { fs.closeSync(fd); } catch {}
     try { fs.unlinkSync(temporary); } catch {}
@@ -216,6 +215,12 @@ function main() {
       const current = readManifest(record.manifestPath).data;
       if (![STATES.INTERNAL_REVIEW_PENDING, STATES.REVIEW_PENDING].includes(current.state) || current.git?.head_sha !== headSha || current.git?.working_branch !== branch) {
         throw new Error("run changed while verification was executing; refusing evidence replacement");
+      }
+      if (execGit(paths.worktree, ["rev-parse", "--abbrev-ref", "HEAD"]) !== branch
+        || execGit(paths.worktree, ["rev-parse", "HEAD"]) !== headSha
+        || execGit(paths.worktree, ["rev-parse", "HEAD^{tree}"]) !== treeSha
+        || execGit(paths.worktree, ["status", "--porcelain"])) {
+        throw new Error("retained worktree changed while verification was executing; refusing evidence replacement");
       }
       if (hashFileSha256(evidencePath) !== expectedEvidenceHash) {
         throw new Error("execution evidence changed while verification was executing; refusing replacement");

--- a/skills/relay-dispatch/scripts/record-verification-evidence.js
+++ b/skills/relay-dispatch/scripts/record-verification-evidence.js
@@ -194,18 +194,18 @@ function main() {
   const result = { status: dryRun ? "dry_run" : "recorded", runId: data.run_id, headSha, gateNames: gates.map((gate) => gate.name), reason };
   if (!dryRun) {
     const stageDir = createStagingDir(runDir);
-    let retainStaging = false;
+    const invocationNonce = crypto.randomBytes(8).toString("hex");
     try {
     const timestamp = new Date().toISOString();
     const runs = gates.map((gate, index) => {
       if (gate.type === "command") {
         const output = boundedLog(stageDir, index, gate.command, paths.worktree);
-        return { name: gate.name, command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: output.exitCode, output_path: output.outputName, output_hash: output.outputHash, staged_path: output.outputPath, recorded_by: RECORDED_BY, recorded_at: timestamp };
+        return { name: gate.name, command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: output.exitCode, output_path: `operator-verification-${invocationNonce}-gate-${index + 1}.log`, output_hash: output.outputHash, staged_path: output.outputPath, recorded_by: RECORDED_BY, recorded_at: timestamp };
       }
-      const outputName = `operator-observation-gate-${index + 1}.artifact`;
+      const outputName = `operator-observation-${invocationNonce}-gate-${index + 1}.artifact`;
       const outputPath = path.join(stageDir, outputName);
       const hash = safeArtifact(observationResults.get(gate.name), outputPath);
-      return { name: gate.name, gate_name: gate.name, gate_type: "observation", command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, staged_path: outputPath, recorded_by: RECORDED_BY, recorded_at: timestamp };
+      return { name: gate.name, gate_name: gate.name, gate_type: "observation", result_kind: "operator_observation_artifact", command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, staged_path: outputPath, recorded_by: RECORDED_BY, recorded_at: timestamp };
     });
     if (execGit(paths.worktree, ["status", "--porcelain"]) || execGit(paths.worktree, ["rev-parse", "HEAD"]) !== headSha || execGit(paths.worktree, ["rev-parse", "HEAD^{tree}"]) !== treeSha) {
       throw new Error("verification commands changed the retained worktree; refusing to write evidence");
@@ -231,7 +231,6 @@ function main() {
       }
       const failed = runs.find((run) => run.exit_code !== 0);
       if (failed) {
-        retainStaging = true;
         throw new Error(`verification gate '${failed.name}' exited ${failed.exit_code}; preserving existing evidence`);
       }
       const finalRuns = runs.map(({ staged_path, ...run }) => run);
@@ -247,7 +246,7 @@ function main() {
     });
     result.executionEvidenceHash = finalization.newHash; result.strictPreflightBefore = finalization.strictBefore;
     } finally {
-      if (!retainStaging) discardStagingDir(stageDir);
+      discardStagingDir(stageDir);
     }
   }
   console.log(json ? JSON.stringify(result, null, 2) : `${result.status}: ${result.runId} (${result.gateNames.join(", ")})`);

--- a/skills/relay-dispatch/scripts/record-verification-evidence.js
+++ b/skills/relay-dispatch/scripts/record-verification-evidence.js
@@ -167,7 +167,7 @@ function main() {
       const outputName = `operator-observation-gate-${index + 1}.artifact`;
       const outputPath = path.join(runDir, outputName);
       const hash = safeArtifact(observationResults.get(gate.name), outputPath);
-      return { name: gate.name, command: `observation:${gate.name}`, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, recorded_by: RECORDED_BY, recorded_at: timestamp };
+      return { name: gate.name, gate_name: gate.name, gate_type: "observation", command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, recorded_by: RECORDED_BY, recorded_at: timestamp };
     });
     if (execGit(paths.worktree, ["status", "--porcelain"]) || execGit(paths.worktree, ["rev-parse", "HEAD"]) !== headSha || execGit(paths.worktree, ["rev-parse", "HEAD^{tree}"]) !== treeSha) {
       throw new Error("verification commands changed the retained worktree; refusing to write evidence");

--- a/skills/relay-dispatch/scripts/record-verification-evidence.js
+++ b/skills/relay-dispatch/scripts/record-verification-evidence.js
@@ -234,15 +234,30 @@ function main() {
         throw new Error(`verification gate '${failed.name}' exited ${failed.exit_code}; preserving existing evidence`);
       }
       const finalRuns = runs.map(({ staged_path, ...run }) => run);
-      for (const run of runs) writePrivateFile(path.join(runDir, run.output_path), readSafeArtifact(run.staged_path));
-      const evidence = { ...existing, head_sha: headSha, verification_runs: finalRuns, recorded_at: timestamp, recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason, replaced_evidence_hash: expectedEvidenceHash, head_tree_sha: treeSha, recorded_at: timestamp } };
-      const encoded = `${JSON.stringify(evidence, null, 2)}\n`;
-      const newHash = crypto.createHash("sha256").update(encoded).digest("hex");
-      // Journal first: a crash can leave an orphaned audit attempt, but never a
-      // valid replacement artifact without an audit record. Re-run remains safe.
-      appendRunEvent(paths.repoRoot, data.run_id, { event: EVENTS.OPERATOR_EXECUTION_EVIDENCE, state_from: current.state, state_to: current.state, head_sha: headSha, branch, reason, operator_initiated: true, execution_evidence_path: evidencePath, execution_evidence_hash: newHash, before: { evidence_hash: expectedEvidenceHash }, after: { evidence_hash: newHash, gate_names: gates.map((gate) => gate.name), head_tree_sha: treeSha } }, { lockHeld: true });
-      writeExecutionEvidence(runDir, evidence);
-      return { newHash, strictBefore: strictCurrent.reason };
+      const createdFinalPaths = [];
+      let evidenceWritten = false;
+      try {
+        for (const run of runs) {
+          const finalPath = path.join(runDir, run.output_path);
+          if (fs.existsSync(finalPath)) throw new Error("unique verification artifact destination already exists; refusing replacement");
+          writePrivateFile(finalPath, readSafeArtifact(run.staged_path));
+          createdFinalPaths.push(finalPath);
+        }
+        const evidence = { ...existing, head_sha: headSha, verification_runs: finalRuns, recorded_at: timestamp, recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason, replaced_evidence_hash: expectedEvidenceHash, head_tree_sha: treeSha, recorded_at: timestamp } };
+        const encoded = `${JSON.stringify(evidence, null, 2)}\n`;
+        const newHash = crypto.createHash("sha256").update(encoded).digest("hex");
+        // Journal first: a crash can leave an orphaned audit attempt, but never a
+        // valid replacement artifact without an audit record. Re-run remains safe.
+        appendRunEvent(paths.repoRoot, data.run_id, { event: EVENTS.OPERATOR_EXECUTION_EVIDENCE, state_from: current.state, state_to: current.state, head_sha: headSha, branch, reason, operator_initiated: true, execution_evidence_path: evidencePath, execution_evidence_hash: newHash, before: { evidence_hash: expectedEvidenceHash }, after: { evidence_hash: newHash, gate_names: gates.map((gate) => gate.name), head_tree_sha: treeSha } }, { lockHeld: true });
+        writeExecutionEvidence(runDir, evidence); evidenceWritten = true;
+        return { newHash, strictBefore: strictCurrent.reason };
+      } finally {
+        if (!evidenceWritten) {
+          for (const finalPath of createdFinalPaths) {
+            try { if (fs.lstatSync(finalPath).isFile()) fs.unlinkSync(finalPath); } catch {}
+          }
+        }
+      }
     });
     result.executionEvidenceHash = finalization.newHash; result.strictPreflightBefore = finalization.strictBefore;
     } finally {

--- a/skills/relay-dispatch/scripts/record-verification-evidence.js
+++ b/skills/relay-dispatch/scripts/record-verification-evidence.js
@@ -7,6 +7,7 @@
  * does not recover commits, publish, or advance state.
  */
 
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
@@ -19,6 +20,7 @@ const { extractVerificationGateDefinitions, hashFileSha256, writeExecutionEviden
 const { computeQualityExecutionStatus } = require("../../relay-review/scripts/review-runner/execution-evidence");
 const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
 const { execGit } = require("./exec");
+const { readManifest, withManifestTransaction } = require("./manifest/store");
 
 const args = process.argv.slice(2);
 const CLI_OPTIONS = { commandName: "record-verification-evidence", reservedFlags: ["-h"] };
@@ -71,6 +73,10 @@ function observationMap(values) {
 function readSafeArtifact(source) {
   const resolved = path.resolve(source);
   const noFollow = typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0;
+  if (noFollow === 0) {
+    const initial = fs.lstatSync(resolved);
+    if (initial.isSymbolicLink() || !initial.isFile()) throw new Error("observation artifact must be a readable regular non-symlink file");
+  }
   let fd;
   try {
     fd = fs.openSync(resolved, fs.constants.O_RDONLY | noFollow);
@@ -92,11 +98,41 @@ function readSafeArtifact(source) {
 
 function safeArtifact(source, destination) {
   const data = readSafeArtifact(source);
-  fs.writeFileSync(destination, data, { mode: 0o600 });
+  writePrivateFile(destination, data);
   return hashFileSha256(destination);
 }
 
-function boundedLog(runDir, index, command, cwd) {
+function writePrivateFile(destination, data) {
+  let existing = null;
+  try { existing = fs.lstatSync(destination); } catch (error) { if (error.code !== "ENOENT") throw error; }
+  if (existing?.isSymbolicLink() || (existing && !existing.isFile())) {
+    throw new Error("refusing non-regular or symlinked verification artifact destination");
+  }
+  const temporary = `${destination}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`;
+  let fd;
+  try {
+    fd = fs.openSync(temporary, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+    fs.writeFileSync(fd, data); fs.fchmodSync(fd, 0o600); fs.fsyncSync(fd); fs.closeSync(fd); fd = null;
+    fs.renameSync(temporary, destination);
+    fs.chmodSync(destination, 0o600);
+  } catch (error) {
+    if (fd !== undefined && fd !== null) try { fs.closeSync(fd); } catch {}
+    try { fs.unlinkSync(temporary); } catch {}
+    throw error;
+  }
+}
+
+function createStagingDir(runDir) {
+  const stageDir = path.join(runDir, `.operator-verification-${process.pid}-${crypto.randomBytes(8).toString("hex")}`);
+  fs.mkdirSync(stageDir, { mode: 0o700 }); fs.chmodSync(stageDir, 0o700);
+  return stageDir;
+}
+
+function discardStagingDir(stageDir) {
+  try { fs.rmSync(stageDir, { recursive: true, force: true }); } catch {}
+}
+
+function boundedLog(stageDir, index, command, cwd) {
   let stdout = "";
   let stderr = "";
   let exitCode = 0;
@@ -111,9 +147,9 @@ function boundedLog(runDir, index, command, cwd) {
   }
   const body = Buffer.from(`${stdout}\n${stderr}`, "utf-8").subarray(0, MAX_ARTIFACT_BYTES);
   const outputName = `operator-verification-gate-${index + 1}.log`;
-  const outputPath = path.join(runDir, outputName);
-  fs.writeFileSync(outputPath, body, { mode: 0o600 });
-  return { exitCode, outputName, outputHash: hashFileSha256(outputPath) };
+  const outputPath = path.join(stageDir, outputName);
+  writePrivateFile(outputPath, body);
+  return { exitCode, outputName, outputPath, outputHash: hashFileSha256(outputPath) };
 }
 
 function resolveRecord(repoArg, runId, manifestArg) {
@@ -158,26 +194,56 @@ function main() {
   if (dryRun) observations.forEach((gate) => readSafeArtifact(observationResults.get(gate.name)));
   const result = { status: dryRun ? "dry_run" : "recorded", runId: data.run_id, headSha, gateNames: gates.map((gate) => gate.name), reason };
   if (!dryRun) {
+    const stageDir = createStagingDir(runDir);
+    let retainStaging = false;
+    try {
     const timestamp = new Date().toISOString();
     const runs = gates.map((gate, index) => {
       if (gate.type === "command") {
-        const output = boundedLog(runDir, index, gate.command, paths.worktree);
-        return { name: gate.name, command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: output.exitCode, output_path: output.outputName, output_hash: output.outputHash, recorded_by: RECORDED_BY, recorded_at: timestamp };
+        const output = boundedLog(stageDir, index, gate.command, paths.worktree);
+        return { name: gate.name, command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: output.exitCode, output_path: output.outputName, output_hash: output.outputHash, staged_path: output.outputPath, recorded_by: RECORDED_BY, recorded_at: timestamp };
       }
       const outputName = `operator-observation-gate-${index + 1}.artifact`;
-      const outputPath = path.join(runDir, outputName);
+      const outputPath = path.join(stageDir, outputName);
       const hash = safeArtifact(observationResults.get(gate.name), outputPath);
-      return { name: gate.name, gate_name: gate.name, gate_type: "observation", command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, recorded_by: RECORDED_BY, recorded_at: timestamp };
+      return { name: gate.name, gate_name: gate.name, gate_type: "observation", command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, staged_path: outputPath, recorded_by: RECORDED_BY, recorded_at: timestamp };
     });
     if (execGit(paths.worktree, ["status", "--porcelain"]) || execGit(paths.worktree, ["rev-parse", "HEAD"]) !== headSha || execGit(paths.worktree, ["rev-parse", "HEAD^{tree}"]) !== treeSha) {
       throw new Error("verification commands changed the retained worktree; refusing to write evidence");
     }
-    const previousHash = hashFileSha256(evidencePath);
-    const evidence = { ...existing, head_sha: headSha, verification_runs: runs, recorded_at: timestamp, recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason, replaced_evidence_hash: previousHash, head_tree_sha: treeSha, recorded_at: timestamp } };
-    writeExecutionEvidence(runDir, evidence);
-    const newHash = hashFileSha256(evidencePath);
-    appendRunEvent(paths.repoRoot, data.run_id, { event: EVENTS.OPERATOR_EXECUTION_EVIDENCE, state_from: data.state, state_to: data.state, head_sha: headSha, branch, reason, operator_initiated: true, execution_evidence_path: evidencePath, execution_evidence_hash: newHash, before: { evidence_hash: previousHash }, after: { evidence_hash: newHash, gate_names: gates.map((gate) => gate.name), head_tree_sha: treeSha } });
-    result.executionEvidenceHash = newHash; result.strictPreflightBefore = strictBefore.reason;
+    const expectedEvidenceHash = hashFileSha256(evidencePath);
+    const finalization = withManifestTransaction(record.manifestPath, () => {
+      const current = readManifest(record.manifestPath).data;
+      if (![STATES.INTERNAL_REVIEW_PENDING, STATES.REVIEW_PENDING].includes(current.state) || current.git?.head_sha !== headSha || current.git?.working_branch !== branch) {
+        throw new Error("run changed while verification was executing; refusing evidence replacement");
+      }
+      if (hashFileSha256(evidencePath) !== expectedEvidenceHash) {
+        throw new Error("execution evidence changed while verification was executing; refusing replacement");
+      }
+      const strictCurrent = computeQualityExecutionStatus({ runDir, reviewedHead: headSha, strict: true, manifestData: current });
+      if (strictCurrent.status !== "fail" || !/went unrecorded/.test(strictCurrent.reason || "")) {
+        throw new Error("strict preflight changed while verification was executing; refusing replacement");
+      }
+      const failed = runs.find((run) => run.exit_code !== 0);
+      if (failed) {
+        retainStaging = true;
+        throw new Error(`verification gate '${failed.name}' exited ${failed.exit_code}; preserving existing evidence`);
+      }
+      const finalRuns = runs.map(({ staged_path, ...run }) => run);
+      for (const run of runs) writePrivateFile(path.join(runDir, run.output_path), readSafeArtifact(run.staged_path));
+      const evidence = { ...existing, head_sha: headSha, verification_runs: finalRuns, recorded_at: timestamp, recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason, replaced_evidence_hash: expectedEvidenceHash, head_tree_sha: treeSha, recorded_at: timestamp } };
+      const encoded = `${JSON.stringify(evidence, null, 2)}\n`;
+      const newHash = crypto.createHash("sha256").update(encoded).digest("hex");
+      // Journal first: a crash can leave an orphaned audit attempt, but never a
+      // valid replacement artifact without an audit record. Re-run remains safe.
+      appendRunEvent(paths.repoRoot, data.run_id, { event: EVENTS.OPERATOR_EXECUTION_EVIDENCE, state_from: current.state, state_to: current.state, head_sha: headSha, branch, reason, operator_initiated: true, execution_evidence_path: evidencePath, execution_evidence_hash: newHash, before: { evidence_hash: expectedEvidenceHash }, after: { evidence_hash: newHash, gate_names: gates.map((gate) => gate.name), head_tree_sha: treeSha } }, { lockHeld: true });
+      writeExecutionEvidence(runDir, evidence);
+      return { newHash, strictBefore: strictCurrent.reason };
+    });
+    result.executionEvidenceHash = finalization.newHash; result.strictPreflightBefore = finalization.strictBefore;
+    } finally {
+      if (!retainStaging) discardStagingDir(stageDir);
+    }
   }
   console.log(json ? JSON.stringify(result, null, 2) : `${result.status}: ${result.runId} (${result.gateNames.join(", ")})`);
 }

--- a/skills/relay-dispatch/scripts/record-verification-evidence.js
+++ b/skills/relay-dispatch/scripts/record-verification-evidence.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+"use strict";
+
+/*
+ * Record a same-HEAD, operator-executed replacement for a strict-review
+ * evidence artifact whose required rubric gates are absent.  This deliberately
+ * does not recover commits, publish, or advance state.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const { resolveManifestRecord } = require("./relay-resolver");
+const { appendRunEvent, EVENTS } = require("./relay-events");
+const { STATES } = require("./manifest/lifecycle");
+const { getCanonicalRepoRoot, getRunDir, validateManifestPaths } = require("./manifest/paths");
+const { getRubricAnchorStatus, readTextFileWithoutFollowingSymlinks } = require("./manifest/rubric");
+const { extractVerificationGateDefinitions, hashFileSha256, writeExecutionEvidence } = require("./execution-evidence");
+const { computeQualityExecutionStatus } = require("../../relay-review/scripts/review-runner/execution-evidence");
+const { findUnknownFlags, modeLabel, readArg, schemaHasFlag } = require("./cli-args");
+const { execGit } = require("./exec");
+
+const args = process.argv.slice(2);
+const CLI_OPTIONS = { commandName: "record-verification-evidence", reservedFlags: ["-h"] };
+const hasFlag = (flag) => schemaHasFlag(args, flag, CLI_OPTIONS);
+const arg = (flag, fallback) => readArg(args, flag, fallback, CLI_OPTIONS);
+const MAX_ARTIFACT_BYTES = 1024 * 1024;
+const RECORDED_BY = "operator-confirmed-verification-v1";
+
+function help(exitCode) {
+  console.log("Usage: record-verification-evidence.js (--repo <path> --run-id <id> | --manifest <path>) --reason <text> [--observation-result <gate-name>=<file>]... [--dry-run] [--json]");
+  console.log("\nRun every exact command gate serially in a clean retained worktree and replace only same-HEAD strict-preflight-blocked evidence.");
+  console.log("Observation gates require one regular, non-symlink artifact each; the artifact is size-capped and copied into the run directory.");
+  console.log("\nOptions:");
+  for (const [flag, text] of [
+    ["--repo", "Repository root used with --run-id (default: .)"], ["--run-id", "Relay run identifier"],
+    ["--manifest", "Explicit manifest path"], ["--reason", "Required audit reason"],
+    ["--observation-result", "Repeatable gate-name=regular-file observation artifact"], ["--dry-run", "Validate and print no artifact bodies"],
+    ["--json", "Output JSON"], ["--help", "Show this help"],
+  ]) console.log(`  ${flag} ${modeLabel(flag)} ${text}`);
+  process.exit(exitCode);
+}
+
+function requireValue(value, flag) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${flag} requires a non-empty value`);
+  return value.trim();
+}
+
+function repeatedObservationArgs(argv) {
+  const values = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--observation-result") values.push(argv[index + 1]);
+    else if (argv[index].startsWith("--observation-result=")) values.push(argv[index].slice("--observation-result=".length));
+  }
+  return values.map((value) => requireValue(value, "--observation-result"));
+}
+
+function observationMap(values) {
+  const result = new Map();
+  for (const value of values) {
+    const equals = value.indexOf("=");
+    if (equals <= 0 || equals === value.length - 1) throw new Error("--observation-result must be <gate-name>=<file>");
+    const name = value.slice(0, equals).trim();
+    const source = value.slice(equals + 1).trim();
+    if (!name || !source || result.has(name)) throw new Error("--observation-result gate names must be unique and non-empty");
+    result.set(name, source);
+  }
+  return result;
+}
+
+function readSafeArtifact(source) {
+  const resolved = path.resolve(source);
+  const noFollow = typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0;
+  let fd;
+  try {
+    fd = fs.openSync(resolved, fs.constants.O_RDONLY | noFollow);
+  } catch {
+    throw new Error("observation artifact must be a readable regular non-symlink file");
+  }
+  let data;
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) throw new Error("observation artifact must be a regular non-symlink file");
+    if (stat.size > MAX_ARTIFACT_BYTES) throw new Error(`observation artifact exceeds ${MAX_ARTIFACT_BYTES} bytes`);
+    data = fs.readFileSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  if (data.length > MAX_ARTIFACT_BYTES) throw new Error(`observation artifact exceeds ${MAX_ARTIFACT_BYTES} bytes`);
+  return data;
+}
+
+function safeArtifact(source, destination) {
+  const data = readSafeArtifact(source);
+  fs.writeFileSync(destination, data, { mode: 0o600 });
+  return hashFileSha256(destination);
+}
+
+function boundedLog(runDir, index, command, cwd) {
+  let stdout = "";
+  let stderr = "";
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.env.SHELL || "/bin/sh", ["-lc", command], {
+      cwd, encoding: "utf-8", maxBuffer: MAX_ARTIFACT_BYTES,
+    }) || "";
+  } catch (error) {
+    exitCode = Number.isInteger(error.status) && error.status >= 0 ? error.status : 1;
+    stdout = String(error.stdout || "");
+    stderr = String(error.stderr || error.message || "");
+  }
+  const body = Buffer.from(`${stdout}\n${stderr}`, "utf-8").subarray(0, MAX_ARTIFACT_BYTES);
+  const outputName = `operator-verification-gate-${index + 1}.log`;
+  const outputPath = path.join(runDir, outputName);
+  fs.writeFileSync(outputPath, body, { mode: 0o600 });
+  return { exitCode, outputName, outputHash: hashFileSha256(outputPath) };
+}
+
+function resolveRecord(repoArg, runId, manifestArg) {
+  return resolveManifestRecord({ repoRoot: path.resolve(repoArg || "."), runId, manifestPath: manifestArg });
+}
+
+function main() {
+  if (!args.length || hasFlag(["--help", "-h"])) help(hasFlag(["--help", "-h"]) ? 0 : 1);
+  const unknown = findUnknownFlags(args, "record-verification-evidence");
+  if (unknown.length) throw new Error(`Unknown flag(s): ${unknown.join(", ")}`);
+  const repoArg = arg("--repo"); const runId = arg("--run-id"); const manifestArg = arg("--manifest");
+  const reason = requireValue(arg("--reason"), "--reason"); const dryRun = hasFlag("--dry-run"); const json = hasFlag("--json");
+  if (!runId && !manifestArg) throw new Error("Either --run-id or --manifest is required");
+  if (runId && manifestArg) throw new Error("Use either --run-id or --manifest, not both");
+  const record = resolveRecord(repoArg, runId, manifestArg);
+  const expectedRepoRoot = manifestArg && !repoArg ? undefined : getCanonicalRepoRoot(path.resolve(repoArg || "."));
+  const paths = validateManifestPaths(record.data?.paths, { expectedRepoRoot, manifestPath: record.manifestPath, runId: record.data?.run_id, caller: "record-verification-evidence" });
+  const data = { ...record.data, paths: { ...(record.data.paths || {}), repo_root: paths.repoRoot, worktree: paths.worktree } };
+  if (![STATES.INTERNAL_REVIEW_PENDING, STATES.REVIEW_PENDING].includes(data.state)) throw new Error("record-verification-evidence requires state=internal_review_pending or review_pending");
+  if (!paths.worktree || data.cleanup?.worktree_removed !== false) throw new Error("record-verification-evidence requires a retained worktree");
+  const branch = requireValue(data.git?.working_branch, "manifest git.working_branch");
+  if (execGit(paths.worktree, ["rev-parse", "--abbrev-ref", "HEAD"]) !== branch) throw new Error("manifest worktree branch does not match git.working_branch");
+  if (execGit(paths.worktree, ["status", "--porcelain"])) throw new Error("retained worktree must be clean");
+  const headSha = execGit(paths.worktree, ["rev-parse", "HEAD"]); const treeSha = execGit(paths.worktree, ["rev-parse", "HEAD^{tree}"]);
+  if (data.git?.head_sha !== headSha) throw new Error("manifest git.head_sha must match retained worktree HEAD");
+  const runDir = getRunDir(paths.repoRoot, data.run_id); const evidencePath = path.join(runDir, "execution-evidence.json");
+  const existing = JSON.parse(readTextFileWithoutFollowingSymlinks(evidencePath));
+  if (existing.head_sha !== headSha) throw new Error("existing execution evidence must match retained worktree HEAD");
+  const strictBefore = computeQualityExecutionStatus({ runDir, reviewedHead: headSha, strict: true, manifestData: data });
+  const missingGateBlock = /went unrecorded/.test(strictBefore.reason || "");
+  if (strictBefore.status !== "fail" || !missingGateBlock) throw new Error("existing evidence is not a same-HEAD strict-preflight missing/unrecorded-gate block; refusing replacement");
+  const anchor = getRubricAnchorStatus(data, { runDir, includeContent: true });
+  if (!anchor.satisfied) throw new Error(`rubric anchor invalid: ${anchor.error}`);
+  const gates = extractVerificationGateDefinitions(anchor.content);
+  if (!gates.length) throw new Error("rubric has no verification gates to record");
+  const observationResults = observationMap(repeatedObservationArgs(args));
+  const observations = gates.filter((gate) => gate.type === "observation");
+  for (const gate of observations) if (!observationResults.has(gate.name)) throw new Error(`missing --observation-result for observation gate '${gate.name}'`);
+  for (const name of observationResults.keys()) if (!observations.some((gate) => gate.name === name)) throw new Error(`--observation-result does not match an observation gate: '${name}'`);
+  // Dry-run intentionally reads no bodies into output, but still validates the
+  // source's no-symlink/regular-file/size boundary before promising success.
+  if (dryRun) observations.forEach((gate) => readSafeArtifact(observationResults.get(gate.name)));
+  const result = { status: dryRun ? "dry_run" : "recorded", runId: data.run_id, headSha, gateNames: gates.map((gate) => gate.name), reason };
+  if (!dryRun) {
+    const timestamp = new Date().toISOString();
+    const runs = gates.map((gate, index) => {
+      if (gate.type === "command") {
+        const output = boundedLog(runDir, index, gate.command, paths.worktree);
+        return { name: gate.name, command: gate.command, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: output.exitCode, output_path: output.outputName, output_hash: output.outputHash, recorded_by: RECORDED_BY, recorded_at: timestamp };
+      }
+      const outputName = `operator-observation-gate-${index + 1}.artifact`;
+      const outputPath = path.join(runDir, outputName);
+      const hash = safeArtifact(observationResults.get(gate.name), outputPath);
+      return { name: gate.name, command: `observation:${gate.name}`, cwd: paths.worktree, head_sha: headSha, verification_tree_sha: treeSha, exit_code: 0, output_path: outputName, output_hash: hash, recorded_by: RECORDED_BY, recorded_at: timestamp };
+    });
+    if (execGit(paths.worktree, ["status", "--porcelain"]) || execGit(paths.worktree, ["rev-parse", "HEAD"]) !== headSha || execGit(paths.worktree, ["rev-parse", "HEAD^{tree}"]) !== treeSha) {
+      throw new Error("verification commands changed the retained worktree; refusing to write evidence");
+    }
+    const previousHash = hashFileSha256(evidencePath);
+    const evidence = { ...existing, head_sha: headSha, verification_runs: runs, recorded_at: timestamp, recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason, replaced_evidence_hash: previousHash, head_tree_sha: treeSha, recorded_at: timestamp } };
+    writeExecutionEvidence(runDir, evidence);
+    const newHash = hashFileSha256(evidencePath);
+    appendRunEvent(paths.repoRoot, data.run_id, { event: EVENTS.OPERATOR_EXECUTION_EVIDENCE, state_from: data.state, state_to: data.state, head_sha: headSha, branch, reason, operator_initiated: true, execution_evidence_path: evidencePath, execution_evidence_hash: newHash, before: { evidence_hash: previousHash }, after: { evidence_hash: newHash, gate_names: gates.map((gate) => gate.name), head_tree_sha: treeSha } });
+    result.executionEvidenceHash = newHash; result.strictPreflightBefore = strictBefore.reason;
+  }
+  console.log(json ? JSON.stringify(result, null, 2) : `${result.status}: ${result.runId} (${result.gateNames.join(", ")})`);
+}
+
+try { main(); } catch (error) { console.error(`Error: ${error.message}`); process.exit(1); }

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -24,6 +24,7 @@ const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
 const FORCE_FINALIZE_GUIDANCE = 'finalize-run --force-finalize-nonready --reason "pre-261 run, no artifact"';
 const VERIFICATION_HASH_FIELDS = ["output_hash", "stdout_hash", "stderr_hash"];
 const CONFIRMED_VERIFICATION_RECORDED_BY_SUFFIX = "-confirmed-verification-v1";
+const OPERATOR_VERIFICATION_RECORDED_BY = "operator-confirmed-verification-v1";
 
 function isNonEmptyString(value) {
   return typeof value === "string" && value.trim() !== "";
@@ -147,6 +148,8 @@ function observationRunMatches(gate, run, requireOperatorObservationProvenance) 
   if (gate.type !== "observation" || !requireOperatorObservationProvenance) return true;
   return run.gate_type === "observation"
     && run.result_kind === "operator_observation_artifact"
+    && run.gate_name === gate.name
+    && run.name === gate.name
     && isNonEmptyString(run.output_path)
     && isNonEmptyString(run.output_hash)
     && SHA256_PATTERN.test(run.output_hash);
@@ -234,6 +237,23 @@ function confirmedVerificationTreeReason(artifact, reviewedHead, manifestData) {
   );
 }
 
+function operatorVerificationTreeReason(artifact, reviewedHead, manifestData) {
+  if (!isOperatorRecordedEvidence(artifact)) return null;
+  const invalidRecorder = artifact.verification_runs.find((run) => (
+    run.recorded_by !== OPERATOR_VERIFICATION_RECORDED_BY
+  ));
+  if (invalidRecorder) {
+    return "strict operator execution evidence requires every verification_run to be recorded_by operator-confirmed-verification-v1";
+  }
+  const missingTree = artifact.verification_runs.find((run) => (
+    !isNonEmptyString(run.verification_tree_sha) || !SHA40_PATTERN.test(run.verification_tree_sha)
+  ));
+  if (missingTree) {
+    return "strict operator execution evidence requires verification_tree_sha for every verification_run";
+  }
+  return confirmedVerificationTreeReason(artifact, reviewedHead, manifestData);
+}
+
 function validateVerificationHash(value, fieldName) {
   if (value !== undefined && (!isNonEmptyString(value) || !SHA256_PATTERN.test(value))) {
     throw new Error(`execution evidence verification_runs[].${fieldName} must be a sha256 hex digest when present`);
@@ -281,14 +301,6 @@ function validateVerificationRun(run, index) {
     throw new Error(
       `execution evidence verification_runs[${index}] requires at least one of ${VERIFICATION_HASH_FIELDS.join(", ")}`
     );
-  }
-  if (run.gate_type === "observation") {
-    if (run.result_kind !== "operator_observation_artifact") {
-      throw new Error(`execution evidence verification_runs[${index}].result_kind must be operator_observation_artifact for observation evidence`);
-    }
-    if (!isNonEmptyString(run.output_path) || !isNonEmptyString(run.output_hash)) {
-      throw new Error(`execution evidence verification_runs[${index}] observation evidence requires output_path and output_hash`);
-    }
   }
 }
 
@@ -612,6 +624,14 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false, m
         reviewedHead,
         manifestData
       );
+      const operatorTreeReason = operatorVerificationTreeReason(
+        artifactLoad.artifact,
+        reviewedHead,
+        manifestData
+      );
+      if (operatorTreeReason) {
+        return { status: "fail", reason: operatorTreeReason };
+      }
       if (verificationTreeReason) {
         return {
           status: "fail",

--- a/skills/relay-review/scripts/review-runner/execution-evidence.js
+++ b/skills/relay-review/scripts/review-runner/execution-evidence.js
@@ -134,10 +134,31 @@ function rebrandVerificationGateReason(artifact, gates, policies = [
   );
 }
 
-function findMissingVerificationGates(gates, verificationRuns) {
+function isOperatorRecordedEvidence(artifact) {
+  return artifact?.recorded_by === "record-verification-evidence-operator-v1"
+    || isObject(artifact?.operator_verification)
+    || (Array.isArray(artifact?.verification_runs) && artifact.verification_runs.some((run) => (
+      run?.recorded_by === "operator-confirmed-verification-v1"
+    )));
+}
+
+function observationRunMatches(gate, run, requireOperatorObservationProvenance) {
+  if (run.command !== gate.command) return false;
+  if (gate.type !== "observation" || !requireOperatorObservationProvenance) return true;
+  return run.gate_type === "observation"
+    && run.result_kind === "operator_observation_artifact"
+    && isNonEmptyString(run.output_path)
+    && isNonEmptyString(run.output_hash)
+    && SHA256_PATTERN.test(run.output_hash);
+}
+
+function findMissingVerificationGates(gates, verificationRuns, artifact) {
   const unmatchedRuns = [...verificationRuns];
+  const requireOperatorObservationProvenance = isOperatorRecordedEvidence(artifact);
   return gates.filter((gate) => {
-    const matchIndex = unmatchedRuns.findIndex((run) => run.command === gate.command);
+    const matchIndex = unmatchedRuns.findIndex((run) => (
+      observationRunMatches(gate, run, requireOperatorObservationProvenance)
+    ));
     if (matchIndex === -1) return true;
     unmatchedRuns.splice(matchIndex, 1);
     return false;
@@ -260,6 +281,14 @@ function validateVerificationRun(run, index) {
     throw new Error(
       `execution evidence verification_runs[${index}] requires at least one of ${VERIFICATION_HASH_FIELDS.join(", ")}`
     );
+  }
+  if (run.gate_type === "observation") {
+    if (run.result_kind !== "operator_observation_artifact") {
+      throw new Error(`execution evidence verification_runs[${index}].result_kind must be operator_observation_artifact for observation evidence`);
+    }
+    if (!isNonEmptyString(run.output_path) || !isNonEmptyString(run.output_hash)) {
+      throw new Error(`execution evidence verification_runs[${index}] observation evidence requires output_path and output_hash`);
+    }
   }
 }
 
@@ -560,7 +589,8 @@ function computeQualityExecutionStatus({ runDir, reviewedHead, strict = false, m
       }
       const missingGates = findMissingVerificationGates(
         verificationGates,
-        artifactLoad.artifact.verification_runs
+        artifactLoad.artifact.verification_runs,
+        artifactLoad.artifact
       );
       if (missingGates.length > 0) {
         return {

--- a/tests/relay-dispatch/scripts/cli-schema.test.js
+++ b/tests/relay-dispatch/scripts/cli-schema.test.js
@@ -187,6 +187,7 @@ const HELP_COMMANDS = [
   ["persist-request", path.join(__dirname, "..", "..", "..", "skills", "relay-ready", "scripts", "persist-request.js")],
   ["probe-executor-env", path.join(__dirname, "..", "..", "..", "skills", "relay-plan", "scripts", "probe-executor-env.js")],
   ["recover-commit", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "recover-commit.js")],
+  ["record-verification-evidence", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "record-verification-evidence.js")],
   ["reconcile-run", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "reconcile-run.js")],
   ["relay-config", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "relay-config.js")],
   ["rebrand-evidence", path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "rebrand-evidence.js")],

--- a/tests/relay-dispatch/scripts/execution-evidence.test.js
+++ b/tests/relay-dispatch/scripts/execution-evidence.test.js
@@ -80,6 +80,25 @@ test("verification gates seed the evidence command and identify malformed comman
   );
 });
 
+test("verification gate extraction preserves legacy typed command and ignores manual checks without commands", () => {
+  const rubric = [
+    "evaluation:", "  verification:", "    checks:",
+    "      - name: legacy automated suite", "        type: automated", "        command: node --test legacy.test.js",
+    "      - name: manual release inspection", "        type: manual", "        target: inspect release",
+    "      - name: contract check", "        type: contract", "        command: node --test contract.test.js",
+  ].join("\n");
+
+  assert.deepEqual(extractVerificationGates(rubric), [{
+    name: "legacy automated suite", type: "automated", command: "node --test legacy.test.js",
+  }, {
+    name: "contract check", type: "contract", command: "node --test contract.test.js",
+  }]);
+  assert.equal(
+    resolveExecutionEvidenceTestCommand({ rubricYaml: rubric }),
+    "node --test legacy.test.js && node --test contract.test.js"
+  );
+});
+
 test("dispatch execution evidence records all fields and uses an atomic rename in the run dir", () => {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-dispatch-execution-"));
   const resultFile = path.join(runDir, "result.txt");

--- a/tests/relay-dispatch/scripts/record-verification-evidence.test.js
+++ b/tests/relay-dispatch/scripts/record-verification-evidence.test.js
@@ -1,0 +1,85 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  STATES, createManifestSkeleton, createRunId, ensureRunLayout, updateManifestState, writeManifest,
+} = require("../../../skills/relay-dispatch/scripts/relay-manifest");
+const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
+const { writeExecutionEvidence } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
+const { COMMAND_FLAGS } = require("../../../skills/relay-dispatch/scripts/cli-schema");
+
+const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "record-verification-evidence.js");
+
+function fixture() {
+  const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-record-evidence-")));
+  const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-record-home-")));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: repoRoot });
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "base\n");
+  execFileSync("git", ["add", "."], { cwd: repoRoot }); execFileSync("git", ["commit", "-m", "base"], { cwd: repoRoot });
+  const worktree = path.join(repoRoot, "wt"); execFileSync("git", ["worktree", "add", worktree, "-b", "issue-1113"], { cwd: repoRoot });
+  const head = execFileSync("git", ["-C", worktree, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  const runId = createRunId({ issueNumber: 1113, branch: "issue-1113", timestamp: new Date("2026-07-31T00:00:00Z") });
+  const layout = ensureRunLayout(repoRoot, runId);
+  fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), [
+    "evaluation:", "  verification:", "    checks:", "      - name: unit", "        type: command", "        command: node -e \"process.stdout.write('ok')\"",
+    "      - name: screenshot", "        type: observation",
+  ].join("\n"));
+  let manifest = createManifestSkeleton({ repoRoot, runId, branch: "issue-1113", baseBranch: "main", issueNumber: 1113, worktreePath: worktree, orchestrator: "codex", executor: "codex", reviewer: "codex" });
+  manifest = updateManifestState(manifest, STATES.DISPATCHED, "await");
+  manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "review");
+  manifest.anchor.rubric_path = "rubric.yaml"; manifest.git.head_sha = head; writeManifest(layout.manifestPath, manifest);
+  writeExecutionEvidence(layout.runDir, { schema_version: 1, head_sha: head, test_command: "unspecified", test_result_hash: "unspecified", test_result_summary: "unspecified", recorded_at: "2026-07-31T00:00:00Z", recorded_by: "rebrand" });
+  const observation = path.join(repoRoot, "observation.txt"); fs.writeFileSync(observation, "checked\n");
+  return { repoRoot, relayHome, runId, runDir: layout.runDir, head, observation };
+}
+
+function invoke(item, extra = []) {
+  return spawnSync(process.execPath, [SCRIPT, "--repo", item.repoRoot, "--run-id", item.runId, "--reason", "same-head audited re-verification", ...extra], { cwd: item.repoRoot, encoding: "utf8", env: { ...process.env, RELAY_HOME: item.relayHome } });
+}
+
+test("CLI schema registers record-verification-evidence", () => {
+  assert.deepEqual(COMMAND_FLAGS["record-verification-evidence"], ["--repo", "--run-id", "--manifest", "--reason", "--observation-result", "--dry-run", "--json", "--help"]);
+});
+
+test("records exact command and hash-backed observation only for strict missing gates", () => {
+  const item = fixture();
+  const dry = invoke(item, ["--observation-result", `screenshot=${item.observation}`, "--dry-run", "--json"]);
+  assert.equal(dry.status, 0, dry.stderr); assert.equal(JSON.parse(dry.stdout).status, "dry_run");
+  const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`, "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  const evidence = JSON.parse(fs.readFileSync(path.join(item.runDir, "execution-evidence.json"), "utf8"));
+  assert.equal(evidence.head_sha, item.head); assert.equal(evidence.verification_runs.length, 2);
+  assert.equal(evidence.verification_runs[0].command, "node -e \"process.stdout.write('ok')\"");
+  assert.equal(evidence.verification_runs[0].verification_tree_sha.length, 40);
+  assert.equal(evidence.verification_runs[1].command, "observation:screenshot");
+  assert.ok(fs.existsSync(path.join(item.runDir, evidence.verification_runs[1].output_path)));
+  const events = readRunEvents(item.repoRoot, item.runId).filter((entry) => entry.event === "operator_execution_evidence");
+  assert.equal(events.length, 1); assert.deepEqual(events[0].after.gate_names, ["unit", "screenshot"]);
+});
+
+test("refuses arbitrary overwrite after the strict preflight is already satisfied", () => {
+  const item = fixture();
+  assert.equal(invoke(item, ["--observation-result", `screenshot=${item.observation}`]).status, 0);
+  const second = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
+  assert.notEqual(second.status, 0); assert.match(second.stderr, /refusing replacement/);
+});
+
+test("refuses observation symlinks", () => {
+  const item = fixture(); const link = path.join(item.repoRoot, "observation-link"); fs.symlinkSync(item.observation, link);
+  const result = invoke(item, ["--observation-result", `screenshot=${link}`]);
+  assert.notEqual(result.status, 0); assert.match(result.stderr, /regular non-symlink/);
+});
+
+test("copies binary observation artifacts without decoding them", () => {
+  const item = fixture(); const bytes = Buffer.from([0, 255, 128, 10]); fs.writeFileSync(item.observation, bytes);
+  const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
+  assert.equal(result.status, 0, result.stderr);
+  const evidence = JSON.parse(fs.readFileSync(path.join(item.runDir, "execution-evidence.json"), "utf8"));
+  assert.deepEqual(fs.readFileSync(path.join(item.runDir, evidence.verification_runs[1].output_path)), bytes);
+});

--- a/tests/relay-dispatch/scripts/record-verification-evidence.test.js
+++ b/tests/relay-dispatch/scripts/record-verification-evidence.test.js
@@ -11,12 +11,14 @@ const {
 const { readRunEvents } = require("../../../skills/relay-dispatch/scripts/relay-events");
 const { writeExecutionEvidence } = require("../../../skills/relay-dispatch/scripts/execution-evidence");
 const { COMMAND_FLAGS } = require("../../../skills/relay-dispatch/scripts/cli-schema");
+const { computeQualityExecutionStatus } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "record-verification-evidence.js");
 
 function fixture() {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-record-evidence-")));
   const relayHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-record-home-")));
+  process.env.RELAY_HOME = relayHome;
   execFileSync("git", ["init", "-b", "main"], { cwd: repoRoot, stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoRoot });
   execFileSync("git", ["config", "user.name", "Test"], { cwd: repoRoot });
@@ -28,15 +30,16 @@ function fixture() {
   const layout = ensureRunLayout(repoRoot, runId);
   fs.writeFileSync(path.join(layout.runDir, "rubric.yaml"), [
     "evaluation:", "  verification:", "    checks:", "      - name: unit", "        type: command", "        command: node -e \"process.stdout.write('ok')\"",
-    "      - name: screenshot", "        type: observation",
+    "      - name: screenshot", "        type: observation", "        command: node -e \"process.stdout.write('observed')\"",
   ].join("\n"));
   let manifest = createManifestSkeleton({ repoRoot, runId, branch: "issue-1113", baseBranch: "main", issueNumber: 1113, worktreePath: worktree, orchestrator: "codex", executor: "codex", reviewer: "codex" });
+  manifest.anchor.rubric_path = "rubric.yaml";
   manifest = updateManifestState(manifest, STATES.DISPATCHED, "await");
   manifest = updateManifestState(manifest, STATES.REVIEW_PENDING, "review");
-  manifest.anchor.rubric_path = "rubric.yaml"; manifest.git.head_sha = head; writeManifest(layout.manifestPath, manifest);
+  manifest.git.head_sha = head; writeManifest(layout.manifestPath, manifest);
   writeExecutionEvidence(layout.runDir, { schema_version: 1, head_sha: head, test_command: "unspecified", test_result_hash: "unspecified", test_result_summary: "unspecified", recorded_at: "2026-07-31T00:00:00Z", recorded_by: "rebrand" });
   const observation = path.join(repoRoot, "observation.txt"); fs.writeFileSync(observation, "checked\n");
-  return { repoRoot, relayHome, runId, runDir: layout.runDir, head, observation };
+  return { repoRoot, relayHome, runId, runDir: layout.runDir, head, observation, manifest };
 }
 
 function invoke(item, extra = []) {
@@ -57,10 +60,14 @@ test("records exact command and hash-backed observation only for strict missing 
   assert.equal(evidence.head_sha, item.head); assert.equal(evidence.verification_runs.length, 2);
   assert.equal(evidence.verification_runs[0].command, "node -e \"process.stdout.write('ok')\"");
   assert.equal(evidence.verification_runs[0].verification_tree_sha.length, 40);
-  assert.equal(evidence.verification_runs[1].command, "observation:screenshot");
+  assert.equal(evidence.verification_runs[1].command, "node -e \"process.stdout.write('observed')\"");
+  assert.equal(evidence.verification_runs[1].gate_type, "observation");
   assert.ok(fs.existsSync(path.join(item.runDir, evidence.verification_runs[1].output_path)));
   const events = readRunEvents(item.repoRoot, item.runId).filter((entry) => entry.event === "operator_execution_evidence");
   assert.equal(events.length, 1); assert.deepEqual(events[0].after.gate_names, ["unit", "screenshot"]);
+  evidence.verification_runs.pop(); fs.writeFileSync(path.join(item.runDir, "execution-evidence.json"), `${JSON.stringify(evidence)}\n`);
+  const strict = computeQualityExecutionStatus({ runDir: item.runDir, reviewedHead: item.head, strict: true, manifestData: item.manifest });
+  assert.equal(strict.status, "fail"); assert.match(strict.reason, /screenshot/);
 });
 
 test("refuses arbitrary overwrite after the strict preflight is already satisfied", () => {

--- a/tests/relay-dispatch/scripts/record-verification-evidence.test.js
+++ b/tests/relay-dispatch/scripts/record-verification-evidence.test.js
@@ -75,6 +75,7 @@ test("records exact command and hash-backed observation only for strict missing 
   assert.equal(evidence.verification_runs[0].verification_tree_sha.length, 40);
   assert.equal(evidence.verification_runs[1].command, "node -e \"process.stdout.write('observed')\"");
   assert.equal(evidence.verification_runs[1].gate_type, "observation");
+  assert.equal(evidence.verification_runs[1].result_kind, "operator_observation_artifact");
   assert.ok(fs.existsSync(path.join(item.runDir, evidence.verification_runs[1].output_path)));
   const events = readRunEvents(item.repoRoot, item.runId).filter((entry) => entry.event === "operator_execution_evidence");
   assert.equal(events.length, 1); assert.deepEqual(events[0].after.gate_names, ["unit", "screenshot"]);
@@ -104,31 +105,30 @@ test("copies binary observation artifacts without decoding them", () => {
   assert.deepEqual(fs.readFileSync(path.join(item.runDir, evidence.verification_runs[1].output_path)), bytes);
 });
 
-test("nonzero command preserves the old evidence and leaves only bounded diagnostics", () => {
+test("nonzero command preserves old evidence and cleans its private staging", () => {
   const item = fixture(); const evidencePath = path.join(item.runDir, "execution-evidence.json"); const before = fs.readFileSync(evidencePath, "utf8");
   fs.writeFileSync(path.join(item.runDir, "rubric.yaml"), "evaluation:\n  verification:\n    checks:\n      - name: unit\n        type: command\n        command: node -e \"process.exit(7)\"\n");
   const result = invoke(item);
   assert.notEqual(result.status, 0); assert.match(result.stderr, /exited 7/);
   assert.equal(fs.readFileSync(evidencePath, "utf8"), before);
-  const diagnosticDir = fs.readdirSync(item.runDir).find((name) => name.startsWith(".operator-verification-"));
-  assert.ok(diagnosticDir); assert.ok(fs.existsSync(path.join(item.runDir, diagnosticDir, "operator-verification-gate-1.log")));
+  assert.equal(fs.readdirSync(item.runDir).some((name) => name.startsWith(".operator-verification-")), false);
 });
 
-test("refuses symlinked log destinations without touching their target", () => {
+test("nonce-qualified final artifact names never touch legacy deterministic destinations", () => {
   const item = fixture(); const victim = path.join(item.repoRoot, "victim.txt"); fs.writeFileSync(victim, "keep");
   fs.symlinkSync(victim, path.join(item.runDir, "operator-verification-gate-1.log"));
   const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
-  assert.notEqual(result.status, 0); assert.match(result.stderr, /symlinked verification artifact destination/);
+  assert.equal(result.status, 0, result.stderr);
   assert.equal(fs.readFileSync(victim, "utf8"), "keep");
 });
 
-test("replaces stale regular destinations atomically and normalizes private mode", () => {
+test("nonce-qualified final artifact names leave stale regular destinations untouched", () => {
   const item = fixture(); const stale = path.join(item.runDir, "operator-verification-gate-1.log");
   fs.writeFileSync(stale, "stale"); fs.chmodSync(stale, 0o644);
   const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(fs.statSync(stale).mode & 0o777, 0o600);
-  assert.notEqual(fs.readFileSync(stale, "utf8"), "stale");
+  assert.equal(fs.statSync(stale).mode & 0o777, 0o644);
+  assert.equal(fs.readFileSync(stale, "utf8"), "stale");
 });
 
 test("concurrent recorders serialize final replacement and reject the loser", async () => {
@@ -150,9 +150,21 @@ test("concurrent recorders serialize final replacement and reject the loser", as
   assert.equal(hashFile(path.join(item.runDir, evidence.verification_runs[0].output_path)), evidence.verification_runs[0].output_hash);
 });
 
-test("event append failure leaves old evidence in place", () => {
+test("event append failure preserves partial evidence and its referenced artifact", () => {
   const item = fixture(); const evidencePath = path.join(item.runDir, "execution-evidence.json"); const before = fs.readFileSync(evidencePath, "utf8");
+  const priorName = "prior-partial-gate-1.log"; const priorPath = path.join(item.runDir, priorName); fs.writeFileSync(priorPath, "prior\n", { mode: 0o600 });
+  const partial = { ...JSON.parse(before), verification_runs: [{ name: "unit", command: "node -e \"process.stdout.write('ok')\"", cwd: item.manifest.paths.worktree, head_sha: item.head, exit_code: 0, output_path: priorName, output_hash: hashFile(priorPath), recorded_by: "operator", recorded_at: "2026-07-31T00:00:00.000Z" }] };
+  fs.writeFileSync(evidencePath, `${JSON.stringify(partial)}\n`); const partialBytes = fs.readFileSync(evidencePath, "utf8");
   fs.symlinkSync(path.join(item.repoRoot, "events-target"), path.join(item.runDir, "events.jsonl"));
   const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
-  assert.notEqual(result.status, 0); assert.equal(fs.readFileSync(evidencePath, "utf8"), before);
+  assert.notEqual(result.status, 0); assert.equal(fs.readFileSync(evidencePath, "utf8"), partialBytes);
+  assert.equal(fs.readFileSync(priorPath, "utf8"), "prior\n");
+});
+
+test("commandless observation is ignored rather than recorded as an empty command", () => {
+  const item = fixture();
+  fs.writeFileSync(path.join(item.runDir, "rubric.yaml"), "evaluation:\n  verification:\n    checks:\n      - name: unit\n        type: command\n        command: node -e \"process.stdout.write('ok')\"\n      - name: visual note\n        type: observation\n");
+  const result = invoke(item); assert.equal(result.status, 0, result.stderr);
+  const evidence = JSON.parse(fs.readFileSync(path.join(item.runDir, "execution-evidence.json"), "utf8"));
+  assert.deepEqual(evidence.verification_runs.map((run) => run.command), ["node -e \"process.stdout.write('ok')\""]);
 });

--- a/tests/relay-dispatch/scripts/record-verification-evidence.test.js
+++ b/tests/relay-dispatch/scripts/record-verification-evidence.test.js
@@ -1,6 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { execFileSync, spawnSync } = require("child_process");
+const { execFileSync, spawn, spawnSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -14,6 +15,10 @@ const { COMMAND_FLAGS } = require("../../../skills/relay-dispatch/scripts/cli-sc
 const { computeQualityExecutionStatus } = require("../../../skills/relay-review/scripts/review-runner/execution-evidence");
 
 const SCRIPT = path.join(__dirname, "..", "..", "..", "skills", "relay-dispatch", "scripts", "record-verification-evidence.js");
+
+function hashFile(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
 
 function fixture() {
   const repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-record-evidence-")));
@@ -44,6 +49,14 @@ function fixture() {
 
 function invoke(item, extra = []) {
   return spawnSync(process.execPath, [SCRIPT, "--repo", item.repoRoot, "--run-id", item.runId, "--reason", "same-head audited re-verification", ...extra], { cwd: item.repoRoot, encoding: "utf8", env: { ...process.env, RELAY_HOME: item.relayHome } });
+}
+
+function invokeAsync(item, extra = []) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [SCRIPT, "--repo", item.repoRoot, "--run-id", item.runId, "--reason", "same-head audited re-verification", ...extra], { cwd: item.repoRoot, env: { ...process.env, RELAY_HOME: item.relayHome } });
+    let stderr = ""; child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (status) => resolve({ status, stderr }));
+  });
 }
 
 test("CLI schema registers record-verification-evidence", () => {
@@ -89,4 +102,54 @@ test("copies binary observation artifacts without decoding them", () => {
   assert.equal(result.status, 0, result.stderr);
   const evidence = JSON.parse(fs.readFileSync(path.join(item.runDir, "execution-evidence.json"), "utf8"));
   assert.deepEqual(fs.readFileSync(path.join(item.runDir, evidence.verification_runs[1].output_path)), bytes);
+});
+
+test("nonzero command preserves the old evidence and leaves only bounded diagnostics", () => {
+  const item = fixture(); const evidencePath = path.join(item.runDir, "execution-evidence.json"); const before = fs.readFileSync(evidencePath, "utf8");
+  fs.writeFileSync(path.join(item.runDir, "rubric.yaml"), "evaluation:\n  verification:\n    checks:\n      - name: unit\n        type: command\n        command: node -e \"process.exit(7)\"\n");
+  const result = invoke(item);
+  assert.notEqual(result.status, 0); assert.match(result.stderr, /exited 7/);
+  assert.equal(fs.readFileSync(evidencePath, "utf8"), before);
+  const diagnosticDir = fs.readdirSync(item.runDir).find((name) => name.startsWith(".operator-verification-"));
+  assert.ok(diagnosticDir); assert.ok(fs.existsSync(path.join(item.runDir, diagnosticDir, "operator-verification-gate-1.log")));
+});
+
+test("refuses symlinked log destinations without touching their target", () => {
+  const item = fixture(); const victim = path.join(item.repoRoot, "victim.txt"); fs.writeFileSync(victim, "keep");
+  fs.symlinkSync(victim, path.join(item.runDir, "operator-verification-gate-1.log"));
+  const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
+  assert.notEqual(result.status, 0); assert.match(result.stderr, /symlinked verification artifact destination/);
+  assert.equal(fs.readFileSync(victim, "utf8"), "keep");
+});
+
+test("replaces stale regular destinations atomically and normalizes private mode", () => {
+  const item = fixture(); const stale = path.join(item.runDir, "operator-verification-gate-1.log");
+  fs.writeFileSync(stale, "stale"); fs.chmodSync(stale, 0o644);
+  const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.statSync(stale).mode & 0o777, 0o600);
+  assert.notEqual(fs.readFileSync(stale, "utf8"), "stale");
+});
+
+test("concurrent recorders serialize final replacement and reject the loser", async () => {
+  const item = fixture();
+  const rubricPath = path.join(item.runDir, "rubric.yaml");
+  fs.writeFileSync(rubricPath, [
+    "evaluation:", "  verification:", "    checks:", "      - name: unit", "        type: command",
+    "        command: node -e \"const fs=require('fs'); const p=process.env.RELAY_HOME + '/race'; if (!fs.existsSync(p)) { fs.writeFileSync(p, '1'); setTimeout(() => process.stdout.write('first'), 50); } else { setTimeout(() => process.stdout.write('second'), 500); }\"",
+    "      - name: screenshot", "        type: observation", "        command: node -e \"process.stdout.write('observed')\"",
+  ].join("\n"));
+  const args = ["--observation-result", `screenshot=${item.observation}`];
+  const [left, right] = await Promise.all([invokeAsync(item, args), invokeAsync(item, args)]);
+  assert.deepEqual([left.status, right.status].sort(), [0, 1]);
+  assert.match(`${left.stderr}${right.stderr}`, /strict preflight changed while verification was executing/);
+  const evidence = JSON.parse(fs.readFileSync(path.join(item.runDir, "execution-evidence.json"), "utf8"));
+  assert.equal(hashFile(path.join(item.runDir, evidence.verification_runs[0].output_path)), evidence.verification_runs[0].output_hash);
+});
+
+test("event append failure leaves old evidence in place", () => {
+  const item = fixture(); const evidencePath = path.join(item.runDir, "execution-evidence.json"); const before = fs.readFileSync(evidencePath, "utf8");
+  fs.symlinkSync(path.join(item.repoRoot, "events-target"), path.join(item.runDir, "events.jsonl"));
+  const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
+  assert.notEqual(result.status, 0); assert.equal(fs.readFileSync(evidencePath, "utf8"), before);
 });

--- a/tests/relay-dispatch/scripts/record-verification-evidence.test.js
+++ b/tests/relay-dispatch/scripts/record-verification-evidence.test.js
@@ -159,6 +159,7 @@ test("event append failure preserves partial evidence and its referenced artifac
   const result = invoke(item, ["--observation-result", `screenshot=${item.observation}`]);
   assert.notEqual(result.status, 0); assert.equal(fs.readFileSync(evidencePath, "utf8"), partialBytes);
   assert.equal(fs.readFileSync(priorPath, "utf8"), "prior\n");
+  assert.equal(fs.readdirSync(item.runDir).some((name) => /^(operator-verification|operator-observation)-[0-9a-f]{16}-/.test(name)), false);
 });
 
 test("commandless observation is ignored rather than recorded as an empty command", () => {

--- a/tests/relay-dispatch/scripts/record-verification-evidence.test.js
+++ b/tests/relay-dispatch/scripts/record-verification-evidence.test.js
@@ -142,7 +142,10 @@ test("concurrent recorders serialize final replacement and reject the loser", as
   const args = ["--observation-result", `screenshot=${item.observation}`];
   const [left, right] = await Promise.all([invokeAsync(item, args), invokeAsync(item, args)]);
   assert.deepEqual([left.status, right.status].sort(), [0, 1]);
-  assert.match(`${left.stderr}${right.stderr}`, /strict preflight changed while verification was executing/);
+  assert.match(
+    `${left.stderr}${right.stderr}`,
+    /(?:execution evidence|strict preflight) changed while verification was executing/
+  );
   const evidence = JSON.parse(fs.readFileSync(path.join(item.runDir, "execution-evidence.json"), "utf8"));
   assert.equal(hashFile(path.join(item.runDir, evidence.verification_runs[0].output_path)), evidence.verification_runs[0].output_hash);
 });

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -185,6 +185,38 @@ test("execution-evidence strict mode prefers verification_runs when present", ()
   );
 });
 
+test("strict verification preserves all frozen command gates, including observation gates", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-observation-gates-"));
+  const head = "a".repeat(40);
+  const gates = [
+    ["unit", "command", "node --test unit.test.js"],
+    ["integration", "automated", "node --test integration.test.js"],
+    ["lint", "evaluated", "node --test lint.test.js"],
+    ["desktop", "observation", "node -e \"process.stdout.write('desktop')\""],
+    ["mobile", "observation", "node -e \"process.stdout.write('mobile')\""],
+    ["accessibility", "observation", "node -e \"process.stdout.write('a11y')\""],
+  ];
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+    "evaluation:", "  verification:", "    checks:",
+    ...gates.flatMap(([name, type, command]) => [
+      `      - name: ${name}`, `        type: ${type}`, `        command: ${command}`,
+    ]),
+  ].join("\n"));
+  const runs = gates.map(([name, type, command], index) => ({
+    name, gate_name: name, ...(type === "observation" ? { gate_type: "observation" } : {}), command,
+    cwd: "/repo", head_sha: head, exit_code: 0, output_hash: String(index).padStart(64, "a"),
+    recorded_by: "operator", recorded_at: "2026-07-31T00:00:00.000Z",
+  }));
+  writeArtifact(runDir, makeArtifact(head, { verification_runs: runs }));
+  assert.deepEqual(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }), { status: "pass", reason: null });
+
+  runs.splice(4, 1); // Removing a frozen observation command must not be silently accepted.
+  writeArtifact(runDir, makeArtifact(head, { verification_runs: runs }));
+  const missingObservation = computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true });
+  assert.equal(missingObservation.status, "fail");
+  assert.match(missingObservation.reason, /mobile/);
+});
+
 test("execution-evidence strict preflight binds confirmed verification proof to reviewed HEAD tree", () => {
   const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-confirmed-tree-"));
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-confirmed-tree-run-"));

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -1,6 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { execFileSync } = require("node:child_process");
+const crypto = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -41,6 +42,10 @@ function writeArtifact(runDir, artifact) {
   const artifactPath = path.join(runDir, EXECUTION_EVIDENCE_FILENAME);
   fs.writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf-8");
   return artifactPath;
+}
+
+function sha256File(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
 test("execution-evidence parses a strict schema_version=1 artifact", () => {
@@ -215,6 +220,33 @@ test("strict verification preserves all frozen command gates, including observat
   const missingObservation = computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true });
   assert.equal(missingObservation.status, "fail");
   assert.match(missingObservation.reason, /mobile/);
+});
+
+test("operator evidence requires provenance-bound observation runs", () => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-operator-observation-"));
+  const head = "a".repeat(40);
+  const command = "node --test unit.test.js";
+  const observationCommand = "inspect screenshot artifact";
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
+    "evaluation:", "  verification:", "    checks:",
+    "      - name: unit", "        type: command", `        command: ${command}`,
+    "      - name: screenshot", "        type: observation", `        command: ${observationCommand}`,
+  ].join("\n"));
+  const log = path.join(runDir, "unit.log"); const screenshot = path.join(runDir, "screenshot.artifact");
+  fs.writeFileSync(log, "unit\n"); fs.writeFileSync(screenshot, "screenshot\n");
+  const baseRuns = [{ command, cwd: "/repo", head_sha: head, exit_code: 0, output_path: "unit.log", output_hash: sha256File(log), recorded_by: "operator", recorded_at: "2026-08-01T00:00:00.000Z" }, {
+    command: observationCommand, cwd: "/repo", head_sha: head, exit_code: 0, gate_type: "observation", result_kind: "operator_observation_artifact", output_path: "screenshot.artifact", output_hash: sha256File(screenshot), recorded_by: "operator", recorded_at: "2026-08-01T00:00:00.000Z",
+  }];
+  const operatorArtifact = () => makeArtifact(head, { recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason: "test" }, verification_runs: JSON.parse(JSON.stringify(baseRuns)) });
+  writeArtifact(runDir, operatorArtifact());
+  assert.equal(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }).status, "pass");
+
+  for (const field of ["gate_type", "result_kind"]) {
+    const invalid = operatorArtifact(); delete invalid.verification_runs[1][field]; writeArtifact(runDir, invalid);
+    assert.equal(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }).status, "fail", field);
+  }
+  const substituted = operatorArtifact(); delete substituted.verification_runs[1].gate_type; delete substituted.verification_runs[1].result_kind; writeArtifact(runDir, substituted);
+  assert.equal(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }).status, "fail");
 });
 
 test("execution-evidence strict preflight binds confirmed verification proof to reviewed HEAD tree", () => {

--- a/tests/relay-review/scripts/review-runner-execution-evidence.test.js
+++ b/tests/relay-review/scripts/review-runner-execution-evidence.test.js
@@ -222,31 +222,42 @@ test("strict verification preserves all frozen command gates, including observat
   assert.match(missingObservation.reason, /mobile/);
 });
 
-test("operator evidence requires provenance-bound observation runs", () => {
-  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-operator-observation-"));
-  const head = "a".repeat(40);
-  const command = "node --test unit.test.js";
-  const observationCommand = "inspect screenshot artifact";
-  fs.writeFileSync(path.join(runDir, "rubric.yaml"), [
-    "evaluation:", "  verification:", "    checks:",
-    "      - name: unit", "        type: command", `        command: ${command}`,
-    "      - name: screenshot", "        type: observation", `        command: ${observationCommand}`,
-  ].join("\n"));
-  const log = path.join(runDir, "unit.log"); const screenshot = path.join(runDir, "screenshot.artifact");
-  fs.writeFileSync(log, "unit\n"); fs.writeFileSync(screenshot, "screenshot\n");
-  const baseRuns = [{ command, cwd: "/repo", head_sha: head, exit_code: 0, output_path: "unit.log", output_hash: sha256File(log), recorded_by: "operator", recorded_at: "2026-08-01T00:00:00.000Z" }, {
-    command: observationCommand, cwd: "/repo", head_sha: head, exit_code: 0, gate_type: "observation", result_kind: "operator_observation_artifact", output_path: "screenshot.artifact", output_hash: sha256File(screenshot), recorded_by: "operator", recorded_at: "2026-08-01T00:00:00.000Z",
-  }];
-  const operatorArtifact = () => makeArtifact(head, { recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason: "test" }, verification_runs: JSON.parse(JSON.stringify(baseRuns)) });
-  writeArtifact(runDir, operatorArtifact());
-  assert.equal(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }).status, "pass");
+test("operator evidence binds observation identity and every run to the reviewed tree", () => {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-operator-tree-repo-"));
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "relay-review-operator-tree-run-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: repoPath });
+  fs.writeFileSync(path.join(repoPath, "README.md"), "tree\n"); execFileSync("git", ["add", "."], { cwd: repoPath }); execFileSync("git", ["commit", "-m", "tree"], { cwd: repoPath, stdio: "pipe" });
+  const head = git(repoPath, "rev-parse", "HEAD"); const tree = git(repoPath, "rev-parse", "HEAD^{tree}");
+  const command = "node --test unit.test.js"; const observationCommand = "inspect screenshot artifact";
+  fs.writeFileSync(path.join(runDir, "rubric.yaml"), ["evaluation:", "  verification:", "    checks:", "      - name: unit", "        type: command", `        command: ${command}`, "      - name: desktop", "        type: observation", `        command: ${observationCommand}`, "      - name: mobile", "        type: observation", `        command: ${observationCommand}`].join("\n"));
+  const buildRun = (name, commandText, outputName) => {
+    const outputPath = path.join(runDir, outputName); fs.writeFileSync(outputPath, `${name}\n`);
+    return { name, gate_name: name, ...(name === "unit" ? {} : { gate_type: "observation", result_kind: "operator_observation_artifact" }), command: commandText, cwd: repoPath, head_sha: head, verification_tree_sha: tree, exit_code: 0, output_path: outputName, output_hash: sha256File(outputPath), recorded_by: "operator-confirmed-verification-v1", recorded_at: "2026-08-01T00:00:00.000Z" };
+  };
+  const baseRuns = [buildRun("unit", command, "unit.log"), buildRun("desktop", observationCommand, "desktop.artifact"), buildRun("mobile", observationCommand, "mobile.artifact")];
+  const buildOperatorArtifact = () => makeArtifact(head, { recorded_by: "record-verification-evidence-operator-v1", operator_verification: { reason: "test" }, verification_runs: JSON.parse(JSON.stringify(baseRuns)) });
+  const compute = (artifact) => {
+    writeArtifact(runDir, artifact);
+    return computeQualityExecutionStatus({
+      runDir, reviewedHead: head, strict: true, manifestData: { paths: { worktree: repoPath } },
+    });
+  };
+  assert.equal(compute(buildOperatorArtifact()).status, "pass");
 
+  const swapped = buildOperatorArtifact(); [swapped.verification_runs[1].gate_name, swapped.verification_runs[2].gate_name] = [swapped.verification_runs[2].gate_name, swapped.verification_runs[1].gate_name];
+  assert.equal(compute(swapped).status, "fail");
   for (const field of ["gate_type", "result_kind"]) {
-    const invalid = operatorArtifact(); delete invalid.verification_runs[1][field]; writeArtifact(runDir, invalid);
-    assert.equal(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }).status, "fail", field);
+    const invalidObservation = buildOperatorArtifact(); delete invalidObservation.verification_runs[1][field];
+    assert.equal(compute(invalidObservation).status, "fail", field);
   }
-  const substituted = operatorArtifact(); delete substituted.verification_runs[1].gate_type; delete substituted.verification_runs[1].result_kind; writeArtifact(runDir, substituted);
-  assert.equal(computeQualityExecutionStatus({ runDir, reviewedHead: head, strict: true }).status, "fail");
+  const badRecorder = buildOperatorArtifact(); badRecorder.verification_runs.forEach((run) => { run.recorded_by = "operator"; });
+  assert.equal(compute(badRecorder).status, "fail");
+  const missingTree = buildOperatorArtifact(); missingTree.verification_runs.forEach((run) => { delete run.verification_tree_sha; });
+  assert.equal(compute(missingTree).status, "fail");
+  const mismatchedTree = buildOperatorArtifact(); mismatchedTree.verification_runs.forEach((run) => { run.verification_tree_sha = "b".repeat(40); });
+  assert.equal(compute(mismatchedTree).status, "fail");
 });
 
 test("execution-evidence strict preflight binds confirmed verification proof to reviewed HEAD tree", () => {


### PR DESCRIPTION
## Summary

Closes #1113.

Adds a fail-closed `record-verification-evidence.js` operator CLI for same-HEAD evidence re-verification after stale verification runs are removed.

- Resolves the anchored rubric and runs each exact command gate serially in the retained worktree.
- Requires hash-backed, regular non-symlink artifacts for observation gates; copies only bounded artifacts into the run directory.
- Refuses dirty, terminal, stale, mismatched-HEAD, and already-valid/arbitrary replacement cases.
- Records HEAD tree binding and an `operator_execution_evidence` event with old/new hashes, gate names, and reason.

## Validation

- `node --test --test-concurrency=1 tests/relay-ready/scripts/*.test.js tests/relay-plan/scripts/*.test.js tests/relay-dispatch/scripts/*.test.js tests/relay-review/scripts/*.test.js tests/relay-merge/scripts/*.test.js tests/relay/scripts/*.test.js tests/relay-config/scripts/*.test.js tests/relay-fleet/scripts/*.test.js tests/skills-lint/scripts/*.test.js`
- `node --test tests/relay-dispatch/scripts/record-verification-evidence.test.js tests/relay-dispatch/scripts/cli-schema.test.js`

## Review focus

The CLI deliberately executes rubric-provided command strings through the operator's shell in the validated retained worktree. This is necessary to preserve the frozen exact command; review the bounded-log and observation-artifact privacy boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 동일한 검증 기준점에서 누락된 검증 증거를 다시 수집하고 안전하게 기록하는 기능을 추가했습니다.
  - 명령 실행 결과와 관찰 결과 파일을 함께 지원합니다.
  - 미리보기(`dry-run`) 및 JSON 출력 옵션을 제공합니다.
  - 관찰 결과의 형식과 출처를 검증하고 파일 해시를 보존합니다.

- **문서**
  - 증거 재검증 절차와 관찰 결과 보존 기준을 문서화했습니다.

- **버그 수정**
  - 변경된 작업 영역, 잘못된 파일 형식, 중복 증거 덮어쓰기를 방지합니다.

- **테스트**
  - 명령·관찰 증거 기록, 미리보기, 입력 검증 및 원본 보존 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->