### PR TITLE
Use ambient CLI auth and retire credential staging

### DIFF
--- a/backlog/sprints/2026-08-trusted-local-native-relay.md
+++ b/backlog/sprints/2026-08-trusted-local-native-relay.md
@@ -13,8 +13,8 @@ Relay uses the developer's ambient CLI authentication and configuration, request
 
 ## Plan
 - [x] #1231 Define the trusted-local execution contract and native capability inventory [PR:#1237]
-- [~] #1232 Atomically replace Relay sandbox-exec with native-when-available execution [branch:issue/1232-native-first-host]
-- [ ] #1233 Use ambient CLI auth/config and retire credential staging safely
+- [x] #1232 Atomically replace Relay sandbox-exec with native-when-available execution [PR:#1238]
+- [~] #1233 Use ambient CLI auth/config and retire credential staging safely [branch:issue/1233-ambient-cli-auth]
 - [ ] #1234 Retire the 13-cell isolation release gate and subtract obsolete tests/docs
 - [ ] #1235 Dogfood ambient native Relay across all seven adapters and close the migration
 - [ ] #1230 Reconcile the epic and milestone after all five leaves close
@@ -31,6 +31,8 @@ Relay uses the developer's ambient CLI authentication and configuration, request
 - #1141 and #1158 are superseded by #1230; their live failure evidence remains historical input.
 
 ## Progress
+- 2026-08-13: #1233 implementation completed and independently reviewed LGTM on Spec, Standards/trust, and simplification axes. Relay now inherits sanitized ambient CLI HOME/XDG/auth without credential copying or public selectors; environment bytes cross only an already-unlinked FD/pipe, executor cleanup is process/scope-only, and reviewer cleanup retains the signed staged-input root. Final pre-merge legacy inventory remained 109 incomplete / 109 credential-root / 109 settled / 0 open / 0 parse errors. Authoritative focused gate passed 159/159 with zero skips; the full serialized gate passed 631 total (629 pass, 2 intentional live-canary skips, 0 fail). Diff: 32 files, +438/-1028.
+- 2026-08-13: #1232 merged via PR #1238 after all 11 checks passed, including the new Ubuntu native-first production-seam job. Started #1233 on `issue/1233-ambient-cli-auth`; pre-cutover inventory found 109/109 cleanup-incomplete records canonically settled and zero open credential-root obligations.
 - 2026-08-12: #1231 merged via PR #1237 after 9/9 CI; issue closed. Started #1232 on `issue/1232-native-first-host`; Luna(max) owns the bounded production/test implementation with cross-family review afterward.
 - 2026-08-12: Started #1231 on `issue/1231-trusted-local-contract`; Qwen 3.8 Max owns the bounded contract/capability documentation implementation, followed by independent review before merge.
 - 2026-08-12: Claude Opus 5 and Pi/Qwen independent reviews converged on the trusted-local native-first direction and identified atomic adapter/host replacement, review-input preservation, process cleanup, and existing cleanup obligations as required boundaries.

--- a/docs/decisions/2026-08-12-trusted-local-execution-contract.md
+++ b/docs/decisions/2026-08-12-trusted-local-execution-contract.md
@@ -1,13 +1,13 @@
 # Trusted-local execution contract
 
