### PR TITLE
fix(relay): make lost-scope cleanup actionable

### DIFF
--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -193,8 +193,12 @@ sandbox guarantee:
   executor whose descendants are Apple-signed binaries is therefore not
   scope-verifiable and must be treated as contract-violating for containment.
 
-Operators recover a fail-closed cleanup with `relay-recover recover`, which
-settles the signed obligation, or by terminating the reported identities by hand.
+Operators recover a fail-closed cleanup with `relay-recover recover`. If an exact
+recorded identity is still live but its scope marker is no longer provable, Relay
+returns `HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED` without signalling it. The
+operator must independently verify and terminate that exact pid/pgid/start-time
+identity, then rerun canonical recovery so Relay can sign settlement. Killing by
+name or by a stale PID alone is outside the safety contract.
 
 The linked-worktree administration directory, common object store, refs, config,
 and hooks are deliberately outside the executor write set. Executors leave dirty

--- a/skills/relay-dispatch/references/recovery-playbook.md
+++ b/skills/relay-dispatch/references/recovery-playbook.md
@@ -41,6 +41,16 @@ when the recommended action includes recording verification. Use
 `--break-lock` only after `inspect` identifies a stale or unknown owner and the
 authenticated terminal-result checks described in the output can succeed.
 
+If cleanup reports `HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED`, the signed
+obligation still names a live process but Relay can no longer prove its inherited
+scope marker. Relay sends no signal in that state. Independently inspect the
+reported `pid`, `pgid`, and `started_at`, terminate only that exact process using
+an operator-controlled facility, then rerun the same canonical `recover
+--break-lock` command. Do not kill by process name or reuse an old PID-only
+command: the identity may have changed. Once the recorded identity is absent,
+Relay signs cleanup settlement, publishes the terminal attempt result, and
+continues recovery idempotently.
+
 ## Safety contract
 
 - Treat `run.json`, the fact journal, intents, receipts, and merge

--- a/skills/relay-dispatch/scripts/host.js
+++ b/skills/relay-dispatch/scripts/host.js
@@ -766,7 +766,15 @@ function reapExactIdentity(identity, seal) {
     if (identityGone(identity, 0)) return;
     const sent = signalScoped(identity, signal, seal);
     if (!sent.verified && !sent.absent) {
-      fail("cleanup process could not be bound to the run process scope", "HOST_CLEANUP_INCOMPLETE", { recommended_action: "inspect", pid: identity.pid });
+      fail(
+        "cleanup process is still live but its inherited Relay scope cannot be proven; Relay did not signal it",
+        "HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED",
+        {
+          recommended_action: "terminate_exact_process_externally_then_retry",
+          process_identity: { ...identity },
+          relay_signalled: false,
+        },
+      );
     }
     if (identityGone(identity, settleMs)) return;
   }

--- a/skills/relay/scripts/relay-recover.js
+++ b/skills/relay/scripts/relay-recover.js
@@ -69,6 +69,28 @@ function formatText(result) {
   return lines.join("\n");
 }
 
