### PR TITLE
Reword task-profile readiness trigger to orchestrator judgment (#1160)

### DIFF
--- a/skills/relay-plan/references/task-profile.md
+++ b/skills/relay-plan/references/task-profile.md
@@ -32,7 +32,7 @@ Build the profile from the same planning evidence used for the rubric:
 - probe signal: use available tests, CI, scripts, and detected project tools as evidence for domains and runnable verification, not as automatic commands.
 - task risk: surface trust boundaries, state machines, public APIs, migrations, data loss, prompt contracts, or backward-compatibility concerns as `risk_tags`.
 - calibration class: select the primary observation surface as `task_class`; do not add a second class merely because implementation code is involved.
-- readiness route: when task risk includes `route_decision: ready_light`, default to `size: S` and `execution_mode: quick` unless risk tags require stronger review or fresh context.
+- readiness route: when the orchestrator's ready-light readiness judgment (per the relay-ready SKILL.md checklist) applies, default to `size: S` and `execution_mode: quick` unless risk tags require stronger review or fresh context.
 
 ## Planner Boundary
 


### PR DESCRIPTION
One-bullet prose fix flagged during #1156: `task-profile.md:35` conditioned ready-light sizing on `route_decision: ready_light`, a JSON field of the deleted scored-readiness envelope. The trigger is now the orchestrator's ready-light readiness judgment (relay-ready SKILL.md checklist); the `size: S` / `execution_mode: quick` defaults and the risk-tag exception clause are unchanged. `rubric-validation.md`'s test-pinned "Planning profile: ready_light" blocks are untouched.

**Executed by `pi` × `nous-portal/deepseek/deepseek-v4-flash-0731` through the real relay dispatch pipeline** (run `issue-1160-20260804115132762-f00c0151`) — first live validation of the deepseek delegation route on an edit-only task shaped for the pi adapter's toolset. Orchestrator-verified: repo grep shows zero `route_decision` references under `skills/`; relay-plan + skills-lint suites 148 pass / 0 fail.

Closes #1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)