-**Status:** Accepted 2026-08-12; `#1232` implemented · Issue `#1231` · Epic `#1230` · Milestone "Trusted-local native Relay"
+**Status:** Accepted 2026-08-12; `#1232` and `#1233` implemented · Issue `#1231` · Epic `#1230` · Milestone "Trusted-local native Relay"
 **Supersedes:** the mandatory Relay-owned isolation + staged-credential policy of `#1141` and the dispatch-availability policy derived from it in `#1158` ([Supersession](#supersession-of-1141-and-1158)).
 **Runtime status:** `#1232` has removed Relay-owned `sandbox-exec` and its
 non-darwin admission failure. Dispatch, review, observer, and recovery launch
 directly on the trusted local host; adapter-native filesystem controls are
-requested atomically and reported as non-durable diagnostics. `#1233` remains
-separate: explicit owner-only credential staging and its cleanup obligations
-are still present in this runtime.
+requested atomically and reported as non-durable diagnostics. `#1233` has
+moved adapter authentication/configuration to ambient user HOME/XDG state and
+removed credential staging.
 
 ## Context
 
@@ -24,7 +24,7 @@ freezes the contract and the exact native capability inventory for `#1232`–`#1
 
 ### 1. One trusted-local execution path
 
-One execution contract: no trusted/hardened switch, no second mode, no mode registry. Executions launch directly on the operator's trusted local host; secrets are never serialized into facts or argv. Where a CLI supports native filesystem isolation, Relay requests it; where it does not, Relay still runs and reports the absence. A direct process may read other files accessible to that local user, so this is not a hostile-worker boundary. `#1232` removes the mandatory outer sandbox; `#1233` will separately move credentials to ambient HOME/auth/config and delete staging after its cleanup rule.
+One execution contract: no trusted/hardened switch, no second mode, no mode registry. Executions launch directly on the operator's trusted local host; secrets are never serialized into facts or argv. Where a CLI supports native filesystem isolation, Relay requests it; where it does not, Relay still runs and reports the absence. A direct process may read other files accessible to that local user, so this is not a hostile-worker boundary. `#1232` removed the mandatory outer sandbox; `#1233` moved authentication and configuration to ambient HOME/XDG state after its cleanup rule was satisfied.
 
 ### 2. Native capability inventory (seven adapters)
 
@@ -32,13 +32,13 @@ Filesystem isolation (OS/CLI enforcement of writable paths) and tool-network con
 
 | Adapter | FS isolation CLI capability | Current Relay request | Tool/network control | Ambient auth evidence | Platform evidence |
 | --- | --- | --- | --- | --- | --- | --- |
-| `claude` | Native Bash sandbox via `sandbox.enabled` settings (Seatbelt on macOS, bubblewrap on Linux/WSL2); no CLI sandbox flag; built-in file tools remain permission-bound, not OS-sandboxed [^1] | Dispatch enables native Bash/Bash with `allowUnsandboxedCommands:false`; primary review is `--safe-mode`/`Read` only and explicitly `not_requested` | Native Bash network proxy plus tool permissions; direct file tools use permissions | `#1233` target: ambient `~/.claude` OAuth/settings or supported token env | macOS live; Linux/WSL2 vendor-declared, not locally exercised |
-| `codex` | Native — `--sandbox read-only\|workspace-write\|danger-full-access` declared in help | `--sandbox workspace-write` dispatch; `read-only` review | Informational — no fail-closed tool-network switch | `#1233` target: `~/.codex/auth.json`, `~/.codex/config.toml`, or `OPENAI_API_KEY` | macOS live; Linux unverified |
-| `opencode` | None — help declares no sandbox | None; diagnostic only | Informational | `#1233` target: `~/.local/share/opencode/auth.json`, `~/.config/opencode/opencode.json[c]` | macOS live; Linux unverified |
-| `pi` | None — help declares no sandbox | None; diagnostic only | Native constrained toolset — `--tools read,grep,find,ls[,write,edit]`, `--no-extensions --no-skills --no-session --no-context-files`; adapter `networkControl: "native"` | `#1233` target: `~/.pi/agent/{auth,settings,models}.json`; optional QWEN token env keys | macOS live; Linux unverified |
-| `antigravity` | Declaration-only — `--sandbox` ("terminal restrictions") declared in help; enforcement unverified by Relay | `--sandbox`; declaration-only diagnostic | Informational — no verifiable tool-network block | `#1233` target: `~/.gemini/oauth_creds.json` + `config/config.json` | macOS live; Linux unverified |
-| `cursor` | Native — `--sandbox enabled\|disabled` declared in help | `--sandbox enabled` dispatch and review | Informational | `#1233` target: `~/.cursor/cli-config.json`, or `CURSOR_API_KEY` | macOS live; Linux unverified |
-| `cline` | None — help declares no sandbox | None; diagnostic only | Informational | `#1233` target: `~/.cline/data/settings/providers.json` | macOS live; Linux unverified (dispatch-only; no primary review) |
+| `claude` | Native Bash sandbox via `sandbox.enabled` settings (Seatbelt on macOS, bubblewrap on Linux/WSL2); no CLI sandbox flag; built-in file tools remain permission-bound, not OS-sandboxed [^1] | Dispatch enables native Bash/Bash with `allowUnsandboxedCommands:false`; primary review is `--safe-mode`/`Read` only and explicitly `not_requested` | Native Bash network proxy plus tool permissions; direct file tools use permissions | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux/WSL2 vendor-declared, not locally exercised |
+| `codex` | Native — `--sandbox read-only\|workspace-write\|danger-full-access` declared in help | `--sandbox workspace-write` dispatch; `read-only` review | Informational — no fail-closed tool-network switch | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux unverified |
+| `opencode` | None — help declares no sandbox | None; diagnostic only | Informational | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux unverified |
+| `pi` | None — help declares no sandbox | None; diagnostic only | Native constrained toolset — `--tools read,grep,find,ls[,write,edit]`, `--no-extensions --no-skills --no-session --no-context-files`; adapter `networkControl: "native"` | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux unverified |
+| `antigravity` | Declaration-only — `--sandbox` ("terminal restrictions") declared in help; enforcement unverified by Relay | `--sandbox`; declaration-only diagnostic | Informational — no verifiable tool-network block | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux unverified |
+| `cursor` | Native — `--sandbox enabled\|disabled` declared in help | `--sandbox enabled` dispatch and review | Informational | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux unverified |
+| `cline` | None — help declares no sandbox | None; diagnostic only | Informational | Ambient user HOME/XDG CLI session; no Relay selector | macOS live; Linux unverified (dispatch-only; no primary review) |
 
 [^1]: Local evidence, this host 2026-08-12. Versions: claude 2.1.228, codex 0.147.0, agent 2026.08.11-e8db854, agy 1.1.11, pi 0.84.1, opencode 1.18.16, cline 3.0.49. `claude --help` defines `--safe-mode` as customization disabling and exposes no sandbox flag; Anthropic's [sandboxing reference](https://code.claude.com/docs/en/sandboxing) documents the settings-based Bash sandbox, OS/platform enforcement, nonblocking unavailable fallback, and the separate permission boundary for built-in file tools.
 
@@ -56,19 +56,23 @@ Relay's threat model is a trusted single-user development host. Multi-tenant or 
 
 Worktree-only dispatch; immutable `run.json` and append-only `events.jsonl` through `facts.appendFact`; inspect-before-write and re-inspect under the run lock with the same action key; staged review-input integrity (immutable, directly contained prompt/diff/criteria/schema paths with SHA-256 bindings); argv-only spawning, executable binding, timeout/cancellation, and process cleanup under `inherited_scope_no_daemon`; recovery through the single general writer (`recover.js` via `host.withRunLock`); exact-SHA independent review bound to frozen Done Criteria; explicit merge with no bypass. The bundle contains no executor transcript. A staged-input mutation, drift, or containment violation fails typed with zero review facts rather than becoming a retryable runtime escalation. None of these is relaxed by this contract.
 
-### 6. Settle before cutover
+### 6. Settled cutover
 
-`cleanup_incomplete` records carry `obligation.credential_root` (path plus dev/ino binding) alongside any surviving process identities.
+New `cleanup_incomplete` records carry process identities and, for review, an
+exact `obligation.staged_input_root` (path plus dev/ino binding).
 
 **Inventory (2026-08-12, this host):** 109 `host-attempt-*.cleanup-incomplete.json` markers under `~/.relay/runs`, all carrying `credential_root` obligations and every one matched by a `cleanup-settled.json` marker — zero open credential-root obligations at acceptance time.
 
-**Rule:** before `#1233` deletes the staging reader, every `cleanup_incomplete` record carrying a credential-root obligation must be settled through canonical `relay-recover recover --run-dir <dir> --reason "<why>"` (`HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED` means externally terminating the exact recorded identities and rerunning recovery). The matching `cleanup-settled.json` marker is the evidence. No compatibility reader, no migration overlay; records discovered after cutover are inert history.
+**Cutover:** the pre-cutover inventory is settled (109 markers, 109 settled,
+zero open). Historical credential-root artifacts are inert history: no
+compatibility reader or migration overlay remains. New recovery removes only
+the signed staged review-input root after exact process settlement.
 
 ## Consequences
 
 - `#1232` (implemented): atomically removes the outer `sandbox-exec` boundary; Codex/Cursor request their native sandboxes; adds the visible capability diagnostic of §3.
-- `#1233`: moves all seven adapters to ambient HOME/auth/config and deletes credential staging after the §6 rule is satisfied.
-- `#1234`: retires the 13-cell gate and subtracts obsolete tests/docs; `#1235` dogfoods all seven adapters and closes the migration. Staging metadata (`credentialTransport`, staged-file catalogs) becomes inert as staging is deleted.
+- `#1233` (implemented): moves all seven adapters to ambient HOME/auth/config and deletes credential staging after the §6 rule was satisfied.
+- `#1234` (tracked follow-up): retires the test-only 13-cell gate and its obsolete tests/docs; it does not own runtime authentication behavior. `#1235` dogfoods all seven adapters and closes the migration.
 
 ## Supersession of #1141 and #1158
 
@@ -79,4 +83,4 @@ Worktree-only dispatch; immutable `run.json` and append-only `events.jsonl` thro
 - Sprint convergence: `backlog/sprints/2026-08-trusted-local-native-relay.md`; epic `#1230` ordering.
 - Adapter descriptors `skills/relay-dispatch/scripts/adapters/*.js`; capability prose `skills/relay-dispatch/references/agent-adapter-platform.md`.
 - Warning-discard proof: `adapter-contract.js` `capabilities()` attaches `warnings`; `dispatch.js` has no consumer.
-- Settlement: `docs/relay-operator-guide.md` ("survivors are reported, not killed"); `host.js` `paths.cleanup`/`paths.settled`, `obligation.credential_root`; inventory counted 2026-08-12 (109/109 settled).
+- Settlement: `docs/relay-operator-guide.md` ("survivors are reported, not killed"); `host.js` `paths.cleanup`/`paths.settled`, `obligation.staged_input_root`; inventory counted 2026-08-12 (109/109 settled).

--- a/docs/relay-operator-guide.md
+++ b/docs/relay-operator-guide.md
@@ -128,14 +128,10 @@ node skills/relay-config/scripts/relay-config.js \
 The release-only adapter canary lives in the test suite; it is
 intentionally not an installed operator command. See the [adapter platform](../skills/relay-dispatch/references/agent-adapter-platform.md).
 
-Release evidence is all-or-nothing across 13 required cells (seven dispatch and
-six declared primary-review cells). Run it only with explicit per-phase
-credential selectors, for example
-`--credential-env codex:dispatch:OPENAI_API_KEY`; repeat the selector for the
-review phase and for every adapter. Missing credentials or CLIs are reported as
-`not_run_*`, exit nonzero, and cannot be treated as a release pass. The runner
-prints only credential environment names/file IDs and cryptographic digests,
-never values or source paths.
+The release-only adapter canary invokes each CLI with the operator's ambient
+local authentication and configuration. Missing authentication or CLIs remain
+non-release evidence; the runner never receives credential values or source
+paths as arguments.
 
 ### Prompt and credential limits
 
@@ -143,24 +139,12 @@ Claude, Codex, OpenCode, Pi, and Cursor receive prompts over digest-bound stdin.
 Cline and Antigravity are the two argv-visible exceptions: prompt text may be
 visible in the local process list, and Relay rejects prompts at 256 KiB.
 
-Provider credentials are never selected implicitly. A foreground dispatch may
-opt in an environment value with repeatable `--credential-env NAME` or a
-declared adapter credential file with repeatable
-`--credential-file ID=/absolute/source`, for example:
-
-```bash
-node skills/relay-dispatch/scripts/dispatch.js . \
-  --executor codex --credential-env OPENAI_API_KEY \
-  --credential-file auth=/absolute/path/to/auth.json \
-  -b issue-42 --prompt-file /tmp/dispatch.md --rubric-file /tmp/rubric.yaml
-```
-
-Credential flags cannot be combined with `--detach`; this keeps source paths
-out of detached argv. Primary review accepts the same repeatable flags and
-adapter file IDs. It copies selected files into a private, short-lived HOME/XDG
-tree and exposes only the named environment values; it never searches the
-operator's HOME. A reviewer without explicit usable credentials stops as
-credentials unavailable.
+Provider authentication is ambient local CLI state: HOME, XDG configuration,
+keychain-backed sessions, and supported token variables remain visible exactly
+as in direct use. Relay neither copies auth files nor rewrites HOME/XDG.
+`--credential-env` and `--credential-file` are retired unknown options. Review
+still stages only its immutable prompt/diff/criteria/schema bundle and removes
+that exact bound staging root during cleanup/recovery.
 
 ### Process containment: `inherited_scope_no_daemon`
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -183,8 +183,8 @@ starts as a Relay run.
   never before its authoritative signed close.
 - Signals are bound to the inherited process-scope marker and revalidated
   immediately before delivery; unverifiable targets fail closed.
-- Signed credential roots are removed by rename-to-quarantine and dev/ino
-  revalidation; a swapped path is preserved as evidence, never deleted.
+- Signed staged review-input roots are removed by rename-to-quarantine and
+  dev/ino revalidation; a swapped path is preserved as evidence, never deleted.
 - External GitHub and merge observations use a fresh nonce-bound observer only
   on the GitHub route; local delivery has no forge observation.
 - PR comments, mutable files, prior prompts, executor transcripts, and legacy

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -65,8 +65,7 @@ Essential flags:
 - `--executor, -e` and `--model, -m` select execution. Resume cannot replace the executor bound in `run.json`.
 - `--sandbox`, `--network-access`, `--timeout`, `--reasoning`, and `--copy` configure the attempt. Copy inputs must be regular files contained by the repository.
 - Provider control-plane transport is always available to the trusted CLI. `--network-access` governs model/tool networking: `disabled` requires an adapter-native deny and fails closed for adapters that cannot enforce one; `enabled` explicitly permits the adapter's network-capable tools.
-- `--credential-env NAME` and `--credential-file ID=/absolute/source` explicitly opt a credential into a foreground attempt. They are repeatable, adapter-declared, and incompatible with `--detach`.
-- Unattended Claude Max runs require an operator-generated `CLAUDE_CODE_OAUTH_TOKEN` selected with `--credential-env`; Relay never extracts the macOS Keychain login.
+- CLI authentication, HOME, XDG config, and supported token variables come from the operator's ambient local environment. Credential selector flags were removed and fail as unknown options; Relay never copies auth files or records their paths.
 - Every adapter declares whether its dispatch toolset can execute commands. A prompt demanding command execution (fenced shell block, `node --test`, `npm test`/`npm run`, `npx`, `git commit`/`push`/`rebase`/`merge`, or an imperative "run"/"execute" next to a backticked command) is rejected with `TOOLSET_MISMATCH` for a no-shell executor (`pi`, `claude`) before any durable state exists. `--allow-toolset-mismatch` downgrades it to a stderr warning.
 - `--fleet-id` requires typed `--ownership-json` with exactly `sprint`, `track`, and `component`; parent and ownership digest are immutable.
 - `--detach` starts a detached dispatch supervisor, prints a receipt, and returns before executor completion.

--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -62,7 +62,7 @@ therefore disclose prompt content while `agy` is running.
 
 The test-only live runner requires an exact 13-cell matrix: dispatch for all
 seven adapters plus primary review for every adapter that declares it (six at
-present). Every cell must pass; a missing CLI, absent explicit credential,
+present). Every cell must pass; a missing CLI, unavailable ambient login,
 diagnostic fallback, timeout, sandbox/authentication failure, or unexecuted cell
 keeps the evidence `incomplete_non_release` and makes the command exit nonzero.
 
@@ -72,14 +72,14 @@ Each review cell crosses `runStore.invokeIndependentReviewer`, must return that
 run's nonce through an exact JSON schema, and must leave the repository
 unchanged. These are the production isolation entry boundaries; the runner does
 not call `dispatch.js` because that would create lifecycle facts and publication
-work unrelated to an adapter canary. Production CLI credential parsing has its
-own contract tests, and the runner independently parses explicit
-`adapter:phase` credential selectors.
+work unrelated to an adapter canary. The runner performs no credential
+selection: every cell invokes its CLI through the ordinary ambient local
+HOME/XDG session.
 
 Evidence records source-tree and dirty-state digests, runner/runtime hashes,
-platform, executable identity/version, credential environment names and file
-IDs, prompt/invocation/output digests, and boundary/cleanup/process audits. It
-never records credential values or credential source paths, and the recorded
+platform, executable identity/version, prompt/invocation/output digests, and
+boundary/cleanup/process audits. It never records ambient environment values
+or source paths, and the recorded
 executable identity is the basename only — the old absolute-path evidence was
 archived as superseded (2026-08-07, #1153) and the next canary run regenerates
 current evidence under `docs/plans/relay-runtime-core-reset-vnext/`; it is
@@ -105,7 +105,7 @@ but never an admission failure. These argv descriptors still require the host
 supervisor for immutable staging, executable binding, timeout/cancellation, and
 scope-safe cleanup.
 
-## Prompt and credential transport
+## Prompt and ambient CLI sessions
 
 Claude, OpenCode, Pi, Cursor, and Codex transport the exact prompt over stdin
 (`codex` uses its stdin-dash form). Prompt bytes and their SHA-256 binding are
@@ -114,34 +114,25 @@ exceptions because their installed CLIs expose no safe stdin prompt contract;
 both reject prompts at the conservative 256 KiB limit, and their prompt content
 is visible to local process-list readers for the lifetime of the CLI.
 
-Dispatch does not inherit ambient provider credentials. Operators must opt in
-to each value with repeatable `--credential-env NAME` and to each declared
-adapter file with `--credential-file ID=/absolute/source`. Valid file IDs come
-from adapter metadata: Claude and Codex expose `auth` plus their settings/config
-file, OpenCode exposes `auth`, `config_json`, and `config_jsonc`, Pi exposes
-`auth`, `settings`, and `models`, Cursor exposes `cli_config`, Cline exposes
-`providers`, and Antigravity exposes `oauth` plus `config`. Cursor may instead
-use an explicitly selected `CURSOR_API_KEY`. Missing or structurally unsafe
-session files remain typed `credentials_unavailable` evidence.
-Sources are validated as exact private regular files and staged into an
-attempt-private HOME/XDG root, then removed after the process tree terminates.
+Dispatch and review inherit the local user's ordinary CLI session, including
+`HOME`, XDG configuration roots, provider authentication, and custom CA
+configuration. Relay neither copies credential files nor creates a private
+HOME/XDG tree. It removes only narrowly dangerous Relay and runtime-injection
+environment keys before handing that ambient environment to the detached host;
+the values themselves travel only through the host's unlinked secret-FD
+payload and never into durable run artifacts. `--credential-env` and
+`--credential-file` are retired unknown options. An unavailable ambient login
+is a typed authentication failure that the operator fixes with that CLI's
+normal login/setup flow.
 
 Claude dispatch runs with `--settings` that enables its native Bash sandbox and
 permits Bash while `allowUnsandboxedCommands:false` blocks automatic fallback.
 Claude primary review instead uses `--safe-mode`, permits only `Read`, and
 explicitly disallows `Bash`, `Write`, and `Edit`; its native-isolation
-diagnostic is `not_requested`. An unattended Claude Max canary requires
-the operator to generate a
-long-lived token with `claude setup-token` and explicitly select
-`CLAUDE_CODE_OAUTH_TOKEN` for both phase cells. Relay never extracts the macOS
-Keychain login, and `--bare` is not used because it rejects subscription OAuth.
-
-Credential flags are foreground-dispatch only. `--detach` with either flag
-fails closed so credential source paths are never copied into detached process
-argv. Primary review accepts the same repeated flags and catalog, but stages
-selected values only inside its short-lived private HOME/XDG tree. Neither path
-performs discovery or inherits an ambient HOME. A reviewer without the
-explicitly requested credentials must stop as unavailable.
+diagnostic is `not_requested`. An unattended Claude Max canary uses the
+operator's existing Claude CLI login session. Relay never extracts the macOS
+Keychain login,
+and `--bare` is not used because it rejects subscription OAuth.
 
 ## Capability Matrix
 

--- a/skills/relay-dispatch/scripts/adapter-contract.js
+++ b/skills/relay-dispatch/scripts/adapter-contract.js
@@ -5,42 +5,16 @@ const { spawnSync } = require("child_process");
 const PHASES = Object.freeze(["dispatch", "primary_review"]);
 const OUTPUT_PROTOCOLS = Object.freeze(["text_stdout", "json_result", "jsonl_run_result"]);
 const SHA256_RE = /^[0-9a-f]{64}$/;
-const CREDENTIAL_ROOTS = new Set(["home", "xdg_config", "xdg_data"]);
-const CREDENTIAL_ACCESS = new Set(["read", "read_write"]);
 const FILESYSTEM_ISOLATION = new Set(["native", "native_bash", "declaration_only", "not_requested", "none"]);
 const NATIVE_FILESYSTEM_REQUESTS = new Set(["workspace-write", "read-only", "enabled"]);
 // Supported CLIs must preserve the inherited scope marker and must not daemonize
 // or clear it from descendants; host cleanup relies on that contract.
 const PROCESS_CONTAINMENT = "inherited_scope_no_daemon";
-const CREDENTIAL_ENV_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const RESERVED_CREDENTIAL_ENV = /^(?:HOME|PATH|TMPDIR|TMP|TEMP|XDG_CONFIG_HOME|XDG_DATA_HOME|RELAY_PROCESS_SCOPE|NODE_OPTIONS|NODE_PATH|BASH_ENV|ENV|ZDOTDIR|JAVA_TOOL_OPTIONS|_JAVA_OPTIONS|JDK_JAVA_OPTIONS|PHPRC|PHP_INI_SCAN_DIR|PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|PERL5OPT|PERL5LIB|PERL5DB|RUBYOPT|RUBYLIB|GEM_HOME|GEM_PATH|GCONV_PATH|LOCPATH|NLSPATH)$|^(?:DYLD|LD)_|^LUA_(?:INIT|PATH|CPATH)(?:_.*)?$|^RELAY_/;
 const RUNTIME_PARENT_KEYS = ["executableParent", "interpreterParent"];
-const PRIVATE_ENV_ROOTS = new Set([...CREDENTIAL_ROOTS, "scratch"]);
 
 function deepFreeze(value) {
   if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze(child); return Object.freeze(value);
-}
-
-function normalizeCredentialMetadata(credentials = {}) {
-  const files = credentials.files || [], envHints = credentials.envHints || [];
-  if (!Array.isArray(files) || !Array.isArray(envHints) || envHints.some((name) => typeof name !== "string" || !CREDENTIAL_ENV_RE.test(name) || RESERVED_CREDENTIAL_ENV.test(name))) {
-    throw new Error("adapter credential metadata must contain files and environment-name hints");
-  }
-  const ids = new Set(), targets = new Set();
-  for (const file of files) {
-    const keys = Object.keys(file || {}).sort().join(",");
-    if (keys !== "access,id,recommendedSource,targetRel,targetRoot" || !/^[a-z][a-z0-9_-]*$/.test(file.id || "")
-      || !CREDENTIAL_ROOTS.has(file.targetRoot) || !CREDENTIAL_ACCESS.has(file.access)
-      || typeof file.recommendedSource !== "string" || typeof file.targetRel !== "string" || path.isAbsolute(file.targetRel)
-      || !file.targetRel || file.targetRel.split(/[\\/]/).some((part) => !part || part === "." || part === "..")) {
-      throw new Error("adapter credential file metadata is invalid");
-    }
-    const target = `${file.targetRoot}:${file.targetRel}`;
-    if (ids.has(file.id) || targets.has(target)) throw new Error("adapter credential metadata contains an id or target collision");
-    ids.add(file.id); targets.add(target);
-  }
-  return deepFreeze({ files: files.map((file) => ({ ...file })), envHints: [...envHints] });
 }
 
 function normalizeRuntimeDependencies(value = {}) {
@@ -49,42 +23,6 @@ function normalizeRuntimeDependencies(value = {}) {
   for (const key of RUNTIME_PARENT_KEYS) {
     const depth = value[key]; if (depth !== null && (!Number.isInteger(depth) || depth < 0 || depth > 2)) throw new Error("adapter runtime dependency parent depth is invalid"); normalized[key] = depth;
   } return Object.freeze(normalized);
-}
-function normalizePrivateEnvPaths(value = []) {
-  if (!Array.isArray(value)) throw new Error("adapter private environment paths must be an array");
-  const keys = new Set(); return deepFreeze(value.map((item) => {
-    if (!item || Object.keys(item).sort().join(",") !== "key,relative,root" || !CREDENTIAL_ENV_RE.test(item.key || "") || RESERVED_CREDENTIAL_ENV.test(item.key)
-      || keys.has(item.key) || !PRIVATE_ENV_ROOTS.has(item.root) || typeof item.relative !== "string" || path.isAbsolute(item.relative)
-      || !item.relative || item.relative.split(/[\\/]/).some((part) => !part || part === "." || part === "..")) throw new Error("adapter private environment path is invalid");
-    keys.add(item.key); return { ...item };
-  }));
-}
-// This is deliberately value-free: callers use it before a dry run or before
-// opening any credential source.  The host/reviewer own the later byte trust
-// boundary, while both phases share one catalog and argv grammar.
-function credentialRequest(metadata = {}, { envNames = [], fileSpecs = [] } = {}) {
-  const credentials = normalizeCredentialMetadata(metadata);
-  if (!Array.isArray(envNames) || !Array.isArray(fileSpecs)) throw new Error("credential options must be arrays");
-  const files = new Map(credentials.files.map((item) => [item.id, item]));
-  const seenEnv = new Set(), seenIds = new Set(), seenTargets = new Set(), ids = [];
-  for (const name of envNames) {
-    if (typeof name !== "string" || !CREDENTIAL_ENV_RE.test(name) || RESERVED_CREDENTIAL_ENV.test(name) || seenEnv.has(name)) {
-      throw new Error("credential environment name is unsafe, reserved, or duplicated");
-    }
-    seenEnv.add(name);
-  }
-  for (const spec of fileSpecs) {
-    const equals = typeof spec === "string" ? spec.indexOf("=") : -1;
-    const id = equals > 0 ? spec.slice(0, equals) : "", source = equals > 0 ? spec.slice(equals + 1) : "", item = files.get(id);
-    if (!item || !path.isAbsolute(source) || path.resolve(source) !== source) {
-      throw new Error("credential file must be a declared ID=/absolute/source");
-    }
-    const target = `${item.targetRoot}:${item.targetRel}`;
-    if (seenIds.has(id) || seenTargets.has(target)) throw new Error("credential file contains an id or target collision");
-    seenIds.add(id); seenTargets.add(target); ids.push(id);
-  }
-  return Object.freeze({ metadata: credentials, envNames: Object.freeze([...seenEnv]), fileSpecs: Object.freeze([...fileSpecs]),
-    summary: Object.freeze({ env_names: Object.freeze([...seenEnv]), file_ids: Object.freeze(ids) }) });
 }
 
 class AdapterCapabilityError extends Error {
@@ -112,7 +50,7 @@ function decodeTrustedPrompt(promptBytes) {
 
 function normalizeInvocationShape(invocation) {
   if (!invocation || typeof invocation !== "object") throw new Error("adapter invocation must be an object");
-  if (Object.keys(invocation).some((key) => !["command", "args", "cwd", "stdinPath", "stdinSha256", "privateEnvPaths"].includes(key))) throw new Error("adapter invocation contains unsupported metadata");
+  if (Object.keys(invocation).some((key) => !["command", "args", "cwd", "stdinPath", "stdinSha256"].includes(key))) throw new Error("adapter invocation contains unsupported metadata");
   if (typeof invocation.command !== "string" || !invocation.command || invocation.command.includes("\n")) throw new Error("adapter invocation command must be one executable argv value");
   if (!Array.isArray(invocation.args) || invocation.args.some((value) => typeof value !== "string" || value.includes("\0"))) throw new Error("adapter invocation args must be an array of string argv values");
   requireAbsolutePath(invocation.cwd, "adapter invocation cwd");
@@ -121,7 +59,6 @@ function normalizeInvocationShape(invocation) {
     command: invocation.command,
     args: Object.freeze([...invocation.args]),
     cwd: invocation.cwd,
-    privateEnvPaths: normalizePrivateEnvPaths(invocation.privateEnvPaths),
     ...(invocation.stdinPath ? {
       stdinPath: requireAbsolutePath(invocation.stdinPath, "adapter invocation stdinPath"),
       stdinSha256: SHA256_RE.test(invocation.stdinSha256 || "")
@@ -339,21 +276,20 @@ function createNativeAdapter({
   if (phaseMetadata.dispatch?.supported && typeof phaseMetadata.dispatch.commandExecution !== "boolean") {
     throw new Error("native adapter dispatch phase must declare commandExecution");
   }
-  if (!new Set(["explicit_bundle", "unrepresentable"]).has(metadata.credentialTransport)) throw new Error("native adapter credential transport declaration is invalid");
   const runtimeDependencies = normalizeRuntimeDependencies(metadata.runtimeDependencies);
   const bindInvocationPolicy = (invocation, toolNetworkAccess) => Object.freeze({ ...invocation, networkAccess: "enabled", toolNetworkAccess, runtimeDependencies });
   return Object.freeze({
     name,
     defaults: Object.freeze({ timeoutMs }),
-    metadata: deepFreeze({ ...metadata, runtimeDependencies, credentials: normalizeCredentialMetadata(metadata.credentials) }),
+    metadata: deepFreeze({ ...metadata, runtimeDependencies }),
     probe({ env = process.env, timeoutMs: probeTimeoutMs = 5000, spawn = spawnSync } = {}) {
       const binary = env[metadata.cliBinaryEnv] || cliBinary;
       return probeBinary(binary, { env, timeoutMs: probeTimeoutMs, spawn });
     },
     capabilities({ phase, request = null }) {
       const value = phaseMetadata[phase];
-      if (!value) return Object.freeze({ supported: false, reason: "unknown phase", credentialTransport: metadata.credentialTransport });
-      let capability = { ...value, credentialTransport: metadata.credentialTransport };
+      if (!value) return Object.freeze({ supported: false, reason: "unknown phase" });
+      let capability = { ...value };
       if (value.supported && phase === "dispatch" && request && validateDispatch) {
         const validation = validateDispatch({
           sandbox: request.sandbox || (request.readOnly ? "read-only" : "workspace-write"),
@@ -394,12 +330,10 @@ module.exports = {
   PHASES,
   assertInvocationShape: normalizeInvocationShape,
   createNativeAdapter,
-  credentialRequest,
   filesystemIsolationDiagnostic,
   decodeTrustedPrompt,
   formatAdapterPhase,
   makeParseOutcome,
-  normalizePrivateEnvPaths,
   parseOutput,
   parseJsonObject,
   probeBinary,

--- a/skills/relay-dispatch/scripts/adapters/antigravity.js
+++ b/skills/relay-dispatch/scripts/adapters/antigravity.js
@@ -23,10 +23,7 @@ module.exports = createNativeAdapter({
   name: "antigravity",
   timeoutMs: 1800000,
   outputProtocol: (phase) => phase === "primary_review" ? "json_result" : "text_stdout",
-  metadata: { cliBinary: "agy", cliBinaryEnv: "RELAY_ANTIGRAVITY_BIN", outputProtocol: "phase-specific", providerDefault: "google", providerFromModel: true, promptTransport: "argv_visible", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", credentialTransport: "explicit_bundle", runtimeDependencies: { executableParent: null, interpreterParent: null }, promptTransportWarning: "prompt content is visible in the local process list; bounded to less than 256 KiB", credentials: { files: [
-    { id: "oauth", targetRoot: "home", targetRel: ".gemini/oauth_creds.json", access: "read_write", recommendedSource: "~/.gemini/oauth_creds.json" },
-    { id: "config", targetRoot: "home", targetRel: ".gemini/config/config.json", access: "read_write", recommendedSource: "~/.gemini/config/config.json" },
-  ], envHints: [] } },
+  metadata: { cliBinary: "agy", cliBinaryEnv: "RELAY_ANTIGRAVITY_BIN", outputProtocol: "phase-specific", providerDefault: "google", providerFromModel: true, promptTransport: "argv_visible", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", runtimeDependencies: { executableParent: null, interpreterParent: null }, promptTransportWarning: "prompt content is visible in the local process list; bounded to less than 256 KiB" },
   phases: {
     // `agy --sandbox` does not provide a verifiable tool-network block.
     dispatch: { supported: true, write: true, readOnly: false, networkControl: "informational", filesystemIsolation: "declaration_only", cancellation: "process", structuredOutput: "text", commandExecution: true },

--- a/skills/relay-dispatch/scripts/adapters/claude.js
+++ b/skills/relay-dispatch/scripts/adapters/claude.js
@@ -12,17 +12,12 @@ module.exports = createNativeAdapter({
   metadata: {
     processContainment: "inherited_scope_no_daemon",
     providerTransport: "remote_required",
-    credentialTransport: "explicit_bundle",
     runtimeDependencies: { executableParent: null, interpreterParent: null },
     cliBinary: "claude",
     outputProtocol: "text_stdout",
     providerDefault: "anthropic",
     providerFromModel: true,
     promptTransport: "stdin",
-    credentials: { files: [
-      { id: "auth", targetRoot: "home", targetRel: ".claude/.credentials.json", access: "read_write", recommendedSource: "~/.claude/.credentials.json" },
-      { id: "settings", targetRoot: "home", targetRel: ".claude/settings.json", access: "read", recommendedSource: "~/.claude/settings.json" },
-    ], envHints: ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] },
   },
   phases: {
     dispatch: { supported: true, write: true, readOnly: false, networkControl: "informational", filesystemIsolation: "native_bash", cancellation: "process", structuredOutput: "text", commandExecution: true },

--- a/skills/relay-dispatch/scripts/adapters/cline.js
+++ b/skills/relay-dispatch/scripts/adapters/cline.js
@@ -31,9 +31,7 @@ module.exports = createNativeAdapter({
   name: "cline",
   timeoutMs: 1800000,
   outputProtocol: "jsonl_run_result",
-  metadata: { cliBinary: "cline", cliBinaryEnv: "RELAY_CLINE_BIN", outputProtocol: "jsonl_run_result", providerDefault: "cline-pass", providerFromModel: true, resultErrorLabel: "Cline JSONL", reviewScript: null, promptTransport: "argv_visible", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", credentialTransport: "explicit_bundle", runtimeDependencies: { executableParent: 1, interpreterParent: null }, promptTransportWarning: "installed CLI help declares only a positional prompt; prompt content is visible in the local process list and bounded to less than 256 KiB", credentials: { files: [
-    { id: "providers", targetRoot: "home", targetRel: ".cline/data/settings/providers.json", access: "read_write", recommendedSource: "~/.cline/data/settings/providers.json" },
-  ], envHints: [] } },
+  metadata: { cliBinary: "cline", cliBinaryEnv: "RELAY_CLINE_BIN", outputProtocol: "jsonl_run_result", providerDefault: "cline-pass", providerFromModel: true, resultErrorLabel: "Cline JSONL", reviewScript: null, promptTransport: "argv_visible", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", runtimeDependencies: { executableParent: 1, interpreterParent: null }, promptTransportWarning: "installed CLI help declares only a positional prompt; prompt content is visible in the local process list and bounded to less than 256 KiB" },
   phases: {
     dispatch: { supported: true, write: true, readOnly: false, networkControl: "informational", filesystemIsolation: "none", cancellation: "process", structuredOutput: "jsonl", commandExecution: true },
     primary_review: { supported: false, reason: "Cline primary review remains blocked pending a strict live canary" },

--- a/skills/relay-dispatch/scripts/adapters/codex.js
+++ b/skills/relay-dispatch/scripts/adapters/codex.js
@@ -17,12 +17,7 @@ module.exports = createNativeAdapter({
     promptTransport: "stdin_dash",
     processContainment: "inherited_scope_no_daemon",
     providerTransport: "remote_required",
-    credentialTransport: "explicit_bundle",
     runtimeDependencies: { executableParent: null, interpreterParent: null },
-    credentials: { files: [
-      { id: "auth", targetRoot: "home", targetRel: ".codex/auth.json", access: "read_write", recommendedSource: "~/.codex/auth.json" },
-      { id: "config", targetRoot: "home", targetRel: ".codex/config.toml", access: "read", recommendedSource: "~/.codex/config.toml" },
-    ], envHints: ["OPENAI_API_KEY"] },
   },
   phases: {
     // Codex has no fail-closed tool-network switch; provider transport remains enabled.

--- a/skills/relay-dispatch/scripts/adapters/cursor.js
+++ b/skills/relay-dispatch/scripts/adapters/cursor.js
@@ -1,7 +1,6 @@
 const { createNativeAdapter } = require("../adapter-contract");
 
 function binary() { return process.env.RELAY_CURSOR_AGENT_BIN || "agent"; }
-const privateEnvPaths = [{ key: "CURSOR_CONFIG_DIR", root: "home", relative: ".cursor" }, { key: "CURSOR_DATA_DIR", root: "scratch", relative: "cursor-data" }];
 
 function validateDispatch({ sandbox, networkAccess }) { void sandbox; void networkAccess; return { ok: true, warnings: [] }; }
 
@@ -12,7 +11,6 @@ module.exports = createNativeAdapter({
   metadata: {
     processContainment: "inherited_scope_no_daemon",
     providerTransport: "remote_required",
-    credentialTransport: "explicit_bundle",
     runtimeDependencies: { executableParent: 0, interpreterParent: null },
     cliBinary: "agent",
     cliBinaryEnv: "RELAY_CURSOR_AGENT_BIN",
@@ -20,9 +18,6 @@ module.exports = createNativeAdapter({
     providerDefault: "cursor",
     providerFromModel: true,
     promptTransport: "stdin",
-    credentials: { files: [
-      { id: "cli_config", targetRoot: "home", targetRel: ".cursor/cli-config.json", access: "read_write", recommendedSource: "~/.cursor/cli-config.json" },
-    ], envHints: ["CURSOR_API_KEY"] },
   },
   phases: {
     dispatch: { supported: true, write: true, readOnly: true, networkControl: "informational", filesystemIsolation: "native", filesystemIsolationRequest: "enabled", cancellation: "process", structuredOutput: "text", commandExecution: true },
@@ -33,11 +28,11 @@ module.exports = createNativeAdapter({
     const args = ["--print", "--trust", "--auto-review", "--workspace", cwd, "--output-format", "text", "--sandbox", "enabled"];
     void sandbox;
     if (model) args.push("--model", model);
-    return { command: binary(), args, cwd, stdinPath: promptPath, stdinSha256: promptSha256, privateEnvPaths };
+    return { command: binary(), args, cwd, stdinPath: promptPath, stdinSha256: promptSha256 };
   },
   buildReview({ cwd, promptPath, promptSha256, model }) {
     const args = ["--print", "--trust", "--mode", "ask", "--workspace", cwd, "--output-format", "text", "--sandbox", "enabled"];
     if (model) args.push("--model", model);
-    return { command: binary(), args, cwd, stdinPath: promptPath, stdinSha256: promptSha256, privateEnvPaths };
+    return { command: binary(), args, cwd, stdinPath: promptPath, stdinSha256: promptSha256 };
   },
 });

--- a/skills/relay-dispatch/scripts/adapters/opencode.js
+++ b/skills/relay-dispatch/scripts/adapters/opencode.js
@@ -12,12 +12,7 @@ module.exports = createNativeAdapter({
   name: "opencode",
   timeoutMs: 1800000,
   outputProtocol: (phase) => phase === "primary_review" ? "json_result" : "text_stdout",
-  metadata: { cliBinary: "opencode", outputProtocol: "phase-specific", providerDefault: "opencode", providerFromModel: true, promptTransport: "stdin", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", credentialTransport: "explicit_bundle", runtimeDependencies: { executableParent: null, interpreterParent: null },
-    credentials: { files: [
-      { id: "auth", targetRoot: "xdg_data", targetRel: "opencode/auth.json", access: "read_write", recommendedSource: "~/.local/share/opencode/auth.json" },
-      { id: "config_json", targetRoot: "xdg_config", targetRel: "opencode/opencode.json", access: "read", recommendedSource: "~/.config/opencode/opencode.json" },
-      { id: "config_jsonc", targetRoot: "xdg_config", targetRel: "opencode/opencode.jsonc", access: "read", recommendedSource: "~/.config/opencode/opencode.jsonc" },
-    ], envHints: [] } },
+  metadata: { cliBinary: "opencode", outputProtocol: "phase-specific", providerDefault: "opencode", providerFromModel: true, promptTransport: "stdin", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", runtimeDependencies: { executableParent: null, interpreterParent: null } },
   phases: {
     dispatch: { supported: true, write: true, readOnly: false, networkControl: "informational", filesystemIsolation: "none", cancellation: "process", structuredOutput: "text", commandExecution: true },
     primary_review: { supported: true, write: false, readOnly: true, networkControl: "informational", filesystemIsolation: "none", cancellation: "process", structuredOutput: "json" },

--- a/skills/relay-dispatch/scripts/adapters/pi.js
+++ b/skills/relay-dispatch/scripts/adapters/pi.js
@@ -16,12 +16,7 @@ module.exports = createNativeAdapter({
   name: "pi",
   timeoutMs: 1800000,
   outputProtocol: (phase) => phase === "primary_review" ? "json_result" : "text_stdout",
-  metadata: { cliBinary: "pi", cliBinaryEnv: "RELAY_PI_BIN", outputProtocol: "phase-specific", providerDefault: "pi", providerFromModel: true, promptTransport: "stdin", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", credentialTransport: "explicit_bundle", runtimeDependencies: { executableParent: 1, interpreterParent: null },
-    credentials: { files: [
-      { id: "auth", targetRoot: "home", targetRel: ".pi/agent/auth.json", access: "read_write", recommendedSource: "~/.pi/agent/auth.json" },
-      { id: "settings", targetRoot: "home", targetRel: ".pi/agent/settings.json", access: "read_write", recommendedSource: "~/.pi/agent/settings.json" },
-      { id: "models", targetRoot: "home", targetRel: ".pi/agent/models.json", access: "read", recommendedSource: "~/.pi/agent/models.json" },
-    ], envHints: ["QWEN_TOKEN_PLAN_API_KEY", "QWEN_TOKEN_PLAN_CN_API_KEY"] } },
+  metadata: { cliBinary: "pi", cliBinaryEnv: "RELAY_PI_BIN", outputProtocol: "phase-specific", providerDefault: "pi", providerFromModel: true, promptTransport: "stdin", processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required", runtimeDependencies: { executableParent: 1, interpreterParent: null } },
   phases: {
     // buildDispatch pins --tools read,grep,find,ls,write,edit: no shell, no command execution.
     dispatch: { supported: true, write: true, readOnly: false, networkControl: "native", filesystemIsolation: "none", cancellation: "process", structuredOutput: "text", commandExecution: false },

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -11,7 +11,7 @@ const path = require("path");
 const { parseArgs: parseNodeArgs } = require("util");
 
 const { getAdapter, listAdapters } = require("./adapters");
-const { assertInvocationShape, credentialRequest: validateCredentialRequest, filesystemIsolationDiagnostic, validateCapabilities } = require("./adapter-contract");
+const { assertInvocationShape, filesystemIsolationDiagnostic, validateCapabilities } = require("./adapter-contract");
 const facts = require("./facts");
 const host = require("./host");
 const recover = require("./recover");
@@ -31,8 +31,6 @@ const OPTIONS = Object.freeze({
   "network-access": { type: "string", default: "disabled" },
   timeout: { type: "string" },
   reasoning: { type: "string" },
-  "credential-env": { type: "string", multiple: true, default: [] },
-  "credential-file": { type: "string", multiple: true, default: [] },
   copy: { type: "string" },
   "issue-number": { type: "string" },
   "fleet-id": { type: "string" },
@@ -280,11 +278,6 @@ function validateCopyInputs(repoRoot, copyValue) {
   return inputs;
 }
 
-function credentialRequest(adapter, values) {
-  try { return validateCredentialRequest(adapter.metadata.credentials, { envNames: values["credential-env"] || [], fileSpecs: values["credential-file"] || [] }); }
-  catch (error) { fail(error.message, "INVALID_CREDENTIAL"); }
-}
-
 function copyInputs(repoRoot, worktree, copyValue) {
   const copied = [];
   for (const opened of validateCopyInputs(repoRoot, copyValue)) {
@@ -473,7 +466,7 @@ function dryRunInvocation({ cli, identity, adapter, inputs }) {
     });
     return { command: invocation.command, args: [...invocation.args], cwd: invocation.cwd, validation: "adapter_build_invocation",
       launch_boundary: "host_supervisor_required_do_not_execute_raw",
-      prompt_transport: adapter.metadata.promptTransport, network_access: invocation.networkAccess, tool_network_access: invocation.toolNetworkAccess, private_env_paths: invocation.privateEnvPaths };
+      prompt_transport: adapter.metadata.promptTransport, network_access: invocation.networkAccess, tool_network_access: invocation.toolNetworkAccess };
   } finally {
     fs.rmSync(temporary, { recursive: true, force: true });
   }
@@ -585,9 +578,6 @@ async function startAttempt({ cli, identity, adapter, prompt, rubric, criteria, 
     });
     startSha = git(record.git.worktree, ["rev-parse", "HEAD"]);
     timeoutMs = (cli.timeoutSeconds || adapter.defaults.timeoutMs / 1000) * 1000;
-    const requestedCredentials = credentialRequest(adapter, cli.values);
-    // The durable attempt intent deliberately precedes credential reads. launchLocalSupervisor binds them next,
-    // under this same run lock and before publishing config or spawning any host/executor process.
     facts.appendFact({ eventsPath: path.join(runDir, "events.jsonl"), lockContext, fact: attemptFact({
       runId: cli.runId, attemptId, type: "attempt_started", actor,
       payload: { executor: adapter.name, model: cli.values.model || null, start_sha: startSha, host_kind: "local_supervisor", host_handle: lockContext.host_handle, stdout_path: stdoutPath, stderr_path: stderrPath, result_path: resultPath, timeout_ms: timeoutMs },
@@ -604,9 +594,7 @@ async function startAttempt({ cli, identity, adapter, prompt, rubric, criteria, 
       executorSandbox: cli.values.sandbox,
       executorNetworkAccess: cli.values["network-access"],
       runtimeDependencies: invocation.runtimeDependencies,
-      privateEnvPaths: invocation.privateEnvPaths,
       timeoutMs,
-      credentialRequest: { metadata: requestedCredentials.metadata, envNames: requestedCredentials.envNames, fileSpecs: requestedCredentials.fileSpecs, env: process.env },
       processContainment: adapter.metadata.processContainment,
       lockContext,
     });
@@ -628,7 +616,7 @@ async function startAttempt({ cli, identity, adapter, prompt, rubric, criteria, 
 
 async function recoverIncompleteHostCleanup(started, hostError) {
   // A signed cleanup obligation is the only authority to reap a scoped
-  // executor and remove its staged credentials. Never release this owner by
+  // executor and remove its staged input. Never release this owner by
   // hand: breakStaleRunLock verifies and settles that exact obligation first.
   const inspection = host.inspectOwnership({ runDir: started.runDir });
   try {
@@ -653,7 +641,7 @@ async function finishAttempt({ cli, adapter, started }) {
       terminal = settled.terminal; finalizerLock = settled.lockContext;
     } else if (new Set(["HOST_RESULT_TIMEOUT", "HOST_RESULT_MISMATCH"]).has(error.code)) {
       // These have no signed cleanup obligation. Retain the owner and evidence
-      // for canonical recovery rather than guessing that credentials are gone.
+      // for canonical recovery rather than guessing that the host is gone.
       throw error;
     } else {
       const observed = observeAttemptWorktree(started.record.git.worktree);
@@ -703,7 +691,6 @@ async function executeForeground(cli, overrides = {}) {
   }
   const inspectRun = overrides.inspectRun || recover.inspectProductionRun;
   const identity = repositoryIdentity(canonicalCheckout(cli.repo));
-  const requestedCredentials = credentialRequest(adapter, cli.values);
   const capabilityRequest = { sandbox: cli.values.sandbox, readOnly: cli.values.sandbox === "read-only", networkAccess: cli.values["network-access"] };
   validateCapabilities(adapter, "dispatch", capabilityRequest);
   const filesystemIsolation = filesystemIsolationDiagnostic(adapter, "dispatch", capabilityRequest);
@@ -715,7 +702,7 @@ async function executeForeground(cli, overrides = {}) {
   const inputs = loadInputs(cli, prompt);
   if (cli.values["dry-run"]) {
     const invocation = dryRunInvocation({ cli, identity, adapter, inputs });
-    return { status: "dry-run", run_id: cli.runId, repo: identity.repoRoot, executor: adapter.name, model: cli.values.model || null, credential_request: requestedCredentials.summary, filesystem_isolation: filesystemIsolation, durable_bytes_written: 0, invocation, ...(resumeInspection ? { inspection: resumeInspection } : {}), recovery: "canonical relay-recover only" };
+    return { status: "dry-run", run_id: cli.runId, repo: identity.repoRoot, executor: adapter.name, model: cli.values.model || null, filesystem_isolation: filesystemIsolation, durable_bytes_written: 0, invocation, ...(resumeInspection ? { inspection: resumeInspection } : {}), recovery: "canonical relay-recover only" };
   }
   const started = await startAttempt({ cli, identity, adapter, prompt: inputs.prompt, rubric: inputs.rubric, criteria: inputs.criteria, resumeInspection, inspectRun });
   const launch = { status: "dispatched", run_id: cli.runId, run_dir: started.runDir, worktree: started.record.git.worktree, attempt_id: started.attemptId, host_handle: started.receipt.host_handle, filesystem_isolation: filesystemIsolation };
@@ -733,7 +720,6 @@ function processLive(pid) {
 }
 
 async function executeDetached(cli, argv) {
-  if ((cli.values["credential-env"] || []).length || (cli.values["credential-file"] || []).length) fail("credential options require foreground dispatch so source paths are not copied into another process argv", "INVALID_CREDENTIAL");
   const notifyPath = path.join(os.tmpdir(), `relay-dispatch-${crypto.randomUUID()}.json`);
   const env = { ...process.env, RELAY_DISPATCH_INTERNAL_RUN_ID: cli.runId, RELAY_DISPATCH_NOTIFY_PATH: notifyPath };
   const childArgs = argv.filter((arg) => arg !== "--detach");
@@ -782,4 +768,4 @@ async function main(argv = process.argv.slice(2)) {
 
 if (require.main === module) main().then((code) => { process.exitCode = code; });
 
-module.exports = { assertDispatchToolset, assertResumeInspection, credentialRequest, detectCommandExecutionDemand, dryRunInvocation, executeForeground, finishAttempt, main, parseCli, repositoryIdentity, startAttempt, validateCopyInputs };
+module.exports = { assertDispatchToolset, assertResumeInspection, detectCommandExecutionDemand, dryRunInvocation, executeForeground, finishAttempt, main, parseCli, repositoryIdentity, startAttempt, validateCopyInputs };

--- a/skills/relay-dispatch/scripts/host.js
+++ b/skills/relay-dispatch/scripts/host.js
@@ -5,7 +5,6 @@ const crypto = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { normalizePrivateEnvPaths } = require("./adapter-contract");
 
 const OWNERSHIP = "ownership";
 const OWNER_RE = /^(\d{12})\.owner\.json$/;
@@ -14,6 +13,7 @@ const TERMINAL = new Set(["completed", "failed", "cancelled", "timed_out", "spaw
 const BREAK_PROBE_MS = 10_000;
 const PROCESS_SCOPE_KEY = "RELAY_PROCESS_SCOPE";
 const PROCESS_CONTRACT = "inherited_scope_no_daemon";
+const AMBIENT_ENVIRONMENT_INJECTION = /^(?:RELAY_.*|NODE_OPTIONS|NODE_PATH|BASH_ENV|ENV|ZDOTDIR|JAVA_TOOL_OPTIONS|_JAVA_OPTIONS|JDK_JAVA_OPTIONS|PHPRC|PHP_INI_SCAN_DIR|PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|PERL5OPT|PERL5LIB|PERL5DB|RUBYOPT|RUBYLIB|GEM_HOME|GEM_PATH|GCONV_PATH|LOCPATH|NLSPATH)$|^(?:DYLD|LD)_|^LUA_(?:INIT|PATH|CPATH)(?:_.*)?$/;
 const PS_ROW_RE = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+([A-Z][a-z]{2}\s+[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(.*)$/;
 const SCOPE_RE = new RegExp(`(?:^|\\s)${PROCESS_SCOPE_KEY}=([0-9a-f]{64})(?=\\s|$)`);
 const issuedLocks = new WeakSet();
@@ -24,8 +24,6 @@ const issuedInspections = new WeakSet();
 const inspectionStates = new WeakMap();
 const issuedProcessScopes = new WeakSet();
 const processScopeStates = new WeakMap();
-const issuedCredentialBundles = new WeakSet();
-const credentialBundleStates = new WeakMap();
 
 class HostError extends Error {
   constructor(message, code, details = {}) {
@@ -48,20 +46,6 @@ function verifySigned(value, secret, field = "auth_sha256") {
 function safeAttempt(attemptId) {
   if (typeof attemptId !== "string" || !ATTEMPT_RE.test(attemptId)) fail("invalid attempt id", "INVALID_ATTEMPT_ID");
   return attemptId;
-}
-function normalizedPrivatePaths(value, code = "INVALID_INVOCATION") { try { return normalizePrivateEnvPaths(value); } catch (cause) { fail(cause.message, code, { cause }); } }
-function attemptPrivateRoot(runDir, owner, short) {
-  const parent = canonicalDir(short ? fs.realpathSync("/tmp") : runDir, "executor private parent"), name = short ? `relay-${sha256(`${owner.lock_id}:${owner.attempt_id}`).slice(0, 32)}` : `executor-credentials-${owner.attempt_id}`;
-  const target = path.join(parent, name);
-  if (short && Buffer.byteLength(target) > 64) fail("short private root exceeds 64 bytes", "INVALID_INVOCATION"); return target;
-}
-function privatePathEnvironment(declarations, roots, environment, code) {
-  const values = {}; for (const item of normalizedPrivatePaths(declarations, code)) {
-    if (Object.hasOwn(environment, item.key)) fail("private environment path collides with caller environment", code);
-    const root = roots[item.root], target = root && path.resolve(root, item.relative), relative = root && path.relative(root, target);
-    if (!relative || relative.startsWith("..") || path.isAbsolute(relative) || (item.root === "scratch" && Buffer.byteLength(target) > 83)) fail("private environment path escapes its root or exceeds the short-path limit", code);
-    fs.mkdirSync(target, { recursive: true, mode: 0o700 }); fs.chmodSync(target, 0o700); values[item.key] = target;
-  } return values;
 }
 function canonicalDir(value, label) {
   if (typeof value !== "string" || !path.isAbsolute(value)) fail(`${label} must be absolute`, "INVALID_PATH");
@@ -135,17 +119,8 @@ function resolveExecutable(command, env = process.env) {
   fail(`executable not found: ${command}`, "INVALID_INVOCATION");
 }
 function environmentEntries(value, label) {
-  if (value === undefined) return {};
-  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`, "INVALID_INVOCATION");
-  const result = {};
-  for (const [key, entry] of Object.entries(value)) {
-    const injection = /^(?:SSL_CERT_FILE|NODE_OPTIONS|NODE_PATH|BASH_ENV|ENV|ZDOTDIR|JAVA_TOOL_OPTIONS|_JAVA_OPTIONS|JDK_JAVA_OPTIONS|PHPRC|PHP_INI_SCAN_DIR|PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|PERL5OPT|PERL5LIB|PERL5DB|RUBYOPT|RUBYLIB|GEM_HOME|GEM_PATH|GCONV_PATH|LOCPATH|NLSPATH)$|^(?:DYLD|LD)_|^LUA_(?:INIT|PATH|CPATH)(?:_.*)?$/.test(key);
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || injection || typeof entry !== "string" || entry.includes("\0")) {
-      fail(`${label} contains an invalid environment entry`, "INVALID_INVOCATION");
-    }
-    result[key] = entry;
-  }
-  return result;
+  try { return ambientEnvironment({}, label, value === undefined ? {} : value); }
+  catch (error) { fail(error.message, "INVALID_INVOCATION"); }
 }
 function minimalEnvironment(source = process.env) {
   const result = {};
@@ -155,6 +130,21 @@ function minimalEnvironment(source = process.env) {
     }
   }
   return result;
+}
+// Ambient CLI auth/config may flow through the host's unlinked FD, but runtime
+// startup injection never does. The sanitizer owns no durable values.
+function ambientEnvironment(source = process.env, label = "ambient environment", overrides = {}) {
+  if (!source || typeof source !== "object" || Array.isArray(source) || !overrides || typeof overrides !== "object" || Array.isArray(overrides)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const safe = {}, valid = (key, value) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key)
+    && !AMBIENT_ENVIRONMENT_INJECTION.test(key) && typeof value === "string" && !value.includes("\0");
+  for (const [key, value] of Object.entries(source)) if (valid(key, value)) safe[key] = value;
+  for (const [key, value] of Object.entries(overrides)) {
+    if (!valid(key, value)) throw new Error(`${label} contains an invalid environment entry`);
+    safe[key] = value;
+  }
+  return safe;
 }
 function regularFileBinding(filePath, label, { canonical = true } = {}) {
   const fd = fs.openSync(filePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
@@ -174,73 +164,6 @@ function verifyFileBinding(binding, label) {
     fail(`${label} changed after launch`, "HOST_INPUT_CHANGED");
   }
   return observed.path;
-}
-function credentialSource(filePath, label) {
-  if (typeof filePath !== "string" || !path.isAbsolute(filePath) || path.resolve(filePath) !== filePath) fail(`${label} source must be absolute and canonical`, "INVALID_CREDENTIAL");
-  let fd;
-  try {
-    fd = fs.openSync(filePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
-    const before = fs.fstatSync(fd), named = fs.lstatSync(filePath);
-    if (!before.isFile() || named.isSymbolicLink() || before.dev !== named.dev || before.ino !== named.ino || fs.realpathSync(filePath) !== filePath
-      || (typeof process.getuid === "function" && before.uid !== process.getuid()) || (before.mode & 0o077) !== 0) fail(`${label} source must be a current-user owner-only regular file`, "UNTRUSTED_CREDENTIAL");
-    const bytes = fs.readFileSync(fd), after = fs.fstatSync(fd), renamed = fs.lstatSync(filePath);
-    if (before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || before.mtimeMs !== after.mtimeMs
-      || before.ctimeMs !== after.ctimeMs || after.dev !== renamed.dev || after.ino !== renamed.ino || renamed.isSymbolicLink() || bytes.length !== after.size) {
-      bytes.fill(0); fail(`${label} source changed while read`, "CREDENTIAL_CHANGED");
-    }
-    return { path: filePath, dev: before.dev, ino: before.ino, size: bytes.length, sha: sha256(bytes), bytes };
-  } catch (error) {
-    if (error instanceof HostError) throw error;
-    fail(`${label} source is unavailable`, "UNTRUSTED_CREDENTIAL");
-  } finally { if (fd !== undefined) fs.closeSync(fd); }
-}
-function prepareCredentialBundle({ metadata = {}, envNames = [], fileSpecs = [], env = process.env } = {}) {
-  if (!Array.isArray(envNames) || !Array.isArray(fileSpecs)) fail("credential options must be arrays", "INVALID_CREDENTIAL");
-  const catalog = new Map((metadata.files || []).map((item) => [item.id, item])), seenEnv = new Set(), seenId = new Set(), seenTarget = new Set(), values = {}, files = [];
-  for (const name of envNames) {
-    if (seenEnv.has(name) || /^(?:HOME|PATH|TMPDIR|TMP|TEMP|XDG_CONFIG_HOME|XDG_DATA_HOME|RELAY_PROCESS_SCOPE)$|^RELAY_/.test(name || "")) fail(`credential environment name is reserved or duplicated: ${name}`, "INVALID_CREDENTIAL");
-    environmentEntries({ [name]: "checked" }, "credential environment");
-    if (typeof env[name] !== "string") fail(`credential environment value is missing: ${name}`, "CREDENTIAL_MISSING");
-    seenEnv.add(name); values[name] = env[name];
-  }
-  try { for (const spec of fileSpecs) {
-    if (typeof spec !== "string") fail("credential file must be ID=/absolute/source", "INVALID_CREDENTIAL");
-    const equals = spec.indexOf("="), id = spec.slice(0, equals), sourcePath = spec.slice(equals + 1), item = catalog.get(id);
-    if (equals < 1 || !item) fail(`unknown credential file id: ${id || spec}`, "INVALID_CREDENTIAL");
-    if (!/^[a-z][a-z0-9_-]*$/.test(item.id || "") || !["home", "xdg_config", "xdg_data"].includes(item.targetRoot)
-      || !["read", "read_write"].includes(item.access) || typeof item.targetRel !== "string" || path.isAbsolute(item.targetRel)
-      || !item.targetRel || item.targetRel.split(/[\\/]/).some((part) => !part || part === "." || part === "..")) fail("credential target metadata is invalid", "INVALID_CREDENTIAL");
-    const target = `${item.targetRoot}:${item.targetRel}`;
-    if (seenId.has(id) || seenTarget.has(target)) fail("credential file id or target collision", "INVALID_CREDENTIAL");
-    seenId.add(id); seenTarget.add(target);
-    files.push({ ...item, source: credentialSource(sourcePath, `credential '${id}'`) });
-  } } catch (error) {
-    for (const item of files) item.source.bytes.fill(0);
-    for (const key of Object.keys(values)) { values[key] = ""; delete values[key]; }
-    throw error;
-  }
-  const bundle = Object.freeze({ env_names: Object.freeze([...seenEnv]), files: Object.freeze(files.map(({ source, recommendedSource, ...item }) => Object.freeze({ ...item, size: source.size, sha: source.sha }))) });
-  issuedCredentialBundles.add(bundle); credentialBundleStates.set(bundle, { values, files }); return bundle;
-}
-function credentialState(bundle) {
-  if (!bundle) return { values: {}, files: [], publicFiles: [], envNames: [] };
-  if (!issuedCredentialBundles.has(bundle)) fail("issued credential bundle required", "INVALID_CREDENTIAL");
-  const state = credentialBundleStates.get(bundle), files = [];
-  try {
-    for (const item of state.files) {
-      const fresh = credentialSource(item.source.path, `credential '${item.id}'`);
-      if (fresh.dev !== item.source.dev || fresh.ino !== item.source.ino || fresh.size !== item.source.size || fresh.sha !== item.source.sha) {
-        fresh.bytes.fill(0); fail(`credential '${item.id}' changed after validation`, "CREDENTIAL_CHANGED");
-      }
-      files.push({ ...item, source: fresh });
-    }
-    return { values: { ...state.values }, files, publicFiles: bundle.files, envNames: bundle.env_names };
-  } catch (error) { for (const item of files) item.source.bytes.fill(0); throw error; }
-  finally {
-    for (const item of state.files) item.source.bytes.fill(0);
-    for (const key of Object.keys(state.values)) { state.values[key] = ""; delete state.values[key]; }
-    credentialBundleStates.delete(bundle); issuedCredentialBundles.delete(bundle);
-  }
 }
 function shebangExecutables(executable, env) {
   const found = [], seen = new Set(); let current = executable;
@@ -497,7 +420,7 @@ function auditProcessScope(capability) {
 }
 hostInvocation.beginProcessScope = beginProcessScope;
 hostInvocation.auditProcessScope = auditProcessScope;
-hostInvocation.privatePathEnvironment = privatePathEnvironment;
+hostInvocation.ambientEnvironment = ambientEnvironment;
 hostInvocation.bindRegularFile = (filePath, label) => regularFileBinding(filePath, label, { canonical: false });
 hostInvocation.bindRuntimeFiles = ({ command, env = process.env, runtimeDependencies = { executableParent: null, interpreterParent: null } } = {}) => {
   const prepared = runtimeBindingSet(command, env, runtimeDependencies);
@@ -505,7 +428,6 @@ hostInvocation.bindRuntimeFiles = ({ command, env = process.env, runtimeDependen
 };
 hostInvocation.verifyRuntimeFiles = ({ command, runtimeFiles, runtimeDependencies = { executableParent: null, interpreterParent: null }, env = process.env, reenumerate = true } = {}) =>
   verifyRuntimeFileBindings({ command, runtimeFiles, runtimeDependencies, environment: env, reenumerate });
-hostInvocation.readOwnerCredential = (filePath, label) => credentialSource(filePath, label).bytes;
 hostInvocation.removeBoundDirectory = removeBoundDirectory;
 function waitForProcessGroupAbsence(pgid, timeoutMs) { return Boolean(pollUntil(() => !groupExists(pgid), timeoutMs, 10)); }
 function reapProcessGroup(pgid, seal) {
@@ -717,12 +639,19 @@ function inspectOwnership({ runDir } = {}) {
   return inspection;
 }
 function cleanupObligation(value, runDir, owner) {
-  const obligation = value?.obligation, reviewerRoot = value?.kind === "reviewer" && typeof obligation?.credential_root?.path === "string"
-    && path.dirname(obligation.credential_root.path) === fs.realpathSync("/tmp") && /^relay-review-[A-Za-z0-9_-]+$/.test(path.basename(obligation.credential_root.path));
-  const expectedRoots = reviewerRoot ? [obligation.credential_root.path] : [attemptPrivateRoot(runDir, owner, false), attemptPrivateRoot(runDir, owner, true)];
-  if (!obligation || !Array.isArray(obligation.processes) || !obligation.credential_root || !expectedRoots.includes(obligation.credential_root.path)
-    || !((obligation.credential_root.dev === null && obligation.credential_root.ino === null)
-      || (Number.isInteger(obligation.credential_root.dev) && Number.isInteger(obligation.credential_root.ino)))) fail("cleanup obligation is invalid", "HOST_ARTIFACT_INVALID");
+  void runDir; void owner;
+  const obligation = value?.obligation, staged = obligation?.staged_input_root;
+  if (!value || !["executor", "reviewer"].includes(value.kind)
+    || !obligation || typeof obligation !== "object" || Array.isArray(obligation)
+    || Object.keys(obligation).sort().join(",") !== "processes,scope_seal,staged_input_root") {
+    fail("cleanup obligation is invalid", "HOST_ARTIFACT_INVALID");
+  }
+  const reviewerRoot = value.kind === "reviewer" && staged && typeof staged.path === "string"
+    && path.dirname(staged.path) === fs.realpathSync("/tmp") && /^relay-review-[A-Za-z0-9_-]+$/.test(path.basename(staged.path));
+  if (!Array.isArray(obligation.processes) || (value.kind === "reviewer" ? !reviewerRoot : staged !== null)
+    || (value.kind === "reviewer" && (!Number.isInteger(staged.dev) || !Number.isInteger(staged.ino)))) {
+    fail("cleanup obligation is invalid", "HOST_ARTIFACT_INVALID");
+  }
   const identities = value.identities, terminal = value.terminal;
   if (!identities || (value.kind !== "reviewer" && !identities.supervisor) || (identities.executor !== null && !identities.executor)) fail("cleanup host identities are invalid", "HOST_ARTIFACT_INVALID");
   if (identities.supervisor) exactIdentity(identities.supervisor, "cleanup supervisor"); if (identities.executor) exactIdentity(identities.executor, "cleanup executor");
@@ -732,7 +661,7 @@ function cleanupObligation(value, runDir, owner) {
   if (seal !== null && !/^[0-9a-f]{64}$/.test(seal)) fail("cleanup process scope seal is invalid", "HOST_ARTIFACT_INVALID");
   if (!terminal || !["completed", "failed", "cancelled", "timed_out", "spawn_error"].includes(terminal.status)
     || (terminal.exit_code !== null && !Number.isInteger(terminal.exit_code)) || (terminal.signal !== null && typeof terminal.signal !== "string")) fail("cleanup terminal context is invalid", "HOST_ARTIFACT_INVALID");
-  return { kind: value.kind || "executor", processes, credential_root: { ...obligation.credential_root }, scope_seal: seal, terminal };
+  return { kind: value.kind, processes, staged_input_root: staged ? { ...staged } : null, scope_seal: seal, terminal };
 }
 function identityGone(identity, timeoutMs) {
   return Boolean(pollUntil(() => { const row = probeRow(identity.pid); return !sameProcess(row?.identity, identity) || /^Z/.test(row.identity.state); }, timeoutMs));
@@ -823,21 +752,22 @@ function removeBoundDirectory(target, expected, label, { fault, reclaim = true }
   }
   syncDir(path.dirname(target)); return true;
 }
-function removeExactCredentialRoot(root, runDir, owner, fault) {
+function removeExactStagedInputRoot(root, fault) {
+  if (!root) return;
   const target = root.path, reviewerRoot = path.dirname(target) === fs.realpathSync("/tmp") && /^relay-review-[A-Za-z0-9_-]+$/.test(path.basename(target));
-  if (![attemptPrivateRoot(runDir, owner, false), attemptPrivateRoot(runDir, owner, true)].includes(target) && !reviewerRoot) fail("cleanup credential root is outside the attempt boundary", "HOST_ARTIFACT_INVALID");
+  if (!reviewerRoot) fail("cleanup staged input root is outside the review staging boundary", "HOST_ARTIFACT_INVALID");
   if (root.dev === null) {
-    if (fs.existsSync(target)) fail("credential root identity changed before recovery", "HOST_CLEANUP_INCOMPLETE", { recommended_action: "inspect" });
+    if (fs.existsSync(target)) fail("staged input root identity changed before recovery", "HOST_CLEANUP_INCOMPLETE", { recommended_action: "inspect" });
     return;
   }
   const binding = { dev: root.dev, ino: root.ino };
-  removeBoundDirectory(target, binding, "cleanup credential root",
-    { fault: fault ? (stage) => fault(`credential_${stage}`) : null });
+  removeBoundDirectory(target, binding, "cleanup staged input root",
+    { fault: fault ? (stage) => fault(`staged_input_${stage}`) : null });
   // Removal unlinks a pathname, so a rename racing the delete could leave the bound tree alive under a
   // quarantine name while the delete still reported success. Settling is only honest if nothing carrying
   // the signed identity survives, so re-scan and fail closed instead of trusting the delete's return.
   const surviving = quarantineSiblings(target, binding);
-  if (surviving.length) fail("cleanup credential root survived removal under a quarantine name", "HOST_CLEANUP_INCOMPLETE",
+  if (surviving.length) fail("cleanup staged input root survived removal under a quarantine name", "HOST_CLEANUP_INCOMPLETE",
     { recommended_action: "inspect", quarantinePath: surviving[0] });
 }
 function settleCleanup({ state, cleanupPath, fault, terminalStatus = "failed" }) {
@@ -847,7 +777,7 @@ function settleCleanup({ state, cleanupPath, fault, terminalStatus = "failed" })
   const obligation = cleanupObligation(read.value, state.runDir, owner), paths = attemptPaths(state.runDir, owner.attempt_id);
   for (const identity of obligation.processes) reapExactIdentity(identity, obligation.scope_seal);
   if (obligation.kind === "reviewer") reapSealedScope(obligation.scope_seal);
-  removeExactCredentialRoot(obligation.credential_root, state.runDir, owner, fault); fault?.("after_cleanup");
+  removeExactStagedInputRoot(obligation.staged_input_root, fault); fault?.("after_cleanup");
   const settledBody = { v: 2, attempt_id: owner.attempt_id, lock_id: owner.lock_id, host_handle: owner.host_handle,
     cleanup_sha256: sha256(read.bytes), settled_at: new Date().toISOString() };
   if (!publishOnce(paths.settled, signed(settledBody, owner.secret))) readBoundArtifact(paths.settled, "cleanup settled", owner, { cleanup_sha256: settledBody.cleanup_sha256 });
@@ -866,7 +796,7 @@ function retainReviewerCleanup(capability, { root, binding, scopeSeal } = {}) {
   const paths = attemptPaths(state.runDir, state.owner.attempt_id), body = { v: 2, kind: "reviewer", attempt_id: state.owner.attempt_id,
     lock_id: state.owner.lock_id, host_handle: state.owner.host_handle, identities: { supervisor: null, executor: null }, error: "reviewer cleanup pending",
     terminal: { status: "failed", exit_code: null, signal: null }, obligation: { processes: [],
-      credential_root: { path: root, dev: binding.dev, ino: binding.ino }, scope_seal: scopeSeal }, observed_at: new Date().toISOString() };
+      staged_input_root: { path: root, dev: binding.dev, ino: binding.ino }, scope_seal: scopeSeal }, observed_at: new Date().toISOString() };
   if (!publishOnce(paths.cleanup, signed(body, state.owner.secret))) readBoundArtifact(paths.cleanup, "cleanup-incomplete status", state.owner);
   return Object.freeze({ path: paths.cleanup, complete(terminalStatus) {
     const resultPath = settleCleanup({ state, cleanupPath: paths.cleanup, terminalStatus });
@@ -928,8 +858,8 @@ function waitForStartup({ child, paths, owner, configSha, timeoutMs }) {
 }
 function launchLocalSupervisor({ runDir, attemptId, command, args = [], trustedWorktreeRoot, cwd, stdoutPath, stderrPath, resultPath,
   inputFiles = [], stdinPath = null, stdinSha256 = null, executorResultPath = null, executorSandbox = "workspace-write", executorNetworkAccess = "disabled", timeoutMs = 30_000,
-  cancelGraceMs = 1_000, supervisorStartupTimeoutMs = 30_000, executorEnv = {}, ephemeralEnv = {}, credentialRequest = null, processContainment = PROCESS_CONTRACT,
-  runtimeDependencies = { executableParent: null, interpreterParent: null }, privateEnvPaths = [], testCredentialPrepared = null, testCleanupFailurePath = null, testGateBarrierPath = null, lockContext } = {}) {
+  cancelGraceMs = 1_000, supervisorStartupTimeoutMs = 30_000, executorEnv = {}, processContainment = PROCESS_CONTRACT,
+  runtimeDependencies = { executableParent: null, interpreterParent: null }, testGateBarrierPath = null, testBeforeSupervisorSpawn = null, lockContext } = {}) {
   if (lockContext === undefined) fail("production launch requires a lock capability", "HOST_LOCK_REQUIRED");
   const state = stateFor(lockContext), run = canonicalDir(runDir, "runDir"); assertRunLockHeld(lockContext, run);
   if (attemptId !== state.owner.attempt_id) fail("attempt does not match lock", "HOST_LOCK_IDENTITY_MISMATCH"); safeAttempt(attemptId);
@@ -943,28 +873,20 @@ function launchLocalSupervisor({ runDir, attemptId, command, args = [], trustedW
   if (Boolean(stdinPath) !== Boolean(stdinSha256) || (stdinSha256 && !/^[0-9a-f]{64}$/.test(stdinSha256))) fail("stdinPath and stdinSha256 must form an exact binding", "INVALID_INVOCATION");
   const declaredInputs = [...new Set([...inputFiles, ...(stdinPath ? [stdinPath] : [])])];
   const inputSources = declaredInputs.map((file) => directChild(run, file, "executor input", { exists: true }));
-  const explicitEnvironment = environmentEntries(executorEnv, "executorEnv"), ephemeralEnvironment = environmentEntries(ephemeralEnv, "ephemeralEnv");
-  const privatePaths = normalizedPrivatePaths(privateEnvPaths);
-  if (Object.hasOwn(explicitEnvironment, PROCESS_SCOPE_KEY) || Object.hasOwn(ephemeralEnvironment, PROCESS_SCOPE_KEY)) fail(`${PROCESS_SCOPE_KEY} is host-reserved`, "INVALID_INVOCATION");
-  ephemeralEnvironment[PROCESS_SCOPE_KEY] = crypto.randomBytes(32).toString("hex");
-  if (Object.keys(ephemeralEnvironment).some((key) => Object.hasOwn(explicitEnvironment, key))) fail("ephemeralEnv keys must be distinct", "INVALID_INVOCATION");
-  if ((testGateBarrierPath || testCredentialPrepared || testCleanupFailurePath) && !process.env.NODE_TEST_CONTEXT) fail("test host seam is unavailable", "INVALID_INVOCATION");
-  if (testCredentialPrepared !== null && typeof testCredentialPrepared !== "function") fail("test credential seam is invalid", "INVALID_INVOCATION");
+  const explicitEnvironment = environmentEntries(executorEnv, "executorEnv");
+  if (Object.hasOwn(explicitEnvironment, PROCESS_SCOPE_KEY)) fail(`${PROCESS_SCOPE_KEY} is host-reserved`, "INVALID_INVOCATION");
+  const scopeToken = crypto.randomBytes(32).toString("hex");
+  if ((testGateBarrierPath || testBeforeSupervisorSpawn) && !process.env.NODE_TEST_CONTEXT) fail("test host seam is unavailable", "INVALID_INVOCATION");
+  if (testBeforeSupervisorSpawn !== null && typeof testBeforeSupervisorSpawn !== "function") fail("test host seam is invalid", "INVALID_INVOCATION");
   const gateBarrier = testGateBarrierPath ? directChild(run, testGateBarrierPath, "test gate barrier") : null;
-  const cleanupFailure = testCleanupFailurePath ? directChild(run, testCleanupFailurePath, "test cleanup failure", { exists: true }) : null;
   const runtime = hostInvocation.bindRuntimeFiles({ command, env: process.env, runtimeDependencies });
   const paths = attemptPaths(run, attemptId), stdout = directChild(run, stdoutPath || path.join(run, `attempt-${attemptId}.stdout.log`), "stdout"),
     stderr = directChild(run, stderrPath || path.join(run, `attempt-${attemptId}.stderr.log`), "stderr"),
     result = directChild(run, resultPath || path.join(run, `attempt-${attemptId}.result.json`), "result"),
     executorResult = executorResultPath ? directChild(run, executorResultPath, "executor result") : null,
-    tmp = directChild(run, path.join(run, `executor-tmp-${attemptId}`), "executor tmp", { directory: true }),
-    credentialRoot = directChild(path.dirname(attemptPrivateRoot(run, state.owner, privatePaths.some((item) => item.root === "scratch"))), attemptPrivateRoot(run, state.owner, privatePaths.some((item) => item.root === "scratch")), "executor private root", { directory: true });
-  const preparedCredentials = credentialRequest ? prepareCredentialBundle(credentialRequest) : null;
-  if (testCredentialPrepared) testCredentialPrepared();
-  const credentials = credentialState(preparedCredentials);
-  if (privatePaths.some((item) => Object.hasOwn(explicitEnvironment, item.key) || Object.hasOwn(ephemeralEnvironment, item.key) || credentials.envNames.includes(item.key))) fail("private environment path collides with caller environment", "INVALID_INVOCATION");
+    tmp = directChild(run, path.join(run, `executor-tmp-${attemptId}`), "executor tmp", { directory: true });
   const inputStages = inputSources.map((unused, index) => directChild(run, path.join(run, `host-input-${attemptId}-${index}.bin`), "staged executor input"));
-  for (const target of [paths.config, paths.supervisor, paths.running, paths.cleanup, paths.settled, paths.cancel, stdout, stderr, result, executorResult, credentialRoot, ...inputStages].filter(Boolean)) {
+  for (const target of [paths.config, paths.supervisor, paths.running, paths.cleanup, paths.settled, paths.cancel, stdout, stderr, result, executorResult, ...inputStages].filter(Boolean)) {
     if (fs.existsSync(target)) fail("attempt artifact already exists", "HOST_ATTEMPT_ALREADY_LAUNCHED", { artifactPath: target, recommended_action: "inspect" });
   }
   fs.mkdirSync(tmp, { mode: 0o700 });
@@ -984,28 +906,27 @@ function launchLocalSupervisor({ runDir, attemptId, command, args = [], trustedW
     if (argument.startsWith("@") && replacements.has(argument.slice(1))) return `@${replacements.get(argument.slice(1))}`;
     return argument;
   });
-  const executorEnvironment = { ...minimalEnvironment(process.env), ...explicitEnvironment, TMPDIR: tmp, TMP: tmp, TEMP: tmp };
-  const secretPayload = Buffer.from(JSON.stringify({ owner_secret: state.owner.secret, ephemeral_env: ephemeralEnvironment, credential_env: credentials.values,
-    credential_files: credentials.files.map((item) => ({ id: item.id, bytes: item.source.bytes.toString("base64") })) }), "utf8");
-  for (const item of credentials.files) item.source.bytes.fill(0);
-  for (const key of Object.keys(credentials.values)) { credentials.values[key] = ""; delete credentials.values[key]; }
-  if (secretPayload.length > 8 * 1024 * 1024) { secretPayload.fill(0); fail("ephemeral credential payload is too large", "INVALID_INVOCATION"); }
+  const secretPayload = Buffer.from(JSON.stringify({ owner_secret: state.owner.secret,
+    ambient_env: { ...ambientEnvironment(process.env), ...explicitEnvironment, TMPDIR: tmp, TMP: tmp, TEMP: tmp }, scope_token: scopeToken }), "utf8");
+  if (secretPayload.length > 8 * 1024 * 1024) { secretPayload.fill(0); fail("ambient environment payload is too large", "INVALID_INVOCATION"); }
   const config = { v: 2, attempt_id: attemptId, lock_id: state.owner.lock_id, host_kind: "local_supervisor", host_handle: state.owner.host_handle,
     nonce: crypto.randomBytes(32).toString("hex"), command: runtime.command, args: stagedArgs, process_contract: processContainment, input_files: inputBindings,
-    stdin_binding: stdinIndex < 0 ? null : { index: stdinIndex, size: inputBindings[stdinIndex].size, sha256: stdinSha256 }, env: executorEnvironment,
-    ephemeral_env_keys: Object.keys(ephemeralEnvironment), credential_env_keys: credentials.envNames, credentials: credentials.publicFiles, credential_root: credentialRoot, private_env_paths: privatePaths,
-    scope_seal: scopeSeal(ephemeralEnvironment[PROCESS_SCOPE_KEY]),
+    stdin_binding: stdinIndex < 0 ? null : { index: stdinIndex, size: inputBindings[stdinIndex].size, sha256: stdinSha256 },
+    scope_seal: scopeSeal(scopeToken),
     worktree, cwd: worktree, stdout, stderr, result, executor_result: executorResult,
     tmp, sandbox: executorSandbox, network: "enabled", tool_network: executorNetworkAccess, runtime_dependencies: runtimeDependencies, runtime_files: runtime.runtime_files, timeout_ms: timeoutMs, grace_ms: cancelGraceMs,
-    supervisor: paths.supervisor, running: paths.running, cleanup: paths.cleanup, cancel: paths.cancel, ownership: path.dirname(state.ownerPath), test_gate_barrier: gateBarrier, test_cleanup_failure: cleanupFailure };
+    supervisor: paths.supervisor, running: paths.running, cleanup: paths.cleanup, cancel: paths.cancel, ownership: path.dirname(state.ownerPath), test_gate_barrier: gateBarrier };
   if (!publishOnce(paths.config, config)) fail("attempt has already been launched", "HOST_ATTEMPT_ALREADY_LAUNCHED");
   const configSha = sha256(fs.readFileSync(paths.config)), stdoutFd = fs.openSync(stdout, "wx", 0o600), stderrFd = fs.openSync(stderr, "wx", 0o600);
   const secretPath = path.join(run, `.host-secret-${attemptId}-${crypto.randomBytes(8).toString("hex")}`), secretFd = fs.openSync(secretPath, "wx+", 0o600);
   let child;
   try {
-    fs.writeFileSync(secretFd, secretPayload); fs.fsyncSync(secretFd); fs.unlinkSync(secretPath); syncDir(run);
+    // Never write ambient session bytes through a named directory entry: create the
+    // private inode, unlink the empty name durably, then fill only the live FD.
+    fs.unlinkSync(secretPath); syncDir(run); fs.writeFileSync(secretFd, secretPayload); fs.fsyncSync(secretFd);
+    testBeforeSupervisorSpawn?.({ runDir: run, configPath: paths.config });
     child = spawn(process.execPath, [__filename, "--supervise", paths.config, configSha], { cwd: run, detached: true,
-      env: { ...minimalEnvironment(process.env), [PROCESS_SCOPE_KEY]: ephemeralEnvironment[PROCESS_SCOPE_KEY] },
+      env: { ...minimalEnvironment(process.env), [PROCESS_SCOPE_KEY]: scopeToken },
       stdio: ["ignore", "ignore", stderrFd, secretFd, stdoutFd, stderrFd] });
   } finally {
     secretPayload.fill(0); try { fs.unlinkSync(secretPath); } catch {}
@@ -1050,44 +971,19 @@ async function waitForTerminalResult(receipt, { timeoutMs = receipt.timeout_ms +
   fail("timed out waiting for terminal result", "HOST_RESULT_TIMEOUT");
 }
 
-function stageCredentials(config, secretFiles, state = {}) {
-  const root = directChild(path.dirname(config.credential_root), config.credential_root, "executor credential root", { directory: true });
-  fs.mkdirSync(root, { mode: 0o700 }); fs.chmodSync(root, 0o700); const rootStat = fs.lstatSync(root);
-  Object.assign(state, { root, binding: { dev: rootStat.dev, ino: rootStat.ino } });
-  const roots = { home: path.join(root, "home"), xdg_config: path.join(root, "xdg-config"), xdg_data: path.join(root, "xdg-data"), scratch: path.join(root, "scratch") };
-  for (const value of Object.values(roots)) fs.mkdirSync(value, { mode: 0o700 });
-  const readable = [], writable = [], readonly = [], secrets = new Map((secretFiles || []).map((item) => [item.id, item.bytes]));
-  for (const item of config.credentials || []) {
-    if (!/^[a-z][a-z0-9_-]*$/.test(item.id || "") || !Object.hasOwn(roots, item.targetRoot) || !["read", "read_write"].includes(item.access)
-      || typeof item.targetRel !== "string" || path.isAbsolute(item.targetRel) || item.targetRel.split(/[\\/]/).some((part) => !part || part === "." || part === "..")) fail("credential target is invalid", "HOST_CONFIG_MISMATCH");
-    const encoded = secrets.get(item.id); if (typeof encoded !== "string") fail("credential bytes are unavailable", "HOST_CONFIG_MISMATCH");
-    const bytes = Buffer.from(encoded, "base64");
-    if (bytes.length !== item.size || sha256(bytes) !== item.sha) { bytes.fill(0); fail("credential bytes do not match binding", "HOST_CONFIG_MISMATCH"); }
-    const target = path.join(roots[item.targetRoot], item.targetRel), relative = path.relative(roots[item.targetRoot], target);
-    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) { bytes.fill(0); fail("credential target escapes root", "HOST_CONFIG_MISMATCH"); }
-    fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
-    for (let parent = path.dirname(target); parent.startsWith(root) && parent !== root; parent = path.dirname(parent)) fs.chmodSync(parent, 0o700);
-    fs.writeFileSync(target, bytes, { flag: "wx", mode: 0o600 }); fs.chmodSync(target, 0o600); bytes.fill(0); readable.push(target);
-    if (item.access === "read_write") writable.push(target); else readonly.push(target);
-  }
-  if (secrets.size !== (config.credentials || []).length) fail("credential descriptors do not match payload", "HOST_CONFIG_MISMATCH");
-  return Object.assign(state, { roots, readable, writable, readonly });
-}
-function credentialRootBinding(root, binding = null) { return { path: path.resolve(root), dev: binding?.dev ?? null, ino: binding?.ino ?? null }; }
-function cleanupCredentialRoot(root, config, binding = null) {
-  if (config.test_cleanup_failure && fs.existsSync(config.test_cleanup_failure)) fail("injected cleanup failure", "TEST_CLEANUP_FAILURE");
-  if (!binding) { if (fs.existsSync(root)) fail("credential root binding is unavailable", "HOST_CLEANUP_INCOMPLETE"); return false; }
-  removeBoundDirectory(path.resolve(root), binding, "executor credential root");
-}
-
 function runExecutorGate(configPath, configSha) {
   const bytes = fs.readFileSync(configPath); if (sha256(bytes) !== configSha) fail("gate config mismatch", "HOST_CONFIG_MISMATCH");
   const config = JSON.parse(bytes), release = Buffer.alloc(1), hold = () => {}, ephemeralBytes = fs.readFileSync(5);
   if (config.process_contract !== PROCESS_CONTRACT) fail("executor process containment contract is invalid", "HOST_CONFIG_MISMATCH");
-  if (ephemeralBytes.length > 8 * 1024 * 1024) fail("ephemeral environment payload is invalid", "HOST_CONFIG_MISMATCH");
-  let gateSecrets, ephemeralEnvironment, credentialEnvironment, stagedCredentials = null;
-  try { gateSecrets = JSON.parse(ephemeralBytes.toString("utf8")); ephemeralEnvironment = environmentEntries(gateSecrets.ephemeral_env, "ephemeral environment");
-    credentialEnvironment = environmentEntries(gateSecrets.credential_env, "credential environment"); } finally { ephemeralBytes.fill(0); }
+  if (ephemeralBytes.length > 8 * 1024 * 1024) fail("ambient environment payload is invalid", "HOST_CONFIG_MISMATCH");
+  let gatePayload;
+  try { gatePayload = JSON.parse(ephemeralBytes.toString("utf8")); } finally { ephemeralBytes.fill(0); }
+  const runtimeEnvironment = environmentEntries(gatePayload?.ambient_env, "ambient environment"), scopeToken = gatePayload?.scope_token;
+  if (!/^[0-9a-f]{64}$/.test(scopeToken || "") || scopeToken !== process.env[PROCESS_SCOPE_KEY] || scopeSeal(scopeToken) !== config.scope_seal) {
+    fail("executor process scope is unavailable", "HOST_CONFIG_MISMATCH");
+  }
+  runtimeEnvironment[PROCESS_SCOPE_KEY] = scopeToken;
+  gatePayload = null;
   process.on("SIGTERM", hold); process.on("SIGINT", hold);
   if (fs.readSync(3, release, 0, 1, null) !== 1 || release[0] !== 1) return;
   let settled = false;
@@ -1101,19 +997,6 @@ function runExecutorGate(configPath, configSha) {
       if (!binding || binding.size !== config.stdin_binding.size || binding.sha256 !== config.stdin_binding.sha256) fail("executor stdin binding is invalid", "HOST_CONFIG_MISMATCH");
       stdinBytes = regularFileBinding(inputPaths[config.stdin_binding.index], "executor stdin").bytes;
     }
-    const runtimeEnvironment = environmentEntries(config.env, "config env");
-    if (!Array.isArray(config.ephemeral_env_keys) || config.ephemeral_env_keys.length !== Object.keys(ephemeralEnvironment).length) fail("ephemeral environment keys are invalid", "HOST_CONFIG_MISMATCH");
-    for (const key of config.ephemeral_env_keys) {
-      if (!Object.hasOwn(ephemeralEnvironment, key)) fail("ephemeral environment is unavailable", "HOST_CONFIG_MISMATCH");
-      runtimeEnvironment[key] = ephemeralEnvironment[key];
-    }
-    if (!Array.isArray(config.credential_env_keys) || config.credential_env_keys.length !== Object.keys(credentialEnvironment).length
-      || config.credential_env_keys.some((key) => !Object.hasOwn(credentialEnvironment, key))) fail("credential environment binding is invalid", "HOST_CONFIG_MISMATCH");
-    Object.assign(runtimeEnvironment, credentialEnvironment);
-    stagedCredentials = { root: config.credential_root };
-    stageCredentials(config, gateSecrets.credential_files, stagedCredentials);
-    Object.assign(runtimeEnvironment, privatePathEnvironment(config.private_env_paths, stagedCredentials.roots, runtimeEnvironment, "HOST_CONFIG_MISMATCH"));
-    runtimeEnvironment.HOME = stagedCredentials.roots.home; runtimeEnvironment.XDG_CONFIG_HOME = stagedCredentials.roots.xdg_config; runtimeEnvironment.XDG_DATA_HOME = stagedCredentials.roots.xdg_data;
     const invocation = hostInvocation({ command: config.command, args: config.args, env: runtimeEnvironment });
     // Verify immediately before pathname spawn, then again after it exits.
     // The two observations deliberately do not claim an atomic exec/dyld byte
@@ -1121,8 +1004,6 @@ function runExecutorGate(configPath, configSha) {
     hostInvocation.verifyRuntimeFiles({ command: config.command, runtimeFiles: config.runtime_files, runtimeDependencies: config.runtime_dependencies, env: runtimeEnvironment });
     const baseline = processBaseline(), tracked = new Map(), gateIdentity = fingerprint(process.pid);
     if (!gateIdentity) fail("executor gate identity unavailable", "HOST_IDENTITY_UNAVAILABLE");
-    const scopeToken = runtimeEnvironment[PROCESS_SCOPE_KEY];
-    if (!/^[0-9a-f]{64}$/.test(scopeToken || "") || scopeSeal(scopeToken) !== config.scope_seal) fail("executor process scope is unavailable", "HOST_CONFIG_MISMATCH");
     const worker = spawn(invocation.command, invocation.args, { cwd: config.cwd, env: invocation.env, stdio: [stdinBytes ? "pipe" : "ignore", "inherit", "inherit"] });
     try { verifyInputs(); }
     catch (error) { try { worker.kill("SIGKILL"); } catch {}; if (stdinBytes) stdinBytes.fill(0); throw error; }
@@ -1140,19 +1021,15 @@ function runExecutorGate(configPath, configSha) {
         }
       } catch {}
     }, 10);
-    for (const values of [ephemeralEnvironment, credentialEnvironment]) for (const key of Object.keys(values)) { values[key] = ""; runtimeEnvironment[key] = ""; }
-    gateSecrets = null;
     const finishWorker = (fields) => {
       if (settled) return;
       clearInterval(lineagePoll);
-      const credentialRoot = credentialRootBinding(stagedCredentials.root, stagedCredentials.binding); let cleanupError = null, audit = null;
-      try { cleanupCredentialRoot(stagedCredentials.root, config, stagedCredentials.binding); } catch (error) { cleanupError = error; }
+      let audit = null;
       try {
         audit = escapedProcessAudit({ baseline, tracked, scopeToken, gateIdentity });
-        if (cleanupError || audit.remaining) return publish({ status: "cleanup_incomplete", exit_code: fields.exit_code, signal: fields.signal,
-          error: cleanupError ? `credential cleanup failed: ${cleanupError.message}`
-            : `escaped process audit cleanup incomplete: matched=${audit.matched} reaped=${audit.reaped} remaining=${audit.remaining}`,
-          obligation: { processes: audit.remaining_identities, credential_root: credentialRoot, scope_seal: config.scope_seal } });
+        if (audit.remaining) return publish({ status: "cleanup_incomplete", exit_code: fields.exit_code, signal: fields.signal,
+          error: `escaped process audit cleanup incomplete: matched=${audit.matched} reaped=${audit.reaped} remaining=${audit.remaining}`,
+          obligation: { processes: audit.remaining_identities, staged_input_root: null, scope_seal: config.scope_seal } });
         if (audit.matched) return publish({ status: "failed", exit_code: fields.exit_code, signal: fields.signal,
           error: `escaped process audit failed: matched=${audit.matched} reaped=${audit.reaped} remaining=${audit.remaining}` });
         try { hostInvocation.verifyRuntimeFiles({ command: config.command, runtimeFiles: config.runtime_files, runtimeDependencies: config.runtime_dependencies, env: runtimeEnvironment, reenumerate: false }); }
@@ -1162,49 +1039,37 @@ function runExecutorGate(configPath, configSha) {
       } catch (error) {
         const processes = [...tracked.values()].filter((identity) => sameProcess(fingerprint(identity.pid), identity)).map((identity) => exactIdentity(identity));
         return publish({ status: "cleanup_incomplete", exit_code: fields.exit_code, signal: fields.signal,
-          error: `escaped process audit unavailable: ${error.message}`, obligation: { processes, credential_root: credentialRoot, scope_seal: config.scope_seal } });
+          error: `escaped process audit unavailable: ${error.message}`, obligation: { processes, staged_input_root: null, scope_seal: config.scope_seal } });
       }
     };
     worker.once("error", (error) => finishWorker({ status: "spawn_error", exit_code: null, signal: null, error: error.message }));
     worker.once("close", (code, signal) => finishWorker({ status: code === 0 ? "completed" : "failed", exit_code: code, signal: signal || null, error: null }));
-  } catch (error) { for (const values of [ephemeralEnvironment, credentialEnvironment]) if (values) for (const key of Object.keys(values)) values[key] = "";
-    let cleanupFailed = false;
-    if (stagedCredentials) try { cleanupCredentialRoot(stagedCredentials.root, config, stagedCredentials.binding); } catch { cleanupFailed = true; }
-    publish({ status: cleanupFailed ? "cleanup_incomplete" : "spawn_error", exit_code: null, signal: null, error: cleanupFailed ? "credential cleanup failed" : error.message,
-      ...(cleanupFailed ? { obligation: { processes: [], credential_root: credentialRootBinding(stagedCredentials.root, stagedCredentials.binding), scope_seal: config.scope_seal } } : {}) }); }
+  } catch (error) { publish({ status: "spawn_error", exit_code: null, signal: null, error: error.message }); }
 }
 function runSupervisor(configPath, configSha) {
   const bytes = fs.readFileSync(configPath); if (sha256(bytes) !== configSha) fail("supervisor config mismatch", "HOST_CONFIG_MISMATCH");
   const secretSize = fs.fstatSync(3).size; if (secretSize > 8 * 1024 * 1024) fail("host secret payload is invalid", "HOST_CONFIG_MISMATCH");
   const secretBuffer = Buffer.alloc(secretSize); if (fs.readSync(3, secretBuffer, 0, secretSize, 0) !== secretSize) fail("host secret payload is truncated", "HOST_CONFIG_MISMATCH");
   let secretPayload; try { secretPayload = JSON.parse(secretBuffer.toString("utf8")); } finally { secretBuffer.fill(0); }
-  const secret = secretPayload?.owner_secret, ephemeralEnvironment = environmentEntries(secretPayload?.ephemeral_env || {}, "ephemeral environment"),
-    credentialEnvironment = environmentEntries(secretPayload?.credential_env || {}, "credential environment");
+  const secret = secretPayload?.owner_secret, scopeToken = secretPayload?.scope_token;
   if (!/^[0-9a-f]{64}$/.test(secret)) fail("host secret is invalid", "HOST_CONFIG_MISMATCH");
   const config = JSON.parse(bytes), supervisor = waitFingerprint(process.pid); if (!supervisor) fail("supervisor identity unavailable", "HOST_IDENTITY_UNAVAILABLE");
-  const scopeToken = process.env[PROCESS_SCOPE_KEY];
-  if (scopeSeal(scopeToken) !== config.scope_seal) fail("supervisor process scope is unavailable", "HOST_CONFIG_MISMATCH");
-  if (!Array.isArray(config.ephemeral_env_keys) || config.ephemeral_env_keys.length !== Object.keys(ephemeralEnvironment).length
-    || config.ephemeral_env_keys.some((key) => !Object.hasOwn(ephemeralEnvironment, key))) fail("ephemeral environment binding is invalid", "HOST_CONFIG_MISMATCH");
-  if (!Array.isArray(config.credential_env_keys) || config.credential_env_keys.length !== Object.keys(credentialEnvironment).length
-    || config.credential_env_keys.some((key) => !Object.hasOwn(credentialEnvironment, key))) fail("credential environment binding is invalid", "HOST_CONFIG_MISMATCH");
+  if (!/^[0-9a-f]{64}$/.test(scopeToken || "") || process.env[PROCESS_SCOPE_KEY] !== scopeToken || scopeSeal(scopeToken) !== config.scope_seal) fail("supervisor process scope is unavailable", "HOST_CONFIG_MISMATCH");
   publishOnce(config.supervisor, signed({ v: 2, attempt_id: config.attempt_id, lock_id: config.lock_id, host_handle: config.host_handle,
     config_sha256: configSha, nonce: config.nonce, supervisor, started_at: new Date().toISOString() }, secret));
   let child, childClosed = false, executorIdentity = null, finished = false, requested = null, pendingClose = null, deadline, escalation, cancelPoll, barrierPoll, outcome = "", overflow = false;
-  const cleanupCredentials = () => { if (fs.existsSync(config.credential_root)) fail("executor credential root remains without a trusted binding", "HOST_CLEANUP_INCOMPLETE"); };
   const cleanupIncomplete = (error, obligation = null, terminal = {}) => {
     if (finished) return; finished = true; clearTimeout(deadline); clearTimeout(escalation); clearInterval(cancelPoll); clearInterval(barrierPoll);
     const priorStatus = TERMINAL.has(terminal.status) ? terminal.status : "failed", provided = obligation?.processes || [];
     const processes = [supervisor, executorIdentity, ...provided].filter(Boolean).map((identity) => exactIdentity(identity));
-    publishOnce(config.cleanup, signed({ v: 2, attempt_id: config.attempt_id, lock_id: config.lock_id, host_handle: config.host_handle,
+    publishOnce(config.cleanup, signed({ v: 2, kind: "executor", attempt_id: config.attempt_id, lock_id: config.lock_id, host_handle: config.host_handle,
       identities: { supervisor: exactIdentity(supervisor), executor: executorIdentity ? exactIdentity(executorIdentity) : null },
       error: error.message, terminal: { status: priorStatus, exit_code: terminal.exit_code ?? null, signal: terminal.signal || null },
-      obligation: { processes: [...new Map(processes.map((identity) => [identity.pid, identity])).values()], credential_root: obligation?.credential_root || credentialRootBinding(config.credential_root),
+      obligation: { processes: [...new Map(processes.map((identity) => [identity.pid, identity])).values()], staged_input_root: null,
         scope_seal: config.scope_seal }, observed_at: new Date().toISOString() }, secret));
   };
   function finish(fields) {
     if (finished) return;
-    try { cleanupCredentials(); } catch (error) { return cleanupIncomplete(new Error(`credential cleanup failed: ${error.message}`), null, fields); }
     finished = true; clearTimeout(deadline); clearTimeout(escalation); clearInterval(cancelPoll); clearInterval(barrierPoll);
     const body = { attempt_id: config.attempt_id, lock_id: config.lock_id, host_kind: "local_supervisor", host_handle: config.host_handle,
       ...fields, completed_at: new Date().toISOString() };
@@ -1232,9 +1097,8 @@ function runSupervisor(configPath, configSha) {
   try {
     child = spawn(process.execPath, [__filename, "--executor-gate", configPath, configSha], { cwd: config.cwd, detached: true,
       env: { ...minimalEnvironment(process.env), [PROCESS_SCOPE_KEY]: scopeToken }, stdio: ["ignore", 4, 5, "pipe", "pipe", "pipe"] });
-    const ephemeralPipe = Buffer.from(JSON.stringify({ ephemeral_env: ephemeralEnvironment, credential_env: credentialEnvironment, credential_files: secretPayload.credential_files || [] })); child.stdio[5].end(ephemeralPipe, () => ephemeralPipe.fill(0));
-    for (const values of [ephemeralEnvironment, credentialEnvironment]) for (const key of Object.keys(values)) { values[key] = ""; }
-    secretPayload.ephemeral_env = {}; secretPayload.credential_env = {}; secretPayload.credential_files = [];
+    const ambientPipe = Buffer.from(JSON.stringify({ ambient_env: secretPayload.ambient_env, scope_token: scopeToken })); child.stdio[5].end(ambientPipe, () => ambientPipe.fill(0));
+    secretPayload.ambient_env = {};
     child.stdio[4].setEncoding("utf8"); child.stdio[4].on("data", (chunk) => { if (outcome.length + chunk.length > 16_384) overflow = true; else outcome += chunk; });
     const executor = waitFingerprint(child.pid); if (!executor || executor.pgid !== child.pid) fail("executor group identity unavailable", "HOST_IDENTITY_UNAVAILABLE"); executorIdentity = executor;
     config.executor_started_at = executor.started_at;

--- a/skills/relay-dispatch/scripts/run-store.js
+++ b/skills/relay-dispatch/scripts/run-store.js
@@ -3,7 +3,6 @@ const { spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { credentialRequest: normalizeCredentialRequest } = require("./adapter-contract");
 const host = require("./host");
 
 const RUN_VERSION = 3;
@@ -371,10 +370,13 @@ function boundedEnvironment(overrides = {}, allowlist = REVIEW_ENV) {
   }
   return env;
 }
+function ambientEnvironment(overrides = {}) {
+  return host.hostInvocation.ambientEnvironment(process.env, "ambient process environment", overrides);
+}
 function isolatedFailureReason(result, outcome) {
   if (result.error?.code === "ETIMEDOUT") return "invocation_timeout";
   const stderr = String(result.stderr || "");
-  if (/not authenticated|not logged in|authentication|credentials? required|api[_ -]?key.{0,80}(?:missing|required|not set)|unauthorized|forbidden/i.test(stderr)) return "credentials_unavailable";
+  if (/not authenticated|not logged in|authentication|credentials? required|api[_ -]?key.{0,80}(?:missing|required|not set)|unauthorized|forbidden/i.test(stderr)) return "ambient_auth_unavailable";
   if (/sqlite_readonly|readonly database|operation not permitted|permission denied|filesystem\.open|sandbox/i.test(stderr)) return "execution_environment_unavailable";
   if (result.signal) return "invocation_cancelled";
   if (Number.isInteger(result.status) && result.status !== 0) return "cli_nonzero_exit";
@@ -399,12 +401,10 @@ function attachReviewInputError(error, inputBindingError) {
   if (!error.cause) error.cause = inputBindingError;
   return error;
 }
-function runHosted({ invocation, readRoot, writeRoot, timeoutMs = 120000, env, parseOutcome, envAllowlist = REVIEW_ENV, stdinBinding = null, inputBindings = [], credentials = null, processScope = null }) {
+function runHosted({ invocation, readRoot, writeRoot, timeoutMs = 120000, env, parseOutcome, envAllowlist = REVIEW_ENV, useAmbientEnvironment = false, stdinBinding = null, inputBindings = [], processScope = null }) {
   if (!Array.isArray(invocation?.args) || invocation.args.some((arg) => typeof arg !== "string" || arg.includes("\0"))) throw new Error("hosted invocation requires string argv values");
-  const childEnv = boundedEnvironment(env, envAllowlist); childEnv.HOME = credentials?.roots.home || writeRoot; childEnv.XDG_CONFIG_HOME = credentials?.roots.xdg_config || writeRoot;
-  childEnv.XDG_DATA_HOME = credentials?.roots.xdg_data || writeRoot; childEnv.TMPDIR = writeRoot;
-  Object.assign(childEnv, credentials?.environment || {});
-  Object.assign(childEnv, host.hostInvocation.privatePathEnvironment(invocation.privateEnvPaths, credentials?.roots || {}, childEnv, "INVALID_INVOCATION"));
+  const childEnv = useAmbientEnvironment ? ambientEnvironment(env) : boundedEnvironment(env, envAllowlist);
+  if (useAmbientEnvironment) childEnv.TMPDIR = writeRoot;
   processScope ||= host.hostInvocation.beginProcessScope(); Object.assign(childEnv, processScope.env);
   const runtime = host.hostInvocation.bindRuntimeFiles({ command: invocation.command, env: childEnv, runtimeDependencies: invocation.runtimeDependencies });
   const runtimeError = (error) => { error.executed_runtime = runtime.runtime_files; return error; };
@@ -427,7 +427,7 @@ function runHosted({ invocation, readRoot, writeRoot, timeoutMs = 120000, env, p
   try { host.hostInvocation.verifyRuntimeFiles({ command: runtime.command, runtimeFiles: runtime.runtime_files,
     runtimeDependencies: invocation.runtimeDependencies, env: childEnv, reenumerate: false }); }
   catch (error) { runtimeIntegrityError = error; }
-  // The process-group reap must run even when the scope audit throws or times out, or a credential-holding
+  // The process-group reap must run even when the scope audit throws or times out, or a reviewer
   // descendant would outlive the reviewer. Both audit failures are aggregated and reported together.
   const auditErrors = [];
   let scopedAudit = null, processGroupAudit = null;
@@ -475,28 +475,6 @@ function runHosted({ invocation, readRoot, writeRoot, timeoutMs = 120000, env, p
     runtime_audit: Object.freeze({ pgid: result.pid || null, process_group_absent: true, process_scope_remaining: 0, scope_seal: processScope.seal, quiet_window_ms: 250 }) });
 }
 
-function stageReviewerCredentials(stage, request) {
-  request ||= { metadata: {}, envNames: [], fileSpecs: [], env: {} }; const normalized = normalizeCredentialRequest(request.metadata, request);
-  const root = path.join(stage, "reviewer-credentials"), roots = { home: path.join(root, "home"), xdg_config: path.join(root, "xdg-config"), xdg_data: path.join(root, "xdg-data"), scratch: path.join(root, "scratch") };
-  fs.mkdirSync(root, { mode: 0o700 }); for (const value of Object.values(roots)) fs.mkdirSync(value, { mode: 0o700 });
-  const sources = new Map(normalized.fileSpecs.map((spec) => [spec.slice(0, spec.indexOf("=")), spec.slice(spec.indexOf("=") + 1)]));
-  const readable = [], writable = [], readonly = [], environment = {};
-  try {
-    for (const name of normalized.envNames) {
-      if (typeof request.env?.[name] !== "string") throw new Error(`credential environment value is missing: ${name}`);
-      environment[name] = request.env[name];
-    }
-    for (const item of normalized.metadata.files) {
-      const source = sources.get(item.id); if (!source) continue;
-      const bytes = host.hostInvocation.readOwnerCredential(source, `credential '${item.id}'`), target = path.join(roots[item.targetRoot], item.targetRel);
-      if (!contained(roots[item.targetRoot], target)) { bytes.fill(0); throw new Error("credential target escapes its private root"); }
-      fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 }); fs.chmodSync(path.dirname(target), 0o700);
-      try { fs.writeFileSync(target, bytes, { flag: "wx", mode: 0o600 }); } finally { bytes.fill(0); }
-      readable.push(target); if (item.access === "read_write") writable.push(target); else readonly.push(target);
-    }
-    return { root, roots, readable, writable, readonly, environment };
-  } catch (error) { for (const key of Object.keys(environment)) delete environment[key]; throw error; }
-}
 function invokeExternalObserver({ observer, request, timeoutMs = 120000 }) {
   const stage = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "relay-observer-")));
   try {
@@ -520,7 +498,7 @@ function invokeExternalObserver({ observer, request, timeoutMs = 120000 }) {
       } }).output;
   } finally { fs.rmSync(stage, { recursive: true, force: true }); }
 }
-function invokeIndependentReviewer({ runDir, request, buildInvocation, parseOutcome, timeoutMs, env, credentialRequest = null }) {
+function invokeIndependentReviewer({ runDir, request, buildInvocation, parseOutcome, timeoutMs, env }) {
   const record = readRunRecord({ runDir });
   let diff, prompt;
   try {
@@ -562,11 +540,10 @@ function invokeIndependentReviewer({ runDir, request, buildInvocation, parseOutc
     executed_prompt_sha256: stagedBindings.prompt.sha256,
     request_sha256: digest(Buffer.from(JSON.stringify({ run_id: record.run_id, reviewed_sha: request.reviewed_sha, ...paths }))) });
     const resultPath = path.join(output, "reviewer-result.json");
-    const credentials = stageReviewerCredentials(stage, credentialRequest);
     const invocation = buildInvocation(Object.freeze({ cwd: inputs, ...paths, promptBytes: Buffer.from(stagedBindings.prompt.bytes), requestPath: null, resultPath, schemaPath }));
     for (const [label, fileBinding] of Object.entries(stagedBindings)) verifyRegularFileBinding(fileBinding, `staged review ${label}`);
     outcome = runHosted({ invocation: { ...invocation, resultPath }, readRoot: inputs, writeRoot: output, timeoutMs, env, parseOutcome, stdinBinding: stagedBindings.prompt,
-      inputBindings: Object.entries(stagedBindings), credentials, processScope });
+      inputBindings: Object.entries(stagedBindings), processScope, useAmbientEnvironment: true });
     for (const [label, fileBinding] of Object.entries(stagedBindings)) verifyRegularFileBinding(fileBinding, `staged review ${label}`);
   } catch (error) { if (binding) error.review_binding = binding; failure = error; const audit = error.runtime_audit;
     preserveStage = Boolean(audit && !(audit.process_group_absent === true && audit.process_scope_remaining === 0));

--- a/skills/relay-review/SKILL.md
+++ b/skills/relay-review/SKILL.md
@@ -34,9 +34,9 @@ node skills/relay-review/scripts/review-runner.js \
   --json
 ```
 
-Optional inputs are `--model <opaque-model>`, `--timeout <seconds>`, repeated
-`--credential-env NAME`, and repeated declared
-`--credential-file ID=/absolute/source`. `--reviewer` may only repeat the
+Optional inputs are `--model <opaque-model>` and `--timeout <seconds>`. CLI
+authentication and HOME/XDG configuration remain ambient; credential selector
+flags are unknown. `--reviewer` may only repeat the
 immutable `run.json` reviewer binding; Relay does not implement mutable
 reviewer swaps or routing precedence.
 
@@ -66,10 +66,9 @@ The reviewer returns only:
 
 ## Execution and failure behavior
 
-- Credentials are explicit only: repeat `--credential-env NAME` or a declared
-  adapter `--credential-file ID=/absolute/source`. Sources must be canonical,
-  owner-only regular files. They are copied into a private staged HOME/XDG tree
-  and removed after invocation; GitHub tokens are never inherited.
+- Authentication and HOME/XDG configuration are ambient user-local CLI state.
+  Relay does not copy credential files, rewrite HOME/XDG, or serialize auth
+  values or source paths. The review input bundle is still separately staged.
 - GitHub-route reviewers use `--network-access enabled` (the default); selecting `disabled` fails before invocation. Enabled transport is unrestricted reviewer-process network and does not claim provider-only or tool-network separation. Local review has no forge transport requirement.
 - Relay runs directly on the trusted local host. It requests the adapter's native filesystem isolation where available; absent or declaration-only isolation is returned as a non-durable `filesystem_isolation` diagnostic and does not reject review.
 - The staged prompt, diff, criteria, schema, and executable bindings are rechecked after invocation. Any mutation or drift yields no review fact.

--- a/skills/relay-review/references/runner-notes.md
+++ b/skills/relay-review/references/runner-notes.md
@@ -71,7 +71,7 @@ retryable runtime escalation.
 
 ## Concurrency
 
-The expensive reviewer call holds a dedicated per-run execution lock. This gives any uncertain process cleanup a signed recovery authority before credential staging can be removed. Persistence later acquires a new per-run lock generation, re-runs inspection, and refuses any changed action, delivery, or head/tree. Concurrent review attempts therefore converge to at most one fact. Nothing is serialized repository-wide: unrelated runs in one repository proceed independently.
+The expensive reviewer call holds a dedicated per-run execution lock. This gives any uncertain process cleanup a signed recovery authority before the exact staged input root can be removed. Persistence later acquires a new per-run lock generation, re-runs inspection, and refuses any changed action, delivery, or head/tree. Concurrent review attempts therefore converge to at most one fact. Nothing is serialized repository-wide: unrelated runs in one repository proceed independently.
 
 ## Direct adapter invocation
 
@@ -90,14 +90,12 @@ The runner rechecks the immutable run digest, exact review binding, and retry
 subject under the run lock. A second failure and model-returned escalation both
 fail closed; Relay never starts an automatic retry loop.
 
-Reviewer authentication is opt-in and uses the same adapter credential catalog
-as dispatch. Repeat `--credential-env NAME` for an exact environment value or
-`--credential-file ID=/absolute/source` for a declared file target. The runtime
-does not discover credentials or inherit an ambient HOME. It validates each
-source as a stable, canonical, current-user owner-only regular file, copies it
-at mode `0600` below a private staged HOME/XDG tree, grants only the declared
-read or read/write file access, and removes the staging tree after invocation.
-An unavailable credential remains a blocking invocation failure.
+Reviewer authentication uses the operator's ambient local CLI HOME/XDG/config
+and supported auth environment. Relay does not copy credentials, rewrite
+HOME/XDG, or serialize credentials/source paths in artifacts, argv, facts, or
+diagnostics. It still stages and binds only the immutable review inputs; that
+exact staged-input root is removed after process settlement and is the sole
+non-process recovery resource.
 
 ## Removed options
 

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -11,7 +11,7 @@ const path = require("path");
 const { parseArgs } = require("util");
 
 const { getAdapter } = require("../../relay-dispatch/scripts/adapters");
-const { credentialRequest, filesystemIsolationDiagnostic, validateCapabilities } = require("../../relay-dispatch/scripts/adapter-contract");
+const { filesystemIsolationDiagnostic, validateCapabilities } = require("../../relay-dispatch/scripts/adapter-contract");
 const facts = require("../../relay-dispatch/scripts/facts");
 const host = require("../../relay-dispatch/scripts/host");
 const { inspectProductionRun } = require("../../relay-dispatch/scripts/recover");
@@ -27,8 +27,6 @@ const OPTIONS = Object.freeze({
   reviewer: { type: "string" },
   model: { type: "string" },
   timeout: { type: "string" },
-  "credential-env": { type: "string", multiple: true, default: [] },
-  "credential-file": { type: "string", multiple: true, default: [] },
   "network-access": { type: "string", default: "enabled" },
   json: { type: "boolean", default: false },
   help: { type: "boolean", short: "h", default: false },
@@ -73,8 +71,6 @@ function usage() {
     "  --reviewer <name>  Must equal the immutable run reviewer binding.",
     "  --model <name>     Optional opaque model selection for that adapter.",
     "  --timeout <sec>    Reviewer timeout in seconds.",
-    "  --credential-env <name>       Explicit credential environment name (repeatable).",
-    "  --credential-file <id=path>   Declared private credential-file mapping (repeatable).",
     "  --network-access <enabled|disabled>  Model/tool network policy; provider transport remains enabled (default: enabled).",
     "  --json             Emit one JSON object.",
   ].join("\n");
@@ -375,12 +371,11 @@ function productionServices() {
   }
   return {
     inspectRun: (input) => inspectProductionRun(input),
-    invokeReviewer({ runDir, request, adapter, model, timeoutMs, networkAccess, credentialRequest: requestedCredentials }) {
+    invokeReviewer({ runDir, request, adapter, model, timeoutMs, networkAccess }) {
       return runStore.invokeIndependentReviewer({
         runDir,
         request,
         timeoutMs,
-        credentialRequest: requestedCredentials,
         buildInvocation: ({ cwd, promptPath, promptBytes, resultPath, schemaPath }) => adapter.buildInvocation({
           phase: "primary_review", cwd, promptPath, promptBytes, resultPath, schemaPath, model,
           timeoutMs, sandbox: "read-only", networkAccess,
@@ -405,10 +400,6 @@ async function runReview(cli, overrides = {}) {
   const capabilityRequest = { readOnly: true, networkAccess: cli.values["network-access"] };
   validateCapabilities(adapter, "primary_review", capabilityRequest);
   const filesystemIsolation = filesystemIsolationDiagnostic(adapter, "primary_review", capabilityRequest);
-  let requestedCredentials;
-  try { requestedCredentials = credentialRequest(adapter.metadata.credentials, { envNames: cli.values["credential-env"], fileSpecs: cli.values["credential-file"] }); }
-  catch (error) { fail(error.message, "INVALID_CREDENTIAL"); }
-  const credentialEnv = Object.fromEntries(requestedCredentials.envNames.map((name) => [name, process.env[name]]));
   const initial = await services.inspectRun({ runDir });
   if (!/^[0-9a-f]{64}$/.test(String(initial.snapshot?.run_sha256 || ""))) {
     fail("initial inspection is missing a valid run digest", "RUN_RECORD_BINDING_CHANGED");
@@ -437,7 +428,6 @@ async function runReview(cli, overrides = {}) {
       model: cli.values.model || null,
       timeoutMs,
       networkAccess: cli.values["network-access"],
-      credentialRequest: { ...requestedCredentials, env: credentialEnv },
       request: {
         diff_path: diffPath,
         prompt_path: promptPath,

--- a/tests/relay-dispatch/fixtures/reviewer-crash-worker.js
+++ b/tests/relay-dispatch/fixtures/reviewer-crash-worker.js
@@ -1,17 +1,18 @@
 "use strict";
 const fs = require("fs");
 const { spawn } = require("child_process");
+const path = require("path");
 const host = require("../../../skills/relay-dispatch/scripts/host");
 const store = require("../../../skills/relay-dispatch/scripts/run-store");
 const config = JSON.parse(fs.readFileSync(process.argv[2], "utf8")), cut = config.cut;
 const die = () => process.kill(process.pid, "SIGKILL");
 if (cut === "pending") { const real = host.retainReviewerCleanup; host.retainReviewerCleanup = (...args) => { const value = real(...args); die(); return value; }; }
-if (cut === "credential") { const real = fs.writeFileSync; fs.writeFileSync = (...args) => { const value = real(...args); if (String(args[0]).includes("reviewer-credentials") && String(args[0]).endsWith("auth.json")) die(); return value; }; }
+if (cut === "staged") { const real = fs.writeFileSync; fs.writeFileSync = (...args) => { const value = real(...args); if (String(args[0]).includes("relay-review-") && String(args[0]).includes(`${path.sep}inputs${path.sep}`)) die(); return value; }; }
 if (cut === "pre_spawn") { const real = host.hostInvocation.verifyRuntimeFiles; let first = true; host.hostInvocation.verifyRuntimeFiles = (...args) => { const value = real(...args); if (first) { first = false; die(); } return value; }; }
 if (cut === "before_cleanup") { const real = host.retainReviewerCleanup; host.retainReviewerCleanup = (...args) => { const value = real(...args); return { ...value, complete: die }; }; }
 const source = cut === "spawned" ? "setInterval(()=>{},1000)" : "process.stdout.write(JSON.stringify({ok:true}))";
 if (cut === "spawned") { const killer = spawn(process.execPath, ["-e", `setTimeout(()=>process.kill(${process.pid},'SIGKILL'),500)`], { detached: true, stdio: "ignore" }); killer.unref(); }
 store.invokeIndependentReviewer({ runDir: config.runDir, request: config.request, timeoutMs: 5_000,
-  credentialRequest: config.credentials, buildInvocation: ({ cwd }) => ({ command: process.execPath, args: ["-e", source], cwd,
+  buildInvocation: ({ cwd }) => ({ command: process.execPath, args: ["-e", source], cwd,
     runtimeDependencies: { executableParent: 1, interpreterParent: null }, networkAccess: "disabled" }),
   parseOutcome: ({ exitCode, stdoutPath }) => ({ status: exitCode === 0 ? "succeeded" : "failed", output: JSON.parse(fs.readFileSync(stdoutPath, "utf8")) }) });

--- a/tests/relay-dispatch/scripts/adapter-contract.test.js
+++ b/tests/relay-dispatch/scripts/adapter-contract.test.js
@@ -72,17 +72,18 @@ test("new adapter registry preserves exactly the seven supported executors", () 
     assert.ok(adapter.metadata.cliBinary);
     assert.equal(adapter.metadata.processContainment, contract.PROCESS_CONTAINMENT);
     assert.equal(adapter.metadata.providerTransport, "remote_required");
-    assert.equal(adapter.metadata.credentialTransport, "explicit_bundle");
+    assert.equal(Object.hasOwn(adapter.metadata, "credentialTransport"), false);
+    assert.equal(Object.hasOwn(adapter.metadata, "credentials"), false);
     assert.ok(adapter.metadata.runtimeDependencies);
     assert.ok(Number.isInteger(adapter.defaults.timeoutMs));
   }
 });
 
-test("session-backed adapters expose owner-only credential bundles without secret argv", () => {
+test("session-backed adapters rely on the ambient host session without secret argv", () => {
   for (const name of ["antigravity", "cline", "cursor"]) {
     const adapter = getAdapter(name), capability = adapter.capabilities({ phase: "dispatch", request: { sandbox: "workspace-write", networkAccess: "enabled" } });
-    assert.equal(capability.credentialTransport, "explicit_bundle", name);
-    assert.ok(adapter.metadata.credentials.files.length > 0, name);
+    assert.equal(Object.hasOwn(capability, "credentialTransport"), false, name);
+    assert.equal(Object.hasOwn(adapter.metadata, "credentials"), false, name);
     const invocation = invocationFor(adapter); assert.equal(invocation.args.includes("-k"), false, name);
   }
 });
@@ -378,7 +379,7 @@ test("Codex and Cursor request their native sandbox without an outer Relay bound
     assert.equal(codex.args.includes("--skip-git-repo-check"), phase === "primary_review");
     assert.equal(codex.args.includes("--add-dir"), false);
     assert.deepEqual(cursor.args.slice(cursor.args.indexOf("--sandbox"), cursor.args.indexOf("--sandbox") + 2), ["--sandbox", "enabled"]);
-    assert.deepEqual(cursor.privateEnvPaths, [{ key: "CURSOR_CONFIG_DIR", root: "home", relative: ".cursor" }, { key: "CURSOR_DATA_DIR", root: "scratch", relative: "cursor-data" }]);
+    assert.equal(Object.hasOwn(cursor, "privateEnvPaths"), false);
   }
   assert.equal(getAdapter("cursor").capabilities({ phase: "dispatch", request: { sandbox: "read-only", networkAccess: "enabled" } }).supported, true);
   assert.deepEqual(contract.filesystemIsolationDiagnostic(getAdapter("codex"), "dispatch", {
@@ -391,14 +392,8 @@ test("adapter metadata is static and carries no integration side channel", () =>
     const adapter = getAdapter(name);
     assert.equal(Object.hasOwn(adapter, "integrations"), false, name);
     assert.equal(Object.values(adapter.metadata).some((value) => typeof value === "function"), false, `${name} metadata must be static`);
-    assert.ok(Array.isArray(adapter.metadata.credentials.files), `${name} credential files`);
-    assert.ok(Array.isArray(adapter.metadata.credentials.envHints), `${name} credential env hints`);
-    for (const file of adapter.metadata.credentials.files) {
-      assert.deepEqual(Object.keys(file).sort(), ["access", "id", "recommendedSource", "targetRel", "targetRoot"], name);
-    }
+    assert.equal(Object.hasOwn(adapter.metadata, "credentials"), false, `${name} has no credential catalog`);
   }
-  assert.deepEqual(getAdapter("pi").metadata.credentials.envHints, ["QWEN_TOKEN_PLAN_API_KEY", "QWEN_TOKEN_PLAN_CN_API_KEY"]);
-  assert.deepEqual(getAdapter("claude").metadata.credentials.envHints, ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]);
 });
 
 test("Claude dispatch enables native Bash while primary review is tool-read-only", () => {
@@ -427,32 +422,10 @@ test("Claude dispatch enables native Bash while primary review is tool-read-only
     sandbox: "workspace-write", networkAccess: "disabled" }), /tool network disable/);
 });
 
-test("private environment paths are closed, relative, rooted, and collision-free", () => {
-  const shape = (privateEnvPaths) => ({ command: process.execPath, args: [], cwd, privateEnvPaths });
-  assert.deepEqual(contract.assertInvocationShape(shape([{ key: "TOOL_DIR", root: "scratch", relative: "tool-data" }])).privateEnvPaths,
-    [{ key: "TOOL_DIR", root: "scratch", relative: "tool-data" }]);
-  for (const value of [[{ key: "TOOL_DIR", root: "scratch", relative: "/tmp/escape" }], [{ key: "TOOL_DIR", root: "home", relative: "../escape" }],
-    [{ key: "HOME", root: "home", relative: ".tool" }], [{ key: "TOOL_DIR", root: "outside", relative: ".tool" }],
-    [{ key: "TOOL_DIR", root: "home", relative: ".tool" }, { key: "TOOL_DIR", root: "scratch", relative: "tool" }]]) {
-    assert.throws(() => contract.assertInvocationShape(shape(value)), /private environment path is invalid/);
-  }
-});
-
-test("credential requests are value-free, catalog-bound, and reject reserved or ambiguous inputs", () => {
-  const metadata = getAdapter("codex").metadata.credentials;
-  const missingSource = path.join(root, "not-opened-auth.json");
-  const request = contract.credentialRequest(metadata, {
-    envNames: ["OPENAI_API_KEY"], fileSpecs: [`auth=${missingSource}`],
-  });
-  assert.deepEqual(request.summary, { env_names: ["OPENAI_API_KEY"], file_ids: ["auth"] });
-  assert.equal(fs.existsSync(missingSource), false, "normalization must not open a credential source");
-  for (const name of ["HOME", "NODE_OPTIONS", "NODE_PATH", "BASH_ENV", "PYTHONPATH", "DYLD_INSERT_LIBRARIES", "LD_PRELOAD"])
-    assert.throws(() => contract.credentialRequest(metadata, { envNames: [name] }), /unsafe, reserved/, name);
-  assert.throws(() => contract.credentialRequest({ files: [], envHints: ["NODE_OPTIONS"] }), /metadata/);
-  assert.throws(() => contract.credentialRequest(metadata, { envNames: ["TOKEN", "TOKEN"] }), /duplicated/);
-  assert.throws(() => contract.credentialRequest(metadata, { fileSpecs: [`unknown=${missingSource}`] }), /declared/);
-  assert.throws(() => contract.credentialRequest(metadata, { fileSpecs: ["auth=relative"] }), /absolute/);
-  assert.throws(() => contract.credentialRequest(metadata, { fileSpecs: [`auth=${missingSource}`, `auth=${missingSource}`] }), /collision/);
+test("invocation contract rejects retired private-environment metadata", () => {
+  assert.throws(() => contract.assertInvocationShape({ command: process.execPath, args: [], cwd,
+    privateEnvPaths: [{ key: "TOOL_DIR", root: "scratch", relative: "tool-data" }] }), /unsupported metadata/);
+  assert.equal(Object.hasOwn(contract, "credentialRequest"), false);
 });
 
 test("review invocation is an immutable direct descriptor without hidden lifecycle hooks", () => {

--- a/tests/relay-dispatch/scripts/adapter-live-canary-runner.js
+++ b/tests/relay-dispatch/scripts/adapter-live-canary-runner.js
@@ -11,7 +11,7 @@ const { execFileSync } = require("node:child_process");
 const host = require("../../../skills/relay-dispatch/scripts/host");
 const runStore = require("../../../skills/relay-dispatch/scripts/run-store");
 const { ADAPTER_PHASES, getAdapter, listAdapters } = require("../../../skills/relay-dispatch/scripts/adapters");
-const { credentialRequest, resolveAdapterProvider } = require("../../../skills/relay-dispatch/scripts/adapter-contract");
+const { resolveAdapterProvider } = require("../../../skills/relay-dispatch/scripts/adapter-contract");
 
 const PROJECT_ROOT = path.resolve(__dirname, "../../..");
 const PHASES = Object.freeze([ADAPTER_PHASES.DISPATCH, ADAPTER_PHASES.PRIMARY_REVIEW]);
@@ -94,16 +94,12 @@ function classifyFailure(error, provisioned = false) {
   if (error?.code === "HOST_CLEANUP_INCOMPLETE" || error?.runtime_audit?.status === "cleanup_incomplete") {
     return failure("failed", "host_cleanup_incomplete", "cleanup", "HOST_CLEANUP_INCOMPLETE");
   }
-  if (new Set(["UNTRUSTED_CREDENTIAL", "INVALID_CREDENTIAL", "CREDENTIAL_CHANGED", "CREDENTIAL_MISSING"]).has(error?.code)) {
-    return failure("failed", "credential_source_rejected", "credential_staging", error.code);
-  }
-  if (error?.code === "CREDENTIAL_NETWORK_ISOLATION_UNAVAILABLE") return failure("failed", "credential_network_isolation_unavailable", "sandbox", error.code);
-  if (error?.failure_reason === "credentials_unavailable") return provisioned ? failure("failed", "credential_auth_failed", "authentication", "AUTHENTICATION_FAILED") : { status: "not_run", reason: "not_run_credentials_unavailable" };
+  if (error?.failure_reason === "ambient_auth_unavailable") return failure("failed", "ambient_auth_failed", "authentication", "AUTHENTICATION_FAILED");
   if (error?.failure_reason === "execution_environment_unavailable") return failure("failed", "sandbox_environment_failed", "sandbox", "EXECUTION_ENVIRONMENT_UNAVAILABLE");
   if (new Set(["CANARY_OUTPUT_INVALID", "CANARY_NONCE_INVALID"]).has(error?.code)) return failure("failed", "canary_output_invalid", "output", error.code);
   if (/timed.?out|ETIMEDOUT/i.test(detail)) return failure("failed", "invocation_timeout", "timeout", "INVOCATION_TIMEOUT");
   if (/process (?:group|scope) survived|escaped process audit failed/i.test(detail)) return failure("failed", "process_scope_survived", "cleanup", "PROCESS_SCOPE_SURVIVED");
-  if (AUTH_FAILURE.test(detail)) return provisioned ? failure("failed", "credential_auth_failed", "authentication", "AUTHENTICATION_FAILED") : { status: "not_run", reason: "not_run_credentials_unavailable" };
+  if (AUTH_FAILURE.test(detail)) return failure("failed", "ambient_auth_failed", "authentication", "AUTHENTICATION_FAILED");
   if (ENVIRONMENT_FAILURE.test(detail)) return failure("failed", "sandbox_environment_failed", "sandbox", "SANDBOX_DENIED");
   return failure("failed", "invocation_failed", "invocation", error?.code && /^[A-Z][A-Z0-9_]+$/.test(error.code) ? error.code : "INVOCATION_FAILED");
 }
@@ -124,7 +120,7 @@ function probeEvidence(adapter, probe) {
       (adapter.metadata?.cliBinaryEnv && process.env[adapter.metadata.cliBinaryEnv]) || adapter.metadata?.cliBinary || adapter.name,
     ) : null };
 }
-function invocationDigest(invocation) { return sha(Buffer.from(JSON.stringify({ command: path.basename(invocation.command), args: invocation.args, stdin_sha256: invocation.stdinSha256 || null, private_env_paths: invocation.privateEnvPaths }))); }
+function invocationDigest(invocation) { return sha(Buffer.from(JSON.stringify({ command: path.basename(invocation.command), args: invocation.args, stdin_sha256: invocation.stdinSha256 || null }))); }
 function executedRuntimeEvidence(files) {
   if (!Array.isArray(files) || !files.length) throw new Error("canary execution has no authoritative runtime binding");
   const binding = files[0];
@@ -134,14 +130,6 @@ function executedRuntimeEvidence(files) {
   const executable = { basename: path.basename(binding.path), dev: binding.dev, ino: binding.ino, size: binding.size, sha256: binding.sha256 };
   if (["basename", "dev", "ino", "size", "sha256"].some((key) => executable[key] === undefined) || !SHA256_RE.test(executable.sha256 || "")) throw new Error("canary executable runtime binding is invalid");
   return { digest: sha(Buffer.from(JSON.stringify(files))), executable };
-}
-function credentialsFor(adapter, phase, selections) {
-  const key = `${adapter.name}:${phase}`, selected = selections?.[key];
-  if (!selected || (!selected.envNames?.length && !selected.fileSpecs?.length)) return null;
-  const request = credentialRequest(adapter.metadata?.credentials, { envNames: selected.envNames || [], fileSpecs: selected.fileSpecs || [] });
-  const env = Object.fromEntries(request.envNames.map((name) => [name, process.env[name]]));
-  if (Object.values(env).some((value) => typeof value !== "string" || value.length === 0)) return null;
-  return { ...request, env, public: request.summary };
 }
 function phasePrompt(fixture, phase, nonce) {
   const promptPath = path.join(fixture.runDir, `${phase}-${nonce}.prompt.md`);
@@ -159,17 +147,16 @@ function reviewRequest(fixture, prompt, nonce) {
     reviewed_sha: fixture.record.git.start_sha, current_sha: fixture.record.git.start_sha,
     diff_sha256: sha(fs.readFileSync(diffPath)), prompt_sha256: prompt.digest, schema };
 }
-function runReviewAttempt(fixture, adapter, model, timeoutMs, credentials, prompt, nonce, toolNetwork) {
+function runReviewAttempt(fixture, adapter, model, timeoutMs, prompt, nonce, toolNetwork) {
   let invocation;
   const outcome = runStore.invokeIndependentReviewer({ runDir: fixture.runDir, request: reviewRequest(fixture, prompt, nonce), timeoutMs,
-    credentialRequest: credentials,
     buildInvocation: ({ cwd, promptPath, promptBytes, resultPath, schemaPath }) => {
       invocation = adapter.buildInvocation({ phase: ADAPTER_PHASES.PRIMARY_REVIEW, cwd, promptPath, promptBytes,
         resultPath, schemaPath, model, timeoutMs, sandbox: "read-only", networkAccess: toolNetwork.access }); return invocation;
     }, parseOutcome: (input) => adapter.parseOutcome(input) });
   return { outcome, invocation };
 }
-async function runDispatchAttempt(fixture, adapter, model, timeoutMs, credentials, prompt, toolNetwork, onCleanupIncomplete) {
+async function runDispatchAttempt(fixture, adapter, model, timeoutMs, prompt, toolNetwork, onCleanupIncomplete) {
   const attemptId = `canary-${crypto.randomBytes(6).toString("hex")}`, executorResultPath = path.join(fixture.runDir, `${attemptId}.executor-output`);
   const invocation = adapter.buildInvocation({ phase: ADAPTER_PHASES.DISPATCH, cwd: fixture.worktree,
     promptPath: prompt.path, promptBytes: prompt.bytes, resultPath: executorResultPath, model, timeoutMs,
@@ -180,8 +167,7 @@ async function runDispatchAttempt(fixture, adapter, model, timeoutMs, credential
     receipt = host.launchLocalSupervisor({ runDir: fixture.runDir, attemptId, command: invocation.command, args: invocation.args,
       trustedWorktreeRoot: fixture.worktree, cwd: invocation.cwd, inputFiles: [prompt.path], stdinPath: invocation.stdinPath,
       stdinSha256: invocation.stdinSha256, executorResultPath, executorSandbox: "workspace-write", executorNetworkAccess: toolNetwork.access,
-      timeoutMs, credentialRequest: credentials, processContainment: adapter.metadata.processContainment, runtimeDependencies: invocation.runtimeDependencies,
-      privateEnvPaths: invocation.privateEnvPaths, testCleanupFailurePath: fixture.testCleanupFailurePath || null, lockContext: capability });
+      timeoutMs, processContainment: adapter.metadata.processContainment, runtimeDependencies: invocation.runtimeDependencies, lockContext: capability });
     terminal = await host.waitForTerminalResult(receipt, { timeoutMs: timeoutMs + 10_000 });
     const outcome = adapter.parseOutcome({ phase: ADAPTER_PHASES.DISPATCH, exitCode: terminal.exit_code, signal: terminal.signal,
       timedOut: terminal.status === "timed_out", cancelled: terminal.status === "cancelled", stdoutPath: receipt.stdout_path,
@@ -221,7 +207,7 @@ function dispatchMutationAssessment(before, after, fixture, prompt, nonce) {
   return { boundary, expected: boundary && exact };
 }
 
-async function runCell(adapter, phase, fixture, { timeoutMs, credentialSelections, onFixture, onError, onCleanupIncomplete }) {
+async function runCell(adapter, phase, fixture, { timeoutMs, onFixture, onError, onCleanupIncomplete }) {
   const model = PRIMARY_MODELS[adapter.name] || null, nonce = crypto.randomBytes(16).toString("hex"), prompt = phasePrompt(fixture, phase, nonce);
   const capability = adapter.capabilities({ phase }), nativeToolNetwork = capability.networkControl === "native";
   const toolNetwork = { access: nativeToolNetwork ? "disabled" : "enabled", enforcement: nativeToolNetwork ? "native" : "unsupported_explicit_enabled" };
@@ -230,17 +216,11 @@ async function runCell(adapter, phase, fixture, { timeoutMs, credentialSelection
     nonce_sha256: sha(Buffer.from(nonce)), prompt_sha256: prompt.digest };
   const probe = adapter.probe({ timeoutMs: Math.min(timeoutMs, 10_000) }), probeRecord = probeEvidence(adapter, probe);
   if (probe.status !== "available") return { ...base, status: "not_run", reason: probe.status === "skipped" ? "not_run_cli_unavailable" : "not_run_probe_failed", probe: probeRecord, checks: {} };
-  if (capability.credentialTransport === "unrepresentable") return { ...base, status: "not_run", reason: "not_run_credentials_unrepresentable",
-    blocker: { type: "credentials_unrepresentable", code: "CREDENTIALS_UNREPRESENTABLE" }, probe: probeRecord, credential_request: { env_names: [], file_ids: [] }, checks: {} };
-  const credentials = credentialsFor(adapter, phase, credentialSelections);
-  if (!credentials) return { ...base, status: "not_run", reason: "not_run_credentials_unavailable", probe: probeRecord,
-    credential_request: { env_names: [], file_ids: [] }, checks: {} };
   const before = snapshotFixture(fixture), started = Date.now(); if (onFixture) onFixture(fixture, adapter, phase);
-  const executionCredentials = adapter.metadata?.providerDefault === "test" ? null : credentials;
   try {
     const execution = phase === ADAPTER_PHASES.DISPATCH
-      ? await runDispatchAttempt(fixture, adapter, model, timeoutMs, executionCredentials, prompt, toolNetwork, onCleanupIncomplete)
-      : runReviewAttempt(fixture, adapter, model, timeoutMs, executionCredentials, prompt, nonce, toolNetwork);
+      ? await runDispatchAttempt(fixture, adapter, model, timeoutMs, prompt, toolNetwork, onCleanupIncomplete)
+      : runReviewAttempt(fixture, adapter, model, timeoutMs, prompt, nonce, toolNetwork);
     if (phase === ADAPTER_PHASES.PRIMARY_REVIEW) validateCanaryVerdict(execution.outcome.output, nonce);
     quietWindow(); const after = snapshotFixture(fixture), dispatchAssessment = phase === ADAPTER_PHASES.DISPATCH
       ? dispatchMutationAssessment(before, after, fixture, prompt, nonce) : null;
@@ -257,7 +237,7 @@ async function runCell(adapter, phase, fixture, { timeoutMs, credentialSelection
       ? fs.readFileSync(path.join(fixture.worktree, prompt.artifactName))
       : Buffer.from(JSON.stringify(execution.outcome.output));
     const executedRuntime = executedRuntimeEvidence(execution.executedRuntime || execution.outcome.executed_runtime);
-    return { ...base, status: "passed", reason: "production_path_passed", probe: probeRecord, credential_request: credentials.public, executed_runtime: executedRuntime,
+    return { ...base, status: "passed", reason: "production_path_passed", probe: probeRecord, executed_runtime: executedRuntime,
       invocation_sha256: invocationDigest(execution.invocation), output_sha256: sha(outputBytes), checks: { boundary: "passed", nonce: "passed",
         cleanup: "passed", process_scope_absent: "passed", elapsed_ms: Date.now() - started } };
   } catch (error) {
@@ -265,11 +245,11 @@ async function runCell(adapter, phase, fixture, { timeoutMs, credentialSelection
     if (onError) onError(error, adapter, phase); quietWindow(); const after = snapshotFixture(fixture), classified = classifyFailure(error, true);
     const boundary = phase === ADAPTER_PHASES.DISPATCH ? dispatchMutationAssessment(before, after, fixture, prompt, nonce).boundary : sameSnapshot(before, after);
     if (!boundary && classified.failure?.type !== "cleanup") Object.assign(classified, { reason: "boundary_mutated", failure: { type: "boundary", code: "BOUNDARY_MUTATED" } });
-    const notStarted = classified.failure?.type === "credential_staging", cleanupFailed = classified.failure?.type === "cleanup", runtimeAudit = error.runtime_audit;
-    const cleanup = notStarted ? "not_started" : cleanupFailed ? "failed" : runtimeAudit?.process_group_absent === true ? "passed" : "unknown";
-    return { ...base, ...classified, probe: probeRecord, credential_request: credentials.public,
+    const cleanupFailed = classified.failure?.type === "cleanup", runtimeAudit = error.runtime_audit;
+    const cleanup = cleanupFailed ? "failed" : runtimeAudit?.process_group_absent === true ? "passed" : "unknown";
+    return { ...base, ...classified, probe: probeRecord,
       checks: { boundary: boundary ? "passed" : "failed", nonce: "failed", cleanup,
-        process_scope_absent: notStarted ? "not_started" : runtimeAudit?.process_group_absent === true ? "passed" : "unknown", elapsed_ms: Date.now() - started },
+        process_scope_absent: runtimeAudit?.process_group_absent === true ? "passed" : "unknown", elapsed_ms: Date.now() - started },
       ...(cleanupFailed ? { cleanup_proof: cleanupProof(error) } : {}) };
   }
 }
@@ -317,7 +297,7 @@ async function runCanaries(options = {}) {
   const descriptors = Object.getOwnPropertyDescriptors(options);
   if (Object.values(descriptors).some((descriptor) => descriptor.get || descriptor.set)) throw new Error("canary options cannot contain accessors");
   const own = Object.fromEntries(Object.entries(descriptors).map(([key, descriptor]) => [key, descriptor.value]));
-  const { timeoutMs = 120_000, credentialSelections = {}, onFixture = null, onError = null, onCleanupIncomplete = null } = own;
+  const { timeoutMs = 120_000, onFixture = null, onError = null, onCleanupIncomplete = null } = own;
   if (onCleanupIncomplete !== null && typeof onCleanupIncomplete !== "function") throw new Error("onCleanupIncomplete must be a function");
   const customMatrix = Object.hasOwn(own, "adapters");
   const productionMatrix = !customMatrix && onFixture === null && onError === null && onCleanupIncomplete === null;
@@ -333,7 +313,7 @@ async function runCanaries(options = {}) {
     for (const adapter of adapters) {
       for (const phase of PHASES) if (phase === ADAPTER_PHASES.DISPATCH || adapter.capabilities({ phase }).supported) {
         const fixture = initializeFixture(root, outsideBase, adapter.name, phase);
-        results.push(await runCell(adapter, phase, fixture, { timeoutMs, credentialSelections, onFixture, onError, onCleanupIncomplete }));
+        results.push(await runCell(adapter, phase, fixture, { timeoutMs, onFixture, onError, onCleanupIncomplete }));
       }
     }
     const required = requiredMatrix(adapters), completed = results.filter((entry) => entry.status === "passed").map((entry) => `${entry.adapter}:${entry.phase}`);
@@ -389,7 +369,6 @@ function validateReport(report, { requireCurrentSource = false } = {}) {
     if (entry.failure?.type === "cleanup" && !(entry.failure.code === "HOST_CLEANUP_INCOMPLETE" && entry.checks?.cleanup === "failed"
       && entry.cleanup_proof?.reported === true && Object.hasOwn(entry.cleanup_proof, "terminal_status")
       && (!Object.hasOwn(entry.cleanup_proof, "artifact_sha256") || SHA256_RE.test(entry.cleanup_proof.artifact_sha256)))) throw new Error("canary report cleanup proof invalid");
-    if (entry.credential_request && (!Array.isArray(entry.credential_request.env_names) || !Array.isArray(entry.credential_request.file_ids))) throw new Error("canary report credential evidence invalid");
   }
   const passed = report.results.filter((entry) => entry.status === "passed").length, failed = report.results.filter((entry) => entry.status === "failed").length,
     notRun = report.results.filter((entry) => entry.status === "not_run").length, missing = report.policy.required_cells.filter((cell) => {
@@ -409,31 +388,27 @@ function canaryExitCode(report) {
   return FRESH_PRODUCTION_RUNS.has(report) && report.summary.required === report.policy.required_cells.length && report.summary.passed === report.summary.required
     && report.summary.failed === 0 && report.summary.not_run === 0 && report.summary.missing.length === 0 ? 0 : 1;
 }
-function parseCredentialArgs(argv) {
-  const selections = {}, consumed = new Set();
-  for (let index = 0; index < argv.length; index += 1) {
-    const flag = argv[index]; if (!["--credential-env", "--credential-file"].includes(flag)) continue;
-    const value = argv[index + 1]; if (!value || value.startsWith("--")) throw new Error(`${flag} requires adapter:phase:value`);
-    const match = value.match(/^([a-z0-9-]+):(dispatch|primary_review):(.+)$/); if (!match) throw new Error(`${flag} requires adapter:phase:value`);
-    const key = `${match[1]}:${match[2]}`, selection = selections[key] ||= { envNames: [], fileSpecs: [] };
-    (flag === "--credential-env" ? selection.envNames : selection.fileSpecs).push(match[3]); consumed.add(index); consumed.add(index + 1); index += 1;
-  }
-  return { selections, argv: argv.filter((unused, index) => !consumed.has(index)) };
-}
 async function main(argv = process.argv.slice(2)) {
   if (argv.includes("--help") || argv.includes("-h")) {
-    process.stdout.write("Usage: node tests/relay-dispatch/scripts/adapter-live-canary-runner.js [--timeout-ms <1..120000>] [--credential-env <adapter:phase:NAME>] [--credential-file <adapter:phase:ID=/absolute/source>] [--output <path>]\n"); return;
+    process.stdout.write("Usage: node tests/relay-dispatch/scripts/adapter-live-canary-runner.js [--timeout-ms <1..120000>] [--output <path>]\n"); return;
   }
-  const parsed = parseCredentialArgs(argv), timeoutIndex = parsed.argv.indexOf("--timeout-ms"), outputIndex = parsed.argv.indexOf("--output");
-  const timeoutMs = timeoutIndex >= 0 ? Number(parsed.argv[timeoutIndex + 1]) : 120_000;
+  let timeoutValue = null, outputPath = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option !== "--timeout-ms" && option !== "--output") throw new Error(`Unknown option: ${option}`);
+    const value = argv[++index];
+    if (!value || value.startsWith("--")) throw new Error(`${option} requires a value`);
+    if (option === "--timeout-ms") timeoutValue = value; else outputPath = value;
+  }
+  const timeoutMs = timeoutValue === null ? 120_000 : Number(timeoutValue);
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 120_000) throw new Error("--timeout-ms must be an integer between 1 and 120000");
-  const report = validateReport(await runCanaries({ timeoutMs, credentialSelections: parsed.selections }));
+  const report = validateReport(await runCanaries({ timeoutMs }));
   const exitCode = canaryExitCode(report);
   const outputReport = { ...report, generated_by: "tests/relay-dispatch/scripts/adapter-live-canary-runner.js" };
   const output = `${JSON.stringify(outputReport, null, 2)}\n`;
-  if (outputIndex >= 0) { const outputPath = parsed.argv[outputIndex + 1]; if (!outputPath || outputPath.startsWith("--")) throw new Error("--output requires a file path"); fs.writeFileSync(path.resolve(outputPath), output); }
+  if (outputPath !== null) fs.writeFileSync(path.resolve(outputPath), output);
   process.stdout.write(output); process.exitCode = exitCode;
 }
 
 if (require.main === module) main().catch((error) => { console.error(`Error: ${error.message}`); process.exitCode = 1; });
-module.exports = { canaryExitCode, canonicalRuntimeSha256Keys, classifyFailure, parseCredentialArgs, requiredMatrix, runCanaries, sourceProvenance, validateCanaryVerdict, validateReport };
+module.exports = { canaryExitCode, canonicalRuntimeSha256Keys, classifyFailure, requiredMatrix, runCanaries, sourceProvenance, validateCanaryVerdict, validateReport };

--- a/tests/relay-dispatch/scripts/adapter-live-canary.test.js
+++ b/tests/relay-dispatch/scripts/adapter-live-canary.test.js
@@ -7,11 +7,10 @@ const { spawnSync } = require("node:child_process");
 const { makeParseOutcome } = require("../../../skills/relay-dispatch/scripts/adapter-contract");
 const { listAdapters } = require("../../../skills/relay-dispatch/scripts/adapters");
 const host = require("../../../skills/relay-dispatch/scripts/host");
-const { canaryExitCode, canonicalRuntimeSha256Keys, classifyFailure, parseCredentialArgs, requiredMatrix, runCanaries, sourceProvenance, validateCanaryVerdict, validateReport } = require("./adapter-live-canary-runner");
+const { canaryExitCode, canonicalRuntimeSha256Keys, classifyFailure, requiredMatrix, runCanaries, sourceProvenance, validateCanaryVerdict, validateReport } = require("./adapter-live-canary-runner");
 
 const RUNNER = path.join(__dirname, "adapter-live-canary-runner.js");
 function hash(bytes) { return crypto.createHash("sha256").update(bytes).digest("hex"); }
-function selection(...cells) { return Object.fromEntries(cells.map((cell) => [cell, { envNames: ["TEST_CANARY_TOKEN"], fileSpecs: [] }])); }
 
 test("release canary is test-only and requires the exact 7-dispatch plus 6-review matrix", () => {
   assert.equal(fs.existsSync(path.join(__dirname, "../../../skills/relay-dispatch/scripts/adapter-live-canary.js")), false);
@@ -38,8 +37,7 @@ function fakeAdapter(name, mode = "pass", state = {}) {
   return {
     name,
     defaults: { timeoutMs: 10_000 },
-    metadata: { cliBinary: process.execPath, outputProtocol: "phase-specific", providerDefault: "test", processContainment: "inherited_scope_no_daemon",
-      credentials: { files: [], envHints: ["TEST_CANARY_TOKEN"] } },
+    metadata: { cliBinary: process.execPath, outputProtocol: "phase-specific", providerDefault: "test", processContainment: "inherited_scope_no_daemon" },
     probe() { return mode === "unavailable" ? { status: "skipped", error: "CLI not found", raw: null } : { status: "available", error: null, raw: "test 1.0" }; },
     capabilities({ phase }) { return { supported: phase === "dispatch" || (phase === "primary_review" && name !== "cline"), write: phase === "dispatch", readOnly: phase !== "dispatch" }; },
     buildInvocation({ phase, cwd, promptPath, promptBytes }) {
@@ -64,10 +62,8 @@ function fakeAdapter(name, mode = "pass", state = {}) {
   };
 }
 
-test("two production phase cells pass only with explicit credentials and exact nonce evidence", { skip: process.platform !== "darwin" }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret";
-  const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("healthy")],
-    credentialSelections: selection("healthy:dispatch", "healthy:primary_review") });
+test("two production phase cells use the ambient CLI session and exact nonce evidence", { skip: process.platform !== "darwin" }, async () => {
+  const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("healthy")] });
   assert.equal(report.summary.required, 2);
   assert.equal(report.summary.passed, 2, JSON.stringify(report.results));
   assert.equal(canaryExitCode(report), 1, "a custom matrix is diagnostic and cannot be release evidence");
@@ -77,47 +73,30 @@ test("two production phase cells pass only with explicit credentials and exact n
     assert.match(result.invocation_sha256, /^[a-f0-9]{64}$/); assert.match(result.output_sha256, /^[a-f0-9]{64}$/); assert.match(result.executed_runtime.digest, /^[a-f0-9]{64}$/);
     assert.match(result.executed_runtime.executable.sha256, /^[a-f0-9]{64}$/); assert.equal(typeof result.executed_runtime.executable.basename, "string");
     assert.equal(/[\\/]/.test(result.executed_runtime.executable.basename), false);
-    assert.deepEqual(result.credential_request, { env_names: ["TEST_CANARY_TOKEN"], file_ids: [] });
-    assert.doesNotMatch(JSON.stringify(result), /unit-secret/);
+    assert.equal(Object.hasOwn(result, "credential_request"), false);
   }
 });
 
-test("missing CLI and missing explicit credentials are non-release not_run cells", async () => {
-  const report = await runCanaries({ timeoutMs: 1_000, adapters: [fakeAdapter("missing", "unavailable"), fakeAdapter("unprovisioned")] });
+test("missing CLI is a non-release not_run cell", async () => {
+  const report = await runCanaries({ timeoutMs: 1_000, adapters: [fakeAdapter("missing", "unavailable")] });
   assert.ok(report.results.every((entry) => entry.status === "not_run"));
   assert.ok(report.results.some((entry) => entry.reason === "not_run_cli_unavailable"));
-  assert.ok(report.results.some((entry) => entry.reason === "not_run_credentials_unavailable"));
   assert.equal(canaryExitCode(report), 1);
 });
 
-test("structurally unrepresentable credentials stay typed not_run even when a dummy secret is selected", async () => {
-  const adapter = fakeAdapter("blocked");
-  adapter.capabilities = ({ phase }) => ({ supported: phase === "dispatch" || phase === "primary_review", credentialTransport: "unrepresentable" });
-  process.env.TEST_CANARY_TOKEN = "must-not-be-used";
-  const report = await runCanaries({ timeoutMs: 1_000, adapters: [adapter],
-    credentialSelections: selection("blocked:dispatch", "blocked:primary_review") });
-  assert.ok(report.results.every((entry) => entry.reason === "not_run_credentials_unrepresentable"));
-  assert.ok(report.results.every((entry) => entry.blocker?.code === "CREDENTIALS_UNREPRESENTABLE"));
-  assert.doesNotMatch(JSON.stringify(report), /must-not-be-used/);
-});
-
-test("provisioned authentication failure is failed, never skipped or not_run", { skip: process.platform !== "darwin" }, async () => {
-  process.env.TEST_CANARY_TOKEN = "wrong-secret";
-  const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("auth", "auth")],
-    credentialSelections: selection("auth:dispatch", "auth:primary_review") });
+test("ambient authentication failure is failed, never skipped or not_run", { skip: process.platform !== "darwin" }, async () => {
+  const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("auth", "auth")] });
   assert.ok(report.results.every((entry) => entry.status === "failed"), JSON.stringify(report.results));
-  assert.ok(report.results.every((entry) => entry.reason === "credential_auth_failed"));
+  assert.ok(report.results.every((entry) => entry.reason === "ambient_auth_failed"), JSON.stringify(report.results));
   assert.ok(report.results.every((entry) => entry.checks.boundary === "passed"), JSON.stringify(report.results));
   assert.equal(canaryExitCode(report), 1);
 });
 
-test("typed credential staging failures retain no message or source path", () => {
-  const error = new Error("credential '/private/secret/auth.json' source must be owner-only");
-  error.code = "UNTRUSTED_CREDENTIAL";
+test("ambient authentication failures remain typed without durable values", () => {
+  const error = new Error("authentication token is required");
   const classified = classifyFailure(error, true);
-  assert.deepEqual(classified, { status: "failed", reason: "credential_source_rejected",
-    failure: { type: "credential_staging", code: "UNTRUSTED_CREDENTIAL" } });
-  assert.doesNotMatch(JSON.stringify(classified), /private|secret|auth\.json/);
+  assert.deepEqual(classified, { status: "failed", reason: "ambient_auth_failed",
+    failure: { type: "authentication", code: "AUTHENTICATION_FAILED" } });
 });
 
 test("host cleanup failures remain typed and carry a redacted cleanup proof", () => {
@@ -126,69 +105,11 @@ test("host cleanup failures remain typed and carry a redacted cleanup proof", ()
     failure: { type: "cleanup", code: "HOST_CLEANUP_INCOMPLETE" } });
 });
 
-test("dispatch cleanup-incomplete is settled before canary fixtures are removed", { skip: process.platform !== "darwin", timeout: 20_000 }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret";
-  let fixtureRoot, settled = false;
-  const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("cleanup-settle")],
-    credentialSelections: selection("cleanup-settle:dispatch", "cleanup-settle:primary_review"),
-    onFixture(fixture, unused, phase) {
-      if (phase !== "dispatch") return;
-      fixtureRoot = fixture.root; fixture.testCleanupFailurePath = path.join(fixture.runDir, "cleanup.fail");
-      fs.writeFileSync(fixture.testCleanupFailurePath, "inject cleanup failure\n", { mode: 0o600 });
-    },
-    onError(error, unused, phase) {
-      if (phase !== "dispatch") return;
-      assert.equal(error.code, "HOST_CLEANUP_INCOMPLETE");
-      assert.equal(host.inspectOwnership({ runDir: path.join(fixtureRoot, "canary-cleanup-settle-dispatch") }).status, "absent");
-      const runDir = path.join(fixtureRoot, "canary-cleanup-settle-dispatch"), names = fs.readdirSync(runDir);
-      assert.ok(names.some((name) => name.endsWith(".cleanup-incomplete.json")));
-      assert.ok(names.some((name) => name.endsWith(".cleanup-settled.json")));
-      assert.ok(names.some((name) => name.endsWith(".result.json")));
-      settled = true;
-    } });
-  assert.equal(settled, true);
-  assert.equal(report.results[0].reason, "host_cleanup_incomplete");
-  assert.equal(fs.existsSync(fixtureRoot), false, "settled fixture may be removed");
-});
-
-test("unsettleable dispatch cleanup preserves signed evidence and aborts the canary", { skip: process.platform !== "darwin", timeout: 20_000 }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret";
-  let fixture, credentialRoot, displacedRoot;
-  try {
-    await assert.rejects(runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("cleanup-preserve")],
-      credentialSelections: selection("cleanup-preserve:dispatch", "cleanup-preserve:primary_review"),
-      onFixture(value, unused, phase) {
-        if (phase !== "dispatch") return;
-        fixture = value; value.testCleanupFailurePath = path.join(value.runDir, "cleanup.fail");
-        fs.writeFileSync(value.testCleanupFailurePath, "inject cleanup failure\n", { mode: 0o600 });
-      },
-      onCleanupIncomplete(value) {
-        const name = fs.readdirSync(value.runDir).find((entry) => entry.endsWith(".cleanup-incomplete.json"));
-        const cleanup = JSON.parse(fs.readFileSync(path.join(value.runDir, name), "utf8"));
-        credentialRoot = cleanup.obligation.credential_root.path; displacedRoot = `${credentialRoot}.displaced`;
-        fs.renameSync(credentialRoot, displacedRoot); fs.mkdirSync(credentialRoot, { mode: 0o700 });
-      } }), (error) => error.code === "CANARY_CLEANUP_UNSETTLED" && /evidence preserved/.test(error.message));
-    assert.ok(fixture && fs.existsSync(fixture.root));
-    assert.ok(fs.readdirSync(fixture.runDir).some((name) => name.endsWith(".cleanup-incomplete.json")));
-    assert.notEqual(host.inspectOwnership({ runDir: fixture.runDir }).status, "absent");
-    assert.equal(fs.readFileSync(path.join(fixture.outside, "sentinel"), "utf8"), "outside sentinel\n");
-  } finally {
-    if (credentialRoot && displacedRoot && fs.existsSync(displacedRoot)) {
-      fs.rmSync(credentialRoot, { recursive: true, force: true }); fs.renameSync(displacedRoot, credentialRoot);
-      await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: fixture.runDir }), reason: "test cleanup after preserved canary evidence" });
-    }
-    if (fixture) {
-      fs.rmSync(path.dirname(fixture.root), { recursive: true, force: true });
-      fs.rmSync(path.dirname(fixture.outside), { recursive: true, force: true });
-    }
-  }
-});
-
 test("a post-receipt timeout is cancelled and settled before canary fixture deletion", { skip: process.platform !== "darwin", timeout: 20_000 }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret"; const realWait = host.waitForTerminalResult; let calls = 0, observedAbsent = false;
+  const realWait = host.waitForTerminalResult; let calls = 0, observedAbsent = false;
   host.waitForTerminalResult = async (...args) => { if (calls++ === 0) { await new Promise((resolve) => setTimeout(resolve, 1_000)); const error = new Error("injected result timeout"); error.code = "HOST_RESULT_TIMEOUT"; throw error; } return realWait(...args); };
   try {
-    const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("cline")], credentialSelections: selection("cline:dispatch"),
+    const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("cline")],
       onError(unused, unusedAdapter, unusedPhase) { observedAbsent = true; } });
     assert.equal(report.results[0].status, "failed"); assert.equal(observedAbsent, true); assert.ok(calls >= 2);
   } finally { host.waitForTerminalResult = realWait; }
@@ -205,14 +126,14 @@ test("a post-receipt timeout is cancelled and settled before canary fixture dele
 // intact and destroys no evidence. Cleanup settlement is not asserted: this path publishes no
 // cleanup-incomplete artifact, so `settleCleanup` is never reachable and the check would be vacuous.
 test("an invalid post-receipt terminal aborts with a typed cause and destroys no evidence", { skip: process.platform !== "darwin", timeout: 20_000 }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret"; const realWait = host.waitForTerminalResult; let fixture, terminalBytes, resultPath, corrupted = false;
+  const realWait = host.waitForTerminalResult; let fixture, terminalBytes, resultPath, corrupted = false;
   host.waitForTerminalResult = async (...args) => {
     if (!corrupted) { await realWait(...args); resultPath = args[0].result_path; terminalBytes = fs.readFileSync(resultPath); fs.writeFileSync(resultPath, "{}\n"); corrupted = true;
       const error = new Error("injected invalid terminal"); error.code = "HOST_ARTIFACT_INVALID"; throw error; }
     return realWait(...args);
   };
   try {
-    await assert.rejects(runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("cline")], credentialSelections: selection("cline:dispatch"), onFixture(value) { fixture = value; } }),
+    await assert.rejects(runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("cline")], onFixture(value) { fixture = value; } }),
       (error) => error.code === "CANARY_CLEANUP_UNSETTLED" && error.preserveCanaryEvidence === true
         && error.originalError instanceof Error && error.originalError.code === "HOST_ARTIFACT_INVALID"
         && error.cause instanceof Error && typeof error.cause.code === "string");
@@ -227,34 +148,27 @@ test("an invalid post-receipt terminal aborts with a typed cause and destroys no
 });
 
 test("dispatch and review cells use phase-pristine fixtures", { skip: process.platform !== "darwin" }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret";
   const fixtures = [];
   const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("pristine")],
-    credentialSelections: selection("pristine:dispatch", "pristine:primary_review"),
     onFixture(fixture, adapter, phase) { fixtures.push({ phase, root: fixture.root }); } });
   assert.equal(report.summary.passed, 2, JSON.stringify(report.results));
   assert.equal(fixtures.length, 2); assert.notEqual(fixtures[0].root, fixtures[1].root);
 });
 
 test("boundary mutation and stale or fallback nonce cannot produce a pass", { skip: process.platform !== "darwin" }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret";
   for (const mode of ["wrong-nonce", "fallback-marker"]) {
-    const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("negative", mode)],
-      credentialSelections: selection("negative:dispatch", "negative:primary_review") });
+    const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("negative", mode)] });
     assert.equal(canaryExitCode(report), 1);
     assert.ok(report.results.some((entry) => entry.status === "failed"));
   }
-  const state = {}, report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("mutator", "builder-mutation", state)],
-    credentialSelections: selection("mutator:dispatch", "mutator:primary_review"), onFixture(fixture) { state.target = path.join(fixture.outside, "sentinel"); } });
+  const state = {}, report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter("mutator", "builder-mutation", state)], onFixture(fixture) { state.target = path.join(fixture.outside, "sentinel"); } });
   assert.equal(canaryExitCode(report), 1);
   assert.ok(report.results.some((entry) => entry.reason === "boundary_mutated"));
 });
 
 test("clean exit with a missing or wrong nonce artifact is output failure, not boundary mutation", { skip: process.platform !== "darwin" }, async () => {
-  process.env.TEST_CANARY_TOKEN = "unit-secret";
   for (const mode of ["missing-artifact", "wrong-artifact"]) {
-    const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter(`output-${mode}`, mode)],
-      credentialSelections: selection(`output-${mode}:dispatch`, `output-${mode}:primary_review`) });
+    const report = await runCanaries({ timeoutMs: 10_000, adapters: [fakeAdapter(`output-${mode}`, mode)] });
     const dispatch = report.results.find((entry) => entry.phase === "dispatch");
     assert.equal(dispatch.status, "failed"); assert.equal(dispatch.reason, "canary_output_invalid", JSON.stringify(dispatch));
     assert.deepEqual(dispatch.failure, { type: "output", code: "CANARY_OUTPUT_INVALID" });
@@ -356,22 +270,14 @@ test("current evidence is new-shape only: no checked-in cell leaks an absolute h
   assert.throws(() => validateReport(last), /passed-cell evidence invalid/, "the old absolute-path shape must be rejected");
 });
 
-test("credential CLI grammar is phase-explicit and retains no values in the public selector", () => {
-  const parsed = parseCredentialArgs(["--credential-env", "codex:dispatch:OPENAI_API_KEY", "--credential-file", "codex:primary_review:auth=/private/auth.json",
-    "--credential-env", "claude:dispatch:CLAUDE_CODE_OAUTH_TOKEN", "--credential-env", "claude:primary_review:CLAUDE_CODE_OAUTH_TOKEN", "--timeout-ms", "5"]);
-  assert.deepEqual(parsed.selections, {
-    "codex:dispatch": { envNames: ["OPENAI_API_KEY"], fileSpecs: [] },
-    "codex:primary_review": { envNames: [], fileSpecs: ["auth=/private/auth.json"] },
-    "claude:dispatch": { envNames: ["CLAUDE_CODE_OAUTH_TOKEN"], fileSpecs: [] },
-    "claude:primary_review": { envNames: ["CLAUDE_CODE_OAUTH_TOKEN"], fileSpecs: [] },
-  });
-  assert.deepEqual(parsed.argv, ["--timeout-ms", "5"]);
-  assert.throws(() => parseCredentialArgs(["--credential-env", "codex:OPENAI_API_KEY"]), /adapter:phase:value/);
-});
-
-test("runner help documents explicit phase credentials", () => {
+test("runner rejects retired selectors exactly like other unknown options", () => {
+  const retired = spawnSync(process.execPath, [RUNNER, "--credential-env", "OPENAI_API_KEY"], { encoding: "utf8" });
+  const unknown = spawnSync(process.execPath, [RUNNER, "--not-an-option", "value"], { encoding: "utf8" });
+  assert.equal(retired.status, 1);
+  assert.equal(unknown.status, 1);
+  assert.match(retired.stderr, /^Error: Unknown option: --credential-env\n$/);
+  assert.match(unknown.stderr, /^Error: Unknown option: --not-an-option\n$/);
   const result = spawnSync(process.execPath, [RUNNER, "--help"], { encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /adapter:phase:NAME/);
-  assert.match(result.stdout, /adapter:phase:ID=\/absolute\/source/);
+  assert.match(result.stdout, /--timeout-ms/);
 });

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -118,20 +118,12 @@ test("dry-run validates the closed Relay surface while writing zero durable byte
   assert.equal(fs.existsSync(stateDir), false);
   assert.equal(fs.existsSync(value.relayHome), false);
   const cursor = run(value, ["--executor", "cursor", "--branch", "cursor-dry", "--prompt", "x", "--rubric-file", value.rubric, "--dry-run", "--json"]);
-  assert.equal(cursor.status, 0, cursor.stderr); assert.deepEqual(json(cursor.stdout).invocation.private_env_paths,
-    [{ key: "CURSOR_CONFIG_DIR", root: "home", relative: ".cursor" }, { key: "CURSOR_DATA_DIR", root: "scratch", relative: "cursor-data" }]);
-
-  const absentSource = path.join(value.root, "never-read-auth.json");
-  const credentialDryRun = run(value, ["--branch", "credential-dry", "--prompt", "x", "--rubric-file", value.rubric, "--credential-env", "OPENAI_API_KEY",
-    "--credential-file", `auth=${absentSource}`, "--dry-run", "--json"], { ...value.env, OPENAI_API_KEY: undefined });
-  assert.equal(credentialDryRun.status, 0, credentialDryRun.stderr);
-  assert.deepEqual(json(credentialDryRun.stdout).credential_request, { env_names: ["OPENAI_API_KEY"], file_ids: ["auth"] });
-  assert.doesNotMatch(credentialDryRun.stdout + credentialDryRun.stderr, /never-read-auth/);
-  assert.equal(fs.existsSync(absentSource), false);
-  const customEnv = run(value, ["--branch", "custom-env-dry", "--prompt", "x", "--rubric-file", value.rubric,
-    "--credential-env", "CUSTOM_PROVIDER_TOKEN", "--dry-run", "--json"], { ...value.env, CUSTOM_PROVIDER_TOKEN: undefined });
-  assert.equal(customEnv.status, 0, customEnv.stderr);
-  assert.deepEqual(json(customEnv.stdout).credential_request.env_names, ["CUSTOM_PROVIDER_TOKEN"]);
+  assert.equal(cursor.status, 0, cursor.stderr);
+  assert.equal(Object.hasOwn(json(cursor.stdout).invocation, "private_env_paths"), false);
+  const retired = run(value, ["--branch", "retired-credential", "--prompt", "x", "--rubric-file", value.rubric,
+    "--credential-env", "OPENAI_API_KEY", "--dry-run", "--json"]);
+  assert.notEqual(retired.status, 0);
+  assert.match(retired.stderr, /Unknown option/);
 
   git(value.repo, ["branch", "existing-dry"]);
   const existingBranch = run(value, ["--branch", "existing-dry", "--prompt", "x", "--rubric-file", value.rubric, "--dry-run", "--json"]);

--- a/tests/relay-dispatch/scripts/host-supervisor.test.js
+++ b/tests/relay-dispatch/scripts/host-supervisor.test.js
@@ -75,10 +75,10 @@ function ownerSecret(runDir) {
   return JSON.parse(fs.readFileSync(path.join(ownership, name), "utf8"));
 }
 
-function writeCleanupObligation(runDir, attemptId, obligation) {
+function writeCleanupObligation(runDir, attemptId, obligation, kind = obligation.staged_input_root ? "reviewer" : "executor") {
   const owner = ownerSecret(runDir);
   const body = {
-    v: 2, attempt_id: attemptId, lock_id: owner.lock_id, host_handle: owner.host_handle,
+    v: 2, kind, attempt_id: attemptId, lock_id: owner.lock_id, host_handle: owner.host_handle,
     identities: { supervisor: { pid: owner.process.pid, pgid: owner.process.pgid, started_at: owner.process.started_at }, executor: null },
     error: "injected cleanup obligation", terminal: { status: "failed", exit_code: 1, signal: null },
     obligation, observed_at: new Date().toISOString(),
@@ -86,6 +86,12 @@ function writeCleanupObligation(runDir, attemptId, obligation) {
   const signature = crypto.createHmac("sha256", owner.secret).update(JSON.stringify(body)).digest("hex");
   fs.writeFileSync(path.join(runDir, `host-attempt-${attemptId}.cleanup-incomplete.json`),
     `${JSON.stringify({ ...body, auth_sha256: signature })}\n`, { mode: 0o600 });
+}
+
+function stagedInputRoot(t) {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "relay-review-")));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
 }
 
 test("a same-second PID reuse without the inherited scope token is never signalled", { timeout: 30_000 }, async (t) => {
@@ -139,9 +145,8 @@ test("lost cleanup scope proof requires exact external action and then converges
   await waitForFile(marker);
   assert.equal(fs.readFileSync(marker, "utf8"), scope.env.RELAY_PROCESS_SCOPE, "the process must inherit the run scope before dropping it");
   await new Promise((resolve) => setTimeout(resolve, 300));
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [liveIdentity(foreign.pid)], credential_root: { path: credentialRoot, dev: null, ino: null },
+    processes: [liveIdentity(foreign.pid)], staged_input_root: null,
     scope_seal: scope.seal,
   });
   const inspection = host.inspectOwnership({ runDir: value.runDir });
@@ -174,9 +179,8 @@ test("Linux cleanup retains stat identity when proc cmdline is unreadable", { ti
   t.after(() => { if (!processDead(foreign.pid)) try { process.kill(-foreign.pid, "SIGKILL"); } catch {} try { host.releaseRunLock(capability); } catch {} });
   await waitForFile(marker);
   await new Promise((resolve) => setTimeout(resolve, 300));
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [liveIdentity(foreign.pid)], credential_root: { path: credentialRoot, dev: null, ino: null },
+    processes: [liveIdentity(foreign.pid)], staged_input_root: null,
     scope_seal: scope.seal,
   });
   const realReadFile = fs.readFileSync;
@@ -224,26 +228,26 @@ test("cleanup recovery treats an exact zombie as gone even when ps redacts its s
     if (/^Z/.test(state)) return state; await new Promise((resolve) => setTimeout(resolve, 20));
   } return ""; })();
   assert.match(zombie, /^Z/, "the stopped parent must leave an exact zombie identity");
-  writeCleanupObligation(value.runDir, attemptId, { processes: [identity], credential_root: { path: path.join(value.runDir, `executor-credentials-${attemptId}`), dev: null, ino: null }, scope_seal: scope.seal });
+  writeCleanupObligation(value.runDir, attemptId, { processes: [identity], staged_input_root: null, scope_seal: scope.seal });
   await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "settle exact zombie" });
   assert.equal(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
   assert.equal(fs.existsSync(path.join(value.runDir, `attempt-${attemptId}.result.json`)), true);
   assert.equal(processDead(parent.pid), false, "recovery must not signal a process outside the exact obligation");
 });
 
-test("a credential-root pathname swap is quarantined, preserved as evidence, and never deleted", { timeout: 30_000 }, async (t) => {
+test("a staged-input-root pathname swap is quarantined, preserved as evidence, and never deleted", { timeout: 30_000 }, async (t) => {
   const value = roots("root-swap"), attemptId = "root-swap", capability = lock(value, attemptId);
   t.after(() => { try { host.releaseRunLock(capability); } catch {} });
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 });
-  fs.writeFileSync(path.join(credentialRoot, "auth.json"), "bound-secret", { mode: 0o600 });
-  const bound = fs.lstatSync(credentialRoot), stashed = `${credentialRoot}.stashed`;
+  const stagedRoot = stagedInputRoot(t);
+  fs.writeFileSync(path.join(stagedRoot, "input.md"), "bound-input", { mode: 0o600 });
+  const bound = fs.lstatSync(stagedRoot), stashed = `${stagedRoot}.stashed`;
+  t.after(() => fs.rmSync(stashed, { recursive: true, force: true }));
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [], credential_root: { path: credentialRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
+    processes: [], staged_input_root: { path: stagedRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
   });
   const realRename = fs.renameSync;
   fs.renameSync = function swapBeforeQuarantine(from, to) {
-    if (String(from) === credentialRoot) {
+    if (String(from) === stagedRoot) {
       fs.renameSync = realRename;
       realRename(from, stashed);
       fs.mkdirSync(from, { mode: 0o700 });
@@ -253,58 +257,57 @@ test("a credential-root pathname swap is quarantined, preserved as evidence, and
   };
   let failure;
   try {
-    await assert.rejects(host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "settle a swapped credential root" }),
+    await assert.rejects(host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "settle a swapped staged input root" }),
       (error) => { failure = error; return error.code === "HOST_CLEANUP_INCOMPLETE" && /was replaced before quarantined removal/.test(error.message); });
   } finally { fs.renameSync = realRename; }
   assert.equal(fs.existsSync(failure.quarantinePath), true, "the swapped tree is preserved as evidence");
   assert.equal(fs.readFileSync(path.join(failure.quarantinePath, "planted"), "utf8"), "attacker");
-  assert.equal(path.dirname(failure.quarantinePath), value.runDir);
-  assert.equal(fs.readFileSync(path.join(stashed, "auth.json"), "utf8"), "bound-secret");
+  assert.equal(path.dirname(failure.quarantinePath), path.dirname(stagedRoot));
+  assert.equal(fs.readFileSync(path.join(stashed, "input.md"), "utf8"), "bound-input");
   assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), false);
 });
 
 // Covers the window where a prior removal quarantined the bound root and then failed to roll it back:
 // the obligation still names the original pathname, which is now absent. Absence must not be read as
-// cleanup success while a sibling quarantine still holds the signed identity and its secret bytes.
-test("an unrolled-back quarantine is reclaimed instead of settling on an absent pathname", async (t) => {
+// cleanup success while a sibling quarantine still holds the signed identity and its staged bytes.
+test("an unrolled-back staged-input quarantine is reclaimed instead of settling on an absent pathname", async (t) => {
   const value = roots("quarantine-orphan"), attemptId = "quarantine-orphan", capability = lock(value, attemptId);
   t.after(() => { try { host.releaseRunLock(capability); } catch {} });
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 });
-  fs.writeFileSync(path.join(credentialRoot, "auth.json"), "bound-secret", { mode: 0o600 });
-  const bound = fs.lstatSync(credentialRoot);
+  const stagedRoot = stagedInputRoot(t);
+  fs.writeFileSync(path.join(stagedRoot, "input.md"), "bound-input", { mode: 0o600 });
+  const bound = fs.lstatSync(stagedRoot);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [], credential_root: { path: credentialRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
+    processes: [], staged_input_root: { path: stagedRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
   });
   // Replay a failed removal whose rollback also failed: bound root renamed aside, original pathname gone.
-  const orphan = path.join(value.runDir, `.executor-credentials-${attemptId}.quarantine.${process.pid}.deadbeefdeadbeef`);
-  fs.renameSync(credentialRoot, orphan);
-  assert.equal(fs.existsSync(credentialRoot), false);
+  const orphan = path.join(path.dirname(stagedRoot), `.${path.basename(stagedRoot)}.quarantine.${process.pid}.deadbeefdeadbeef`);
+  fs.renameSync(stagedRoot, orphan);
+  assert.equal(fs.existsSync(stagedRoot), false);
   assert.equal(fs.lstatSync(orphan).ino, bound.ino, "the quarantine must still carry the signed identity");
 
   await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "reclaim an orphaned quarantine" });
 
-  assert.equal(fs.existsSync(orphan), false, "the secret-bearing quarantine must be removed, not orphaned");
-  assert.equal(fs.readdirSync(value.runDir).some((name) => name.includes(".quarantine.")), false);
+  assert.equal(fs.existsSync(orphan), false, "the staged-input quarantine must be removed, not orphaned");
+  assert.equal(fs.readdirSync(path.dirname(stagedRoot)).some((name) => name.includes(`${path.basename(stagedRoot)}.quarantine.`)), false);
   assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), true);
   assert.equal(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
 });
 
 // Reclaim must not delete by pathname. Between the identity check and the removal, a racing process can
 // move the real quarantine away and leave a decoy at that name; the removal must land on neither.
-test("a reclaimed quarantine swapped before removal is preserved, not deleted", { timeout: 30_000 }, async (t) => {
+test("a reclaimed staged-input quarantine swapped before removal is preserved, not deleted", { timeout: 30_000 }, async (t) => {
   const value = roots("quarantine-reclaim-swap"), attemptId = "quarantine-reclaim-swap", capability = lock(value, attemptId);
   t.after(() => { try { host.releaseRunLock(capability); } catch {} });
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 });
-  fs.writeFileSync(path.join(credentialRoot, "auth.json"), "bound-secret", { mode: 0o600 });
-  const bound = fs.lstatSync(credentialRoot);
+  const stagedRoot = stagedInputRoot(t);
+  fs.writeFileSync(path.join(stagedRoot, "input.md"), "bound-input", { mode: 0o600 });
+  const bound = fs.lstatSync(stagedRoot);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [], credential_root: { path: credentialRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
+    processes: [], staged_input_root: { path: stagedRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
   });
-  const orphan = path.join(value.runDir, `.executor-credentials-${attemptId}.quarantine.${process.pid}.abadcafeabadcafe`);
-  fs.renameSync(credentialRoot, orphan);
-  const stashed = path.join(value.runDir, "stashed-real-quarantine");
+  const orphan = path.join(path.dirname(stagedRoot), `.${path.basename(stagedRoot)}.quarantine.${process.pid}.abadcafeabadcafe`);
+  fs.renameSync(stagedRoot, orphan);
+  const stashed = path.join(path.dirname(stagedRoot), "stashed-real-quarantine");
+  t.after(() => fs.rmSync(stashed, { recursive: true, force: true }));
 
   const realRename = fs.renameSync;
   fs.renameSync = function swapReclaimedQuarantine(from, to) {
@@ -321,7 +324,7 @@ test("a reclaimed quarantine swapped before removal is preserved, not deleted", 
     await assert.rejects(host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "reclaim a swapped quarantine" }),
       (error) => { failure = error; return error.code === "HOST_CLEANUP_INCOMPLETE" && /was replaced before quarantined removal/.test(error.message); });
   } finally { fs.renameSync = realRename; }
-  assert.equal(fs.readFileSync(path.join(stashed, "auth.json"), "utf8"), "bound-secret", "the real secret tree must not be deleted");
+  assert.equal(fs.readFileSync(path.join(stashed, "input.md"), "utf8"), "bound-input", "the real staged tree must not be deleted");
   assert.equal(fs.existsSync(failure.quarantinePath), true, "the decoy is preserved as evidence");
   assert.equal(fs.readFileSync(path.join(failure.quarantinePath, "planted"), "utf8"), "attacker");
   assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), false, "settled must not be published");
@@ -330,18 +333,18 @@ test("a reclaimed quarantine swapped before removal is preserved, not deleted", 
 // Removal unlinks a pathname, so a rename racing the delete can leave the bound tree alive under another
 // quarantine name while the delete still returns success. Settling must depend on a post-condition scan,
 // not on the delete's return value.
-test("a bound tree surviving removal under a quarantine name blocks settling", async (t) => {
+test("a staged-input tree surviving removal under a quarantine name blocks settling", async (t) => {
   const value = roots("quarantine-survives"), attemptId = "quarantine-survives", capability = lock(value, attemptId);
   t.after(() => { try { host.releaseRunLock(capability); } catch {} });
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 });
-  fs.writeFileSync(path.join(credentialRoot, "auth.json"), "bound-secret", { mode: 0o600 });
-  const bound = fs.lstatSync(credentialRoot);
+  const stagedRoot = stagedInputRoot(t);
+  fs.writeFileSync(path.join(stagedRoot, "input.md"), "bound-input", { mode: 0o600 });
+  const bound = fs.lstatSync(stagedRoot);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [], credential_root: { path: credentialRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
+    processes: [], staged_input_root: { path: stagedRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
   });
   // Race the delete: move the verified tree to another quarantine name so the rmSync unlinks nothing.
-  const survivor = path.join(value.runDir, `.executor-credentials-${attemptId}.quarantine.${process.pid}.5ur5170r5ur5170r`);
+  const survivor = path.join(path.dirname(stagedRoot), `.${path.basename(stagedRoot)}.quarantine.${process.pid}.5ur5170r5ur5170r`);
+  t.after(() => fs.rmSync(survivor, { recursive: true, force: true }));
   const realRm = fs.rmSync;
   fs.rmSync = function renameInsteadOfRemoving(target, options) {
     if (String(target).includes(".quarantine.")) { fs.rmSync = realRm; fs.renameSync(target, survivor); return undefined; }
@@ -351,26 +354,26 @@ test("a bound tree surviving removal under a quarantine name blocks settling", a
     await assert.rejects(host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "settle after a racing rename" }),
       (error) => error.code === "HOST_CLEANUP_INCOMPLETE" && /survived removal under a quarantine name/.test(error.message));
   } finally { fs.rmSync = realRm; }
-  assert.equal(fs.readFileSync(path.join(survivor, "auth.json"), "utf8"), "bound-secret", "the surviving tree is retained as evidence");
+  assert.equal(fs.readFileSync(path.join(survivor, "input.md"), "utf8"), "bound-input", "the surviving tree is retained as evidence");
   assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), false, "settled must not be published");
 });
 
 // A quarantine whose identity does not match the signed binding is someone else's tree. It must be left
-// untouched and must not be mistaken for the bound root.
-test("a quarantine that does not match the signed identity is not reclaimed", async (t) => {
+// untouched and must not be mistaken for the bound staged-input root.
+test("a staged-input quarantine that does not match the signed identity is not reclaimed", async (t) => {
   const value = roots("quarantine-foreign"), attemptId = "quarantine-foreign", capability = lock(value, attemptId);
   t.after(() => { try { host.releaseRunLock(capability); } catch {} });
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 });
-  const bound = fs.lstatSync(credentialRoot);
+  const stagedRoot = stagedInputRoot(t);
+  const bound = fs.lstatSync(stagedRoot);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [], credential_root: { path: credentialRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
+    processes: [], staged_input_root: { path: stagedRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
   });
-  const displaced = path.join(value.runDir, ".displaced-bound-root");
-  fs.renameSync(credentialRoot, displaced);
+  const displaced = path.join(path.dirname(stagedRoot), ".displaced-staged-input-root");
+  fs.renameSync(stagedRoot, displaced);
   t.after(() => fs.rmSync(displaced, { recursive: true, force: true }));
-  const foreign = path.join(value.runDir, `.executor-credentials-${attemptId}.quarantine.${process.pid}.00000000000000ff`);
+  const foreign = path.join(path.dirname(stagedRoot), `.${path.basename(stagedRoot)}.quarantine.${process.pid}.00000000000000ff`);
   fs.mkdirSync(foreign, { mode: 0o700 });
+  t.after(() => fs.rmSync(foreign, { recursive: true, force: true }));
   fs.writeFileSync(path.join(foreign, "unrelated"), "not-ours", { mode: 0o600 });
   assert.notEqual(fs.lstatSync(foreign).ino, bound.ino);
 
@@ -380,26 +383,40 @@ test("a quarantine that does not match the signed identity is not reclaimed", as
   assert.equal(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
 });
 
-test("a quarantine removal failure rolls the bound root back for convergent recovery", async (t) => {
+test("a staged-input quarantine removal failure rolls the bound root back for convergent recovery", async (t) => {
   const value = roots("quarantine-rm-failure"), attemptId = "quarantine-rm-failure", capability = lock(value, attemptId);
   t.after(() => { try { host.releaseRunLock(capability); } catch {} });
-  const credentialRoot = path.join(value.runDir, `executor-credentials-${attemptId}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 }); fs.writeFileSync(path.join(credentialRoot, "auth.json"), "bound-secret", { mode: 0o600 });
-  const bound = fs.lstatSync(credentialRoot);
+  const stagedRoot = stagedInputRoot(t);
+  fs.writeFileSync(path.join(stagedRoot, "input.md"), "bound-input", { mode: 0o600 });
+  const bound = fs.lstatSync(stagedRoot);
   writeCleanupObligation(value.runDir, attemptId, {
-    processes: [], credential_root: { path: credentialRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
+    processes: [], staged_input_root: { path: stagedRoot, dev: bound.dev, ino: bound.ino }, scope_seal: null,
   });
   await assert.rejects(host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "inject quarantine removal failure",
-    fault(stage) { if (stage === "credential_after_quarantine") throw new Error("injected rm failure"); } }),
+    fault(stage) { if (stage === "staged_input_after_quarantine") throw new Error("injected rm failure"); } }),
   (error) => error.code === "HOST_CLEANUP_INCOMPLETE" && /rolled back/.test(error.message));
-  assert.equal(fs.readFileSync(path.join(credentialRoot, "auth.json"), "utf8"), "bound-secret");
-  assert.equal(fs.readdirSync(value.runDir).some((name) => name.includes(".quarantine.")), false);
+  assert.equal(fs.readFileSync(path.join(stagedRoot, "input.md"), "utf8"), "bound-input");
+  assert.equal(fs.readdirSync(path.dirname(stagedRoot)).some((name) => name.includes(`${path.basename(stagedRoot)}.quarantine.`)), false);
   assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), false);
   assert.notEqual(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
   await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "retry rolled-back cleanup" });
   assert.equal(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
-  assert.equal(fs.existsSync(credentialRoot), false);
-  assert.equal(fs.readdirSync(value.runDir).some((name) => name.includes("auth.json") || name.includes(".quarantine.")), false);
+  assert.equal(fs.existsSync(stagedRoot), false);
+  assert.equal(fs.readdirSync(path.dirname(stagedRoot)).some((name) => name.includes(`${path.basename(stagedRoot)}.quarantine.`)), false);
+});
+
+test("cleanup artifacts reject legacy roots, unknown keys, and unknown kinds", async (t) => {
+  for (const [label, obligation, kind] of [
+    ["legacy-root", { processes: [], scope_seal: null, staged_input_root: null, credential_root: null }, "executor"],
+    ["unknown-key", { processes: [], scope_seal: null, staged_input_root: null, extra: true }, "executor"],
+    ["unknown-kind", { processes: [], scope_seal: null, staged_input_root: null }, "legacy"],
+  ]) {
+    const value = roots(`cleanup-schema-${label}`), attemptId = `cleanup-schema-${label}`, capability = lock(value, attemptId);
+    t.after(() => { try { host.releaseRunLock(capability); } catch {} });
+    writeCleanupObligation(value.runDir, attemptId, obligation, kind);
+    await assert.rejects(host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: `reject ${label}` }),
+      (error) => error.code === "HOST_ARTIFACT_INVALID" && /cleanup obligation is invalid/.test(error.message));
+  }
 });
 
 test("config claim starts the executor exactly once and terminal bytes are authenticated", async () => {
@@ -469,25 +486,56 @@ test("cancel terminates the executor process group and descendants within a boun
   host.releaseRunLock(capability);
 });
 
-test("executor inherits only the minimal host environment plus explicit adapter entries", async () => {
+test("executor inherits ambient host auth/config while blocking Relay and runtime injection", async () => {
   const value = roots("env-canary"), attemptId = "env-canary", capability = lock(value, attemptId);
   const marker = path.join(value.worktree, "environment.txt"), barrier = path.join(value.runDir, "env.release");
   const previous = process.env.RELAY_PARENT_SECRET_CANARY;
   process.env.RELAY_PARENT_SECRET_CANARY = "must-not-cross";
   try {
-    const script = `require('fs').writeFileSync(${JSON.stringify(marker)},[process.env.RELAY_PARENT_SECRET_CANARY||'missing',process.env.RELAY_EXPLICIT_SAFE||'missing',process.env.RELAY_EPHEMERAL_TOKEN||'missing'].join(':'))`;
+    const script = `require('fs').writeFileSync(${JSON.stringify(marker)},[process.env.RELAY_PARENT_SECRET_CANARY||'missing',process.env.EXPLICIT_SAFE||'missing'].join(':'))`;
     const receipt = host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", script],
-      trustedWorktreeRoot: value.worktree, cwd: value.worktree, executorEnv: { RELAY_EXPLICIT_SAFE: "allowed" }, ephemeralEnv: { RELAY_EPHEMERAL_TOKEN: "one-shot" }, testGateBarrierPath: barrier, lockContext: capability });
+      trustedWorktreeRoot: value.worktree, cwd: value.worktree, executorEnv: { EXPLICIT_SAFE: "allowed" }, testGateBarrierPath: barrier, lockContext: capability });
     const running = JSON.parse(fs.readFileSync(path.join(value.runDir, `host-attempt-${attemptId}.running.json`)));
-    assert.doesNotMatch(spawnSync("/bin/ps", ["eww", "-p", `${running.supervisor.pid},${running.executor.pid}`], { encoding: "utf8" }).stdout, /one-shot/);
+    assert.doesNotMatch(spawnSync("/bin/ps", ["eww", "-p", `${running.supervisor.pid},${running.executor.pid}`], { encoding: "utf8" }).stdout, /must-not-cross/);
     fs.writeFileSync(barrier, "release", { mode: 0o600 });
     const result = await host.waitForTerminalResult(receipt);
     assert.equal(result.status, "completed");
-    assert.equal(fs.readFileSync(marker, "utf8"), "missing:allowed:one-shot");
-    assert.doesNotMatch(fs.readFileSync(path.join(value.runDir, `host-attempt-${attemptId}.config.json`), "utf8"), /must-not-cross|one-shot/);
+    assert.equal(fs.readFileSync(marker, "utf8"), "missing:allowed");
+    const config = JSON.parse(fs.readFileSync(path.join(value.runDir, `host-attempt-${attemptId}.config.json`), "utf8"));
+    assert.equal(Object.hasOwn(config, "ambient_env"), false);
+    assert.equal(Object.hasOwn(config, "executor_env"), false);
+    assert.doesNotMatch(JSON.stringify(config), /must-not-cross/);
     assert.equal(fs.readdirSync(value.runDir).some((name) => name.startsWith(".host-secret-")), false);
   } finally {
     if (previous === undefined) delete process.env.RELAY_PARENT_SECRET_CANARY; else process.env.RELAY_PARENT_SECRET_CANARY = previous;
+    host.releaseRunLock(capability);
+  }
+});
+
+test("host ambient sanitizer preserves CLI session values and rejects startup injection", () => {
+  const safe = host.hostInvocation.ambientEnvironment({ HOME: "/tmp/home", XDG_CONFIG_HOME: "/tmp/config", SSL_CERT_FILE: "/tmp/ca.pem",
+    RELAY_PROCESS_SCOPE: "forged", RELAY_ARBITRARY_INJECTION: "forged", NODE_OPTIONS: "--require=evil", LD_PRELOAD: "evil", BASH_ENV: "/tmp/evil" }, "test ambient");
+  assert.deepEqual(safe, { HOME: "/tmp/home", XDG_CONFIG_HOME: "/tmp/config", SSL_CERT_FILE: "/tmp/ca.pem" });
+  assert.throws(() => host.hostInvocation.ambientEnvironment({}, "test ambient", { NODE_PATH: "/tmp/evil" }), /invalid environment entry/);
+});
+
+test("ambient host payload has no named-file window before supervisor spawn", () => {
+  const value = roots("secret-fd"), attemptId = "secret-fd", capability = lock(value, attemptId), marker = "ambient-secret-must-not-persist";
+  const previous = process.env.HOST_SECRET_PRESPAWN;
+  process.env.HOST_SECRET_PRESPAWN = marker;
+  try {
+    assert.throws(() => host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", "0"],
+      trustedWorktreeRoot: value.worktree, cwd: value.worktree, lockContext: capability,
+      testBeforeSupervisorSpawn({ runDir, configPath }) {
+        assert.equal(runDir, value.runDir);
+        assert.equal(fs.readdirSync(runDir).some((name) => name.startsWith(".host-secret-")), false);
+        assert.doesNotMatch(fs.readFileSync(configPath, "utf8"), new RegExp(marker));
+        throw new Error("injected pre-spawn failure");
+      },
+    }), /injected pre-spawn failure/);
+    assert.equal(fs.readdirSync(value.runDir).some((name) => name.startsWith(".host-secret-")), false);
+  } finally {
+    if (previous === undefined) delete process.env.HOST_SECRET_PRESPAWN; else process.env.HOST_SECRET_PRESPAWN = previous;
     host.releaseRunLock(capability);
   }
 });
@@ -626,169 +674,25 @@ test("bound prompt reaches native executor only through exact stdin bytes and me
   } finally { host.releaseRunLock(capability); }
 });
 
-test("credential request stages exact private HOME/XDG files and keeps sources and values out of durable and argv surfaces", async () => {
-  const value = roots("credentials"), attemptId = "credentials", capability = lock(value, attemptId);
-  const source = path.join(value.root, "auth.json"), proof = path.join(value.worktree, "credential-proof.json");
-  const secret = "credential-secret-7f1d", envSecret = "environment-secret-3a9c";
-  fs.writeFileSync(source, secret, { mode: 0o600 }); fs.chmodSync(source, 0o600);
-  const metadata = { files: [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read" }], envHints: [] };
-  const script = [
-    "const fs=require('fs'),path=require('path');",
-    "const cache=path.join(process.env.HOME,'.tool/cache/state.json');fs.mkdirSync(path.dirname(cache),{recursive:true});fs.writeFileSync(cache,'state');",
-    "let authWrite='written';try{fs.writeFileSync(path.join(process.env.HOME,'.tool/auth.json'),'changed')}catch(e){authWrite='denied:'+e.code}",
-    "fs.writeFileSync(process.argv[1],JSON.stringify({home:process.env.HOME,xdg:process.env.XDG_CONFIG_HOME,data:process.env.XDG_DATA_HOME,",
-    "file:fs.readFileSync(path.join(process.env.HOME,'.tool/auth.json'),'utf8'),cache:fs.readFileSync(cache,'utf8'),authWrite,env:process.env.TOOL_API_KEY,modes:[fs.statSync(process.env.HOME).mode&511,fs.statSync(path.join(process.env.HOME,'.tool/auth.json')).mode&511]}));",
-  ].join("");
+test("host preserves ambient HOME/XDG and auth environment without serializing them", async () => {
+  const value = roots("ambient-env"), attemptId = "ambient-env", capability = lock(value, attemptId);
+  const proof = path.join(value.worktree, "ambient-proof.json"), ambient = "ambient-auth-canary";
+  const previous = { auth: process.env.AMBIENT_AUTH_CANARY, relay: process.env.RELAY_PARENT_SECRET_CANARY };
+  process.env.AMBIENT_AUTH_CANARY = ambient; process.env.RELAY_PARENT_SECRET_CANARY = "must-not-cross";
   try {
+    const script = "require('fs').writeFileSync(process.argv[1],JSON.stringify({home:process.env.HOME,config:process.env.XDG_CONFIG_HOME,data:process.env.XDG_DATA_HOME,auth:process.env.AMBIENT_AUTH_CANARY,relay:process.env.RELAY_PARENT_SECRET_CANARY||null}))";
     const receipt = host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", script, proof],
-      trustedWorktreeRoot: value.worktree, cwd: value.worktree, credentialRequest: { metadata, envNames: ["TOOL_API_KEY"], fileSpecs: [`auth=${source}`], env: { TOOL_API_KEY: envSecret } }, lockContext: capability });
-    const configPath = path.join(value.runDir, `host-attempt-${attemptId}.config.json`), configText = fs.readFileSync(configPath, "utf8"), config = JSON.parse(configText);
-    assert.deepEqual(config.credentials, [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read", size: Buffer.byteLength(secret), sha: crypto.createHash("sha256").update(secret).digest("hex") }]);
-    assert.doesNotMatch(configText, new RegExp(`${secret}|${envSecret}|${source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
-    assert.doesNotMatch(JSON.stringify(config.args), new RegExp(`${secret}|${envSecret}|${source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+      trustedWorktreeRoot: value.worktree, cwd: value.worktree, lockContext: capability });
+    const configText = fs.readFileSync(path.join(value.runDir, `host-attempt-${attemptId}.config.json`), "utf8");
+    assert.doesNotMatch(configText, new RegExp(`${ambient}|must-not-cross`));
     assert.equal((await host.waitForTerminalResult(receipt)).status, "completed");
     const observed = JSON.parse(fs.readFileSync(proof, "utf8"));
-    // The trusted-local path no longer fabricates a filesystem boundary around
-    // staged credentials. Their source binding and post-run cleanup remain until
-    // #1233 removes staging altogether.
-    assert.equal(observed.file, "changed"); assert.equal(observed.cache, "state"); assert.equal(observed.authWrite, "written"); assert.equal(observed.env, envSecret); assert.deepEqual(observed.modes, [0o700, 0o600]);
-    assert.match(observed.home, /executor-credentials-credentials\/home$/); assert.match(observed.xdg, /executor-credentials-credentials\/xdg-config$/); assert.match(observed.data, /executor-credentials-credentials\/xdg-data$/);
-    assert.equal(fs.existsSync(path.dirname(observed.home)), false);
-    for (const name of fs.readdirSync(value.runDir).filter((name) => /\.(?:json|log)$/.test(name))) {
-      const text = fs.readFileSync(path.join(value.runDir, name), "utf8"); assert.doesNotMatch(text, new RegExp(`${secret}|${envSecret}`), name);
-    }
-  } finally { host.releaseRunLock(capability); }
-});
-
-test("private environment paths use distinct short attempt roots and clean exactly", async () => {
-  const value = roots("private-env-paths"), observed = [];
-  const declarations = [{ key: "TOOL_CONFIG_DIR", root: "home", relative: ".tool" }, { key: "TOOL_DATA_DIR", root: "scratch", relative: "tool-data" }];
-  for (const attemptId of ["private-path-a", "private-path-b"]) {
-    const capability = lock(value, attemptId), proof = path.join(value.worktree, `${attemptId}.json`);
-    try {
-      const script = "const fs=require('fs');fs.writeFileSync(process.argv[1],JSON.stringify({home:process.env.HOME,config:process.env.TOOL_CONFIG_DIR,data:process.env.TOOL_DATA_DIR}));";
-      const receipt = host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", script, proof],
-        trustedWorktreeRoot: value.worktree, cwd: value.worktree, privateEnvPaths: declarations, lockContext: capability });
-      const config = JSON.parse(fs.readFileSync(path.join(value.runDir, `host-attempt-${attemptId}.config.json`), "utf8"));
-      assert.deepEqual(config.private_env_paths, declarations); assert.ok(Buffer.byteLength(config.credential_root) <= 64); assert.match(config.credential_root, /\/relay-[0-9a-f]{32}$/);
-      assert.equal((await host.waitForTerminalResult(receipt)).status, "completed"); const output = JSON.parse(fs.readFileSync(proof, "utf8")); observed.push(output);
-      assert.equal(output.config, path.join(output.home, ".tool")); assert.match(output.data, /\/scratch\/tool-data$/); assert.ok(Buffer.byteLength(output.data) <= 83);
-      assert.equal(fs.existsSync(config.credential_root), false);
-    } finally { host.releaseRunLock(capability); }
-  }
-  assert.notEqual(path.dirname(observed[0].home), path.dirname(observed[1].home));
-  const longAttempt = "private-reject-length", longCapability = lock(value, longAttempt);
-  try {
-    const receipt = host.launchLocalSupervisor({ runDir: value.runDir, attemptId: longAttempt, command: process.execPath, args: ["-e", "0"], trustedWorktreeRoot: value.worktree,
-      cwd: value.worktree, privateEnvPaths: [{ key: "TOOL_DATA_DIR", root: "scratch", relative: "x".repeat(80) }], lockContext: longCapability });
-    const terminal = await host.waitForTerminalResult(receipt); assert.equal(terminal.status, "spawn_error"); assert.match(terminal.error, /short-path limit/);
-    assert.equal(fs.existsSync(JSON.parse(fs.readFileSync(path.join(value.runDir, `host-attempt-${longAttempt}.config.json`), "utf8")).credential_root), false);
-  } finally { host.releaseRunLock(longCapability); }
-  for (const privateEnvPaths of [[{ key: "TOOL_DATA_DIR", root: "scratch", relative: "/tmp/escape" }], declarations]) {
-    const attemptId = `private-reject-${privateEnvPaths.length}`, capability = lock(value, attemptId);
-    try { assert.throws(() => host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", "0"], trustedWorktreeRoot: value.worktree,
-      cwd: value.worktree, privateEnvPaths, ...(privateEnvPaths.length > 1 ? { executorEnv: { TOOL_DATA_DIR: "/tmp/caller" } } : {}), lockContext: capability }),
-    (error) => error.code === "INVALID_INVOCATION"); } finally { host.releaseRunLock(capability); }
-  }
-});
-
-test("credential sources and catalog selections fail closed before supervisor artifacts", () => {
-  const metadata = { files: [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read" }], envHints: ["TOOL_API_KEY"] };
-  for (const kind of ["world", "symlink", "fifo"]) {
-    const value = roots(`credential-${kind}`), attemptId = `credential-${kind}`, capability = lock(value, attemptId), source = path.join(value.root, "source");
-    try {
-      if (kind === "world") fs.writeFileSync(source, "secret", { mode: 0o644 });
-      else if (kind === "symlink") { const target = path.join(value.root, "target"); fs.writeFileSync(target, "secret", { mode: 0o600 }); fs.symlinkSync(target, source); }
-      else spawnSync("mkfifo", [source]);
-      assert.throws(() => host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", "0"], trustedWorktreeRoot: value.worktree, cwd: value.worktree,
-        credentialRequest: { metadata, fileSpecs: [`auth=${source}`] }, lockContext: capability }), (error) => ["UNTRUSTED_CREDENTIAL", "INVALID_CREDENTIAL"].includes(error.code));
-      assert.equal(fs.readdirSync(value.runDir).some((name) => name.includes(`host-attempt-${attemptId}`)), false);
-    } finally { host.releaseRunLock(capability); }
-  }
-});
-
-test("credential source inode/content swap between prepare and bind fails before config publication", () => {
-  const value = roots("credential-swap"), attemptId = "credential-swap", capability = lock(value, attemptId);
-  const source = path.join(value.root, "source"), replacement = path.join(value.root, "replacement");
-  fs.writeFileSync(source, "first-secret", { mode: 0o600 }); fs.writeFileSync(replacement, "second-secret", { mode: 0o600 });
-  const metadata = { files: [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read" }], envHints: [] };
-  try {
-    assert.throws(() => host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", "0"],
-      trustedWorktreeRoot: value.worktree, cwd: value.worktree, credentialRequest: { metadata, fileSpecs: [`auth=${source}`] },
-      testCredentialPrepared: () => fs.renameSync(replacement, source), lockContext: capability }), (error) => error.code === "CREDENTIAL_CHANGED");
-    assert.equal(fs.readdirSync(value.runDir).some((name) => name.includes(`host-attempt-${attemptId}`)), false);
-  } finally { host.releaseRunLock(capability); }
-});
-
-test("partial credential prepare failure zeroes already-read source buffers", () => {
-  const value = roots("credential-partial"), attemptId = "credential-partial", capability = lock(value, attemptId);
-  const first = path.join(value.root, "first"), second = path.join(value.root, "second"), secret = "first-partial-secret";
-  fs.writeFileSync(first, secret, { mode: 0o600 }); fs.writeFileSync(second, "unsafe", { mode: 0o644 });
-  const metadata = { files: [
-    { id: "first", targetRoot: "home", targetRel: ".tool/first", access: "read" },
-    { id: "second", targetRoot: "home", targetRel: ".tool/second", access: "read" },
-  ], envHints: [] };
-  const originalRead = fs.readFileSync; let captured = null;
-  fs.readFileSync = function readAndCapture(target, ...args) {
-    const bytes = originalRead.call(this, target, ...args);
-    if (Number.isInteger(target) && Buffer.isBuffer(bytes) && bytes.toString("utf8") === secret) captured = bytes;
-    return bytes;
-  };
-  try {
-    assert.throws(() => host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", "0"],
-      trustedWorktreeRoot: value.worktree, cwd: value.worktree, credentialRequest: { metadata, fileSpecs: [`first=${first}`, `second=${second}`] }, lockContext: capability }),
-    (error) => error.code === "UNTRUSTED_CREDENTIAL");
-    assert.ok(captured); assert.equal(captured.every((byte) => byte === 0), true);
-    assert.equal(fs.readdirSync(value.runDir).some((name) => name.includes(`host-attempt-${attemptId}`)), false);
-  } finally { fs.readFileSync = originalRead; host.releaseRunLock(capability); }
-});
-
-test("cleanup-incomplete recovery settles exact obligations and converges after a crash", async () => {
-  const value = roots("credential-cleanup"), attemptId = "credential-cleanup", capability = lock(value, attemptId);
-  const marker = path.join(value.runDir, "cleanup.fail"); fs.writeFileSync(marker, "fail", { mode: 0o600 });
-  try {
-    const receipt = host.launchLocalSupervisor({ runDir: value.runDir, attemptId, command: process.execPath, args: ["-e", "0"],
-      trustedWorktreeRoot: value.worktree, cwd: value.worktree, testCleanupFailurePath: marker, lockContext: capability });
-    await assert.rejects(host.waitForTerminalResult(receipt, { timeoutMs: 10_000 }), (error) => {
-      assert.equal(error.code, "HOST_CLEANUP_INCOMPLETE"); assert.match(error.cleanup_sha256, /^[0-9a-f]{64}$/); return true;
-    });
-    const cleanupPath = path.join(value.runDir, `host-attempt-${attemptId}.cleanup-incomplete.json`), cleanup = JSON.parse(fs.readFileSync(cleanupPath, "utf8"));
-    assert.match(cleanup.auth_sha256, /^[0-9a-f]{64}$/); assert.match(cleanup.error, /cleanup failed/);
-    assert.equal(cleanup.obligation.credential_root.path, path.join(value.runDir, `executor-credentials-${attemptId}`));
-    assert.ok(Number.isInteger(cleanup.obligation.credential_root.dev));
-    assert.ok(cleanup.obligation.processes.every((identity) => Number.isInteger(identity.pid) && identity.started_at));
-    assert.equal(fs.existsSync(receipt.result_path), false);
-    fs.rmSync(marker, { force: true });
-    // The recorded supervisor/executor are short-lived; a same-second PID reuse (macOS lstart is
-    // second-resolution) can transiently make the exact reap look like a foreign unscoped process,
-    // which the host correctly refuses to signal (HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED, see the dedicated
-    // "a same-second PID reuse without the inherited scope token" test above). Production recovery
-    // re-observes and retries, so this test does too: the reused pid exits within a second and the
-    // retry converges. This is not a timeout widening; the transient bind failure is a first-class
-    // recovery-observable state and convergence is still asserted below.
-    const settleRetrying = async (fault) => {
-      for (let attempt = 0; attempt < 10; attempt += 1) {
-        try {
-          return await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir: value.runDir }), reason: "recover cleanup", ...(fault ? { fault } : {}) });
-        } catch (error) {
-          if (error.code === "HOST_CLEANUP_EXTERNAL_ACTION_REQUIRED") {
-            await new Promise((resolve) => setTimeout(resolve, 100));
-            continue;
-          }
-          throw error;
-        }
-      }
-      assert.fail("cleanup settle did not converge across 10 re-observations");
-    };
-    await assert.rejects(settleRetrying((stage) => { if (stage === "after_settled") throw new Error("crash after settled proof"); }), /crash after settled proof/);
-    assert.equal(fs.existsSync(path.join(value.runDir, `host-attempt-${attemptId}.cleanup-settled.json`)), true);
-    assert.equal(fs.existsSync(receipt.result_path), false);
-    await settleRetrying();
-    assert.equal(host.inspectOwnership({ runDir: value.runDir }).status, "absent");
-    assert.equal((await host.waitForTerminalResult(receipt)).status, "failed");
-    assert.equal(fs.existsSync(cleanup.obligation.credential_root.path), false);
+    assert.equal(observed.home, process.env.HOME); assert.equal(observed.config, process.env.XDG_CONFIG_HOME);
+    assert.equal(observed.data, process.env.XDG_DATA_HOME); assert.equal(observed.auth, ambient); assert.equal(observed.relay, null);
   } finally {
-    fs.rmSync(marker, { force: true }); fs.rmSync(path.join(value.runDir, `executor-credentials-${attemptId}`), { recursive: true, force: true }); try { host.releaseRunLock(capability); } catch {}
+    if (previous.auth === undefined) delete process.env.AMBIENT_AUTH_CANARY; else process.env.AMBIENT_AUTH_CANARY = previous.auth;
+    if (previous.relay === undefined) delete process.env.RELAY_PARENT_SECRET_CANARY; else process.env.RELAY_PARENT_SECRET_CANARY = previous.relay;
+    host.releaseRunLock(capability);
   }
 });
 
@@ -796,11 +700,9 @@ test("pre-exec environment injection keys fail before supervisor launch", () => 
   const value = roots("env-injection"), capability = lock(value, "env-injection"), marker = path.join(value.worktree, "injected");
   const options = { runDir: value.runDir, attemptId: "env-injection", command: process.execPath, args: ["-e", "0"], trustedWorktreeRoot: value.worktree, cwd: value.worktree, lockContext: capability };
   try {
-    for (const key of ["SSL_CERT_FILE", "NODE_OPTIONS", "NODE_PATH", "DYLD_INSERT_LIBRARIES", "LD_PRELOAD", "BASH_ENV", "ENV", "ZDOTDIR", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS", "LUA_INIT", "PHPRC", "PHP_INI_SCAN_DIR", "PYTHONSTARTUP", "PYTHONPATH", "PERL5OPT", "RUBYOPT", "GEM_HOME"])
+    for (const key of ["RELAY_EXPLICIT_SAFE", "NODE_OPTIONS", "NODE_PATH", "DYLD_INSERT_LIBRARIES", "LD_PRELOAD", "BASH_ENV", "ENV", "ZDOTDIR", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS", "LUA_INIT", "PHPRC", "PHP_INI_SCAN_DIR", "PYTHONSTARTUP", "PYTHONPATH", "PERL5OPT", "RUBYOPT", "GEM_HOME"])
       assert.throws(() => host.launchLocalSupervisor({ ...options, executorEnv: { [key]: marker } }), (error) => error.code === "INVALID_INVOCATION", key);
-    assert.throws(() => host.launchLocalSupervisor({ ...options, ephemeralEnv: { NODE_OPTIONS: marker } }), (error) => error.code === "INVALID_INVOCATION");
-    fs.writeFileSync(path.join(value.worktree, ".zshenv"), `print -r -- $RELAY_EPHEMERAL_TOKEN > ${marker}\n`);
-    assert.throws(() => host.launchLocalSupervisor({ ...options, command: "/bin/zsh", args: ["-c", ":"], executorEnv: { ZDOTDIR: value.worktree }, ephemeralEnv: { RELAY_EPHEMERAL_TOKEN: "pre-sandbox-secret" } }), (error) => error.code === "INVALID_INVOCATION");
+    assert.doesNotThrow(() => host.launchLocalSupervisor({ ...options, executorEnv: { SSL_CERT_FILE: marker } }));
     assert.equal(fs.existsSync(marker), false);
   } finally { host.releaseRunLock(capability); }
 });

--- a/tests/relay-dispatch/scripts/recover-stale-owner.test.js
+++ b/tests/relay-dispatch/scripts/recover-stale-owner.test.js
@@ -215,22 +215,19 @@ function writeAuthenticatedCancelledResult(f, owner) {
 }
 
 function writeAuthenticatedCleanup(f, owner) {
-  const credentialRoot = path.join(f.runDir, `executor-credentials-${owner.attempt_id}`);
-  fs.mkdirSync(credentialRoot, { mode: 0o700 });
-  fs.writeFileSync(path.join(credentialRoot, "secret"), "test-only", { mode: 0o600 });
-  const stat = fs.statSync(credentialRoot), identity = {
+  const identity = {
     pid: owner.process.pid, pgid: owner.process.pgid, started_at: owner.process.started_at,
   };
   const unsigned = {
-    v: 2, attempt_id: owner.attempt_id, lock_id: owner.lock_id, host_handle: owner.host_handle,
+    v: 2, kind: "executor", attempt_id: owner.attempt_id, lock_id: owner.lock_id, host_handle: owner.host_handle,
     identities: { supervisor: identity, executor: null }, error: "injected cleanup obligation",
     terminal: { status: "failed", exit_code: 1, signal: null },
-    obligation: { processes: [identity], credential_root: { path: credentialRoot, dev: stat.dev, ino: stat.ino } },
+    obligation: { processes: [identity], staged_input_root: null, scope_seal: null },
     observed_at: new Date().toISOString(),
   };
   const marker = { ...unsigned, auth_sha256: crypto.createHmac("sha256", owner.secret).update(JSON.stringify(unsigned)).digest("hex") };
   fs.writeFileSync(path.join(f.runDir, `host-attempt-${owner.attempt_id}.cleanup-incomplete.json`), `${JSON.stringify(marker)}\n`, { mode: 0o600 });
-  return credentialRoot;
+  return null;
 }
 
 function createForeignUnknownOwner(f, attemptId) {
@@ -379,7 +376,7 @@ test("canonical recover settles an authenticated cleanup obligation and records 
   const f = fixture("cleanup-obligation");
   t.after(() => fs.rmSync(f.root, { recursive: true, force: true }));
   await childJsonAndExit(startOwner(f, { attemptId: "cleanup-owner", exit: true }));
-  const owner = rawOwner(f.runDir), credentialRoot = writeAuthenticatedCleanup(f, owner);
+  const owner = rawOwner(f.runDir); writeAuthenticatedCleanup(f, owner);
   await withFakeGh(f, async () => {
     const inspected = await runtime.inspectRun({ runDir: f.runDir });
     assert.equal(inspected.observations.host.cleanup_pending, true);
@@ -390,7 +387,6 @@ test("canonical recover settles an authenticated cleanup obligation and records 
     });
     assert.equal(recovered.status, "converged");
     assert.deepEqual(recovered.applied.map((entry) => entry.step), ["close_dead_attempt"]);
-    assert.equal(fs.existsSync(credentialRoot), false);
     assert.equal(fs.existsSync(path.join(f.runDir, "host-attempt-cleanup-owner.cleanup-settled.json")), true);
     assert.equal(fs.existsSync(path.join(f.runDir, "attempt-cleanup-owner.result.json")), true);
     assert.equal(factsFor(f).filter((entry) => entry.type === "attempt_interrupted" && entry.attempt_id === "cleanup-owner").length, 1);

--- a/tests/relay-dispatch/scripts/run-store.test.js
+++ b/tests/relay-dispatch/scripts/run-store.test.js
@@ -195,9 +195,6 @@ test("reviewer process-group reap still runs when the scope audit throws and bot
   fs.writeFileSync(diffPath, "diff\n", { mode: 0o600 }); fs.writeFileSync(promptPath, "prompt\n", { mode: 0o600 });
   const request = { diff_path: diffPath, prompt_path: promptPath, done_criteria_path: criteriaPath, reviewed_sha: "a".repeat(40), current_sha: "a".repeat(40),
     diff_sha256: crypto.createHash("sha256").update("diff\n").digest("hex"), prompt_sha256: crypto.createHash("sha256").update("prompt\n").digest("hex") };
-  const credentialSource = path.join(path.dirname(runDir), "review-audit-secret"); fs.writeFileSync(credentialSource, "audit-secret", { mode: 0o600 });
-  const credentialRequest = { metadata: { files: [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read", recommendedSource: "test" }], envHints: [] },
-    envNames: ["TOOL_TOKEN"], fileSpecs: [`auth=${credentialSource}`], env: { TOOL_TOKEN: "audit-env-secret" } };
   const originalMkdtemp = fs.mkdtempSync; let stage;
   fs.mkdtempSync = function captureStage(prefix, ...args) { const value = originalMkdtemp.call(this, prefix, ...args); if (String(prefix).includes("relay-review-")) stage = value; return value; };
   const realAudit = host.hostInvocation.auditProcessScope, realReap = host.hostInvocation.reapProcessGroup;
@@ -211,7 +208,7 @@ test("reviewer process-group reap still runs when the scope audit throws and bot
     const error = new Error("process-group audit timed out"); error.code = "HOST_GROUP_AUDIT_FAILED"; throw error;
   };
   try {
-    assert.throws(() => store.invokeIndependentReviewer({ runDir, request, timeoutMs: 10_000, env: {}, credentialRequest,
+    assert.throws(() => store.invokeIndependentReviewer({ runDir, request, timeoutMs: 10_000, env: {},
       buildInvocation: ({ cwd, resultPath }) => ({ command: process.execPath, args: ["-e", [
         "const {spawn}=require('child_process'),fs=require('fs');",
         "const child=spawn(process.execPath,['-e',\"process.on('SIGTERM',()=>{});setInterval(()=>{},1000)\"],{stdio:'ignore'});",
@@ -230,12 +227,11 @@ test("reviewer process-group reap still runs when the scope audit throws and bot
     assert.ok(Number.isInteger(escapedPid));
     const end = Date.now() + 2_000, waiter = new Int32Array(new SharedArrayBuffer(4)); let live = true;
     while (live && Date.now() < end) { try { process.kill(escapedPid, 0); Atomics.wait(waiter, 0, 0, 20); } catch (error) { live = error.code !== "ESRCH"; } }
-    assert.equal(live, false, "a credential-inheriting reviewer descendant must not outlive an audit failure");
+    assert.equal(live, false, "a reviewer descendant must not outlive an audit failure");
   } finally {
     host.hostInvocation.auditProcessScope = realAudit; host.hostInvocation.reapProcessGroup = realReap; fs.mkdtempSync = originalMkdtemp;
   }
   assert.ok(stage);
-  assert.equal(fs.readFileSync(path.join(stage, "reviewer-credentials", "home", ".tool", "auth.json"), "utf8"), "audit-secret");
   assert.equal(host.inspectOwnership({ runDir }).reason, "cleanup_incomplete");
   return host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir }), reason: "settle preserved reviewer test evidence" }).then(() => {
   assert.equal(fs.existsSync(stage), false);
@@ -243,30 +239,27 @@ test("reviewer process-group reap still runs when the scope audit throws and bot
   });
 });
 
-test("signed pending reviewer cleanup recovers every crash cut before secret stage deletion", async () => {
+test("signed pending reviewer cleanup recovers every crash cut before staged-input deletion", async () => {
   const worker = path.join(__dirname, "../fixtures/reviewer-crash-worker.js");
-  for (const cut of ["pending", "credential", "pre_spawn", "spawned", "before_cleanup"]) {
+  for (const cut of ["pending", "staged", "pre_spawn", "spawned", "before_cleanup"]) {
     const runDir = tempDir(`review-crash-${cut}`), criteriaPath = path.join(runDir, "done-criteria.md"), diffPath = path.join(runDir, "diff.patch"), promptPath = path.join(runDir, "prompt.md");
     fs.writeFileSync(criteriaPath, "criterion\n", { mode: 0o600 }); fs.writeFileSync(diffPath, "diff\n", { mode: 0o600 }); fs.writeFileSync(promptPath, "prompt\n", { mode: 0o600 });
     createRunRecord({ runDir, record: record(runDir, { contract: { done_criteria_path: criteriaPath, done_criteria_sha256: crypto.createHash("sha256").update("criterion\n").digest("hex") } }) });
-    const source = path.join(path.dirname(runDir), `auth-${cut}.json`); fs.writeFileSync(source, "secret", { mode: 0o600 });
     const request = { diff_path: diffPath, prompt_path: promptPath, done_criteria_path: criteriaPath, reviewed_sha: "a".repeat(40), current_sha: "a".repeat(40),
       diff_sha256: crypto.createHash("sha256").update("diff\n").digest("hex"), prompt_sha256: crypto.createHash("sha256").update("prompt\n").digest("hex") };
-    const credentials = { metadata: { files: [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read", recommendedSource: "test" }], envHints: [] }, envNames: [], fileSpecs: [`auth=${source}`], env: {} };
-    const configPath = path.join(path.dirname(runDir), `worker-${cut}.json`); fs.writeFileSync(configPath, JSON.stringify({ cut, runDir, request, credentials }), { mode: 0o600 });
+    const configPath = path.join(path.dirname(runDir), `worker-${cut}.json`); fs.writeFileSync(configPath, JSON.stringify({ cut, runDir, request }), { mode: 0o600 });
     const result = spawnSync(process.execPath, [worker, configPath], { timeout: 10_000 }); assert.equal(result.signal, "SIGKILL", cut);
     const cleanupName = fs.readdirSync(runDir).find((name) => name.endsWith(".cleanup-incomplete.json")); assert.ok(cleanupName, cut);
-    const cleanup = JSON.parse(fs.readFileSync(path.join(runDir, cleanupName), "utf8")), stage = cleanup.obligation.credential_root.path;
+    const cleanup = JSON.parse(fs.readFileSync(path.join(runDir, cleanupName), "utf8")), stage = cleanup.obligation.staged_input_root.path;
     assert.equal(fs.existsSync(stage), true, cut); await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir }), reason: `recover reviewer crash ${cut}` });
     assert.equal(fs.existsSync(stage), false, cut); assert.equal(host.inspectOwnership({ runDir }).status, "absent", cut);
     assert.ok(fs.readdirSync(runDir).some((name) => name.endsWith(".cleanup-settled.json")), cut);
   }
 });
 
-test("independent review stages explicit owner-only credentials into private HOME/XDG and removes them after execution", async () => {
-  const runDir = tempDir("review-credentials"), criteriaPath = path.join(runDir, "done-criteria.md"), source = path.join(path.dirname(runDir), "auth.json");
-  const criteria = "criterion\n", secret = "review-credential-secret", envSecret = "review-environment-secret";
-  fs.writeFileSync(criteriaPath, criteria, { mode: 0o600 }); fs.writeFileSync(source, secret, { mode: 0o600 }); fs.chmodSync(source, 0o600);
+test("independent review preserves ambient HOME/XDG and auth while removing staged input", () => {
+  const runDir = tempDir("review-ambient"), criteriaPath = path.join(runDir, "done-criteria.md"), criteria = "criterion\n";
+  fs.writeFileSync(criteriaPath, criteria, { mode: 0o600 });
   createRunRecord({ runDir, record: record(runDir, { contract: { done_criteria_path: criteriaPath, done_criteria_sha256: crypto.createHash("sha256").update(criteria).digest("hex") } }) });
   const diffPath = path.join(runDir, "diff.patch"), promptPath = path.join(runDir, "prompt.md");
   fs.writeFileSync(diffPath, "diff\n", { mode: 0o600 }); fs.writeFileSync(promptPath, "prompt\n", { mode: 0o600 });
@@ -274,43 +267,23 @@ test("independent review stages explicit owner-only credentials into private HOM
     diff_sha256: crypto.createHash("sha256").update("diff\n").digest("hex"), prompt_sha256: crypto.createHash("sha256").update("prompt\n").digest("hex") };
   const originalMkdtemp = fs.mkdtempSync; let stage;
   fs.mkdtempSync = function captureStage(prefix, ...args) { const value = originalMkdtemp.call(this, prefix, ...args); if (String(prefix).includes("relay-review-")) stage = value; return value; };
-  const script = "const fs=require('fs'),path=require('path');const cache=path.join(process.env.HOME,'.tool/cache/state.json');fs.mkdirSync(path.dirname(cache),{recursive:true});fs.writeFileSync(cache,'state');let authWrite='written',runtimeReadable='readable';try{fs.writeFileSync(path.join(process.env.HOME,'.tool/auth.json'),'changed')}catch(e){authWrite='denied:'+e.code}try{fs.readFileSync(process.execPath)}catch(e){runtimeReadable='denied:'+e.code}const value={home:process.env.HOME,config:process.env.XDG_CONFIG_HOME,data:process.env.XDG_DATA_HOME,privateConfig:process.env.TOOL_CONFIG_DIR,privateData:process.env.TOOL_DATA_DIR,auth:fs.readFileSync(path.join(process.env.HOME,'.tool/auth.json'),'utf8'),cache:fs.readFileSync(cache,'utf8'),authWrite,env:process.env.TOOL_TOKEN,ca:process.env.SSL_CERT_FILE||null,runtimeReadable,modes:[fs.statSync(process.env.HOME).mode&511,fs.statSync(path.join(process.env.HOME,'.tool/auth.json')).mode&511]};fs.writeFileSync(process.argv[1],JSON.stringify(value));";
-  const invoke = (credentialRequest) => store.invokeIndependentReviewer({ runDir, request, timeoutMs: 10_000, env: {}, credentialRequest,
-    buildInvocation: ({ cwd, promptPath, promptBytes, resultPath }) => ({ command: process.execPath, args: ["-e", script, resultPath], cwd, stdinPath: promptPath, stdinSha256: crypto.createHash("sha256").update(promptBytes).digest("hex"), networkAccess: "enabled",
-      privateEnvPaths: [{ key: "TOOL_CONFIG_DIR", root: "home", relative: ".tool" }, { key: "TOOL_DATA_DIR", root: "scratch", relative: "tool-data" }] }),
-    parseOutcome: ({ exitCode, resultPath }) => ({ status: exitCode === 0 ? "succeeded" : "failed", output: JSON.parse(fs.readFileSync(resultPath, "utf8")) }),
-  });
-  const explicit = { metadata: { files: [{ id: "auth", targetRoot: "home", targetRel: ".tool/auth.json", access: "read", recommendedSource: "~/.tool/auth.json" }], envHints: [] }, envNames: ["TOOL_TOKEN"], fileSpecs: [`auth=${source}`], env: { TOOL_TOKEN: envSecret } };
+  const previous = { auth: process.env.REVIEW_AMBIENT_AUTH, relay: process.env.RELAY_REVIEW_LEAK };
+  process.env.REVIEW_AMBIENT_AUTH = "ambient-review-auth"; process.env.RELAY_REVIEW_LEAK = "blocked";
   try {
-    const outcome = invoke(explicit);
-    assert.equal(outcome.output.auth, "changed"); assert.equal(outcome.output.cache, "state"); assert.equal(outcome.output.authWrite, "written"); assert.equal(outcome.output.env, envSecret); assert.deepEqual(outcome.output.modes, [0o700, 0o600]);
-    assert.equal(outcome.output.ca, null); assert.equal(outcome.output.runtimeReadable, "readable");
-    assert.match(outcome.output.home, /reviewer-credentials\/home$/); assert.match(outcome.output.config, /reviewer-credentials\/xdg-config$/); assert.match(outcome.output.data, /reviewer-credentials\/xdg-data$/);
-    assert.equal(outcome.output.privateConfig, path.join(outcome.output.home, ".tool")); assert.match(outcome.output.privateData, /reviewer-credentials\/scratch\/tool-data$/); assert.ok(Buffer.byteLength(outcome.output.privateData) <= 83);
-    assert.doesNotMatch(JSON.stringify(outcome.review_binding), new RegExp(`${secret}|${envSecret}|${source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
-    const realRetain = host.retainReviewerCleanup; let retainedStage;
-    try {
-      host.retainReviewerCleanup = (...args) => { const value = realRetain(...args); return { ...value, complete() { const error = new Error("injected reviewer cleanup failure"); error.code = "HOST_CLEANUP_INCOMPLETE"; throw error; } }; };
-      assert.throws(() => invoke(explicit), (error) => { retainedStage = error.review_evidence_path; return error.code === "HOST_CLEANUP_INCOMPLETE"; });
-      assert.equal(fs.existsSync(retainedStage), true, "review stage must be restored to its signed pathname");
-    } finally {
-      host.retainReviewerCleanup = realRetain;
-      if (retainedStage && fs.existsSync(retainedStage)) await host.breakStaleRunLock({ inspection: host.inspectOwnership({ runDir }), reason: "review quarantine test recovery" });
-    }
-    assert.doesNotThrow(() => invoke({ ...explicit, envNames: ["SSL_CERT_FILE"], env: { SSL_CERT_FILE: source } }));
-    fs.chmodSync(source, 0o644);
-    assert.throws(() => invoke(explicit), /owner-only regular file/);
-    fs.chmodSync(source, 0o600);
-    const link = path.join(path.dirname(source), "auth-link.json"); fs.symlinkSync(source, link);
-    assert.throws(() => invoke({ ...explicit, fileSpecs: [`auth=${link}`] }), (error) => {
-      assert.match(error.message, /owner-only regular file|source is unavailable/); assert.doesNotMatch(error.message, new RegExp(link)); return true;
+    const outcome = store.invokeIndependentReviewer({ runDir, request, timeoutMs: 10_000,
+      buildInvocation: ({ cwd, promptPath, promptBytes, resultPath }) => ({ command: process.execPath,
+        args: ["-e", "require('fs').writeFileSync(process.argv[1],JSON.stringify({home:process.env.HOME,config:process.env.XDG_CONFIG_HOME,data:process.env.XDG_DATA_HOME,auth:process.env.REVIEW_AMBIENT_AUTH,relay:process.env.RELAY_REVIEW_LEAK||null,tmp:process.env.TMPDIR}))", resultPath], cwd, stdinPath: promptPath, stdinSha256: crypto.createHash("sha256").update(promptBytes).digest("hex"), networkAccess: "enabled" }),
+      parseOutcome: ({ exitCode, resultPath }) => ({ status: exitCode === 0 ? "succeeded" : "failed", output: JSON.parse(fs.readFileSync(resultPath, "utf8")) }),
     });
-    const missing = path.join(path.dirname(source), "missing-private-source.json");
-    assert.throws(() => invoke({ ...explicit, fileSpecs: [`auth=${missing}`] }), (error) => {
-      assert.match(error.message, /source is unavailable/); assert.doesNotMatch(error.message, new RegExp(missing)); return true;
-    });
-    assert.throws(() => invoke({ ...explicit, env: {} }), /environment value is missing/);
-  } finally { fs.mkdtempSync = originalMkdtemp; assert.ok(stage); assert.equal(fs.existsSync(stage), false); }
+    assert.equal(outcome.output.home, process.env.HOME); assert.equal(outcome.output.config, process.env.XDG_CONFIG_HOME);
+    assert.equal(outcome.output.data, process.env.XDG_DATA_HOME); assert.equal(outcome.output.auth, "ambient-review-auth");
+    assert.equal(outcome.output.relay, null); assert.equal(outcome.output.tmp, path.join(stage, "inputs", "output"));
+    assert.equal(fs.existsSync(stage), false, "the exact signed staged-input root is removed after review");
+  } finally {
+    fs.mkdtempSync = originalMkdtemp;
+    if (previous.auth === undefined) delete process.env.REVIEW_AMBIENT_AUTH; else process.env.REVIEW_AMBIENT_AUTH = previous.auth;
+    if (previous.relay === undefined) delete process.env.RELAY_REVIEW_LEAK; else process.env.RELAY_REVIEW_LEAK = previous.relay;
+  }
 });
 
 test("external observer rejects an executable replaced after runtime binding", () => {

--- a/tests/relay-dispatch/scripts/runtime-contract.test.js
+++ b/tests/relay-dispatch/scripts/runtime-contract.test.js
@@ -297,16 +297,17 @@ process.stdin.on("end", () => process.stdout.write(JSON.stringify({
   assert.equal(verdict.output.executor_session_token, null);
   assert.equal(verdict.output.executor_worktree, null);
   assert.equal(verdict.output.cwd.startsWith(runDir), false);
-  assert.equal(verdict.output.home, path.join(path.dirname(verdict.output.cwd), "reviewer-credentials", "home"));
+  assert.equal(verdict.output.home, process.env.HOME);
   fs.writeFileSync(promptPath, "mutated executor-side prompt\n");
   request.prompt_sha256 = shaFile(promptPath);
-  assert.throws(() => runtime.invokeIndependentReviewer({
+  const ambientVerdict = runtime.invokeIndependentReviewer({
     runDir,
     request,
     buildInvocation,
     parseOutcome,
     env: { EXECUTOR_SESSION_TOKEN: "leak" },
-  }), /not allowed/);
+  });
+  assert.equal(ambientVerdict.output.executor_session_token, "leak");
   const transcriptPath = path.join(runDir, "executor-transcript.txt");
   fs.writeFileSync(transcriptPath, "private executor reasoning\n");
   assert.throws(() => runtime.invokeIndependentReviewer({

--- a/tests/relay-dispatch/scripts/toolset-mismatch.test.js
+++ b/tests/relay-dispatch/scripts/toolset-mismatch.test.js
@@ -87,9 +87,7 @@ function probeDescriptor(dispatchPhase) {
     metadata: {
       cliBinary: "probe", outputProtocol: "text_stdout", promptTransport: "stdin",
       processContainment: "inherited_scope_no_daemon", providerTransport: "remote_required",
-      credentialTransport: "explicit_bundle",
       runtimeDependencies: { executableParent: null, interpreterParent: null },
-      credentials: { files: [], envHints: [] },
     },
     phases: { dispatch: dispatchPhase, primary_review: { supported: false, reason: "probe" } },
     buildDispatch: () => ({ command: "probe", args: [], cwd: "/" }),

--- a/tests/relay-review/scripts/review-runner.test.js
+++ b/tests/relay-review/scripts/review-runner.test.js
@@ -154,7 +154,7 @@ test("Relay runner records one exact-SHA pass and the derived action advances to
   const exactDiff = Buffer.from(`${rawDiff}${rawDiff.endsWith("\n") || !rawDiff ? "" : "\n"}`, "utf8");
   assert.equal(captured.request.diff_sha256, crypto.createHash("sha256").update(exactDiff).digest("hex"));
   assert.deepEqual(fs.readFileSync(captured.request.diff_path), exactDiff);
-  assert.deepEqual(Object.keys(captured.credentialRequest.env), [], "ambient environment must not cross the reviewer boundary");
+  assert.equal(Object.hasOwn(captured, "credentialRequest"), false, "credential selections never cross the reviewer boundary");
   const prompt = fs.readFileSync(captured.request.prompt_path, "utf8");
   const verificationPrefix = "Verification fact: ";
   const verificationLine = prompt.split("\n").find((line) => line.startsWith(verificationPrefix));
@@ -809,10 +809,8 @@ test("fresh run snapshot drift rejects the append", async () => {
 
 test("immutable reviewer binding and closed CLI reject legacy policy surfaces", async () => {
   const value = await fixture("binding");
-  const credentialCli = runner.parseCli(["--repo", value.repo, "--run-dir", value.runDir,
-    "--credential-env", "OPENAI_API_KEY", "--credential-file", `auth=${path.join(value.root, "auth.json")}`]);
-  assert.deepEqual(credentialCli.values["credential-env"], ["OPENAI_API_KEY"]);
-  assert.deepEqual(credentialCli.values["credential-file"], [`auth=${path.join(value.root, "auth.json")}`]);
+  assert.throws(() => runner.parseCli(["--repo", value.repo, "--run-dir", value.runDir, "--credential-env", "OPENAI_API_KEY"]), /Unknown option/);
+  assert.throws(() => runner.parseCli(["--repo", value.repo, "--run-dir", value.runDir, "--credential-file", "auth=/private/auth.json"]), /Unknown option/);
   const override = runner.parseCli(["--repo", value.repo, "--run-dir", value.runDir, "--reviewer", "claude"]);
   await assert.rejects(runner.runReview(override, { inspectRun: value.inspectRun }), /immutable binding/);
   assert.throws(() => runner.parseCli(["--repo", value.repo, "--run-dir", value.runDir, "--review-budget", "3"]), /Unknown option/);

--- a/tests/skills-lint/scripts/test-directives.test.js
+++ b/tests/skills-lint/scripts/test-directives.test.js
@@ -8,13 +8,11 @@ const path = require("node:path");
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const TESTS_ROOT = path.join(REPO_ROOT, "tests");
 
-// These are permanent environment boundaries: nine macOS sandbox canaries and
+// These are permanent environment boundaries: seven live adapter canaries and
 // two opt-in live executor checks. Every other Relay test must always run.
 const ALLOWED_SKIPS = new Set([
-  "relay-dispatch/scripts/adapter-live-canary.test.js :: two production phase cells pass only with explicit credentials and exact nonce evidence",
-  "relay-dispatch/scripts/adapter-live-canary.test.js :: provisioned authentication failure is failed, never skipped or not_run",
-  "relay-dispatch/scripts/adapter-live-canary.test.js :: dispatch cleanup-incomplete is settled before canary fixtures are removed",
-  "relay-dispatch/scripts/adapter-live-canary.test.js :: unsettleable dispatch cleanup preserves signed evidence and aborts the canary",
+  "relay-dispatch/scripts/adapter-live-canary.test.js :: two production phase cells use the ambient CLI session and exact nonce evidence",
+  "relay-dispatch/scripts/adapter-live-canary.test.js :: ambient authentication failure is failed, never skipped or not_run",
   "relay-dispatch/scripts/adapter-live-canary.test.js :: a post-receipt timeout is cancelled and settled before canary fixture deletion",
   "relay-dispatch/scripts/adapter-live-canary.test.js :: an invalid post-receipt terminal aborts with a typed cause and destroys no evidence",
   "relay-dispatch/scripts/adapter-live-canary.test.js :: dispatch and review cells use phase-pristine fixtures",


### PR DESCRIPTION
Closes #1233

## Summary
- inherit sanitized ambient CLI HOME/XDG/auth for all seven adapters without copying credentials
- remove credential selectors, catalogs, private HOME/XDG roots, and legacy credential-root cleanup handling
- preserve process cleanup and signed reviewer staged-input recovery with a closed cleanup schema
- pass ambient bytes only through an already-unlinked FD/pipe; keep observer environment allowlisted

## Evidence
- focused: 159/159 pass, 0 skip
- full serialized gate: 631 total, 629 pass, 2 intentional live canary skips, 0 fail
- independent Spec, Standards/trust, and simplification reviews: LGTM
- pre-merge legacy inventory: 109/109 settled, 0 open, 0 parse errors
- git diff --check and touched production syntax checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * CLI가 사용자의 로컬 인증 및 HOME/XDG 설정을 자동으로 사용합니다.
  * 리뷰·디스패치 과정에서 인증 정보 복사와 별도 스테이징이 제거되었습니다.

* **변경 사항**
  * `--credential-env` 및 `--credential-file` 옵션이 제거되었습니다.
  * 인증 정보와 민감한 환경 경로가 실행 결과 및 증거에 기록되지 않습니다.
  * 리뷰 입력 정리와 경로 교체 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->