+function formatFailure(error, json) {
+  const failure = {
+    ok: false,
+    code: error.code || "RECOVERY_FAILED",
+    error: error.message,
+  };
+  if (error.code === "HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED") {
+    failure.recommended_action = error.recommended_action;
+    failure.process_identity = error.process_identity;
+    failure.relay_signalled = false;
+  }
+  if (json) return JSON.stringify(failure);
+  const identity = failure.process_identity;
+  const process = identity
+    ? ` Exact process: pid=${identity.pid}, pgid=${identity.pgid}, started_at=${identity.started_at}.`
+    : "";
+  const next = failure.recommended_action
+    ? " Verify and terminate that exact process outside Relay, then rerun the same canonical recovery."
+    : "";
+  return `relay-recover: ${failure.code}: ${failure.error}.${process}${next}`;
+}
+
 async function main(argv = process.argv.slice(2)) {
   const command = argv[0];
   const rest = argv.slice(1);
@@ -113,7 +135,7 @@ if (require.main === module) {
   main().then((code) => {
     process.exitCode = code;
   }).catch((error) => {
-    console.error(`relay-recover: ${error.message}`);
+    console.error(formatFailure(error, process.argv.slice(2).includes("--json")));
     process.exitCode = 1;
   });
 }

--- a/tests/relay-dispatch/scripts/host-supervisor.test.js
+++ b/tests/relay-dispatch/scripts/host-supervisor.test.js
@@ -54,6 +54,15 @@ function spawnIdle(env) {
   return { pid: Number(launched.stdout.trim()) };
 }
 
+function spawnScopeDroppingIdle(env, markerPath) {
+  const shell = 'printf %s "$RELAY_PROCESS_SCOPE" > "$1"; shift; exec /usr/bin/env -u RELAY_PROCESS_SCOPE "$@"';
+  const args = ["-c", shell, "relay-drop-scope", markerPath, process.execPath, "-e", IDLE];
+  const launcher = `const c=require('child_process').spawn('/bin/sh',${JSON.stringify(args)},{detached:true,stdio:'ignore',env:${JSON.stringify(env)}});c.unref();process.stdout.write(String(c.pid))`;
+  const launched = spawnSync(process.execPath, ["-e", launcher], { encoding: "utf8", timeout: 20_000 });
+  assert.equal(launched.status, 0, launched.stderr);
+  return { pid: Number(launched.stdout.trim()) };
+}
+
 function ownerSecret(runDir) {
   const ownership = path.join(runDir, "ownership");
   const name = fs.readdirSync(ownership).filter((entry) => entry.endsWith(".owner.json")).sort().at(-1);
@@ -116,21 +125,39 @@ test("group reap signals only individually scope-verified PIDs and preserves an 
   assert.equal(processDead(pids.outsider), false, "the unscoped member is never reached by a group signal");
 });
 
-test("a reused cleanup PID fails closed instead of signalling an unrelated process", { timeout: 30_000 }, async (t) => {
-  const value = roots("pid-reuse"), attemptId = "pid-reuse", capability = lock(value, attemptId);
-  const foreign = spawnIdle({ PATH: process.env.PATH });
+test("lost cleanup scope proof requires exact external action and then converges", { timeout: 30_000 }, async (t) => {
+  const value = roots("scope-loss"), attemptId = "scope-loss", capability = lock(value, attemptId);
+  const scope = host.sandboxInvocation.beginProcessScope(), marker = path.join(value.root, "inherited-scope.txt");
+  const foreign = spawnScopeDroppingIdle({ PATH: process.env.PATH, ...scope.env }, marker);
   t.after(() => { if (!processDead(foreign.pid)) try { process.kill(-foreign.pid, "SIGKILL"); } catch {} try { host.releaseRunLock(capability); } catch {} });
+  await waitForFile(marker);
+  assert.equal(fs.readFileSync(marker, "utf8"), scope.env.RELAY_PROCESS_SCOPE, "the process must inherit the run scope before dropping it");
   await new Promise((resolve) => setTimeout(resolve, 300));
   const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
   writeCleanupObligation(value.runDir, attemptId, {
     processes: [liveIdentity(foreign.pid)], credential_root: { path: credentialRoot, dev: null, ino: null },
-    scope_seal: crypto.randomBytes(32).toString("hex"),
+    scope_seal: scope.seal,
   });
   const inspection = host.inspectOwnership({ runDir: value.runDir });
-  await assert.rejects(host.breakStaleRunLock({ inspection, reason: "settle a reused cleanup identity" }),
-    (error) => error.code === "HOST_CLEANUP_INCOMPLETE" && /could not be bound to the run process scope/.test(error.message));
+  await assert.rejects(host.breakStaleRunLock({ inspection, reason: "settle an unverified cleanup identity" }), (error) => {
+    assert.equal(error.code, "HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED");
+    assert.equal(error.recommended_action, "terminate_exact_process_externally_then_retry");
+    assert.deepEqual(error.process_identity, liveIdentity(foreign.pid));
+    assert.equal(error.relay_signalled, false);
+    return true;
+  });
   assert.equal(processDead(foreign.pid), false, "a cleanup obligation must never signal an unverifiable identity");
   assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), false);
+
+  process.kill(foreign.pid, "SIGKILL");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await host.breakStaleRunLock({
+    inspection: host.inspectOwnership({ runDir: value.runDir }),
+    reason: "exact external process termination completed",
+  });
+  assert.equal(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
+  assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), true);
+  assert.equal(fs.existsSync(path.join(value.runDir, `attempt-${attemptId}.result.json`)), true);
 });
 
 test("cleanup recovery treats an exact zombie as gone even when ps redacts its scope environment", { timeout: 30_000 }, async (t) => {
@@ -800,7 +827,7 @@ test("cleanup-incomplete recovery settles exact obligations and converges after 
     fs.rmSync(marker, { force: true });
     // The recorded supervisor/executor are short-lived; a same-second PID reuse (macOS lstart is
     // second-resolution) can transiently make the exact reap look like a foreign unscoped process,
-    // which the host correctly refuses to signal (HOST_CLEANUP_INCOMPLETE, see the dedicated
+    // which the host correctly refuses to signal (HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED, see the dedicated
     // "a same-second PID reuse without the inherited scope token" test above). Production recovery
     // re-observes and retries, so this test does too: the reused pid exits within a second and the
     // retry converges. This is not a timeout widening; the transient bind failure is a first-class
@@ -810,7 +837,7 @@ test("cleanup-incomplete recovery settles exact obligations and converges after 
         try {
           return await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "recover cleanup", ...(fault ? { fault } : {}) });
         } catch (error) {
-          if (error.code === "HOST_CLEANUP_INCOMPLETE" && /could not be bound to the run process scope/.test(error.message)) {
+          if (error.code === "HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED") {
             await new Promise((resolve) => setTimeout(resolve, 100));
             continue;
           }

--- a/tests/relay-dispatch/scripts/relay-recover-cli.test.js
+++ b/tests/relay-dispatch/scripts/relay-recover-cli.test.js
@@ -225,7 +225,10 @@ test("canonical CLI fails closed when run.json is absent", (t) => {
     encoding: "utf8",
   });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /run\.json is missing/);
+  const failure = JSON.parse(result.stderr);
+  assert.equal(failure.ok, false);
+  assert.equal(failure.code, "RUN_RECORD_MISSING");
+  assert.match(failure.error, /run\.json is missing from/);
 });
 
 test("recover CLI requires an explicit audit reason", (t) => {


### PR DESCRIPTION
Closes #1225

## Summary
- refuse to signal an exact cleanup identity when its inherited Relay scope can no longer be proven
- return a typed operator action with exact pid/pgid/start-time evidence and preserve signed cleanup state
- converge through the existing canonical recovery after the exact process is independently terminated
- document the no-name/no-stale-PID safety boundary and expose structured CLI failures

## Verification
- independent Standards review: LGTM, no P1/P2
- independent Spec review: LGTM, no P1/P2
- full serialized gate: 634 tests, 632 pass, 0 fail, 2 expected live-canary skips
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프로세스의 안전한 식별이 확인되지 않으면 Relay가 자동 종료 대신 외부 정리를 요청합니다.
  * 운영자는 정확한 PID, PGID, 시작 시간을 확인해 프로세스를 종료한 뒤 복구를 재시도할 수 있습니다.
  * 복구 실패 시 오류 코드, 메시지 및 필요한 외부 조치가 텍스트와 JSON으로 명확히 제공됩니다.
  * 프로세스가 이미 종료된 경우에도 정리와 복구 결과가 일관되게 완료됩니다.
* **버그 수정**
  * 실행 기록이 누락된 경우 구조화된 오류 응답과 누락된 경로를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->