### PR TITLE
Extract sprint threading into an optional integration reference (#1164)

### DIFF
--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -28,7 +28,7 @@ Standard Codex path: stamp `RELAY_ORCHESTRATOR=codex` and review through `review
 
 Run `git fetch origin`. Task evidence: collect the first available source—local task file, `gh issue view <N>`, or user description—and use its `track:` or `component:` value as the sprint ownership handle. If no issue number, use a descriptive branch name and skip issue-close in merge.
 
-Before any sprint read, invoke the resolved dev-backlog `sprint-state.js --track <track> --json backlog` or `sprint-state.js --component <component> --json backlog` and use `active_sprint.path` as the owning sprint. With no handle, use `sprint-state.js --json backlog` only when exactly one sprint is active; if a selector lookup is unavailable or unresolved, allow that same fallback only when the single sprint's track/component matches. Never choose an arbitrary/global active sprint or parse sprint markdown in relay to resolve ownership. If no owner resolves, skip sprint tracking; otherwise re-read that sprint's Running Context, batch information, and completed/in-flight changes and apply previous-task context.
+Sprint tracking is optional; when in use, resolve ownership per [sprint-integration.md](references/sprint-integration.md).
 
 Run the route preflight. It answers one question: does this issue already have a PR or an in-flight vNext run?
 
@@ -71,7 +71,7 @@ Follow `inspection.recommended_action` exactly:
 - `redispatch` → call dispatch with the immutable `run_id`; all other resume attempts fail before writing.
 - `wait` → keep polling; `operator_attention` or `none` → stop and resolve the blocker.
 
-Capture `run_id`, `run_dir`, and the current action key. The immutable record is `~/.relay/runs/<repo-slug>/<run-id>/run.json`; lifecycle state is folded from `events.jsonl` plus live observations, not mutated in a manifest. Before an in-flight write, resolve the owner through the same dev-backlog `sprint-state.js --track/--component --json` contract and matching-selector N==1 failure fallback, then update only its `active_sprint.path`; skip when no owner resolves.
+Capture `run_id`, `run_dir`, and the current action key. The immutable record is `~/.relay/runs/<repo-slug>/<run-id>/run.json`; lifecycle state is folded from `events.jsonl` plus live observations, not mutated in a manifest. For in-flight writes, resolve ownership per the same [sprint-integration.md](references/sprint-integration.md) contract.
 
 ## Step 4: Review (relay-review)
 
@@ -97,4 +97,4 @@ If relay-review returns LGTM, the review runner should already have recorded `re
 When multiple independent tasks are ready, prepare a `relay-fleet` batch but preserve `/relay`'s `ready_to_merge` stop until the user explicitly authorizes landing it; after authorization, `relay-fleet` is the default parallel batch drive. See `references/batch-mode.md` for the remaining conflict-recovery note and the "when in doubt, run sequentially" principle.
 ## Summary Checklist
 
-Verify Done Criteria fully implemented, relay-review LGTM/audit comment, `ready_to_merge` state, and any sprint/follow-up updates.
+Verify Done Criteria fully implemented, relay-review LGTM/audit comment, `ready_to_merge` state, and any sprint/follow-up updates per [sprint-integration.md](references/sprint-integration.md).

--- a/skills/relay/references/sprint-integration.md
+++ b/skills/relay/references/sprint-integration.md
@@ -1,0 +1,20 @@
+# Sprint Integration
+
+Sprint tracking is optional. When in use, resolve ownership through the
+dev-backlog `sprint-state.js` contract below; `../SKILL.md` defers here for
+sprint ownership resolution. The task's `track:` or `component:` value is the
+sprint ownership handle.
+
+## Ownership Resolution
+
+(a) Before any sprint read, invoke the resolved dev-backlog `sprint-state.js --track <track> --json backlog` or `sprint-state.js --component <component> --json backlog` and use `active_sprint.path` as the owning sprint.
+
+(b) With no handle, use `sprint-state.js --json backlog` only when exactly one sprint is active; if a selector lookup is unavailable or unresolved, allow that same fallback only when the single sprint's track/component matches.
+
+(c) Never choose an arbitrary/global active sprint or parse sprint markdown in relay to resolve ownership.
+
+(d) If no owner resolves, skip sprint tracking; otherwise re-read that sprint's Running Context, batch information, and completed/in-flight changes and apply previous-task context.
+
+## In-Flight Writes
+
+(e) Before an in-flight write, resolve the owner through the same dev-backlog `sprint-state.js --track/--component --json` contract and matching-selector N==1 failure fallback, then update only its `active_sprint.path`; skip when no owner resolves.


### PR DESCRIPTION
Wave 3-C of the slimming arc (option C: loosen relay-side coupling now; script relocation to dev-backlog later). relay-merge already frames bookkeeping as optional (§3 "Optional post-merge project updates"), so the remaining coupling was `/relay`'s composition prose: three sites weaving the dev-backlog `sprint-state.js` ownership contract into the default flow.

Those sites are now one-line optional pointers; the full contract moved verbatim-in-semantics to `skills/relay/references/sprint-integration.md` (five rules: selector forms + `active_sprint.path`; N==1 single-active-sprint fallback with track/component match; never-parse-sprint-markdown; skip-when-no-owner + Running Context re-read; in-flight update-only-`active_sprint.path`). Core loop prose now stands without dev-backlog machinery — the future `append-learnings.js`/`sprint-owner.js` relocation becomes a script move with no SKILL.md redesign.

**Executed by `pi` × `nous-portal/deepseek/deepseek-v4-flash-0731` via relay dispatch** (run `issue-1164-20260804123937523-8942ffb3`), including a live crash-only recovery: the first attempt's supervisor was externally killed without a result — settled via two-probe liveness recovery + audited `--break-lock` + operator removal of the leaked staged-credential root, then redispatched on the same immutable run.

Orchestrator-verified: frontmatter byte-identical (description contracts pinned), SKILL.md 100 lines, diff = exactly 2 files, all five semantics present in the reference, full serialized gate **567 pass / 0 fail** at load ~4.

Closes #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * Sprint 소유권 확인 및 진행 중 기록 절차를 새로운 통합 문서로 정리했습니다.
  * Sprint 선택 기준, 단일 활성 Sprint 대체 규칙, 기록 생략 조건을 명확히 했습니다.
  * 관련 안내에서 세부 절차를 통합 문서 참조 방식으로 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->