### PR TITLE
Recover relay run issue-1250-dirty-reviewed-worktree-20260814042834122-58125f51

### DIFF
--- a/skills/relay-dispatch/scripts/inspect.js
+++ b/skills/relay-dispatch/scripts/inspect.js
@@ -701,6 +701,20 @@ function foldRunFacts({
     });
   }
   if (latestReview && PASS_VERDICTS.has(latestReview.payload.verdict) && reviewBindingMatches) {
+    // The reviewed commit remains authoritative, but a retained GitHub
+    // worktree with live uncommitted reviewable bytes is not the reviewed
+    // worktree.  Project that live drift as a typed observation blocker so
+    // inspect and merge cannot derive readiness from the same passing facts.
+    // Local delivery reaches its existing publication-incomplete branch above
+    // and keeps its Reviewed Result recovery behavior unchanged.
+    if (!localReviewReady && gitFacts.reviewable_dirty === true) {
+      return result("none", "reviewed_worktree_dirty", {
+        head_sha: headSha,
+        reviewed_sha: latestReview.payload.reviewed_sha,
+        pr_number: prNumber,
+        diagnostics: [...diagnostics, { code: "reviewed_worktree_dirty" }],
+      });
+    }
     if (localReviewReady) {
       return result("recover", "reviewed_result_ready", {
         head_sha: headSha,
@@ -849,6 +863,13 @@ function deriveBlockers(snapshot, facts, seen, derived) {
   if (Number(seen.github.matching_pr_count) > 1) out.push(blocker("ambiguous_pr", "multiple PRs match the immutable run identity"));
   if (["ahead_local", "diverged"].includes(seen.git.remote_relation)) out.push(blocker("remote_branch_conflict", "remote branch cannot be advanced safely"));
   if (seen.github.pr_state === "MERGED" && !matchingRecordedPr(facts, seen.github)) out.push(blocker("unrecorded_merged_pr", "a merged branch PR is not bound to the durable run PR identity"));
+  if (derived.reason === "reviewed_worktree_dirty") {
+    out.push(blocker(
+      "reviewed_worktree_dirty",
+      "the retained worktree contains uncommitted reviewable changes after review",
+      true,
+    ));
+  }
   if (derived.reason === "github_pr_closed_unmerged") out.push(blocker("github_pr_closed_unmerged", "the durable run PR is closed without a merge"));
   if (derived.reason === "fact_conflict") out.push(blocker("fact_conflict", "durable facts or external identity conflict"));
   return out;

--- a/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
+++ b/tests/relay-dispatch/scripts/inspect-recover-blackbox.test.js
@@ -548,6 +548,33 @@ test("inspect accepts the immediate single passing retry", async () => {
   assert.equal(result.derived.reason, "ready_to_merge");
 });
 
+test("production inspect blocks dirty reviewed bytes and re-enables readiness when restored clean", async () => {
+  const observations = publicationObservations({
+    git: { ...publicationObservations().git, reviewable_work: false, reviewable_dirty: true },
+    github: {
+      ...publicationObservations().github,
+      matching_pr_count: 1, pr_number: 42, pr_state: "OPEN",
+      pr_head_sha: HEAD, pr_base_sha: START,
+    },
+  });
+  const h = harness({
+    facts: [pullRequestFact(HEAD), verificationFact(), reviewFact({ eventId: "dirty-reviewed-pass", verdict: "pass", baseSha: START })],
+    observations,
+  });
+  const dirty = await inspectRun(h);
+  assert.equal(dirty.derived.action, "none");
+  assert.equal(dirty.derived.reason, "reviewed_worktree_dirty");
+  assert.equal(dirty.blockers[0].code, "reviewed_worktree_dirty");
+  assert.equal(dirty.recommended_action.kind, "operator_attention");
+  assert.equal(dirty.recommended_action.reason, "reviewed_worktree_dirty");
+
+  h.state.observations.git.reviewable_dirty = false;
+  const clean = await inspectRun(h);
+  assert.equal(clean.derived.action, "merge");
+  assert.equal(clean.derived.reason, "ready_to_merge");
+  assert.equal(clean.recommended_action.kind, "merge");
+});
+
 test("a historical passing GitHub review without base evidence derives one fresh review", async () => {
   const observations = publicationObservations({
     git: { ...publicationObservations().git, reviewable_work: false },

--- a/tests/relay-dispatch/scripts/run-fold.test.js
+++ b/tests/relay-dispatch/scripts/run-fold.test.js
@@ -167,6 +167,28 @@ test("fold implements active, publication, review, stale, changes, and ready pre
   assert.equal(ready.reason, "ready_to_merge");
 });
 
+test("a dirty retained GitHub worktree blocks an otherwise exact reviewed merge", () => {
+  const input = {
+    runRecord: runRecord(),
+    facts: [pr(), verification(), review("pass", 5)],
+    githubFacts: livePrFacts(),
+    gitFacts: {
+      head_sha: HEAD,
+      tree_sha: TREE,
+      reviewable_work: true,
+      reviewable_dirty: true,
+    },
+  };
+  const dirty = foldRunFacts(input);
+  assert.equal(dirty.action, "none");
+  assert.equal(dirty.reason, "reviewed_worktree_dirty");
+  assert.equal(dirty.diagnostics.at(-1).code, "reviewed_worktree_dirty");
+
+  const clean = foldRunFacts({ ...input, gitFacts: { ...input.gitFacts, reviewable_dirty: false } });
+  assert.equal(clean.action, "merge");
+  assert.equal(clean.reason, "ready_to_merge");
+});
+
 test("#1207 proven no-remote Git runs recover verification and advance to local review", () => {
   const local = {
     local_delivery: true,

--- a/tests/relay-merge/scripts/finalize-run.test.js
+++ b/tests/relay-merge/scripts/finalize-run.test.js
@@ -507,6 +507,31 @@ test("live PR head drift and closed GitHub state fail closed before merge", asyn
   }
 });
 
+test("dirty reviewed worktree blocks finalize before any GitHub merge call", async () => {
+  const value = await fixture("dirty-reviewed");
+  fs.writeFileSync(path.join(value.worktree, "file.txt"), "uncommitted drift\n");
+  const factBytes = fs.readFileSync(path.join(value.runDir, "events.jsonl"));
+
+  const dirty = await withGh(value, () => recover.inspectProductionRun({ runDir: value.runDir }));
+  assert.equal(dirty.derived.action, "none");
+  assert.equal(dirty.derived.reason, "reviewed_worktree_dirty");
+  assert.equal(dirty.recommended_action.kind, "operator_attention");
+  assert.equal(dirty.blockers[0].code, "reviewed_worktree_dirty");
+  await assert.rejects(
+    withGh(value, () => finalize.finalizeRun(value.cli, services())),
+    (error) => error.code === "MERGE_BLOCKED" || /dirty|blocked/i.test(error.message),
+  );
+  assert.equal((fs.readFileSync(value.gh.logPath, "utf8").match(/^pr merge /gm) || []).length, 0);
+  assert.deepEqual(fs.readFileSync(path.join(value.runDir, "events.jsonl")), factBytes);
+
+  fs.writeFileSync(path.join(value.worktree, "file.txt"), "after\n");
+  const clean = await withGh(value, () => recover.inspectProductionRun({ runDir: value.runDir }));
+  assert.equal(clean.derived.action, "merge");
+  assert.equal(clean.derived.reason, "ready_to_merge");
+  assert.equal(clean.recommended_action.kind, "merge");
+  assert.deepEqual(fs.readFileSync(path.join(value.runDir, "events.jsonl")), factBytes);
+});
+
 test("GitHub merge failure cannot be classified or recorded as success", async () => {
   const value = await fixture("gh-failure", { github: { mergeExitCode: 1 } });
   await assert.rejects(


### PR DESCRIPTION
## Recovery Summary

<!-- relay-recovery-operation:recover-1860ec2d0b1a48860978a1c789fd93aa -->

- Run: issue-1250-dirty-reviewed-worktree-20260814042834122-58125f51
- Reason: publish #1250 dirty reviewed worktree merge blocker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 이미 검토가 완료된 변경사항 이후 작업 트리에 미커밋 변경이 남아 있으면 병합을 차단합니다.
  * 해당 상태를 재시도 가능한 차단 사유로 표시하고 운영자 확인을 요청합니다.
  * 작업 트리를 정리하면 병합 준비 및 병합 처리가 정상적으로 재개됩니다.
  * 작업 트리가 정리되지 않은 상태에서는 병합 호출과 관련 기록이 생성되지 않습니다.

* **테스트**
  * 작업 트리 변경 감지, 병합 차단, 복구 후 정상 진행 동작을 검증하는 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->