### PR TITLE
Fix three stale reference-doc imprecisions

### DIFF
--- a/skills/relay-plan/references/iteration-protocol.md
+++ b/skills/relay-plan/references/iteration-protocol.md
@@ -1,6 +1,6 @@
 # Execution Contract
 
-This compatibility-named reference defines the compact completion responsibilities that every dispatch prompt must include. Take the base template at `../../relay/references/prompt-template.md` and append the sections listed in `SKILL.md` § 10. Relay specifies observable completion, not the executor's internal iteration strategy.
+This compatibility-named reference defines the compact completion responsibilities that every dispatch prompt must include. Take the base template at `../../relay/references/prompt-template.md` and append the sections named in the Default Path of `SKILL.md`: Setup, optional Working Guidance, Evaluation Channels, and Completion Responsibilities. Relay specifies observable completion, not the executor's internal iteration strategy.
 
 ## Optional TDD Factor Flavor
 

--- a/skills/relay-plan/references/rubric-design-guide.md
+++ b/skills/relay-plan/references/rubric-design-guide.md
@@ -54,7 +54,7 @@ rubric:
 
 `tdd_anchor: <path-string>` is a per-factor opt-in. Its presence means the dispatch prompt inserts Step 0a for that factor. Do not add a top-level `tdd_mode`.
 
-`tdd_runner: <jest|pytest|mocha|vitest|...>` is an optional companion. If it is omitted, the executor falls back to the first `test_infra` entry from `probe-executor-env.js --project-only --json`. If no test infra is reported, the executor stops before Step 0a with a clear error.
+`tdd_runner: <jest|pytest|mocha|vitest|...>` is an optional companion. If it is omitted, the runner resolves per `iteration-protocol.md`: the first `test_infra` entry from `probe-executor-env.js --project-only --json`; when no source yields a runner, the executor stops before Step 0a with an error naming that factor, and one unresolved factor stops the whole Step 0a block.
 
 Use `tdd_anchor` only when red-first testing fits the factor's contract: crisp behavior, a specific path, and a runner that can target that path. Leave documentation, prose, UI judgment, and broad design factors without `tdd_anchor`.
 

--- a/skills/relay/references/preflight-guards.md
+++ b/skills/relay/references/preflight-guards.md
@@ -38,8 +38,9 @@ error the way the retired probe did.
 - Signals read: the request text, plus an accepted relay-ready handoff under
   `~/.relay/requests/<repo-slug>/` whose recorded source identity — the issue
   number, the issue URL, or the request id the operator was given — matches this
-  issue. Only such a matching handoff supersedes the issue's own criteria; a
-  newer bundle for a different issue is irrelevant.
+  issue. Only such a matching handoff supersedes the issue's own criteria
+  (canonical matching rule: `../../relay-ready/SKILL.md`); a newer bundle for a
+  different issue is irrelevant.
 - Events emitted: none.
 - Factors: clarity, granularity, verifiability, task shape, and risk, as defined
   in `../../relay-ready/SKILL.md`.


### PR DESCRIPTION
Three unfiled minors from the 2026-08-04 slimming-arc handoff, batched as one edit-only leaf:

- `relay-plan/references/iteration-protocol.md`: the `SKILL.md § 10` pointer went stale when relay-plan lost numbered sections (#1163); now names the Default Path sections directly.
- `relay-plan/references/rubric-design-guide.md`: `tdd_runner` fallback wording aligned with the fail-closed rule restored in iteration-protocol.md — error names the factor, one unresolved factor stops the whole Step 0a block.
- `relay/references/preflight-guards.md`: the supersede sentence now points at its canonical source (`relay-ready/SKILL.md`) so the unpinned mirror cannot drift silently.

Executed by pi × deepseek-v4-flash-0731 via /delegate (edit-only lane of the executor routing matrix); diff verified to be exactly the three replacements. Full serialized gate green on this branch: relay-plan + relay + relay-ready + skills-lint 118 pass, dispatch + review + merge + fleet + config 449 pass / 2 known skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)