### PR TITLE
Guard merge against overlapping base advances

### DIFF
--- a/skills/relay-dispatch/scripts/facts.js
+++ b/skills/relay-dispatch/scripts/facts.js
@@ -51,7 +51,7 @@ const PAYLOAD_SCHEMAS = Object.freeze({
     required: [
       "round", "verdict", "reviewed_sha", "done_criteria_sha256",
       "reviewer", "review_artifact", "override",
-    ], optional: ["executed_runtime", "escalation_kind", "retry_of_event_id"],
+    ], optional: ["base_sha", "executed_runtime", "escalation_kind", "retry_of_event_id"],
   },
   // Optional above so historical journals stay readable; required below on every append this runtime makes.
   recovery_applied: {
@@ -75,7 +75,7 @@ const PAYLOAD_SCHEMAS = Object.freeze({
 // Fields that are schema-optional so historical journals keep parsing, but that this runtime must
 // never append without. Enforced on the append path only; readers stay tolerant of older facts.
 const APPEND_REQUIRED_EVIDENCE = Object.freeze({
-  review_recorded: Object.freeze(["executed_runtime"]),
+  review_recorded: Object.freeze(["base_sha", "executed_runtime"]),
 });
 
 const ATTEMPT_TYPES = new Set([
@@ -250,6 +250,7 @@ function validatePayload(type, payload, { allowFutureFields = false, appending =
       integer(payload.round, "payload.round", { minimum: 1 });
       if (!REVIEW_VERDICTS.has(payload.verdict)) fail("INVALID_FACT", "payload.verdict is invalid");
       sha(payload.reviewed_sha, "payload.reviewed_sha");
+      if (payload.base_sha !== undefined) sha(payload.base_sha, "payload.base_sha");
       sha(payload.done_criteria_sha256, "payload.done_criteria_sha256", { sha256: true });
       string(payload.reviewer, "payload.reviewer");
       string(payload.review_artifact, "payload.review_artifact");

--- a/skills/relay-dispatch/scripts/inspect.js
+++ b/skills/relay-dispatch/scripts/inspect.js
@@ -616,6 +616,14 @@ function foldRunFacts({
         diagnostics,
       });
     }
+    if (!latestReview.payload.base_sha) {
+      return withGithubAvailability(result("review", "review_base_evidence_missing", {
+        head_sha: headSha,
+        reviewed_sha: latestReview.payload.reviewed_sha,
+        pr_number: prNumber,
+        diagnostics: [...diagnostics, { code: "review_base_evidence_missing", event_id: latestReview.event_id }],
+      }), githubFacts);
+    }
     return withGithubAvailability(result("merge", "ready_to_merge", {
       head_sha: headSha,
       reviewed_sha: latestReview.payload.reviewed_sha,

--- a/skills/relay-dispatch/scripts/recover.js
+++ b/skills/relay-dispatch/scripts/recover.js
@@ -540,7 +540,7 @@ function observeGithub(runRecord, { localHeadSha = null, recordedPrNumber = null
   try {
     const rows = JSON.parse(execGh(runRecord.repo.root, [
       "pr", "list", "--repo", remote, "--head", branch, "--state", "all", "--limit", "100",
-      "--json", "number,state,url,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,isCrossRepository,mergedAt,mergeCommit,body",
+      "--json", "number,state,url,headRefName,headRefOid,baseRefName,baseRefOid,headRepository,headRepositoryOwner,isCrossRepository,mergedAt,mergeCommit,body",
     ], { timeout: 15_000 }));
     const selection = selectGithubPr(rows, { remote, branch, baseBranch, localHeadSha, recordedPrNumber });
     const pr = selection.pr;
@@ -555,7 +555,8 @@ function observeGithub(runRecord, { localHeadSha = null, recordedPrNumber = null
       pr_number: pr?.number || null, pr_state: pr?.state || null,
       head_ref: pr?.headRefName || branch, base_ref: pr?.baseRefName || baseBranch,
       head_repo: pr ? selection.headRepo(pr) : remote,
-      pr_head_sha: pr?.headRefOid || null, merge_sha: pr?.mergeCommit?.oid || null,
+      pr_head_sha: pr?.headRefOid || null, pr_base_sha: pr?.baseRefOid || null,
+      merge_sha: pr?.mergeCommit?.oid || null,
       url: pr?.url || null, body: pr?.body || null,
     };
   } catch (error) {
@@ -563,7 +564,7 @@ function observeGithub(runRecord, { localHeadSha = null, recordedPrNumber = null
       available: false, lookup_complete: false, pr_lookup_complete: false, matching_pr_count: null,
       repo: remote,
       pr_number: null, pr_state: null, head_ref: branch, base_ref: baseBranch,
-      pr_head_sha: null, merge_sha: null,
+      pr_head_sha: null, pr_base_sha: null, merge_sha: null,
       error: commandFailure(error),
     };
   }
@@ -582,13 +583,13 @@ function externalMergeObserver(record) {
     `const repo=${expectedRepo};`,
     "const b=process.argv.indexOf('--gh-bin');",
     "const bin=b>=0?process.argv[b+1]:'gh';",
-    "const ghArgs=['pr','view',String(q.pr_number),'--repo',repo,'--json','number,state,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,isCrossRepository,mergeCommit'];",
+    "const ghArgs=['pr','view',String(q.pr_number),'--repo',repo,'--json','number,state,headRefName,headRefOid,baseRefName,baseRefOid,headRepository,headRepositoryOwner,isCrossRepository,mergeCommit'];",
     "const nodeScript=process.argv.includes('--gh-node-script');",
     "const raw=execFileSync(nodeScript?process.execPath:bin,nodeScript?[bin,...ghArgs]:ghArgs,{encoding:'utf8',stdio:['ignore','pipe','pipe']});",
     "const p=JSON.parse(raw);",
     "const hr=p.headRepository&&p.headRepository.nameWithOwner||(p.headRepositoryOwner&&p.headRepositoryOwner.login&&p.headRepository&&p.headRepository.name?`${p.headRepositoryOwner.login}/${p.headRepository.name}`:null);",
     `if((q.repo&&q.repo!==repo)||p.headRefName!==${expectedHead}||p.baseRefName!==${expectedBase}||hr!==repo)throw new Error('exact PR repo/head/base identity mismatch');`,
-    "process.stdout.write(JSON.stringify({nonce:input.nonce,repo,head_repo:hr,pr_number:p.number,pr_state:p.state,pr_head_sha:p.headRefOid,head_ref:p.headRefName,base_ref:p.baseRefName,merge_sha:p.mergeCommit&&p.mergeCommit.oid}));",
+    "process.stdout.write(JSON.stringify({nonce:input.nonce,repo,head_repo:hr,pr_number:p.number,pr_state:p.state,pr_head_sha:p.headRefOid,pr_base_sha:p.baseRefOid,head_ref:p.headRefName,base_ref:p.baseRefName,merge_sha:p.mergeCommit&&p.mergeCommit.oid}));",
   ].join("");
   const args = [
     { kind: "literal", value: "-e" },

--- a/skills/relay-merge/SKILL.md
+++ b/skills/relay-merge/SKILL.md
@@ -75,13 +75,24 @@ intent. If a crash leaves that intent but GitHub proves neither the exact merge
 nor a queued request, finalize fails with an ambiguous-outcome error and
 requires canonical recovery instead of risking a duplicate call.
 
-The final preflight rechecks the immutable configured base and source SHA. The
+The final preflight rechecks the immutable configured base and source SHA. If
+the base commit advanced since review, finalize requires the reviewed base to
+be its ancestor and compares the exact reviewed Git path set with GitHub's base
+advance paths. Zero overlap remains mergeable; overlap fails typed and requires
+updating the branch onto the current base, then canonical verification and
+review. Path overlap is a proxy, so semantic conflicts across different paths
+remain outside this proof. GitHub compare caps file evidence at 300 entries;
+that boundary and incomplete commit pagination fail closed.
+
+The
 GitHub merge API provides an atomic expected-source-SHA guard
 (`--match-head-commit`) but no expected-base compare-and-swap. Therefore a base
 retarget detected before the request fails closed, while the remaining
 post-check/pre-request base nanorace—in which an external collaborator changes
 PR metadata—is a documented GitHub platform threat boundary, not a weakened
 source-SHA or configured-base invariant.
+Merge-queue/base movement after a request is rechecked on resume, but Relay
+cannot undo an externally completed merge.
 
 ### 3. Optional post-merge project updates
 

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -95,9 +95,9 @@ function gitRaw(repo, args) {
   });
 }
 
-function nulPaths(bytes) {
+function nulFields(bytes) {
   if (!Buffer.isBuffer(bytes)) fail("Git path evidence must be bytes", "MERGE_BASE_EVIDENCE_INCOMPLETE");
-  const paths = [];
+  const fields = [];
   let offset = 0;
   while (offset < bytes.length) {
     const end = bytes.indexOf(0, offset);
@@ -107,8 +107,27 @@ function nulPaths(bytes) {
     if (!Buffer.from(decoded, "utf8").equals(value)) {
       fail("Git path evidence contains a non-UTF-8 path", "MERGE_BASE_EVIDENCE_INCOMPLETE");
     }
-    if (decoded) paths.push(decoded);
+    if (!decoded) fail("Git path evidence contains an empty field", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+    fields.push(decoded);
     offset = end + 1;
+  }
+  return fields;
+}
+
+function reviewedDiffPaths(bytes) {
+  const fields = nulFields(bytes);
+  const paths = [];
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++];
+    if (!/^[ACDMRTUXB][0-9]{0,3}$/.test(status)) {
+      fail("Git path evidence contains an invalid status", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+    }
+    const count = /^[RC]/.test(status) ? 2 : 1;
+    if (index + count > fields.length) {
+      fail("Git path evidence has an incomplete status record", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+    }
+    paths.push(...fields.slice(index, index + count));
+    index += count;
   }
   return paths;
 }
@@ -173,8 +192,9 @@ function assertBaseIntegrity(record, binding, liveBase) {
         && (typeof file.previous_filename !== "string" || file.previous_filename.length === 0))
     ) fail("GitHub base-advance path evidence is malformed", "MERGE_BASE_EVIDENCE_INCOMPLETE");
   }
-  const reviewedPaths = nulPaths(gitRaw(record.git.worktree, [
-    "diff", "--name-only", "-z", "--no-ext-diff", `${record.git.start_sha}..${binding.head}`, "--",
+  const reviewedPaths = reviewedDiffPaths(gitRaw(record.git.worktree, [
+    "diff", "--name-status", "-z", "--find-renames", "--no-ext-diff",
+    `${record.git.start_sha}..${binding.head}`, "--",
   ]));
   const prPaths = new Set(reviewedPaths);
   const advancedPaths = advancedFiles.flatMap((file) => [file.filename, file.previous_filename]).filter(Boolean);

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -119,7 +119,8 @@ function reviewedDiffPaths(bytes) {
   const paths = [];
   for (let index = 0; index < fields.length;) {
     const status = fields[index++];
-    if (!/^(?:[ADMTUXB]|[RC](?:100|[0-9]{1,2}))$/.test(status)) {
+    const scored = /^([RC])([0-9]{1,3})$/.exec(status);
+    if (!/^[ADMTUXB]$/.test(status) && (!scored || Number(scored[2]) > 100)) {
       fail("Git path evidence contains an invalid status", "MERGE_BASE_EVIDENCE_INCOMPLETE");
     }
     const count = /^[RC]/.test(status) ? 2 : 1;

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -140,6 +140,12 @@ function assertBaseIntegrity(record, binding, liveBase) {
   if (comparison.status !== "ahead") {
     fail("live PR base is not a descendant of the reviewed base", "MERGE_BASE_NOT_DESCENDANT");
   }
+  if (
+    comparison.base_commit?.sha !== reviewedBase
+    || comparison.merge_base_commit?.sha !== reviewedBase
+    || comparison.head_commit?.sha !== liveBase
+    || comparePages.some((page) => !page || typeof page !== "object" || Array.isArray(page) || !Array.isArray(page.commits))
+  ) fail("GitHub comparison is not bound to the exact reviewed and live bases", "MERGE_BASE_EVIDENCE_INCOMPLETE");
   const commits = comparePages.flatMap((page) => Array.isArray(page.commits) ? page.commits : []);
   const commitShas = commits.map((commit) => commit?.sha);
   if (
@@ -148,6 +154,7 @@ function assertBaseIntegrity(record, binding, liveBase) {
     || commits.length !== comparison.total_commits
     || commitShas.some((sha) => !SHA1_RE.test(String(sha || "")))
     || new Set(commitShas).size !== commitShas.length
+    || commitShas.at(-1) !== liveBase
   ) {
     fail("GitHub base-advance commit pagination is incomplete", "MERGE_BASE_EVIDENCE_INCOMPLETE");
   }
@@ -700,7 +707,6 @@ async function finalizeRun(cli, overrides = {}) {
     binding = {
       head: derivedHead,
       prNumber: derivedPr,
-      review,
       reviewedBase: review?.payload?.base_sha,
       liveBase: initial.observations?.github?.pr_base_sha,
     };

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -119,7 +119,7 @@ function reviewedDiffPaths(bytes) {
   const paths = [];
   for (let index = 0; index < fields.length;) {
     const status = fields[index++];
-    if (!/^[ACDMRTUXB][0-9]{0,3}$/.test(status)) {
+    if (!/^(?:[ADMTUXB]|[RC](?:100|[0-9]{1,2}))$/.test(status)) {
       fail("Git path evidence contains an invalid status", "MERGE_BASE_EVIDENCE_INCOMPLETE");
     }
     const count = /^[RC]/.test(status) ? 2 : 1;

--- a/skills/relay-merge/scripts/finalize-run.js
+++ b/skills/relay-merge/scripts/finalize-run.js
@@ -88,8 +88,97 @@ function git(repo, args) {
   return command(repo, process.env.RELAY_GIT_BIN || "git", ["-C", repo, ...args]);
 }
 
+function gitRaw(repo, args) {
+  return execFileSync(process.env.RELAY_GIT_BIN || "git", ["-C", repo, ...args], {
+    cwd: repo,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function nulPaths(bytes) {
+  if (!Buffer.isBuffer(bytes)) fail("Git path evidence must be bytes", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+  const paths = [];
+  let offset = 0;
+  while (offset < bytes.length) {
+    const end = bytes.indexOf(0, offset);
+    if (end < 0) fail("Git path evidence has an incomplete record", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+    const value = bytes.subarray(offset, end);
+    const decoded = value.toString("utf8");
+    if (!Buffer.from(decoded, "utf8").equals(value)) {
+      fail("Git path evidence contains a non-UTF-8 path", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+    }
+    if (decoded) paths.push(decoded);
+    offset = end + 1;
+  }
+  return paths;
+}
+
 function gh(repo, args) {
   return command(repo, process.env.RELAY_GH_BIN || "gh", args);
+}
+
+function githubApiPages(repo, endpoint) {
+  const value = JSON.parse(gh(repo, ["api", "--paginate", "--slurp", endpoint]));
+  if (!Array.isArray(value) || !value.length) fail("GitHub returned an incomplete paginated response", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+  return value;
+}
+
+function assertBaseIntegrity(record, binding, liveBase) {
+  const reviewedBase = binding.reviewedBase;
+  if (!SHA1_RE.test(String(reviewedBase || "")) || !SHA1_RE.test(String(liveBase || ""))) {
+    fail("reviewed and live base SHAs are required", "MERGE_BASE_EVIDENCE_MISSING");
+  }
+  if (reviewedBase === liveBase) return { status: "identical", overlapping_paths: [] };
+  const comparePages = githubApiPages(
+    record.repo.root,
+    `repos/${record.repo.remote}/compare/${reviewedBase}...${liveBase}?per_page=100`,
+  );
+  const comparison = comparePages[0];
+  if (!comparison || typeof comparison !== "object" || Array.isArray(comparison)) {
+    fail("GitHub base-advance comparison is malformed", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+  }
+  if (comparison.status !== "ahead") {
+    fail("live PR base is not a descendant of the reviewed base", "MERGE_BASE_NOT_DESCENDANT");
+  }
+  const commits = comparePages.flatMap((page) => Array.isArray(page.commits) ? page.commits : []);
+  const commitShas = commits.map((commit) => commit?.sha);
+  if (
+    !Number.isInteger(comparison.total_commits)
+    || comparison.total_commits < 1
+    || commits.length !== comparison.total_commits
+    || commitShas.some((sha) => !SHA1_RE.test(String(sha || "")))
+    || new Set(commitShas).size !== commitShas.length
+  ) {
+    fail("GitHub base-advance commit pagination is incomplete", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+  }
+  const advancedFiles = Array.isArray(comparison.files) ? comparison.files : null;
+  if (!advancedFiles || advancedFiles.length >= 300) {
+    fail("GitHub base-advance file evidence is incomplete", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+  }
+  for (const file of advancedFiles) {
+    if (
+      !file
+      || typeof file !== "object"
+      || Array.isArray(file)
+      || typeof file.filename !== "string"
+      || file.filename.length === 0
+      || (file.previous_filename !== undefined
+        && (typeof file.previous_filename !== "string" || file.previous_filename.length === 0))
+    ) fail("GitHub base-advance path evidence is malformed", "MERGE_BASE_EVIDENCE_INCOMPLETE");
+  }
+  const reviewedPaths = nulPaths(gitRaw(record.git.worktree, [
+    "diff", "--name-only", "-z", "--no-ext-diff", `${record.git.start_sha}..${binding.head}`, "--",
+  ]));
+  const prPaths = new Set(reviewedPaths);
+  const advancedPaths = advancedFiles.flatMap((file) => [file.filename, file.previous_filename]).filter(Boolean);
+  const overlap = [...new Set(advancedPaths.filter((name) => prPaths.has(name)))].sort();
+  if (overlap.length) {
+    const error = new Error(`base advanced across reviewed PR paths: ${overlap.join(", ")}; update the branch onto the current base, then run canonical verification and review`);
+    error.code = "MERGE_BASE_PATH_OVERLAP";
+    error.collision_paths = overlap;
+    throw error;
+  }
+  return { status: "advanced_without_overlap", overlapping_paths: [] };
 }
 
 function operatorName(repo, explicit) {
@@ -302,6 +391,7 @@ function normalizePr(record, raw) {
     pr_number: raw?.number,
     pr_state: raw?.state,
     pr_head_sha: raw?.headRefOid,
+    pr_base_sha: raw?.baseRefOid,
     head_ref: raw?.headRefName,
     base_ref: raw?.baseRefName,
     merge_sha: raw?.mergeCommit?.oid || null,
@@ -313,7 +403,7 @@ function normalizePr(record, raw) {
 function observeLivePr(record, prNumber) {
   const raw = JSON.parse(gh(record.repo.root, [
     "pr", "view", String(prNumber), "--repo", record.repo.remote,
-    "--json", "number,state,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus",
+    "--json", "number,state,headRefName,headRefOid,baseRefName,baseRefOid,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus",
   ]));
   return normalizePr(record, raw);
 }
@@ -353,11 +443,11 @@ function mergeObserver(record) {
     "const input=JSON.parse(fs.readFileSync(process.argv[i+1],'utf8')),q=input.request;",
     `const repo=${JSON.stringify(record.repo.remote)};`,
     "const b=process.argv.indexOf('--gh-bin'),bin=b>=0?process.argv[b+1]:'gh';",
-    "const a=['pr','view',String(q.pr_number),'--repo',repo,'--json','number,state,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus'];",
+    "const a=['pr','view',String(q.pr_number),'--repo',repo,'--json','number,state,headRefName,headRefOid,baseRefName,baseRefOid,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus'];",
     "const raw=execFileSync(process.argv.includes('--gh-node-script')?process.execPath:bin,process.argv.includes('--gh-node-script')?[bin,...a]:a,{encoding:'utf8',stdio:['ignore','pipe','pipe']});",
     "const p=JSON.parse(raw),hr=p.headRepository&&p.headRepository.nameWithOwner||(p.headRepositoryOwner&&p.headRepositoryOwner.login&&p.headRepository&&p.headRepository.name?`${p.headRepositoryOwner.login}/${p.headRepository.name}`:null);",
     `if((q.repo&&q.repo!==repo)||hr!==repo||p.headRefName!==${JSON.stringify(record.git.branch)}||p.baseRefName!==${JSON.stringify(record.git.base_branch)})throw new Error('exact PR identity mismatch');`,
-    "process.stdout.write(JSON.stringify({nonce:input.nonce,repo,head_repo:hr,pr_number:p.number,pr_state:p.state,pr_head_sha:p.headRefOid,head_ref:p.headRefName,base_ref:p.baseRefName,merge_sha:p.mergeCommit&&p.mergeCommit.oid||null,auto_merge_request:p.autoMergeRequest||null,merge_state_status:p.mergeStateStatus||null}));",
+    "process.stdout.write(JSON.stringify({nonce:input.nonce,repo,head_repo:hr,pr_number:p.number,pr_state:p.state,pr_head_sha:p.headRefOid,pr_base_sha:p.baseRefOid,head_ref:p.headRefName,base_ref:p.baseRefName,merge_sha:p.mergeCommit&&p.mergeCommit.oid||null,auto_merge_request:p.autoMergeRequest||null,merge_state_status:p.mergeStateStatus||null}));",
   ].join("");
   const args = [
     { kind: "literal", value: "-e" },
@@ -388,6 +478,7 @@ function assertExactPr(observed, record, binding, allowedStates) {
     || observed.head_repo !== record.repo.remote
     || observed.pr_number !== binding.prNumber
     || observed.pr_head_sha !== binding.head
+    || !SHA1_RE.test(String(observed.pr_base_sha || ""))
     || observed.head_ref !== record.git.branch
     || observed.base_ref !== record.git.base_branch
   ) fail("fresh GitHub observation changed PR identity or state", "MERGE_LIVE_OBSERVATION_MISMATCH");
@@ -466,6 +557,7 @@ function productionServices() {
   return {
     authenticatedGithubLogin,
     cleanupWorktree,
+    assertBaseIntegrity,
     inspectRun: inspectProductionRun,
     mergeObserver,
     mergePullRequest,
@@ -604,7 +696,14 @@ async function finalizeRun(cli, overrides = {}) {
       || !SHA1_RE.test(String(derivedHead || ""))
       || !Number.isInteger(derivedPr)
     ) throw error;
-    binding = { head: derivedHead, prNumber: derivedPr };
+    const review = initial.facts.filter((fact) => fact.type === "review_recorded").at(-1);
+    binding = {
+      head: derivedHead,
+      prNumber: derivedPr,
+      review,
+      reviewedBase: review?.payload?.base_sha,
+      liveBase: initial.observations?.github?.pr_base_sha,
+    };
   }
   const method = cli.values["merge-method"];
   const preferredId = operationId(record, binding, method, cli.values["operation-id"] || null);
@@ -617,6 +716,7 @@ async function finalizeRun(cli, overrides = {}) {
   if (cli.values["dry-run"]) {
     if (initial.derived?.action !== "merge") fail("dry-run cannot resume an in-flight merge", "MERGE_DRY_RUN_RESUME_UNSUPPORTED");
     const gate = requireMergeAction(initial, record);
+    services.assertBaseIntegrity(record, gate, gate.liveBase);
     return {
       run_id: record.run_id,
       status: "ready_to_merge",
@@ -655,6 +755,9 @@ async function finalizeRun(cli, overrides = {}) {
       binding,
       hasAuthorization ? new Set(["OPEN", "MERGED"]) : new Set(["OPEN"]),
     );
+    if (freshBinding.liveBase && direct.pr_base_sha !== freshBinding.liveBase) {
+      fail("direct GitHub observation changed the live base SHA", "MERGE_BASE_OBSERVATION_MISMATCH");
+    }
     const revalidated = await services.revalidateExternalFacts({
       runDir,
       lockContext,
@@ -663,6 +766,7 @@ async function finalizeRun(cli, overrides = {}) {
         repo: record.repo.remote,
         pr_number: binding.prNumber,
         expected_pr_head_sha: binding.head,
+        expected_pr_base_sha: direct.pr_base_sha,
         expected_head_ref: record.git.branch,
         expected_base_ref: record.git.base_branch,
         expected_state: direct.pr_state,
@@ -677,12 +781,15 @@ async function finalizeRun(cli, overrides = {}) {
           hasAuthorization ? new Set(["OPEN", "MERGED"]) : new Set(["OPEN"]),
         );
         if (
+          observed.pr_base_sha !== direct.pr_base_sha
+          ||
           isMergePending(observed) !== isMergePending(direct)
           || (isMergePending(direct) && pendingMethod(observed) !== pendingMethod(direct))
         ) fail("merge queue state changed across independent observations", "MERGE_QUEUE_OBSERVATION_MISMATCH");
         return { authorized: true };
       },
     });
+    services.assertBaseIntegrity(record, freshBinding, revalidated.facts.pr_base_sha);
     if (!hasAuthorization && isMergePending(revalidated.facts)) {
       fail("an existing external merge queue request requires canonical recover", "MERGE_RECOVER_REQUIRED");
     }
@@ -779,6 +886,7 @@ async function finalizeRun(cli, overrides = {}) {
         binding,
         new Set(["OPEN"]),
       );
+      services.assertBaseIntegrity(record, freshBinding, preflight.pr_base_sha);
       if (isMergePending(preflight)) {
         fail("merge queue state changed immediately before the merge request", "MERGE_QUEUE_OBSERVATION_MISMATCH");
       }
@@ -912,6 +1020,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  assertBaseIntegrity,
   assertExactPr,
   cleanupWorktree,
   finalizeRun,

--- a/skills/relay-merge/scripts/review-gate.js
+++ b/skills/relay-merge/scripts/review-gate.js
@@ -141,6 +141,12 @@ function requireMergeAction(inspection, record) {
     || review.payload.done_criteria_sha256 !== record.contract.done_criteria_sha256
     || review.payload.reviewer !== record.roles.reviewer
   ) fail("passing review is not bound to the exact head and frozen Done Criteria", "MERGE_REVIEW_MISMATCH");
+  if (!SHA1_RE.test(String(review.payload.base_sha || ""))) {
+    fail("passing review is missing its exact reviewed base SHA; run a fresh review", "MERGE_REVIEW_BASE_MISSING");
+  }
+  if (!SHA1_RE.test(String(github.pr_base_sha || ""))) {
+    fail("live PR observation is missing its exact base SHA", "MERGE_LIVE_BASE_MISSING");
+  }
 
   const verification = latestFact(inspection.facts, "verification_recorded");
   if (
@@ -152,7 +158,7 @@ function requireMergeAction(inspection, record) {
     || verification.payload.done_criteria_sha256 !== record.contract.done_criteria_sha256
   ) fail("passing verification is not bound to the exact head, tree, and Done Criteria", "MERGE_VERIFICATION_MISMATCH");
 
-  return { head, prNumber, review, verification };
+  return { head, prNumber, review, verification, reviewedBase: review.payload.base_sha, liveBase: github.pr_base_sha };
 }
 
 function terminalMergeFact(runDir, factsModule) {

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -187,12 +187,16 @@ function requireReviewAction(inspection, record) {
     return { head, tree, prNumber: null, verification, retryOfEventId, local: true };
   }
   const head = inspection.observations?.github?.pr_head_sha;
+  const base = inspection.observations?.github?.pr_base_sha;
   const prNumber = inspection.observations?.github?.pr_number;
   if (!SHA1_RE.test(String(head || "")) || head !== inspection.derived.head_sha) {
     fail("live PR head must exactly equal the derived current head", "REVIEW_HEAD_MISMATCH");
   }
   if (!Number.isInteger(prNumber) || prNumber < 1 || prNumber !== inspection.derived.pr_number) {
     fail("live PR identity must exactly equal the durable derived PR", "REVIEW_PR_MISMATCH");
+  }
+  if (!SHA1_RE.test(String(base || ""))) {
+    fail("live PR base must be an exact commit SHA", "REVIEW_BASE_MISSING");
   }
   const durablePr = inspection.facts.filter((fact) => fact.type === "pull_request_recorded").at(-1);
   if (!durablePr || durablePr.payload.pr_number !== prNumber || durablePr.payload.head_sha !== head) {
@@ -214,7 +218,7 @@ function requireReviewAction(inspection, record) {
   )) {
     fail("retry review action is not bound to the latest durable escalation", "REVIEW_RETRY_BINDING_MISMATCH");
   }
-  return { head, prNumber, verification, retryOfEventId, local: false };
+  return { head, base, prNumber, verification, retryOfEventId, local: false };
 }
 
 function reviewPrompt({ record, binding, criteria, diff }) {
@@ -232,6 +236,7 @@ function reviewPrompt({ record, binding, criteria, diff }) {
     `Branch: ${record.git.branch} -> ${record.git.base_branch}`,
     binding.local ? "PR: none (local Git review)" : `PR: #${binding.prNumber}`,
     `Reviewed SHA: ${binding.head}`,
+    `Base SHA: ${binding.base || record.git.start_sha}`,
     `Done Criteria SHA-256: ${record.contract.done_criteria_sha256}`,
     `Verification fact: ${JSON.stringify(binding.verification)}`,
     "",
@@ -431,6 +436,7 @@ async function runReview(cli, overrides = {}) {
         prompt_path: promptPath,
         done_criteria_path: record.contract.done_criteria_path,
         reviewed_sha: binding.head,
+        base_sha: binding.base || record.git.start_sha,
         current_sha: binding.head,
         diff_sha256: diffDigest,
         prompt_sha256: promptDigest,
@@ -508,6 +514,7 @@ async function runReview(cli, overrides = {}) {
     if (
       freshBinding.retryOfEventId !== binding.retryOfEventId
       || freshBinding.head !== binding.head
+      || freshBinding.base !== binding.base
       || freshBinding.local !== binding.local
       || freshBinding.tree !== binding.tree
       || freshBinding.prNumber !== binding.prNumber
@@ -546,6 +553,7 @@ async function runReview(cli, overrides = {}) {
         round,
         verdict: verdict.verdict === "pass" ? "lgtm" : verdict.verdict,
         reviewed_sha: binding.head,
+        base_sha: binding.base || record.git.start_sha,
         done_criteria_sha256: record.contract.done_criteria_sha256,
         reviewer,
         review_artifact: artifactPath,

--- a/tests/relay-dispatch/scripts/facts.test.js
+++ b/tests/relay-dispatch/scripts/facts.test.js
@@ -97,6 +97,7 @@ function payload(type) {
     },
     review_recorded: {
       round: 1, verdict: "pass", reviewed_sha: SHA2,
+      base_sha: SHA,
       done_criteria_sha256: HASH, reviewer: "claude",
       review_artifact: "/r/review.json", override: null,
     },
@@ -420,6 +421,12 @@ test("appending a review verdict without executed runtime evidence fails closed"
       (error) => error.code === "INVALID_FACT" && /executed_runtime is required when appending review_recorded/.test(error.message),
     );
     assert.equal(readFacts({ eventsPath }).facts.length, 0, "the rejected verdict must not reach the journal");
+    const missingBase = fact("review_recorded");
+    delete missingBase.payload.base_sha;
+    assert.throws(
+      () => appendFact({ eventsPath, fact: { ...missingBase, payload: { ...missingBase.payload, executed_runtime } }, lockContext: lock }),
+      (error) => error.code === "INVALID_FACT" && /base_sha is required when appending review_recorded/.test(error.message),
+    );
     const bound = fact("review_recorded");
     appendFact({ eventsPath, fact: { ...bound, payload: { ...bound.payload, executed_runtime } }, lockContext: lock });
     assert.equal(readFacts({ eventsPath }).facts.at(-1).payload.executed_runtime.executable.ino, 2);

--- a/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
+++ b/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
@@ -152,7 +152,7 @@ function verificationFact() {
   };
 }
 
-function reviewFact({ eventId, verdict = "escalated", escalationKind, retryOfEventId } = {}) {
+function reviewFact({ eventId, verdict = "escalated", escalationKind, retryOfEventId, baseSha } = {}) {
   return {
     event_id: eventId,
     run_id: "issue-1135-test",
@@ -163,6 +163,7 @@ function reviewFact({ eventId, verdict = "escalated", escalationKind, retryOfEve
       round: retryOfEventId ? 2 : 1,
       verdict,
       reviewed_sha: HEAD,
+      ...(baseSha ? { base_sha: baseSha } : {}),
       done_criteria_sha256: HASH,
       reviewer: "claude",
       review_artifact: "/run/review.json",
@@ -501,7 +502,7 @@ test("inspect exposes one retry for a runtime escalation and exhausts that subje
     git: { ...publicationObservations().git, reviewable_work: false },
     github: {
       ...publicationObservations().github,
-      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN", pr_head_sha: HEAD,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN", pr_head_sha: HEAD, pr_base_sha: START,
     },
   });
   const firstFact = reviewFact({ eventId: "review-runtime-1", escalationKind: "runtime_failure" });
@@ -536,6 +537,7 @@ test("inspect accepts the immediate single passing retry", async () => {
   const retryPass = reviewFact({
     eventId: "review-runtime-pass-2",
     verdict: "pass",
+    baseSha: START,
     retryOfEventId: firstFact.event_id,
   });
   const result = await inspectRun(harness({
@@ -544,6 +546,23 @@ test("inspect accepts the immediate single passing retry", async () => {
   }));
   assert.equal(result.derived.action, "merge");
   assert.equal(result.derived.reason, "ready_to_merge");
+});
+
+test("a historical passing GitHub review without base evidence derives one fresh review", async () => {
+  const observations = publicationObservations({
+    git: { ...publicationObservations().git, reviewable_work: false },
+    github: {
+      ...publicationObservations().github,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN",
+      pr_head_sha: HEAD, pr_base_sha: START,
+    },
+  });
+  const result = await inspectRun(harness({
+    facts: [pullRequestFact(HEAD), verificationFact(), reviewFact({ eventId: "historical-pass", verdict: "pass" })],
+    observations,
+  }));
+  assert.equal(result.derived.action, "review");
+  assert.equal(result.derived.reason, "review_base_evidence_missing");
 });
 
 test("inspect rejects a passing retry without a matching initial runtime failure", async () => {

--- a/tests/relay-dispatch/scripts/run-fold.test.js
+++ b/tests/relay-dispatch/scripts/run-fold.test.js
@@ -88,7 +88,7 @@ function verification(index = 4, overrides = {}) {
 
 function review(verdict, index = 4, reviewedSha = HEAD, hash = HASH) {
   return fact("review_recorded", index, {
-    round: 1, verdict, reviewed_sha: reviewedSha, done_criteria_sha256: hash,
+    round: 1, verdict, reviewed_sha: reviewedSha, base_sha: START, done_criteria_sha256: hash,
     reviewer: "claude", review_artifact: "/r/review.json", override: null,
   });
 }
@@ -99,6 +99,7 @@ function livePrFacts(prNumber = 42, overrides = {}) {
     pr_number: prNumber,
     repo: "owner/repo",
     pr_head_sha: HEAD,
+    pr_base_sha: START,
     head_ref: "work",
     base_ref: "main",
     pr_state: "OPEN",
@@ -745,19 +746,19 @@ test("#1209 freezes GitHub action, reason, and action-key contracts", async () =
     ["publication recovery", [started(), finished()], publication,
       "recover", "publication_incomplete", "17783b1eb88a4ae0bedfd64c697c7280d8bebf6cf2649e244228de1c61ae722a"],
     ["review", baseFacts, { ...publication, github: open },
-      "review", "review_missing", "4d8ae47b98c90b1ba1b7c0c81abea2f29f934b9d8e38f3e7e320fec0bceb1354"],
+      "review", "review_missing", "1663d8b5a357664e54e8582010ab03c140142e588392a9129a69413da6e59596"],
     ["stale review", [...baseFacts, review("pass", 5, START)], { ...publication, github: open },
-      "review", "review_stale", "bfca830e29b3f3108cb7f61fda91d2197ab8115bab12942f45267e1e6da3018d"],
+      "review", "review_stale", "6daf7d4139abde3abf9fa3fe4fe8c8ade2e23dc8aa531d60f2ac429f8c939eb5"],
     ["ready to merge", [...baseFacts, review("pass", 5)], { ...publication, github: open },
-      "merge", "ready_to_merge", "d0a837542d6801de5c0205e3c2f0a0ff9e2536f66a36309440cbeca3819816bd"],
+      "merge", "ready_to_merge", "24a67bb5446a87f71475db6bddf0b5c7fab192768e274e00cc7c1ed4ec37c6a4"],
     ["externally merged", [started(), finished(), pr()], {
       ...publication,
       github: { ...open, pr_state: "MERGED", merge_sha: TARGET },
-    }, "recover", "merged_pr_unrecorded", "5b3a7c5628fafee5c631bbd798eee56c7dce2ace4e22b28db502ddeae300ac53"],
+    }, "recover", "merged_pr_unrecorded", "a5ccad2aeb73aeeaa275c8912365bbae2c740e6b25d3b372b516de840a617f2b"],
     ["GitHub unavailable", baseFacts, {
       ...publication,
       github: { ...open, available: false },
-    }, "none", "github_unavailable", "3d5880c22fafe7de50341e9271c1e7e644ed288f280421220b4341f75d8e948e"],
+    }, "none", "github_unavailable", "2c9bb31af3f937cf3a7cf884fe5eae7045ee77752830a0ab7dfbea1b9b3b99cb"],
     ["merge conflict observation", [started(), finished()], {
       ...publication,
       git: { ...publication.git, remote_relation: "diverged" },

--- a/tests/relay-merge/fixtures/merge-observer.js
+++ b/tests/relay-merge/fixtures/merge-observer.js
@@ -15,6 +15,7 @@ process.stdout.write(JSON.stringify({
   pr_number: request.pr_number,
   pr_state: merged ? "MERGED" : "OPEN",
   pr_head_sha: request.expected_pr_head_sha,
+  pr_base_sha: request.expected_pr_base_sha || "a".repeat(40),
   head_ref: request.expected_head_ref,
   base_ref: request.expected_base_ref,
   merge_sha: merged ? (request.expected_result_target_sha || "c".repeat(40)) : null,

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -62,7 +62,7 @@ function row() {
 }
 if (args[0] === "auth" && args[1] === "token") process.stdout.write("test-token\\n");
 else if (args[0] === "api" && args[1] === "user") process.stdout.write(state.authLogin + "\\n");
-else if (args[0] === "api" && args.includes("--slurp")) process.stdout.write(JSON.stringify([state.compareResponse]));
+else if (args[0] === "api" && args.includes("--slurp")) process.stdout.write(JSON.stringify(state.comparePages || [state.compareResponse]));
 else if (args[0] === "pr" && args[1] === "list") process.stdout.write(JSON.stringify([row()]));
 else if (args[0] === "pr" && args[1] === "view") {
   if (state.retargetBaseOnView) {
@@ -231,6 +231,15 @@ const result=spawnSync("/usr/bin/git",args,{stdio:"inherit"});process.exit(resul
 `, { mode: 0o755 });
   const value = { root, repo, origin, worktree, runDir, record, label, head, tree, criteriaHash, gitBin };
   await appendReadyFacts(value);
+  const configuredGithub = { ...github };
+  if (configuredGithub.compareResponse) {
+    configuredGithub.compareResponse = {
+      ...configuredGithub.compareResponse,
+      base_commit: { sha: start },
+      merge_base_commit: { sha: start },
+      head_commit: { sha: configuredGithub.baseRefOid },
+    };
+  }
   const gh = writeFakeGh(root, {
     number: 42,
     state: "OPEN",
@@ -244,7 +253,7 @@ const result=spawnSync("/usr/bin/git",args,{stdio:"inherit"});process.exit(resul
     authLogin: "relay-bot",
     mergeExitCode: 0,
     advanceHeadOnMerge: null,
-    ...github,
+    ...configuredGithub,
   });
   value.gh = gh;
   value.cli = finalize.parseCli(["--repo", repo, "--run-dir", runDir, "--json"]);
@@ -367,13 +376,28 @@ test("base movement allows zero reviewed-path overlap and rejects unsafe or inco
     const advanced = "e".repeat(40);
     const writeComparison = (compareResponse) => {
       const state = JSON.parse(fs.readFileSync(value.gh.statePath, "utf8"));
-      fs.writeFileSync(value.gh.statePath, JSON.stringify({ ...state, compareResponse }));
+      fs.writeFileSync(value.gh.statePath, JSON.stringify({
+        ...state,
+        ...(Array.isArray(compareResponse)
+          ? { comparePages: compareResponse }
+          : { compareResponse, comparePages: null }),
+      }));
     };
-    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "other.txt" }] });
+    const comparison = (overrides = {}) => ({
+      status: "ahead",
+      base_commit: { sha: binding.reviewedBase },
+      merge_base_commit: { sha: binding.reviewedBase },
+      head_commit: { sha: advanced },
+      total_commits: 1,
+      commits: [{ sha: advanced }],
+      files: [],
+      ...overrides,
+    });
+    writeComparison(comparison({ files: [{ filename: "other.txt" }] }));
     assert.deepEqual(finalize.assertBaseIntegrity(value.record, binding, advanced), {
       status: "advanced_without_overlap", overlapping_paths: [],
     });
-    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "renamed.txt", previous_filename: "file.txt" }] });
+    writeComparison(comparison({ files: [{ filename: "renamed.txt", previous_filename: "file.txt" }] }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
       (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === "file.txt");
     const unusual = "한글\npath.txt";
@@ -381,16 +405,20 @@ test("base movement allows zero reviewed-path overlap and rejects unsafe or inco
     git(value.worktree, ["add", unusual]);
     git(value.worktree, ["commit", "-m", "add unusual path"]);
     binding.head = git(value.worktree, ["rev-parse", "HEAD"]);
-    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: unusual }] });
+    writeComparison(comparison({ files: [{ filename: unusual }] }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
       (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === unusual);
-    writeComparison({ status: "diverged", total_commits: 1, commits: [{ sha: advanced }], files: [] });
+    writeComparison(comparison({ status: "diverged" }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_NOT_DESCENDANT" });
-    writeComparison({ status: "ahead", total_commits: 2, commits: [{ sha: advanced }], files: [] });
+    writeComparison(comparison({ total_commits: 2 }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
-    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: null }] });
+    writeComparison(comparison({ files: [{ filename: null }] }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
-    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: Array.from({ length: 300 }, (_, index) => ({ filename: `f-${index}` })) });
+    writeComparison(comparison({ head_commit: { sha: "f".repeat(40) } }));
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+    writeComparison([comparison(), {}]);
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+    writeComparison(comparison({ files: Array.from({ length: 300 }, (_, index) => ({ filename: `f-${index}` })) }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
   } finally {
     if (prior === undefined) delete process.env.RELAY_GH_BIN;
@@ -400,9 +428,15 @@ test("base movement allows zero reviewed-path overlap and rejects unsafe or inco
 
 test("finalize merges a non-overlapping base advance and makes zero merge calls on overlap", async () => {
   const advanced = "e".repeat(40);
+  const compareResponse = (filename) => ({
+    status: "ahead",
+    total_commits: 1,
+    commits: [{ sha: advanced }],
+    files: [{ filename }],
+  });
   const noOverlap = await fixture("base-no-overlap", { github: {
     baseRefOid: advanced,
-    compareResponse: { status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "other.txt" }] },
+    compareResponse: compareResponse("other.txt"),
   } });
   const merged = await withGh(noOverlap, () => finalize.finalizeRun(noOverlap.cli, services()));
   assert.equal(merged.status, "merged");
@@ -410,7 +444,7 @@ test("finalize merges a non-overlapping base advance and makes zero merge calls 
 
   const overlap = await fixture("base-overlap", { github: {
     baseRefOid: advanced,
-    compareResponse: { status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "file.txt" }] },
+    compareResponse: compareResponse("file.txt"),
   } });
   await assert.rejects(
     withGh(overlap, () => finalize.finalizeRun(overlap.cli, services())),

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -408,6 +408,14 @@ test("base movement allows zero reviewed-path overlap and rejects unsafe or inco
     writeComparison(comparison({ files: [{ filename: unusual }] }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
       (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === unusual);
+    fs.writeFileSync(path.join(value.worktree, "file.txt"), "before\n");
+    git(value.worktree, ["commit", "-am", "restore rename source"]);
+    git(value.worktree, ["mv", "file.txt", "renamed.txt"]);
+    git(value.worktree, ["commit", "-m", "rename reviewed path"]);
+    binding.head = git(value.worktree, ["rev-parse", "HEAD"]);
+    writeComparison(comparison({ files: [{ filename: "file.txt" }] }));
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
+      (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === "file.txt");
     writeComparison(comparison({ status: "diverged" }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_NOT_DESCENDANT" });
     writeComparison(comparison({ total_commits: 2 }));

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -48,6 +48,7 @@ function row() {
     url: "https://example.test/pr/42",
     headRefName: state.headRefName,
     headRefOid: state.headRefOid,
+    baseRefOid: state.baseRefOid,
     baseRefName: state.baseRefName,
     headRepository: { nameWithOwner: state.repo, name: state.repo.split("/").at(-1) },
     headRepositoryOwner: { login: state.repo.split("/")[0] },
@@ -61,6 +62,7 @@ function row() {
 }
 if (args[0] === "auth" && args[1] === "token") process.stdout.write("test-token\\n");
 else if (args[0] === "api" && args[1] === "user") process.stdout.write(state.authLogin + "\\n");
+else if (args[0] === "api" && args.includes("--slurp")) process.stdout.write(JSON.stringify([state.compareResponse]));
 else if (args[0] === "pr" && args[1] === "list") process.stdout.write(JSON.stringify([row()]));
 else if (args[0] === "pr" && args[1] === "view") {
   if (state.retargetBaseOnView) {
@@ -158,6 +160,7 @@ async function appendReadyFacts(value) {
         round: 1,
         verdict: "lgtm",
         reviewed_sha: value.head,
+        base_sha: value.record.git.start_sha,
         done_criteria_sha256: value.criteriaHash,
         reviewer: "codex",
         review_artifact: path.join(value.runDir, "review.json"),
@@ -234,6 +237,7 @@ const result=spawnSync("/usr/bin/git",args,{stdio:"inherit"});process.exit(resul
     headRefName: record.git.branch,
     headRefOid: head,
     baseRefName: "main",
+    baseRefOid: start,
     repo: record.repo.remote,
     mergeCommit: null,
     resultTargetSha: "c".repeat(40),
@@ -349,6 +353,70 @@ test("Relay finalize performs one explicit merge, records exact provenance, and 
   const log = fs.readFileSync(value.gh.logPath, "utf8");
   assert.equal((log.match(/^pr merge /gm) || []).length, 1);
   assert.match(log, new RegExp(`pr merge 42 .*--match-head-commit ${value.head}`));
+});
+
+test("base movement allows zero reviewed-path overlap and rejects unsafe or incomplete evidence", async () => {
+  const value = await fixture("base-integrity");
+  const prior = process.env.RELAY_GH_BIN;
+  process.env.RELAY_GH_BIN = value.gh.scriptPath;
+  try {
+    const binding = { head: value.head, prNumber: 42, reviewedBase: value.record.git.start_sha };
+    assert.deepEqual(finalize.assertBaseIntegrity(value.record, binding, value.record.git.start_sha), {
+      status: "identical", overlapping_paths: [],
+    });
+    const advanced = "e".repeat(40);
+    const writeComparison = (compareResponse) => {
+      const state = JSON.parse(fs.readFileSync(value.gh.statePath, "utf8"));
+      fs.writeFileSync(value.gh.statePath, JSON.stringify({ ...state, compareResponse }));
+    };
+    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "other.txt" }] });
+    assert.deepEqual(finalize.assertBaseIntegrity(value.record, binding, advanced), {
+      status: "advanced_without_overlap", overlapping_paths: [],
+    });
+    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "renamed.txt", previous_filename: "file.txt" }] });
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
+      (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === "file.txt");
+    const unusual = "한글\npath.txt";
+    fs.writeFileSync(path.join(value.worktree, unusual), "reviewed\n");
+    git(value.worktree, ["add", unusual]);
+    git(value.worktree, ["commit", "-m", "add unusual path"]);
+    binding.head = git(value.worktree, ["rev-parse", "HEAD"]);
+    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: unusual }] });
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
+      (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === unusual);
+    writeComparison({ status: "diverged", total_commits: 1, commits: [{ sha: advanced }], files: [] });
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_NOT_DESCENDANT" });
+    writeComparison({ status: "ahead", total_commits: 2, commits: [{ sha: advanced }], files: [] });
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: null }] });
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+    writeComparison({ status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: Array.from({ length: 300 }, (_, index) => ({ filename: `f-${index}` })) });
+    assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+  } finally {
+    if (prior === undefined) delete process.env.RELAY_GH_BIN;
+    else process.env.RELAY_GH_BIN = prior;
+  }
+});
+
+test("finalize merges a non-overlapping base advance and makes zero merge calls on overlap", async () => {
+  const advanced = "e".repeat(40);
+  const noOverlap = await fixture("base-no-overlap", { github: {
+    baseRefOid: advanced,
+    compareResponse: { status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "other.txt" }] },
+  } });
+  const merged = await withGh(noOverlap, () => finalize.finalizeRun(noOverlap.cli, services()));
+  assert.equal(merged.status, "merged");
+  assert.equal((fs.readFileSync(noOverlap.gh.logPath, "utf8").match(/^pr merge /gm) || []).length, 1);
+
+  const overlap = await fixture("base-overlap", { github: {
+    baseRefOid: advanced,
+    compareResponse: { status: "ahead", total_commits: 1, commits: [{ sha: advanced }], files: [{ filename: "file.txt" }] },
+  } });
+  await assert.rejects(
+    withGh(overlap, () => finalize.finalizeRun(overlap.cli, services())),
+    (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === "file.txt",
+  );
+  assert.equal((fs.readFileSync(overlap.gh.logPath, "utf8").match(/^pr merge /gm) || []).length, 0);
 });
 
 test("crash after GitHub merge resumes the durable authorization without a duplicate merge fact", async () => {

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -428,12 +428,18 @@ test("base movement allows zero reviewed-path overlap and rejects unsafe or inco
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
     writeComparison(comparison());
     const malformedGit = path.join(value.root, "malformed-git.js");
-    fs.writeFileSync(malformedGit, '#!/usr/bin/env node\nprocess.stdout.write(Buffer.from("M999\\0file.txt\\0"));\n', { mode: 0o755 });
+    fs.writeFileSync(malformedGit, '#!/usr/bin/env node\nprocess.stdout.write(Buffer.from(process.env.RELAY_TEST_GIT_BYTES, "base64"));\n', { mode: 0o755 });
     const priorGit = process.env.RELAY_GIT_BIN;
     process.env.RELAY_GIT_BIN = malformedGit;
     try {
+      process.env.RELAY_TEST_GIT_BYTES = Buffer.from("R076\0file.txt\0renamed.txt\0").toString("base64");
+      writeComparison(comparison({ files: [{ filename: "file.txt" }] }));
+      assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced),
+        (error) => error.code === "MERGE_BASE_PATH_OVERLAP" && error.collision_paths[0] === "file.txt");
+      process.env.RELAY_TEST_GIT_BYTES = Buffer.from("M999\0file.txt\0").toString("base64");
       assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
     } finally {
+      delete process.env.RELAY_TEST_GIT_BYTES;
       if (priorGit === undefined) delete process.env.RELAY_GIT_BIN;
       else process.env.RELAY_GIT_BIN = priorGit;
     }

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -426,6 +426,17 @@ test("base movement allows zero reviewed-path overlap and rejects unsafe or inco
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
     writeComparison([comparison(), {}]);
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+    writeComparison(comparison());
+    const malformedGit = path.join(value.root, "malformed-git.js");
+    fs.writeFileSync(malformedGit, '#!/usr/bin/env node\nprocess.stdout.write(Buffer.from("M999\\0file.txt\\0"));\n', { mode: 0o755 });
+    const priorGit = process.env.RELAY_GIT_BIN;
+    process.env.RELAY_GIT_BIN = malformedGit;
+    try {
+      assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
+    } finally {
+      if (priorGit === undefined) delete process.env.RELAY_GIT_BIN;
+      else process.env.RELAY_GIT_BIN = priorGit;
+    }
     writeComparison(comparison({ files: Array.from({ length: 300 }, (_, index) => ({ filename: `f-${index}` })) }));
     assert.throws(() => finalize.assertBaseIntegrity(value.record, binding, advanced), { code: "MERGE_BASE_EVIDENCE_INCOMPLETE" });
   } finally {

--- a/tests/relay-merge/scripts/review-gate-core.test.js
+++ b/tests/relay-merge/scripts/review-gate-core.test.js
@@ -7,6 +7,7 @@ const { requireMergeAction } = require("../../../skills/relay-merge/scripts/revi
 
 const head = "a".repeat(40);
 const tree = "b".repeat(40);
+const base = "e".repeat(40);
 const criteria = "c".repeat(64);
 const record = {
   repo: { remote: "owner/repo" },
@@ -31,6 +32,7 @@ function inspection() {
         head_ref: "issue-42",
         base_ref: "main",
         pr_head_sha: head,
+        pr_base_sha: base,
       },
       git: {
         head_sha: head,
@@ -42,7 +44,7 @@ function inspection() {
     facts: [
       { type: "pull_request_recorded", payload: { pr_number: 42, repo: "owner/repo", head_ref: "issue-42", base_ref: "main", head_sha: head } },
       { type: "verification_recorded", payload: { status: "passed", exit_code: 0, head_sha: head, tree_sha: tree, done_criteria_sha256: criteria } },
-      { type: "review_recorded", payload: { verdict: "lgtm", reviewed_sha: head, done_criteria_sha256: criteria, reviewer: "codex" } },
+      { type: "review_recorded", payload: { verdict: "lgtm", reviewed_sha: head, base_sha: base, done_criteria_sha256: criteria, reviewer: "codex" } },
     ],
   };
 }
@@ -51,6 +53,8 @@ test("merge gate binds live PR, remote/worktree head, verification, review, and 
   const binding = requireMergeAction(inspection(), record);
   assert.equal(binding.head, head);
   assert.equal(binding.prNumber, 42);
+  assert.equal(binding.reviewedBase, base);
+  assert.equal(binding.liveBase, base);
 });
 
 test("merge gate rejects mutable observation, review, and verification drift", () => {

--- a/tests/relay-review/fixtures/fake-gh.js
+++ b/tests/relay-review/fixtures/fake-gh.js
@@ -9,6 +9,7 @@ const mergeGateResponse = (fixture) => ({
   mergeable: fixture.mergeable || "MERGEABLE",
   statusCheckRollup: fixture.statusCheckRollup || [],
   headRefOid: fixture.headRefOid || "a".repeat(40),
+  baseRefOid: fixture.baseRefOid || "b".repeat(40),
   title: fixture.title || "Fixture PR",
 });
 
@@ -60,7 +61,7 @@ const PR_VIEW_JSON_REGISTRY = Object.freeze({
     const state = loadState();
     return { state: state.state, mergeCommit: state.mergeCommit };
   },
-  "number,state,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus": finalizeResponse,
+  "number,state,headRefName,headRefOid,baseRefName,baseRefOid,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus": finalizeResponse,
   "comments,commits,mergeable,statusCheckRollup": mergeGateResponse,
   "baseRefName,comments,commits,mergeable,statusCheckRollup": mergeGateResponse,
   "baseRefName,comments,commits,mergeable,statusCheckRollup,headRefOid": mergeGateResponse,

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -120,7 +120,7 @@ async function fixture(label, { local = false } = {}) {
       facts: current,
       observations: local
         ? { git: { local_delivery: true, head_sha: head, tree_sha: tree, reviewable_dirty: false }, github: {} }
-        : { github: { pr_number: 42, pr_head_sha: head, pr_state: "OPEN" } },
+        : { github: { pr_number: 42, pr_head_sha: head, pr_base_sha: startSha, pr_state: "OPEN" } },
       derived: { action, head_sha: head, pr_number: local ? null : 42, retry_of_event_id: retryable ? review.event_id : null },
       recommended_action: { kind: action, reason: retryable ? "review_retryable_escalation" : exhausted ? "review_escalated_retry_exhausted" : review?.payload?.verdict === "escalated" ? "review_escalated" : review ? review.payload.verdict : "review_missing", key: "c".repeat(64), steps: [], required_inputs: [] },
     };
@@ -147,6 +147,7 @@ test("Relay runner records one exact-SHA pass and the derived action advances to
   assert.equal(result.done_criteria_sha256, value.criteriaHash);
   assert.equal(result.recommended_action.kind, "merge");
   assert.equal(captured.request.reviewed_sha, value.head);
+  assert.equal(captured.request.base_sha, value.startSha);
   assert.equal(captured.request.current_sha, value.head);
   const rawDiff = execFileSync("git", ["-C", value.repo, "diff", "--binary", "--no-ext-diff",
     `${value.startSha}..${value.head}`, "--"], { encoding: "utf8" });
@@ -185,6 +186,22 @@ test("Relay runner records one exact-SHA pass and the derived action advances to
   );
   await assert.rejects(runner.runReview(value.cli, { inspectRun: value.inspectRun, invokeReviewer: async () => { throw new Error("must not run"); } }), /not 'review'/);
   assert.equal(facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded").length, 1);
+});
+
+test("GitHub base drift during review appends no verdict fact", async () => {
+  const value = await fixture("base-drift");
+  let inspections = 0;
+  const inspectRun = async (...args) => {
+    const result = await value.inspectRun(...args);
+    inspections += 1;
+    if (inspections > 1) result.observations.github.pr_base_sha = "f".repeat(40);
+    return result;
+  };
+  await assert.rejects(runner.runReview(value.cli, {
+    inspectRun,
+    invokeReviewer: async (input) => reviewerSuccess(input, { verdict: "pass", summary: "base moved", issues: [] }),
+  }), (error) => error.code === "REVIEW_BINDING_CHANGED");
+  assert.equal(facts.readFacts({ eventsPath: value.eventsPath }).facts.filter((fact) => fact.type === "review_recorded").length, 0);
 });
 
 test("#1208 production-shaped no-origin review records the exact verification projection", async () => {
@@ -378,7 +395,7 @@ test("#1208 canonical fold alone controls reviewed-close branch exceptions befor
       at: "2026-08-01T00:03:00.000Z", actor: "codex",
       payload: {
         round: 1, verdict: mode === "invalid" ? "changes_requested" : "lgtm",
-        reviewed_sha: value.head, done_criteria_sha256: value.criteriaHash,
+        reviewed_sha: value.head, base_sha: value.startSha, done_criteria_sha256: value.criteriaHash,
         reviewer: "codex", review_artifact: path.join(value.runDir, "forged-review.json"),
         executed_runtime: {
           digest: crypto.createHash("sha256").update(JSON.stringify(EXECUTED_RUNTIME)).digest("hex"),

--- a/tests/skills-lint/scripts/pr-view-json-contract.test.js
+++ b/tests/skills-lint/scripts/pr-view-json-contract.test.js
@@ -79,7 +79,7 @@ test("enumerates pr view fields from an argv variable assembled separately", () 
 });
 
 test("Relay regression: missing exact merge-observation fields names finalize-run", () => {
-  const finalizeFields = "number,state,headRefName,headRefOid,baseRefName,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus";
+  const finalizeFields = "number,state,headRefName,headRefOid,baseRefName,baseRefOid,headRepository,headRepositoryOwner,mergeCommit,autoMergeRequest,mergeStateStatus";
   const registryWithoutFinalizeFields = Object.fromEntries(
     Object.entries(PR_VIEW_JSON_REGISTRY).filter(([fields]) => fields !== finalizeFields),
   );


### PR DESCRIPTION
Closes #1174

## Summary
- persist the exact PR base SHA in every new review fact while preserving historical journals
- allow benign descendant base advances only when complete GitHub compare evidence has zero path overlap with the exact reviewed diff
- fail closed on overlap, divergence, malformed/incomplete pagination, rename-source collisions, and the 300-file evidence cap
- recheck direct and isolated live base observations under the merge lock and immediately before the merge request

## Evidence
- full serialized gate: 638 tests / 636 pass / 0 fail / 2 expected live-canary skips
- independent Standards and Spec reviews: LGTM
- measurement basis: base moved 14.3%; overlapping advances 3.8%; hard pin would reject 61 benign advances

## Residual bounds
Path overlap is a proxy and cannot detect cross-file semantic conflicts. GitHub exposes no expected-base CAS for merge, so the documented final check/request nanorace remains; source-head CAS is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 리뷰 및 병합 과정에서 검토된 기준 커밋과 현재 기준 커밋을 확인합니다.
  - 기준 브랜치 변경, 경로 중첩, 불완전한 비교 정보가 감지되면 병합을 중단하고 재검토를 요구합니다.
  - PR 관찰 결과에 기준 커밋 정보를 포함합니다.

- **버그 수정**
  - 기준 커밋 정보가 누락된 과거 리뷰가 잘못 병합되지 않도록 검증을 강화했습니다.
  - 리뷰 진행 중 기준 브랜치가 변경되면 리뷰 결과를 무효화합니다.

- **테스트**
  - 기준 커밋 변경, 경로 충돌 및 불완전한 비교 결과에 대한 검증 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->