### PR TITLE
Close #1173 items 3-5: honest gate wording, fleet leaf escape hatch, orchestrator verification anchor

### DIFF
--- a/.pi-lens.json
+++ b/.pi-lens.json
@@ -1,0 +1,5 @@
+{
+  "format": { "enabled": false },
+  "autofix": { "enabled": false },
+  "actionableWarnings": { "autoFix": { "enabled": false } }
+}

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -55,7 +55,7 @@ function usage() {
     "  dispatch.js [<repo>] --run-id <id> (--prompt <text> | --prompt-file <path>) [options]",
     "",
     `Executors: ${listAdapters().join(", ")}`,
-    "A prompt demanding command execution is rejected for an executor whose dispatch toolset has no shell; override with --allow-toolset-mismatch.",
+    "A prompt matching a known command-demand pattern is rejected when the executor's dispatch capability declares no command-execution tool; --allow-toolset-mismatch downgrades that rejection to a warning. Detection is literal pattern matching, not proof of intent.",
     "Dispatch never commits, pushes, opens a PR, or runs recovery. Use relay-recover for those actions.",
   ].join("\n");
 }

--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -50,7 +50,7 @@ relay-fleet only fans out already-decomposed leaf contracts; it never splits a r
 
 All leaves must carry the same normalized owner. `ownership.track` must equal the basename of `ownership.sprint` without `.md`; `component` is a separate dev-backlog scope key and need not equal the track. Before admission, the canonical path, track, and component must exactly match the trusted schema-v2 `sprint-state.js --track` result, and the path must resolve to an existing regular file in the current repo's `backlog/sprints/`; relay-fleet does not parse that markdown. Missing, malformed, contradictory, unresolved, stale, or mixed-track ownership is rejected before a cohort or child dispatch exists: one fleet is one track.
 
