### PR TITLE
Recover relay run issue-1216-bounded-review-retry-final-20260810172509480-53c701a9

### DIFF
--- a/skills/relay-dispatch/scripts/facts.js
+++ b/skills/relay-dispatch/scripts/facts.js
@@ -51,7 +51,7 @@ const PAYLOAD_SCHEMAS = Object.freeze({
     required: [
       "round", "verdict", "reviewed_sha", "done_criteria_sha256",
       "reviewer", "review_artifact", "override",
-    ], optional: ["executed_runtime"],
+    ], optional: ["executed_runtime", "escalation_kind", "retry_of_event_id"],
   },
   // Optional above so historical journals stay readable; required below on every append this runtime makes.
   recovery_applied: {
@@ -253,6 +253,19 @@ function validatePayload(type, payload, { allowFutureFields = false, appending =
       sha(payload.done_criteria_sha256, "payload.done_criteria_sha256", { sha256: true });
       string(payload.reviewer, "payload.reviewer");
       string(payload.review_artifact, "payload.review_artifact");
+      if (payload.escalation_kind !== undefined
+        && !new Set(["runtime_failure", "reviewer"]).has(payload.escalation_kind)) {
+        fail("INVALID_FACT", "payload.escalation_kind is invalid");
+      }
+      if (payload.retry_of_event_id !== undefined) string(payload.retry_of_event_id, "payload.retry_of_event_id");
+      if (appending) {
+        if (payload.verdict === "escalated" && payload.escalation_kind === undefined) {
+          fail("INVALID_FACT", "payload.escalation_kind is required when appending escalated review_recorded");
+        }
+        if (payload.verdict !== "escalated" && payload.escalation_kind !== undefined) {
+          fail("INVALID_FACT", "payload.escalation_kind is only allowed for escalated review_recorded");
+        }
+      }
       if (payload.executed_runtime !== undefined) {
         exactKeys(payload.executed_runtime, ["digest", "executable"], "payload.executed_runtime");
         sha(payload.executed_runtime.digest, "payload.executed_runtime.digest", { sha256: true });

--- a/skills/relay-dispatch/scripts/inspect.js
+++ b/skills/relay-dispatch/scripts/inspect.js
@@ -381,11 +381,23 @@ function foldRunFacts({
     && fact.payload.escalation_kind === "runtime_failure"
     && fact.payload.retry_of_event_id === undefined
   )) || null;
+  const retryReviews = subjectReviews.filter((fact) => fact.payload.retry_of_event_id !== undefined);
+  const retryLineageValid = retryReviews.length === 0 || Boolean(
+    firstRuntimeFailure
+    && retryReviews.length === 1
+    && retryReviews[0].payload.retry_of_event_id === firstRuntimeFailure.event_id
+    && subjectReviews[subjectReviews.indexOf(firstRuntimeFailure) + 1] === retryReviews[0]
+  );
   if (
     reviewBindingMatches
-    && firstRuntimeFailure
-    && latestReview.event_id !== firstRuntimeFailure.event_id
-    && latestReview.payload.retry_of_event_id !== firstRuntimeFailure.event_id
+    && (
+      !retryLineageValid
+      || (
+        firstRuntimeFailure
+        && latestReview.event_id !== firstRuntimeFailure.event_id
+        && latestReview.payload.retry_of_event_id !== firstRuntimeFailure.event_id
+      )
+    )
   ) {
     return none("review_retry_binding_invalid", {
       head_sha: headSha,

--- a/skills/relay-dispatch/scripts/inspect.js
+++ b/skills/relay-dispatch/scripts/inspect.js
@@ -11,6 +11,7 @@ function result(action, reason, base = {}) {
     head_sha: base.head_sha || null,
     reviewed_sha: base.reviewed_sha || null,
     pr_number: base.pr_number || null,
+    retry_of_event_id: base.retry_of_event_id || null,
     terminal_kind: base.terminal_kind || null,
     terminal: base.terminal === true || Boolean(base.terminal_kind),
     activeAttempt: base.activeAttempt || null,
@@ -366,8 +367,33 @@ function foldRunFacts({
   const reviewBindingMatches = Boolean(
     latestReview
     && latestReview.payload.reviewed_sha === prHead
-    && latestReview.payload.done_criteria_sha256 === criteriaHash,
+    && latestReview.payload.done_criteria_sha256 === criteriaHash
+    && latestReview.payload.reviewer === runRecord.roles?.reviewer,
   );
+  const subjectReviews = latestReview
+    ? reviews.filter((fact) => (
+      fact.payload.reviewed_sha === latestReview.payload.reviewed_sha
+      && fact.payload.done_criteria_sha256 === latestReview.payload.done_criteria_sha256
+    ))
+    : [];
+  const firstRuntimeFailure = subjectReviews.find((fact) => (
+    fact.payload.verdict === "escalated"
+    && fact.payload.escalation_kind === "runtime_failure"
+    && fact.payload.retry_of_event_id === undefined
+  )) || null;
+  if (
+    reviewBindingMatches
+    && firstRuntimeFailure
+    && latestReview.event_id !== firstRuntimeFailure.event_id
+    && latestReview.payload.retry_of_event_id !== firstRuntimeFailure.event_id
+  ) {
+    return none("review_retry_binding_invalid", {
+      head_sha: headSha,
+      reviewed_sha: latestReview.payload.reviewed_sha,
+      pr_number: prNumber,
+      diagnostics: [...diagnostics, { code: "review_retry_binding_invalid", event_id: latestReview.event_id }],
+    });
+  }
   if (
     latestReview
     && latestReview.payload.verdict === "changes_requested"
@@ -431,6 +457,34 @@ function foldRunFacts({
     }), githubFacts);
   }
   if (latestReview?.payload?.verdict === "escalated") {
+    const isRetryFailure = Boolean(
+      firstRuntimeFailure
+      && latestReview.event_id !== firstRuntimeFailure.event_id
+      && latestReview.payload.retry_of_event_id === firstRuntimeFailure.event_id
+      && latestReview.payload.escalation_kind === "runtime_failure",
+    );
+    if (
+      reviewBindingMatches
+      && latestReview.payload.escalation_kind === "runtime_failure"
+      && firstRuntimeFailure
+      && latestReview.event_id === firstRuntimeFailure.event_id
+    ) {
+      return withGithubAvailability(result("review", "review_retryable_escalation", {
+        head_sha: headSha,
+        reviewed_sha: latestReview.payload.reviewed_sha,
+        pr_number: prNumber,
+        retry_of_event_id: latestReview.event_id,
+        diagnostics,
+      }), githubFacts);
+    }
+    if (isRetryFailure) {
+      return none("review_escalated_retry_exhausted", {
+        head_sha: headSha,
+        reviewed_sha: latestReview.payload.reviewed_sha,
+        pr_number: prNumber,
+        diagnostics: [...diagnostics, { code: "review_retry_exhausted", event_id: latestReview.event_id }],
+      });
+    }
     return none("review_escalated", {
       head_sha: headSha,
       reviewed_sha: latestReview.payload.reviewed_sha,

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -56,7 +56,7 @@ The reviewer returns only:
 {"verdict":"pass|changes_requested|escalated","summary":"...","issues":[]}
 ```
 
-`pass` is stored as `lgtm`; `changes_requested` derives `redispatch`; reviewer invocation or result errors are durably recorded as `escalated`. Rounds are derived from prior `review_recorded` facts. There is no review budget, mutable round state, manual verdict application, detached review supervisor, PR-comment authority, or manifest transition.
+`pass` is stored as `lgtm`; `changes_requested` derives `redispatch`; reviewer invocation or result errors are durably recorded as `escalated`. A runtime invocation failure permits one explicit `review` retry bound to its fact; a second failure fails closed. Model-returned escalation is not retryable. Rounds are derived from prior `review_recorded` facts. There is no automatic loop, review budget, mutable round state, manual verdict application, detached review supervisor, PR-comment authority, or manifest transition.
 
 ## Isolation and failure behavior
 

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -58,6 +58,12 @@ Codex and Claude receive the staged JSON schema through native structured-output
 
 The review environment allowlist excludes `GH_TOKEN` and `GITHUB_TOKEN`. The runtime does not expose the run directory, executor worktree, dispatch prompt, transcript, or session state to the reviewer sandbox.
 
+A runtime invocation failure is classified in its durable review fact and may
+derive one explicit `review` retry with `retry_of_event_id` bound to that fact.
+The runner rechecks the immutable run digest, exact review binding, and retry
+subject under the run lock. A second failure and model-returned escalation both
+fail closed; Relay never starts an automatic retry loop.
+
 Reviewer authentication is opt-in and uses the same adapter credential catalog
 as dispatch. Repeat `--credential-env NAME` for an exact environment value or
 `--credential-file ID=/absolute/source` for a declared file target. The runtime

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -408,14 +408,32 @@ async function runReview(cli, overrides = {}) {
     if (error.review_evidence_preserved) throw error;
     stagedBinding = error.review_binding || null;
     executedRuntime = normalizeExecutedRuntime(error.executed_runtime);
-    verdict = { verdict: "escalated", summary: `Reviewer invocation failed: ${error.message}`, issues: [] };
-    escalationKind = "runtime_failure";
+    const reviewerResultFailure = error.code === "REVIEW_RESULT_INVALID"
+      || error.failure_reason === "output_protocol_mismatch";
+    verdict = {
+      verdict: "escalated",
+      summary: `${reviewerResultFailure ? "Reviewer result invalid" : "Reviewer invocation failed"}: ${error.message}`,
+      issues: [],
+    };
+    escalationKind = reviewerResultFailure ? "reviewer" : "runtime_failure";
   }
   if (!verdict) {
     stagedBinding = outcome.review_binding;
     executedRuntime = normalizeExecutedRuntime(outcome.executed_runtime);
-    verdict = normalizeVerdict(outcome.output);
-    if (verdict.verdict === "escalated") escalationKind = "reviewer";
+    try {
+      verdict = normalizeVerdict(outcome.output);
+      if (verdict.verdict === "escalated") escalationKind = "reviewer";
+    } catch (error) {
+      // The provider invocation completed, but its result was not a valid reviewer
+      // result. Preserve the staged runtime/bindings and record this as reviewer
+      // uncertainty; it must not qualify for the environmental retry.
+      verdict = {
+        verdict: "escalated",
+        summary: `Reviewer result invalid: ${error.message}`,
+        issues: [],
+      };
+      escalationKind = "reviewer";
+    }
   }
   const written = await services.withRunLock(runDir, async (lockContext) => {
     const freshRecord = runStore.readRunRecord({ runDir });

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -148,7 +148,8 @@ function resolveRun(cli) {
 
 function requireReviewAction(inspection, record) {
   if (inspection.blockers?.length) fail(`review is blocked: ${inspection.blockers[0].code}`, "REVIEW_BLOCKED");
-  if (inspection.recommended_action?.kind !== "review" || inspection.derived?.action !== "review") {
+  const actionKind = inspection.recommended_action?.kind;
+  if (actionKind !== "review" || inspection.derived?.action !== "review") {
     fail(`derived lifecycle action is '${inspection.recommended_action?.kind || "unknown"}', not 'review'`, "REVIEW_ACTION_MISMATCH");
   }
   const head = inspection.observations?.github?.pr_head_sha;
@@ -169,7 +170,17 @@ function requireReviewAction(inspection, record) {
     && fact.payload.done_criteria_sha256 === record.contract.done_criteria_sha256
   ));
   if (!verification) fail("review requires passed verification for the exact head and Done Criteria", "REVIEW_VERIFICATION_MISSING");
-  return { head, prNumber, verification };
+  const latestReview = inspection.facts.filter((fact) => fact.type === "review_recorded").at(-1) || null;
+  const retrying = inspection.recommended_action.reason === "review_retryable_escalation";
+  const retryOfEventId = retrying ? inspection.derived.retry_of_event_id : null;
+  if (retrying && (
+    typeof retryOfEventId !== "string"
+    || !latestReview
+    || latestReview.event_id !== retryOfEventId
+  )) {
+    fail("retry review action is not bound to the latest durable escalation", "REVIEW_RETRY_BINDING_MISMATCH");
+  }
+  return { head, prNumber, verification, retryOfEventId };
 }
 
 function reviewPrompt({ record, binding, criteria, diff }) {
@@ -308,6 +319,10 @@ function normalizeExecutedRuntime(files) {
   return { digest: crypto.createHash("sha256").update(JSON.stringify(files)).digest("hex"), executable: Object.fromEntries(keys.map((key) => [key, executable[key]])) };
 }
 
+function runRecordDigest(record) {
+  return crypto.createHash("sha256").update(JSON.stringify(record)).digest("hex");
+}
+
 function productionServices() {
   function withRunLock(runDir, callback) {
     const canonical = fs.realpathSync(runDir);
@@ -337,6 +352,7 @@ function productionServices() {
 async function runReview(cli, overrides = {}) {
   const services = { ...productionServices(), ...overrides };
   const { runDir, record } = resolveRun(cli);
+  const resolvedRunDigest = runRecordDigest(record);
   const reviewer = cli.values.reviewer || record.roles.reviewer;
   if (reviewer !== record.roles.reviewer) {
     fail(`reviewer override is not part of the Relay contract; immutable binding is '${record.roles.reviewer}'`, "REVIEWER_BINDING_MISMATCH");
@@ -348,6 +364,12 @@ async function runReview(cli, overrides = {}) {
   catch (error) { fail(error.message, "INVALID_CREDENTIAL"); }
   const credentialEnv = Object.fromEntries(requestedCredentials.envNames.map((name) => [name, process.env[name]]));
   const initial = await services.inspectRun({ runDir });
+  if (!/^[0-9a-f]{64}$/.test(String(initial.snapshot?.run_sha256 || ""))) {
+    fail("initial inspection is missing a valid run digest", "RUN_RECORD_BINDING_CHANGED");
+  }
+  if (initial.snapshot.run_sha256 !== resolvedRunDigest) {
+    fail("resolved run record does not match the canonical inspection", "RUN_RECORD_BINDING_CHANGED");
+  }
   const binding = requireReviewAction(initial, record);
   const criteriaBytes = readFrozenCriteria(record);
   const criteria = criteriaBytes.toString("utf8");
@@ -360,9 +382,10 @@ async function runReview(cli, overrides = {}) {
   const promptDigest = crypto.createHash("sha256").update(promptBytes).digest("hex");
   const promptPath = immutableBytes(path.join(inputDir, `prompt-${binding.head}-${promptDigest}.md`), promptBytes);
   const timeoutMs = (cli.timeoutSeconds || Math.ceil(adapter.defaults.timeoutMs / 1000)) * 1000;
-  let verdict, stagedBinding, executedRuntime;
+  let verdict, stagedBinding, executedRuntime, escalationKind = null;
+  let outcome;
   try {
-    const outcome = await services.invokeReviewer({
+    outcome = await services.invokeReviewer({
       runDir,
       adapter,
       model: cli.values.model || null,
@@ -377,20 +400,29 @@ async function runReview(cli, overrides = {}) {
         current_sha: binding.head,
         diff_sha256: diffDigest,
         prompt_sha256: promptDigest,
+        ...(binding.retryOfEventId ? { retry_of_event_id: binding.retryOfEventId } : {}),
         schema: REVIEW_RESULT_SCHEMA,
       },
     });
-    stagedBinding = outcome.review_binding;
-    executedRuntime = normalizeExecutedRuntime(outcome.executed_runtime);
-    verdict = normalizeVerdict(outcome.output);
   } catch (error) {
     if (error.review_evidence_preserved) throw error;
     stagedBinding = error.review_binding || null;
     executedRuntime = normalizeExecutedRuntime(error.executed_runtime);
     verdict = { verdict: "escalated", summary: `Reviewer invocation failed: ${error.message}`, issues: [] };
+    escalationKind = "runtime_failure";
+  }
+  if (!verdict) {
+    stagedBinding = outcome.review_binding;
+    executedRuntime = normalizeExecutedRuntime(outcome.executed_runtime);
+    verdict = normalizeVerdict(outcome.output);
+    if (verdict.verdict === "escalated") escalationKind = "reviewer";
   }
   const written = await services.withRunLock(runDir, async (lockContext) => {
     const freshRecord = runStore.readRunRecord({ runDir });
+    const freshRunDigest = runRecordDigest(freshRecord);
+    if (freshRunDigest !== resolvedRunDigest || freshRunDigest !== initial.snapshot.run_sha256) {
+      fail("immutable run record changed during independent review", "RUN_RECORD_CHANGED");
+    }
     if (freshRecord.contract.done_criteria_sha256 !== record.contract.done_criteria_sha256) {
       fail("immutable Done Criteria contract changed during independent review", "DONE_CRITERIA_CONTRACT_CHANGED");
     }
@@ -410,8 +442,23 @@ async function runReview(cli, overrides = {}) {
       fail("reviewer result is not bound to the exact staged prompt and diff", "REVIEW_INPUT_BINDING_CHANGED");
     }
     const fresh = await services.inspectRun({ runDir });
+    if (!/^[0-9a-f]{64}$/.test(String(fresh.snapshot?.run_sha256 || ""))) {
+      fail("fresh inspection is missing a valid run digest", "RUN_RECORD_CHANGED");
+    }
+    if (fresh.snapshot.run_sha256 !== resolvedRunDigest
+      || fresh.snapshot.run_sha256 !== initial.snapshot.run_sha256) {
+      fail("run record changed between canonical inspections", "RUN_RECORD_CHANGED");
+    }
+    if ((fresh.derived?.retry_of_event_id || null) !== binding.retryOfEventId) {
+      fail("review retry subject changed during independent review", "REVIEW_BINDING_CHANGED");
+    }
     const freshBinding = requireReviewAction(fresh, freshRecord);
-    if (freshBinding.head !== binding.head || freshBinding.prNumber !== binding.prNumber) {
+    if (
+      freshBinding.retryOfEventId !== binding.retryOfEventId
+      || freshBinding.head !== binding.head
+      || freshBinding.prNumber !== binding.prNumber
+      || JSON.stringify(freshBinding.verification) !== JSON.stringify(binding.verification)
+    ) {
       fail("review binding changed during independent review", "REVIEW_BINDING_CHANGED");
     }
     const round = Math.max(0, ...fresh.facts.filter((fact) => fact.type === "review_recorded").map((fact) => fact.payload.round)) + 1;
@@ -445,6 +492,8 @@ async function runReview(cli, overrides = {}) {
         reviewer,
         review_artifact: artifactPath,
         executed_runtime: executedRuntime,
+        ...(escalationKind ? { escalation_kind: escalationKind } : {}),
+        ...(binding.retryOfEventId ? { retry_of_event_id: binding.retryOfEventId } : {}),
         override: null,
       },
     };

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -88,7 +88,7 @@ node "${RELAY_SKILL_ROOT:-skills}/relay-review/scripts/review-runner.js" \
 
 Invoke **relay-review** in an isolated context. It records immutable review evidence and facts while keeping frozen Done Criteria as the review anchor. A requested change remains blocking until the corrected HEAD receives a passing primary review. Do NOT review inline.
 
-The runner returns `verdict` and a fresh `recommended_action`. `lgtm` must recommend `merge` before Step 5. `changes_requested` must recommend `redispatch`; send a new prompt through `dispatch --run-id`, follow any recovery needed to republish the corrected HEAD, then review again. `escalated`, `operator_attention`, or a mismatched action stops the loop for investigation.
+The runner returns `verdict` and a fresh `recommended_action`. `lgtm` must recommend `merge` before Step 5. `changes_requested` must recommend `redispatch`; send a new prompt through `dispatch --run-id`, follow any recovery needed to republish the corrected HEAD, then review again. A runtime invocation failure may recommend one explicit `review` retry bound to that failure; a second failure, model-returned `escalated`, `operator_attention`, or a mismatched action stops for investigation.
 
 ## Step 5: Ready to Merge
 

--- a/tests/relay-dispatch/scripts/facts.test.js
+++ b/tests/relay-dispatch/scripts/facts.test.js
@@ -428,6 +428,27 @@ test("appending a review verdict without executed runtime evidence fails closed"
   }
 });
 
+test("review escalation classification is required only for current escalated appends", () => {
+  const eventsPath = tempEvents("review-escalation-kind");
+  const lock = acquireFactLock(eventsPath);
+  const executed_runtime = { digest: HASH, executable: { path: "/bin/reviewer", dev: 1, ino: 2, size: 3, sha256: HASH } };
+  try {
+    const escalated = fact("review_recorded");
+    escalated.payload = { ...escalated.payload, verdict: "escalated", executed_runtime };
+    assert.throws(() => appendFact({ eventsPath, fact: escalated, lockContext: lock }), /escalation_kind is required/);
+
+    const pass = fact("review_recorded");
+    pass.payload = { ...pass.payload, executed_runtime, escalation_kind: "reviewer" };
+    assert.throws(() => appendFact({ eventsPath, fact: pass, lockContext: lock }), /only allowed for escalated/);
+
+    const historical = fact("review_recorded");
+    historical.payload = { ...historical.payload, verdict: "escalated" };
+    assert.equal(validateFact(historical).known, true, "old escalations remain readable but fail closed in inspect");
+  } finally {
+    releaseRunLock(lock);
+  }
+});
+
 test("journal path and fact run identity are bound to immutable run.json", () => {
   const eventsPath = tempEvents("identity");
   const lock = acquireFactLock(eventsPath);

--- a/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
+++ b/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
@@ -135,6 +135,44 @@ function pullRequestFact(headSha = START) {
   };
 }
 
+function verificationFact() {
+  return {
+    event_id: "verification-review",
+    run_id: "issue-1135-test",
+    type: "verification_recorded",
+    at: "2026-08-01T00:03:00Z",
+    actor: "owner",
+    payload: {
+      head_sha: HEAD, tree_sha: TREE, done_criteria_sha256: HASH,
+      command: "node --test", verification_request_sha256: "f".repeat(64),
+      declared_command_count: 1, completed_command_count: 1,
+      result_path: "/run/verification.log", result_sha256: "f".repeat(64),
+      exit_code: 0, status: "passed", operator: "owner",
+    },
+  };
+}
+
+function reviewFact({ eventId, verdict = "escalated", escalationKind, retryOfEventId } = {}) {
+  return {
+    event_id: eventId,
+    run_id: "issue-1135-test",
+    type: "review_recorded",
+    at: "2026-08-01T00:04:00Z",
+    actor: "claude",
+    payload: {
+      round: retryOfEventId ? 2 : 1,
+      verdict,
+      reviewed_sha: HEAD,
+      done_criteria_sha256: HASH,
+      reviewer: "claude",
+      review_artifact: "/run/review.json",
+      ...(escalationKind ? { escalation_kind: escalationKind } : {}),
+      ...(retryOfEventId ? { retry_of_event_id: retryOfEventId } : {}),
+      override: null,
+    },
+  };
+}
+
 function publicationObservations(overrides = {}) {
   return {
     git: {
@@ -174,6 +212,34 @@ test("inspect is byte-read-only and emits one stable recommended action", async 
   assert.deepEqual(first.recommended_action.steps, ["push_branch", "record_or_create_pr"]);
   assert.equal(first.recommended_action.key, second.recommended_action.key);
   assert.deepEqual(first.facts, [attemptFinished()]);
+});
+
+test("inspect exposes one retry for a runtime escalation and exhausts that subject", async () => {
+  const observations = publicationObservations({
+    git: { ...publicationObservations().git, reviewable_work: false },
+    github: {
+      ...publicationObservations().github,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN", pr_head_sha: HEAD,
+    },
+  });
+  const firstFact = reviewFact({ eventId: "review-runtime-1", escalationKind: "runtime_failure" });
+  const first = await inspectRun(harness({ facts: [pullRequestFact(HEAD), verificationFact(), firstFact], observations }));
+  assert.equal(first.derived.action, "review");
+  assert.equal(first.derived.retry_of_event_id, firstFact.event_id);
+  assert.equal(first.recommended_action.kind, "review");
+
+  const retryFailure = reviewFact({
+    eventId: "review-runtime-2",
+    escalationKind: "runtime_failure",
+    retryOfEventId: firstFact.event_id,
+  });
+  const exhausted = await inspectRun(harness({
+    facts: [pullRequestFact(HEAD), verificationFact(), firstFact, retryFailure],
+    observations,
+  }));
+  assert.equal(exhausted.derived.action, "none");
+  assert.equal(exhausted.derived.reason, "review_escalated_retry_exhausted");
+  assert.equal(exhausted.recommended_action.kind, "none");
 });
 
 test("recover refuses a stale inspect key before effects or durable writes", async () => {

--- a/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
+++ b/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
@@ -242,6 +242,76 @@ test("inspect exposes one retry for a runtime escalation and exhausts that subje
   assert.equal(exhausted.recommended_action.kind, "none");
 });
 
+test("inspect accepts the immediate single passing retry", async () => {
+  const observations = publicationObservations({
+    git: { ...publicationObservations().git, reviewable_work: false },
+    github: {
+      ...publicationObservations().github,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN", pr_head_sha: HEAD,
+    },
+  });
+  const firstFact = reviewFact({ eventId: "review-runtime-pass-1", escalationKind: "runtime_failure" });
+  const retryPass = reviewFact({
+    eventId: "review-runtime-pass-2",
+    verdict: "pass",
+    retryOfEventId: firstFact.event_id,
+  });
+  const result = await inspectRun(harness({
+    facts: [pullRequestFact(HEAD), verificationFact(), firstFact, retryPass],
+    observations,
+  }));
+  assert.equal(result.derived.action, "merge");
+  assert.equal(result.derived.reason, "ready_to_merge");
+});
+
+test("inspect rejects a passing retry without a matching initial runtime failure", async () => {
+  const observations = publicationObservations({
+    git: { ...publicationObservations().git, reviewable_work: false },
+    github: {
+      ...publicationObservations().github,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN", pr_head_sha: HEAD,
+    },
+  });
+  const arbitraryRetry = reviewFact({
+    eventId: "review-arbitrary-retry",
+    verdict: "pass",
+    retryOfEventId: "missing-runtime-failure",
+  });
+  const result = await inspectRun(harness({
+    facts: [pullRequestFact(HEAD), verificationFact(), arbitraryRetry],
+    observations,
+  }));
+  assert.equal(result.derived.action, "none");
+  assert.equal(result.derived.reason, "review_retry_binding_invalid");
+});
+
+test("inspect rejects a third pass reusing the first retry event", async () => {
+  const observations = publicationObservations({
+    git: { ...publicationObservations().git, reviewable_work: false },
+    github: {
+      ...publicationObservations().github,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN", pr_head_sha: HEAD,
+    },
+  });
+  const firstFact = reviewFact({ eventId: "review-runtime-third-1", escalationKind: "runtime_failure" });
+  const retryFailure = reviewFact({
+    eventId: "review-runtime-third-2",
+    escalationKind: "runtime_failure",
+    retryOfEventId: firstFact.event_id,
+  });
+  const thirdPass = reviewFact({
+    eventId: "review-runtime-third-3",
+    verdict: "pass",
+    retryOfEventId: firstFact.event_id,
+  });
+  const result = await inspectRun(harness({
+    facts: [pullRequestFact(HEAD), verificationFact(), firstFact, retryFailure, thirdPass],
+    observations,
+  }));
+  assert.equal(result.derived.action, "none");
+  assert.equal(result.derived.reason, "review_retry_binding_invalid");
+});
+
 test("recover refuses a stale inspect key before effects or durable writes", async () => {
   const h = harness({ facts: [attemptFinished()], observations: publicationObservations() });
   const effects = { converge: async (step) => { h.state.effects.push(step); return { converged: true }; } };

--- a/tests/relay-dispatch/scripts/run-fold.test.js
+++ b/tests/relay-dispatch/scripts/run-fold.test.js
@@ -23,6 +23,7 @@ function runRecord() {
     repo: { remote: "owner/repo" },
     git: { branch: "work", base_branch: "main" },
     contract: { done_criteria_sha256: HASH },
+    roles: { reviewer: "claude" },
   };
 }
 
@@ -489,25 +490,25 @@ test("#1209 freezes GitHub action, reason, and action-key contracts", async () =
   };
   const cases = [
     ["publication recovery", [started(), finished()], publication,
-      "recover", "publication_incomplete", "f7bcde21c47296320f322c368376f855b9da03da47103ecae53c4f40f6230fbd"],
+      "recover", "publication_incomplete", "17783b1eb88a4ae0bedfd64c697c7280d8bebf6cf2649e244228de1c61ae722a"],
     ["review", baseFacts, { ...publication, github: open },
-      "review", "review_missing", "8eb98952991243d41a44240f7b29b30ab84fc0344a2cf6e776f95db1673aa402"],
+      "review", "review_missing", "4d8ae47b98c90b1ba1b7c0c81abea2f29f934b9d8e38f3e7e320fec0bceb1354"],
     ["stale review", [...baseFacts, review("pass", 5, START)], { ...publication, github: open },
-      "review", "review_stale", "4327d7143895359a710de4a530d82c1d4b55b5ee148c56e9af7e318202128fdd"],
+      "review", "review_stale", "bfca830e29b3f3108cb7f61fda91d2197ab8115bab12942f45267e1e6da3018d"],
     ["ready to merge", [...baseFacts, review("pass", 5)], { ...publication, github: open },
-      "merge", "ready_to_merge", "b7525b15d238119500fd0c1a503555382f056ad25ab347650ba7f22a767c8033"],
+      "merge", "ready_to_merge", "d0a837542d6801de5c0205e3c2f0a0ff9e2536f66a36309440cbeca3819816bd"],
     ["externally merged", [started(), finished(), pr()], {
       ...publication,
       github: { ...open, pr_state: "MERGED", merge_sha: TARGET },
-    }, "recover", "merged_pr_unrecorded", "d2c031949c81ad7c5e8dc2920536ae38c12befc7c50b7b0cec46cc00de057c08"],
+    }, "recover", "merged_pr_unrecorded", "5b3a7c5628fafee5c631bbd798eee56c7dce2ace4e22b28db502ddeae300ac53"],
     ["GitHub unavailable", baseFacts, {
       ...publication,
       github: { ...open, available: false },
-    }, "none", "github_unavailable", "02b9ed549207ac9576a7c8c86cb2c2e1de599ee1c91d4fc48150864cd149ace8"],
+    }, "none", "github_unavailable", "3d5880c22fafe7de50341e9271c1e7e644ed288f280421220b4341f75d8e948e"],
     ["merge conflict observation", [started(), finished()], {
       ...publication,
       git: { ...publication.git, remote_relation: "diverged" },
-    }, "operator_attention", "remote_branch_conflict", "1a1a60051aefcef91368d36e84c921ed1d84b218728404f538067db4c5d3a255"],
+    }, "operator_attention", "remote_branch_conflict", "3b00be359fc8b47859f8839e3ac81b8bfa42a853d1a662e637322f1e8b4f98ee"],
   ];
   const observedKeys = {};
   for (const [name, scenarioFacts, seen, kind, reason, key] of cases) {

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -313,6 +313,56 @@ test("model-returned escalation is classified as reviewer uncertainty and is not
   }), /'none', not 'review'/);
 });
 
+test("malformed reviewer output is durably non-retryable reviewer escalation", async () => {
+  const value = await fixture("malformed-review-output");
+  let calls = 0;
+  const result = await runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    invokeReviewer: async (input) => {
+      calls += 1;
+      return reviewerSuccess(input, { verdict: "pass", summary: "ok", issues: [], unexpected: true });
+    },
+  });
+  assert.equal(result.verdict, "escalated");
+  assert.equal(result.recommended_action.kind, "none");
+  assert.equal(result.recommended_action.reason, "review_escalated");
+  const reviews = facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded");
+  assert.equal(reviews.length, 1);
+  assert.equal(reviews[0].payload.escalation_kind, "reviewer");
+  const artifact = JSON.parse(fs.readFileSync(reviews[0].payload.review_artifact, "utf8"));
+  assert.equal(artifact.verdict.verdict, "escalated");
+  assert.match(artifact.verdict.summary, /invalid/i);
+  await assert.rejects(runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    invokeReviewer: async () => { calls += 1; throw new Error("must not retry malformed output"); },
+  }), /'none', not 'review'/);
+  assert.equal(calls, 1);
+  assert.equal(facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded").length, 1);
+});
+
+test("nonzero invocation failures stay retryable while output protocol mismatches do not", async () => {
+  for (const [reason, expectedKind, expectedAction] of [
+    ["cli_nonzero_exit", "runtime_failure", "review"],
+    ["output_protocol_mismatch", "reviewer", "none"],
+  ]) {
+    const value = await fixture(`failure-classification-${reason}`);
+    const result = await runner.runReview(value.cli, {
+      inspectRun: value.inspectRun,
+      async invokeReviewer(input) {
+        const error = new Error(`review failed: ${reason}`);
+        error.failure_reason = reason;
+        error.failure_signals = ["output_protocol"];
+        error.review_binding = reviewBinding(input);
+        error.executed_runtime = EXECUTED_RUNTIME;
+        throw error;
+      },
+    });
+    assert.equal(result.recommended_action.kind, expectedAction);
+    const review = facts.readFacts({ eventsPath: value.eventsPath }).facts.at(-1);
+    assert.equal(review.payload.escalation_kind, expectedKind);
+  }
+});
+
 test("review persistence rejects missing or malformed executed runtime evidence", async () => {
   for (const mode of ["missing", "malformed"]) {
     const value = await fixture(`runtime-${mode}`);

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -92,13 +92,22 @@ async function fixture(label) {
   const inspectRun = async () => {
     const current = facts.readFacts({ eventsPath }).facts;
     const review = current.filter((fact) => fact.type === "review_recorded").at(-1);
-    const action = !review ? "review" : review.payload.verdict === "lgtm" ? "merge" : review.payload.verdict === "changes_requested" ? "redispatch" : "none";
+    const retryable = review?.payload?.verdict === "escalated"
+      && review.payload.escalation_kind === "runtime_failure"
+      && review.payload.retry_of_event_id === undefined;
+    const exhausted = review?.payload?.verdict === "escalated"
+      && review.payload.escalation_kind === "runtime_failure"
+      && review.payload.retry_of_event_id !== undefined;
+    const action = !review ? "review" : review.payload.verdict === "lgtm" ? "merge"
+      : review.payload.verdict === "changes_requested" ? "redispatch"
+        : retryable ? "review" : "none";
     return {
       blockers: [],
+      snapshot: { run_sha256: crypto.createHash("sha256").update(JSON.stringify(record)).digest("hex") },
       facts: current,
       observations: { github: { pr_number: 42, pr_head_sha: head, pr_state: "OPEN" } },
-      derived: { action, head_sha: head, pr_number: 42 },
-      recommended_action: { kind: action, reason: review ? review.payload.verdict : "review_missing", key: "c".repeat(64), steps: [], required_inputs: [] },
+      derived: { action, head_sha: head, pr_number: 42, retry_of_event_id: retryable ? review.event_id : null },
+      recommended_action: { kind: action, reason: retryable ? "review_retryable_escalation" : exhausted ? "review_escalated_retry_exhausted" : review?.payload?.verdict === "escalated" ? "review_escalated" : review ? review.payload.verdict : "review_missing", key: "c".repeat(64), steps: [], required_inputs: [] },
     };
   };
   const cli = runner.parseCli(["--repo", repo, "--run-dir", runDir, "--json"]);
@@ -174,9 +183,134 @@ test("changes_requested and invocation error are durable blocking review facts",
     },
   });
   assert.equal(errorResult.verdict, "escalated");
-  assert.equal(errorResult.recommended_action.kind, "none");
+  assert.equal(errorResult.recommended_action.kind, "review");
   const artifact = JSON.parse(fs.readFileSync(errorResult.review_artifact, "utf8"));
   assert.match(artifact.verdict.summary, /adapter crashed/);
+  const errorFacts = facts.readFacts({ eventsPath: errored.eventsPath }).facts.filter((fact) => fact.type === "review_recorded");
+  assert.equal(errorFacts[0].payload.escalation_kind, "runtime_failure");
+});
+
+test("a runtime escalation permits one explicitly bound retry, then fails closed", async () => {
+  const value = await fixture("retry");
+  let calls = 0;
+  const first = await runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    async invokeReviewer(input) {
+      calls += 1;
+      const error = new Error("transient transport failure");
+      error.review_binding = reviewBinding(input);
+      error.executed_runtime = EXECUTED_RUNTIME;
+      throw error;
+    },
+  });
+  assert.equal(first.recommended_action.kind, "review");
+  const firstFact = facts.readFacts({ eventsPath: value.eventsPath }).facts.at(-1);
+
+  const second = await runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    async invokeReviewer(input) {
+      calls += 1;
+      assert.equal(input.request.retry_of_event_id, firstFact.event_id);
+      return reviewerSuccess(input, { verdict: "pass", summary: "retry passed", issues: [] });
+    },
+  });
+  assert.equal(second.verdict, "lgtm");
+  assert.equal(second.recommended_action.kind, "merge");
+  const reviewFacts = facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded");
+  assert.equal(reviewFacts.length, 2);
+  assert.equal(reviewFacts[1].payload.retry_of_event_id, firstFact.event_id);
+
+  await assert.rejects(runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    invokeReviewer: async () => { throw new Error("must not retry a passed retry"); },
+  }), /not 'review'/);
+
+  const exhausted = await fixture("retry-exhausted");
+  let exhaustedCalls = 0;
+  await runner.runReview(exhausted.cli, {
+    inspectRun: exhausted.inspectRun,
+    async invokeReviewer(input) {
+      exhaustedCalls += 1;
+      const error = new Error("first transient failure");
+      error.review_binding = reviewBinding(input);
+      error.executed_runtime = EXECUTED_RUNTIME;
+      throw error;
+    },
+  });
+  const retryFailure = await runner.runReview(exhausted.cli, {
+    inspectRun: exhausted.inspectRun,
+    async invokeReviewer(input) {
+      exhaustedCalls += 1;
+      assert.equal(input.request.retry_of_event_id, facts.readFacts({ eventsPath: exhausted.eventsPath }).facts.at(-1).event_id);
+      const error = new Error("second transient failure");
+      error.review_binding = reviewBinding(input);
+      error.executed_runtime = EXECUTED_RUNTIME;
+      throw error;
+    },
+  });
+  assert.equal(retryFailure.recommended_action.kind, "none");
+  assert.equal(retryFailure.recommended_action.reason, "review_escalated_retry_exhausted");
+  await assert.rejects(runner.runReview(exhausted.cli, {
+    inspectRun: exhausted.inspectRun,
+    invokeReviewer: async () => { throw new Error("unbounded retry"); },
+  }), /derived lifecycle action is 'none'/);
+  assert.equal(calls, 2);
+  assert.equal(exhaustedCalls, 2);
+});
+
+test("concurrent failing retries append exactly one second-round fact", async () => {
+  const value = await fixture("retry-race");
+  await runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    invokeReviewer: async (input) => {
+      const error = new Error("temporary provider failure");
+      error.review_binding = reviewBinding(input);
+      error.executed_runtime = EXECUTED_RUNTIME;
+      throw error;
+    },
+  });
+  let arrivals = 0;
+  let release;
+  const bothInvoked = new Promise((resolve) => { release = resolve; });
+  const invokeReviewer = async (input) => {
+    arrivals += 1;
+    if (arrivals === 2) release();
+    await bothInvoked;
+    const error = new Error("provider remains unavailable");
+    error.review_binding = reviewBinding(input);
+    error.executed_runtime = EXECUTED_RUNTIME;
+    throw error;
+  };
+  let lockTail = Promise.resolve();
+  const withRunLock = (runDir, callback) => {
+    const turn = lockTail.then(() => runtime.withRunLock(runDir, callback));
+    lockTail = turn.catch(() => {});
+    return turn;
+  };
+  const settled = await Promise.allSettled([
+    runner.runReview(value.cli, { inspectRun: value.inspectRun, invokeReviewer, withRunLock }),
+    runner.runReview(value.cli, { inspectRun: value.inspectRun, invokeReviewer, withRunLock }),
+  ]);
+  assert.equal(settled.filter((entry) => entry.status === "fulfilled").length, 1);
+  assert.equal(settled.find((entry) => entry.status === "rejected").reason.code, "REVIEW_BINDING_CHANGED");
+  const reviewFacts = facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded");
+  assert.deepEqual(reviewFacts.map((fact) => fact.payload.round), [1, 2]);
+});
+
+test("model-returned escalation is classified as reviewer uncertainty and is not retryable", async () => {
+  const value = await fixture("model-escalation");
+  const result = await runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    invokeReviewer: async (input) => reviewerSuccess(input, { verdict: "escalated", summary: "evidence is ambiguous", issues: [] }),
+  });
+  assert.equal(result.recommended_action.kind, "none");
+  assert.equal(result.recommended_action.reason, "review_escalated");
+  const review = facts.readFacts({ eventsPath: value.eventsPath }).facts.at(-1);
+  assert.equal(review.payload.escalation_kind, "reviewer");
+  await assert.rejects(runner.runReview(value.cli, {
+    inspectRun: value.inspectRun,
+    invokeReviewer: async () => { throw new Error("must not retry model escalation"); },
+  }), /'none', not 'review'/);
 });
 
 test("review persistence rejects missing or malformed executed runtime evidence", async () => {
@@ -188,6 +322,39 @@ test("review persistence rejects missing or malformed executed runtime evidence"
     } }), /runtime binding/);
     assert.equal(facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded").length, 0);
   }
+});
+
+test("initial run snapshot must be valid and match resolved run.json before invocation", async () => {
+  for (const mode of ["missing", "malformed", "mismatch"]) {
+    const value = await fixture(`initial-snapshot-${mode}`);
+    let reviewerCalls = 0;
+    await assert.rejects(runner.runReview(value.cli, {
+      async inspectRun(input) {
+        const inspection = await value.inspectRun(input);
+        if (mode === "missing") delete inspection.snapshot.run_sha256;
+        else inspection.snapshot.run_sha256 = mode === "malformed" ? "bad" : "f".repeat(64);
+        return inspection;
+      },
+      invokeReviewer: async () => { reviewerCalls += 1; throw new Error("must not run"); },
+    }), (error) => error.code === "RUN_RECORD_BINDING_CHANGED");
+    assert.equal(reviewerCalls, 0);
+    assert.equal(facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded").length, 0);
+  }
+});
+
+test("fresh run snapshot drift rejects the append", async () => {
+  const value = await fixture("fresh-snapshot-drift");
+  let inspections = 0;
+  await assert.rejects(runner.runReview(value.cli, {
+    async inspectRun(input) {
+      const inspection = await value.inspectRun(input);
+      inspections += 1;
+      if (inspections === 2) inspection.snapshot.run_sha256 = "f".repeat(64);
+      return inspection;
+    },
+    invokeReviewer: async (input) => reviewerSuccess(input, { verdict: "pass", summary: "ok", issues: [] }),
+  }), (error) => error.code === "RUN_RECORD_CHANGED");
+  assert.equal(facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded").length, 0);
 });
 
 test("immutable reviewer binding and closed CLI reject legacy policy surfaces", async () => {


### PR DESCRIPTION
## Recovery Summary

<!-- relay-recovery-operation:recover-454e567389dee421eaed7278b038ffe1 -->

- Run: issue-1216-bounded-review-retry-final-20260810172509480-53c701a9
- Reason: Publish bounded one-retry-per-review-subject implementation after Luna execution, dogfood correction, independent correctness and simplification LGTM, and 77 focused tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 리뷰 실행 중 런타임 오류가 발생하면 연결된 리뷰 재시도 1회를 지원합니다.
  - 재시도 성공 시 정상 진행되며, 두 번째 실패는 추가 시도 없이 종료됩니다.
  - 모델이 에스컬레이션한 결과는 자동 재시도하지 않습니다.

- **버그 수정**
  - 잘못된 재시도 연결과 불완전한 에스컬레이션 정보를 거부합니다.
  - 리뷰 실행 중 기록 변경이나 검증 불일치를 감지해 안전하게 중단합니다.

- **테스트**
  - 재시도, 동시 실행 경합, 실패 종료 및 기록 무결성 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->