### PR TITLE
Recover relay run fix-merge-observer-network-trust-20260811011553272-fff865b4

### DIFF
--- a/skills/relay-dispatch/scripts/host.js
+++ b/skills/relay-dispatch/scripts/host.js
@@ -388,7 +388,7 @@ function sandboxInvocation({ role, command, args = [], readRoots = [], writeRoot
     ...runtimeDependencyRules(runtimeExecutables, runtimeDependencies, env).map((root) => `(subpath "${quote(root)}")`)].join(" ");
   const deniedWrites = deniedWriteFiles.map((file) => `(deny file-write* (literal "${quote(file)}"))`).join(" ");
   const transportMach = networkAccess === "enabled"
-    ? '(allow mach-lookup (global-name "com.apple.SystemConfiguration.configd") (global-name "com.apple.system.opendirectoryd.libinfo"))'
+    ? '(allow mach-lookup (global-name "com.apple.SystemConfiguration.configd") (global-name "com.apple.system.opendirectoryd.libinfo") (global-name "com.apple.trustd.agent"))'
     : "";
   const systemCa = networkAccess === "enabled" ? trustedSystemCaFile() : null;
   const systemCaRule = systemCa ? `(literal "${quote(systemCa)}")` : "";

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -377,6 +377,7 @@ function mergeObserver(record) {
     command: process.execPath,
     args,
     env: { GH_TOKEN: githubToken(record.repo.root) },
+    networkAccess: "enabled",
   };
 }
 

--- a/tests/relay-dispatch/scripts/host-supervisor.test.js
+++ b/tests/relay-dispatch/scripts/host-supervisor.test.js
@@ -590,23 +590,42 @@ test("a missing system CA bundle fails typed instead of raw ENOENT", () => {
   } finally { fs.realpathSync = original; }
 });
 
