### PR TITLE
Recover relay run issue-1252-20260814070349131-7259a210

### DIFF
--- a/backlog/sprints/2026-08-model-freedom-dispatch-subtraction.md
+++ b/backlog/sprints/2026-08-model-freedom-dispatch-subtraction.md
@@ -20,7 +20,7 @@ Make the routine trusted-local dispatch path executor/model/task-shaped: Relay s
 
 ### Batch 2 — Remove normal-path policy ceremony
 
-- [ ] #1252 — default trusted-local networking to the normal usable path and remove the misleading public dispatch sandbox choice (depends on #1251)
+- [x] #1252 — default trusted-local networking to the normal usable path and remove the misleading public dispatch sandbox choice (depends on #1251)
 
 ## Running Context
 

--- a/docs/decisions/2026-08-12-trusted-local-execution-contract.md
+++ b/docs/decisions/2026-08-12-trusted-local-execution-contract.md
@@ -1,6 +1,6 @@
 # Trusted-local execution contract
 
-**Status:** Accepted 2026-08-12; `#1232`, `#1233`, and `#1234` implemented · Issue `#1231` · Epic `#1230` · Milestone "Trusted-local native Relay"
+**Status:** Accepted 2026-08-12; `#1232`, `#1233`, `#1234`, and `#1252` implemented · Issue `#1231` · Epic `#1230` · Milestone "Trusted-local native Relay"
 **Supersedes:** the mandatory Relay-owned isolation + staged-credential policy of `#1141` and the dispatch-availability policy derived from it in `#1158` ([Supersession](#supersession-of-1141-and-1158)).
 **Runtime status:** `#1232` has removed Relay-owned `sandbox-exec` and its
 non-darwin admission failure. Dispatch, review, observer, and recovery launch
@@ -46,7 +46,7 @@ Filesystem isolation (OS/CLI enforcement of writable paths) and tool-network con
 
 - Missing or declaration-only native filesystem isolation never fails admission; it must emit a visible, nonblocking diagnostic.
 - Foreground and dry-run dispatch, and foreground review result objects, carry requested/effective filesystem-isolation diagnostics. No new fact kind, no schema change, no durable diagnostic artifact, no second mode.
-- Unchanged: the fail-closed tool-network semantics — a phase without native network control rejects `networkAccess: disabled` requests, and enabling tool networking remains an explicit authorization.
+- `#1252`: tool networking defaults to `enabled` for trusted-local dispatch, so routine new and resume dispatch carries no network ceremony. The fail-closed semantics now apply only to an explicit `networkAccess: disabled` advanced request: a phase without native network control rejects it before any branch, worktree, run, fact, or provider effect. The public `--sandbox` flag is retired; dispatch has fixed writable-worktree semantics while the adapter/phase owns its truthful native filesystem request.
 
 ### 4. Hostile multi-tenant execution is out of scope
 
@@ -76,6 +76,7 @@ the signed staged review-input root after exact process settlement.
 - `#1232` (implemented): atomically removes the outer `sandbox-exec` boundary; Codex/Cursor request their native sandboxes; adds the visible capability diagnostic of §3.
 - `#1233` (implemented): moves all seven adapters to ambient HOME/auth/config and deletes credential staging after the §6 rule was satisfied.
 - `#1234` (implemented): retires the provider-credential-dependent 13-cell release gate and its obsolete tests/docs. Static adapter argv contracts and the nonblocking native-isolation diagnostic remain; `#1235` dogfoods normal operator use without becoming a release gate.
+- `#1252` (implemented): defaults trusted-local dispatch/redispatch tool networking to `enabled`, retires the public dispatch `--sandbox` flag and its fleet leaf/schema/argv forwarding, and freezes dispatch to writable-worktree semantics with adapter-owned native filesystem requests. Explicit `enabled` is byte-equivalent; explicit `disabled` remains the advanced native-deny request.
 
 ## Supersession of #1141 and #1158
 

--- a/docs/external-tool-workflow.md
+++ b/docs/external-tool-workflow.md
@@ -52,7 +52,7 @@ CE is most useful here as **specialist review** and **structured learning captur
 
 - **Treating gstack `review` as the merge gate.** It is a pre-landing helper. The relay merge gate is `gate-check.js`, not gstack.
 - **Re-running gstack `plan-eng-review` after dispatch.** If you want planning changes, escalate to a re-plan inside relay (re-persist the anchor). Otherwise the relay reviewer scores against a stale anchor and gives the wrong verdict.
-- **Loading superpowers skills inside the dispatch worktree.** The executor runs in an isolated worktree with `--sandbox workspace-write --network-access disabled`. Skills that need network or arbitrary subagents won't work cleanly there. Use superpowers in the orchestrator session (planning, reviewing reviews, deciding next dispatch).
+- **Loading superpowers skills inside the dispatch worktree.** The executor runs directly on the trusted local host inside a retained worktree with tool networking enabled by default. Skills that assume orchestrator-session structure or arbitrary subagents won't behave identically there. Use superpowers in the orchestrator session (planning, reviewing reviews, deciding next dispatch).
 - **Letting CE specialist findings silently rewrite the relay rubric.** If a CE specialist proposes a new factor, that's a planner-side decision: surface it, decide, then re-plan. Do not edit the persisted rubric out-of-band.
 - **Coupling relay scripts to gstack/superpowers/CE internals.** Relay scripts must keep working without any of these tools installed. If a workflow needs them, document the workflow; don't import the dependency.
 

--- a/skills/relay-config/scripts/relay-config.js
+++ b/skills/relay-config/scripts/relay-config.js
@@ -45,7 +45,6 @@ function run(argv = process.argv.slice(2)) {
   const actor = executor || reviewer;
   const capability = validateCapabilities(getAdapter(actor), selectedPhase, {
     readOnly: selectedPhase === ADAPTER_PHASES.PRIMARY_REVIEW,
-    sandbox: selectedPhase === ADAPTER_PHASES.PRIMARY_REVIEW ? "read-only" : "workspace-write",
     networkAccess: "enabled",
   });
   const model = args.getArg("--model") || null;

--- a/skills/relay-dispatch/SKILL.md
+++ b/skills/relay-dispatch/SKILL.md
@@ -35,16 +35,16 @@ the GitHub route. Dispatch itself never initializes Git or selects a forge.
 
 ```bash
 # Foreground (blocking — simple tasks, default executor: codex)
-node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -b feature-auth -p "..." --rubric-file rubric.yaml --network-access enabled
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -b feature-auth -p "..." --rubric-file rubric.yaml
 
 # Detached (recommended for long/background work; survives caller shell exit)
-node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -b feature-auth -p "..." --rubric-file rubric.yaml --network-access enabled --detach --json
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -b feature-auth -p "..." --rubric-file rubric.yaml --detach --json
 
 # Same-run resume after a changes-requested review
-node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . --run-id issue-42-20260403120000000 --prompt-file review-round-2-redispatch.md --network-access enabled
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . --run-id issue-42-20260403120000000 --prompt-file review-round-2-redispatch.md
 
 # With explicit executor
-node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -e codex -b feature-auth -p "..." --rubric-file rubric.yaml --network-access enabled
+node "${RELAY_SKILL_ROOT:-skills}/relay-dispatch/scripts/dispatch.js" . -e codex -b feature-auth -p "..." --rubric-file rubric.yaml
 ```
 
 For background and parallel dispatch, see `../relay/SKILL.md` § Batch Mode (single source of truth for the parallel-fork flow).
@@ -63,8 +63,8 @@ Essential flags:
 - `--prompt, -p` or `--prompt-file` supplies the executor prompt.
 - `--rubric-file` is required for new dispatches. `--done-criteria-file` freezes a separate review anchor; otherwise the rubric is frozen as Done Criteria.
 - `--executor, -e` and `--model, -m` select execution. On `--run-id`, omit `--executor` to use the immutable executor bound in `run.json`; an explicit different executor fails before reading the prompt or writing an attempt. `--model` remains per-attempt.
-- `--sandbox`, `--network-access`, `--timeout`, `--reasoning`, and `--copy` configure the attempt. Copy inputs must be regular files contained by the repository.
-- Provider control-plane transport is always available to the trusted CLI. `--network-access` governs model/tool networking: `disabled` requires an adapter-native deny and fails closed for adapters that cannot enforce one; `enabled` explicitly permits the adapter's network-capable tools.
+- `--network-access`, `--timeout`, `--reasoning`, and `--copy` configure the attempt. Copy inputs must be regular files contained by the repository.
+- Provider control-plane transport is always available to the trusted CLI. Tool networking defaults to `enabled` for trusted-local dispatch; the explicit `--network-access disabled` advanced request requires an adapter-native deny and fails closed for adapters that cannot enforce one. The retired public `--sandbox` flag fails as an unknown option; dispatch always uses writable-worktree semantics and the adapter/phase owns its truthful native filesystem request.
 - CLI authentication, HOME, XDG config, and supported token variables come from the operator's ambient local environment. Credential selector flags were removed and fail as unknown options; Relay never copies auth files or records their paths.
 - Adapters retain their actual invocation tools and native capability declarations. Prompt wording never controls dispatch admission or selects a different outcome/verification contract.
 - `--fleet-id` requires typed `--ownership-json` with exactly `sprint`, `track`, and `component`; parent and ownership digest are immutable.
@@ -76,14 +76,14 @@ Essential flags:
 The durable layout is `~/.relay/runs/<repo-slug>/<run-id>/`: immutable `run.json`, `done-criteria.md`, and `rubric.yaml`; append-only `events.jsonl`; and per-attempt prompt, log, and result artifacts. Retired routing hints and readiness identity flags do not participate in dispatch.
 
 Relay runs directly on the trusted local host; it has no filesystem admission
-or profile compiler. `--sandbox` is passed only to an adapter that can express
-native filesystem isolation (Codex requests `workspace-write` or `read-only`,
-Cursor requests `enabled`, Claude enables its documented Bash sandbox, and
-Antigravity keeps its declared flag). Pi, OpenCode, and Cline run directly.
-Foreground and dry-run JSON return the non-durable `filesystem_isolation`
-requested/effective diagnostic; missing or declaration-only isolation never
-rejects dispatch. Use an external container or VM for a hostile-worker threat
-model.
+or profile compiler. Dispatch always runs with writable-worktree semantics and
+lets each adapter/phase request its own truthful native filesystem isolation
+(Codex requests `workspace-write`, Cursor requests `enabled`, Claude enables
+its documented Bash sandbox, and Antigravity keeps its declared flag). Pi,
+OpenCode, and Cline run directly. Foreground and dry-run JSON return the
+non-durable `filesystem_isolation` requested/effective diagnostic; missing or
+declaration-only isolation never rejects dispatch. Use an external container
+or VM for a hostile-worker threat model.
 
 Executor attempts preserve immutable input staging, executable binding,
 timeout/cancellation, inherited-scope cleanup, and durable facts. Relay itself

--- a/skills/relay-dispatch/references/agent-adapter-platform.md
+++ b/skills/relay-dispatch/references/agent-adapter-platform.md
@@ -65,9 +65,9 @@ The trusted local CLI's remote provider control-plane transport is available.
 be enforced by native adapter policy. Pi exposes a native constrained tool set;
 Claude, Codex, Cursor, Antigravity, OpenCode, and Cline are informational
 only because their installed CLI flags do not prove that every internal or
-server-side or managed-policy tool is network-disabled. A phase without a native deny fails
-closed when tool networking is disabled. Enabling tool networking is an
-explicit authorization.
+server-side or managed-policy tool is network-disabled. Tool networking
+defaults to `enabled` for trusted-local dispatch; an explicit `disabled`
+request requires a native deny and fails closed for a phase without one.
 
 Relay owns no filesystem profile or platform admission. Codex requests its
 native `workspace-write` dispatch or `read-only` review sandbox, Cursor enables

--- a/skills/relay-dispatch/scripts/adapter-contract.js
+++ b/skills/relay-dispatch/scripts/adapter-contract.js
@@ -159,7 +159,7 @@ function validateCapabilities(adapter, phase, request = {}) {
   if (!PHASES.includes(phase)) throw new AdapterCapabilityError(adapter.name, phase, "unknown phase");
   const capability = adapter.capabilities({ phase, request });
   if (!capability.supported) throw new AdapterCapabilityError(adapter.name, phase, capability.reason || "phase is unsupported");
-  if (request.readOnly === true && !capability.readOnly) {
+  if (phase === "primary_review" && request.readOnly === true && !capability.readOnly) {
     throw new AdapterCapabilityError(adapter.name, phase, "read-only execution is unsupported");
   }
   if (request.networkAccess === "disabled" && capability.networkControl !== "native") {
@@ -177,11 +177,7 @@ function filesystemIsolationDiagnostic(adapter, phase, request = {}) {
   let diagnostic;
   switch (effective) {
     case "native":
-      // `enabled` is an adapter-owned on/off switch (Cursor).  Read/write
-      // modes are operator-facing (Codex), so the diagnostic mirrors argv.
-      requested = capability.filesystemIsolationRequest === "enabled"
-        ? "enabled"
-        : request.readOnly || request.sandbox === "read-only" ? "read-only" : "workspace-write";
+      requested = capability.filesystemIsolationRequest;
       diagnostic = null;
       break;
     case "native_bash":
@@ -302,16 +298,13 @@ function createNativeAdapter({
       if (!value) return Object.freeze({ supported: false, reason: "unknown phase" });
       let capability = { ...value };
       if (value.supported && phase === "dispatch" && request && validateDispatch) {
-        const validation = validateDispatch({
-          sandbox: request.sandbox || (request.readOnly ? "read-only" : "workspace-write"),
-          networkAccess: request.networkAccess || "disabled",
-        });
+        const validation = validateDispatch({ networkAccess: request.networkAccess || "disabled" });
         capability = { ...capability, supported: validation.ok, ...(validation.ok ? {} : { reason: validation.error }), warnings: validation.warnings || [] };
       }
       return Object.freeze(capability);
     },
-    buildInvocation({ phase, cwd, promptPath, promptBytes, resultPath, schemaPath = null, model = null, timeoutMs: requestedTimeoutMs, sandbox = "workspace-write", networkAccess = "disabled", reasoning = null }) {
-      validateCapabilities(this, phase, { readOnly: sandbox === "read-only", sandbox, networkAccess });
+    buildInvocation({ phase, cwd, promptPath, promptBytes, resultPath, schemaPath = null, model = null, timeoutMs: requestedTimeoutMs, networkAccess = "disabled", reasoning = null }) {
+      validateCapabilities(this, phase, phase === "primary_review" ? { readOnly: true, networkAccess } : { networkAccess });
       for (const [value, label] of [[cwd, "cwd"], [promptPath, "promptPath"], [resultPath, "resultPath"], ...(schemaPath ? [[schemaPath, "schemaPath"]] : [])]) requireAbsolutePath(value, label);
       requireSafeOptionalValue(model, "model");
       const trustedPrompt = decodeTrustedPrompt(promptBytes);
@@ -321,7 +314,7 @@ function createNativeAdapter({
         cwd, prompt: trustedPrompt.prompt, promptPath, promptSha256: trustedPrompt.sha256, resultPath, model,
         timeoutSeconds: Math.max(1, Math.floor((requestedTimeoutMs || timeoutMs) / 1000)),
       };
-      const phaseOptions = phase === "dispatch" ? { sandbox, networkAccess, reasoning } : { schemaPath };
+      const phaseOptions = phase === "dispatch" ? { networkAccess, reasoning } : { schemaPath };
       return bindInvocationPolicy(normalizeInvocationShape(builder({ ...common, ...phaseOptions })), networkAccess);
     },
     parseOutcome(input) {

--- a/skills/relay-dispatch/scripts/adapters/antigravity.js
+++ b/skills/relay-dispatch/scripts/adapters/antigravity.js
@@ -9,8 +9,7 @@ function boundedArgv(args) {
   return args;
 }
 
-function validateDispatch({ sandbox, networkAccess }) {
-  if (sandbox !== "workspace-write") return { ok: false, error: "antigravity executor supports only --sandbox workspace-write semantics; read-only dispatch is not safely representable" };
+function validateDispatch({ networkAccess }) {
   void networkAccess; const warnings = [];
   return { ok: true, warnings };
 }
@@ -38,9 +37,8 @@ const native = createNativeAdapter({
     primary_review: { supported: true, write: false, readOnly: true, networkControl: "informational", filesystemIsolation: "declaration_only", cancellation: "process", structuredOutput: "json" },
   },
   validateDispatch,
-  buildDispatch({ cwd, prompt, sandbox, timeoutSeconds }) {
-    const args = ["--prompt", worktreePrompt(cwd, prompt), "--print-timeout", `${timeoutSeconds}s`, "--mode", "accept-edits", "--output-format", "json", "--disable-slash-commands"];
-    if (sandbox === "workspace-write") args.push("--sandbox");
+  buildDispatch({ cwd, prompt, timeoutSeconds }) {
+    const args = ["--prompt", worktreePrompt(cwd, prompt), "--print-timeout", `${timeoutSeconds}s`, "--mode", "accept-edits", "--output-format", "json", "--disable-slash-commands", "--sandbox"];
     return { command: process.env.RELAY_ANTIGRAVITY_BIN || "agy", args: boundedArgv(args), cwd };
   },
   buildReview({ cwd, prompt, schemaPath, timeoutSeconds }) {

--- a/skills/relay-dispatch/scripts/adapters/claude.js
+++ b/skills/relay-dispatch/scripts/adapters/claude.js
@@ -3,7 +3,7 @@ const { createNativeAdapter } = require("../adapter-contract");
 
 const NATIVE_BASH_SANDBOX = JSON.stringify({ sandbox: { enabled: true, autoAllowBashIfSandboxed: true, allowUnsandboxedCommands: false } });
 
-function validateDispatch({ sandbox, networkAccess }) { void sandbox; void networkAccess; return { ok: true, warnings: [] }; }
+function validateDispatch({ networkAccess }) { void networkAccess; return { ok: true, warnings: [] }; }
 
 module.exports = createNativeAdapter({
   name: "claude",

--- a/skills/relay-dispatch/scripts/adapters/cline.js
+++ b/skills/relay-dispatch/scripts/adapters/cline.js
@@ -19,12 +19,9 @@ function worktreePrompt(cwd, prompt) {
   return ["[RELAY WORKTREE BOUNDARY]", `Repository worktree: ${cwd}`, "Run every shell command from that repository worktree.", "Do not read, write, git add, git commit, or create files outside that repository worktree.", "Do not use cline --worktree; relay already created and owns this worktree.", "", prompt].join("\n");
 }
 
-function validateDispatch({ sandbox, networkAccess }) {
-  const warnings = [];
-  if (sandbox !== "workspace-write") warnings.push(`cline executor: --sandbox '${sandbox}' is not enforced by cline; proceeding with workspace-write semantics.`);
+function validateDispatch({ networkAccess }) {
   void networkAccess;
-  warnings.push("cline executor has no native relay sandbox; relay uses its own worktree boundary and never cline --worktree.");
-  return { ok: true, warnings };
+  return { ok: true, warnings: ["cline executor has no native relay sandbox; relay uses its own worktree boundary and never cline --worktree."] };
 }
 
 module.exports = createNativeAdapter({

--- a/skills/relay-dispatch/scripts/adapters/codex.js
+++ b/skills/relay-dispatch/scripts/adapters/codex.js
@@ -1,7 +1,7 @@
 const { createNativeAdapter } = require("../adapter-contract");
 
-function validateDispatch({ sandbox, networkAccess }) {
-  void sandbox; void networkAccess;
+function validateDispatch({ networkAccess }) {
+  void networkAccess;
   return { ok: true, warnings: [] };
 }
 
@@ -25,12 +25,13 @@ module.exports = createNativeAdapter({
     primary_review: { supported: true, write: false, readOnly: true, networkControl: "informational", filesystemIsolation: "native", filesystemIsolationRequest: "read-only", cancellation: "process", structuredOutput: "json" },
   },
   validateDispatch,
-  buildDispatch({ cwd, promptPath, promptSha256, resultPath, model, sandbox, networkAccess, reasoning }) {
+  buildDispatch({ cwd, promptPath, promptSha256, resultPath, model, networkAccess, reasoning }) {
     const args = ["exec", "-C", cwd, "--color", "never", "-o", resultPath];
     if (reasoning) args.push("-c", `model_reasoning_effort=${reasoning}`);
     void networkAccess;
     if (model) args.push("-m", model);
-    args.push("--sandbox", sandbox);
+    // Dispatch has fixed writable-worktree semantics; this is Codex's own native request.
+    args.push("--sandbox", "workspace-write");
     args.push("-");
     return { command: "codex", args, cwd, stdinPath: promptPath, stdinSha256: promptSha256 };
   },

--- a/skills/relay-dispatch/scripts/adapters/cursor.js
+++ b/skills/relay-dispatch/scripts/adapters/cursor.js
@@ -2,7 +2,7 @@ const { createNativeAdapter } = require("../adapter-contract");
 
 function binary() { return process.env.RELAY_CURSOR_AGENT_BIN || "agent"; }
 
-function validateDispatch({ sandbox, networkAccess }) { void sandbox; void networkAccess; return { ok: true, warnings: [] }; }
+function validateDispatch({ networkAccess }) { void networkAccess; return { ok: true, warnings: [] }; }
 
 module.exports = createNativeAdapter({
   name: "cursor",
@@ -24,9 +24,8 @@ module.exports = createNativeAdapter({
     primary_review: { supported: true, write: false, readOnly: true, networkControl: "informational", filesystemIsolation: "native", filesystemIsolationRequest: "enabled", cancellation: "process", structuredOutput: "json" },
   },
   validateDispatch,
-  buildDispatch({ cwd, promptPath, promptSha256, model, sandbox }) {
+  buildDispatch({ cwd, promptPath, promptSha256, model }) {
     const args = ["--print", "--trust", "--auto-review", "--workspace", cwd, "--output-format", "text", "--sandbox", "enabled"];
-    void sandbox;
     if (model) args.push("--model", model);
     return { command: binary(), args, cwd, stdinPath: promptPath, stdinSha256: promptSha256 };
   },

--- a/skills/relay-dispatch/scripts/adapters/opencode.js
+++ b/skills/relay-dispatch/scripts/adapters/opencode.js
@@ -1,11 +1,8 @@
 const { createNativeAdapter } = require("../adapter-contract");
 
-function validateDispatch({ sandbox, networkAccess }) {
-  const warnings = [];
-  if (sandbox !== "workspace-write") warnings.push(`opencode executor: --sandbox '${sandbox}' is not enforced by opencode (no native sandboxing); proceeding with workspace-write semantics.`);
+function validateDispatch({ networkAccess }) {
   void networkAccess;
-  warnings.push("opencode executor is experimental; an independent primary review remains required.");
-  return { ok: true, warnings };
+  return { ok: true, warnings: ["opencode executor is experimental; an independent primary review remains required."] };
 }
 
 module.exports = createNativeAdapter({

--- a/skills/relay-dispatch/scripts/adapters/pi.js
+++ b/skills/relay-dispatch/scripts/adapters/pi.js
@@ -5,11 +5,9 @@ function normalizeThinking(reasoning) {
   return reasoning === "xhigh" ? "high" : null;
 }
 
-function validateDispatch({ sandbox, networkAccess }) {
-  const warnings = [];
-  if (sandbox !== "workspace-write") warnings.push(`pi executor: --sandbox '${sandbox}' is not enforced by pi; proceeding with workspace-write semantics.`);
+function validateDispatch({ networkAccess }) {
   void networkAccess;
-  return { ok: true, warnings };
+  return { ok: true, warnings: [] };
 }
 
 module.exports = createNativeAdapter({

--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -27,8 +27,7 @@ const OPTIONS = Object.freeze({
   "done-criteria-file": { type: "string" },
   executor: { type: "string", short: "e", default: "codex" },
   model: { type: "string", short: "m" },
-  sandbox: { type: "string", default: "workspace-write" },
-  "network-access": { type: "string", default: "disabled" },
+  "network-access": { type: "string", default: "enabled" },
   timeout: { type: "string" },
   reasoning: { type: "string" },
   copy: { type: "string" },
@@ -44,7 +43,6 @@ const OPTIONS = Object.freeze({
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled", "timed_out", "spawn_error"]);
 const RUN_ID_RE = /^[a-z0-9][a-z0-9-]{0,126}$/;
 const TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
-
 function usage() {
   return [
     "Usage:",
@@ -196,7 +194,6 @@ function parseCli(argv) {
   if (!values.branch && !values["run-id"] && !internalRunId) fail("--branch or --run-id is required");
   if (values.prompt === undefined && values["prompt-file"] === undefined) fail("--prompt or --prompt-file is required");
   if (values.prompt !== undefined && values["prompt-file"] !== undefined) fail("--prompt and --prompt-file are mutually exclusive");
-  if (!new Set(["workspace-write", "read-only"]).has(values.sandbox)) fail("--sandbox must be workspace-write or read-only");
   if (!new Set(["disabled", "enabled"]).has(values["network-access"])) fail("--network-access must be disabled or enabled");
   const issueNumber = values["issue-number"] === undefined ? null : Number(values["issue-number"]);
   if (issueNumber !== null && (!Number.isInteger(issueNumber) || issueNumber <= 0)) fail("--issue-number must be a positive integer");
@@ -425,7 +422,6 @@ function dryRunInvocation({ cli, identity, adapter, inputs }) {
       resultPath,
       model: cli.values.model || null,
       timeoutMs: (cli.timeoutSeconds || adapter.defaults.timeoutMs / 1000) * 1000,
-      sandbox: cli.values.sandbox,
       networkAccess: cli.values["network-access"],
       reasoning: cli.values.reasoning || null,
     });
@@ -534,12 +530,12 @@ async function startAttempt({ cli, identity, adapter, prompt, rubric, criteria, 
       }
     }
     immutableBytes(promptPath, prompt.bytes);
-    validateCapabilities(adapter, "dispatch", { sandbox: cli.values.sandbox, readOnly: cli.values.sandbox === "read-only", networkAccess: cli.values["network-access"] });
+    validateCapabilities(adapter, "dispatch", { networkAccess: cli.values["network-access"] });
     invocation = adapter.buildInvocation({
       phase: "dispatch", cwd: record.git.worktree, promptPath, resultPath: outputPath,
       promptBytes: prompt.bytes,
       model: cli.values.model || null, timeoutMs: (cli.timeoutSeconds || adapter.defaults.timeoutMs / 1000) * 1000,
-      sandbox: cli.values.sandbox, networkAccess: cli.values["network-access"], reasoning: cli.values.reasoning || null,
+      networkAccess: cli.values["network-access"], reasoning: cli.values.reasoning || null,
     });
     startSha = git(record.git.worktree, ["rev-parse", "HEAD"]);
     timeoutMs = (cli.timeoutSeconds || adapter.defaults.timeoutMs / 1000) * 1000;
@@ -556,7 +552,6 @@ async function startAttempt({ cli, identity, adapter, prompt, rubric, criteria, 
       stdinPath: invocation.stdinPath || null,
       stdinSha256: invocation.stdinSha256 || null,
       executorResultPath: outputPath,
-      executorSandbox: cli.values.sandbox,
       executorNetworkAccess: cli.values["network-access"],
       runtimeDependencies: invocation.runtimeDependencies,
       timeoutMs,
@@ -657,7 +652,7 @@ async function executeForeground(cli, overrides = {}) {
   }
   const inspectRun = overrides.inspectRun || recover.inspectProductionRun;
   const identity = repositoryIdentity(canonicalCheckout(cli.repo));
-  const capabilityRequest = { sandbox: cli.values.sandbox, readOnly: cli.values.sandbox === "read-only", networkAccess: cli.values["network-access"] };
+  const capabilityRequest = { networkAccess: cli.values["network-access"] };
   validateCapabilities(adapter, "dispatch", capabilityRequest);
   const filesystemIsolation = filesystemIsolationDiagnostic(adapter, "dispatch", capabilityRequest);
   let resumeInspection = null;

--- a/skills/relay-fleet/SKILL.md
+++ b/skills/relay-fleet/SKILL.md
@@ -50,7 +50,7 @@ relay-fleet only fans out already-decomposed leaf contracts; it never splits a r
 
 All leaves must carry the same normalized owner. `ownership.track` must equal the basename of `ownership.sprint` without `.md`; `component` is a separate dev-backlog scope key and need not equal the track. Before admission, the canonical path, track, and component must exactly match the trusted schema-v2 `sprint-state.js --track` result, and the path must resolve to an existing regular file in the current repo's `backlog/sprints/`; relay-fleet does not parse that markdown. Missing, malformed, contradictory, unresolved, stale, or mixed-track ownership is rejected before a cohort or child dispatch exists: one fleet is one track.
 
-Optional per-leaf fields passed through to the current `dispatch.js` contract are `executor`, `model`, `sandbox`, `network_access`, `timeout`, `reasoning`, and `copy`. Submit dependent work in a later fleet wave after its prerequisite fleet is terminal; the immutable cohort intentionally carries no second dependency scheduler.
+Optional per-leaf fields passed through to the current `dispatch.js` contract are `executor`, `model`, `network_access`, `timeout`, `reasoning`, and `copy`. Submit dependent work in a later fleet wave after its prerequisite fleet is terminal; the immutable cohort intentionally carries no second dependency scheduler.
 If a leaf selects an unsupported executor or an unavailable model provider, pause that leaf and correct the explicit leaf input before resuming the fleet.
 
 ## Commands

--- a/skills/relay-fleet/scripts/relay-fleet.js
+++ b/skills/relay-fleet/scripts/relay-fleet.js
@@ -22,7 +22,7 @@ const ID_RE = /^[a-z0-9][a-z0-9-]{0,126}$/;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const LEAF_FIELDS = new Set([
   "leaf_ref", "issue_number", "branch", "prompt_file", "prompt_sha256", "rubric_file", "rubric_sha256",
-  "done_criteria_file", "done_criteria_sha256", "ownership", "executor", "model", "sandbox",
+  "done_criteria_file", "done_criteria_sha256", "ownership", "executor", "model",
   "network_access", "timeout", "reasoning", "copy",
 ]);
 const OPTIONS = Object.freeze({
@@ -35,7 +35,7 @@ const OPTIONS = Object.freeze({
   "dispatch-script": { type: "string", default: DEFAULT_DISPATCH_SCRIPT },
   "review-script": { type: "string", default: DEFAULT_REVIEW_SCRIPT },
   "finalize-script": { type: "string", default: DEFAULT_FINALIZE_SCRIPT },
-  executor: { type: "string" }, model: { type: "string" }, sandbox: { type: "string" },
+  executor: { type: "string" }, model: { type: "string" },
   "network-access": { type: "string" }, timeout: { type: "string" }, reasoning: { type: "string" },
   copy: { type: "string" },
   reviewer: { type: "string" }, "reviewer-model": { type: "string" },
@@ -148,7 +148,7 @@ function normalizeLeaf(raw, index, base, freeze) {
     rubric_file: rubric.file, rubric_sha256: rubric.digest,
     done_criteria_file: done.file, done_criteria_sha256: done.digest,
     ownership,
-    executor: optional("executor"), model: optional("model"), sandbox: optional("sandbox"),
+    executor: optional("executor"), model: optional("model"),
     network_access: optional("network_access"),
     timeout: raw.timeout == null ? null : String(issueNumber(raw.timeout, `leaves[${index}].timeout`)),
     reasoning: optional("reasoning"), copy: Array.isArray(raw.copy) ? raw.copy.join(",") : optional("copy"),
@@ -330,7 +330,7 @@ function parseArgs(argv) {
   return {
     repo: parsed.values.repo, fleetId: parsed.values["fleet-id"], leavesFile: parsed.values["leaves-file"], status: parsed.values.status,
     review: parsed.values.review, parallel, dispatchScript: path.resolve(parsed.values["dispatch-script"]), reviewScript: path.resolve(parsed.values["review-script"]),
-    finalizeScript: path.resolve(parsed.values["finalize-script"]), executor: parsed.values.executor, model: parsed.values.model, sandbox: parsed.values.sandbox,
+    finalizeScript: path.resolve(parsed.values["finalize-script"]), executor: parsed.values.executor, model: parsed.values.model,
     networkAccess: parsed.values["network-access"], timeout: parsed.values.timeout, reasoning: parsed.values.reasoning, copy: parsed.values.copy,
     reviewer: parsed.values.reviewer, reviewerModel: parsed.values["reviewer-model"], mergeMethod: parsed.values["merge-method"],
     dryRun: parsed.values["dry-run"], json: parsed.values.json, help: parsed.values.help,
@@ -340,7 +340,7 @@ function push(args, flag, value) { if (value != null && value !== "") args.push(
 function buildDispatchArgs({ repoRoot, fleetId, leaf, options, runId = null }) {
   const args = [options.dispatchScript, repoRoot, ...(runId ? ["--run-id", runId] : ["--branch", leaf.branch]), "--issue-number", String(leaf.issue_number), "--prompt-file", leaf.prompt_file, "--rubric-file", leaf.rubric_file, "--done-criteria-file", leaf.done_criteria_file, "--fleet-id", fleetId, "--ownership-json", JSON.stringify(leaf.ownership), "--json"];
   push(args, "--executor", leaf.executor || options.executor); push(args, "--model", leaf.model || options.model);
-  push(args, "--sandbox", leaf.sandbox || options.sandbox); push(args, "--network-access", leaf.network_access || options.networkAccess);
+  push(args, "--network-access", leaf.network_access || options.networkAccess);
   push(args, "--timeout", leaf.timeout || options.timeout); push(args, "--reasoning", leaf.reasoning || options.reasoning); push(args, "--copy", leaf.copy || options.copy);
   if (options.dryRun) args.push("--dry-run");
   return args;

--- a/skills/relay-review/scripts/review-runner.js
+++ b/skills/relay-review/scripts/review-runner.js
@@ -378,7 +378,7 @@ function productionServices() {
         timeoutMs,
         buildInvocation: ({ cwd, promptPath, promptBytes, resultPath, schemaPath }) => adapter.buildInvocation({
           phase: "primary_review", cwd, promptPath, promptBytes, resultPath, schemaPath, model,
-          timeoutMs, sandbox: "read-only", networkAccess,
+          timeoutMs, networkAccess,
         }),
         parseOutcome: (input) => adapter.parseOutcome(input),
         providerUnavailableSignals: adapter.providerUnavailableSignals,

--- a/tests/relay-dispatch/scripts/adapter-contract.test.js
+++ b/tests/relay-dispatch/scripts/adapter-contract.test.js
@@ -52,7 +52,6 @@ function invocationFor(adapter, phase = "dispatch") {
     schemaPath,
     model: "provider/model; literally-not-a-shell-command",
     timeoutMs: 123456,
-    sandbox: "workspace-write",
     networkAccess: "enabled",
     reasoning: "high",
   });
@@ -82,7 +81,7 @@ test("new adapter registry preserves exactly the seven supported executors", () 
 
 test("session-backed adapters rely on the ambient host session without secret argv", () => {
   for (const name of ["antigravity", "cline", "cursor"]) {
-    const adapter = getAdapter(name), capability = adapter.capabilities({ phase: "dispatch", request: { sandbox: "workspace-write", networkAccess: "enabled" } });
+    const adapter = getAdapter(name), capability = adapter.capabilities({ phase: "dispatch", request: { networkAccess: "enabled" } });
     assert.equal(Object.hasOwn(capability, "credentialTransport"), false, name);
     assert.equal(Object.hasOwn(adapter.metadata, "credentials"), false, name);
     const invocation = invocationFor(adapter); assert.equal(invocation.args.includes("-k"), false, name);
@@ -97,11 +96,11 @@ test("provider transport is outer-enabled while only verified adapters may force
     assert.ok(Object.isFrozen(invocation.runtimeDependencies), name);
   }
   for (const name of ["claude", "codex", "cursor", "antigravity", "opencode", "cline"]) assert.throws(() => getAdapter(name).buildInvocation({
-    phase: "dispatch", cwd, promptPath, promptBytes: fs.readFileSync(promptPath), resultPath, sandbox: "workspace-write", networkAccess: "disabled",
+    phase: "dispatch", cwd, promptPath, promptBytes: fs.readFileSync(promptPath), resultPath, networkAccess: "disabled",
   }), (error) => error instanceof contract.AdapterCapabilityError && /tool network disable/.test(error.message), name);
   for (const name of ["pi"]) {
     const invocation = getAdapter(name).buildInvocation({ phase: "dispatch", cwd, promptPath, promptBytes: fs.readFileSync(promptPath), resultPath,
-      sandbox: "workspace-write", networkAccess: "disabled", timeoutSeconds: 123 });
+      networkAccess: "disabled", timeoutSeconds: 123 });
     assert.equal(invocation.networkAccess, "enabled", name);
     assert.equal(invocation.toolNetworkAccess, "disabled", name);
   }
@@ -142,7 +141,6 @@ test("Codex omits the reasoning override when the operator did not select one", 
     resultPath,
     model: null,
     timeoutMs: 123456,
-    sandbox: "workspace-write",
     networkAccess: "enabled",
   });
   assert.equal(invocation.args.includes("model_reasoning_effort=xhigh"), false);
@@ -157,7 +155,7 @@ test("phase matrix is fail-closed before an invocation is built", () => {
     () => invocationFor(getAdapter("cline"), "primary_review"),
     (error) => error instanceof contract.AdapterCapabilityError && /structured primary-review output contract/.test(error.message)
   );
-  assert.equal(contract.validateCapabilities(getAdapter("cursor"), "dispatch", { readOnly: true, sandbox: "read-only", networkAccess: "enabled" }).supported, true);
+  assert.equal(contract.validateCapabilities(getAdapter("cursor"), "dispatch", { networkAccess: "enabled" }).supported, true);
   assert.equal(contract.validateCapabilities(getAdapter("codex"), "primary_review", { readOnly: true }).supported, true);
   assert.equal(
     getAdapter("codex").buildInvocation({
@@ -166,7 +164,6 @@ test("phase matrix is fail-closed before an invocation is built", () => {
       promptPath,
       promptBytes: fs.readFileSync(promptPath),
       resultPath,
-      sandbox: "read-only",
       networkAccess: "enabled",
     }).networkAccess,
     "enabled",
@@ -230,7 +227,6 @@ test("native invocation requires trusted prompt bytes and rejects invalid UTF-8 
     cwd,
     promptPath,
     resultPath,
-    sandbox: "workspace-write",
     networkAccess: "enabled",
   };
   assert.throws(() => adapter.buildInvocation(input), /promptBytes must be a Buffer/);
@@ -356,7 +352,6 @@ test("dry-run uses the same real adapter builder and argv as launch for all seve
       copy: null,
       model: "provider/model; literally-not-a-shell-command",
       reasoning: "high",
-      sandbox: "workspace-write",
       "network-access": "enabled",
     };
     const cli = { creating: false, runId: `dry-${name}`, timeoutSeconds: 123, values };
@@ -374,7 +369,6 @@ test("dry-run uses the same real adapter builder and argv as launch for all seve
       resultPath,
       model: values.model,
       timeoutMs: 123_000,
-      sandbox: values.sandbox,
       networkAccess: values["network-access"],
       reasoning: values.reasoning,
     });
@@ -386,7 +380,7 @@ test("dry-run uses the same real adapter builder and argv as launch for all seve
   }
 });
 
-test("Codex and Cursor request their native sandbox without an outer Relay boundary", () => {
+test("Codex and Cursor derive native requests from phase metadata without an outer Relay boundary", () => {
   for (const phase of ["dispatch", "primary_review"]) {
     const codex = invocationFor(getAdapter("codex"), phase), cursor = invocationFor(getAdapter("cursor"), phase);
     assert.deepEqual(codex.args.slice(codex.args.indexOf("--sandbox"), codex.args.indexOf("--sandbox") + 2), ["--sandbox", phase === "primary_review" ? "read-only" : "workspace-write"]);
@@ -395,10 +389,29 @@ test("Codex and Cursor request their native sandbox without an outer Relay bound
     assert.deepEqual(cursor.args.slice(cursor.args.indexOf("--sandbox"), cursor.args.indexOf("--sandbox") + 2), ["--sandbox", "enabled"]);
     assert.equal(Object.hasOwn(cursor, "privateEnvPaths"), false);
   }
-  assert.equal(getAdapter("cursor").capabilities({ phase: "dispatch", request: { sandbox: "read-only", networkAccess: "enabled" } }).supported, true);
+  assert.equal(getAdapter("cursor").capabilities({ phase: "dispatch", request: { networkAccess: "enabled" } }).supported, true);
   assert.deepEqual(contract.filesystemIsolationDiagnostic(getAdapter("codex"), "dispatch", {
-    sandbox: "read-only", readOnly: true, networkAccess: "enabled",
-  }), { requested: "read-only", effective: "native", diagnostic: null });
+    networkAccess: "enabled",
+  }), { requested: "workspace-write", effective: "native", diagnostic: null });
+});
+
+test("dispatch keeps fixed writable-worktree semantics while the adapter owns its native filesystem request", () => {
+  const promptBytes = fs.readFileSync(promptPath);
+  const base = { phase: "dispatch", cwd, promptPath, promptBytes, resultPath, model: null, timeoutMs: 123_000, networkAccess: "enabled" };
+  const codex = getAdapter("codex").buildInvocation(base);
+  assert.deepEqual(codex.args.slice(codex.args.indexOf("--sandbox"), codex.args.indexOf("--sandbox") + 2), ["--sandbox", "workspace-write"], "Codex dispatch argv is fixed to workspace-write");
+  const cursor = getAdapter("cursor").buildInvocation(base);
+  assert.deepEqual(cursor.args.slice(cursor.args.indexOf("--sandbox"), cursor.args.indexOf("--sandbox") + 2), ["--sandbox", "enabled"], "Cursor dispatch argv is fixed to enabled");
+  const antigravity = getAdapter("antigravity").buildInvocation(base);
+  assert.equal(antigravity.args.includes("--sandbox"), true, "Antigravity keeps its declared --sandbox flag");
+  const claude = getAdapter("claude").buildInvocation(base);
+  assert.equal(claude.args.includes(JSON.stringify({ sandbox: { enabled: true, autoAllowBashIfSandboxed: true, allowUnsandboxedCommands: false } })), true, "Claude dispatch enables its native Bash sandbox settings");
+});
+
+test("generic adapter invocation defaults tool networking to disabled", () => {
+  assert.throws(() => getAdapter("codex").buildInvocation({
+    phase: "dispatch", cwd, promptPath, promptBytes: fs.readFileSync(promptPath), resultPath,
+  }), /tool network disable/);
 });
 
 test("adapter metadata is static and carries no integration side channel", () => {
@@ -433,7 +446,7 @@ test("Claude dispatch enables native Bash while primary review is tool-read-only
   });
   assert.equal(getAdapter("claude").capabilities({ phase: "dispatch" }).networkControl, "informational");
   assert.throws(() => getAdapter("claude").buildInvocation({ phase: "dispatch", cwd, promptPath, promptBytes: fs.readFileSync(promptPath), resultPath,
-    sandbox: "workspace-write", networkAccess: "disabled" }), /tool network disable/);
+    networkAccess: "disabled" }), /tool network disable/);
 });
 
 test("invocation contract rejects retired private-environment metadata", () => {
@@ -520,7 +533,6 @@ test("Antigravity rejects prompts above its conservative argv budget before proc
     resultPath,
     schemaPath,
     timeoutMs: 123_000,
-    sandbox: "read-only",
     networkAccess: "enabled",
   }), /argv.*256 KiB.*process list/i);
   assert.equal(getAdapter("antigravity").metadata.promptTransport, "argv_visible");
@@ -543,7 +555,6 @@ test("all supported primary review adapters pass capability negotiation", () => 
     const adapter = getAdapter(name);
     const capability = contract.validateCapabilities(adapter, "primary_review", {
       readOnly: true,
-      sandbox: "read-only",
       networkAccess: "enabled",
     });
     assert.equal(capability.supported, true, name);

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -86,8 +86,9 @@ process.stdout.write("fake pi completed\\n");
 }
 
 function run(value, args, env = value.env) {
-  const network = args.includes("--network-access") ? [] : ["--network-access", "enabled"];
-  return spawnSync(process.execPath, [DISPATCH, value.repo, ...args, ...network], { encoding: "utf8", env, timeout: 60_000 });
+  // Tool networking defaults to enabled; tests exercise the default unless they
+  // pass an explicit --network-access value.
+  return spawnSync(process.execPath, [DISPATCH, value.repo, ...args], { encoding: "utf8", env, timeout: 60_000 });
 }
 
 function json(stdout) { return JSON.parse(stdout); }
@@ -207,6 +208,8 @@ test("dry-run validates the closed Relay surface while writing zero durable byte
   assert.equal(json(result.stdout).durable_bytes_written, 0);
   assert.equal(json(result.stdout).invocation.validation, "adapter_build_invocation");
   assert.equal(json(result.stdout).invocation.launch_boundary, "host_supervisor_required_do_not_execute_raw");
+  assert.equal(json(result.stdout).invocation.network_access, "enabled", "routine dispatch defaults tool networking to enabled");
+  assert.equal(json(result.stdout).invocation.tool_network_access, "enabled", "routine dispatch defaults tool networking to enabled");
   assert.deepEqual(json(result.stdout).filesystem_isolation, { requested: "workspace-write", effective: "native", diagnostic: null });
   assert.equal(fs.existsSync(stateDir), false);
   assert.equal(fs.existsSync(value.relayHome), false);
@@ -249,6 +252,14 @@ test("tool-network disable fails closed for informational executors and preserve
     "--network-access", "disabled", "--dry-run", "--json"]);
   assert.notEqual(unsupported.status, 0);
   assert.match(unsupported.stderr, /tool network disable/i);
+  // The explicit native-deny request fails before any branch, worktree, run, or fact effects.
+  const rejected = run(value, ["--branch", "network-disabled-rejected", "--prompt-file", value.prompt, "--rubric-file", value.rubric,
+    "--network-access", "disabled", "--json"]);
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /tool network disable/i);
+  assert.equal(git(value.repo, ["branch", "--list", "network-disabled-rejected"]), "", "a rejected advanced request must not create a branch");
+  assert.equal(git(value.repo, ["worktree", "list"]).includes("network-disabled-rejected"), false, "a rejected advanced request must not register a worktree");
+  assert.equal(fs.existsSync(fixtureRunsDir(value)), false, "a rejected advanced request must not create a run directory");
   // pi is the only adapter declaring networkControl "native"; claude is deliberately informational,
   // because safe mode preserves admin-managed hooks and so cannot prove complete tool egress denial.
   const result = run(value, ["--executor", "pi", "--branch", "network-disabled-native", "--prompt-file", value.prompt, "--rubric-file", value.rubric,
@@ -258,9 +269,23 @@ test("tool-network disable fails closed for informational executors and preserve
   assert.equal(fs.existsSync(fixtureRunsDir(value)), false);
 });
 
+test("dispatch defaults tool networking to enabled and rejects the retired sandbox flag", () => {
+  const value = fixture("dispatch-defaults");
+  const parsed = dispatch.parseCli([value.repo, "--branch", "defaults-b", "--prompt", "x", "--rubric-file", value.rubric]);
+  assert.equal(parsed.values["network-access"], "enabled");
+  assert.equal(Object.hasOwn(parsed.values, "sandbox"), false);
+  const explicit = dispatch.parseCli([value.repo, "--branch", "defaults-b", "--prompt", "x", "--rubric-file", value.rubric, "--network-access", "enabled"]);
+  assert.equal(explicit.values["network-access"], "enabled");
+  assert.throws(() => dispatch.parseCli([value.repo, "--branch", "defaults-b", "--prompt", "x", "--rubric-file", value.rubric, "--sandbox", "workspace-write"]), /unknown flag/i);
+  const retired = run(value, ["--branch", "defaults-b", "--prompt-file", value.prompt, "--rubric-file", value.rubric, "--sandbox", "workspace-write", "--json"]);
+  assert.notEqual(retired.status, 0);
+  assert.match(retired.stderr, /unknown flag/i);
+  assert.equal(fs.existsSync(value.relayHome), false, "a retired --sandbox input must fail before durable effects");
+});
+
 test("retired dispatch flags fail closed instead of being silently ignored", () => {
   const value = fixture("retired-dispatch-flags");
-  for (const flag of ["--request-id", "--leaf-id", "--allow-toolset-mismatch"]) {
+  for (const flag of ["--request-id", "--leaf-id", "--allow-toolset-mismatch", "--sandbox"]) {
     const result = run(value, ["--branch", "closed-surface", "--prompt", "x", "--rubric-file", value.rubric, flag, "legacy", "--dry-run", "--json"]);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /unknown flag/i);
@@ -1184,7 +1209,7 @@ test("resume without --executor resolves the immutable Pi adapter and appends a 
   assert.equal(output.inspection.derived.reason, "attempt_failed_no_work");
   const eventsPath = path.join(output.run_dir, "events.jsonl");
   const beforeAttempts = facts.readFacts({ eventsPath }).facts.filter((fact) => fact.type.startsWith("attempt_")).length;
-  const resumed = run(value, ["--run-id", output.run_id, "--prompt", "write the requested bounded file", "--network-access", "enabled", "--json"], {
+  const resumed = run(value, ["--run-id", output.run_id, "--prompt", "write the requested bounded file", "--json"], {
     ...value.env, RELAY_PI_BIN: value.fakePi,
   });
   assert.equal(resumed.status, 0, `${resumed.stderr}\n${resumed.stdout}`);

--- a/tests/relay-dispatch/scripts/executors.test.js
+++ b/tests/relay-dispatch/scripts/executors.test.js
@@ -8,15 +8,15 @@ test("flat adapter registry retains all seven executor names", () => {
 });
 
 test("filesystem-isolation diagnostics are static, visible, and nonblocking", () => {
-  const opencode = getAdapter("opencode").capabilities({ phase: "dispatch", request: { sandbox: "read-only", networkAccess: "disabled" } });
+  const opencode = getAdapter("opencode").capabilities({ phase: "dispatch", request: { networkAccess: "disabled" } });
   assert.equal(opencode.supported, true);
   assert.equal(opencode.warnings.length > 0, true);
-  assert.deepEqual(filesystemIsolationDiagnostic(getAdapter("opencode"), "dispatch", { sandbox: "read-only", networkAccess: "enabled" }), {
+  assert.deepEqual(filesystemIsolationDiagnostic(getAdapter("opencode"), "dispatch", { networkAccess: "enabled" }), {
     requested: "unavailable", effective: "none", diagnostic: "opencode has no native filesystem sandbox; continuing directly on the trusted local host.",
   });
-  const cursor = getAdapter("cursor").capabilities({ phase: "dispatch", request: { sandbox: "read-only", networkAccess: "disabled" } });
+  const cursor = getAdapter("cursor").capabilities({ phase: "dispatch", request: { networkAccess: "disabled" } });
   assert.equal(cursor.supported, true);
-  assert.deepEqual(filesystemIsolationDiagnostic(getAdapter("cursor"), "dispatch", { sandbox: "read-only", networkAccess: "enabled" }), {
+  assert.deepEqual(filesystemIsolationDiagnostic(getAdapter("cursor"), "dispatch", { networkAccess: "enabled" }), {
     requested: "enabled", effective: "native", diagnostic: null,
   });
 });

--- a/tests/relay-dispatch/scripts/runtime-contract.test.js
+++ b/tests/relay-dispatch/scripts/runtime-contract.test.js
@@ -372,7 +372,7 @@ printf '%s\\n' '{"verdict":"pass","summary":"direct","issues":[]}' > "$out"
         },
         buildInvocation: ({ cwd, promptPath: stagedPrompt, promptBytes, resultPath, schemaPath }) => adapter.buildInvocation({
           phase: "primary_review", cwd, promptPath: stagedPrompt, promptBytes, resultPath, schemaPath,
-          sandbox: "read-only", networkAccess: "enabled",
+          networkAccess: "enabled",
         }),
         parseOutcome: (input) => adapter.parseOutcome(input),
       });

--- a/tests/relay-fleet/scripts/fleet-derived.test.js
+++ b/tests/relay-fleet/scripts/fleet-derived.test.js
@@ -82,12 +82,16 @@ test("closed fleet CLI rejects removed child-dispatch flags", () => {
   assert.equal(fleet.parseArgs(["--fleet-id", "fleet-a", "--json"]).json, true);
 });
 
-test("immutable leaf schema rejects retired lineage and policy fields", async () => {
+test("immutable leaf schema rejects retired lineage, policy, and sandbox fields", async () => {
   const fixture = setup();
   await fixtureWork(fixture, () => {
     const leavesFile = path.join(fixture.repo, "retired.json");
     fs.writeFileSync(leavesFile, JSON.stringify({ leaves: [{ ...leaf(fixture.repo, 99), request_id: "old-request" }] }));
     assert.throws(() => fleet.loadLeavesFile(fixture.repo, leavesFile), /unsupported fields: request_id/);
+    const sandboxFile = path.join(fixture.repo, "sandbox-retired.json");
+    fs.writeFileSync(sandboxFile, JSON.stringify({ leaves: [{ ...leaf(fixture.repo, 98), sandbox: "workspace-write" }] }));
+    assert.throws(() => fleet.loadLeavesFile(fixture.repo, sandboxFile), /unsupported fields: sandbox/);
+    assert.equal(fs.existsSync(fleet.getFleetLeavesStorePath(fixture.repo, "fleet-sandbox-retired")), false);
   });
 });
 
@@ -135,7 +139,7 @@ test("dispatch invokes only no-child new and exact redispatch resume, without re
     const result = await fleet.runFleet({ repo: fixture.repo, fleetId: "fleet-dispatch", leavesFile, parallel: 2, dispatchScript, reviewScript: dispatchScript, finalizeScript: dispatchScript, services: { inspectRun: inspector({ [resumed.runId]: "redispatch" }) } });
     const calls = fs.readFileSync(capture, "utf8").trim().split("\n").map(JSON.parse);
     assert.equal(calls.length, 2); assert.equal(result.dispatch.filter((item) => item.mode === "new").length, 1); assert.equal(result.dispatch.filter((item) => item.mode === "resume").length, 1);
-    for (const args of calls) for (const retired of ["--leaf-id", "--request-id", "--publish-policy", "--test-command"]) assert.equal(args.includes(retired), false);
+    for (const args of calls) for (const retired of ["--leaf-id", "--request-id", "--publish-policy", "--test-command", "--sandbox"]) assert.equal(args.includes(retired), false);
   });
 });
 


### PR DESCRIPTION
## Recovery Summary

<!-- relay-recovery-operation:recover-4d59111c858de1579ac3de6a243602dc -->

- Run: issue-1252-20260814070349131-7259a210
- Reason: publish verified #1252 zero-ceremony dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - trusted-local dispatch에서 도구 네트워크가 기본적으로 활성화됩니다.
  - 네트워크 비활성화를 명시하면 지원되지 않는 환경에서 실행 전에 거부됩니다.
  - `--sandbox` 옵션과 fleet 설정의 sandbox 필드가 폐기되었습니다.
  - dispatch는 쓰기 가능한 worktree를 사용하며, 파일시스템 격리는 실행 단계와 환경에 따라 처리됩니다.
  - 재개 및 dry-run 실행도 변경된 기본 네트워크 정책을 따릅니다.
- **문서**
  - 외부 도구 사용, 실행기 선택, 네트워크 및 파일시스템 격리 안내를 최신 동작에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->