-Optional per-leaf fields passed through to the current `dispatch.js` contract are `executor`, `model`, `sandbox`, `network_access`, `timeout`, `reasoning`, and `copy`. Submit dependent work in a later fleet wave after its prerequisite fleet is terminal; the immutable cohort intentionally carries no second dependency scheduler.
+Optional per-leaf fields passed through to the current `dispatch.js` contract are `executor`, `model`, `sandbox`, `network_access`, `timeout`, `reasoning`, `copy`, and `allow_toolset_mismatch` (a boolean that forwards `--allow-toolset-mismatch` for a leaf whose prompt demands commands its executor cannot run). Submit dependent work in a later fleet wave after its prerequisite fleet is terminal; the immutable cohort intentionally carries no second dependency scheduler.
 If a leaf selects an unsupported executor or an unavailable model provider, pause that leaf and correct the explicit leaf input before resuming the fleet.
 
 ## Commands

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -23,7 +23,7 @@ const SHA256_RE = /^[0-9a-f]{64}$/;
 const LEAF_FIELDS = new Set([
   "leaf_ref", "issue_number", "branch", "prompt_file", "prompt_sha256", "rubric_file", "rubric_sha256",
   "done_criteria_file", "done_criteria_sha256", "ownership", "executor", "model", "sandbox",
-  "network_access", "timeout", "reasoning", "copy",
+  "network_access", "timeout", "reasoning", "copy", "allow_toolset_mismatch",
 ]);
 const OPTIONS = Object.freeze({
   repo: { type: "string", default: "." },
@@ -140,6 +140,8 @@ function normalizeLeaf(raw, index, base, freeze) {
     const value = raw[name] ?? (alias ? raw[alias] : undefined);
     return value == null ? null : requiredString(String(value), `leaves[${index}].${name}`);
   };
+  const allowMismatch = raw.allow_toolset_mismatch;
+  if (allowMismatch != null && typeof allowMismatch !== "boolean") fail(`leaves[${index}].allow_toolset_mismatch must be a boolean`);
   return Object.freeze({
     leaf_ref: leafRef,
     issue_number: issueNumber(raw.issue_number, `leaves[${index}].issue_number`),
@@ -152,6 +154,7 @@ function normalizeLeaf(raw, index, base, freeze) {
     network_access: optional("network_access"),
     timeout: raw.timeout == null ? null : String(issueNumber(raw.timeout, `leaves[${index}].timeout`)),
     reasoning: optional("reasoning"), copy: Array.isArray(raw.copy) ? raw.copy.join(",") : optional("copy"),
+    allow_toolset_mismatch: allowMismatch,
   });
 }
 function validateLeaves(repoRoot, leaves) {
@@ -342,6 +345,7 @@ function buildDispatchArgs({ repoRoot, fleetId, leaf, options, runId = null }) {
   push(args, "--executor", leaf.executor || options.executor); push(args, "--model", leaf.model || options.model);
   push(args, "--sandbox", leaf.sandbox || options.sandbox); push(args, "--network-access", leaf.network_access || options.networkAccess);
   push(args, "--timeout", leaf.timeout || options.timeout); push(args, "--reasoning", leaf.reasoning || options.reasoning); push(args, "--copy", leaf.copy || options.copy);
+  if (leaf.allow_toolset_mismatch) args.push("--allow-toolset-mismatch");
   if (options.dryRun) args.push("--dry-run");
   return args;
 }

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -77,6 +77,8 @@ Capture `run_id`, `run_dir`, and the current action key. The immutable record is
 
 **MANDATORY. Do NOT skip this step.**
 
+**Verify before review — orchestrator-enforced for shell-free completion.** When the dispatched executor's dispatch capability declares no command-execution tool (today Claude and Pi; resolve with `relay-config check --executor <name> --phase dispatch --json`), the executor returned observation checks, not executed-test claims. Before invoking relay-review, the orchestrator performs each returned verification against the retained worktree and states the result; if the executor returned a stuck note, that becomes the blocking reason instead. Review must not begin on unverified changes. This is the orchestrator's obligation, not the executor's prompt — the executor-facing template cannot enforce it.
+
 Invoke relay-review only when inspection recommends `review`:
 
 ```bash
@@ -97,4 +99,4 @@ If relay-review returns LGTM, the review runner should already have recorded `re
 When multiple independent tasks are ready, prepare a `relay-fleet` batch but preserve `/relay`'s `ready_to_merge` stop until the user explicitly authorizes landing it; after authorization, `relay-fleet` is the default parallel batch drive. See `references/batch-mode.md` for the remaining conflict-recovery note and the "when in doubt, run sequentially" principle.
 ## Summary Checklist
 
-Verify Done Criteria fully implemented, relay-review LGTM/audit comment, `ready_to_merge` state, and any sprint/follow-up updates per [sprint-integration.md](references/sprint-integration.md).
+Verify Done Criteria fully implemented, relay-review LGTM/audit comment, `ready_to_merge` state, and any sprint/follow-up updates per [sprint-integration.md](references/sprint-integration.md). For a shell-free executor, orchestrator-performed verification (Step 4) must be recorded before review.

--- a/tests/ledger/vnext-baseline.generated.json
+++ b/tests/ledger/vnext-baseline.generated.json
@@ -5,8 +5,8 @@
     "relayDispatchRuntimeJavaScriptFiles": 16,
     "relayDispatchRuntimeJavaScriptLoc": 6128,
     "relayTestFiles": 48,
-    "relayTestLoc": 13837,
-    "relayRegistrationSites": 539,
+    "relayTestLoc": 13854,
+    "relayRegistrationSites": 540,
     "dynamicRegistrationSites": 4
   },
   "measuredRuntime": {

--- a/tests/ledger/vnext-test-sites.generated.json
+++ b/tests/ledger/vnext-test-sites.generated.json
@@ -3,7 +3,7 @@
   "accountingContract": "lexical-registration-site-v1",
   "generatedBy": "node tests/skills-lint/scripts/vnext-test-ledger.js generate",
   "files": 48,
-  "registrationSites": 539,
+  "registrationSites": 540,
   "dynamicRegistrationSites": 4,
   "columns": ["path","kind","ordinal","name","line","dynamic","directive","decision"],
   "rows": [
@@ -323,6 +323,7 @@
     ["tests/relay-fleet/scripts/vnext-derived.test.js","test",7,"wait action never double-dispatches an existing child",142,false,null,{"owner":"runtime-core-reset","rationale":"An immutable fleet cohort must remain byte-idempotent, status must not mutate it, and duplicate child identity matches must fail closed."}],
     ["tests/relay-fleet/scripts/vnext-derived.test.js","test",8,"--review drives exact review actions and serial merge actions through current CLIs",152,false,null,{"owner":"runtime-core-reset","rationale":"An immutable fleet cohort must remain byte-idempotent, status must not mutate it, and duplicate child identity matches must fail closed."}],
     ["tests/relay-fleet/scripts/vnext-derived.test.js","test",9,"artifact drift is operator attention and dry-run publishes no cohort",169,false,null,{"owner":"runtime-core-reset","rationale":"An immutable fleet cohort must remain byte-idempotent, status must not mutate it, and duplicate child identity matches must fail closed."}],
+    ["tests/relay-fleet/scripts/vnext-derived.test.js","test",10,"fleet leaf allow_toolset_mismatch threads the dispatch flag and rejects non-booleans",182,false,null,{"owner":"runtime-core-reset","rationale":"An immutable fleet cohort must remain byte-idempotent, status must not mutate it, and duplicate child identity matches must fail closed."}],
     ["tests/relay-merge/scripts/append-learnings.test.js","describe",1,"parseArgs",76,false,null,{"owner":"runtime-core-reset","rationale":"This registration exercises replaceable helper or CLI formatting behavior rather than a canonical invariant."}],
     ["tests/relay-merge/scripts/append-learnings.test.js","it",2,"requires --repo, --run-id, --pr",77,false,null,{"owner":"runtime-core-reset","rationale":"This registration exercises replaceable helper or CLI formatting behavior rather than a canonical invariant."}],
     ["tests/relay-merge/scripts/append-learnings.test.js","it",3,"parses required + optional flags",83,false,null,{"owner":"runtime-core-reset","rationale":"This registration exercises replaceable helper or CLI formatting behavior rather than a canonical invariant."}],

--- a/tests/relay-fleet/scripts/vnext-derived.test.js
+++ b/tests/relay-fleet/scripts/vnext-derived.test.js
@@ -176,3 +176,20 @@ test("artifact drift is operator attention and dry-run publishes no cohort", asy
     assert.equal(result.dry_run, true); assert.equal(fs.existsSync(fleet.getFleetLeavesStorePath(fixture.repo, "fleet-dry")), false);
   });
 });
+
+// #1173 item 4: the --allow-toolset-mismatch escape hatch must thread through a fleet leaf override,
+// and the leaf field must reject non-booleans instead of coercing them.
+test("fleet leaf allow_toolset_mismatch threads the dispatch flag and rejects non-booleans", async () => {
+  const fixture = setup();
+  await fixtureWork(fixture, () => {
+    const item = { ...leaf(fixture.repo, 40), allow_toolset_mismatch: true };
+    const leavesFile = path.join(fixture.repo, "leaves.json");
+    fs.writeFileSync(leavesFile, JSON.stringify({ leaves: [item] }));
+    const [loaded] = fleet.loadLeavesFile(fixture.repo, leavesFile);
+    assert.equal(loaded.allow_toolset_mismatch, true);
+    const args = fleet.buildDispatchArgs({ repoRoot: fixture.repo, fleetId: "fleet-toolset", leaf: loaded, options: { dispatchScript: "dispatch.js" } });
+    assert.equal(args.includes("--allow-toolset-mismatch"), true);
+    fs.writeFileSync(leavesFile, JSON.stringify({ leaves: [{ ...leaf(fixture.repo, 41), allow_toolset_mismatch: "yes" }] }));
+    assert.throws(() => fleet.loadLeavesFile(fixture.repo, leavesFile), /allow_toolset_mismatch must be a boolean/);
+  });
+});


### PR DESCRIPTION
Closes the remaining #1173 items after #1180 landed items 1-2.

## Item 3 — usage() best-effort wording
`usage()` said a command-demanding prompt is *rejected* for a no-shell executor, overstating what the gate guarantees. Now: rejected only when a **known** command-demand pattern matches AND the executor's dispatch capability **declares** no command-execution tool; the flag downgrades to a warning; detection is literal pattern matching, not proof of intent.

## Item 4 — fleet leaf escape hatch
`--allow-toolset-mismatch` existed for single dispatch only. relay-fleet leaves now accept `allow_toolset_mismatch` (boolean; non-boolean rejected), threaded into `buildDispatchArgs` per leaf. Regression test asserts the flag lands in dispatch argv and non-booleans fail closed. Documented in relay-fleet SKILL.md.

## Item 5 — fail-closed handoff gap
The demand to perform the returned verification lived only in the executor-facing shell-free prompt template — an executor that ignored it left the orchestrator unaware (fails open). relay/SKILL.md Step 4 now anchors the obligation where the orchestrator can enforce it: for a shell-free executor, perform each returned verification against the retained worktree and state the result before invoking relay-review; review must not begin on unverified changes.

## Also
Adds `.pi-lens.json` disabling auto-format/autofix — the pi-lens biome default reformats these hand-formatted 2-space files to tabs on every edit (and strips `use strict`), drowning real changes.

Verified: relay-dispatch 330 pass / 2 skip, relay-fleet + skills-lint 60 pass / 0 fail, ledger regenerated, runtime inventory clean.