### PR TITLE
fix(dispatch): salvage typed terminal result when the gate faults after settle (#1271)

### DIFF
--- a/skills/relay-dispatch/scripts/dispatch.js
+++ b/skills/relay-dispatch/scripts/dispatch.js
@@ -701,6 +701,29 @@ async function executeDetached(cli, argv) {
   fail("detached dispatcher did not publish a launch receipt", "DISPATCH_START_FAILED");
 }
 
+// When a foreground dispatch throws after the attempt already settled (the gate
+// exiting mid-flight during Relay cancellation, e.g. a post-settle inspection
+// fault), the terminal state is still durable: an attempt_finished fact and its
+// host result file. Salvage the typed shape for stdout instead of losing it to a
+// stderr-only error. Exit-code semantics are unchanged: the caller still returns 1.
+async function salvageTerminalResult(cli) {
+  if (!cli || !cli.runId || !cli.repo || cli.values["dry-run"]) return null;
+  const runDir = runStore.resolveRunDirectory(canonicalCheckout(cli.repo), cli.runId);
+  const inspection = await recover.inspectProductionRun({ runDir });
+  const finished = inspection.facts.filter((fact) => fact.type === "attempt_finished"
+    && new Set(["cancelled", "failed", "timed_out"]).has(fact.payload?.status)).at(-1);
+  if (!finished) return null;
+  const hostResult = JSON.parse(fs.readFileSync(finished.payload.result_path, "utf8"));
+  if (!TERMINAL_STATUSES.has(hostResult.status)) return null;
+  const adapter = getAdapter(cli.values.executor);
+  const capabilityRequest = { networkAccess: cli.values["network-access"], model: cli.values.model || null };
+  return { status: finished.payload.status, host_status: hostResult.status,
+    ...(hostResult.termination ? { termination: hostResult.termination } : {}),
+    run_id: cli.runId, run_dir: runDir, attempt_id: finished.attempt_id,
+    filesystem_isolation: filesystemIsolationDiagnostic(adapter, "dispatch", capabilityRequest),
+    recovery: "canonical relay-recover only", inspection };
+}
+
 async function main(argv = process.argv.slice(2)) {
   let cli;
   try {
@@ -722,6 +745,11 @@ async function main(argv = process.argv.slice(2)) {
     const payload = { ok: false, code: error.code || "DISPATCH_FAILED", error: error.message };
     if (process.env.RELAY_DISPATCH_NOTIFY_PATH) {
       try { atomicJson(process.env.RELAY_DISPATCH_NOTIFY_PATH, payload); } catch {}
+    }
+    let salvaged = null;
+    try { salvaged = await salvageTerminalResult(cli); } catch {}
+    if (salvaged) {
+      console.log(cli?.values?.json ? JSON.stringify(salvaged, null, 2) : `${salvaged.status}: ${salvaged.run_id}`);
     }
     console.error(cli?.values?.json ? JSON.stringify(payload) : `relay-dispatch: ${error.message}`);
     return 1;

--- a/tests/relay-dispatch/fixtures/dispatch-post-settle-fault-preload.js
+++ b/tests/relay-dispatch/fixtures/dispatch-post-settle-fault-preload.js
@@ -1,0 +1,21 @@
+"use strict";
+
+// Fault injection for issue #1271: the gate exits mid-flight while Relay
+// cancellation settles the attempt. The first post-settle inspection throws,
+// so dispatch's main catch must salvage the typed terminal shape from durable
+// facts instead of losing it to a stderr-only error. The fault fires once so
+// the salvage's own read-only inspection observes real settled state.
+const recoverPath = require.resolve("../../../skills/relay-dispatch/scripts/recover");
+const recover = require(recoverPath);
+if (process.env.RELAY_TEST_POST_SETTLE_FAULT === "1") {
+  const inspectProductionRun = recover.inspectProductionRun;
+  let faulted = false;
+  recover.inspectProductionRun = async (input) => {
+    const inspection = await inspectProductionRun(input);
+    if (!faulted && inspection.facts.some((fact) => fact.type === "attempt_finished")) {
+      faulted = true;
+      throw new Error("simulated post-settle gate exit");
+    }
+    return inspection;
+  };
+}

--- a/tests/relay-dispatch/scripts/dispatch.test.js
+++ b/tests/relay-dispatch/scripts/dispatch.test.js
@@ -26,6 +26,7 @@ const CRASH_AFTER_START = path.join(ROOT, "tests/relay-dispatch/fixtures/dispatc
 const ADAPTER_RUNTIME_PRELOAD = path.join(ROOT, "tests/relay-dispatch/fixtures/adapter-runtime-preload.js");
 const READ_ONCE_PRELOAD = path.join(ROOT, "tests/relay-dispatch/fixtures/dispatch-prompt-read-once-preload.js");
 const RUN_CLAIM_RACE = path.join(ROOT, "tests/relay-dispatch/fixtures/dispatch-run-claim-race-preload.js");
+const POST_SETTLE_FAULT = path.join(ROOT, "tests/relay-dispatch/fixtures/dispatch-post-settle-fault-preload.js");
 
 function git(repo, args) {
   return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
@@ -966,6 +967,28 @@ test("recognized OpenCode stderr remains typed when the gate exits during Relay 
   const output = json(result.stdout);
   assert.ok(new Set(["cancelled", "failed"]).has(output.status), JSON.stringify(output));
   assert.equal(output.termination, "provider_unavailable", JSON.stringify(output));
+});
+
+test("a settled attempt keeps its typed stdout shape when the gate faults during Relay cancellation", { timeout: 60_000 }, () => {
+  const value = fixture("opencode-post-settle-fault");
+  const result = run(value, ["--executor", "opencode", "--branch", "opencode-post-settle-fault", "--prompt-file", value.prompt,
+    "--rubric-file", value.rubric, "--timeout", "30", "--json"], {
+    ...value.env,
+    FAKE_OPENCODE_SIGNAL: "insufficient_quota", FAKE_OPENCODE_STAY_ALIVE: "1",
+    NODE_OPTIONS: [value.env.NODE_OPTIONS, `--require=${POST_SETTLE_FAULT}`].filter(Boolean).join(" "),
+    RELAY_TEST_POST_SETTLE_FAULT: "1",
+  });
+  assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stderr, /simulated post-settle gate exit/, "the injected fault must actually fire");
+  const output = json(result.stdout);
+  assert.equal(output.status, "cancelled");
+  assert.equal(output.host_status, "cancelled");
+  assert.equal(output.termination, "provider_unavailable");
+  assert.ok(output.run_dir && output.attempt_id);
+  const journal = facts.readFacts({ eventsPath: path.join(output.run_dir, "events.jsonl") });
+  const finished = journal.facts.find((fact) => fact.type === "attempt_finished");
+  assert.equal(finished.payload.status, "cancelled");
+  assert.equal(finished.attempt_id, output.attempt_id);
 });
 
 test("a malformed structured adapter result cannot turn an exit-zero host result into a completed attempt", () => {


### PR DESCRIPTION
Closes #1271

## Problem
`dispatch` exits 1 (expected) but with **empty stdout** when the gate exits mid-flight during Relay cancellation: `finishAttempt` throws (`HOST_RESULT_TIMEOUT`/`HOST_RESULT_MISMATCH` or the general catch), `main`'s catch prints only to stderr, and the typed `{status, termination: "provider_unavailable"}` public state never reaches stdout — the flaky failure in `dispatch.test.js` (`json(result.stdout)` → `Unexpected end of JSON input`).

## Change
- `skills/relay-dispatch/scripts/dispatch.js`: add `salvageTerminalResult(cli)` — in `main`'s catch, re-inspect the run ledger via `recover.inspectProductionRun`; when a terminal `attempt_finished` fact exists, read the host result file and print the typed JSON shape to stdout (status/host_status/termination/run_id/run_dir/attempt_id/filesystem_isolation). Exit code stays 1; genuine errors without a settled attempt keep stderr-only behavior.
- `tests/relay-dispatch/fixtures/dispatch-post-settle-fault-preload.js`: deterministic fault injection — first post-settle inspection throws, simulating the gate exit.
- `tests/relay-dispatch/scripts/dispatch.test.js`: new behavioral test asserting the typed stdout shape survives the injected post-settle fault (status `cancelled`, termination `provider_unavailable`, durable attempt_finished fact matches). Existing flaky test untouched.

## Verification
- `node --test --test-concurrency=1 tests/relay-dispatch/scripts/dispatch.test.js` → 48/48 pass
- Cancellation tests x5 loop → 10/10 pass
- `node --test --test-concurrency=1 tests/relay-dispatch/scripts/*.test.js` → 343/343 pass