### PR TITLE
docs: describe recover as the routine publication conveyor, retire stale route references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ route first requires Git and classifies the source: no configured remote uses
 local Reviewed Result delivery, while an identity-matching GitHub source keeps
 the existing PR route. `inspect` derives the next action from durable facts and
 fresh observations. The one recovery command alone may commit, publish a
-GitHub revision, record verification, or close a run. Review and merge bind the
-exact current SHA and frozen criteria.
+GitHub revision, record verification, or close a run. Recovery is also the
+routine publication and verification conveyor: 96% of `recovery_applied`
+events serve the routine conveyor, with crash convergence a measured small
+subset (2026-08-15 reading). Review and merge bind the exact current SHA and
+frozen criteria.
 The GitHub `/relay` cycle stops at `ready_to_merge` until you explicitly land it;
 the local route closes through a Reviewed Result. Use `/relay-merge` only when you explicitly want to land the reviewed GitHub change.
 
@@ -70,11 +73,13 @@ node skills/relay-merge/scripts/finalize-run.js --repo . --run-id <id> --json
 
 ## Executors
 
-All current executors are retained: Claude, Codex, OpenCode, Pi, Antigravity,
-Cursor, and Cline. The adapter registry gives each a common argv, capability,
-and output contract; it does not own lifecycle or registration state. Cline is
-dispatch-only because it has no registered structured primary-review output
-contract.
+Codex is the default route — recent real usage is 38 of 52 runs `codex|codex`,
+with non-codex executor runs serving as adapter dogfood. Claude, Codex,
+OpenCode, Pi, Antigravity, Cursor, and Cline are all retained; the non-codex
+adapters remain available and selectable via `relay-config`. The adapter
+registry gives each a common argv, capability, and output contract; it does
+not own lifecycle or registration state. Cline is dispatch-only because it
+has no registered structured primary-review output contract.
 
 ```bash
 node skills/relay-config/scripts/relay-config.js doctor --json

--- a/backlog/sprints/_context.md
+++ b/backlog/sprints/_context.md
@@ -34,12 +34,6 @@ One fleet represents one validated track. Every leaf carries the same normalized
 ### Route-facing documentation requires the full repository gate
 Relay configuration vocabulary is exposed through both `skills/relay-config/` and the delegated core under `skills/relay-dispatch/`. Changes to either surface, especially SKILL.md wording, must run the serialized full repository suite because sibling suites pin the public prose and aliases.
 
-### Hardened advisory evidence is event-rooted
-For hardened review, filenames and advisory request/result/decision metadata are untrusted claims. Merge validation starts from the latest round's durable advisory success event, uses its HEAD/round-bound resolved-lane snapshot, and cross-checks every configured lane against the event-bound artifact's contained regular-file path, profile, hash, reviewed HEAD, status, and required findings. Both `blindspot` and `adversarial` profiles are valid when the bindings agree.
-
-### Calibration cohorts must preserve real task risk
-Risk-path observation compares compact runs only with compact-eligible full-path controls. Never lower a task's risk classification or manufacture examples to fill a cohort; record an under-sampled class explicitly and continue calibration instead.
-
 ## Known Gotchas
 
 ### `rubric-lifecycle-gap`

--- a/backlog/sprints/_context.md
+++ b/backlog/sprints/_context.md
@@ -31,9 +31,6 @@ Dev-backlog schema-v2 JSON is the source of truth for sprint ownership. Resoluti
 
 One fleet represents one validated track. Every leaf carries the same normalized owner through its child manifest and finalize path; missing, contradictory, ambiguous, or mixed ownership must fail before fleet manifest, issue lock, worktree, or dispatch side effects.
 
-### Unified route configuration is the single source of truth
-`routes.json` drives dispatch and review routing. It maps into the existing policy-shaped object in memory; do not generate a derived `policy.json`, and keep `evaluateRelayRoute()` behavior stable. Legacy `policy.json` holders retain legacy precedence until explicitly migrated.
-
 ### Route-facing documentation requires the full repository gate
 Relay configuration vocabulary is exposed through both `skills/relay-config/` and the delegated core under `skills/relay-dispatch/`. Changes to either surface, especially SKILL.md wording, must run the serialized full repository suite because sibling suites pin the public prose and aliases.
 
@@ -49,7 +46,7 @@ Risk-path observation compares compact runs only with compact-eligible full-path
 Relay rubric was historically ephemeral: generated in orchestrator context, embedded in dispatch prompt, lost after. Reviewer never saw it. This manifests as "enforcement layers built on missing artifacts" anti-pattern. Phase 0 (sprint `2026-04-agentic-patterns-phase-0`) is the fix.
 
 Confidence: 9/10. Source: observed.
-Related files: `skills/relay-dispatch/scripts/dispatch.js`, `skills/relay-review/scripts/review-runner.js`, `skills/relay-dispatch/scripts/relay-manifest.js`.
+Related files: `skills/relay-dispatch/scripts/dispatch.js`, `skills/relay-review/scripts/review-runner.js`.
 
 ### Reviewer independence is a feature, not a limitation
 Willison's patterns assume the same agent remembers and improves over time. Relay's reviewer intentionally runs in fresh context (`context: fork` / `--ephemeral`). Do not add memory to the reviewer. Do not let planning bias leak into review.

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -110,6 +110,15 @@ Recovery alone may close a dead attempt, commit reviewable work, place a GitHub
 branch revision on the remote ref (Publication), record/create the exact
 Change Request, record verification, or append the local Reviewed Result's
 `run_closed` fact.
+
+Measurement (2026-08-15): canonical recovery is also the routine publication
+and verification conveyor, not only crash machinery. Across recent vNext runs,
+219 of 228 `recovery_applied` events (96%) served the routine conveyor —
+`verification_stale` (104), `publication_incomplete` (80),
+`verification_missing` (35) — while the crash rule `attempt_liveness_unknown`
+fired in 8 of 52 runs (15.4%). Crash convergence is a real but measured small
+subset of recovery work.
+
 Every recovery step is authorized by a fresh action key and re-observed after
 the side effect. An explicit close carries a durable operator and reason.
 


### PR DESCRIPTION
Closes #1266

## 작업 내용
- `references/architecture.md`: canonical recovery가 routine publication/verification conveyor를 소유한다는 측정 근거 추가 (2026-08-15 reading: recovery_applied 219/228 = 96% routine, crash rule `attempt_liveness_unknown` 8/52 runs). Contract vocabulary 무변경.
- `README.md`: Flow 섹션에 recovery = routine conveyor 문장 추가; Executors 섹션을 codex 기본 라우트(38/52 runs) + 나머지 어댑터 `relay-config`로 선택 가능하게 재작성 (7개 어댑터 전부 유지, Cline dispatch-only 사실 유지)
- `backlog/sprints/_context.md`: 런타임에 존재하지 않는 메커니즘(routes.json/policy.json/evaluateRelayRoute) 서술 삭제; `rubric-lifecycle-gap` Related files에서 relay-manifest.js 제거 (test fixture로만 존재)
- `docs/README.md`: retitle 없음 — index 정확성 유지 확인

## 검증 (로컬)
- `node --test tests/relay-dispatch/scripts/docs-defaults.test.js` → 13/13 pass (doc/SKILL prose pinning suite)
- `node --test tests/skills-lint/scripts/*.test.js` → 34/34 pass
- `references/architecture.md`에 pinned-absent strings (routes.json/policy.json/route-plan.json/relay-config plan-run/--route-intent-file) 0건 확인
- runtime/script/test 코드 무변경 (docs only)