-test("network policy is explicit and grants only transport Mach services, never Keychain", () => {
+test("network policy is explicit and grants only transport and per-user trust Mach services, never Keychain", () => {
   const value = roots("network-profile"), proof = path.join(value.runDir, "network-proof.json");
   const disabled = host.sandboxInvocation({ role: "executor", command: process.execPath, readRoots: [value.worktree], networkAccess: "disabled" }).args[1];
   const script = "const fs=require('fs');let sibling='readable';try{fs.readFileSync('/private/etc/hosts')}catch(e){sibling='denied:'+e.code}fs.writeFileSync(process.argv[1],JSON.stringify({ca:process.env.SSL_CERT_FILE,certificate:fs.readFileSync(process.env.SSL_CERT_FILE,'utf8').includes('BEGIN CERTIFICATE'),sibling}))";
   const invocation = host.sandboxInvocation({ role: "executor", command: process.execPath, args: ["-e", script, proof], readRoots: [value.worktree], writeFiles: [proof], networkAccess: "enabled" });
   const enabled = invocation.args[1], ca = fs.realpathSync("/etc/ssl/cert.pem");
-  assert.doesNotMatch(disabled, /allow network|SystemConfiguration\.configd|opendirectoryd\.libinfo/);
+  assert.doesNotMatch(disabled, /allow network|SystemConfiguration\.configd|opendirectoryd\.libinfo|trustd/);
   assert.match(enabled, /allow network/); assert.match(enabled, /SystemConfiguration\.configd/); assert.match(enabled, /opendirectoryd\.libinfo/);
+  assert.match(enabled, /\(global-name "com\.apple\.trustd\.agent"\)/);
   assert.match(enabled, new RegExp(`literal "${ca.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`));
   assert.doesNotMatch(enabled, /\(subpath "\/(?:private\/)?etc/);
-  assert.doesNotMatch(enabled, /securityd|SecurityServer|appleevent-send\)"?$/);
+  assert.doesNotMatch(enabled, /com\.apple\.trustd"|securityd|SecurityServer|keychain|mach-lookup.*regex|mach-lookup.*global-prefix/);
   assert.equal(Object.hasOwn(host.sandboxInvocation({ role: "executor", command: process.execPath, networkAccess: "disabled" }).env, "SSL_CERT_FILE"), false);
   assert.equal(spawnSync(invocation.command, invocation.args, { cwd: value.worktree, env: invocation.env }).status, 0);
   const observed = JSON.parse(fs.readFileSync(proof, "utf8"));
   assert.equal(observed.ca, ca); assert.equal(observed.certificate, true); assert.match(observed.sibling, /^denied:/);
   assert.throws(() => host.sandboxInvocation({ role: "executor", command: process.execPath, networkAccess: "enabled", env: { ...process.env, SSL_CERT_FILE: proof } }),
     (error) => error.code === "INVALID_INVOCATION" && /host-reserved/.test(error.message));
+});
+
+test("offline trust evaluation needs exactly the per-user trust agent lookup", () => {
+  const value = roots("offline-trust"), certificate = path.join(value.worktree, "root.pem");
+  const match = fs.readFileSync("/etc/ssl/cert.pem", "utf8").match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/);
+  assert.ok(match, "the trusted root-owned CA literal contains a certificate");
+  fs.writeFileSync(certificate, `${match[0]}\n`, { mode: 0o600 });
+  const options = { role: "executor", command: "/usr/bin/security",
+    args: ["verify-cert", "-c", certificate, "-r", certificate, "-N", "-L", "-l", "-q"], readFiles: [certificate] };
+  const disabled = host.sandboxInvocation({ ...options, networkAccess: "disabled" });
+  const enabled = host.sandboxInvocation({ ...options, networkAccess: "enabled" });
+  const exactAgentOnly = { ...disabled, args: [...disabled.args] };
+  exactAgentOnly.args[1] = exactAgentOnly.args[1].replace("(allow file-read-metadata)",
+    '(allow file-read-metadata)(allow mach-lookup (global-name "com.apple.trustd.agent"))');
+  const run = (invocation) => spawnSync(invocation.command, invocation.args, { cwd: value.worktree, env: invocation.env, encoding: "utf8" });
+  assert.notEqual(run(disabled).status, 0, "offline trust fails without the agent lookup");
+  assert.equal(run(enabled).status, 0, "network-enabled policy permits offline trust evaluation");
+  assert.equal(run(exactAgentOnly).status, 0, "the exact agent lookup alone permits the same offline trust evaluation");
 });
 
 test("staged input bytes remain bound when the caller path mutates after launch", async () => {

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -268,6 +268,31 @@ function services(overrides = {}) {
   };
 }
 
+test("production merge observer enables network through the real isolated observer seam", () => {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-production-observer-")));
+  const fakeGh = path.join(root, "fake-gh.js"), prior = { bin: process.env.RELAY_GH_BIN, token: process.env.GH_TOKEN };
+  const record = { repo: { root, remote: "owner/repo" }, git: { branch: "issue-1214", base_branch: "main" } };
+  fs.writeFileSync(fakeGh, `"use strict";
+const args=process.argv.slice(2);
+if(args[0]!=="pr"||args[1]!=="view")process.exit(2);
+process.stdout.write(JSON.stringify({number:42,state:"OPEN",headRefName:"issue-1214",headRefOid:"${"a".repeat(40)}",baseRefName:"main",headRepository:{nameWithOwner:"owner/repo"},mergeCommit:null,autoMergeRequest:null,mergeStateStatus:"CLEAN"}));
+`, { mode: 0o700 });
+  process.env.RELAY_GH_BIN = fakeGh; process.env.GH_TOKEN = "test-token";
+  try {
+    const observer = finalize.mergeObserver(record);
+    assert.equal(observer.networkAccess, "enabled");
+    const observed = runStore.invokeExternalObserver({ observer, request: { nonce: "production-observer-nonce",
+      request: { pr_number: 42, repo: "owner/repo" } } });
+    assert.equal(observed.nonce, "production-observer-nonce");
+    assert.equal(observed.pr_head_sha, "a".repeat(40));
+    assert.equal(observed.head_repo, "owner/repo");
+  } finally {
+    if (prior.bin === undefined) delete process.env.RELAY_GH_BIN; else process.env.RELAY_GH_BIN = prior.bin;
+    if (prior.token === undefined) delete process.env.GH_TOKEN; else process.env.GH_TOKEN = prior.token;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 function hardCrashFinalize(value, mode) {
   const override = mode === "after-intent"
     ? "afterRequestIntent(){process.exit(91);}"


### PR DESCRIPTION
## Recovery Summary

<!-- relay-recovery-operation:recover-a75c28c61d8f3e753bb4d7c653dd7213 -->

- Run: fix-merge-observer-network-trust-20260811011553272-fff865b4
- Reason: Publish the combined minimal merge-observer network and exact macOS trustd.agent boundary after host-focused and full serialized gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 오프라인 인증서 신뢰 평가가 필요한 경우 보안 검증 서비스 조회를 지원합니다.
  * 병합 관찰 작업에서 네트워크 접근이 활성화되어 관련 PR 정보를 정상적으로 확인할 수 있습니다.

* **테스트**
  * 네트워크 권한 및 허용·차단되는 보안 서비스 조회 동작을 검증하는 테스트를 추가했습니다.
  * 병합 과정의 네트워크 접근과 PR 정보 반환에 대한 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->